### PR TITLE
Fix OTel context loss in blocking @ConsumeEvent with fire-and-forget messages

### DIFF
--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/VertxEventBusBlockingTracingTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/VertxEventBusBlockingTracingTest.java
@@ -1,0 +1,167 @@
+package io.quarkus.opentelemetry.deployment.instrumentation;
+
+import static java.net.HttpURLConnection.HTTP_OK;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.quarkus.opentelemetry.deployment.common.TestUtil;
+import io.quarkus.opentelemetry.deployment.common.exporter.TestSpanExporter;
+import io.quarkus.opentelemetry.deployment.common.exporter.TestSpanExporterProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.ConsumeEvent;
+import io.restassured.RestAssured;
+import io.smallrye.common.annotation.Blocking;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.ext.web.Router;
+
+/**
+ * Tests that OTel trace context is properly propagated to blocking @ConsumeEvent handlers
+ * when using fire-and-forget EventBus messages (publish/send without reply).
+ * <p>
+ * This covers the fix for the race condition in HandlerRegistration.dispatch() where
+ * tracer.sendResponse() was called on the event loop thread before the worker thread
+ * had a chance to run, removing the OTel context from Vert.x locals.
+ * <p>
+ * The test verifies context propagation by creating a custom span inside the blocking
+ * handler using the current OTel context. If context is not propagated, the custom span
+ * will have a different traceId than the HTTP server span.
+ */
+public class VertxEventBusBlockingTracingTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root
+                    .addClasses(EventConsumers.class, TestUtil.class, TestSpanExporter.class,
+                            TestSpanExporterProvider.class)
+                    .addAsResource(new StringAsset(TestSpanExporterProvider.class.getCanonicalName()),
+                            "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider"))
+            .overrideConfigKey("quarkus.otel.traces.exporter", "test-span-exporter")
+            .overrideConfigKey("quarkus.otel.metrics.exporter", "none")
+            .overrideConfigKey("quarkus.otel.logs.exporter", "none")
+            .overrideConfigKey("quarkus.otel.bsp.schedule.delay", "200");
+
+    @Inject
+    TestSpanExporter spanExporter;
+
+    @AfterEach
+    void tearDown() {
+        spanExporter.reset();
+    }
+
+    @Test
+    void blockingConsumeEventShouldPropagateTraceContext() {
+        RestAssured.when().get("/hello/blocking-publish")
+                .then()
+                .statusCode(HTTP_OK)
+                .body(equalTo("ok"));
+
+        // Wait for spans: HTTP server + EventBus producer + EventBus consumer + custom "inside-handler" span
+        List<SpanData> spans = spanExporter.getFinishedSpanItemsAtLeast(4);
+
+        SpanData httpSpan = spans.stream()
+                .filter(s -> s.getKind() == SpanKind.SERVER)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No HTTP server span found. Spans: " + spans));
+
+        String httpTraceId = httpSpan.getTraceId();
+
+        // Find the custom span created inside the blocking handler
+        SpanData handlerSpan = spans.stream()
+                .filter(s -> s.getName().equals("inside-blocking-handler"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "No 'inside-blocking-handler' span found. Spans: " + spans));
+
+        // The custom span created inside the blocking handler should share the same traceId
+        // as the HTTP span. Before the fix, this would be a different traceId because
+        // Context.current() returned root context in the worker thread.
+        assertEquals(httpTraceId, handlerSpan.getTraceId(),
+                "Span created inside blocking handler should have the same traceId as the HTTP span");
+    }
+
+    @Test
+    void blockingAnnotationConsumeEventShouldPropagateTraceContext() {
+        RestAssured.when().get("/hello/blocking-annotation-publish")
+                .then()
+                .statusCode(HTTP_OK)
+                .body(equalTo("ok"));
+
+        List<SpanData> spans = spanExporter.getFinishedSpanItemsAtLeast(4);
+
+        SpanData httpSpan = spans.stream()
+                .filter(s -> s.getKind() == SpanKind.SERVER)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No HTTP server span found. Spans: " + spans));
+
+        String httpTraceId = httpSpan.getTraceId();
+
+        SpanData handlerSpan = spans.stream()
+                .filter(s -> s.getName().equals("inside-blocking-annotation-handler"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "No 'inside-blocking-annotation-handler' span found. Spans: " + spans));
+
+        assertEquals(httpTraceId, handlerSpan.getTraceId(),
+                "Span created inside @Blocking handler should have the same traceId as the HTTP span");
+    }
+
+    @Singleton
+    public static class EventConsumers {
+
+        @Inject
+        Tracer tracer;
+
+        @ConsumeEvent(value = "blocking-publish", blocking = true)
+        void consumeBlocking(String message) {
+            // Create a span using the current OTel context.
+            // Before the fix, Context.current() would return empty/root context here
+            // because HandlerRegistration.dispatch() called sendResponse() (which removes
+            // the OTel context from Vert.x locals) before this worker thread ran.
+            Span span = tracer.spanBuilder("inside-blocking-handler").startSpan();
+            try (Scope scope = span.makeCurrent()) {
+                span.setAttribute("test.message", message);
+            } finally {
+                span.end();
+            }
+        }
+
+        @ConsumeEvent("blocking-annotation-publish")
+        @Blocking
+        void consumeBlockingAnnotation(String message) {
+            Span span = tracer.spanBuilder("inside-blocking-annotation-handler").startSpan();
+            try (Scope scope = span.makeCurrent()) {
+                span.setAttribute("test.message", message);
+            } finally {
+                span.end();
+            }
+        }
+
+        void registerRoutes(@Observes Router router, EventBus eventBus) {
+            router.get("/hello/blocking-publish").handler(rc -> {
+                eventBus.publish("blocking-publish", "test");
+                rc.end("ok");
+            });
+
+            router.get("/hello/blocking-annotation-publish").handler(rc -> {
+                eventBus.publish("blocking-annotation-publish", "test");
+                rc.end("ok");
+            });
+        }
+    }
+}

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/EventBusInstrumenterVertxTracer.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/EventBusInstrumenterVertxTracer.java
@@ -5,6 +5,7 @@ import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.M
 import static io.quarkus.opentelemetry.runtime.config.build.OTelBuildConfig.INSTRUMENTATION_NAME;
 
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
@@ -12,11 +13,15 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.Messagin
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.quarkus.opentelemetry.runtime.config.runtime.OTelRuntimeConfig;
+import io.quarkus.opentelemetry.runtime.tracing.instrumentation.vertx.OpenTelemetryVertxTracer.SpanOperation;
+import io.quarkus.vertx.runtime.VertxEventBusConsumerRecorder;
+import io.vertx.core.Context;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.spi.tracing.TagExtractor;
 
 @SuppressWarnings("rawtypes")
 public class EventBusInstrumenterVertxTracer implements InstrumenterVertxTracer<Message, Message> {
+
     private final Instrumenter<Message, Message> consumerInstrumenter;
     private final Instrumenter<Message, Message> producerInstrumenter;
 
@@ -48,6 +53,66 @@ public class EventBusInstrumenterVertxTracer implements InstrumenterVertxTracer<
     @Override
     public Instrumenter<Message, Message> getReceiveResponseInstrumenter() {
         return producerInstrumenter;
+    }
+
+    /**
+     * Overrides the default {@code sendResponse()} to support deferred scope closing
+     * for blocking EventBus consumer handlers with fire-and-forget messages.
+     * <p>
+     * When a blocking handler sets {@link VertxEventBusConsumerRecorder#DEFER_SEND_RESPONSE_KEY}
+     * on the Vert.x context, this method stores the scope closing and span ending logic as a
+     * {@link Runnable} under {@link VertxEventBusConsumerRecorder#DEFERRED_TRACE_CLEANUP_KEY}
+     * instead of executing it immediately.
+     * This prevents the OTel context from being removed from Vert.x locals before
+     * the worker thread runs the handler.
+     *
+     * @see <a href="https://github.com/eclipse-vertx/vert.x/issues/6021">eclipse-vertx/vert.x#6021</a>
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public <R> void sendResponse(
+            final Context context,
+            final R response,
+            final SpanOperation spanOperation,
+            final Throwable failure,
+            final TagExtractor<R> tagExtractor) {
+
+        if (spanOperation == null) {
+            return;
+        }
+
+        Scope scope = spanOperation.getScope();
+        if (scope == null) {
+            return;
+        }
+
+        Object request = spanOperation.getRequest();
+        Instrumenter<Message, Message> instrumenter = getSendResponseInstrumenter();
+
+        if (failure != null && response == null) {
+            if (spanOperation.tryEndSpan()) {
+                instrumenter.end(spanOperation.getSpanContext(), (Message) request, (Message) response, failure);
+            }
+        } else {
+            Boolean defer = context.getLocal(VertxEventBusConsumerRecorder.DEFER_SEND_RESPONSE_KEY);
+            if (Boolean.TRUE.equals(defer)) {
+                context.removeLocal(VertxEventBusConsumerRecorder.DEFER_SEND_RESPONSE_KEY);
+                context.putLocal(VertxEventBusConsumerRecorder.DEFERRED_TRACE_CLEANUP_KEY, (Runnable) () -> {
+                    try (scope) {
+                        if (spanOperation.tryEndSpan()) {
+                            instrumenter.end(spanOperation.getSpanContext(), (Message) request, (Message) response,
+                                    failure);
+                        }
+                    }
+                });
+                return;
+            }
+            try (scope) {
+                if (spanOperation.tryEndSpan()) {
+                    instrumenter.end(spanOperation.getSpanContext(), (Message) request, (Message) response, failure);
+                }
+            }
+        }
     }
 
     private static Instrumenter<Message, Message> getConsumerInstrumenter(final OpenTelemetry openTelemetry,

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/VertxEventBusConsumerRecorder.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/VertxEventBusConsumerRecorder.java
@@ -47,6 +47,23 @@ public class VertxEventBusConsumerRecorder {
 
     private static final Logger LOGGER = Logger.getLogger(VertxEventBusConsumerRecorder.class.getName());
 
+    /**
+     * Context local key used by blocking EventBus consumer handlers to signal that
+     * the tracer's {@code sendResponse()} should defer scope closing and span ending.
+     * When set to {@code true} on the Vert.x context, the tracer stores a cleanup
+     * {@link Runnable} under {@link #DEFERRED_TRACE_CLEANUP_KEY} instead of closing immediately.
+     *
+     * @see <a href="https://github.com/eclipse-vertx/vert.x/issues/6021">eclipse-vertx/vert.x#6021</a>
+     */
+    public static final String DEFER_SEND_RESPONSE_KEY = "quarkus.otel.defer-send-response";
+
+    /**
+     * Context local key where the deferred cleanup {@link Runnable} is stored by the tracer.
+     * The worker thread must retrieve and run this to properly close the OTel scope
+     * and end the span.
+     */
+    public static final String DEFERRED_TRACE_CLEANUP_KEY = "quarkus.otel.deferred-trace-cleanup";
+
     static volatile Vertx vertx;
     static volatile List<MessageConsumer<?>> messageConsumers;
 
@@ -126,6 +143,16 @@ public class VertxEventBusConsumerRecorder {
                                 // message.
                                 setCurrentContextSafe(true);
                                 if (blocking) {
+                                    ContextInternal currentContext = (ContextInternal) Vertx.currentContext();
+                                    // For fire-and-forget messages (no reply address), signal the tracer
+                                    // to defer sendResponse() so the OTel context remains available
+                                    // in the worker thread. Without this, Vert.x's
+                                    // InboundDeliveryContext.execute() calls sendResponse() on the event
+                                    // loop right after dispatch() returns, closing the OTel scope before
+                                    // the worker thread runs.
+                                    if (m.replyAddress() == null) {
+                                        currentContext.putLocal(DEFER_SEND_RESPONSE_KEY, Boolean.TRUE);
+                                    }
                                     if (runOnVirtualThread) {
                                         VirtualThreadsRecorder.getCurrent().execute(new Runnable() {
                                             @Override
@@ -139,11 +166,13 @@ public class VertxEventBusConsumerRecorder {
                                                     } else {
                                                         m.fail(ConsumeEvent.FAILURE_CODE, e.toString());
                                                     }
+                                                } finally {
+                                                    runDeferredTraceCleanup(currentContext);
                                                 }
                                             }
                                         });
                                     } else {
-                                        Future<Void> future = Vertx.currentContext().executeBlocking(new Callable<Void>() {
+                                        Future<Void> future = currentContext.executeBlocking(new Callable<Void>() {
                                             @Override
                                             public Void call() {
                                                 try {
@@ -155,6 +184,8 @@ public class VertxEventBusConsumerRecorder {
                                                     } else {
                                                         m.fail(ConsumeEvent.FAILURE_CODE, e.toString());
                                                     }
+                                                } finally {
+                                                    runDeferredTraceCleanup(currentContext);
                                                 }
                                                 return null;
                                             }
@@ -209,6 +240,25 @@ public class VertxEventBusConsumerRecorder {
             return (RuntimeException) e;
         } else {
             return new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Runs the deferred trace cleanup stored by the tracer's {@code sendResponse()}.
+     * This closes the OTel scope and ends the span from the worker thread,
+     * ensuring the OTel context was available during handler execution.
+     *
+     * @see <a href="https://github.com/eclipse-vertx/vert.x/issues/6021">eclipse-vertx/vert.x#6021</a>
+     */
+    static void runDeferredTraceCleanup(ContextInternal ctx) {
+        Runnable cleanup = ctx.getLocal(DEFERRED_TRACE_CLEANUP_KEY);
+        if (cleanup != null) {
+            ctx.removeLocal(DEFERRED_TRACE_CLEANUP_KEY);
+            try {
+                cleanup.run();
+            } catch (Throwable e) {
+                LOGGER.warn("Unable to run deferred trace cleanup", e);
+            }
         }
     }
 

--- a/integration-tests/opentelemetry/src/main/java/io/quarkus/it/opentelemetry/EventBusBlockingResource.java
+++ b/integration-tests/opentelemetry/src/main/java/io/quarkus/it/opentelemetry/EventBusBlockingResource.java
@@ -1,0 +1,62 @@
+package io.quarkus.it.opentelemetry;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import io.quarkus.vertx.ConsumeEvent;
+import io.smallrye.common.annotation.Blocking;
+import io.vertx.core.eventbus.EventBus;
+
+@Path("/eventbus-blocking")
+public class EventBusBlockingResource {
+
+    @Inject
+    EventBus eventBus;
+
+    @GET
+    @Path("/publish")
+    public String publish() {
+        eventBus.publish("blocking-publish", "test");
+        return "ok";
+    }
+
+    @GET
+    @Path("/publish-annotation")
+    public String publishAnnotation() {
+        eventBus.publish("blocking-annotation-publish", "test");
+        return "ok";
+    }
+
+    @Singleton
+    public static class EventConsumers {
+
+        @Inject
+        Tracer tracer;
+
+        @ConsumeEvent(value = "blocking-publish", blocking = true)
+        void consumeBlocking(String message) {
+            Span span = tracer.spanBuilder("inside-blocking-handler").startSpan();
+            try (Scope scope = span.makeCurrent()) {
+                span.setAttribute("test.message", message);
+            } finally {
+                span.end();
+            }
+        }
+
+        @ConsumeEvent("blocking-annotation-publish")
+        @Blocking
+        void consumeBlockingAnnotation(String message) {
+            Span span = tracer.spanBuilder("inside-blocking-annotation-handler").startSpan();
+            try (Scope scope = span.makeCurrent()) {
+                span.setAttribute("test.message", message);
+            } finally {
+                span.end();
+            }
+        }
+    }
+}

--- a/integration-tests/opentelemetry/src/test/java/io/quarkus/it/opentelemetry/EventBusBlockingTracingIT.java
+++ b/integration-tests/opentelemetry/src/test/java/io/quarkus/it/opentelemetry/EventBusBlockingTracingIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.opentelemetry;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class EventBusBlockingTracingIT extends EventBusBlockingTracingTest {
+}

--- a/integration-tests/opentelemetry/src/test/java/io/quarkus/it/opentelemetry/EventBusBlockingTracingTest.java
+++ b/integration-tests/opentelemetry/src/test/java/io/quarkus/it/opentelemetry/EventBusBlockingTracingTest.java
@@ -1,0 +1,93 @@
+package io.quarkus.it.opentelemetry;
+
+import static io.restassured.RestAssured.get;
+import static io.restassured.RestAssured.given;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.common.mapper.TypeRef;
+
+@QuarkusTest
+public class EventBusBlockingTracingTest {
+
+    @BeforeEach
+    @AfterEach
+    void reset() {
+        await().atMost(5, SECONDS).until(() -> {
+            List<Map<String, Object>> spans = getSpans();
+            if (spans.size() == 0) {
+                return true;
+            } else {
+                given().get("/reset").then().statusCode(HTTP_OK);
+                return false;
+            }
+        });
+    }
+
+    private List<Map<String, Object>> getSpans() {
+        return get("/export").body().as(new TypeRef<>() {
+        });
+    }
+
+    @Test
+    void blockingConsumeEventShouldPropagateTraceContext() {
+        given().get("/eventbus-blocking/publish").then().statusCode(HTTP_OK);
+
+        // Wait until the custom handler span appears (more reliable than counting total spans)
+        await().atMost(Duration.ofSeconds(10)).until(() -> getSpans().stream()
+                .anyMatch(s -> "inside-blocking-handler".equals(s.get("name"))));
+
+        List<Map<String, Object>> spans = getSpans();
+
+        Map<String, Object> httpSpan = spans.stream()
+                .filter(s -> "SERVER".equals(s.get("kind")))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No HTTP server span found. Spans: " + spans));
+
+        String httpTraceId = (String) httpSpan.get("traceId");
+
+        Map<String, Object> handlerSpan = spans.stream()
+                .filter(s -> "inside-blocking-handler".equals(s.get("name")))
+                .findFirst()
+                .get();
+
+        assertEquals(httpTraceId, handlerSpan.get("traceId"),
+                "Span created inside blocking handler should have the same traceId as the HTTP span");
+    }
+
+    @Test
+    void blockingAnnotationConsumeEventShouldPropagateTraceContext() {
+        given().get("/eventbus-blocking/publish-annotation").then().statusCode(HTTP_OK);
+
+        await().atMost(Duration.ofSeconds(10)).until(() -> getSpans().stream()
+                .anyMatch(s -> "inside-blocking-annotation-handler".equals(s.get("name"))));
+
+        List<Map<String, Object>> spans = getSpans();
+
+        Map<String, Object> httpSpan = spans.stream()
+                .filter(s -> "SERVER".equals(s.get("kind")))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No HTTP server span found. Spans: " + spans));
+
+        String httpTraceId = (String) httpSpan.get("traceId");
+
+        Map<String, Object> handlerSpan = spans.stream()
+                .filter(s -> "inside-blocking-annotation-handler".equals(s.get("name")))
+                .findFirst()
+                .get();
+
+        assertEquals(httpTraceId, handlerSpan.get("traceId"),
+                "Span created inside @Blocking handler should have the same traceId as the HTTP span");
+    }
+}


### PR DESCRIPTION
## Summary

- Fix a race condition where OTel trace context is lost in blocking `@ConsumeEvent` handlers when using fire-and-forget EventBus messages (`send()`/`publish()`)
- Root cause: Vert.x's `InboundDeliveryContext.execute()` calls `tracer.sendResponse()` synchronously after `dispatch()` returns, which removes the OTel context from Vert.x locals before the worker thread runs
- The fix overrides `sendResponse()` and defer to the worker thread's `finally` block
- Added test `VertxEventBusBlockingTracingTest` that verifies trace context propagation (fails without fix, passes with fix)

------

- Upstream Vert.x issue: https://github.com/eclipse-vertx/vert.x/issues/6021

## Details

When a `@ConsumeEvent` handler is marked as `blocking = true` (or annotated with `@Blocking`) and receives a fire-and-forget message (no reply address), the following sequence occurs:

1. `InboundDeliveryContext.execute()` calls `tracer.receiveRequest()` — sets up OTel context in Vert.x locals
2. `dispatch()` submits work to a worker pool and **returns immediately**
3. `InboundDeliveryContext.execute()` calls `tracer.sendResponse()` — **removes OTel context** from Vert.x locals
4. Worker thread runs — `Context.current()` returns root context (broken trace)

## Test plan

- [x] `VertxEventBusBlockingTracingTest` — 2 tests covering `@ConsumeEvent(blocking=true)` and `@Blocking` annotation
- [x] Test verified to **fail without fix** (different traceIds) and **pass with fix** (same traceId)