### PR TITLE
Add MongoDB command obfuscation for OpenTelemetry tracing

### DIFF
--- a/docs/src/main/asciidoc/mongodb.adoc
+++ b/docs/src/main/asciidoc/mongodb.adoc
@@ -700,6 +700,31 @@ Even with all the tracing infrastructure in place the mongodb tracing is not ena
 quarkus.mongodb.tracing.enabled=true
 ----
 
+=== Command Detail Level
+
+By default, MongoDB command details are not included in traces (`OFF` mode). You can control this behavior with the `command-detail-level` property.
+When enabled, the command text is stored in the `db.query.text` attribute following OpenTelemetry semantic conventions.
+
+[source, properties]
+----
+# Command detail level: OFF (default), SANITIZED, or FULL
+quarkus.mongodb.tracing.command-detail-level=SANITIZED
+----
+
+**Detail levels:**
+
+* `OFF` (default) - No command details, only operation metadata (operation name, database, collection)
+* `SANITIZED` - Command structure with type placeholders instead of actual values
+** Example: `{"find": "<string>", "filter": {"email": "<string>", "age": "<int32>"}}`
+** Preserves command structure for debugging while protecting sensitive data
+* `FULL` - Complete command including all data
+** **NOT recommended for production** - may expose sensitive information
+
+[WARNING]
+====
+Using `FULL` mode can expose sensitive data (passwords, emails, personal information) in your traces. Only use in development or when you're certain no sensitive data is involved.
+====
+
 == Testing helpers
 
 xref:#dev-services[Dev Services for MongoDB] is your best option to start a MongoDB database for your unit tests.

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java
@@ -39,6 +39,7 @@ import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.arc.deployment.BeanDiscoveryFinishedBuildItem;
 import io.quarkus.arc.deployment.BeanRegistrationPhaseBuildItem;
+import io.quarkus.arc.deployment.OpenTelemetrySdkBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.arc.deployment.ValidationPhaseBuildItem;
 import io.quarkus.arc.processor.BeanInfo;
@@ -116,8 +117,13 @@ public class MongoClientProcessor {
     }
 
     @BuildStep
