### PR TITLE
Collect compile-only dependencies in QuarkusApplicationModelTask

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -589,6 +589,7 @@ public class QuarkusPlugin implements Plugin<Project> {
         task.getPlatformConfiguration().configureFrom(classpath.getPlatformConfiguration());
         task.getPlatformInfo().configureFrom(classpath.getPlatformPropertiesConfiguration());
         task.getDeploymentClasspath().configureFrom(classpath.getDeploymentConfiguration());
+        task.getCompileOnlyClasspath().configureFrom(classpath.getCompileOnlyWithoutResolvingDeployment());
         task.getDeploymentResolvedWorkaround().from(classpath.getDeploymentConfiguration().getIncoming().getFiles());
         task.getApplicationModel().set(project.getLayout().getBuildDirectory().file(quarkusModelFile));
     }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusApplicationModelTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusApplicationModelTask.java
@@ -113,6 +113,9 @@ public abstract class QuarkusApplicationModelTask extends DefaultTask {
     public abstract QuarkusResolvedClasspath getDeploymentClasspath();
 
     @Nested
+    public abstract QuarkusResolvedClasspath getCompileOnlyClasspath();
+
+    @Nested
     public abstract QuarkusPlatformInfo getPlatformInfo();
 
     @Input
@@ -147,6 +150,7 @@ public abstract class QuarkusApplicationModelTask extends DefaultTask {
 
         collectDependencies(getAppClasspath(), modelBuilder, projectDescriptor.getWorkspaceModule(), projectDescriptor);
         collectExtensionDependencies(getDeploymentClasspath(), modelBuilder);
+        collectCompileOnlyDependencies(getCompileOnlyClasspath(), modelBuilder);
         DefaultApplicationModel model = modelBuilder.build();
         ToolingUtils.serializeAppModel(model, getApplicationModel().get().getAsFile().toPath());
     }
@@ -414,6 +418,69 @@ public abstract class QuarkusApplicationModelTask extends DefaultTask {
             if (d instanceof ResolvedDependencyResult result) {
                 collectExtensionDependencies(result, modelBuilder, resolvedArtifacts, processedModules,
                         clearReloadableFlagChildren);
+            }
+        }
+    }
+
+    private static void collectCompileOnlyDependencies(QuarkusResolvedClasspath classpath,
+            ApplicationModelBuilder modelBuilder) {
+        final Map<ComponentIdentifier, List<QuarkusResolvedArtifact>> artifacts = classpath
+                .resolvedArtifactsByComponentIdentifier();
+        final Set<ModuleVersionIdentifier> processedModules = new HashSet<>();
+        classpath.getRoot().get().getDependencies().forEach(d -> {
+            if (d instanceof ResolvedDependencyResult resolved) {
+                collectCompileOnlyDependencies(resolved, modelBuilder, artifacts, processedModules);
+            }
+        });
+    }
+
+    private static void collectCompileOnlyDependencies(
+            ResolvedDependencyResult resolvedDependency,
+            ApplicationModelBuilder modelBuilder,
+            Map<ComponentIdentifier, List<QuarkusResolvedArtifact>> resolvedArtifacts,
+            Set<ModuleVersionIdentifier> processedModules) {
+        final ModuleVersionIdentifier moduleId = getModuleVersion(resolvedDependency);
+        if (!processedModules.add(moduleId)) {
+            return;
+        }
+        final List<QuarkusResolvedArtifact> artifacts = getResolvedModuleArtifacts(resolvedArtifacts,
+                resolvedDependency.getSelected().getId());
+        if (artifacts.isEmpty()) {
+            return;
+        }
+
+        boolean skip = true;
+        for (QuarkusResolvedArtifact artifact : artifacts) {
+            if (!isDependency(artifact)) {
+                continue;
+            }
+            String classifier = resolveClassifier(moduleId, artifact.file);
+            final ArtifactKey artifactKey = ArtifactKey.of(
+                    moduleId.getGroup(),
+                    moduleId.getName(),
+                    classifier,
+                    artifact.type);
+            if (isApplicationRoot(modelBuilder, artifactKey)) {
+                continue;
+            }
+
+            ResolvedDependencyBuilder dep = modelBuilder.getDependency(artifactKey);
+            if (dep == null) {
+                ArtifactCoords artifactCoords = new GACTV(artifactKey, moduleId.getVersion());
+                dep = toDependency(artifactCoords, artifact.file);
+                modelBuilder.addDependency(dep);
+            }
+            if (!dep.isFlagSet(DependencyFlags.COMPILE_ONLY)) {
+                skip = false;
+                dep.setFlags(DependencyFlags.COMPILE_ONLY);
+            }
+        }
+
+        if (!skip) {
+            for (DependencyResult dependency : resolvedDependency.getSelected().getDependencies()) {
+                if (dependency instanceof ResolvedDependencyResult result) {
+                    collectCompileOnlyDependencies(result, modelBuilder, resolvedArtifacts, processedModules);
+                }
             }
         }
     }

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/dependency/ApplicationDeploymentClasspathBuilder.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/dependency/ApplicationDeploymentClasspathBuilder.java
@@ -416,6 +416,14 @@ public class ApplicationDeploymentClasspathBuilder {
     }
 
     /**
+     * Returns the compile-only configuration without eagerly resolving the deployment configuration.
+     * This is used by {@code QuarkusApplicationModelTask} which resolves lazily.
+     */
+    public Configuration getCompileOnlyWithoutResolvingDeployment() {
+        return project.getConfigurations().getByName(compileOnlyConfigurationName);
+    }
+
+    /**
      * Forces the platform configuration to resolve and then uses that to populate platform imports.
      */
     public PlatformImports getPlatformImports() {

--- a/integration-tests/gradle/src/main/resources/compile-only-dependency-flags-build/build.gradle
+++ b/integration-tests/gradle/src/main/resources/compile-only-dependency-flags-build/build.gradle
@@ -1,0 +1,38 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+}
+
+repositories {
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
+    mavenCentral()
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-rest'
+
+    compileOnly("io.quarkus:quarkus-bootstrap-core:${quarkusPlatformVersion}") {
+        exclude group: '*'
+    }
+}
+
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
+
+compileJava {
+    options.encoding = 'UTF-8'
+    options.compilerArgs << '-parameters'
+}
+
+compileTestJava {
+    options.encoding = 'UTF-8'
+}
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/compile-only-dependency-flags-build/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/compile-only-dependency-flags-build/gradle.properties
@@ -1,0 +1,2 @@
+quarkusPlatformGroupId=io.quarkus
+quarkusPlatformArtifactId=quarkus-bom

