### PR TITLE
Fix annotation from @BuildSteps to @BuildStep in devservice guide

### DIFF
--- a/docs/src/main/asciidoc/extension-writing-dev-service.adoc
+++ b/docs/src/main/asciidoc/extension-writing-dev-service.adoc
@@ -48,7 +48,7 @@ Here, the https://hub.docker.com/_/hello-world[`hello-world`] image is used, but
 
 [source,java]
 ----
-@BuildSteps(onlyIf = { IsDevServicesSupportedByLaunchMode.class, DevServicesConfig.Enabled.class })
+@BuildStep(onlyIf = { IsDevServicesSupportedByLaunchMode.class, DevServicesConfig.Enabled.class })
 public DevServicesResultBuildItem createContainer() {
     DockerImageName dockerImageName = DockerImageName.parse("hello-world");
     GenericContainer container = new GenericContainer<>(dockerImageName)
@@ -118,7 +118,7 @@ For example,
 
 [source,java]
 ----
-@BuildSteps(onlyIf = { IsDevServicesSupportedByLaunchMode.class, DevServicesConfig.Enabled.class })
+@BuildStep(onlyIf = { IsDevServicesSupportedByLaunchMode.class, DevServicesConfig.Enabled.class })
 public DevServicesResultBuildItem createContainer(MyConfig config) {}
 ----
 


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]
Probably was a typo in the dev service guide to use @BuildSteps instead of @BuildStep in the examples.

Note: If you want I can crate an Issue for this, but imo this is not needed for this small change.
<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

