### PR TITLE
DevMCP: Shortern 'getContinuousTestingResults' method name and warn if names are too long

### DIFF
--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/ContinuousTestingProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/ContinuousTestingProcessor.java
@@ -280,7 +280,7 @@ public class ContinuousTestingProcessor {
      */
     private void registerGetResultsMCPMethod(LaunchModeBuildItem launchModeBuildItem, BuildTimeActionBuildItem actions) {
         actions.actionBuilder()
-                .methodName("getContinuousTestingResults")
+                .methodName("getTestResults")
                 .description("Get the results of a Continuous testing test run")
                 .enableMcpFuctionByDefault()
                 .function(ignored -> {

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpToolsService.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpToolsService.java
@@ -10,6 +10,8 @@ import java.util.Map;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import org.jboss.logging.Logger;
+
 import io.quarkus.devui.runtime.comms.JsonRpcRouter;
 import io.quarkus.devui.runtime.jsonrpc.JsonRpcMethod;
 import io.quarkus.devui.runtime.mcp.model.tool.Tool;
@@ -23,6 +25,9 @@ import io.quarkus.runtime.annotations.JsonRpcDescription;
  */
 @ApplicationScoped
 public class McpToolsService {
+
+    private static final Logger LOG = Logger.getLogger(McpToolsService.class);
+    private static final int MAX_TOOL_NAME_LENGTH = 50;
 
     @Inject
     JsonRpcRouter jsonRpcRouter;
@@ -83,6 +88,10 @@ public class McpToolsService {
     private Tool toTool(JsonRpcMethod jsonRpcMethod) {
         Tool tool = new Tool();
         tool.name = jsonRpcMethod.getMethodName();
+        if (tool.name != null && tool.name.length() > MAX_TOOL_NAME_LENGTH) {
+            LOG.warnf("MCP tool name '%s' exceeds %d characters. Some MCP clients may not support long tool names.",
+                    tool.name, MAX_TOOL_NAME_LENGTH);
+        }
         if (jsonRpcMethod.getDescription() != null && !jsonRpcMethod.getDescription().isBlank()) {
             tool.description = jsonRpcMethod.getDescription();
         }


### PR DESCRIPTION
Fix #52701

Second attempt fixing this - this is a much simpler solution