### PR TITLE
Allow dependencyConditionAbsent conditional dependencies

### DIFF
--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionConfiguration.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionConfiguration.java
@@ -24,6 +24,7 @@ public class QuarkusExtensionConfiguration {
     private ListProperty<String> conditionalDependencies;
     private ListProperty<String> conditionalDevDependencies;
     private ListProperty<String> dependencyCondition;
+    private ListProperty<String> dependencyConditionAbsent;
     private RemovedResources removedResources = new RemovedResources();
     private Capabilities capabilities = new Capabilities();
 
@@ -44,6 +45,7 @@ public class QuarkusExtensionConfiguration {
         conditionalDependencies = project.getObjects().listProperty(String.class);
         conditionalDevDependencies = project.getObjects().listProperty(String.class);
         dependencyCondition = project.getObjects().listProperty(String.class);
+        dependencyConditionAbsent = project.getObjects().listProperty(String.class);
     }
 
     public void setDisableValidation(boolean disableValidation) {
@@ -124,6 +126,14 @@ public class QuarkusExtensionConfiguration {
 
     public void setDependencyConditions(List<String> dependencyCondition) {
         this.dependencyCondition.addAll(dependencyCondition);
+    }
+
+    public ListProperty<String> getDependencyConditionsAbsent() {
+        return dependencyConditionAbsent;
+    }
+
+    public void setDependencyConditionsAbsent(List<String> dependencyConditionAbsent) {
+        this.dependencyConditionAbsent.addAll(dependencyConditionAbsent);
     }
 
     public List<Capability> getProvidedCapabilities() {

--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/tasks/ExtensionDescriptorTask.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/tasks/ExtensionDescriptorTask.java
@@ -124,6 +124,12 @@ public class ExtensionDescriptorTask extends DefaultTask {
             props.setProperty(BootstrapConstants.DEPENDENCY_CONDITION, buf.toString());
         }
 
+        List<String> dependencyConditionsAbsent = quarkusExtensionConfiguration.getDependencyConditionsAbsent().get();
+        if (dependencyConditionsAbsent != null && !dependencyConditionsAbsent.isEmpty()) {
+            props.setProperty(BootstrapConstants.DEPENDENCY_CONDITION_ABSENT,
+                    String.join(" ", dependencyConditionsAbsent));
+        }
+
         List<String> parentFirstArtifacts = quarkusExtensionConfiguration.getParentFirstArtifacts().get();
         if (parentFirstArtifacts != null && !parentFirstArtifacts.isEmpty()) {
             String val = String.join(",", parentFirstArtifacts);

--- a/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/tasks/ExtensionDescriptorTaskTest.java
+++ b/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/tasks/ExtensionDescriptorTaskTest.java
@@ -182,6 +182,20 @@ public class ExtensionDescriptorTaskTest {
                 "sunshine?org.acme:ext-b:0.1.0");
     }
 
+    @Test
+    public void shouldPreserveWildcardPatternsInDependencyConditionAbsent() throws IOException {
+        String buildFileContent = TestUtils.getDefaultGradleBuildFileContent(true, Collections.emptyList(),
+                "dependencyConditionAbsent = ['*:quarkus-jdbc-*']");
+        TestUtils.writeFile(buildFile, buildFileContent);
+        TestUtils.runExtensionDescriptorTask(testProjectDir);
+
+        File extensionPropertiesFile = new File(testProjectDir, "build/resources/main/META-INF/quarkus-extension.properties");
+        assertThat(extensionPropertiesFile).exists();
+
+        Properties extensionProperty = TestUtils.readPropertyFile(extensionPropertiesFile.toPath());
+        assertThat(extensionProperty).containsEntry("dependency-condition-absent", "*:quarkus-jdbc-*");
+    }
+
     /*
      * This test will fail if run in an IDE without extra config - it needs an environment variable, and
      * that is increasingly hard to do on Java 17+; see https://github.com/junit-pioneer/junit-pioneer/issues/509

--- a/extensions/hibernate-orm/runtime/pom.xml
+++ b/extensions/hibernate-orm/runtime/pom.xml
@@ -122,6 +122,11 @@
             <artifactId>quarkus-jaxb</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-h2</artifactId>
+            <optional>true</optional>  <!-- conditional dependency -->
+        </dependency>
     </dependencies>
 
     <build>
@@ -137,6 +142,9 @@
                         <excludedArtifact>javax.persistence:javax.persistence-api</excludedArtifact>
                         <excludedArtifact>javax.persistence:persistence-api</excludedArtifact>
                     </excludedArtifacts>
+                    <conditionalDependencies>
+                        <artifact>${project.groupId}:quarkus-jdbc-h2:${project.version}</artifact>
+                    </conditionalDependencies>
                     <conditionalDevDependencies>
                         <artifact>${project.groupId}:${project.artifactId}-dev:${project.version}</artifact>
                     </conditionalDevDependencies>

--- a/extensions/jdbc/jdbc-h2/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-h2/runtime/pom.xml
@@ -48,6 +48,24 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>extension-descriptor</goal>
+                        </goals>
+                        <configuration>
+                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
+                            <dependencyCondition>
+                                <artifact>io.quarkus:quarkus-hibernate-orm</artifact>
+                            </dependencyCondition>
+                            <dependencyConditionAbsent>
+                                <artifact>*:quarkus-jdbc-*</artifact>
+                                <artifact>io.quarkus:quarkus-hibernate-reactive</artifact>
+                            </dependencyConditionAbsent>
+                        </configuration>
+                    </execution>
+                </executions>
                 <configuration>
                     <parentFirstArtifacts>
                         <parentFirstArtifact>com.h2database:h2</parentFirstArtifact>

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/BootstrapConstants.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/BootstrapConstants.java
@@ -12,6 +12,7 @@ public interface BootstrapConstants {
     String CONDITIONAL_DEPENDENCIES = "conditional-dependencies";
     String CONDITIONAL_DEV_DEPENDENCIES = "conditional-dev-dependencies";
     String DEPENDENCY_CONDITION = "dependency-condition";
+    String DEPENDENCY_CONDITION_ABSENT = "dependency-condition-absent";
 
     /**
      * Constant for sharing the additional mappings between test-sources and the corresponding application-sources.

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/util/BootstrapUtils.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/util/BootstrapUtils.java
@@ -51,6 +51,18 @@ public class BootstrapUtils {
         return keys;
     }
 
+    public static ArtifactCoordsPattern[] parseAbsenceDependencyCondition(String s) {
+        final String[] strArr = splitByWhitespace(s);
+        if (strArr == null) {
+            return null;
+        }
+        final ArtifactCoordsPattern[] patterns = new ArtifactCoordsPattern[strArr.length];
+        for (int i = 0; i < strArr.length; ++i) {
+            patterns[i] = ArtifactCoordsPattern.of(strArr[i]);
+        }
+        return patterns;
+    }
+
     /**
      * @deprecated for removal since 3.31.0 in favor of ApplicationModelSerializer methods
      */

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/TsQuarkusExt.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/TsQuarkusExt.java
@@ -74,6 +74,10 @@ public class TsQuarkusExt {
         return setDescriptorProp(BootstrapConstants.DEPENDENCY_CONDITION, buf.toString());
     }
 
+    public TsQuarkusExt setDependencyConditionAbsent(String... patterns) {
+        return setDescriptorProp(BootstrapConstants.DEPENDENCY_CONDITION_ABSENT, String.join(" ", patterns));
+    }
+
     public TsQuarkusExt setDescriptorProp(String name, String value) {
         rtDescr.set(name, value);
         return this;

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/ConditionalDependencyAbsentConditionTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/ConditionalDependencyAbsentConditionTestCase.java
@@ -1,0 +1,120 @@
+package io.quarkus.bootstrap.resolver.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collection;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.bootstrap.resolver.ResolverSetupCleanup;
+import io.quarkus.bootstrap.resolver.TsArtifact;
+import io.quarkus.bootstrap.resolver.TsQuarkusExt;
+import io.quarkus.maven.dependency.ResolvedDependency;
+
+/**
+ * Tests dependencyConditionAbsent behavior for both exact names and wildcard patterns.
+ * <p>
+ * ext-a offers ext-b as a conditional dependency.
+ * ext-b declares an absence condition that must not be matched by any runtime artifact
+ * for ext-b to be activated.
+ */
+public class ConditionalDependencyAbsentConditionTestCase extends ResolverSetupCleanup {
+
+    /**
+     * ext-b is activated because ext-c is not present in the dependency graph
+     * and the exact absence condition {@code io.quarkus.bootstrap.test:ext-c} is satisfied.
+     */
+    @Test
+    public void exactConditionActivatedWhenDependencyAbsent() throws Exception {
+        final TsArtifact root = new TsArtifact("root");
+
+        final TsQuarkusExt extB = new TsQuarkusExt("ext-b");
+        extB.setDependencyConditionAbsent(TsArtifact.DEFAULT_GROUP_ID + ":ext-c");
+        extB.install(repo);
+
+        final TsQuarkusExt extA = new TsQuarkusExt("ext-a");
+        extA.setConditionalDeps(extB);
+        extA.install(repo);
+        root.addDependency(extA);
+
+        repo.install(root);
+
+        final Collection<ResolvedDependency> buildDeps = resolver.resolveModel(root.toArtifact()).getDependencies();
+        assertThat(buildDeps).extracting(ResolvedDependency::getArtifactId).contains("ext-b");
+    }
+
+    /**
+     * ext-b is NOT activated because ext-c is present in the dependency graph,
+     * matching the exact absence condition {@code io.quarkus.bootstrap.test:ext-c}.
+     */
+    @Test
+    public void exactConditionNotActivatedWhenDependencyPresent() throws Exception {
+        final TsArtifact root = new TsArtifact("root");
+
+        final TsQuarkusExt extB = new TsQuarkusExt("ext-b");
+        extB.setDependencyConditionAbsent(TsArtifact.DEFAULT_GROUP_ID + ":ext-c");
+        extB.install(repo);
+
+        final TsQuarkusExt extA = new TsQuarkusExt("ext-a");
+        extA.setConditionalDeps(extB);
+        extA.install(repo);
+        root.addDependency(extA);
+
+        final TsQuarkusExt extC = new TsQuarkusExt("ext-c");
+        extC.install(repo);
+        root.addDependency(extC);
+
+        repo.install(root);
+
+        final Collection<ResolvedDependency> buildDeps = resolver.resolveModel(root.toArtifact()).getDependencies();
+        assertThat(buildDeps).extracting(ResolvedDependency::getArtifactId).doesNotContain("ext-b");
+    }
+
+    /**
+     * ext-b is activated because no artifact matching the wildcard pattern {@code *:ext-c*} is present.
+     */
+    @Test
+    public void wildcardConditionActivatedWhenDependencyAbsent() throws Exception {
+        final TsArtifact root = new TsArtifact("root");
+
+        final TsQuarkusExt extB = new TsQuarkusExt("ext-b");
+        extB.setDependencyConditionAbsent("*:ext-c*");
+        extB.install(repo);
+
+        final TsQuarkusExt extA = new TsQuarkusExt("ext-a");
+        extA.setConditionalDeps(extB);
+        extA.install(repo);
+        root.addDependency(extA);
+
+        repo.install(root);
+
+        final Collection<ResolvedDependency> buildDeps = resolver.resolveModel(root.toArtifact()).getDependencies();
+        assertThat(buildDeps).extracting(ResolvedDependency::getArtifactId).contains("ext-b");
+    }
+
+    /**
+     * ext-b is NOT activated because ext-c is present and matches the wildcard pattern {@code *:ext-c*}.
+     */
+    @Test
+    public void wildcardConditionNotActivatedWhenDependencyPresent() throws Exception {
+        final TsArtifact root = new TsArtifact("root");
+
+        final TsQuarkusExt extB = new TsQuarkusExt("ext-b");
+        extB.setDependencyConditionAbsent("*:ext-c*");
+        extB.install(repo);
+
+        final TsQuarkusExt extA = new TsQuarkusExt("ext-a");
+        extA.setConditionalDeps(extB);
+        extA.install(repo);
+        root.addDependency(extA);
+
+        final TsQuarkusExt extC = new TsQuarkusExt("ext-c");
+        extC.install(repo);
+        root.addDependency(extC);
+
+        repo.install(root);
+
+        final Collection<ResolvedDependency> buildDeps = resolver.resolveModel(root.toArtifact()).getDependencies();
+        assertThat(buildDeps).extracting(ResolvedDependency::getArtifactId).doesNotContain("ext-b");
+    }
+}

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/ApplicationDependencyResolver.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/ApplicationDependencyResolver.java
@@ -535,6 +535,15 @@ public class ApplicationDependencyResolver {
         return dep != null && dep.isFlagSet(DependencyFlags.RUNTIME_CP);
     }
 
+    private boolean isAnyRuntimeArtifactMatching(ArtifactCoordsPattern pattern) {
+        for (ResolvedDependencyBuilder dep : appBuilder.getDependencies()) {
+            if (dep.isFlagSet(DependencyFlags.RUNTIME_CP) && pattern.matches(dep)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private void processRuntimeDeps(DependencyNode root) {
         final AppDep appRoot = new AppDep(root);
         visitRuntimeDeps(appRoot);
@@ -1127,12 +1136,21 @@ public class ApplicationDependencyResolver {
 
         boolean isSatisfied() {
             var extInfo = conditionalDep.ext == null ? null : conditionalDep.ext.info;
-            if (extInfo == null || extInfo.dependencyCondition == null) {
+            if (extInfo == null) {
                 return true;
             }
-            for (ArtifactKey key : extInfo.dependencyCondition) {
-                if (!isRuntimeArtifact(key)) {
-                    return false;
+            if (extInfo.dependencyCondition != null) {
+                for (ArtifactKey key : extInfo.dependencyCondition) {
+                    if (!isRuntimeArtifact(key)) {
+                        return false;
+                    }
+                }
+            }
+            if (extInfo.dependencyConditionAbsent != null) {
+                for (ArtifactCoordsPattern pattern : extInfo.dependencyConditionAbsent) {
+                    if (isAnyRuntimeArtifactMatching(pattern)) {
+                        return false;
+                    }
                 }
             }
             return true;

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/ExtensionInfo.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/ExtensionInfo.java
@@ -14,6 +14,7 @@ import io.quarkus.bootstrap.model.ApplicationModelBuilder;
 import io.quarkus.bootstrap.model.CapabilityContract;
 import io.quarkus.bootstrap.util.BootstrapUtils;
 import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.ArtifactCoordsPattern;
 import io.quarkus.maven.dependency.ArtifactKey;
 
 /**
@@ -26,6 +27,7 @@ class ExtensionInfo {
     final Artifact deploymentArtifact;
     final Artifact[] conditionalDeps;
     final ArtifactKey[] dependencyCondition;
+    final ArtifactCoordsPattern[] dependencyConditionAbsent;
     boolean activated;
 
     ExtensionInfo() {
@@ -34,6 +36,7 @@ class ExtensionInfo {
         deploymentArtifact = null;
         conditionalDeps = null;
         dependencyCondition = null;
+        dependencyConditionAbsent = null;
     }
 
     ExtensionInfo(Artifact runtimeArtifact, Properties props, boolean devMode) throws BootstrapDependencyProcessingException {
@@ -44,6 +47,8 @@ class ExtensionInfo {
         this.conditionalDeps = initConditionalDeps(devMode);
         dependencyCondition = BootstrapUtils
                 .parseDependencyCondition(props.getProperty(BootstrapConstants.DEPENDENCY_CONDITION));
+        dependencyConditionAbsent = BootstrapUtils
+                .parseAbsenceDependencyCondition(props.getProperty(BootstrapConstants.DEPENDENCY_CONDITION_ABSENT));
     }
 
     void ensureActivated(ApplicationModelBuilder appBuilder) {

--- a/independent-projects/extension-maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
+++ b/independent-projects/extension-maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
@@ -243,6 +243,14 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
     private List<String> dependencyCondition = new ArrayList<>(0);
 
     /**
+     * <a href="https://quarkus.io/guides/conditional-extension-dependencies">Extension absence dependency condition</a>:
+     * artifacts listed here must NOT be present for this extension to be enabled
+     * in case it is added as a conditional dependency of another extension.
+     */
+    @Parameter
+    private List<String> dependencyConditionAbsent = new ArrayList<>(0);
+
+    /**
      * Whether to skip validation of the codestart artifact, in case its configured
      */
     @Parameter(property = "skipCodestartValidation")
@@ -494,6 +502,10 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
             }
             props.setProperty(BootstrapConstants.DEPENDENCY_CONDITION, buf.toString());
         }
+        if (!dependencyConditionAbsent.isEmpty()) {
+            props.setProperty(BootstrapConstants.DEPENDENCY_CONDITION_ABSENT,
+                    String.join(" ", dependencyConditionAbsent));
+        }
     }
 
     private void setConditionalDepsProperty(Properties props, String propertyName, List<String> list) {
@@ -529,7 +541,8 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
             final Properties props = getExtensionDescriptor(
                     new DefaultArtifact(d.getGroupId(), d.getArtifactId(), d.getClassifier(), d.getType(), d.getVersion()),
                     false);
-            if (props == null || !props.containsKey(BootstrapConstants.DEPENDENCY_CONDITION)) {
+            if (props == null || (!props.containsKey(BootstrapConstants.DEPENDENCY_CONDITION)
+                    && !props.containsKey(BootstrapConstants.DEPENDENCY_CONDITION_ABSENT))) {
                 continue;
             }
             if (buf == null) {


### PR DESCRIPTION
One thing that came from the session at f2f. Allow to add a conditional dependency when there is no dependency with a specific pattern found. This is also included in this PR, so when the user defines `quarkus-hibernate-orm` but not any of the `quarkus-jdbc-` extensions, we automatically add `quarkus-jdbc-h2` extension so the application can build.

And might be also used in LRA for instance, if user doesn't define any of the `rest-client` or `resteasy-client` extensions.