### PR TITLE
Register discovered config sources in QuarkusComponentTestExtension

### DIFF
--- a/docs/src/main/asciidoc/testing-components.adoc
+++ b/docs/src/main/asciidoc/testing-components.adoc
@@ -303,6 +303,9 @@ By default, only the config properties from `application.properties` and propert
 System properties and ENV variables are _not_ included in the test config by default.
 However, you can use `@QuarkusComponentTest#useSystemConfigSources()` or `QuarkusComponentTestExtensionBuilder#useSystemConfigSources()` to configure this behavior.
 
+Similarly, discovered config sources such as `application.yaml` are _not_ included by default.
+You can use `@QuarkusComponentTest#useDiscoveredConfigSources()` or `QuarkusComponentTestExtensionBuilder#useDiscoveredConfigSources()` to include them.
+
 == Panache entities using the active record pattern
 
 If you are using the active record pattern you cannot easily leverage `Mockito#mockStatic()` to mock static methods declared on `PanacheEntityBase`.

--- a/test-framework/junit-component/pom.xml
+++ b/test-framework/junit-component/pom.xml
@@ -64,6 +64,11 @@
         </dependency>
         <!-- Test dependencies -->
         <dependency>
+            <groupId>io.smallrye.config</groupId>
+            <artifactId>smallrye-config-source-yaml</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.logmanager</groupId>
             <artifactId>jboss-logmanager</artifactId>
             <scope>test</scope>

--- a/test-framework/junit-component/src/main/java/io/quarkus/test/component/QuarkusComponentTest.java
+++ b/test-framework/junit-component/src/main/java/io/quarkus/test/component/QuarkusComponentTest.java
@@ -87,4 +87,11 @@ public @interface QuarkusComponentTest {
      */
     boolean useSystemConfigSources() default false;
 
+    /**
+     * If set to {@code true} then discovered config sources (e.g. {@code application.yaml}) are included in the test config.
+     *
+     * @see QuarkusComponentTestExtensionBuilder#useDiscoveredConfigSources(boolean)
+     */
+    boolean useDiscoveredConfigSources() default false;
+
 }

--- a/test-framework/junit-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestConfiguration.java
+++ b/test-framework/junit-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestConfiguration.java
@@ -65,7 +65,7 @@ class QuarkusComponentTestConfiguration {
 
     static final QuarkusComponentTestConfiguration DEFAULT = new QuarkusComponentTestConfiguration(Map.of(), Set.of(),
             List.of(), false, true, QuarkusComponentTestExtensionBuilder.DEFAULT_CONFIG_SOURCE_ORDINAL, List.of(),
-            DEFAULT_CONVERTERS, null, false, null);
+            DEFAULT_CONVERTERS, null, false, false, null);
 
     private static final Logger LOG = Logger.getLogger(QuarkusComponentTestConfiguration.class);
 