--- a/integration-tests/gradle/src/main/resources/compile-only-dependency-flags-build/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/compile-only-dependency-flags-build/settings.gradle
@@ -1,0 +1,17 @@
+pluginManagement {
+    repositories {
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+                includeGroup 'org.hibernate.orm'
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+        id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+
+rootProject.name = 'compile-only-dependency-flags-build'

--- a/integration-tests/gradle/src/main/resources/compile-only-dependency-flags-build/src/main/java/org/acme/app/ExampleResource.java
+++ b/integration-tests/gradle/src/main/resources/compile-only-dependency-flags-build/src/main/java/org/acme/app/ExampleResource.java
@@ -1,0 +1,16 @@
+package org.acme.app;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class ExampleResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "hello!";
+    }
+}

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/CompileOnlyDependencyFlagsBuildTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/CompileOnlyDependencyFlagsBuildTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.gradle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.bootstrap.app.ApplicationModelSerializer;
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.DependencyFlags;
+
+/**
+ * Tests that compile-only dependencies are properly flagged in the ApplicationModel
+ * produced by {@code QuarkusApplicationModelTask} (the task-based path used by {@code quarkusBuild}).
+ * <p>
+ * This complements {@link CompileOnlyDependencyFlagsTest} which tests the tooling model builder path.
+ */
+public class CompileOnlyDependencyFlagsBuildTest extends QuarkusGradleWrapperTestBase {
+
+    @Test
+    public void compileOnlyFlagsInProdBuild() throws Exception {
+        final File projectDir = getProjectDir("compile-only-dependency-flags-build");
+
+        runGradleWrapper(projectDir, "clean", "quarkusBuild");
+
+        final Path modelDat = projectDir.toPath().resolve("build").resolve("quarkus")
+                .resolve("application-model").resolve("quarkus-app-model.dat");
+        assertThat(modelDat).exists();
+
+        final ApplicationModel model = ApplicationModelSerializer.deserialize(modelDat);
+        final Map<ArtifactKey, String> compileOnlyDeps = new HashMap<>();
+        for (var dep : model.getDependencies(DependencyFlags.COMPILE_ONLY)) {
+            compileOnlyDeps.put(dep.getKey(), DependencyFlags.toNames(dep.getFlags()));
+        }
+
+        assertThat(compileOnlyDeps)
+                .as("Compile-only dependencies should be present in the prod ApplicationModel built by QuarkusApplicationModelTask")
+                .isNotEmpty();
+        assertThat(compileOnlyDeps).containsKey(ArtifactKey.fromString("io.quarkus:quarkus-bootstrap-core::jar"));
+    }
+}


### PR DESCRIPTION
This was working before 3.16 but,
**QuarkusApplicationModelTask** (introduced in **3.16** for configuration‑cache compatibility) was never given **compile‑only dependency collection**.  
This caused compile‑only deps (e.g., **MVNPM packages** used by Web Bundler) to silently disappear from the **ApplicationModel** in production builds.

The tooling model builder path (used by `quarkusDev` / IDE sync) already had this support.  
This commit ports it to the **task‑based path** used by `quarkusBuild`.

The test added is failing without the patch.

PS: It was quite a journey to get to the result and I pushed to get all the reasons, though I am not familiar enough with the code to check if the implementation made by Opus is good, but I tested it and reviewed it to the extent of my knowledge :)

