### PR TITLE
Support nested JSON paths in token.principal-claim for opaque tokens

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -463,9 +463,15 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                     return Uni.createFrom().failure(new AuthenticationCompletionException(errorMessage));
                 }
                 final String principalClaim = resolvedContext.oidcConfig().token().principalClaim().orElse(null);
-                if (principalClaim != null && !tokenJson.containsKey(principalClaim) && userInfo != null
-                        && userInfo.contains(principalClaim)) {
-                    tokenJson.put(principalClaim, userInfo.getString(principalClaim));
+                if (principalClaim != null && userInfo != null) {
+                    Object tokenValue = OidcUtils.findClaimValueByPath(principalClaim, tokenJson);
+                    if (tokenValue == null) {
+                        Object userInfoValue = OidcUtils.findClaimValueByPath(principalClaim,
+                                new JsonObject(userInfo.getJsonObject().toString()));
+                        if (userInfoValue != null) {
+                            tokenJson.put(principalClaim, userInfoValue);
+                        }
+                    }
                 }
                 JsonObject rolesJson = getRolesJson(requestData, resolvedContext, tokenCred, tokenJson,
                         userInfo);
@@ -499,7 +505,10 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                 if (resolvedContext.oidcConfig().token().allowOpaqueTokenIntrospection() &&
                         resolvedContext.oidcConfig().token().verifyAccessTokenWithUserInfo().orElse(false)) {
                     if (resolvedContext.oidcConfig().token().principalClaim().isPresent() && userInfo != null) {
-                        userName = userInfo.getString(resolvedContext.oidcConfig().token().principalClaim().get());
+                        Object principalValue = OidcUtils.findClaimValueByPath(
+                                resolvedContext.oidcConfig().token().principalClaim().get(),
+                                new JsonObject(userInfo.getJsonObject().toString()));
+                        userName = principalValue != null ? principalValue.toString() : null;
                     } else {
                         userName = "";
                     }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -309,6 +309,10 @@ public final class OidcUtils {
         return claimPath.indexOf('/') > 0 ? CLAIM_PATH_PATTERN.split(claimPath) : new String[] { claimPath };
     }
 
+    static Object findClaimValueByPath(String claimPath, JsonObject json) {
+        return findClaimValue(claimPath, json, splitClaimPath(claimPath), 0);
+    }
+
     private static Object findClaimValue(String claimPath, JsonObject json, String[] pathArray, int step) {
         Object claimValue = json.getValue(pathArray[step].replace("\"", ""));
         if (claimValue == null) {


### PR DESCRIPTION
## Issue

Fixes #53106

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Description

When using `quarkus.oidc.token.verify-access-token-with-user-info=true` to validate opaque Bearer tokens, the `quarkus.oidc.token.principal-claim` property only resolves top-level string fields from the UserInfo response. Nested JSON paths like `metadata/name` return `null`, resulting in an empty principal.

This is inconsistent with `quarkus.oidc.roles.role-claim-path` which already supports `/`-separated nested paths via `OidcUtils.findClaimValue()`.

### Changes

**`OidcUtils.java`** — Added package-private `findClaimValueByPath(String, JsonObject)` that wraps the existing private `findClaimValue` + `splitClaimPath` methods, making nested claim path resolution available to `OidcIdentityProvider`.

**`OidcIdentityProvider.java`** — Two code paths fixed:

1. **JWT token path (line ~465):** Replaced flat `containsKey()`/`contains()`/`getString()` with `findClaimValueByPath()` when copying the principal claim from UserInfo into the token JSON.

2. **Opaque token path (line ~502):** Replaced `userInfo.getString()` with `findClaimValueByPath()` when extracting the principal name from UserInfo.

Both paths now convert `UserInfo` (which wraps `jakarta.json.JsonObject`) to a Vertx `JsonObject` using the same pattern as `getRolesJson()` (line 613).

## Verification

- OIDC runtime module compiles successfully
- All 29 existing `OidcUtilsTest` tests pass
- Simple (non-nested) principal claims continue to work since `splitClaimPath` returns a single-element array for paths without `/`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes