### PR TITLE
SmallRye Fault Tolerance: update to 6.11.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -50,7 +50,7 @@
         <smallrye-health.version>4.3.0</smallrye-health.version>
         <smallrye-open-api.version>4.2.4</smallrye-open-api.version>
         <smallrye-graphql.version>2.17.0</smallrye-graphql.version>
-        <smallrye-fault-tolerance.version>6.10.0</smallrye-fault-tolerance.version>
+        <smallrye-fault-tolerance.version>6.11.0</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>4.6.3</smallrye-jwt.version>
         <smallrye-context-propagation.version>2.3.0</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>

--- a/docs/src/main/asciidoc/smallrye-fault-tolerance.adoc
+++ b/docs/src/main/asciidoc/smallrye-fault-tolerance.adoc
@@ -576,7 +576,7 @@ implementation("io.quarkus:quarkus-smallrye-fault-tolerance")
 == Additional resources
 
 SmallRye Fault Tolerance has more features than shown here.
-Please check the link:https://smallrye.io/docs/smallrye-fault-tolerance/6.10.0/index.html[SmallRye Fault Tolerance documentation] to learn about them.
+Please check the link:https://smallrye.io/docs/smallrye-fault-tolerance/6.11.0/index.html[SmallRye Fault Tolerance documentation] to learn about them.
 
 In Quarkus, you can use the SmallRye Fault Tolerance optional features out of the box.
 
@@ -608,7 +608,7 @@ quarkus.fault-tolerance.mp-compatibility=true
 ----
 ====
 
-The link:https://smallrye.io/docs/smallrye-fault-tolerance/6.10.0/reference/programmatic-api.html[programmatic API] is present and integrated with the declarative, annotation-based API.
+The link:https://smallrye.io/docs/smallrye-fault-tolerance/6.11.0/reference/programmatic-api.html[programmatic API] is present and integrated with the declarative, annotation-based API.
 You can use the `Guard`, `TypedGuard` and `@ApplyGuard` APIs out of the box.
 
 Support for Kotlin is present (assuming you use the Quarkus extension for Kotlin), so you can guard your `suspend` functions with fault tolerance annotations.

--- a/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/ConfigUtilJandex.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/ConfigUtilJandex.java
@@ -8,7 +8,7 @@ import org.jboss.jandex.MethodInfo;
 import io.smallrye.config.common.utils.StringUtil;
 import io.smallrye.faulttolerance.autoconfig.ConfigConstants;
 
