### PR TITLE
Fix missing and invalid :categories: attributes in guide headers

### DIFF
--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -7,7 +7,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Configure data sources in {project-name}
 include::_attributes.adoc[]
 :diataxis-type: reference
-:categories: data,getting-started,reactive
+:categories: data,getting-started
 :topics: data,database,datasource,sql,jdbc,reactive
 :extensions: io.quarkus:quarkus-agroal,io.quarkus:quarkus-reactive-mysql-client,io.quarkus:quarkus-reactive-oracle-client,io.quarkus:quarkus-reactive-pg-client,io.quarkus:quarkus-reactive-db2-client,io.quarkus:quarkus-reactive-pg-client,io.quarkus:quarkus-reactive-mssql-client,io.quarkus:quarkus-jdbc-db2,io.quarkus:quarkus-jdbc-h2,io.quarkus:quarkus-jdbc-mariadb,io.quarkus:quarkus-jdbc-mssql,io.quarkus:quarkus-jdbc-mysql,io.quarkus:quarkus-jdbc-oracle,io.quarkus:quarkus-jdbc-postgresql
 

--- a/docs/src/main/asciidoc/drools.adoc
+++ b/docs/src/main/asciidoc/drools.adoc
@@ -5,7 +5,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Defining and executing business rules with Drools
 include::_attributes.adoc[]
-:categories: rule engine
+:categories: business-automation
 :summary: Drools is the most used rule engine implementation in the Java ecosystem. The purpose of this guide is to show how to use to define and execute business rules in Quarkus using Drools.
 :topics: drools,rules,rule engine
 :extensions: org.drools:drools-quarkus

--- a/docs/src/main/asciidoc/extension-faq.adoc
+++ b/docs/src/main/asciidoc/extension-faq.adoc
@@ -7,7 +7,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Frequently asked questions about writing extensions
 include::_attributes.adoc[]
 :diataxis-type: howto
-:categories: extensions
+:categories: writing-extensions
 ////
 :extension-status: preview
 TODO: uncomment the above for experimental or tech-preview content.

--- a/docs/src/main/asciidoc/getting-started-reactive.adoc
+++ b/docs/src/main/asciidoc/getting-started-reactive.adoc
@@ -5,7 +5,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Getting Started With Reactive
 include::_attributes.adoc[]
-:categories: getting-started,reactive
+:categories: getting-started,web
 :summary: Learn more about developing reactive applications with Quarkus.
 :topics: getting-started,reactive
 

--- a/docs/src/main/asciidoc/grpc-virtual-threads.adoc
+++ b/docs/src/main/asciidoc/grpc-virtual-threads.adoc
@@ -7,6 +7,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 include::_attributes.adoc[]
 :runonvthread: https://javadoc.io/doc/io.smallrye.common/smallrye-common-annotation/latest/io/smallrye/common/annotation/RunOnVirtualThread.html
 :blocking_annotation: https://javadoc.io/doc/io.smallrye.reactive/smallrye-reactive-messaging-api/latest/io/smallrye/reactive/messaging/annotations/Blocking.html
+:categories: web
 :topics: grpc,virtual-threads
 :extensions: io.quarkus:quarkus-grpc
 

--- a/docs/src/main/asciidoc/hibernate-reactive.adoc
+++ b/docs/src/main/asciidoc/hibernate-reactive.adoc
@@ -8,6 +8,7 @@ include::_attributes.adoc[]
 :config-file: application.properties
 :reactive-doc-url-prefix: https://hibernate.org/reactive/documentation/1.1/reference/html_single/#getting-started
 :extension-status: preview
+:categories: data
 :topics: data,hibernate-reactive,sql
 :extensions: io.quarkus:quarkus-hibernate-reactive-panache,io.quarkus:quarkus-hibernate-reactive
 

--- a/docs/src/main/asciidoc/mongodb-dev-services.adoc
+++ b/docs/src/main/asciidoc/mongodb-dev-services.adoc
@@ -5,6 +5,9 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Dev Services for MongoDB
 include::_attributes.adoc[]
+:categories: data
+:topics: mongodb,dev-services
+:extensions: io.quarkus:quarkus-mongodb-client
 
 Quarkus supports a feature called Dev Services that allows you to create various datasources without any config. In the case of MongoDB this support extends to the default MongoDB connection.
 What that means practically, is that if you have not configured `quarkus.mongodb.connection-string` nor `quarkus.mongodb.hosts`, Quarkus will automatically start a MongoDB container when

