### PR TITLE
Allow jar and install to run for this project

### DIFF
--- a/integration-tests/devservices/dependent-extension/deployment/disable-unbind-executions
+++ b/integration-tests/devservices/dependent-extension/deployment/disable-unbind-executions
@@ -1,0 +1,1 @@
+This file disables the unbind-executions profile in the quarkus-integration-tests-parent.

--- a/integration-tests/devservices/dependent-extension/runtime/disable-unbind-executions
+++ b/integration-tests/devservices/dependent-extension/runtime/disable-unbind-executions
@@ -1,0 +1,1 @@
+This file disables the unbind-executions profile in the quarkus-integration-tests-parent.

--- a/integration-tests/devservices/disable-unbind-executions
+++ b/integration-tests/devservices/disable-unbind-executions
@@ -1,0 +1,1 @@
+This file disables the unbind-executions profile in the quarkus-integration-tests-parent.

--- a/integration-tests/devservices/simple-extension/deployment/disable-unbind-executions
+++ b/integration-tests/devservices/simple-extension/deployment/disable-unbind-executions
@@ -1,0 +1,1 @@
+This file disables the unbind-executions profile in the quarkus-integration-tests-parent.

--- a/integration-tests/devservices/simple-extension/runtime/disable-unbind-executions
+++ b/integration-tests/devservices/simple-extension/runtime/disable-unbind-executions
@@ -1,0 +1,1 @@
+This file disables the unbind-executions profile in the quarkus-integration-tests-parent.


### PR DESCRIPTION
I'm hoping this fixes 

```
 The POM for io.quarkus:quarkus-integration-test-devservices-dependent-extension:jar:999-SNAPSHOT is missing, no dependency information available
2026-03-16T22:42:02.1715095Z [WARNING] The POM for io.quarkus:quarkus-integration-test-devservices-simple-extension:jar:999-SNAPSHOT is missing, no dependency information available
2026-03-16T22:42:02.1722893Z [WARNING] The POM for io.quarkus:quarkus-integration-test-devservices-dependent-extension-deployment:pom:999-SNAPSHOT is missing, no dependency information available
2026-03-16T22:42:02.1726832Z [WARNING] The POM for io.quarkus:quarkus-integration-test-devservices-simple-extension-deployment:pom:999-SNAPSHOT is missing, no dependency information available
2026-03-16T22:42:02.2109016Z [INFO]
```

in https://github.com/quarkusio/quarkus/pull/53089, caused by #53019 

I think the problem was that when the `unbind-executions` profile was active, the pom and jars didn't get installed to the local maven repository. I still don't entirely understand why this only affected minimal incremental builds, not full builds, but the fix should get things building again. 