### PR TITLE
Stop overriding ObjectMapper naming strategy in Lambda recorder

### DIFF
--- a/extensions/amazon-lambda/common-runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaMapperRecorder.java
+++ b/extensions/amazon-lambda/common-runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaMapperRecorder.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 
 import io.quarkus.arc.Arc;
@@ -26,8 +25,7 @@ public class AmazonLambdaMapperRecorder {
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                 .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true)
                 .registerModule(new JodaModule())
-                .registerModule(new DateModule())
-                .setPropertyNamingStrategy(PropertyNamingStrategies.LOWER_CAMEL_CASE);
+                .registerModule(new DateModule());
     }
 
     public void initContextReaders() {

--- a/extensions/amazon-lambda/common-runtime/src/main/java/io/quarkus/amazon/lambda/runtime/FunctionError.java
+++ b/extensions/amazon-lambda/common-runtime/src/main/java/io/quarkus/amazon/lambda/runtime/FunctionError.java
@@ -1,8 +1,12 @@
 package io.quarkus.amazon.lambda.runtime;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class FunctionError {
 
+    @JsonProperty("errorType")
     private String errorType;
+    @JsonProperty("errorMessage")
     private String errorMessage;
 
     public FunctionError(String errorType, String errorMessage) {

--- a/extensions/amazon-lambda/common-runtime/src/test/java/io/quarkus/amazon/lambda/test/ObjectMapperNamingStrategyTest.java
+++ b/extensions/amazon-lambda/common-runtime/src/test/java/io/quarkus/amazon/lambda/test/ObjectMapperNamingStrategyTest.java
@@ -1,0 +1,64 @@
+package io.quarkus.amazon.lambda.test;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+
+import io.quarkus.amazon.lambda.runtime.FunctionError;
+
+public class ObjectMapperNamingStrategyTest {
+
+    @Test
+    public void testFunctionErrorAlwaysUsesCamelCase() throws Exception {
+        ObjectMapper mapper = new ObjectMapper()
+                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+
+        FunctionError error = new FunctionError("RuntimeError", "something went wrong");
+        String json = mapper.writeValueAsString(error);
+
+        Assertions.assertTrue(json.contains("\"errorType\""), "FunctionError should use camelCase for errorType, got: " + json);
+        Assertions.assertTrue(json.contains("\"errorMessage\""),
+                "FunctionError should use camelCase for errorMessage, got: " + json);
+        Assertions.assertFalse(json.contains("\"error_type\""),
+                "FunctionError should not use snake_case for errorType, got: " + json);
+    }
+
+    @Test
+    public void testUserNamingStrategyIsPreserved() throws Exception {
+        ObjectMapper mapper = new ObjectMapper()
+                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+
+        String json = mapper.writeValueAsString(new UserDto("John", "Doe", 30));
+
+        Assertions.assertTrue(json.contains("\"first_name\""),
+                "User DTO should respect SNAKE_CASE strategy, got: " + json);
+        Assertions.assertTrue(json.contains("\"last_name\""),
+                "User DTO should respect SNAKE_CASE strategy, got: " + json);
+    }
+
+    public static class UserDto {
+        private String firstName;
+        private String lastName;
+        private int userAge;
+
+        public UserDto(String firstName, String lastName, int userAge) {
+            this.firstName = firstName;
+            this.lastName = lastName;
+            this.userAge = userAge;
+        }
+
+        public String getFirstName() {
+            return firstName;
+        }
+
+        public String getLastName() {
+            return lastName;
+        }
+
+        public int getUserAge() {
+            return userAge;
+        }
+    }
+}


### PR DESCRIPTION
`AmazonLambdaMapperRecorder.initObjectMapper()` unconditionally called `.setPropertyNamingStrategy(PropertyNamingStrategies.LOWER_CAMEL_CASE)` on the ObjectMapper used by the Lambda runtime. This silently overrode any application-configured naming strategy (e.g., `SNAKE_CASE` or `KEBAB_CASE`), breaking serialization consistency for user DTOs.

----


- Fixes: #52985