--- a/docs/src/main/asciidoc/mutiny-primer.adoc
+++ b/docs/src/main/asciidoc/mutiny-primer.adoc
@@ -5,7 +5,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Mutiny - Async for mere mortals
 include::_attributes.adoc[]
-:categories: reactive
+:categories: core
 :topics: mutiny,reactive
 :extensions: io.quarkus:quarkus-mutiny
 

--- a/docs/src/main/asciidoc/observability-devservices-lgtm.adoc
+++ b/docs/src/main/asciidoc/observability-devservices-lgtm.adoc
@@ -5,9 +5,9 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Observability Dev Services with Grafana OTel LGTM
 include::_attributes.adoc[]
-:categories: observability,devservices,telemetry,metrics,tracing,logging, opentelemetry, micrometer, prometheus, tempo, loki, grafana
+:categories: observability
 :summary: Instructions on how to use Grafana Otel LGTM
-:topics: observability,grafana,lgtm,otlp,opentelemetry,devservices,micrometer
+:topics: observability,devservices,telemetry,metrics,tracing,logging,opentelemetry,micrometer,prometheus,tempo,loki,grafana,lgtm,otlp
 :extensions: io.quarkus:quarkus-observability-devservices
 
 This Dev Service provides the https://github.com/grafana/docker-otel-lgtm[Grafana OTel-LGTM], an `all-in-one` Docker image containing an https://opentelemetry.io/docs/collector[OpenTelemetry Collector] receiving and then forwarding telemetry data to Prometheus (metrics), Tempo (traces) and Loki (logs).

--- a/docs/src/main/asciidoc/observability-devservices.adoc
+++ b/docs/src/main/asciidoc/observability-devservices.adoc
@@ -5,9 +5,9 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Observability Dev Services
 include::_attributes.adoc[]
-:categories: observability,devservices,telemetry,metrics,tracing,logging
+:categories: observability
 :summary: Entry point for Observability DevServices
-:topics: observability,grafana,lgtm,prometheus,victoriametrics,jaeger,otel,otlp
+:topics: observability,devservices,telemetry,metrics,tracing,logging,grafana,lgtm,prometheus,victoriametrics,jaeger,otel,otlp
 :extensions: io.quarkus:quarkus-observability-devservices
 
 We are already familiar with xref:dev-services.adoc[Dev Service] concept, but in the case of Observability we need a way to orchestrate and connect more than a single Dev Service, usually a whole stack of them; e.g. a metrics agent periodically scraping application for metrics, pushing them into timeseries database, and Grafana feeding graphs of this timeseries data.


### PR DESCRIPTION
## Issue

Fixes #52794

## Type of change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Description

An audit found 3 guides missing `:categories:` entirely and 7 guides with invalid category values that do not match any defined category in the `Category` enum in `YamlMetadataGenerator.java`. These guides do not appear correctly when filtering by category on the website.

### Missing `:categories:` (3 files)
- `grpc-virtual-threads.adoc` — added `:categories: web`
- `hibernate-reactive.adoc` — added `:categories: data`
- `mongodb-dev-services.adoc` — added `:categories: data` (also added missing `:topics:` and `:extensions:`)

### Invalid category values fixed (7 files)
- `datasource.adoc` — removed invalid `reactive` from categories
- `getting-started-reactive.adoc` — replaced invalid `reactive` with `web`
- `mutiny-primer.adoc` — replaced invalid `reactive` with `core`
- `drools.adoc` — replaced invalid `rule engine` (contains space) with `business-automation`
- `extension-faq.adoc` — replaced invalid `extensions` with `writing-extensions`
- `observability-devservices.adoc` — kept only `observability` in categories; moved non-category values to `:topics:`
- `observability-devservices-lgtm.adoc` — kept only `observability` in categories; moved non-category values to `:topics:`

All replacement values were validated against the `Category` enum in `docs/src/main/java/io/quarkus/docs/generation/YamlMetadataGenerator.java`.

## Verification

- Verified all 10 files still compile/render correctly as AsciiDoc
- Cross-referenced every replacement category against the `Category` enum

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation