### PR TITLE
Add missing quarkus.artemis.enabled property to JMS guide

### DIFF
--- a/docs/src/main/asciidoc/jms.adoc
+++ b/docs/src/main/asciidoc/jms.adoc
@@ -381,10 +381,14 @@ This is done in the `src/main/resources/application.properties` file.
 [source,properties]
 ----
 # Configures the Artemis properties.
+quarkus.artemis.enabled=true
 quarkus.artemis.url=tcp://localhost:61616
 quarkus.artemis.username=quarkus
 quarkus.artemis.password=quarkus
 ----
+
+NOTE: The `quarkus.artemis.enabled` property is a build-time setting that must be set to `true` for the `ConnectionFactory` bean to be created.
+Without it, the extension will not produce a `ConnectionFactory` and injection will fail with an `UnsatisfiedResolutionException`.
 
 With the Artemis properties configured, you can resume the steps above from <<get-it-running>>.
 


### PR DESCRIPTION
Fixes #48141

The JMS guide's Artemis configuration section was missing the required `quarkus.artemis.enabled=true` build-time property. Without it, the extension does not produce a `ConnectionFactory` bean, causing an `UnsatisfiedResolutionException` at startup.

Adds the property to the configuration example and a NOTE explaining that it is a build-time requirement.