### PR TITLE
Compare PathFilter objects as values

### DIFF
--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathFilter.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathFilter.java
@@ -6,7 +6,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import io.quarkus.bootstrap.BootstrapConstants;
 import io.quarkus.bootstrap.model.Mappable;
@@ -42,8 +44,11 @@ public class PathFilter implements Mappable, Serializable {
 
     }
 
-    private List<Pattern> includes;
-    private List<Pattern> excludes;
+    private volatile transient Set<String> includesPatterns;
+    private volatile transient Set<String> excludesPatterns;
+
+    private final List<Pattern> includes;
+    private final List<Pattern> excludes;
 
     public PathFilter(Collection<String> includes, Collection<String> excludes) {
         this.includes = compileGlob(includes);
@@ -100,9 +105,28 @@ public class PathFilter implements Mappable, Serializable {
         return result;
     }
 
+    private static Set<String> canonicalPatterns(List<Pattern> patterns) {
+        return patterns == null || patterns.isEmpty() ? Set.of()
+                : patterns.stream().map(Pattern::pattern).collect(Collectors.toSet());
+    }
+
+    private Set<String> canonicalIncludes() {
+        if (includesPatterns == null) {
+            includesPatterns = canonicalPatterns(includes);
+        }
+        return includesPatterns;
+    }
+
+    private Set<String> canonicalExcludes() {
+        if (excludesPatterns == null) {
+            excludesPatterns = canonicalPatterns(excludes);
+        }
+        return excludesPatterns;
+    }
+
     @Override
     public int hashCode() {
-        return Objects.hash(excludes, includes);
+        return Objects.hash(canonicalExcludes(), canonicalIncludes());
     }
 
     @Override
@@ -114,7 +138,8 @@ public class PathFilter implements Mappable, Serializable {
         if (getClass() != obj.getClass())
             return false;
         PathFilter other = (PathFilter) obj;
-        return Objects.equals(excludes, other.excludes) && Objects.equals(includes, other.includes);
+        return Objects.equals(canonicalExcludes(), other.canonicalExcludes())
+                && Objects.equals(canonicalIncludes(), other.canonicalIncludes());
     }
 
     @Override

--- a/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/paths/PathFilterTest.java
+++ b/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/paths/PathFilterTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class PathFilterTest {
+
+    static Stream<Arguments> equalsAndHashCode() {
+        return Stream.of(
+                Arguments.of(List.of(), List.of()),
+                Arguments.of(List.of("a*"), List.of("b*")),
+                Arguments.of(List.of("/a", "b"), List.of("/c")),
+                Arguments.of(List.of("/a", "b"), null),
+                Arguments.of(null, List.of("/a", "b")),
+                Arguments.of(List.of(), null),
+                Arguments.of(null, List.of()));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void equalsAndHashCode(List<String> includes, List<String> excludes) {
+        PathFilter f0 = new PathFilter(includes, excludes);
+        PathFilter f1 = new PathFilter(includes, excludes);
+        assertThat(f0).isEqualTo(f1);
+        assertThat(f0).hasSameHashCodeAs(f1);
+        assertThat(f0).isEqualTo(PathFilter.fromMap(f0.asMap()));
+        assertThat(f0).hasSameHashCodeAs(PathFilter.fromMap(f0.asMap()));
+    }
+
+    @Test
+    void patternOrder() {
+        PathFilter f0 = new PathFilter(List.of("a", "b"), List.of("c", "d"));
+        PathFilter f1 = new PathFilter(List.of("b", "a"), List.of("d", "c"));
+        assertThat(f0).isEqualTo(f1);
+        assertThat(f0).hasSameHashCodeAs(f1);
+        assertThat(f0).isEqualTo(PathFilter.fromMap(f1.asMap()));
+        assertThat(f0).hasSameHashCodeAs(PathFilter.fromMap(f1.asMap()));
+    }
+}


### PR DESCRIPTION
Previously the include/exclude `Pattern` values inside `PathFilter` were compared as object instances (JRE behaviour of the `Pattern` class).

This resulted in `PathFilter` objects loaded from JSON during `ApplicationModel` deserialization becoming different from each other even when their respective pattern RegEx values were equivalent.

This change makes `PathFilter` use `String` representations of include / exclude patterns in equals/hashCode implementations to ensure value comparison semantics.

Fixes #53078
