### PR TITLE
Add standalone OIDC Dev Services to dev-services guide and cross-link docs

### DIFF
--- a/docs/src/main/asciidoc/dev-services.adoc
+++ b/docs/src/main/asciidoc/dev-services.adoc
@@ -99,6 +99,7 @@ xref:kafka-dev-services.adoc[Kafka Dev Services Guide].
 
 include::{generated-dir}/config/quarkus-kafka-client_quarkus.kafka.devservices.adoc[opts=optional, leveloffset=+1]
 
+[[keycloak]]
 === Keycloak
 
 The Keycloak Dev Service will be enabled when the `quarkus-oidc` extension is present in your application, and
@@ -106,6 +107,8 @@ the server address has not been explicitly configured. More information can be f
 xref:security-openid-connect-dev-services.adoc[OIDC Dev Services Guide].
 
 include::{generated-dir}/config/quarkus-devservices-keycloak_quarkus.keycloak.adoc[opts=optional, leveloffset=+1]
+
+A lightweight <<oidc,OIDC Dev Service>> is also available as an alternative to Keycloak.
 
 === Kubernetes
 
@@ -129,6 +132,16 @@ the server address has not been explicitly configured. More information can be f
 xref:mongodb-dev-services.adoc[MongoDB Guide].
 
 include::{generated-dir}/config/quarkus-mongodb-client_quarkus.mongodb.devservices.adoc[opts=optional, leveloffset=+1]
+
+[[oidc]]
+=== OIDC
+
+A standalone OIDC Dev Service is available as a lightweight alternative to <<keycloak,Keycloak>>.
+It is enabled by default when Docker and Podman are not available, or it can be explicitly enabled with `quarkus.oidc.devservices.enabled=true`.
+More information can be found in the
+xref:security-openid-connect-dev-services.adoc#dev-services-for-oidc[OIDC Dev Services Guide].
+
+include::{generated-dir}/config/quarkus-devservices-oidc_quarkus.oidc.adoc[opts=optional, leveloffset=+1]
 
 === RabbitMQ
 

--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -439,10 +439,17 @@ Whichever user you choose, no password is required.
 
 == Configuration reference
 
+=== Keycloak Dev Services
+
 include::{generated-dir}/config/quarkus-devservices-keycloak_quarkus.keycloak.adoc[opts=optional, leveloffset=+1]
+
+=== OIDC Dev Services
+
+include::{generated-dir}/config/quarkus-devservices-oidc_quarkus.oidc.adoc[opts=optional, leveloffset=+1]
 
 == References
 
+* xref:dev-services.adoc[Dev Services Overview]
 * xref:dev-ui.adoc[Dev UI]
 * https://www.keycloak.org/documentation.html[Keycloak Documentation]
 * https://openid.net/connect/[OpenID Connect]


### PR DESCRIPTION
Fixes #46038

The Dev Services overview guide mentions Keycloak but not the standalone OIDC Dev Service. Also, the OIDC dev services guide does not link back to the Dev Services overview page.

Changes:
- Add a new "OIDC" section to `dev-services.adoc` describing the standalone OIDC Dev Service as a lightweight Keycloak alternative, with a config reference include and link to the OIDC dev services guide
- Split the "Configuration reference" section in `security-openid-connect-dev-services.adoc` into separate Keycloak and OIDC subsections, adding the OIDC dev services config include
- Add a link to the Dev Services overview in the References section of the OIDC dev services guide