### PR TITLE
Document Sort.disableEscaping() for HQL functions in Panache guide

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -716,6 +716,14 @@ List<Person> persons = Person.list(Sort.by("birth", Sort.NullPrecedence.NULLS_FI
 
 The `Sort` class has plenty of methods for adding columns and specifying sort direction or the null precedence.
 
+NOTE: Panache escapes column names in `Sort` to prevent HQL injection.
+If you need to use HQL functions such as `lower()` or `upper()` in your sort clause, you must disable escaping:
+
+[source,java]
+----
+List<Person> persons = Person.list(Sort.by("lower(name)").disableEscaping());
+----
+
 === Simplified queries
 
 Normally, HQL queries are of this form: `from EntityName [where ...] [order by ...]`, with optional elements


### PR DESCRIPTION
Panache escapes column names in `Sort` to prevent HQL injection. When users need HQL functions like `lower()` or `upper()` in their sort clause, they must call `disableEscaping()`. This was not documented, causing confusion during upgrades from Quarkus 3.8 to 3.14+.

Adds a NOTE to the Sorting section of the Panache guide with an example of `Sort.by("lower(name)").disableEscaping()`.

- Fixes: #42900