-    AdditionalIndexedClassesBuildItem includeMongoCommandListener(MongoClientBuildTimeConfig buildTimeConfig) {
-        if (buildTimeConfig.tracingEnabled()) {
+    AdditionalIndexedClassesBuildItem includeMongoCommandListener(
+            MongoClientBuildTimeConfig buildTimeConfig,
+            Optional<OpenTelemetrySdkBuildItem> openTelemetrySdkBuildItem) {
+        if (buildTimeConfig.tracingEnabled()
+                && openTelemetrySdkBuildItem
+                        .map(OpenTelemetrySdkBuildItem::isTracingBuildTimeEnabled)
+                        .orElse(false)) {
             return new AdditionalIndexedClassesBuildItem(
                     MongoTracingCommandListener.class.getName(),
                     MongoReactiveContextProvider.class.getName());

--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoTracingConfigTest.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoTracingConfigTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.mongodb;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.mongodb.tracing.MongoTracingCommandListener;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MongoTracingConfigTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("application-tracing-mongoclient.properties");
+
+    @Inject
+    MongoTracingCommandListener listener;
+
+    @Test
+    public void testTracingListenerIsRegistered() {
+        assertNotNull(listener);
+    }
+}

--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoTracingOffTest.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoTracingOffTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.mongodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.mongodb.runtime.MongoConfig;
+import io.quarkus.mongodb.runtime.MongoTracingRuntimeConfig.CommandDetailLevel;
+import io.quarkus.mongodb.tracing.MongoTracingCommandListener;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MongoTracingOffTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withConfigurationResource("application-tracing-off.properties");
+
+    @Inject
+    MongoTracingCommandListener listener;
+
+    @Inject
+    MongoConfig mongoConfig;
+
+    @Test
+    void testTracingListenerIsRegistered() {
+        assertNotNull(listener);
+    }
+
+    @Test
+    void testOffConfiguration() {
+        assertThat(mongoConfig.tracing().commandDetailLevel())
+                .isEqualTo(CommandDetailLevel.OFF);
+    }
+}

--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoTracingSanitizationTest.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoTracingSanitizationTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.mongodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.mongodb.runtime.MongoConfig;
+import io.quarkus.mongodb.runtime.MongoTracingRuntimeConfig.CommandDetailLevel;
+import io.quarkus.mongodb.tracing.MongoTracingCommandListener;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MongoTracingSanitizationTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withConfigurationResource("application-tracing-sanitized.properties");
+
+    @Inject
+    MongoTracingCommandListener listener;
+
+    @Inject
+    MongoConfig mongoConfig;
+
+    @Test
+    void testTracingListenerIsRegistered() {
+        assertNotNull(listener);
+    }
+
+    @Test
+    void testSanitizedConfiguration() {
+        assertThat(mongoConfig.tracing().commandDetailLevel())
+                .isEqualTo(CommandDetailLevel.SANITIZED);
+    }
+}

--- a/extensions/mongodb-client/deployment/src/test/resources/application-tracing-off.properties
+++ b/extensions/mongodb-client/deployment/src/test/resources/application-tracing-off.properties
@@ -1,0 +1,3 @@
+quarkus.mongodb.connection-string=mongodb://127.0.0.1:27018
+quarkus.mongodb.tracing.enabled=true
+quarkus.mongodb.tracing.command-detail-level=OFF

--- a/extensions/mongodb-client/deployment/src/test/resources/application-tracing-sanitized.properties
+++ b/extensions/mongodb-client/deployment/src/test/resources/application-tracing-sanitized.properties
@@ -1,0 +1,3 @@
+quarkus.mongodb.connection-string=mongodb://127.0.0.1:27018
+quarkus.mongodb.tracing.enabled=true
+quarkus.mongodb.tracing.command-detail-level=SANITIZED

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoConfig.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoConfig.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
@@ -109,6 +110,13 @@ public interface MongoConfig {
     @WithDefault("false")
     @WithName("dns.log-activity")
     boolean dnsLookupLogActivity();
+
+    /**
+     * Tracing configuration
+     */
+    @ConfigDocSection
+    @WithDefaults
+    MongoTracingRuntimeConfig tracing();
 
     static boolean isDefaultClient(final String name) {
         return DEFAULT_CLIENT_NAME.equalsIgnoreCase(name) || DEFAULT_REACTIVE_CLIENT_NAME.equalsIgnoreCase(name);

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoTracingRuntimeConfig.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoTracingRuntimeConfig.java
@@ -1,0 +1,39 @@
+package io.quarkus.mongodb.runtime;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
+
+@ConfigGroup
+public interface MongoTracingRuntimeConfig {
+
+    /**
+     * Defines what information from MongoDB commands is included in traces.
+     * <p>
+     * <ul>
+     * <li><b>OFF</b> (default): No command information is included (only operation name, database, collection)</li>
+     * <li><b>SANITIZED</b>: Command structure with BSON type information instead of actual values</li>
+     * <li><b>FULL</b>: Complete command with all data (NOT recommended for production - may expose sensitive data)</li>
+     * </ul>
+     */
+    @WithName("command-detail-level")
+    @WithDefault("OFF")
+    CommandDetailLevel commandDetailLevel();
+
+    enum CommandDetailLevel {
+        /**
+         * No command details, only operation metadata
+         */
+        OFF,
+
+        /**
+         * Command structure with type information (e.g., {"email": "&lt;string&gt;", "age": "&lt;int32&gt;"})
+         */
+        SANITIZED,
+
+        /**
+         * Full command including all data - may expose sensitive information
+         */
+        FULL
+    }
+}

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/tracing/MongoCommandSanitizer.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/tracing/MongoCommandSanitizer.java
@@ -1,0 +1,101 @@
+package io.quarkus.mongodb.tracing;
+
+import java.util.Map;
+
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+
+/**
+ * Sanitizes MongoDB commands for tracing by replacing values with type information.
+ * <p>
+ * This prevents sensitive data from being exposed in traces while maintaining
+ * the command structure for observability.
+ */
+public class MongoCommandSanitizer {
+
+    /**
+     * Sanitizes a BSON command document by replacing all values with their type information.
+     *
+     * @param command the original command document
+     * @return sanitized command as JSON string
+     */
+    public String sanitizeCommand(BsonDocument command) {
+        BsonDocument sanitized = sanitizeDocument(command);
+        return sanitized.toJson();
+    }
+
+    /**
+     * Extracts the collection name from a MongoDB command.
+     *
+     * @param command the command document
+     * @return collection name or null if not found
+     */
+    public String extractCollectionName(BsonDocument command) {
+        // Most commands have the collection name as the first value
+        if (command == null) {
+            return null;
+        }
+        if (!command.isEmpty()) {
+            BsonValue firstValue = command.values().iterator().next();
+            if (firstValue.isString()) {
+                return firstValue.asString().getValue();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Sanitizes a BSON document recursively.
+     *
+     * @param doc the document to sanitize
+     * @return sanitized document
+     */
+    private BsonDocument sanitizeDocument(BsonDocument doc) {
+        BsonDocument sanitized = new BsonDocument();
+        if (doc == null) {
+            return sanitized;
+        }
+        for (Map.Entry<String, BsonValue> entry : doc.entrySet()) {
+            sanitized.put(entry.getKey(), sanitizeValue(entry.getValue()));
+        }
+        return sanitized;
+    }
+
+    /**
+     * Sanitizes a BSON value by replacing it with its type information.
+     *
+     * @param value the value to sanitize
+     * @return sanitized value
+     */
+    private BsonValue sanitizeValue(BsonValue value) {
+        if (value == null) {
+            return new BsonString("<null>");
+        } else if (value.isDocument()) {
+            return sanitizeDocument(value.asDocument());
+        } else if (value.isArray()) {
+            return sanitizeArray(value.asArray());
+        } else {
+            // Replace value with its type
+            return new BsonString("<" + value.getBsonType().name().toLowerCase() + ">");
+        }
+    }
+
+    /**
+     * Sanitizes a BSON array recursively.
+     *
+     * @param array the array to sanitize
+     * @return sanitized array
+     */
+    private BsonArray sanitizeArray(BsonArray array) {
+        BsonArray sanitized = new BsonArray();
+        if (array == null) {
+            return sanitized;
+        }
+        for (BsonValue value : array) {
+            sanitized.add(sanitizeValue(value));
+        }
+        return sanitized;
+    }
+}

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/tracing/MongoTracingCommandListener.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/tracing/MongoTracingCommandListener.java
@@ -21,13 +21,18 @@ import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
+import io.quarkus.mongodb.runtime.MongoConfig;
 import io.quarkus.mongodb.runtime.MongoRequestContext;
+import io.quarkus.mongodb.runtime.MongoTracingRuntimeConfig;
+import io.quarkus.opentelemetry.runtime.config.runtime.OTelRuntimeConfig;
 
 public class MongoTracingCommandListener implements CommandListener {
     private static final org.jboss.logging.Logger LOGGER = Logger.getLogger(MongoTracingCommandListener.class);
-    private static final String KEY = "mongodb.command";
+    private static final String KEY = "db.query.text";
     private final Map<Integer, ContextEvent> requestMap;
     private final Instrumenter<MongoCommand, Void> instrumenter;
+    private final MongoCommandSanitizer sanitizer;
+    private final MongoTracingRuntimeConfig config;
 
     private record MongoCommand(String name, BsonDocument command) {
     }
@@ -36,14 +41,21 @@ public class MongoTracingCommandListener implements CommandListener {
     }
 
     @Inject
-    public MongoTracingCommandListener(OpenTelemetry openTelemetry) {
-        requestMap = new ConcurrentHashMap<>();
+    public MongoTracingCommandListener(
+            OpenTelemetry openTelemetry,
+            MongoConfig mongoConfig,
+            OTelRuntimeConfig oTelRuntimeConfig) {
+
+        this.config = mongoConfig.tracing();
+        this.sanitizer = new MongoCommandSanitizer();
+        this.requestMap = new ConcurrentHashMap<>();
+
         SpanNameExtractor<MongoCommand> spanNameExtractor = MongoCommand::name;
         instrumenter = Instrumenter.<MongoCommand, Void> builder(
                 openTelemetry, "quarkus-mongodb-client", spanNameExtractor)
-                .addAttributesExtractor(new CommandEventAttrExtractor())
+                .setEnabled(!oTelRuntimeConfig.sdkDisabled())
+                .addAttributesExtractor(new CommandEventAttrExtractor(sanitizer, config))
                 .buildInstrumenter(SpanKindExtractor.alwaysClient());
-        LOGGER.debugf("MongoTracingCommandListener created");
     }
 
     @Override
@@ -88,9 +100,32 @@ public class MongoTracingCommandListener implements CommandListener {
 
     private static class CommandEventAttrExtractor implements AttributesExtractor<MongoCommand, Void> {
 
+        private final MongoCommandSanitizer sanitizer;
+        private final MongoTracingRuntimeConfig config;
+
+        CommandEventAttrExtractor(MongoCommandSanitizer sanitizer, MongoTracingRuntimeConfig config) {
+            this.sanitizer = sanitizer;
+            this.config = config;
+        }
+
         @Override
         public void onStart(AttributesBuilder attributesBuilder, Context context, MongoCommand command) {
-            attributesBuilder.put(KEY, command.command().toJson());
+            // Only add operation metadata as standard OTel attributes
+            String collectionName = sanitizer.extractCollectionName(command.command());
+            if (collectionName != null) {
+                attributesBuilder.put("db.collection.name", collectionName);
+            }
+
+            switch (config.commandDetailLevel()) {
+                case OFF:
+                    break;
+                case SANITIZED:
+                    attributesBuilder.put(KEY, sanitizer.sanitizeCommand(command.command()));
+                    break;
+                case FULL:
+                    attributesBuilder.put(KEY, command.command().toJson());
+                    break;
+            }
         }
 
         @Override

--- a/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/tracing/MongoCommandSanitizerTest.java
+++ b/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/tracing/MongoCommandSanitizerTest.java
@@ -1,0 +1,151 @@
+package io.quarkus.mongodb.tracing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonNull;
+import org.bson.BsonString;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class MongoCommandSanitizerTest {
+    private MongoCommandSanitizer sanitizer;
+
+    @BeforeEach
+    void setUp() {
+        sanitizer = new MongoCommandSanitizer();
+    }
+
+    @Test
+    void sanitizeSimpleDocument() {
+        BsonDocument command = new BsonDocument()
+                .append("find", new BsonString("users"))
+                .append("limit", new BsonInt32(10));
+
+        String result = sanitizer.sanitizeCommand(command);
+
+        assertThat(result)
+                .contains("\"find\"")
+                .contains("\"<string>\"")
+                .contains("\"limit\"")
+                .contains("\"<int32>\"")
+                .doesNotContain("users")
+                .doesNotContain("10");
+    }
+
+    @Test
+    void sanitizeNestedDocument() {
+        BsonDocument filter = new BsonDocument()
+                .append("email", new BsonString("test@example.com"))
+                .append("age", new BsonInt32(25));
+
+        BsonDocument command = new BsonDocument()
+                .append("find", new BsonString("users"))
+                .append("filter", filter);
+
+        String result = sanitizer.sanitizeCommand(command);
+
+        assertThat(result)
+                .contains("\"filter\"")
+                .contains("\"email\"")
+                .contains("\"<string>\"")
+                .contains("\"age\"")
+                .contains("\"<int32>\"")
+                .doesNotContain("test@example.com")
+                .doesNotContain("25");
+    }
+
+    @Test
+    void sanitizeArray() {
+        BsonArray updates = new BsonArray();
+        updates.add(new BsonDocument()
+                .append("q", new BsonDocument("_id", new BsonInt32(1)))
+                .append("u", new BsonDocument("$set", new BsonDocument("name", new BsonString("John")))));
+
+        BsonDocument command = new BsonDocument()
+                .append("update", new BsonString("users"))
+                .append("updates", updates);
+
+        String result = sanitizer.sanitizeCommand(command);
+
+        assertThat(result)
+                .contains("\"updates\"")
+                .contains("\"q\"")
+                .contains("\"u\"")
+                .contains("\"$set\"")
+                .contains("\"<string>\"")
+                .doesNotContain("John")
+                .doesNotContain("1");
+    }
+
+    @Test
+    void extractCollectionName() {
+        BsonDocument command = new BsonDocument()
+                .append("find", new BsonString("users"))
+                .append("filter", new BsonDocument());
+
+        String collectionName = sanitizer.extractCollectionName(command);
+
+        assertThat(collectionName)
+                .isEqualTo("users");
+    }
+
+    @Test
+    void extractCollectionNameWithoutCollection() {
+        BsonDocument command = new BsonDocument()
+                .append("ping", new BsonInt32(1));
+
+        String collectionName = sanitizer.extractCollectionName(command);
+
+        assertThat(collectionName)
+                .isNull();
+    }
+
+    @Test
+    void sanitizeNullCommand() {
+        String result = sanitizer.sanitizeCommand(null);
+
+        assertThat(result).isEqualTo("{}");
+    }
+
+    @Test
+    void extractCollectionNameFromNullCommand() {
+        String collectionName = sanitizer.extractCollectionName(null);
+
+        assertThat(collectionName).isNull();
+    }
+
+    @Test
+    void sanitizeDocumentWithBsonNullValue() {
+        BsonDocument command = new BsonDocument()
+                .append("find", new BsonString("users"))
+                .append("optionalField", BsonNull.VALUE);
+
+        String result = sanitizer.sanitizeCommand(command);
+
+        assertThat(result)
+                .contains("\"optionalField\"")
+                .contains("\"<null>\"")
+                .doesNotContain("null_type");
+    }
+
+    @Test
+    void sanitizeArrayWithNullElement() {
+        BsonArray documents = new BsonArray();
+        documents.add(new BsonDocument("name", new BsonString("Alice")));
+        documents.add(BsonNull.VALUE);
+
+        BsonDocument command = new BsonDocument()
+                .append("insert", new BsonString("users"))
+                .append("documents", documents);
+
+        String result = sanitizer.sanitizeCommand(command);
+
+        assertThat(result)
+                .contains("\"<string>\"")
+                .contains("\"<null>\"")
+                .doesNotContain("Alice");
+    }
+}

--- a/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/tracing/MongoTracingCommandListenerTest.java
+++ b/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/tracing/MongoTracingCommandListenerTest.java
@@ -2,8 +2,11 @@ package io.quarkus.mongodb.tracing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.bson.BsonDocument;
+import org.bson.BsonString;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -18,18 +21,36 @@ import com.mongodb.event.CommandSucceededEvent;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.context.Context;
+import io.quarkus.mongodb.runtime.MongoConfig;
 import io.quarkus.mongodb.runtime.MongoRequestContext;
+import io.quarkus.mongodb.runtime.MongoTracingRuntimeConfig;
+import io.quarkus.opentelemetry.runtime.config.runtime.OTelRuntimeConfig;
 
 class MongoTracingCommandListenerTest {
     private ConnectionDescription connDescr;
     private MongoTracingCommandListener listener;
     private BsonDocument command;
+    private MongoConfig mockConfig;
+    private MongoTracingRuntimeConfig mockTracingConfig;
+    private OTelRuntimeConfig mockOTelConfig;
 
     @BeforeEach
     void setUp() {
         connDescr = new ConnectionDescription(new ServerId(new ClusterId(), new ServerAddress()));
-        listener = new MongoTracingCommandListener(OpenTelemetry.noop());
         command = new BsonDocument();
+
+        // Create mock configs
+        mockConfig = mock(MongoConfig.class);
+        mockTracingConfig = mock(MongoTracingRuntimeConfig.class);
+        mockOTelConfig = mock(OTelRuntimeConfig.class);
+
+        // Setup default config values
+        when(mockConfig.tracing()).thenReturn(mockTracingConfig);
+        when(mockTracingConfig.commandDetailLevel())
+                .thenReturn(MongoTracingRuntimeConfig.CommandDetailLevel.OFF);
+        when(mockOTelConfig.sdkDisabled()).thenReturn(false);
+
+        listener = new MongoTracingCommandListener(OpenTelemetry.noop(), mockConfig, mockOTelConfig);
     }
 
     @Test
@@ -121,6 +142,104 @@ class MongoTracingCommandListenerTest {
                 10L,
                 new IllegalStateException("command failed"));
         assertThatNoException().isThrownBy(() -> listener.commandFailed(cmd));
+    }
+
+    @Test
+    void testCommandDetailLevelOff() {
+        when(mockTracingConfig.commandDetailLevel())
+                .thenReturn(MongoTracingRuntimeConfig.CommandDetailLevel.OFF);
+
+        listener = new MongoTracingCommandListener(OpenTelemetry.noop(), mockConfig, mockOTelConfig);
+
+        var startEvent = new CommandStartedEvent(
+                null,
+                1L,
+                10,
+                connDescr,
+                "db",
+                "find",
+                new BsonDocument("find", new BsonString("users"))
+                        .append("filter", new BsonDocument("email", new BsonString("test@example.com"))));
+
+        assertThatNoException().isThrownBy(() -> listener.commandStarted(startEvent));
+    }
+
+    @Test
+    void testCommandDetailLevelFull() {
+        when(mockTracingConfig.commandDetailLevel())
+                .thenReturn(MongoTracingRuntimeConfig.CommandDetailLevel.FULL);
+
+        listener = new MongoTracingCommandListener(OpenTelemetry.noop(), mockConfig, mockOTelConfig);
+
+        var startEvent = new CommandStartedEvent(
+                null,
+                1L,
+                10,
+                connDescr,
+                "db",
+                "find",
+                new BsonDocument("find", new BsonString("users"))
+                        .append("filter", new BsonDocument("email", new BsonString("test@example.com"))));
+
+        assertThatNoException().isThrownBy(() -> listener.commandStarted(startEvent));
+    }
+
+    @Test
+    void testCommandDetailLevelSanitized() {
+        when(mockTracingConfig.commandDetailLevel())
+                .thenReturn(MongoTracingRuntimeConfig.CommandDetailLevel.SANITIZED);
+
+        listener = new MongoTracingCommandListener(OpenTelemetry.noop(), mockConfig, mockOTelConfig);
+
+        var startEvent = new CommandStartedEvent(
+                null,
+                1L,
+                10,
+                connDescr,
+                "db",
+                "find",
+                new BsonDocument("find", new BsonString("users"))
+                        .append("filter", new BsonDocument("email", new BsonString("test@example.com"))));
+
+        assertThatNoException().isThrownBy(() -> listener.commandStarted(startEvent));
+    }
+
+    @Test
+    void testOtelSdkDisabled() {
+        var disabledOTelConfig = mock(OTelRuntimeConfig.class);
+        when(disabledOTelConfig.sdkDisabled()).thenReturn(true);
+        var disabledListener = new MongoTracingCommandListener(OpenTelemetry.noop(), mockConfig, disabledOTelConfig);
+
+        var startEvent = new CommandStartedEvent(
+                null,
+                1L,
+                10,
+                connDescr,
+                "db",
+                "find",
+                new BsonDocument("find", new BsonString("users"))
+                        .append("filter", new BsonDocument("email", new BsonString("test@example.com"))));
+        assertThatNoException().isThrownBy(() -> disabledListener.commandStarted(startEvent));
+
+        CommandSucceededEvent successEvent = new CommandSucceededEvent(null,
+                startEvent.getOperationId(),
+                startEvent.getRequestId(),
+                connDescr,
+                startEvent.getDatabaseName(),
+                startEvent.getCommandName(),
+                startEvent.getCommand(),
+                10L);
+        assertThatNoException().isThrownBy(() -> disabledListener.commandSucceeded(successEvent));
+
+        CommandFailedEvent failedEvent = new CommandFailedEvent(null,
+                1L,
+                11,
+                connDescr,
+                "db",
+                "find",
+                10L,
+                new IllegalStateException("command failed"));
+        assertThatNoException().isThrownBy(() -> disabledListener.commandFailed(failedEvent));
     }
 
 }

--- a/integration-tests/opentelemetry-mongodb-client-instrumentation/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-mongodb-client-instrumentation/src/main/resources/application.properties
@@ -11,3 +11,7 @@ quarkus.mongodb.connection-string=mongodb://localhost:27017
 quarkus.otel.bsp.schedule.delay=100
 quarkus.otel.bsp.export.timeout=5s
 quarkus.mongodb.tracing.enabled=true
+# FULL to preserve existing BookResourceTest behavior; sanitized/off profiles override
+quarkus.mongodb.tracing.command-detail-level=FULL
+%sanitized.quarkus.mongodb.tracing.command-detail-level=SANITIZED
+%off.quarkus.mongodb.tracing.command-detail-level=OFF

--- a/integration-tests/opentelemetry-mongodb-client-instrumentation/src/test/java/io/quarkus/it/opentelemetry/BookResourceOffIT.java
+++ b/integration-tests/opentelemetry-mongodb-client-instrumentation/src/test/java/io/quarkus/it/opentelemetry/BookResourceOffIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.opentelemetry;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class BookResourceOffIT extends BookResourceOffTest {
+}

--- a/integration-tests/opentelemetry-mongodb-client-instrumentation/src/test/java/io/quarkus/it/opentelemetry/BookResourceOffTest.java
+++ b/integration-tests/opentelemetry-mongodb-client-instrumentation/src/test/java/io/quarkus/it/opentelemetry/BookResourceOffTest.java
@@ -1,0 +1,143 @@
+package io.quarkus.it.opentelemetry;
+
+import static io.restassured.RestAssured.get;
+import static io.restassured.RestAssured.given;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.ResourceArg;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.mongodb.MongoTestResource;
+import io.restassured.common.mapper.TypeRef;
+
+@QuarkusTest
+@TestProfile(BookResourceOffTest.OffProfile.class)
+@QuarkusTestResource(value = MongoTestResource.class, initArgs = @ResourceArg(name = MongoTestResource.VERSION, value = "V6_0"))
+class BookResourceOffTest {
+
+    public static class OffProfile implements QuarkusTestProfile {
+        @Override
+        public String getConfigProfile() {
+            return "off";
+        }
+    }
+
+    private final TypeRef<List<Book>> bookListType = new TypeRef<>() {
+    };
+
+    @BeforeEach
+    @AfterEach
+    void reset() {
+        given().get("/reset").then().statusCode(HTTP_OK);
+        await().atMost(Duration.ofSeconds(30L)).until(() -> {
+            // make sure spans are cleared
+            List<Map<String, Object>> spans = getSpans();
+            if (!spans.isEmpty()) {
+                given().get("/reset").then().statusCode(HTTP_OK);
+            }
+            return spans.isEmpty();
+        });
+    }
+
+    @Test
+    void blockingClientNoCommand() {
+        testInsertBooks("/books");
+        reset();
+        assertThat(get("/books").as(bookListType)).hasSize(3);
+        assertNoCommandInSpans(2);
+    }
+
+    @Test
+    void reactiveClientNoCommand() {
+        testInsertBooks("/reactive-books");
+        reset();
+        assertThat(get("/reactive-books").as(bookListType)).hasSize(3);
+        assertNoCommandInSpans(2);
+    }
+
+    @Test
+    void collectionNameStillPresent() {
+        testInsertBooks("/books");
+        reset();
+        assertThat(get("/books").as(bookListType)).hasSize(3);
+
+        await().atMost(Duration.ofSeconds(10L)).until(() -> getSpans().size() >= 1);
+        boolean found = false;
+        for (Map<String, Object> spanData : getSpans()) {
+            if (spanData.get("attributes") instanceof Map attr) {
+                var collectionName = (String) attr.get("db.collection.name");
+                if (collectionName != null) {
+                    assertThat(collectionName).isEqualTo("my-collection");
+                    found = true;
+                }
+            }
+        }
+        assertThat(found).as("Collection name should still be present in OFF mode").isTrue();
+    }
+
+    @Test
+    void spanStillCreated() {
+        testInsertBooks("/books");
+        reset();
+        assertThat(get("/books").as(bookListType)).hasSize(3);
+
+        // Verify spans are still created even in OFF mode
+        await().atMost(Duration.ofSeconds(10L)).until(() -> getSpans().size() == 2);
+        assertThat(getSpans()).isNotEmpty();
+    }
+
+    private void assertNoCommandInSpans(int expectedNumOfSpans) {
+        await().atMost(Duration.ofSeconds(10L)).until(() -> getSpans().size() == expectedNumOfSpans);
+        for (Map<String, Object> spanData : getSpans()) {
+            if (spanData.get("attributes") instanceof Map attr) {
+                var cmd = (String) attr.get("db.query.text");
+                // Command attribute should not be present in OFF mode
+                assertThat(cmd).as("Command should not be present in OFF mode").isNull();
+            }
+        }
+    }
+
+    private void testInsertBooks(String endpoint) {
+        given()
+                .delete(endpoint)
+                .then()
+                .assertThat()
+                .statusCode(200);
+
+        await().atMost(Duration.ofSeconds(60L))
+                .untilAsserted(() -> assertThat(get(endpoint).as(bookListType)).as("must delete all").isEmpty());
+
+        saveBook(new Book("Victor Hugo", "Les Misérables"), endpoint);
+        saveBook(new Book("Victor Hugo", "Notre-Dame de Paris"), endpoint);
+        await().atMost(Duration.ofSeconds(60L))
+                .untilAsserted(() -> assertThat(get(endpoint).as(bookListType)).hasSize(2));
+        saveBook(new Book("Charles Baudelaire", "Les fleurs du mal"), endpoint);
+        await().atMost(Duration.ofSeconds(60L))
+                .untilAsserted(() -> assertThat(get(endpoint).as(bookListType)).hasSize(3));
+    }
+
+    private static void saveBook(Book book, String endpoint) {
+        given()
+                .header("Content-Type", "application/json")
+                .body(book)
+                .post(endpoint)
+                .then().assertThat().statusCode(202);
+    }
+
+    private List<Map<String, Object>> getSpans() {
+        return get("/export").body().as(new TypeRef<>() {
+        });
+    }
+}

--- a/integration-tests/opentelemetry-mongodb-client-instrumentation/src/test/java/io/quarkus/it/opentelemetry/BookResourceSanitizedIT.java
+++ b/integration-tests/opentelemetry-mongodb-client-instrumentation/src/test/java/io/quarkus/it/opentelemetry/BookResourceSanitizedIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.opentelemetry;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class BookResourceSanitizedIT extends BookResourceSanitizedTest {
+}

--- a/integration-tests/opentelemetry-mongodb-client-instrumentation/src/test/java/io/quarkus/it/opentelemetry/BookResourceSanitizedTest.java
+++ b/integration-tests/opentelemetry-mongodb-client-instrumentation/src/test/java/io/quarkus/it/opentelemetry/BookResourceSanitizedTest.java
@@ -1,0 +1,166 @@
+package io.quarkus.it.opentelemetry;
+
+import static io.restassured.RestAssured.get;
+import static io.restassured.RestAssured.given;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.ResourceArg;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.mongodb.MongoTestResource;
+import io.restassured.common.mapper.TypeRef;
+
+@QuarkusTest
+@TestProfile(BookResourceSanitizedTest.SanitizedProfile.class)
+@QuarkusTestResource(value = MongoTestResource.class, initArgs = @ResourceArg(name = MongoTestResource.VERSION, value = "V6_0"))
+class BookResourceSanitizedTest {
+
+    public static class SanitizedProfile implements QuarkusTestProfile {
+        @Override
+        public String getConfigProfile() {
+            return "sanitized";
+        }
+    }
+
+    private final TypeRef<List<Book>> bookListType = new TypeRef<>() {
+    };
+
+    @BeforeEach
+    @AfterEach
+    void reset() {
+        given().get("/reset").then().statusCode(HTTP_OK);
+        await().atMost(Duration.ofSeconds(30L)).until(() -> {
+            // make sure spans are cleared
+            List<Map<String, Object>> spans = getSpans();
+            if (!spans.isEmpty()) {
+                given().get("/reset").then().statusCode(HTTP_OK);
+            }
+            return spans.isEmpty();
+        });
+    }
+
+    @Test
+    void blockingClientSanitized() {
+        testInsertBooks("/books");
+        reset();
+        assertThat(get("/books").as(bookListType)).hasSize(3);
+        assertSanitizedCommandPresent(2);
+    }
+
+    @Test
+    void reactiveClientSanitized() {
+        testInsertBooks("/reactive-books");
+        reset();
+        assertThat(get("/reactive-books").as(bookListType)).hasSize(3);
+        assertSanitizedCommandPresent(2);
+    }
+
+    @Test
+    void commandDoesNotContainSensitiveData() {
+        testInsertBooks("/books");
+        reset();
+        assertThat(get("/books").as(bookListType)).hasSize(3);
+
+        await().atMost(Duration.ofSeconds(10L)).until(() -> getSpans().size() >= 1);
+        boolean found = false;
+        for (Map<String, Object> spanData : getSpans()) {
+            if (spanData.get("attributes") instanceof Map attr) {
+                var cmd = (String) attr.get("db.query.text");
+                if (cmd != null) {
+                    // Command should not contain actual book data
+                    assertThat(cmd)
+                            .doesNotContain("Victor Hugo")
+                            .doesNotContain("Les Misérables")
+                            .doesNotContain("Notre-Dame de Paris")
+                            .doesNotContain("Charles Baudelaire")
+                            .doesNotContain("Les fleurs du mal");
+
+                    // But should contain type placeholders
+                    assertThat(cmd).contains("<string>");
+                    found = true;
+                }
+            }
+        }
+        assertThat(found).as("At least one span should contain a sanitized db.query.text").isTrue();
+    }
+
+    @Test
+    void collectionNamePresent() {
+        testInsertBooks("/books");
+        reset();
+        assertThat(get("/books").as(bookListType)).hasSize(3);
+
+        await().atMost(Duration.ofSeconds(10L)).until(() -> getSpans().size() >= 1);
+        boolean found = false;
+        for (Map<String, Object> spanData : getSpans()) {
+            if (spanData.get("attributes") instanceof Map attr) {
+                var collectionName = (String) attr.get("db.collection.name");
+                if (collectionName != null) {
+                    assertThat(collectionName).isEqualTo("my-collection");
+                    found = true;
+                }
+            }
+        }
+        assertThat(found).as("At least one span should have db.collection.name set").isTrue();
+    }
+
+    private void assertSanitizedCommandPresent(int expectedNumOfSpans) {
+        await().atMost(Duration.ofSeconds(10L)).until(() -> getSpans().size() == expectedNumOfSpans);
+        boolean found = false;
+        for (Map<String, Object> spanData : getSpans()) {
+            if (spanData.get("attributes") instanceof Map attr) {
+                var cmd = (String) attr.get("db.query.text");
+                if (cmd != null) {
+                    // Verify command structure is present but values are sanitized
+                    assertThat(cmd).contains("<string>");
+                    found = true;
+                }
+            }
+        }
+        assertThat(found).isTrue();
+    }
+
+    private void testInsertBooks(String endpoint) {
+        given()
+                .delete(endpoint)
+                .then()
+                .assertThat()
+                .statusCode(200);
+
+        await().atMost(Duration.ofSeconds(60L))
+                .untilAsserted(() -> assertThat(get(endpoint).as(bookListType)).as("must delete all").isEmpty());
+
+        saveBook(new Book("Victor Hugo", "Les Misérables"), endpoint);
+        saveBook(new Book("Victor Hugo", "Notre-Dame de Paris"), endpoint);
+        await().atMost(Duration.ofSeconds(60L))
+                .untilAsserted(() -> assertThat(get(endpoint).as(bookListType)).hasSize(2));
+        saveBook(new Book("Charles Baudelaire", "Les fleurs du mal"), endpoint);
+        await().atMost(Duration.ofSeconds(60L))
+                .untilAsserted(() -> assertThat(get(endpoint).as(bookListType)).hasSize(3));
+    }
+
+    private static void saveBook(Book book, String endpoint) {
+        given()
+                .header("Content-Type", "application/json")
+                .body(book)
+                .post(endpoint)
+                .then().assertThat().statusCode(202);
+    }
+
+    private List<Map<String, Object>> getSpans() {
+        return get("/export").body().as(new TypeRef<>() {
+        });
+    }
+}

--- a/integration-tests/opentelemetry-mongodb-client-instrumentation/src/test/java/io/quarkus/it/opentelemetry/BookResourceTest.java
+++ b/integration-tests/opentelemetry-mongodb-client-instrumentation/src/test/java/io/quarkus/it/opentelemetry/BookResourceTest.java
@@ -113,7 +113,7 @@ class BookResourceTest {
         boolean found = false;
         for (Map<String, Object> spanData : getSpans()) {
             if (spanData.get("attributes") instanceof Map attr) {
-                var cmd = (String) attr.get("mongodb.command");
+                var cmd = (String) attr.get("db.query.text");
                 if (cmd != null) {
                     assertThat(cmd).contains(commandPart).contains("books");
                     found = true;
@@ -138,7 +138,7 @@ class BookResourceTest {
         for (Map<String, Object> spanData : spans) {
             assertThat(spanData).as("span must have trace id").containsEntry("traceId", traceId);
             if (spanData.get("attributes") instanceof Map attr) {
-                var cmd = (String) attr.get("mongodb.command");
+                var cmd = (String) attr.get("db.query.text");
                 if (cmd != null) {
                     assertThat(cmd).contains(commandPart).contains("books");
                     var parentSpanContext = (Map<String, Object>) spanData.get("parentSpanContext");


### PR DESCRIPTION
Docs updated.
Includes deactivating mongodb instrumentation when OTel is disabled. 

### Breaking changes

Added new configs to drive the functionality:
- Command detail level: OFF(new default), SANITIZED, or FULL
`quarkus.mongodb.tracing.command-detail-level=SANITIZED`

Rename `mongodb.command` to `db.query.text` following the latest OTel semantic conventions for DBs: https://opentelemetry.io/docs/specs/semconv/db/mongodb/

----


- Fixes: https://github.com/quarkusio/quarkus/issues/52906