-// copy of a past version of `io.smallrye.faulttolerance.basicconfig.ConfigUtil` and translation from reflection to Jandex
+// copy of a past version of `io.smallrye.faulttolerance.apiimpl.basicconfig.ConfigUtil` and translation from reflection to Jandex
 final class ConfigUtilJandex {
     static String newKey(Class<? extends Annotation> annotation, String member, MethodInfo declaringMethod) {
         return ConfigConstants.PREFIX + "\"" + declaringMethod.declaringClass().name() + "/" + declaringMethod.name()

--- a/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/SmallRyeFaultToleranceProcessor.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/SmallRyeFaultToleranceProcessor.java
@@ -16,6 +16,7 @@ import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget.Kind;
+import org.jboss.jandex.AnnotationTransformation;
 import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
@@ -28,7 +29,6 @@ import io.quarkus.arc.deployment.BeanDefiningAnnotationBuildItem;
 import io.quarkus.arc.deployment.OpenTelemetrySdkBuildItem;
 import io.quarkus.arc.deployment.ValidationPhaseBuildItem;
 import io.quarkus.arc.processor.AnnotationStore;
-import io.quarkus.arc.processor.AnnotationsTransformer;
 import io.quarkus.arc.processor.BeanInfo;
 import io.quarkus.arc.processor.BuildExtension;
 import io.quarkus.arc.processor.BuiltinScope;
@@ -71,11 +71,11 @@ import io.smallrye.faulttolerance.FaultToleranceInterceptor;
 import io.smallrye.faulttolerance.RequestContextIntegration;
 import io.smallrye.faulttolerance.SpecCompatibility;
 import io.smallrye.faulttolerance.autoconfig.FaultToleranceMethod;
+import io.smallrye.faulttolerance.context.propagation.ContextPropagationRequestContextControllerProvider;
+import io.smallrye.faulttolerance.context.propagation.ContextPropagationRunnableWrapper;
 import io.smallrye.faulttolerance.core.util.RunnableWrapper;
 import io.smallrye.faulttolerance.internal.RequestContextControllerProvider;
 import io.smallrye.faulttolerance.internal.StrategyCache;
-import io.smallrye.faulttolerance.propagation.ContextPropagationRequestContextControllerProvider;
-import io.smallrye.faulttolerance.propagation.ContextPropagationRunnableWrapper;
 
 public class SmallRyeFaultToleranceProcessor {
 
@@ -145,16 +145,16 @@ public class SmallRyeFaultToleranceProcessor {
         }
 
         // Add transitive interceptor binding to FT annotations
-        annotationsTransformer.produce(new AnnotationsTransformerBuildItem(new AnnotationsTransformer() {
+        annotationsTransformer.produce(new AnnotationsTransformerBuildItem(new AnnotationTransformation() {
             @Override
-            public boolean appliesTo(Kind kind) {
+            public boolean supports(Kind kind) {
                 return kind == Kind.CLASS;
             }
 
             @Override
-            public void transform(TransformationContext context) {
-                if (DotNames.FT_ANNOTATIONS.contains(context.getTarget().asClass().name())) {
-                    context.transform().add(FaultToleranceBinding.class).done();
+            public void apply(TransformationContext context) {
+                if (DotNames.FT_ANNOTATIONS.contains(context.declaration().asClass().name())) {
+                    context.add(FaultToleranceBinding.class);
                 }
             }
         }));
@@ -178,22 +178,13 @@ public class SmallRyeFaultToleranceProcessor {
                         SpecCompatibility.class,
                         Enablement.class);
 
-        int metricsProviders = 0;
         if (metricsCapability.isPresent() && metricsCapability.get().metricsSupported(MetricsFactory.MICROMETER)) {
             // Priority to Micrometer. We should avoid having OTel + Micrometer on.
             builder.addBeanClass("io.smallrye.faulttolerance.metrics.MicrometerProvider");
-            metricsProviders++;
+        } else if (openTelemetrySdk.map(OpenTelemetrySdkBuildItem::isMetricsBuildTimeEnabled).orElse(false)) {
+            builder.addBeanClass("io.smallrye.faulttolerance.metrics.OpenTelemetryProvider");
         } else {
-            if (openTelemetrySdk.map(OpenTelemetrySdkBuildItem::isMetricsBuildTimeEnabled).orElse(false)) {
-                builder.addBeanClass("io.smallrye.faulttolerance.metrics.OpenTelemetryProvider");
-                metricsProviders++;
-            }
-        }
-
-        if (metricsProviders == 0) {
             builder.addBeanClass("io.smallrye.faulttolerance.metrics.NoopProvider");
-        } else if (metricsProviders > 1) {
-            builder.addBeanClass("io.smallrye.faulttolerance.metrics.CompoundMetricsProvider");
         }
 
         beans.produce(builder.build());
@@ -211,28 +202,24 @@ public class SmallRyeFaultToleranceProcessor {
     }
 
     @BuildStep
-    AnnotationsTransformerBuildItem transformInterceptorPriority(BeanArchiveIndexBuildItem index) {
-        return new AnnotationsTransformerBuildItem(new AnnotationsTransformer() {
+    AnnotationsTransformerBuildItem transformInterceptorPriority() {
+        return new AnnotationsTransformerBuildItem(new AnnotationTransformation() {
             @Override
-            public boolean appliesTo(Kind kind) {
+            public boolean supports(Kind kind) {
                 return kind == Kind.CLASS;
             }
 
             @Override
-            public void transform(TransformationContext ctx) {
-                if (ctx.isClass()) {
-                    if (!ctx.getTarget().asClass().name().equals(DotNames.FAULT_TOLERANCE_INTERCEPTOR)) {
-                        return;
-                    }
-                    Config config = ConfigProvider.getConfig();
+            public void apply(TransformationContext ctx) {
+                if (!ctx.declaration().asClass().name().equals(DotNames.FAULT_TOLERANCE_INTERCEPTOR)) {
+                    return;
+                }
 
-                    OptionalInt priority = config.getValue("mp.fault.tolerance.interceptor.priority", OptionalInt.class);
-                    if (priority.isPresent()) {
-                        ctx.transform()
-                                .remove(ann -> ann.name().toString().equals(Priority.class.getName()))
-                                .add(Priority.class, AnnotationValue.createIntegerValue("value", priority.getAsInt()))
-                                .done();
-                    }
+                Config config = ConfigProvider.getConfig();
+                OptionalInt priority = config.getValue("mp.fault.tolerance.interceptor.priority", OptionalInt.class);
+                if (priority.isPresent()) {
+                    ctx.remove(ann -> ann.name().toString().equals(Priority.class.getName()));
+                    ctx.add(AnnotationInstance.builder(Priority.class).value(priority.getAsInt()).build());
                 }
             }
         });


### PR DESCRIPTION
This commit also moves from the deprecated ArC annotation transformation API to the new Jandex API.

- https://smallrye.io/blog/fault-tolerance-6-11-0/