@@ -74,6 +74,7 @@ class QuarkusComponentTestConfiguration {
     final List<MockBeanConfiguratorImpl<?>> mockConfigurators;
     final boolean useDefaultConfigProperties;
     final boolean useSystemConfigSources;
+    final boolean useDiscoveredConfigSources;
     final boolean addNestedClassesAsComponents;
     final int configSourceOrdinal;
     final List<AnnotationsTransformer> annotationsTransformers;
@@ -86,12 +87,14 @@ class QuarkusComponentTestConfiguration {
             boolean addNestedClassesAsComponents, int configSourceOrdinal,
             List<AnnotationsTransformer> annotationsTransformers, List<Converter<?>> configConverters,
             Consumer<SmallRyeConfigBuilder> configBuilderCustomizer, boolean useSystemConfigSources,
+            boolean useDiscoveredConfigSources,
             List<QuarkusComponentTestCallbacks> listeners) {
         this.configProperties = configProperties;
         this.componentClasses = componentClasses;
         this.mockConfigurators = mockConfigurators;
         this.useDefaultConfigProperties = useDefaultConfigProperties;
         this.useSystemConfigSources = useSystemConfigSources;
+        this.useDiscoveredConfigSources = useDiscoveredConfigSources;
         this.addNestedClassesAsComponents = addNestedClassesAsComponents;
         this.configSourceOrdinal = configSourceOrdinal;
         this.annotationsTransformers = annotationsTransformers;
@@ -111,6 +114,7 @@ class QuarkusComponentTestConfiguration {
         List<Class<?>> componentClasses = new ArrayList<>(this.componentClasses);
         boolean useDefaultConfigProperties = this.useDefaultConfigProperties;
         boolean useSystemConfigSources = this.useSystemConfigSources;
+        boolean useDiscoveredConfigSources = this.useDiscoveredConfigSources;
         boolean addNestedClassesAsComponents = this.addNestedClassesAsComponents;
         int configSourceOrdinal = this.configSourceOrdinal;
         List<AnnotationsTransformer> annotationsTransformers = new ArrayList<>(this.annotationsTransformers);
@@ -127,6 +131,7 @@ class QuarkusComponentTestConfiguration {
             Collections.addAll(componentClasses, testAnnotation.value());
             useDefaultConfigProperties = testAnnotation.useDefaultConfigProperties();
             useSystemConfigSources = testAnnotation.useSystemConfigSources();
+            useDiscoveredConfigSources = testAnnotation.useDiscoveredConfigSources();
             addNestedClassesAsComponents = testAnnotation.addNestedClassesAsComponents();
             configSourceOrdinal = testAnnotation.configSourceOrdinal();
             Class<? extends AnnotationsTransformer>[] transformers = testAnnotation.annotationsTransformers();
@@ -164,7 +169,7 @@ class QuarkusComponentTestConfiguration {
         return new QuarkusComponentTestConfiguration(Map.copyOf(configProperties), Set.copyOf(componentClasses),
                 this.mockConfigurators, useDefaultConfigProperties, addNestedClassesAsComponents, configSourceOrdinal,
                 List.copyOf(annotationsTransformers), List.copyOf(configConverters), configBuilderCustomizer,
-                useSystemConfigSources, callbacks);
+                useSystemConfigSources, useDiscoveredConfigSources, callbacks);
     }
 
     boolean hasCallbacks() {
@@ -240,7 +245,8 @@ class QuarkusComponentTestConfiguration {
         }
         return new QuarkusComponentTestConfiguration(configProperties, componentClasses,
                 mockConfigurators, useDefaultConfigProperties, addNestedClassesAsComponents, configSourceOrdinal,
-                annotationsTransformers, configConverters, configBuilderCustomizer, useSystemConfigSources, callbacks);
+                annotationsTransformers, configConverters, configBuilderCustomizer, useSystemConfigSources,
+                useDiscoveredConfigSources, callbacks);
     }
 
     private static boolean resolvesToBuiltinBean(Class<?> rawType) {

--- a/test-framework/junit-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestExtension.java
+++ b/test-framework/junit-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestExtension.java
@@ -171,7 +171,7 @@ public class QuarkusComponentTestExtension
     public QuarkusComponentTestExtension(Class<?>... additionalComponentClasses) {
         this(new QuarkusComponentTestConfiguration(Map.of(), Set.of(additionalComponentClasses),
                 List.of(), false, true, QuarkusComponentTestExtensionBuilder.DEFAULT_CONFIG_SOURCE_ORDINAL,
-                List.of(), List.of(), null, false, null), false);
+                List.of(), List.of(), null, false, false, null), false);
     }
 
     QuarkusComponentTestExtension(QuarkusComponentTestConfiguration baseConfiguration, boolean startShouldFail) {
@@ -531,6 +531,9 @@ public class QuarkusComponentTestExtension
 
         if (configuration.useSystemConfigSources) {
             configBuilder.addSystemSources();
+        }
+        if (configuration.useDiscoveredConfigSources) {
+            configBuilder.addDiscoveredSources();
         }
 
         @SuppressWarnings("unchecked")

--- a/test-framework/junit-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestExtensionBuilder.java
+++ b/test-framework/junit-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestExtensionBuilder.java
@@ -35,6 +35,7 @@ public class QuarkusComponentTestExtensionBuilder {
     private final List<Converter<?>> configConverters = new ArrayList<>();
     private boolean useDefaultConfigProperties = false;
     private boolean useSystemConfigSources = false;
+    private boolean useDiscoveredConfigSources = false;
     private boolean addNestedClassesAsComponents = true;
     private int configSourceOrdinal = QuarkusComponentTestExtensionBuilder.DEFAULT_CONFIG_SOURCE_ORDINAL;
     private Consumer<SmallRyeConfigBuilder> configBuilderCustomizer;
@@ -151,6 +152,16 @@ public class QuarkusComponentTestExtensionBuilder {
     }
 
     /**
+     * Use discovered config sources (e.g. {@code application.yaml}) in the test config.
+     *
+     * @return self
+     */
+    public QuarkusComponentTestExtensionBuilder useDiscoveredConfigSources(boolean value) {
+        this.useDiscoveredConfigSources = value;
+        return this;
+    }
+
+    /**
      * Configure a new mock of a bean.
      * <p>
      * Note that a mock is created automatically for all unsatisfied dependencies in the test. This API provides full control
@@ -185,7 +196,8 @@ public class QuarkusComponentTestExtensionBuilder {
         return new QuarkusComponentTestExtension(new QuarkusComponentTestConfiguration(Map.copyOf(configProperties),
                 Set.copyOf(componentClasses), List.copyOf(mockConfigurators), useDefaultConfigProperties,
                 addNestedClassesAsComponents, configSourceOrdinal,
-                List.copyOf(annotationsTransformers), converters, configBuilderCustomizer, useSystemConfigSources, null),
+                List.copyOf(annotationsTransformers), converters, configBuilderCustomizer, useSystemConfigSources,
+                useDiscoveredConfigSources, null),
                 buildShouldFail);
     }
 

--- a/test-framework/junit-component/src/test/java/io/quarkus/test/component/ApplicationYamlConfigSourceTest.java
+++ b/test-framework/junit-component/src/test/java/io/quarkus/test/component/ApplicationYamlConfigSourceTest.java
@@ -1,0 +1,33 @@
+package io.quarkus.test.component;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class ApplicationYamlConfigSourceTest {
+
+    @RegisterExtension
+    static final QuarkusComponentTestExtension extension = QuarkusComponentTestExtension.builder()
+            .useDiscoveredConfigSources(true)
+            .build();
+
+    @Inject
+    YamlComponent component;
+
+    @Test
+    public void testYamlConfig() {
+        assertEquals("from-yaml", component.yamlProperty);
+    }
+
+    @Singleton
+    public static class YamlComponent {
+
+        @ConfigProperty(name = "org.acme.yaml-property")
+        String yamlProperty;
+    }
+}

--- a/test-framework/junit-component/src/test/resources/application.yaml
+++ b/test-framework/junit-component/src/test/resources/application.yaml
@@ -1,0 +1,3 @@
+org:
+  acme:
+    yaml-property: from-yaml


### PR DESCRIPTION
`@QuarkusComponentTest` respects `application.properties` but not `application.yaml` because `QuarkusComponentTestExtension` only called `addPropertiesSources()` on the `SmallRyeConfigBuilder`, which registers `.properties` files but not YAML.


- Fixes: #53037