### PR TITLE
Propagate Quarkus properties for Gradle Test tasks

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/actions/BeforeTestAction.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/actions/BeforeTestAction.java
@@ -21,6 +21,7 @@ import org.gradle.api.tasks.testing.Test;
 
 import io.quarkus.bootstrap.BootstrapConstants;
 import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.gradle.tasks.EffectiveConfig;
 import io.quarkus.gradle.tasks.EffectiveConfigProvider;
 import io.quarkus.gradle.tasks.QuarkusPluginExtensionView;
 import io.quarkus.gradle.tooling.ToolingUtils;
@@ -63,10 +64,12 @@ public class BeforeTestAction implements Action<Task> {
             final Path serializedModel = applicationModelPath.get().getAsFile().toPath();
             ApplicationModel applicationModel = ToolingUtils.deserializeAppModel(serializedModel);
 
-            SmallRyeConfig config = effectiveProvider().buildEffectiveConfiguration(applicationModel, new HashMap<>())
-                    .getConfig();
+            EffectiveConfig effectiveConfig = effectiveProvider().buildEffectiveConfiguration(applicationModel,
+                    new HashMap<>());
+            SmallRyeConfig config = effectiveConfig.getConfig();
             config.getOptionalValue(TEST.getProfileKey(), String.class)
                     .ifPresent(value -> props.put(TEST.getProfileKey(), value));
+            props.putAll(effectiveConfig.getQuarkusValues());
 
             props.put(BootstrapConstants.SERIALIZED_TEST_APP_MODEL, serializedModel.toString());
 

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/SystemPropsAsBuildTimeConfigSourceTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/SystemPropsAsBuildTimeConfigSourceTest.java
@@ -33,7 +33,6 @@ public class SystemPropsAsBuildTimeConfigSourceTest extends QuarkusGradleWrapper
         gradleConfigurationCache(false);
         runGradleWrapper(projectDir,
                 "-Dquarkus.example.name=cheburashka",
-                "-Dquarkus.example.runtime-name=crocodile",
                 "-Dquarkus.package.jar.type=mutable-jar",
                 ":example-extension:example-extension-deployment:build",
                 // this quarkusIntTest will make sure runtime config properties passed as env vars when launching the app are effective


### PR DESCRIPTION
Quarkus configuration from Gradle does not propagate for Test tasks. Usually, our Quarkus tasks do that automatically, but in this case, we are using the Gradle Test task, which doesn't use our own.

- Fixes #53059 

Update:

`SystemPropsAsBuildTimeConfigSourceTest` was failing because it was setting a quarkus config as a system property (not propagated), and checking that an Env Var with the same name was the value being used. With this change, it uses the default Config ordinality for sources (System before Env).

The test was added in https://github.com/quarkusio/quarkus/pull/37021, which also fixed issues with config propagation in Gradle. I don't see a reason why the test checks for the non-propagation of system properties in this case. Maybe we need @aloubyansky to check this as well.