### PR TITLE
Extension-based modularity

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,6 +63,7 @@ updates:
       - dependency-name: io.smallrye.beanbag:*
       - dependency-name: io.smallrye.common:*
       - dependency-name: io.smallrye.config:*
+      - dependency-name: io.smallrye.modules:*
       - dependency-name: io.smallrye.reactive:*
       # RX Java 2
       - dependency-name: io.reactivex.rxjava2:rxjava

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -48,6 +48,7 @@
         <smallrye-common.version>2.18.1</smallrye-common.version>
         <smallrye-config.version>3.17.2</smallrye-config.version>
         <smallrye-health.version>4.3.0</smallrye-health.version>
+        <smallrye-modules.version>1.0.beta1</smallrye-modules.version>
         <smallrye-open-api.version>4.3.3</smallrye-open-api.version>
         <smallrye-graphql.version>2.18.1</smallrye-graphql.version>
         <smallrye-fault-tolerance.version>6.11.1</smallrye-fault-tolerance.version>
@@ -1751,6 +1752,41 @@
             <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-jdbc-oracle-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-modular</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-modular-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-modular-spi</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-jlink</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-jlink-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-jlink-launcher</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-jlink-spi</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -4274,6 +4310,11 @@
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-health-provided-checks</artifactId>
                 <version>${smallrye-health.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye.modules</groupId>
+                <artifactId>smallrye-modules</artifactId>
+                <version>${smallrye-modules.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.smallrye</groupId>

--- a/devtools/bom-descriptor-json/pom.xml
+++ b/devtools/bom-descriptor-json/pom.xml
@@ -1313,6 +1313,19 @@
                 </dependency>
                 <dependency>
                     <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-jlink</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-jsonb</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>
@@ -1704,6 +1717,19 @@
                 <dependency>
                     <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-minikube</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-modular</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>
                     <scope>test</scope>

--- a/devtools/bom-descriptor-json/src/main/resources/catalog-overrides.json
+++ b/devtools/bom-descriptor-json/src/main/resources/catalog-overrides.json
@@ -139,6 +139,11 @@
       "name": "Alternative languages",
       "id": "alt-languages",
       "description": "Support for other JVM based languages"
+    },
+    {
+      "name": "Packaging",
+      "id": "packaging",
+      "description": "Support for packaging a built application in various ways"
     }
   ],
   "metadata":{

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -1277,6 +1277,19 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jlink-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jsonb-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
@@ -1668,6 +1681,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-minikube-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-modular-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/docs/src/main/asciidoc/jlink.adoc
+++ b/docs/src/main/asciidoc/jlink.adoc
@@ -1,0 +1,103 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
+[id="jlink"]
+= JLink packaging
+include::_attributes.adoc[]
+:diataxis-type: reference
+:categories: packaging
+:extension-status: experimental
+:summary: The jlink extension produces a custom Java runtime image containing only the modules needed to run the application.
+:topics: jlink,packaging,modules,modularity
+:extensions: io.quarkus:quarkus-jlink
+
+The `jlink` extension produces a custom Java runtime image for a Quarkus application.
+The image contains only the JDK modules and application modules that are needed to run the application, resulting in a smaller, faster, and more self-contained distribution.
+This extension depends on the xref:modularity.adoc[Quarkus modularity extension] to compute the application's module graph.
+
+include::{includes}/extension-status.adoc[]
+
+== Prerequisites
+
+The `jlink` extension requires Java 25 or later.
+Earlier JDK versions have compatibility issues with the `jlink` tool that prevent reliable image generation.
+
+== Usage
+
+Add the `quarkus-jlink` extension to your project.
+When the extension is present, a `jlink` image is produced automatically as part of the normal Quarkus build.
+JAR packaging is disabled when `jlink` is active.
+
+:add-extension-extensions: quarkus-jlink
+include::{includes}/devtools/extension-add.adoc[]
+
+After adding the extension, build the project normally:
+
+include::{includes}/devtools/build.adoc[]
+
+The `jlink` image is written to the output directory (by default, `target/jlink-output/image`).
+
+== Running the image
+
+To run the application, execute the launcher script in the image's `bin` directory:
+
+[source,bash]
+----
+./target/jlink-output/image/bin/<launcher-name>
+----
+
+The launcher name defaults to the value of `quarkus.package.output-name`.
+
+== Image layout
+
+The output directory has the standard `jlink` image structure.
+The `bin/` directory contains the launcher script.
+The `lib/` directory contains the JDK runtime modules.
+Application modules that are not on the boot module path are placed in `lib/quarkus/` and are loaded dynamically on demand after startup by `smallrye-modules`.
+See the xref:modularity.adoc[modularity guide] for an explanation of boot modules and dynamic modules.
+
+== Configuration reference
+
+`quarkus.jlink.enabled`::
+Whether jlink image generation is enabled.
+Type: `boolean`.
+Default: `true`.
+
+`quarkus.jlink.min-heap-size`::
+The minimum heap size to configure in the image's JVM options.
+If not set, no minimum heap size is specified.
+Type: `MemorySize` (optional).
+
+`quarkus.jlink.max-heap-size`::
+The maximum heap size to configure in the image's JVM options.
+If not set, no maximum heap size is specified.
+Type: `MemorySize` (optional).
+
+`quarkus.jlink.image-path`::
+The path of the image directory within the output directory.
+Type: `Path`.
+Default: `image`.
+
+`quarkus.jlink.launcher-name`::
+The name of the launcher script generated in the image's `bin/` directory.
+Type: `String`.
+Default: derived from `quarkus.package.output-name`.
+
+`quarkus.jlink.output-directory`::
+The base output directory for the jlink build.
+Type: `Path`.
+Default: derived from `quarkus.package.output-directory`.
+
+`quarkus.jlink.staging-directory`::
+The path of the staging directory used during the jlink build process, relative to the output directory.
+Type: `Path`.
+Default: `staging`.
+
+== CDS support
+
+Support for Class Data Sharing (CDS) and AOT precompilation within jlink images is planned for a future release.
+
+CDS currently only applies to modules on the boot module path.
+Dynamic modules loaded by `smallrye-modules` are not eligible for CDS precompilation at this time.

--- a/docs/src/main/asciidoc/modularity-reference.adoc
+++ b/docs/src/main/asciidoc/modularity-reference.adoc
@@ -1,0 +1,109 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
+[id="modularity-reference"]
+= Modularity SPI reference
+include::_attributes.adoc[]
+:diataxis-type: reference
+:categories: architecture
+:extension-status: experimental
+:summary: Reference for the build items that Quarkus extensions use to participate in Quarkus modularity.
+:topics: modularity,jpms,modules,extensions,spi
+
+This document describes the build items that extension authors use to integrate with the xref:modularity.adoc[Quarkus modularity] system.
+Extensions can declare boot modules, add inter-module dependencies, and consume the completed module model.
+
+include::{includes}/extension-status.adoc[]
+
+== `BootModulePathBuildItem`
+
+`BootModulePathBuildItem` is a `MultiBuildItem` produced by extensions.
+It declares that a named module must be placed on the boot module path.
+
+An extension should produce this item when it provides a module that must be in the JDK's boot module layer.
+This is necessary when the module is required before the dynamic module loader (`smallrye-modules`) starts, or when the module must participate in the boot class loading chain.
+
+The constructor takes a single `String` parameter: the module name.
+
+[source,java]
+----
+@BuildStep
+BootModulePathBuildItem myBootModule() {
+    return new BootModulePathBuildItem("com.example.my.boot.module");
+}
+----
+
+The modularity extension computes the transitive closure of all declared boot modules.
+If a boot module depends on other modules (via `LINKED` dependencies), those modules are also included in the boot set automatically.
+Automatic modules are excluded from the boot set because they cannot be linked by `jlink`.
+
+== `AddDependencyBuildItem`
+
+`AddDependencyBuildItem` is a `MultiBuildItem` produced by extensions.
+It adds a dependency between two modules at build time.
+
+An extension should produce this item when it needs to wire a module dependency that is not expressed in the Maven POM or in the module's `module-info.class` descriptor.
+This is common when Quarkus extensions generate code that references types from another module, or when service loading relationships must be declared explicitly.
+
+The constructor takes three parameters: the source module name (`String`), the target module name (`String`), and a set of dependency modifiers (`Modifiers<Dependency.Modifier>`).
+
+[source,java]
+----
+@BuildStep
+AddDependencyBuildItem extraDependency() {
+    return new AddDependencyBuildItem(
+        "com.example.source.module",
+        "com.example.target.module",
+        Dependency.Modifier.set(Dependency.Modifier.LINKED, Dependency.Modifier.READ));
+}
+----
+
+When multiple items declare the same source/target pair, their modifier sets are merged.
+
+== `ApplicationModuleInfoBuildItem`
+
+`ApplicationModuleInfoBuildItem` is a `SimpleBuildItem` produced by the modularity extension.
+It contains the completed `AppModuleModel`, which includes the module descriptor for every module in the application, the set of boot modules, and the set of JDK modules in use.
+
+This item is consumed by downstream packaging extensions such as the xref:jlink.adoc[jlink extension].
+Extension authors generally do not need to consume this item unless they are implementing a custom packaging step.
+
+== Dependency modifiers
+
+The `Dependency.Modifier` enum (from `io.smallrye.modules.desc`) defines the following values.
+These are used with `AddDependencyBuildItem` to control how the dependency is wired.
+
+`LINKED`::
+The dependency is linked for class loading.
+Classes from the target module are visible to the source module's class loader.
+
+`READ`::
+The dependency is readable from the source module.
+Exported packages from the target module are accessible to the source module.
+
+`SERVICES`::
+Service implementations in the target module are available to the source module via `ServiceLoader`.
+
+`OPTIONAL`::
+The dependency is optional.
+If the target module is not present at link time, the dependency is silently ignored rather than causing a failure.
+
+`TRANSITIVE`::
+The dependency is transitive.
+Any module that depends on the source module also implicitly depends on the target module.
+
+`SYNTHETIC`::
+The dependency was added by a framework rather than declared in the original module descriptor. _Note:_ because modifier sets are merged when a dependency is declared in two places, this modifier would take precedence over a non-synthetic dependency, which is a minor detail but possibly undesirable. Thus, this modifier may change to be "non-synthetic" or something along those lines in the final version, so that an explicit dependency will never be marked as being synthetic.
+
+`MANDATED`::
+The dependency is mandated by specification (for example, the implicit dependency on `java.base`).
+
+== Related core build items
+
+The `quarkus-core-deployment` module provides two additional build items that affect the module graph.
+These are documented separately but are noted here for completeness.
+
+`ModuleOpenBuildItem` declares that one module should open specified packages to another module (equivalent to the `--add-opens` JVM flag).
+`ModuleEnableNativeAccessBuildItem` declares that a module requires native access (equivalent to the `--enable-native-access` JVM flag).

--- a/docs/src/main/asciidoc/modularity.adoc
+++ b/docs/src/main/asciidoc/modularity.adoc
@@ -1,0 +1,75 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
+[id="modularity"]
+= Quarkus modularity
+include::_attributes.adoc[]
+:diataxis-type: concept
+:categories: architecture
+:extension-status: experimental
+:summary: Quarkus modularity builds on JPMS to produce a complete and enhanced module graph for the application at build time.
+:topics: modularity,jpms,modules,extensions
+
+The Quarkus modularity extension constructs a complete module graph for a Quarkus application at build time.
+It is a superset of the Java Platform Module System (JPMS), enhancing and completing the module information for every artifact in the application.
+This extension is intended to be consumed by other Quarkus extensions (such as the xref:jlink.adoc[jlink extension]) rather than by application developers directly.
+
+include::{includes}/extension-status.adoc[]
+
+== What Quarkus modularity does
+
+Quarkus modularity processes every artifact in the application's dependency graph and produces a unified module model.
+It handles two cases.
+
+For artifacts that contain a `module-info.class` descriptor, the extension reads the existing module information and enhances it with Quarkus-specific dependency data.
+This includes additional `opens` and `exports` directives, extra inter-module dependencies, and service provider information that JPMS does not capture on its own.
+
+For artifacts that lack a `module-info.class` (automatic modules), the extension computes a module descriptor.
+Unlike the default JDK behavior where automatic modules can read every other module, Quarkus scopes each automatic module's dependencies to match its Maven dependency graph.
+This produces a more accurate and constrained set of module relationships.
+
+The extension also supports dependency semantics that go beyond what JPMS provides.
+Module dependencies carry distinct modifiers such as `LINKED`, `READ`, `SERVICES`, and `OPTIONAL`, which control how and whether modules are wired together at both link time and run time.
+
+== Boot modules and dynamic modules
+
+The modularity extension organizes modules into two tiers: boot modules and dynamic modules.
+
+Boot modules are loaded by the JDK's boot module layer.
+A small set of modules must be present on the boot module path in order for the JVM to start in module mode.
+This set includes the module system loader itself (`smallrye-modules`), a minimal launcher, and the transitive dependencies of those components (typically logging support and a few common libraries).
+The boot module set is kept as small as possible.
+
+Dynamic modules are loaded at runtime by `smallrye-modules`.
+This module loader is more capable and more flexible than the JDK's built-in module layer support.
+Application code and the majority of library modules reside in this tier.
+
+One consequence of this split is that JDK AOT precompilation via Class Data Sharing (CDS) currently only supports modules on the boot module path.
+This is a known limitation.
+
+== `smallrye-modules`
+
+The https://github.com/smallrye/smallrye-modules[`smallrye-modules`] project provides the module loader that powers the dynamic module tier.
+It supports extended dependency semantics beyond those offered by JPMS, including the additional modifier types described above.
+
+Extension authors do not usually interact with `smallrye-modules` directly.
+Instead, they use the build items described in the xref:modularity-reference.adoc[modularity SPI reference] to declare boot modules, add inter-module dependencies, and contribute other module metadata at build time.
+
+== How the module model is built
+
+At build time, the modularity extension assembles the module model through the following process.
+
+All runtime artifacts are collected from the application's dependency model.
+Classes and resources generated or transformed during the Quarkus build (such as those produced by ArC or bytecode recorders) are assigned to their owning modules based on package membership.
+
+For each artifact, the extension either reads its `module-info.class` descriptor or computes an automatic module descriptor from its Maven dependencies.
+Contributions from other extensions, provided through build items, are then merged into each module's descriptor.
+These contributions include extra dependencies between modules, additional `opens` and `exports` directives, and native access flags.
+
+The boot module set is computed as the transitive closure of all modules declared as boot modules by extensions.
+Automatic modules are excluded from the boot set because they cannot be linked by `jlink`.
+
+The final result is an `ApplicationModuleInfoBuildItem` containing the complete `AppModuleModel`.
+Downstream packaging extensions, such as the xref:jlink.adoc[`jlink` extension], consume this model to produce the application's runtime image.

--- a/extensions/packaging/jlink/deployment/pom.xml
+++ b/extensions/packaging/jlink/deployment/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-jlink-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-jlink-deployment</artifactId>
+
+    <name>Quarkus - JLink - Deployment</name>
+    <description>The build module for JLink packaging</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-builder</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-modular-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jlink-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jlink</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.quarkus</groupId>
+                                    <artifactId>quarkus-extension-processor</artifactId>
+                                    <version>${project.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/packaging/jlink/deployment/src/main/java/io/quarkus/jlink/deployment/JLinkBuildProvider.java
+++ b/extensions/packaging/jlink/deployment/src/main/java/io/quarkus/jlink/deployment/JLinkBuildProvider.java
@@ -1,0 +1,15 @@
+package io.quarkus.jlink.deployment;
+
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildProvider;
+import io.quarkus.jlink.spi.JLinkImageBuildItem;
+
+/**
+ * A build provider which causes the jlink image to be built.
+ * This is a provided service.
+ */
+public final class JLinkBuildProvider implements BuildProvider {
+    public void installInto(final BuildChainBuilder builder) {
+        builder.addFinal(JLinkImageBuildItem.class);
+    }
+}

--- a/extensions/packaging/jlink/deployment/src/main/java/io/quarkus/jlink/deployment/JLinkConfig.java
+++ b/extensions/packaging/jlink/deployment/src/main/java/io/quarkus/jlink/deployment/JLinkConfig.java
@@ -1,0 +1,62 @@
+package io.quarkus.jlink.deployment;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.quarkus.runtime.configuration.MemorySize;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+/**
+ * Configuration for producing a {@code jlink} image.
+ */
+@ConfigRoot
+@ConfigMapping(prefix = "quarkus.jlink")
+// @WithDynamicDefaults(JLinkConfigDefaults.class)
+public interface JLinkConfig {
+    /**
+     * {@return {@code true} to enable {@code jlink} execution, or {@code false} otherwise}
+     */
+    @WithDefault("true")
+    boolean enabled();
+
+    /**
+     * {@return the minimum heap size to configure for the image}
+     * If not given, then no default value will be set in the resultant {@code jlink} image.
+     */
+    Optional<MemorySize> minHeapSize();
+
+    /**
+     * {@return the maximum heap size to configure for the image}
+     * If not given, then no default value will be set in the resultant {@code jlink} image.
+     */
+    Optional<MemorySize> maxHeapSize();
+
+    /**
+     * {@return the image output path}
+     * If relative, it will be resolved in terms of the packaging output path.
+     */
+    @WithDefault("image")
+    Path imagePath();
+
+    /**
+     * {@return the launcher name}
+     */
+    //TODO TEMPORARY DEFAULT
+    @WithDefault("my-app")
+    String launcherName();
+
+    /**
+     * {@return the output directory}
+     */
+    // TODO: this should be based on some build system configuration
+    @WithDefault("target/jlink-output")
+    Path outputDirectory();
+
+    /**
+     * {@return the path of the staging directory for {@code jlink} output}
+     */
+    @WithDefault("staging")
+    Path stagingDirectory();
+}

--- a/extensions/packaging/jlink/deployment/src/main/java/io/quarkus/jlink/deployment/JLinkConfigCustomizer.java
+++ b/extensions/packaging/jlink/deployment/src/main/java/io/quarkus/jlink/deployment/JLinkConfigCustomizer.java
@@ -1,0 +1,18 @@
+package io.quarkus.jlink.deployment;
+
+import io.smallrye.config.SmallRyeConfigBuilder;
+import io.smallrye.config.SmallRyeConfigBuilderCustomizer;
+
+/**
+ * The factory for the defaults interceptor.
+ */
+// todo: remove if we get @WithDynamicDefaults
+public final class JLinkConfigCustomizer implements SmallRyeConfigBuilderCustomizer {
+    public void configBuilder(final SmallRyeConfigBuilder builder) {
+        builder.withInterceptors(new JLinkConfigDefaultsInterceptor());
+    }
+
+    public int priority() {
+        return Integer.MIN_VALUE + 1;
+    }
+}

--- a/extensions/packaging/jlink/deployment/src/main/java/io/quarkus/jlink/deployment/JLinkConfigDefaults.java
+++ b/extensions/packaging/jlink/deployment/src/main/java/io/quarkus/jlink/deployment/JLinkConfigDefaults.java
@@ -1,0 +1,32 @@
+package io.quarkus.jlink.deployment;
+
+import io.smallrye.config.ConfigSourceInterceptorContext;
+import io.smallrye.config.ConfigValue;
+
+/**
+ * The dynamic configuration default values for {@link JLinkConfig}.
+ */
+public final class JLinkConfigDefaults {
+    public JLinkConfigDefaults() {
+    }
+
+    /**
+     * The default output directory is derived from the default packaging directory.
+     *
+     * @param ctxt the interceptor context (must not be {@code null})
+     * @return the config value, or {@code null} if it is not found
+     */
+    public ConfigValue outputDirectory(ConfigSourceInterceptorContext ctxt) {
+        return ctxt.restart("quarkus.package.output-directory");
+    }
+
+    /**
+     * The default JLink launcher name is derived from the packaging out put name.
+     *
+     * @param ctxt the interceptor context (must not be {@code null})
+     * @return the config value, or {@code null} if it is not found
+     */
+    public ConfigValue launcherName(ConfigSourceInterceptorContext ctxt) {
+        return ctxt.restart("quarkus.package.output-name");
+    }
+}

--- a/extensions/packaging/jlink/deployment/src/main/java/io/quarkus/jlink/deployment/JLinkConfigDefaultsInterceptor.java
+++ b/extensions/packaging/jlink/deployment/src/main/java/io/quarkus/jlink/deployment/JLinkConfigDefaultsInterceptor.java
@@ -1,0 +1,32 @@
+package io.quarkus.jlink.deployment;
+
+import jakarta.annotation.Priority;
+
+import io.smallrye.config.ConfigSourceInterceptor;
+import io.smallrye.config.ConfigSourceInterceptorContext;
+import io.smallrye.config.ConfigValue;
+
+/**
+ * This class connects to {@link JLinkConfigDefaults} until such time that the config
+ * infrastructure can do this itself.
+ */
+// todo: remove if we get @WithDynamicDefaults
+@Priority(Integer.MIN_VALUE + 1)
+public final class JLinkConfigDefaultsInterceptor implements ConfigSourceInterceptor {
+    private final JLinkConfigDefaults defaults = new JLinkConfigDefaults();
+
+    public ConfigValue getValue(final ConfigSourceInterceptorContext context, final String name) {
+        return switch (name) {
+            // TODO: https://github.com/quarkusio/quarkus/issues/54283
+            //case "quarkus.jlink.launcher-name" -> defaults.launcherName(context);
+
+            // TODO: https://github.com/quarkusio/quarkus/issues/54283
+            //case "quarkus.jlink.output-directory" -> defaults.outputDirectory(context);
+
+            // override legacy packaging config to not produce a JAR when this is enabled
+            case "quarkus.package.jar.enabled" -> context.proceed(name).withValue("false");
+
+            default -> context.proceed(name);
+        };
+    }
+}

--- a/extensions/packaging/jlink/deployment/src/main/java/io/quarkus/jlink/deployment/JLinkSteps.java
+++ b/extensions/packaging/jlink/deployment/src/main/java/io/quarkus/jlink/deployment/JLinkSteps.java
@@ -1,0 +1,304 @@
+package io.quarkus.jlink.deployment;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.jar.Manifest;
+import java.util.spi.ToolProvider;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.builder.BuildException;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.gizmo2.Const;
+import io.quarkus.gizmo2.Gizmo;
+import io.quarkus.gizmo2.ParamVar;
+import io.quarkus.gizmo2.desc.MethodDesc;
+import io.quarkus.jlink.launcher.JLinkAppLauncher;
+import io.quarkus.jlink.spi.JLinkImageBuildItem;
+import io.quarkus.jlink.spi.JLinkStagedOutputItem;
+import io.quarkus.modular.spi.ModuleWriter;
+import io.quarkus.modular.spi.items.ApplicationModuleInfoBuildItem;
+import io.quarkus.modular.spi.items.BootModulePathBuildItem;
+import io.quarkus.modular.spi.model.AppModuleModel;
+import io.quarkus.modular.spi.model.DependencyInfo;
+import io.quarkus.modular.spi.model.ModuleInfo;
+import io.smallrye.common.io.Files2;
+import io.smallrye.common.resource.MemoryResource;
+import io.smallrye.common.resource.Resource;
+import io.smallrye.modules.desc.Dependency;
+
+/**
+ * The steps for producing a jlink image from the modular model.
+ */
+public final class JLinkSteps {
+    private static final Logger log = Logger.getLogger("io.quarkus.jlink");
+    private static final Logger jlinkOut = Logger.getLogger("io.quarkus.jlink.out");
+    public static final String APP_MAIN = "io.quarkus.jlink.launcher.AppMain";
+
+    private final JLinkConfig config;
+
+    public JLinkSteps(final JLinkConfig config) {
+        this.config = config;
+    }
+
+    /**
+     * {@return the item for the jlink launcher module}
+     */
+    @BuildStep
+    public BootModulePathBuildItem bootPath() {
+        return new BootModulePathBuildItem("io.quarkus.jlink.launcher");
+    }
+
+    /**
+     * Steps to stage the jlink output into directories so it can be processed by the tool itself.
+     *
+     * @param curateOutcome the curate outcome item (must not be {@code null})
+     * @param moduleInfoItem the modular model item (must not be {@code null})
+     * @return the staged jlink output (not {@code null})
+     * @throws IOException if a file operation fails
+     */
+    @BuildStep
+    public JLinkStagedOutputItem stageOutput(
+            CurateOutcomeBuildItem curateOutcome,
+            ApplicationModuleInfoBuildItem moduleInfoItem) throws IOException {
+
+        // gather information we'll need
+        AppModuleModel model = moduleInfoItem.model();
+        Map<String, ModuleInfo> modulesByName = model.modulesByName();
+
+        // create the staging directory
+        final Path staging = config.outputDirectory().resolve(config.stagingDirectory());
+        Files.createDirectories(staging);
+
+        // create a mapping for each boot module path
+        final Map<String, Path> bmp = new HashMap<>();
+        for (String moduleName : model.bootModules()) {
+            // get this boot module descriptor
+            ModuleInfo moduleInfo = modulesByName.get(moduleName);
+            if (moduleInfo == null) {
+                throw new IllegalStateException("Boot module listed in model is missing from the module index");
+            }
+            // our special launcher module
+            if (moduleName.equals("io.quarkus.jlink.launcher")) {
+                // the list of resources produced by generating the main class
+                List<Resource> dynModuleResources = new ArrayList<>();
+                // generate the simple main class which runs the launcher with the app module info
+                Gizmo gizmo = Gizmo.create((path, bytes) -> dynModuleResources.add(new MemoryResource(path, bytes)));
+                gizmo.class_(APP_MAIN, cc -> {
+                    cc.public_();
+                    cc.staticMethod("main", mc -> {
+                        mc.public_();
+                        ParamVar args = mc.parameter("args", String[].class);
+                        mc.body(b0 -> {
+                            b0.invokeStatic(
+                                    MethodDesc.of(JLinkAppLauncher.class, "run", void.class, String.class, String[].class),
+                                    Const.of(moduleInfoItem.model().appModuleInfo().name()),
+                                    args);
+                            b0.return_();
+                        });
+                    });
+                });
+                // create a derived launcher module which includes our generated class and a dep on the app module
+                moduleInfo = moduleInfo
+                        .withMoreResources(dynModuleResources)
+                        .withMoreDependencies(model.bootModules().stream().filter(n -> !n.equals(moduleName))
+                                .map(n -> new DependencyInfo(n,
+                                        Dependency.Modifier.Set.of(Dependency.Modifier.LINKED, Dependency.Modifier.READ,
+                                                Dependency.Modifier.SERVICES),
+                                        Map.of()))
+                                .toList())
+                        .withMainClass(APP_MAIN);
+            }
+            // write the JAR
+            // TODO: create an actual manifest (if needed)
+            bmp.put(moduleName, ModuleWriter.writeModule(moduleInfo, staging, new Manifest(), true));
+        }
+        return new JLinkStagedOutputItem(staging, bmp);
+    }
+
+    /**
+     * A step to execute jlink on the staged output and copy in the dynamic module set to produce the final image.
+     *
+     * @param stagedOutput the staged jlink output item (must not be {@code null})
+     * @param moduleInfoItem the modular model item (must not be {@code null})
+     * @return an item representing the built image (not {@code null})
+     * @throws BuildException if there is a problem running jlink
+     * @throws IOException if there is a filesystem problem
+     */
+    @BuildStep
+    public JLinkImageBuildItem jlink(
+            JLinkStagedOutputItem stagedOutput,
+            ApplicationModuleInfoBuildItem moduleInfoItem) throws BuildException, IOException {
+        Path imagePath = config.outputDirectory().resolve(config.imagePath());
+
+        // the image must be deleted or jlink will complain
+        if (Files.exists(imagePath)) {
+            Files2.deleteRecursively(imagePath);
+        }
+
+        // use the ToolProvider interface for now; later, explore calling directly via jlink internal API
+        ToolProvider jlinkProvider = ToolProvider.findFirst("jlink")
+                .orElseThrow(() -> new BuildException("jlink is not present"));
+        List<String> jvmArgs = new ArrayList<>();
+        List<String> jlinkArgs = new ArrayList<>();
+
+        // JVM args
+
+        String addedModules = "ALL-MODULE-PATH,jdk.jdwp.agent," + String.join(",", moduleInfoItem.model().jdkModulesUsed());
+
+        // access to module internals
+        jvmArgs.add("--add-exports=java.base/jdk.internal.module=io.smallrye.modules");
+        // add modules to JVM path
+        // xxx replace with injected module dependencies on main module?
+        jvmArgs.add("--add-modules=" + addedModules);
+        // todo: patch for loom
+        //jvmArgs.add("--patch-module");
+        //jvmArgs.add("java.base=" + javaBasePatchPath);
+        // memory
+        // todo: scale these values so they aren't silly long
+        config.minHeapSize().ifPresent(s -> jvmArgs.add("-Xms" + s.asBigInteger()));
+        config.maxHeapSize().ifPresent(s -> jvmArgs.add("-Xmx" + s.asBigInteger()));
+        jvmArgs.add("-Djava.util.logging.manager=org.jboss.logmanager.LogManager");
+        // xxx CDS arguments
+
+        // JLink args
+
+        // bind services
+        //jlinkArgs.add("--bind-services"); // XXX tries to link against jlink for some reason?
+        // minimize the image
+        jlinkArgs.add("--no-header-files");
+        jlinkArgs.add("--no-man-pages");
+        // avoid issues with signed JARs
+        jlinkArgs.add("--ignore-signing-information");
+        // launcher
+        // todo: support multiple launchers? one per profile?
+        jlinkArgs.add("--launcher");
+        jlinkArgs.add(config.launcherName() + "=io.quarkus.jlink.launcher/" + APP_MAIN);
+        // todo: verbose output
+        //jlinkArgs.add("-v");
+        // output path
+        jlinkArgs.add("--output");
+        jlinkArgs.add(imagePath.toString());
+
+        // JLink plugin args
+
+        // CDS arguments -- todo
+        //jlinkArgs.add("--generate-cds-archive");
+        // add necessary JDK options
+        if (!jvmArgs.isEmpty()) {
+            jlinkArgs.add("--add-options=" + String.join(" ", jvmArgs));
+        }
+        // just choose server VM
+        jlinkArgs.add("--vm");
+        jlinkArgs.add("server");
+
+        // ↓↓ these options must be LAST ↓↓
+
+        // build the module path from patched JARs
+        jlinkArgs.add("--module-path");
+        // todo: maybe just a directory instead?
+        jlinkArgs.add(String.join(File.pathSeparator,
+                stagedOutput.bootModulePath().values().stream().map(Path::toString).toArray(String[]::new)));
+
+        // todo: include the whole boot path until --bind-services works
+        jlinkArgs.add("--add-modules");
+        jlinkArgs.add(addedModules);
+
+        // everything looks good; make the directory for the image output
+        Files.createDirectories(imagePath.getParent());
+        log.info("Building image with jlink");
+        log.debugf("JLink arguments: %s", String.join("\n\t", jlinkArgs));
+        Instant start = Instant.now();
+        int result = jlinkProvider.run(
+                new PrintWriter(new LogWriter(jlinkOut, Logger.Level.INFO)),
+                new PrintWriter(new LogWriter(jlinkOut, Logger.Level.WARN)),
+                jlinkArgs.toArray(String[]::new));
+        Instant end = Instant.now();
+        Duration duration = end.compareTo(start) < 0 ? Duration.ZERO : Duration.between(start, end);
+        if (result != 0) {
+            throw new BuildException("Build failed during jlink (exit code " + result + ")");
+        }
+        // produce the dynamic lib files
+        // bundle dynamic modules into the image
+        Path lib = config.outputDirectory().resolve(config.imagePath()).resolve("lib").resolve("quarkus");
+        Files.createDirectories(lib);
+        final AppModuleModel model = moduleInfoItem.model();
+        Map<String, ModuleInfo> modulesByName = model.modulesByName();
+        for (ModuleInfo moduleInfo : modulesByName.values()) {
+            String moduleName = moduleInfo.name();
+            if (model.bootModules().contains(moduleName)) {
+                // skip boot modules
+                continue;
+            }
+            // TODO: create an actual manifest (if needed)
+            ModuleWriter.writeModule(moduleInfo, lib.resolve(moduleInfo.name()), new Manifest(), false);
+        }
+
+        log.infof("JLink image produced in %s at %s; to run the image, execute %s in that directory",
+                format(duration), imagePath, Path.of("bin").resolve(config.launcherName()));
+        return new JLinkImageBuildItem(imagePath, Set.of(config.launcherName()));
+    }
+
+    /**
+     * Produce a classic artifact result build item from the jlink image item.
+     *
+     * @param imageItem the jlink image item (must not be {@code null})
+     * @return the artifact result item (not {@code null})
+     */
+    @BuildStep
+    public ArtifactResultBuildItem produceArtifactResult(JLinkImageBuildItem imageItem) {
+        return new ArtifactResultBuildItem(imageItem.imagePath().toAbsolutePath(), "jlink", Map.of());
+    }
+
+    // todo: we should have a central Duration formatter
+    static CharSequence format(Duration duration) {
+        if (duration.isZero()) {
+            return "0s";
+        }
+        StringBuilder b = new StringBuilder(16);
+        long millis = duration.toMillis();
+        if (millis >= 1000L * 60L * 60L) {
+            long hours = millis / (1000L * 60L * 60L);
+            b.append(hours);
+            b.append('h');
+            millis -= hours * 1000L * 60L * 60L;
+        }
+        if (millis >= 1000L * 60L) {
+            long minutes = millis / (1000L * 60L);
+            b.append(minutes);
+            b.append('m');
+            millis -= minutes * 1000L * 60L;
+        }
+        if (millis >= 0L) {
+            long seconds = millis / (1000L);
+            millis %= 1000L;
+            if (millis > 0 || seconds > 0) {
+                b.append(seconds);
+                if (millis > 0) {
+                    b.append('.');
+                    if (millis < 100) {
+                        b.append('0');
+                    }
+                    if (millis < 10) {
+                        b.append('0');
+                    }
+                    b.append(millis);
+                }
+                b.append('s');
+            }
+        }
+        return b;
+    }
+}

--- a/extensions/packaging/jlink/deployment/src/main/java/io/quarkus/jlink/deployment/LogWriter.java
+++ b/extensions/packaging/jlink/deployment/src/main/java/io/quarkus/jlink/deployment/LogWriter.java
@@ -1,0 +1,131 @@
+package io.quarkus.jlink.deployment;
+
+import java.io.Writer;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.jboss.logging.Logger;
+
+/**
+ * A utility which captures text output and writes it to the log.
+ */
+final class LogWriter extends Writer {
+    private final ReentrantLock lock = new ReentrantLock();
+    private final StringBuilder b = new StringBuilder();
+    private final Logger logger;
+    private final Logger.Level level;
+    private boolean cr;
+
+    LogWriter(Logger logger, Logger.Level level) {
+        this.logger = logger;
+        this.level = level;
+    }
+
+    public void write(final int c) {
+        ReentrantLock lock = this.lock;
+        lock.lock();
+        try {
+            write0(c);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private void write0(final int c) {
+        switch (c) {
+            case '\r' -> {
+                cr = true;
+                flushLine();
+            }
+            case '\n' -> {
+                if (cr) {
+                    // already flushed
+                    cr = false;
+                } else {
+                    flushLine();
+                }
+            }
+            default -> {
+                cr = false;
+                b.append((char) c);
+                // prevent it from getting too big
+                if (b.length() == 1024) {
+                    flushLine();
+                }
+            }
+        }
+    }
+
+    public void write(final char[] cbuf, final int off, final int len) {
+        ReentrantLock lock = this.lock;
+        lock.lock();
+        try {
+            for (int i = 0; i < len; i++) {
+                write0(cbuf[off + i]);
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void write(final String str, final int off, final int len) {
+        ReentrantLock lock = this.lock;
+        lock.lock();
+        try {
+            for (int i = 0; i < len; i++) {
+                write0(str.charAt(off + i));
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void write(final char[] cbuf) {
+        write(cbuf, 0, cbuf.length);
+    }
+
+    public void write(final String str) {
+        write(str, 0, str.length());
+    }
+
+    public Writer append(final CharSequence csq) {
+        return append(csq, 0, csq.length());
+    }
+
+    public Writer append(final CharSequence csq, final int start, final int end) {
+        ReentrantLock lock = this.lock;
+        lock.lock();
+        try {
+            for (int i = start; i < end; i++) {
+                write0(csq.charAt(i));
+            }
+        } finally {
+            lock.unlock();
+        }
+        return this;
+    }
+
+    public Writer append(final char c) {
+        write(c);
+        return this;
+    }
+
+    private void flushLine() {
+        if (!b.isEmpty()) {
+            logger.log(level, b.toString());
+            b.setLength(0);
+        }
+    }
+
+    public void flush() {
+        ReentrantLock lock = this.lock;
+        lock.lock();
+        try {
+            flushLine();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void close() {
+    }
+}

--- a/extensions/packaging/jlink/deployment/src/main/resources/META-INF/services/io.quarkus.builder.BuildProvider
+++ b/extensions/packaging/jlink/deployment/src/main/resources/META-INF/services/io.quarkus.builder.BuildProvider
@@ -1,0 +1,1 @@
+io.quarkus.jlink.deployment.JLinkBuildProvider

--- a/extensions/packaging/jlink/deployment/src/main/resources/META-INF/services/io.smallrye.config.SmallRyeConfigBuilderCustomizer
+++ b/extensions/packaging/jlink/deployment/src/main/resources/META-INF/services/io.smallrye.config.SmallRyeConfigBuilderCustomizer
@@ -1,0 +1,1 @@
+io.quarkus.jlink.deployment.JLinkConfigCustomizer

--- a/extensions/packaging/jlink/deployment/src/test/java/io/quarkus/jlink/deployment/JLinkStepsFormatTest.java
+++ b/extensions/packaging/jlink/deployment/src/test/java/io/quarkus/jlink/deployment/JLinkStepsFormatTest.java
@@ -1,0 +1,66 @@
+package io.quarkus.jlink.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link JLinkSteps#format(Duration)}.
+ */
+class JLinkStepsFormatTest {
+
+    @Test
+    void formatZeroDuration() {
+        assertThat(JLinkSteps.format(Duration.ZERO).toString()).isEqualTo("0s");
+    }
+
+    @Test
+    void formatMillisecondsOnly() {
+        assertThat(JLinkSteps.format(Duration.ofMillis(500)).toString()).isEqualTo("0.500s");
+    }
+
+    @Test
+    void formatSecondsOnly() {
+        assertThat(JLinkSteps.format(Duration.ofSeconds(5)).toString()).isEqualTo("5s");
+    }
+
+    @Test
+    void formatSecondsWithMillis() {
+        assertThat(JLinkSteps.format(Duration.ofMillis(5500)).toString()).isEqualTo("5.500s");
+    }
+
+    @Test
+    void formatMinutesOnly() {
+        assertThat(JLinkSteps.format(Duration.ofMinutes(3)).toString()).isEqualTo("3m");
+    }
+
+    @Test
+    void formatMinutesAndSeconds() {
+        assertThat(JLinkSteps.format(Duration.ofSeconds(185)).toString()).isEqualTo("3m5s");
+    }
+
+    @Test
+    void formatHoursMinutesSeconds() {
+        // 1h 2m 3.456s = 3600000 + 120000 + 3456 = 3723456 ms
+        assertThat(JLinkSteps.format(Duration.ofMillis(3723456)).toString()).isEqualTo("1h2m3.456s");
+    }
+
+    @Test
+    void formatSingleDigitMillisZeroPads() {
+        // 1.005s
+        assertThat(JLinkSteps.format(Duration.ofMillis(1005)).toString()).isEqualTo("1.005s");
+    }
+
+    @Test
+    void formatTwoDigitMillisZeroPads() {
+        // 1.050s
+        assertThat(JLinkSteps.format(Duration.ofMillis(1050)).toString()).isEqualTo("1.050s");
+    }
+
+    @Test
+    void formatHoursOnly() {
+        assertThat(JLinkSteps.format(Duration.ofHours(2)).toString()).isEqualTo("2h");
+    }
+}

--- a/extensions/packaging/jlink/deployment/src/test/java/io/quarkus/jlink/deployment/LogWriterTest.java
+++ b/extensions/packaging/jlink/deployment/src/test/java/io/quarkus/jlink/deployment/LogWriterTest.java
@@ -1,0 +1,116 @@
+package io.quarkus.jlink.deployment;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import org.jboss.logging.Logger;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * Tests for {@link LogWriter}.
+ */
+class LogWriterTest {
+
+    private final Logger logger = mock(Logger.class);
+
+    @Test
+    void writeStringLogsOnNewline() {
+        LogWriter lw = new LogWriter(logger, Logger.Level.INFO);
+        lw.write("hello\n");
+        verify(logger).log(Logger.Level.INFO, "hello");
+    }
+
+    @Test
+    void writeStringLogsOnCarriageReturn() {
+        LogWriter lw = new LogWriter(logger, Logger.Level.INFO);
+        lw.write("hello\r");
+        verify(logger).log(Logger.Level.INFO, "hello");
+    }
+
+    @Test
+    void writeStringCrLfLogsOnce() {
+        LogWriter lw = new LogWriter(logger, Logger.Level.INFO);
+        lw.write("hello\r\n");
+        verify(logger, Mockito.times(1)).log(Logger.Level.INFO, "hello");
+    }
+
+    @Test
+    void writeIntLogsOnNewline() {
+        LogWriter lw = new LogWriter(logger, Logger.Level.INFO);
+        lw.write('A');
+        lw.write('B');
+        verifyNoInteractions(logger);
+        lw.write('\n');
+        verify(logger).log(Logger.Level.INFO, "AB");
+    }
+
+    @Test
+    void writeCharArrayLogsOnNewline() {
+        LogWriter lw = new LogWriter(logger, Logger.Level.INFO);
+        char[] chars = "test\n".toCharArray();
+        lw.write(chars, 0, chars.length);
+        verify(logger).log(Logger.Level.INFO, "test");
+    }
+
+    @Test
+    void flushLogsPartialLine() {
+        LogWriter lw = new LogWriter(logger, Logger.Level.INFO);
+        lw.write("partial");
+        verifyNoInteractions(logger);
+        lw.flush();
+        verify(logger).log(Logger.Level.INFO, "partial");
+    }
+
+    @Test
+    void emptyLineIsNotLogged() {
+        LogWriter lw = new LogWriter(logger, Logger.Level.INFO);
+        lw.write("\n");
+        verify(logger, never()).log(Mockito.any(Logger.Level.class), Mockito.anyString());
+    }
+
+    @Test
+    void flushAt1024Chars() {
+        LogWriter lw = new LogWriter(logger, Logger.Level.INFO);
+        // write exactly 1024 chars without a newline
+        String line = "x".repeat(1024);
+        lw.write(line);
+        verify(logger).log(Logger.Level.INFO, line);
+    }
+
+    @Test
+    void appendCharSequence() {
+        LogWriter lw = new LogWriter(logger, Logger.Level.INFO);
+        lw.append("hello world", 0, 5);
+        lw.write('\n');
+        verify(logger).log(Logger.Level.INFO, "hello");
+    }
+
+    @Test
+    void closeIsNoOp() {
+        LogWriter lw = new LogWriter(logger, Logger.Level.INFO);
+        lw.write("unflushed");
+        lw.close();
+        // close does not flush, so nothing should be logged
+        verifyNoInteractions(logger);
+    }
+
+    @Test
+    void multipleLinesInOneWrite() {
+        LogWriter lw = new LogWriter(logger, Logger.Level.INFO);
+        lw.write("a\nb\nc\n");
+        verify(logger).log(Logger.Level.INFO, "a");
+        verify(logger).log(Logger.Level.INFO, "b");
+        verify(logger).log(Logger.Level.INFO, "c");
+    }
+
+    @Test
+    void usesCorrectLogLevel() {
+        LogWriter lw = new LogWriter(logger, Logger.Level.WARN);
+        lw.write("warning\n");
+        verify(logger).log(Logger.Level.WARN, "warning");
+        verify(logger, never()).log(Mockito.eq(Logger.Level.INFO), Mockito.anyString());
+    }
+}

--- a/extensions/packaging/jlink/launcher/pom.xml
+++ b/extensions/packaging/jlink/launcher/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-jlink-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-jlink-launcher</artifactId>
+
+    <name>Quarkus - JLink - Launcher</name>
+    <description>The special launcher module for JLink packaging</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.smallrye.modules</groupId>
+            <artifactId>smallrye-modules</artifactId>
+        </dependency>
+        <!-- Force the JBoss Log Manager on to the boot module path -->
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>jboss-logmanager</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-bootstrap-runner</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/extensions/packaging/jlink/launcher/src/main/java/io/quarkus/jlink/launcher/JLinkAppLauncher.java
+++ b/extensions/packaging/jlink/launcher/src/main/java/io/quarkus/jlink/launcher/JLinkAppLauncher.java
@@ -1,0 +1,108 @@
+package io.quarkus.jlink.launcher;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.nio.file.Path;
+import java.util.List;
+
+import io.smallrye.modules.LoadedModule;
+import io.smallrye.modules.ModuleFinder;
+import io.smallrye.modules.ModuleLoader;
+
+/**
+ * The application launcher for a jlink'd module application.
+ */
+public final class JLinkAppLauncher {
+    private JLinkAppLauncher() {
+    }
+
+    /**
+     * Launch the application.
+     *
+     * @param args the application arguments
+     */
+    public static void run(String appModule, String[] args) {
+        Module myModule = JLinkAppLauncher.class.getModule();
+        if (myModule == null) {
+            throw new IllegalStateException("Must launch jlink image in module mode only");
+        }
+        ModuleLayer myLayer = myModule.getLayer();
+        if (myLayer == null) {
+            throw new IllegalStateException("Module of jlink image launcher is not in a module layer");
+        }
+
+        @SuppressWarnings("resource")
+        ModuleLoader base = ModuleLoader.forLayer("base", myLayer);
+
+        // try to ascertain our own path
+        String cmd = ProcessHandle.current().info().command()
+                .orElseThrow(() -> new IllegalStateException("Cannot determine image path (ProcessHandle)"));
+        Path cmdPath = Path.of(cmd);
+        Path binPath = cmdPath.getParent();
+        if (binPath == null || !binPath.getFileName().toString().equals("bin")) {
+            throw new IllegalStateException("Cannot determine image path (bin path)");
+        }
+        Path imagePath = binPath.getParent();
+        if (imagePath == null) {
+            throw new IllegalStateException("Cannot determine image path (image path)");
+        }
+
+        Path libPath = imagePath.resolve("lib").resolve("quarkus");
+
+        // create a layer for our dynamic modules
+        ModuleLoader dyn = new ModuleLoader("dyn", ModuleFinder.fromFileSystem(List.of(libPath))) {
+            public LoadedModule loadModule(final String moduleName) {
+                LoadedModule found = base.loadModule(moduleName);
+                if (found == null) {
+                    found = super.loadModule(moduleName);
+                }
+                return found;
+            }
+        };
+
+        // load the application
+        LoadedModule loadedModule = dyn.loadModule(appModule);
+        if (loadedModule == null) {
+            throw new IllegalArgumentException("Application module " + appModule + " not found");
+        }
+
+        // set up TCCL; todo: stop relying on this
+        Thread.currentThread().setContextClassLoader(loadedModule.classLoader());
+
+        // find the main class
+        String mainClassName = loadedModule.module()
+                .getDescriptor()
+                .mainClass()
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Application module " + appModule + " does not have a defined main class"));
+        Class<?> mainClass;
+        try {
+            mainClass = Class.forName(mainClassName, true, loadedModule.classLoader());
+        } catch (ClassNotFoundException e) {
+            throw sneak(e);
+        }
+
+        // find the main method
+        MethodHandles.Lookup publicLookup = MethodHandles.publicLookup();
+        MethodHandle mainMethodHandle;
+        try {
+            mainMethodHandle = publicLookup.findStatic(mainClass, "main", MethodType.methodType(void.class, String[].class));
+        } catch (NoSuchMethodException | IllegalAccessException e) {
+            throw sneak(e);
+        }
+
+        // launch the application
+        try {
+            //noinspection ConfusingArgumentToVarargsMethod
+            mainMethodHandle.invokeExact(args);
+        } catch (Throwable e) {
+            throw sneak(e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <E extends Throwable> RuntimeException sneak(Throwable t) throws E {
+        throw (E) t;
+    }
+}

--- a/extensions/packaging/jlink/launcher/src/main/java/module-info.java
+++ b/extensions/packaging/jlink/launcher/src/main/java/module-info.java
@@ -1,0 +1,11 @@
+module io.quarkus.jlink.launcher {
+    // due to automatic modules:
+    requires java.se;
+    // for logging config stuff
+    requires io.quarkus.bootstrap.runner;
+    requires org.jboss.logmanager;
+    // to boot the dynamic modules
+    requires io.smallrye.modules;
+
+    exports io.quarkus.jlink.launcher;
+}

--- a/extensions/packaging/jlink/pom.xml
+++ b/extensions/packaging/jlink/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-packaging-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-jlink-parent</artifactId>
+
+    <name>Quarkus - JLink</name>
+    <description>The parent POM for JLink packaging</description>
+
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>deployment</module>
+        <module>spi</module>
+        <module>launcher</module>
+        <module>runtime</module>
+    </modules>
+</project>

--- a/extensions/packaging/jlink/runtime/pom.xml
+++ b/extensions/packaging/jlink/runtime/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-jlink-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-jlink</artifactId>
+
+    <name>Quarkus - JLink - Runtime</name>
+    <description>The runtime module for JLink packaging</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-modular</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jlink-launcher</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>io.quarkus.jlink</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>extension-descriptor</goal>
+                        </goals>
+                        <configuration>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.quarkus</groupId>
+                                    <artifactId>quarkus-extension-processor</artifactId>
+                                    <version>${project.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/packaging/jlink/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/packaging/jlink/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,9 @@
+---
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+name: "JLink"
+metadata:
+  categories:
+  - "packaging"
+  status: "experimental"
+  config:
+  - "quarkus.jlink."

--- a/extensions/packaging/jlink/spi/pom.xml
+++ b/extensions/packaging/jlink/spi/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-jlink-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-jlink-spi</artifactId>
+
+    <name>Quarkus - JLink - SPI</name>
+    <description>The SPI module for JLink packaging.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-builder</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+
+</project>

--- a/extensions/packaging/jlink/spi/src/main/java/io/quarkus/jlink/spi/JLinkImageBuildItem.java
+++ b/extensions/packaging/jlink/spi/src/main/java/io/quarkus/jlink/spi/JLinkImageBuildItem.java
@@ -1,0 +1,40 @@
+package io.quarkus.jlink.spi;
+
+import java.nio.file.Path;
+import java.util.Set;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+import io.smallrye.common.constraint.Assert;
+
+/**
+ * A build item representing the jlink image.
+ */
+public final class JLinkImageBuildItem extends SimpleBuildItem {
+    private final Path imagePath;
+    private final Set<String> launcherNames;
+
+    /**
+     * Construct a new instance.
+     *
+     * @param imagePath the image path (must not be {@code null})
+     * @param launcherNames the set of launcher names in the image (must not be {@code null})
+     */
+    public JLinkImageBuildItem(Path imagePath, Set<String> launcherNames) {
+        this.imagePath = Assert.checkNotNullParam("imagePath", imagePath);
+        this.launcherNames = Set.copyOf(Assert.checkNotNullParam("launcherNames", launcherNames));
+    }
+
+    /**
+     * {@return the image path (not {@code null})}
+     */
+    public Path imagePath() {
+        return imagePath;
+    }
+
+    /**
+     * {@return the set of launcher names in the image (not {@code null})}
+     */
+    public Set<String> launcherNames() {
+        return launcherNames;
+    }
+}

--- a/extensions/packaging/jlink/spi/src/main/java/io/quarkus/jlink/spi/JLinkStagedOutputItem.java
+++ b/extensions/packaging/jlink/spi/src/main/java/io/quarkus/jlink/spi/JLinkStagedOutputItem.java
@@ -1,0 +1,40 @@
+package io.quarkus.jlink.spi;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+import io.smallrye.common.constraint.Assert;
+
+/**
+ * A build item which represents the result of staging all {@code jlink} boot artifacts.
+ */
+public final class JLinkStagedOutputItem extends SimpleBuildItem {
+    private final Path stagedOutputPath;
+    private final Map<String, Path> bootModulePath;
+
+    /**
+     * Construct a new instance.
+     *
+     * @param stagedOutputPath the staged output path base directory (must not be {@code null})
+     * @param bootModulePath the path of each patched JAR for the boot module path, by module name (must not be {@code null})
+     */
+    public JLinkStagedOutputItem(final Path stagedOutputPath, final Map<String, Path> bootModulePath) {
+        this.stagedOutputPath = Assert.checkNotNullParam("stagedOutputPath", stagedOutputPath);
+        this.bootModulePath = Map.copyOf(Assert.checkNotNullParam("bootModulePath", bootModulePath));
+    }
+
+    /**
+     * {@return the staged output path base directory (not {@code null})}
+     */
+    public Path stagedOutputPath() {
+        return stagedOutputPath;
+    }
+
+    /**
+     * {@return the path of each patched JAR for the boot module path, by module name (not {@code null})}
+     */
+    public Map<String, Path> bootModulePath() {
+        return bootModulePath;
+    }
+}

--- a/extensions/packaging/modular/deployment/pom.xml
+++ b/extensions/packaging/modular/deployment/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-modular-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-modular-deployment</artifactId>
+
+    <name>Quarkus - Modularity - Deployment</name>
+    <description>The build module for modular builds</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-modular-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-modular</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-bootstrap-app-model</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.common</groupId>
+            <artifactId>smallrye-common-constraint</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>io.quarkus.packaging.common</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.quarkus</groupId>
+                                    <artifactId>quarkus-extension-processor</artifactId>
+                                    <version>${project.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/packaging/modular/deployment/src/main/java/io/quarkus/modular/deployment/ModularitySteps.java
+++ b/extensions/packaging/modular/deployment/src/main/java/io/quarkus/modular/deployment/ModularitySteps.java
@@ -1,0 +1,1186 @@
+package io.quarkus.modular.deployment;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.UncheckedIOException;
+import java.lang.constant.ClassDesc;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
+import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
+import io.quarkus.deployment.builditem.GeneratedServiceProviderBuildItem;
+import io.quarkus.deployment.builditem.MainClassBuildItem;
+import io.quarkus.deployment.builditem.ModuleEnableNativeAccessBuildItem;
+import io.quarkus.deployment.builditem.ModuleOpenBuildItem;
+import io.quarkus.deployment.builditem.TransformedClassesBuildItem;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.maven.dependency.DependencyFlags;
+import io.quarkus.maven.dependency.ResolvedDependency;
+import io.quarkus.modular.spi.items.AddDependencyBuildItem;
+import io.quarkus.modular.spi.items.ApplicationModuleInfoBuildItem;
+import io.quarkus.modular.spi.items.BootModulePathBuildItem;
+import io.quarkus.modular.spi.model.AppModuleModel;
+import io.quarkus.modular.spi.model.AutoDependencyGroup;
+import io.quarkus.modular.spi.model.DependencyInfo;
+import io.quarkus.modular.spi.model.ModuleInfo;
+import io.quarkus.paths.ManifestAttributes;
+import io.quarkus.paths.PathTree;
+import io.smallrye.classfile.Annotation;
+import io.smallrye.classfile.AnnotationElement;
+import io.smallrye.classfile.AnnotationValue;
+import io.smallrye.classfile.Attributes;
+import io.smallrye.classfile.ClassFile;
+import io.smallrye.classfile.ClassModel;
+import io.smallrye.classfile.attribute.ModuleAttribute;
+import io.smallrye.classfile.attribute.ModuleMainClassAttribute;
+import io.smallrye.classfile.attribute.RuntimeInvisibleAnnotationsAttribute;
+import io.smallrye.classfile.constantpool.ClassEntry;
+import io.smallrye.classfile.constantpool.Utf8Entry;
+import io.smallrye.classfile.extras.reflect.AccessFlag;
+import io.smallrye.common.resource.MemoryResource;
+import io.smallrye.common.resource.Resource;
+import io.smallrye.modules.desc.Dependency.Modifier;
+import io.smallrye.modules.desc.ModuleDescriptor;
+import io.smallrye.modules.desc.PackageAccess;
+import io.smallrye.modules.desc.PackageInfo;
+
+public final class ModularitySteps {
+    private static final Logger log = Logger.getLogger("io.quarkus.modular.deployment");
+
+    public ModularitySteps() {
+    }
+
+    @BuildStep
+    public List<BootModulePathBuildItem> standardBootItems() {
+        return List.of(
+                new BootModulePathBuildItem("io.quarkus.bootstrap.runner"),
+                new BootModulePathBuildItem("org.jboss.logmanager"),
+                new BootModulePathBuildItem("org.jboss.logmanager.slf4j"),
+                new BootModulePathBuildItem("io.smallrye.modules"));
+    }
+
+    @BuildStep
+    public List<AddDependencyBuildItem> standardAddedDependencies(
+            CurateOutcomeBuildItem curateOutcome) {
+        // TODO: migrate these to their relevant extensions
+        return List.of(
+                new AddDependencyBuildItem("org.eclipse.microprofile.config", "io.smallrye.config",
+                        Modifier.Set.of(Modifier.SERVICES)),
+                // todo: this one must be READ and LINKED because an ArC synthetic bean requires it
+                new AddDependencyBuildItem("io.netty.transport", "io.quarkus.netty",
+                        Modifier.Set.of(Modifier.SERVICES, Modifier.READ, Modifier.LINKED)),
+                new AddDependencyBuildItem("jakarta.ws.rs", "io.quarkus.resteasy.reactive.common",
+                        Modifier.Set.of(Modifier.SERVICES, Modifier.OPTIONAL)),
+                new AddDependencyBuildItem("org.slf4j", "org.jboss.logmanager.slf4j", Modifier.Set.of(Modifier.SERVICES)));
+    }
+
+    @BuildStep
+    public ApplicationModuleInfoBuildItem buildModularityModel(
+            CurateOutcomeBuildItem curateOutcome,
+            MainClassBuildItem mainClassBuildItem,
+            List<GeneratedClassBuildItem> generatedClasses,
+            List<GeneratedResourceBuildItem> generatedResources,
+            List<GeneratedServiceProviderBuildItem> generatedServices,
+            TransformedClassesBuildItem transformedClasses,
+            List<ModuleOpenBuildItem> opens,
+            // TODO: List<ModuleExportBuildItem> exports,
+            List<ModuleEnableNativeAccessBuildItem> nativeAccesses,
+            List<AddDependencyBuildItem> extraDeps,
+            List<BootModulePathBuildItem> bootPathItems) {
+
+        /* @formatter:off
+         * Build the modular application model. This is done in a few stages.
+         *
+         * • Find all of the artifacts present in the application
+         * • Collect and index the build items relating to modularity (add opens/exports, native access, etc.)
+         * • (temporary) create an index of which packages belong to which modules
+         *   ◦ Note: this is temporary because it prohibits packages from existing in one more module.
+         *     See #44657 for more information on why this is temporarily necessary.
+         * • (temporary) add ArC dependencies
+         *   ◦ Note: this is temporary as we would want to move this to the ArC extension.
+         *     However we presently do not have a strategy for this. See #52933.
+         * • Create the module set from the set of artifacts
+         *   ◦ This may entail traversing dependency sets for automatic modules
+         *   ◦ The output of this stage is a `io.quarkus.modular.spi.model.ModuleInfo` for each module
+         * • Calculate the set of boot modules
+         *   ◦ This is derived from the dependency graph of each BootModulePathBuildItem value
+         * • Assemble the modules into the final ApplicationModuleInfoBuildItem
+         * @formatter:on
+         */
+
+        // Find all artifacts
+
+        ApplicationModel model = curateOutcome.getApplicationModel();
+        // This is the single application artifact/module.
+        ResolvedDependency appArtifact = model.getAppArtifact();
+
+        // tabulate all generated and transformed resources, by package, so we can assign them to modules
+        Map<String, Map<String, Resource>> generatedByPackageAndPath = new HashMap<>();
+        // the set of packages containing ArC generated classes
+        // todo: replace this with some build item that adds the dependency
+        Set<String> arcGeneratedPackages = new HashSet<>();
+        Set<String> arcRuntimeGeneratedPackages = new HashSet<>();
+        Set<String> extraAppModuleDepPackages = new HashSet<>();
+
+        // Collect the initial set of modules that must be on the boot path.
+        Set<String> bootPathModules = bootPathItems.stream().map(BootModulePathBuildItem::moduleName)
+                .collect(Collectors.toSet());
+
+        // Get all known artifacts with their module names and build an index.
+        Map<String, ResolvedDependency> knownNamedModules = model.getDependencies().stream()
+                .filter(d -> d.isFlagSet(DependencyFlags.RUNTIME_CP))
+                .filter(d -> !d.isFlagSet(DependencyFlags.MISSING_FROM_APPLICATION))
+                .map(d -> Map.entry(d.getModuleName(), d))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        // Collect all added dependencies and merge them into a flat map.
+        // In particular, we collapse duplicates by combining modifier sets union-wise.
+        // The mapping here is: from module -> to module -> with modifier(s)
+        Map<String, Map<String, Modifier.Set>> extraDepsMap = extraDeps.stream()
+                .collect(Collectors.groupingBy(
+                        AddDependencyBuildItem::module,
+                        Collectors.groupingBy(
+                                AddDependencyBuildItem::targetModule,
+                                Collectors.mapping(AddDependencyBuildItem::modifiers,
+                                        Collectors.reducing(Modifier.Set.of(), Modifier.Set::withAll)))));
+
+        // Collect all add-opens and merge them into a flat map.
+        // We collapse duplicates by taking the union of the opened packages.
+        // Note that add-opens will take precedence over add-exports.
+        // opening module -> opened module -> package set
+        Map<String, Map<String, Set<String>>> addOpensByModule = opens.stream()
+                .collect(Collectors.groupingBy(
+                        ModuleOpenBuildItem::openingModuleName,
+                        Collectors.groupingBy(
+                                ModuleOpenBuildItem::openedModuleName,
+                                Collectors.flatMapping(mobi -> mobi.packageNames().stream(),
+                                        Collectors.toSet()))));
+        // Collect the set of modules which require native access.
+        Set<String> nativeAccessNames = nativeAccesses.stream()
+                .map(ModuleEnableNativeAccessBuildItem::moduleName)
+                .collect(Collectors.toUnmodifiableSet());
+
+        // Here's the temporary modules-by-package index used until #44657 can be resolved.
+        Map<String, String> modulesByPackageTemporary = new HashMap<>();
+
+        // Analyze generated classes for ArC (#52933) and for #44657.
+        for (GeneratedClassBuildItem gcbi : generatedClasses) {
+            String pn = gcbi.packageName();
+            String bn = gcbi.binaryName();
+            String name = gcbi.internalName() + ".class";
+            // todo: change GeneratedClassBuildItem to use Resource instead of byte[]
+            generatedByPackageAndPath.computeIfAbsent(pn, ModularitySteps::newMap)
+                    .put(name, new MemoryResource(name, gcbi.getClassData()));
+            // TODO: We need a better way to detect ArC dependencies using AddDependencyBuildItem
+            if (bn.endsWith("_Synthetic_Bean") || bn.endsWith("_Subclass")) {
+                arcRuntimeGeneratedPackages.add(pn);
+            }
+            if (bn.endsWith("_Bean") || bn.endsWith("_ArcAnnotationLiteral")) {
+                arcGeneratedPackages.add(pn);
+            }
+            if (bn.contains("_ComponentsProvider")) {
+                // todo: temporarily scrape the constant pool to add extra dependencies to the app module
+                ClassModel cm = ClassFile.of().parse(gcbi.getClassData());
+                cm.constantPool().forEach(pe -> {
+                    if (pe instanceof ClassEntry ce) {
+                        ClassDesc desc = ce.asSymbol();
+                        if (desc.isClassOrInterface()) {
+                            extraAppModuleDepPackages.add(desc.packageName());
+                        }
+                    }
+                });
+            }
+        }
+
+        // impl package -> service name -> impl name
+        Map<String, Map<String, List<String>>> extraServicesByPackage = new HashMap<>();
+        for (GeneratedServiceProviderBuildItem item : generatedServices) {
+            String apiName = item.getServiceInterfaceName();
+            String impl = item.getImplementationClassName();
+            int lastDot = impl.lastIndexOf('.');
+            if (lastDot != -1) {
+                String pkgName = impl.substring(0, lastDot);
+                extraServicesByPackage.computeIfAbsent(pkgName, ModularitySteps::newMap)
+                        .computeIfAbsent(apiName, ModularitySteps::newList)
+                        .add(impl);
+            }
+        }
+        // Gather up the set of generated resources for indexing (#44657).
+        for (GeneratedResourceBuildItem rsrc : generatedResources) {
+            String name = rsrc.getName();
+            String pn;
+            int idx = name.lastIndexOf('/');
+            if (idx == -1) {
+                pn = "";
+            } else {
+                pn = name.substring(0, idx).replace('/', '.');
+            }
+            // todo: change GeneratedResourceBuildItem to use Resource instead of byte[]
+            generatedByPackageAndPath.computeIfAbsent(pn, ModularitySteps::newMap)
+                    .put(name, new MemoryResource(name, rsrc.getData()));
+        }
+
+        // Scan transformed classes to make sure they don't overlap with a generated class and index it (#44657).
+        for (Set<TransformedClassesBuildItem.TransformedClass> set : transformedClasses.getTransformedClassesByJar().values()) {
+            for (TransformedClassesBuildItem.TransformedClass tc : set) {
+                String bn = tc.getClassName();
+                String pn;
+                int idx = bn.lastIndexOf('.');
+                if (idx == -1) {
+                    pn = "";
+                } else {
+                    pn = bn.substring(0, idx);
+                }
+                // replace any existing entry
+                String fileName = tc.getFileName();
+                byte[] data = tc.getData();
+                if (data == null) {
+                    // TODO
+                    if (generatedByPackageAndPath.containsKey(pn)) {
+                        generatedByPackageAndPath.get(pn).remove(fileName);
+                    }
+                } else {
+                    generatedByPackageAndPath.computeIfAbsent(pn, ModularitySteps::newMap)
+                            .put(fileName, new MemoryResource(fileName, data));
+                }
+            }
+        }
+
+        // now start creating the module set
+
+        Set<String> usedJdkModuleNames = new HashSet<>();
+
+        // This is just an index of each artifact by groupId+artifactId.
+        Map<ArtifactKey, ResolvedDependency> allDependenciesByKey = knownNamedModules.values().stream().map(
+                d -> Map.entry(keyOf(d), d)).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        // This will be our collection of all modules in the application.
+        Map<String, ModuleInfo> modulesByName = new HashMap<>();
+
+        // map of all `module-info.class` models
+        Map<ResolvedDependency, ClassModel> moduleInfoClassModels = knownNamedModules.values().stream()
+                .map(d -> {
+                    PathTree contentTree = d.getContentTree();
+                    ClassModel cm = findModuleInfoClass(contentTree, "module-info.class");
+                    if (cm == null) {
+                        // slf4j...
+                        cm = findModuleInfoClass(contentTree, "META-INF/versions/9/module-info.class");
+                    }
+                    return cm == null ? null : Map.entry(d, cm);
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        // The application's module name
+        final String appModuleName = appArtifact.getModuleName();
+
+        // ArC must depend on the application module (for service loading)
+        // todo: ArC should use AddDependencyBuildItem for this.
+        extraDepsMap.computeIfAbsent("io.quarkus.arc", ModularitySteps::newMap)
+                .put(appModuleName, Modifier.Set.of(Modifier.SERVICES));
+
+        // Vert.x core needs to link against `io.quarkus.vertx`.
+        // todo: The Vert.x extension should use AddDependencyBuildItem for this.
+        extraDepsMap.computeIfAbsent("io.vertx.core", ModularitySteps::newMap)
+                .put("io.quarkus.vertx", Modifier.Set.of(Modifier.READ, Modifier.LINKED, Modifier.SYNTHETIC));
+
+        // Now go through the process to build a (Quarkus) module descriptor for each artifact.
+        for (ResolvedDependency dependency : knownNamedModules.values()) {
+            if (!dependency.isRuntimeCp()) {
+                continue;
+            }
+            String moduleName = dependency.getModuleName();
+            if (moduleName.equals(appModuleName)) {
+                // we do app module at the end
+                continue;
+            }
+            // Get the module info.
+            // todo: we're doing a lot of extra transformations here that will eventually move out.
+            final ModuleInfo depModule = getModuleInfo(dependency, generatedByPackageAndPath, moduleInfoClassModels,
+                    allDependenciesByKey, Map.of(), knownNamedModules, mi -> {
+                        // Transformations for a given module.
+                        // These flags ensure we don't add dependencies twice (see #52933).
+                        boolean arcAdded = false;
+                        boolean arcRuntimeAdded = false;
+                        // Add the native-access flag if a build item says to do so.
+                        if (nativeAccessNames.contains(moduleName)) {
+                            mi = mi.withModifier(ModuleDescriptor.Modifier.NATIVE_ACCESS);
+                        }
+                        for (String pkg : mi.packages().keySet()) {
+                            // Add service providers found in build items.
+                            if (extraServicesByPackage.containsKey(pkg)) {
+                                mi = mi.withMoreServices(extraServicesByPackage.remove(pkg));
+                            }
+                            // Handle the ArC stuff (#52933).
+                            // TODO: use build items to do this more efficiently up front
+                            if (!arcAdded && arcGeneratedPackages.contains(pkg)) {
+                                if (!mi.name().equals("io.quarkus.arc")) {
+                                    mi = mi.withMoreDependencies(List.of(new DependencyInfo(
+                                            "io.quarkus.arc",
+                                            Modifier.Set.of(Modifier.LINKED, Modifier.READ, Modifier.SYNTHETIC),
+                                            Map.of())));
+                                }
+                                if (!mi.name().equals("jakarta.cdi")) {
+                                    mi = mi.withMoreDependencies(List.of(new DependencyInfo("jakarta.cdi",
+                                            Modifier.Set.of(Modifier.LINKED, Modifier.READ, Modifier.SYNTHETIC),
+                                            Map.of())));
+                                }
+                                arcAdded = true;
+                            }
+                            if (!arcRuntimeAdded && arcRuntimeGeneratedPackages.contains(pkg)
+                                    && !mi.name().equals("io.quarkus.arc.runtime")) {
+                                mi = mi.withMoreDependencies(List.of(new DependencyInfo(
+                                        "io.quarkus.arc.runtime",
+                                        Modifier.Set.of(Modifier.LINKED, Modifier.READ, Modifier.SYNTHETIC),
+                                        Map.of())));
+                                arcRuntimeAdded = true;
+                            }
+                        }
+                        // TODO: Temporary fixups; remove when we can.
+                        switch (moduleName) {
+                            // todo: needs resteasy release
+                            case "org.jboss.resteasy.core.spi" -> {
+                                mi = mi.withMorePackages(Map.of("org.jboss.resteasy.resteasy_jaxrs.i18n", PackageInfo.of(
+                                        PackageAccess.PRIVATE, Set.of(), Set.of("org.jboss.logging"))));
+                            }
+                        }
+                        // Add extra dependencies from build items.
+                        mi = mi.withMoreDependencies(extraDepsMap.getOrDefault(mi.name(), Map.of())
+                                .entrySet()
+                                .stream()
+                                .map((e) -> new DependencyInfo(e.getKey(), e.getValue(), Map.of()))
+                                .toList());
+                        // Add extra opens from build items.
+                        Map<String, Set<String>> obi = addOpensByModule.getOrDefault(moduleName, Map.of());
+                        if (!obi.isEmpty()) {
+                            mi = mi.withMoreDependencies(obi
+                                    .entrySet()
+                                    .stream()
+                                    .map((e) -> new DependencyInfo(
+                                            e.getKey(),
+                                            Modifier.Set.of(Modifier.READ, Modifier.OPTIONAL),
+                                            e.getValue().stream().collect(
+                                                    Collectors.toMap(Function.identity(), ignored -> PackageAccess.OPEN))))
+                                    .toList());
+                        }
+                        // tabulate any used JDK modules.
+                        mi.dependencies().stream()
+                                .map(DependencyInfo::moduleName)
+                                .filter(n -> n.startsWith("java.") || n.startsWith("jdk.") || n.startsWith("ibm."))
+                                .forEach(usedJdkModuleNames::add);
+                        return mi;
+                    });
+            // Add the module to the index.
+            if (modulesByName.containsKey(moduleName)) {
+                ModuleInfo existing = modulesByName.get(moduleName);
+                if (existing.equals(depModule)) {
+                    // no harm; it's just in there twice for some reason
+                    continue;
+                }
+                throw new IllegalStateException("Module '" + moduleName + "' has been defined twice, in: " +
+                        depModule.resolvedArtifact() + " and " + existing.resolvedArtifact());
+            }
+            modulesByName.put(moduleName, depModule);
+            // Warn about any split packages (temporary until #44657; then we don't care as much about it).
+            depModule.packages().keySet().forEach(pn -> {
+                String existing = modulesByPackageTemporary.putIfAbsent(pn, moduleName);
+                if (existing != null && !existing.equals(moduleName)) {
+                    log.warnf("Package %s is split, in %s and %s", pn, existing, moduleName);
+                }
+            });
+        }
+
+        // Compute the set of extra app module dependencies from ArC component providers.
+        // todo: Remove once #52933 is sorted out.
+        for (String pn : extraAppModuleDepPackages) {
+            String moduleName = modulesByPackageTemporary.get(pn);
+            if (moduleName != null) {
+                extraDepsMap.computeIfAbsent(appModuleName, ModularitySteps::newMap)
+                        .compute(moduleName,
+                                (pn1, mods) -> mods == null
+                                        ? Modifier.Set.of(Modifier.READ, Modifier.LINKED, Modifier.SYNTHETIC)
+                                        : mods.withAll(Modifier.READ, Modifier.LINKED));
+            }
+        }
+
+        // Assemble the initial extra packages map for the application module.
+        // todo: once #44657 is resolved, we should be able to get this from the build items themselves.
+        Map<String, PackageInfo> initialPackages = new HashMap<>(Map.of(
+                "", PackageInfo.PRIVATE,
+                "io.quarkus.runner", PackageInfo.EXPORTED,
+                "io.quarkus.runtime.generated", PackageInfo.EXPORTED,
+                "io.quarkus.deployment.steps", PackageInfo.EXPORTED,
+                "io.quarkus.rest.runtime", PackageInfo.EXPORTED,
+                "io.quarkus.arc.setup", PackageInfo.EXPORTED,
+                "io.quarkus.arc.generator", PackageInfo.EXPORTED,
+                "io.quarkus.runner.recorded", PackageInfo.EXPORTED));
+
+        // claim all unclaimed generated classes and resources (#44657)
+        generatedByPackageAndPath.keySet().forEach(pn -> initialPackages.putIfAbsent(pn, PackageInfo.PRIVATE));
+
+        // Get the descriptor information for the application module.
+        // todo: we do a few extra transformations for ArC due to #52933.
+        final ModuleInfo appModule = getModuleInfo(appArtifact, generatedByPackageAndPath, moduleInfoClassModels,
+                allDependenciesByKey, initialPackages,
+                knownNamedModules, mi -> {
+                    mi = mi.withMainClass(mainClassBuildItem.getClassName());
+                    // add services and dependencies to app module
+                    boolean arcAdded = false;
+                    boolean arcRuntimeAdded = false;
+                    for (String pkg : mi.packages().keySet()) {
+                        if (extraServicesByPackage.containsKey(pkg)) {
+                            mi = mi.withMoreServices(extraServicesByPackage.get(pkg));
+                        }
+                        // TODO: use build items to do this more efficiently up front
+                        if (!arcAdded && arcGeneratedPackages.contains(pkg)) {
+                            mi = mi.withMoreDependencies(List.of(new DependencyInfo(
+                                    "io.quarkus.arc", Modifier.Set.of(Modifier.LINKED, Modifier.READ, Modifier.SYNTHETIC),
+                                    Map.of())));
+                            arcAdded = true;
+                        }
+                        if (!arcRuntimeAdded && arcRuntimeGeneratedPackages.contains(pkg)) {
+                            mi = mi.withMoreDependencies(List.of(new DependencyInfo(
+                                    "io.quarkus.arc.runtime",
+                                    Modifier.Set.of(Modifier.LINKED, Modifier.READ, Modifier.SYNTHETIC),
+                                    Map.of())));
+                            arcRuntimeAdded = true;
+                        }
+                    }
+                    // now add all extra dependencies (from build items)
+                    mi = mi.withMoreDependencies(extraDepsMap.getOrDefault(mi.name(), Map.of())
+                            .entrySet()
+                            .stream()
+                            .map((e) -> new DependencyInfo(e.getKey(), e.getValue(), Map.of()))
+                            .toList());
+                    // tabulate any used JDK modules.
+                    mi.dependencies().stream()
+                            .map(DependencyInfo::moduleName)
+                            .filter(n -> n.startsWith("java.") || n.startsWith("jdk.") || n.startsWith("ibm."))
+                            .forEach(usedJdkModuleNames::add);
+                    return mi;
+                });
+
+        // Register the app module with the others.
+        modulesByName.put(appModuleName, appModule);
+
+        // -----------------------------------
+        // at this point, appModule is frozen!
+        // -----------------------------------
+
+        // determine the set of boot-path modules
+        // todo: this is packaging-dependent!
+        Set<ModuleInfo> bootModuleSet = new HashSet<>();
+        HashSet<String> visited = new HashSet<>();
+        for (ModuleInfo moduleInfo : modulesByName.values()) {
+            if (bootPathModules.contains(moduleInfo.name())) {
+                computeBootPath(moduleInfo, modulesByName, visited, bootModuleSet);
+            }
+        }
+        // Build and return the final modular model.
+        AppModuleModel.Builder amb = AppModuleModel.builder();
+        amb.appModuleInfo(appModule);
+        usedJdkModuleNames.forEach(amb::jdkModuleUsed);
+        bootModuleSet.forEach(m -> amb.bootModule(m.name()));
+        modulesByName.values().forEach(amb::moduleInfo);
+        return new ApplicationModuleInfoBuildItem(amb.build());
+    }
+
+    private static final Set<String> bootLayerNames = ModuleLayer.boot().modules().stream().map(Module::getName)
+            .collect(Collectors.toUnmodifiableSet());
+
+    /**
+     * Add a module to the boot path, including its transitive dependency set.
+     * The Quarkus module dependency model is more flexible than the core JVM model, so this
+     * set should be as minimal as possible to avoid problems due to cycles and so forth.
+     *
+     * @param toAdd the module to add (must not be {@code null})
+     * @param modulesByName the (read-only) index of modules by name (must not be {@code null})
+     * @param visited the visited set (must not be {@code null})
+     * @param set the (writable) set of boot modules (must not be {@code null})
+     * @return {@code true} if further recursion is needed, or {@code false} to bail out
+     */
+    private static boolean computeBootPath(ModuleInfo toAdd, final Map<String, ModuleInfo> modulesByName,
+            final HashSet<String> visited, final Set<ModuleInfo> set) {
+        if (visited.add(toAdd.name())) {
+            if (toAdd.modifiers().contains(ModuleDescriptor.Modifier.AUTOMATIC)
+                    // TODO: remove this once this is modular
+                    && !toAdd.name().equals("org.jboss.logmanager.slf4j")) {
+                // exclude automatic
+                log.infof("Excluding %s from boot path because it is automatic", toAdd.name());
+                return false;
+            }
+            // add its dependencies
+            boolean add = true;
+            for (DependencyInfo dep : toAdd.dependencies()) {
+                if (dep.modifiers().contains(Modifier.LINKED)) {
+                    if (!computeBootPath(modulesByName, visited, set, dep)) {
+                        add = false;
+                        break;
+                    }
+                }
+            }
+            if (add) {
+                for (AutoDependencyGroup grp : toAdd.autoDependencies()) {
+                    for (DependencyInfo dep : grp.dependencies()) {
+                        if (dep.modifiers().contains(Modifier.LINKED)) {
+                            if (!computeBootPath(modulesByName, visited, set, dep)) {
+                                add = false;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            if (add) {
+                set.add(toAdd);
+            } else {
+                log.infof("Excluding %s from boot path because a dependency was excluded", toAdd.name());
+            }
+            return add;
+        }
+        if (set.contains(toAdd)) {
+            return true;
+        } else {
+            log.infof("Excluding %s from boot path because it is cyclical", toAdd.name());
+            return false;
+        }
+    }
+
+    /**
+     * An internal recursion partner for {@link #computeBootPath(ModuleInfo, Map, HashSet, Set)}.
+     * This method should not be called directly outside of that method.
+     *
+     * @param modulesByName the (read-only) index of modules by name (must not be {@code null})
+     * @param visited the visited set (must not be {@code null})
+     * @param set the (writable) set of boot modules (must not be {@code null})
+     * @param dep the dependency to consider (must not be {@code null})
+     * @return {@code true} if further recursion is needed, or {@code false} to bail out
+     */
+    private static boolean computeBootPath(final Map<String, ModuleInfo> modulesByName, final HashSet<String> visited,
+            final Set<ModuleInfo> set, final DependencyInfo dep) {
+        String name = dep.moduleName();
+        // auto-include JDK modules
+        if (bootLayerNames.contains(name)) {
+            return true;
+        }
+        ModuleInfo depStuff = modulesByName.get(name);
+        if (depStuff != null) {
+            return computeBootPath(depStuff, modulesByName, visited, set);
+        }
+        return true;
+    }
+
+    /**
+     * Read and tabulate a services file given an input stream in UTF-8 format.
+     *
+     * @param stream the input stream (must not be {@code null})
+     * @param output the collection to write to (must not be {@code null})
+     * @return the collection passed in to {@code output} (not {@code null})
+     * @param <C> the collection type
+     * @throws IOException if the services file could not be read
+     */
+    private static <C extends Collection<String>> C readServicesFile(InputStream stream, C output) throws IOException {
+        return readServicesFile(new InputStreamReader(stream, StandardCharsets.UTF_8), output);
+    }
+
+    /**
+     * Read and tabulate a services file given a reader.
+     *
+     * @param reader the reader (must not be {@code null})
+     * @param output the collection to write to (must not be {@code null})
+     * @return the collection passed in to {@code output} (not {@code null})
+     * @param <C> the collection type
+     * @throws IOException if the services file could not be read
+     */
+    private static <C extends Collection<String>> C readServicesFile(Reader reader, C output) throws IOException {
+        return reader instanceof BufferedReader br ? readServicesFile(br, output)
+                : readServicesFile(new BufferedReader(reader), output);
+    }
+
+    /**
+     * Read and tabulate a services file given a buffered reader.
+     *
+     * @param reader the buffered reader (must not be {@code null})
+     * @param output the collection to write to (must not be {@code null})
+     * @return the collection passed in to {@code output} (not {@code null})
+     * @param <C> the collection type
+     * @throws IOException if the services file could not be read
+     */
+    private static <C extends Collection<String>> C readServicesFile(BufferedReader reader, C output) throws IOException {
+        String impl;
+        while ((impl = reader.readLine()) != null) {
+            int octothorpe = impl.indexOf('#');
+            if (octothorpe != -1) {
+                impl = impl.substring(0, octothorpe);
+            }
+            impl = impl.trim();
+            if (!impl.isEmpty()) {
+                int lastDot = impl.lastIndexOf('.');
+                if (lastDot != -1) {
+                    output.add(impl);
+                }
+            }
+        }
+        return output;
+    }
+
+    /***
+     * Try to locate a {@code module-info} model in a content tree by path.
+     *
+     * @param contentTree the content tree (must not be {@code null})
+     * @param pathName the path name (must not be {@code null})
+     * @return the parsed {@code module-info} model.
+     */
+    private static ClassModel findModuleInfoClass(final PathTree contentTree, final String pathName) {
+        return contentTree.apply(pathName, v -> {
+            if (v == null) {
+                return null;
+            }
+            try (InputStream is = v.getUrl().openStream()) {
+                return ClassFile.of().parse(is.readAllBytes());
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        });
+    }
+
+    /**
+     * Compute the Quarkus module descriptor for a given artifact.
+     * If the artifact does not have a {@code module-info} descriptor,
+     * then its Quarkus module descriptor will be computed as if
+     * the artifact is an automatic module using its transitive artifact dependency graph.
+     *
+     * @param dependency the dependency to process (must not be {@code null})
+     * @param generatedByPackageAndPath the (temporary) index of generated classes and resource by package and path name
+     * @param moduleInfoClassModels the (read-only) cache of loaded {@code module-info} models by dependency (must not be
+     *        {@code null})
+     * @param allDeps the (read-only) index of all known dependencies by group and artifact ID (must not be {@code null})
+     * @param initialPackages the (read-only) map of initial packages to add to this module (must not be {@code null})
+     * @param knownNamedModules the (read-only) map of artifacts by module name (must not be {@code null})
+     * @param transformation a transformation operation to apply before returning the descriptor (must not be {@code null})
+     * @return the computed module descriptor (not {@code null})
+     */
+    private static ModuleInfo getModuleInfo(
+            ResolvedDependency dependency,
+            Map<String, Map<String, Resource>> generatedByPackageAndPath,
+            Map<ResolvedDependency, ClassModel> moduleInfoClassModels,
+            Map<ArtifactKey, ResolvedDependency> allDeps,
+            Map<String, PackageInfo> initialPackages,
+            Map<String, ResolvedDependency> knownNamedModules,
+            UnaryOperator<ModuleInfo> transformation) {
+
+        PathTree contentTree = dependency.getContentTree();
+        ClassModel cm = moduleInfoClassModels.get(dependency);
+
+        String moduleName = dependency.getModuleName();
+        String moduleVersion = dependency.getVersion();
+        String mainClass = null;
+
+        ModuleDescriptor.Modifier.Set flags = ModuleDescriptor.Modifier.Set.of();
+        final Map<String, PackageInfo> packages = new HashMap<>(initialPackages);
+
+        Set<String> uses;
+        Map<String, List<String>> provides;
+        List<DependencyInfo> requires = new ArrayList<>();
+        Map<String, Map<String, PackageAccess>> depAccesses = new HashMap<>();
+        List<AutoDependencyGroup> autoDeps = List.of();
+
+        // This temporary measure patches modules which have dependency issues
+        // and/or which need to utilize `AddDependencyBuildItem` but do not yet.
+        // todo: this will be removed; do not add to it if you can fix the extension instead.
+        switch (moduleName) {
+            case "io.quarkus.vertx" -> {
+                depAccesses.computeIfAbsent("io.vertx.core", ModularitySteps::newMap)
+                        .put("io.vertx.core.impl", PackageAccess.EXPORTED);
+            }
+            case "io.quarkus.resteasy.reactive.vertx" -> {
+                depAccesses.computeIfAbsent("io.vertx.core", ModularitySteps::newMap)
+                        .putAll(Map.of("io.vertx.core.impl", PackageAccess.EXPORTED,
+                                "io.vertx.core.buffer.impl", PackageAccess.EXPORTED,
+                                "io.vertx.core.http.impl", PackageAccess.EXPORTED,
+                                "io.vertx.core.net.impl", PackageAccess.EXPORTED));
+            }
+            case "io.smallrye.common.vertx" -> {
+                depAccesses.computeIfAbsent("io.vertx.core", ModularitySteps::newMap)
+                        .put("io.vertx.core.impl", PackageAccess.EXPORTED);
+            }
+            case "io.quarkus.rest.client.jaxrs" -> {
+                depAccesses.computeIfAbsent("io.quarkus.resteasy.reactive.client", ModularitySteps::newMap)
+                        .put("org.jboss.resteasy.reactive.client.impl", PackageAccess.EXPORTED);
+            }
+            case "io.quarkus.smallrye.context.propagation" -> {
+                depAccesses.computeIfAbsent("io.smallrye.context.propagation", ModularitySteps::newMap)
+                        .put("io.smallrye.context.impl", PackageAccess.EXPORTED);
+            }
+            case "io.smallrye.mutiny.vertx.core" -> {
+                depAccesses.computeIfAbsent("io.vertx.core", ModularitySteps::newMap)
+                        .put("io.vertx.core.shareddata.impl", PackageAccess.EXPORTED);
+            }
+            case "io.quarkus.oidc" -> {
+                depAccesses.computeIfAbsent("io.vertx.web", ModularitySteps::newMap)
+                        .put("io.vertx.ext.web.impl", PackageAccess.EXPORTED);
+                depAccesses.computeIfAbsent("io.vertx.core", ModularitySteps::newMap)
+                        .putAll(Map.of(
+                                "io.vertx.core.impl", PackageAccess.EXPORTED,
+                                "io.vertx.core.http.impl", PackageAccess.EXPORTED));
+            }
+            case "io.quarkus.vertx.http" -> {
+                depAccesses.computeIfAbsent("io.vertx.web", ModularitySteps::newMap)
+                        .put("io.vertx.ext.web.impl", PackageAccess.EXPORTED);
+                depAccesses.computeIfAbsent("io.vertx.core", ModularitySteps::newMap)
+                        .putAll(Map.of(
+                                "io.vertx.core.impl", PackageAccess.EXPORTED,
+                                "io.vertx.core.http.impl", PackageAccess.EXPORTED));
+            }
+            case "io.vertx.web" -> {
+                depAccesses.computeIfAbsent("io.vertx.core", ModularitySteps::newMap)
+                        .putAll(Map.of(
+                                "io.vertx.core.impl", PackageAccess.EXPORTED,
+                                "io.vertx.core.impl.logging", PackageAccess.EXPORTED,
+                                "io.vertx.core.http.impl", PackageAccess.EXPORTED,
+                                "io.vertx.core.net.impl", PackageAccess.EXPORTED));
+            }
+            case "io.vertx.web.client" -> {
+                depAccesses.computeIfAbsent("io.vertx.core", ModularitySteps::newMap)
+                        .putAll(Map.of(
+                                "io.vertx.core.impl.launcher.commands", PackageAccess.EXPORTED,
+                                "io.vertx.core.impl", PackageAccess.EXPORTED,
+                                "io.vertx.core.http.impl", PackageAccess.EXPORTED));
+                depAccesses.computeIfAbsent("io.vertx.web.common", ModularitySteps::newMap)
+                        .put("io.vertx.ext.web.codec.impl", PackageAccess.EXPORTED);
+            }
+            case "org.jboss.threads" -> {
+                depAccesses.computeIfAbsent("java.base", ModularitySteps::newMap)
+                        .put("java.lang", PackageAccess.OPEN);
+            }
+            case "org.resteasy.core" -> {
+                depAccesses.computeIfAbsent("com.fasterxml.jackson.jakarta.rs.json", ModularitySteps::newMap)
+                        .put("com.fasterxml.jackson.jakarta.rs.json", PackageAccess.OPEN);
+            }
+        }
+
+        // Now build the module info. There are two possibilities:
+        //   • We have a `module-info.class` and should build a regular module from that
+        //   • We do not have `module-info` so we build an automatic module from Maven dependencies
+        if (cm != null) {
+            // there is a descriptor
+            Optional<RuntimeInvisibleAnnotationsAttribute> ria = cm.findAttribute(Attributes.runtimeInvisibleAnnotations());
+            if (ria.isPresent()) {
+                // process annotations from the module declaration
+                RuntimeInvisibleAnnotationsAttribute riaa = ria.get();
+                for (Annotation a : riaa.annotations()) {
+                    switch (a.className().stringValue()) {
+                        case "io.smallrye.common.annotation.AddExports" ->
+                            processAccessAnnotation(a, depAccesses, PackageAccess.EXPORTED);
+                        case "io.smallrye.common.annotation.AddOpens" ->
+                            processAccessAnnotation(a, depAccesses, PackageAccess.OPEN);
+                        case "io.smallrye.common.annotation.AddExports$List" ->
+                            processAccessAnnotationList(a, depAccesses, PackageAccess.EXPORTED);
+                        case "io.smallrye.common.annotation.AddOpens$List" ->
+                            processAccessAnnotationList(a, depAccesses, PackageAccess.OPEN);
+                        case "io.smallrye.common.annotation.NativeAccess" ->
+                            flags = flags.with(ModuleDescriptor.Modifier.NATIVE_ACCESS);
+                    }
+                }
+            }
+            // register the main class
+            mainClass = cm.findAttribute(Attributes.moduleMainClass()).map(ModuleMainClassAttribute::mainClass)
+                    .map(ClassEntry::name)
+                    .map(Utf8Entry::stringValue)
+                    .map(n -> n.replace('/', '.'))
+                    .orElse(null);
+            // figure out which packages we open to everyone
+            Set<String> openedPackages = cm.findAttribute(Attributes.module()).map(ModuleAttribute::opens)
+                    .map(l -> l.stream()
+                            .filter(ei -> ei.opensTo().isEmpty())
+                            .map(ei -> ei.openedPackage().name().stringValue().replace('/', '.'))
+                            .collect(Collectors.toSet()))
+                    .orElse(Set.of());
+            // figure out which packages we export to everyone
+            Set<String> exportedPackages = cm.findAttribute(Attributes.module()).map(ModuleAttribute::exports)
+                    .map(l -> l.stream()
+                            .filter(ei -> ei.exportsTo().isEmpty())
+                            .map(ei -> ei.exportedPackage().name().stringValue().replace('/', '.'))
+                            .collect(Collectors.toSet()))
+                    .orElse(Set.of());
+            // compute a PackageInfo for every package, merging in exported and opened package information
+            cm.findAttribute(Attributes.modulePackages()).ifPresentOrElse(a -> a.packages().forEach(pe -> {
+                String pn = pe.name().stringValue().replace('/', '.');
+                PackageInfo info = openedPackages.contains(pn) ? PackageInfo.OPEN
+                        : exportedPackages.contains(pn) ? PackageInfo.EXPORTED : PackageInfo.PRIVATE;
+                packages.compute(pn, (ignored, old) -> PackageInfo.merge(info, old));
+            }), () -> indexPackages(packages, contentTree));
+            // find the set of used services
+            uses = cm.findAttribute(Attributes.module()).map(ModuleAttribute::uses).orElse(List.of()).stream()
+                    .map(ClassEntry::name)
+                    .map(Utf8Entry::stringValue)
+                    .map(c -> c.replace('/', '.'))
+                    .collect(Collectors.toUnmodifiableSet());
+            // find the set of provided services
+            provides = cm.findAttribute(Attributes.module()).map(ModuleAttribute::provides).orElse(List.of()).stream()
+                    .map(mpi -> Map.entry(
+                            mpi.provides().name().stringValue().replace('/', '.'),
+                            mpi.providesWith().stream().map(ClassEntry::name).map(Utf8Entry::stringValue)
+                                    .map(e -> e.replace('/', '.')).toList()))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            // find the dependency set, marking things `optional` if they are missing
+            cm.findAttribute(Attributes.module()).map(ModuleAttribute::requires).orElse(List.of()).stream()
+                    .map(mri -> Map.entry(
+                            mri.requires().name().stringValue(),
+                            mri.requiresFlags()))
+                    .forEach(e -> {
+                        Modifier.Set modifiers = depModifiersOf(e.getValue());
+                        String depName = e.getKey();
+                        if (!bootLayerNames.contains(depName) && !knownNamedModules.containsKey(depName)) {
+                            // it's actually totally missing...
+                            modifiers = modifiers.with(Modifier.OPTIONAL);
+                        }
+                        requires.add(new DependencyInfo(depName, modifiers,
+                                depAccesses.getOrDefault(depName, Map.of())));
+                    });
+        } else {
+            // create an automatic module
+            flags = flags.with(ModuleDescriptor.Modifier.AUTOMATIC);
+            // process the manifest for standard attributes
+            ManifestAttributes manifestAttributes = contentTree.getManifestAttributes();
+            if (manifestAttributes != null) {
+                // the main class
+                mainClass = manifestAttributes.mainClassName();
+                // add-opens
+                manifestAttributes.addOpens().forEach((mn, pl) -> {
+                    Map<String, PackageAccess> subMap = depAccesses.computeIfAbsent(mn, ModularitySteps::newMap);
+                    pl.forEach(pn -> subMap.put(pn, PackageAccess.OPEN));
+                });
+                // add-exports
+                manifestAttributes.addExports().forEach((mn, pl) -> {
+                    Map<String, PackageAccess> subMap = depAccesses.computeIfAbsent(mn, ModularitySteps::newMap);
+                    pl.forEach(pn -> subMap.putIfAbsent(pn, PackageAccess.EXPORTED));
+                });
+                // enable-native-access
+                if (manifestAttributes.enableNativeAccess()) {
+                    flags = flags.with(ModuleDescriptor.Modifier.NATIVE_ACCESS);
+                }
+            }
+            // create an index of all of the packages based on the content tree
+            indexPackages(packages, contentTree);
+            // process the service files into a service provider map
+            provides = contentTree.apply("META-INF/services", pv -> {
+                if (pv == null) {
+                    return Map.of();
+                }
+                Map<String, List<String>> services = new HashMap<>();
+                try (DirectoryStream<Path> ds = Files.newDirectoryStream(pv.getPath())) {
+                    for (Path svc : ds) {
+                        if (Files.isRegularFile(svc)) {
+                            services.put(svc.getFileName().toString(),
+                                    readServicesFile(Files.newBufferedReader(svc, StandardCharsets.UTF_8), new ArrayList<>()));
+                        }
+                    }
+                } catch (IOException ignored) {
+                }
+                return Map.copyOf(services);
+            });
+            // automatic modules automatically use all services
+            uses = Set.of();
+            // automatic module implicit requirements; the rest come from Maven
+            requires.add(new DependencyInfo("java.base", Modifier.Set.of(Modifier.LINKED,
+                    Modifier.READ, Modifier.SERVICES, Modifier.MANDATED), Map.of()));
+            // todo: ideally we could avoid requiring `java.se` even for automatic modules thru dep analysis
+            requires.add(new DependencyInfo("java.se", Modifier.Set.of(Modifier.LINKED,
+                    Modifier.READ, Modifier.SERVICES, Modifier.SYNTHETIC), Map.of()));
+            // compute automatic dependencies
+            // NOTE: this includes each artifact in the transitive graph; this is NOT THE SAME
+            // as marking the module dependency as `TRANSITIVE` and cannot be replaced with doing so.
+            autoDeps = computeAutomaticDependencies(moduleName, dependency,
+                    allDeps, depAccesses);
+        }
+        // Add generated resources that were previously indexed for us (#44657)
+        // NOTE: modifies the generated packages map
+        List<Resource> generated = packages.keySet().stream()
+                .map(generatedByPackageAndPath::remove)
+                .filter(Objects::nonNull)
+                .map(Map::values)
+                .flatMap(Collection::stream)
+                .sorted(Comparator.comparing(Resource::pathName))
+                .collect(Collectors.toList());
+
+        ModuleInfo mi = new ModuleInfo(moduleName, moduleVersion, flags, dependency, mainClass, packages, requires,
+                autoDeps, uses, provides, generated);
+        return transformation.apply(mi);
+    }
+
+    /**
+     * A work list item for the recursive automatic dependency processing algorithm.
+     *
+     * @param moduleName the module name to depend on (must not be {@code null})
+     * @param artifact the artifact of the dependency module (must not be {@code null})
+     * @param depth the recursion depth
+     * @param optional {@code true} if the dependency should be optional, or {@code false} if it should be required
+     */
+    private record WorkListItem(String moduleName, ResolvedDependency artifact, int depth, boolean optional) {
+    }
+
+    /**
+     * The entry point for automatic dependency processing.
+     * The dependencies are assembled into "groups" so that we can add comments before each group to understand
+     * where each dependency came from.
+     *
+     * @param moduleName the name of the module being considered (must not be {@code null})
+     * @param rootArtifact the artifact of the module being considered (must not be {@code null})
+     * @param allDeps the map of all dependencies in the project (must not be {@code null})
+     * @param depAccesses the dependency extra accesses map
+     * @return the list of automatic dependency groups (not {@code null})
+     */
+    private static List<AutoDependencyGroup> computeAutomaticDependencies(String moduleName, ResolvedDependency rootArtifact,
+            final Map<ArtifactKey, ResolvedDependency> allDeps,
+            final Map<String, Map<String, PackageAccess>> depAccesses) {
+        HashSet<ArtifactKey> visited = new HashSet<>();
+        // ignore any cyclic reference
+        visited.add(keyOf(rootArtifact));
+        final ArrayDeque<WorkListItem> workList = new ArrayDeque<>();
+        ArrayList<AutoDependencyGroup> groups = new ArrayList<>();
+        // add the initial work list entry
+        workList.add(new WorkListItem(moduleName, rootArtifact, 0, false));
+        // run the work list until all dependencies have been processed
+        while (!workList.isEmpty()) {
+            WorkListItem item = workList.removeFirst();
+            computeAutomaticDependencies(item.moduleName(), item.artifact(), allDeps, visited, workList,
+                    groups, item.depth(), item.optional(), depAccesses);
+        }
+        return groups;
+    }
+
+    /**
+     * Process automatic module dependencies.
+     * This is done by recursively visiting the transitive closure of the module's Maven dependencies (even non-automatic
+     * modules),
+     * because automatic modules normally can "see" all of these artifacts.
+     * Note that this is not exactly the same as traditional {@code module-info} transitive dependencies.
+     *
+     * @param moduleName the name of the module being considered (must not be {@code null})
+     * @param artifact the artifact of the module being considered (must not be {@code null})
+     * @param allDeps the map of all dependencies in the project (must not be {@code null})
+     * @param visited the visited set of module names (must not be {@code null})
+     * @param workList the remaining work list (must not be {@code null})
+     * @param groups the groups list (must not be {@code null})
+     * @param depth the nesting depth
+     * @param optional if this subtree is optional
+     * @param depAccesses the dependency extra accesses map
+     */
+    private static void computeAutomaticDependencies(String moduleName, ResolvedDependency artifact,
+            Map<ArtifactKey, ResolvedDependency> allDeps,
+            Set<ArtifactKey> visited, ArrayDeque<WorkListItem> workList,
+            ArrayList<AutoDependencyGroup> groups, int depth, boolean optional,
+            Map<String, Map<String, PackageAccess>> depAccesses) {
+
+        Collection<Dependency> deps = artifact.getDirectDependencies();
+        // map and sort dependencies
+        final List<DependencyInfo> depList = new ArrayList<>(deps.size());
+        for (Dependency dependency : deps) {
+            ArtifactKey key = keyOf(dependency);
+            if (visited.add(key)) {
+                ResolvedDependency resolved = allDeps.get(key);
+                if (resolved == null || !resolved.isResolved() || resolved.getContentTree().isEmpty() ||
+                        dependency.isFlagSet(DependencyFlags.MISSING_FROM_APPLICATION)) {
+                    if (!dependency.isOptional()) {
+                        log.debugf("No dependency found from %s to %s", moduleName, key);
+                    }
+                    continue;
+                }
+                if (!dependency.isFlagSet(DependencyFlags.RUNTIME_CP)) {
+                    log.debugf("Skipping non-runtime dependency from %s to %s", moduleName, key);
+                    continue;
+                }
+                switch (resolved.getScope()) {
+                    case "compile", "provided", "runtime" -> {
+                    }
+                    default -> {
+                        log.debugf("Skipping dependency with scope %s", resolved.getScope());
+                        continue;
+                    }
+                }
+                String depName = resolved.getModuleName();
+                Modifier.Set mods = Modifier.Set.of(Modifier.LINKED, Modifier.READ, Modifier.SERVICES);
+                if (optional || dependency.isOptional() ||
+                        dependency.getScope().equals("provided") ||
+                        depth > 1) {
+                    mods = mods.with(Modifier.OPTIONAL);
+                }
+                depList.add(new DependencyInfo(
+                        depName,
+                        mods,
+                        depAccesses.getOrDefault(depName, Map.of())));
+                workList.addLast(new WorkListItem(depName, resolved, depth + 1, optional || mods.contains(Modifier.OPTIONAL)));
+            }
+        }
+        if (!depList.isEmpty()) {
+            depList.sort(Comparator.comparing(DependencyInfo::moduleName));
+            AutoDependencyGroup group = new AutoDependencyGroup(
+                    moduleName,
+                    depList);
+            groups.add(group);
+        }
+    }
+
+    /**
+     * Create a usable artifact key from a dependency or its coordinates.
+     *
+     * @param dependency the coordinates object (must not be {@code null})
+     * @return the artifact key (group, artifact, and classifier only) (not {@code null})
+     */
+    private static ArtifactKey keyOf(final ArtifactCoords dependency) {
+        return ArtifactKey.gac(dependency.getGroupId(), dependency.getArtifactId(), dependency.getClassifier());
+    }
+
+    /**
+     * Convert JPMS access flags to Quarkus module modifiers.
+     *
+     * @param flags the JPMS access flags set (must not be {@code null})
+     * @return the Quarkus module modifiers (not {@code null})
+     */
+    private static Modifier.Set depModifiersOf(final Set<AccessFlag> flags) {
+        Modifier.Set set = Modifier.Set.of(Modifier.LINKED, Modifier.READ,
+                Modifier.SERVICES);
+        if (flags.contains(AccessFlag.STATIC_PHASE)) {
+            set = set.with(Modifier.OPTIONAL);
+        }
+        if (flags.contains(AccessFlag.TRANSITIVE)) {
+            set = set.with(Modifier.TRANSITIVE);
+        }
+        if (flags.contains(AccessFlag.SYNTHETIC)) {
+            set = set.with(Modifier.SYNTHETIC);
+        }
+        if (flags.contains(AccessFlag.MANDATED)) {
+            set = set.with(Modifier.MANDATED);
+        }
+        return set;
+    }
+
+    /**
+     * Update the given package index based on discovered packages in an automatic module.
+     *
+     * @param packages the packages map to update (must not be {@code null})
+     * @param content the artifact content (must not be {@code null})
+     */
+    private static void indexPackages(final Map<String, PackageInfo> packages, final PathTree content) {
+        content.walk(vp -> {
+            String rp = vp.getResourceName();
+            // flatten MR-JAR structure.
+            if (rp.startsWith("META-INF/versions/")) {
+                int idx = rp.indexOf('/', 18);
+                if (idx == -1) {
+                    // skip weird entry
+                    return;
+                }
+                rp = rp.substring(idx + 1);
+            }
+            // A directory is a package if it contains a class.
+            if (rp.endsWith(".class")) {
+                int idx = rp.lastIndexOf('/');
+                if (idx != -1) {
+                    String pkgName = rp.substring(0, idx).replace('/', '.');
+                    // A package is public if it does not contain a segment named `impl`, `private_`, or `_private`.
+                    packages.compute(pkgName, (n, old) -> {
+                        if (n.endsWith(".impl") || n.contains(".impl.")
+                                || n.endsWith(".private_") || n.contains(".private_.")
+                                || n.endsWith("._private") || n.contains("._private.")) {
+                            return PackageInfo.merge(old, PackageInfo.PRIVATE);
+                        } else {
+                            return PackageInfo.merge(old, PackageInfo.EXPORTED);
+                        }
+                    });
+                }
+            }
+        });
+    }
+
+    /**
+     * Process one of the access annotations: {@code io.smallrye.common.annotation.AddOpens}
+     * or {@code io.smallrye.common.annotation.AddExports}.
+     *
+     * @param ann the annotation (must not be {@code null})
+     * @param depAccesses the writable map of package accesses (must not be {@code null})
+     * @param access the access to grant (must not be {@code null}; based on the annotation type)
+     */
+    private static void processAccessAnnotation(Annotation ann, Map<String, Map<String, PackageAccess>> depAccesses,
+            PackageAccess access) {
+        String moduleName = null;
+        Set<String> packages = null;
+        for (AnnotationElement element : ann.elements()) {
+            switch (element.name().stringValue()) {
+                case "module" -> moduleName = ((AnnotationValue.OfString) element.value()).stringValue();
+                case "packages" -> packages = ((AnnotationValue.OfArray) element.value()).values().stream()
+                        .map(AnnotationValue.OfString.class::cast).map(AnnotationValue.OfString::stringValue)
+                        .collect(Collectors.toSet());
+            }
+        }
+        if (moduleName == null || moduleName.equals("ALL-UNNAMED") || packages == null) {
+            // ignore invalid annotation
+            return;
+        }
+        Map<String, PackageAccess> accesses = depAccesses.computeIfAbsent(moduleName, ModularitySteps::newMap);
+        switch (access) {
+            case OPEN -> packages.forEach(pn -> accesses.put(pn, PackageAccess.OPEN));
+            case EXPORTED -> packages.forEach(pn -> accesses.putIfAbsent(pn, PackageAccess.EXPORTED));
+        }
+    }
+
+    /**
+     * {@return a new map for use in Map.compute*() operations}
+     */
+    private static <K, V> Map<K, V> newMap(Object ignored) {
+        return new HashMap<>();
+    }
+
+    /**
+     * {@return a new list for use in Map.compute*() operations}
+     */
+    private static <E> List<E> newList(Object ignored) {
+        return new ArrayList<>();
+    }
+
+    /**
+     * Process an access annotation list.
+     *
+     * @param ann the list annotation (must not be {@code null})
+     * @param depAccesses the writable map of package accesses (must not be {@code null})
+     * @param access the access to grant (must not be {@code null}; based on the annotation type)
+     */
+    private static void processAccessAnnotationList(Annotation ann, Map<String, Map<String, PackageAccess>> depAccesses,
+            PackageAccess access) {
+        for (AnnotationElement element : ann.elements()) {
+            switch (element.name().stringValue()) {
+                case "value" ->
+                    processAccessAnnotation(((AnnotationValue.OfAnnotation) element.value()).annotation(), depAccesses, access);
+            }
+        }
+    }
+
+}

--- a/extensions/packaging/modular/pom.xml
+++ b/extensions/packaging/modular/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-packaging-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-modular-parent</artifactId>
+
+    <name>Quarkus - Modularity</name>
+    <description>The parent POM for modular packaging</description>
+
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>spi</module>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+</project>

--- a/extensions/packaging/modular/runtime/pom.xml
+++ b/extensions/packaging/modular/runtime/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-modular-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-modular</artifactId>
+
+    <name>Quarkus - Modularity - Runtime</name>
+    <description>The runtime module for modular builds</description>
+
+    <dependencies>
+        <!-- Not really a "real" dependency; excluded from boot modules -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.modules</groupId>
+            <artifactId>smallrye-modules</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>io.quarkus.modular</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>extension-descriptor</goal>
+                        </goals>
+                        <configuration>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.quarkus</groupId>
+                                    <artifactId>quarkus-extension-processor</artifactId>
+                                    <version>${project.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/packaging/modular/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/packaging/modular/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,9 @@
+---
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+name: "Modularity"
+metadata:
+  categories:
+  - "packaging"
+  status: "experimental"
+  config:
+  - "quarkus.modular."

--- a/extensions/packaging/modular/spi/pom.xml
+++ b/extensions/packaging/modular/spi/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-modular-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-modular-spi</artifactId>
+
+    <name>Quarkus - Modularity - SPI</name>
+    <description>The SPI for modular builds</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-builder</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.config</groupId>
+            <artifactId>smallrye-config-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-bootstrap-app-model</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.modules</groupId>
+            <artifactId>smallrye-modules</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/extensions/packaging/modular/spi/src/main/java/io/quarkus/modular/spi/FormattingXMLStreamWriter.java
+++ b/extensions/packaging/modular/spi/src/main/java/io/quarkus/modular/spi/FormattingXMLStreamWriter.java
@@ -1,0 +1,198 @@
+package io.quarkus.modular.spi;
+
+import javax.xml.namespace.NamespaceContext;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+/**
+ * A simple formatter for XML.
+ */
+final class FormattingXMLStreamWriter implements XMLStreamWriter {
+    private final XMLStreamWriter delegate;
+    boolean pendingBreak = false;
+    int level = 0;
+
+    FormattingXMLStreamWriter(final XMLStreamWriter delegate) {
+        this.delegate = delegate;
+    }
+
+    public void writeStartElement(final String localName) throws XMLStreamException {
+        indent();
+        delegate.writeStartElement(localName);
+        pendingBreak = true;
+        level++;
+    }
+
+    public void writeStartElement(final String namespaceURI, final String localName) throws XMLStreamException {
+        indent();
+        delegate.writeStartElement(namespaceURI, localName);
+        pendingBreak = true;
+        level++;
+    }
+
+    public void writeStartElement(final String prefix, final String localName, final String namespaceURI)
+            throws XMLStreamException {
+        indent();
+        delegate.writeStartElement(prefix, namespaceURI, localName);
+        pendingBreak = true;
+        level++;
+    }
+
+    public void writeEmptyElement(final String namespaceURI, final String localName) throws XMLStreamException {
+        indent();
+        delegate.writeEmptyElement(namespaceURI, localName);
+        pendingBreak = true;
+    }
+
+    public void writeEmptyElement(final String prefix, final String localName, final String namespaceURI)
+            throws XMLStreamException {
+        indent();
+        delegate.writeEmptyElement(prefix, namespaceURI, localName);
+        pendingBreak = true;
+    }
+
+    public void writeEmptyElement(final String localName) throws XMLStreamException {
+        indent();
+        delegate.writeEmptyElement(localName);
+        pendingBreak = true;
+    }
+
+    public void writeEndElement() throws XMLStreamException {
+        level--;
+        indent();
+        delegate.writeEndElement();
+        delegate.writeCharacters("\n");
+    }
+
+    public void writeEndDocument() throws XMLStreamException {
+        checkBreak();
+        delegate.writeEndDocument();
+    }
+
+    public void close() throws XMLStreamException {
+        delegate.close();
+    }
+
+    public void flush() throws XMLStreamException {
+        delegate.flush();
+    }
+
+    public void writeAttribute(final String localName, final String value) throws XMLStreamException {
+        delegate.writeAttribute(localName, value);
+    }
+
+    public void writeAttribute(final String prefix, final String namespaceURI, final String localName, final String value)
+            throws XMLStreamException {
+        delegate.writeAttribute(prefix, namespaceURI, localName, value);
+    }
+
+    public void writeAttribute(final String namespaceURI, final String localName, final String value)
+            throws XMLStreamException {
+        delegate.writeAttribute(namespaceURI, localName, value);
+    }
+
+    public void writeNamespace(final String prefix, final String namespaceURI) throws XMLStreamException {
+        delegate.writeNamespace(prefix, namespaceURI);
+    }
+
+    public void writeDefaultNamespace(final String namespaceURI) throws XMLStreamException {
+        delegate.writeDefaultNamespace(namespaceURI);
+    }
+
+    public void writeComment(final String data) throws XMLStreamException {
+        indent();
+        delegate.writeComment(data);
+        delegate.writeCharacters("\n");
+    }
+
+    public void writeProcessingInstruction(final String target) throws XMLStreamException {
+        checkBreak();
+        delegate.writeProcessingInstruction(target);
+    }
+
+    public void writeProcessingInstruction(final String target, final String data) throws XMLStreamException {
+        checkBreak();
+        delegate.writeProcessingInstruction(target, data);
+    }
+
+    public void writeCData(final String data) throws XMLStreamException {
+        checkBreak();
+        delegate.writeCData(data);
+    }
+
+    public void writeDTD(final String dtd) throws XMLStreamException {
+        checkBreak();
+        delegate.writeDTD(dtd);
+    }
+
+    public void writeEntityRef(final String name) throws XMLStreamException {
+        checkBreak();
+        delegate.writeEntityRef(name);
+    }
+
+    public void writeStartDocument() throws XMLStreamException {
+        checkBreak();
+        delegate.writeStartDocument();
+        delegate.writeCharacters("\n\n");
+    }
+
+    public void writeStartDocument(final String version) throws XMLStreamException {
+        checkBreak();
+        delegate.writeStartDocument(version);
+        delegate.writeCharacters("\n\n");
+    }
+
+    public void writeStartDocument(final String encoding, final String version) throws XMLStreamException {
+        checkBreak();
+        delegate.writeStartDocument(encoding, version);
+        delegate.writeCharacters("\n\n");
+    }
+
+    public void writeCharacters(final String text) throws XMLStreamException {
+        checkBreak();
+        delegate.writeCharacters(text);
+    }
+
+    public void writeCharacters(final char[] text, final int start, final int len) throws XMLStreamException {
+        indent();
+        delegate.writeCharacters(text, start, len);
+    }
+
+    public String getPrefix(final String uri) throws XMLStreamException {
+        return delegate.getPrefix(uri);
+    }
+
+    public void setPrefix(final String prefix, final String uri) throws XMLStreamException {
+        delegate.setPrefix(prefix, uri);
+    }
+
+    public void setDefaultNamespace(final String uri) throws XMLStreamException {
+        delegate.setDefaultNamespace(uri);
+    }
+
+    public void setNamespaceContext(final NamespaceContext context) throws XMLStreamException {
+        delegate.setNamespaceContext(context);
+    }
+
+    public NamespaceContext getNamespaceContext() {
+        return delegate.getNamespaceContext();
+    }
+
+    public Object getProperty(final String name) throws IllegalArgumentException {
+        return delegate.getProperty(name);
+    }
+
+    private void indent() throws XMLStreamException {
+        checkBreak();
+        for (int i = 0; i < level; i++) {
+            delegate.writeCharacters("    ");
+        }
+    }
+
+    private void checkBreak() throws XMLStreamException {
+        if (pendingBreak) {
+            pendingBreak = false;
+            delegate.writeCharacters("\n");
+        }
+    }
+}

--- a/extensions/packaging/modular/spi/src/main/java/io/quarkus/modular/spi/JarDirEntry.java
+++ b/extensions/packaging/modular/spi/src/main/java/io/quarkus/modular/spi/JarDirEntry.java
@@ -1,0 +1,46 @@
+package io.quarkus.modular.spi;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.file.attribute.FileTime;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.zip.ZipEntry;
+
+final class JarDirEntry implements Closeable {
+    private final JarOutputStream jarOutput;
+    private final JarEntry entry;
+    private boolean closed;
+
+    JarDirEntry(JarOutputStream jarOutput, String name) throws IOException {
+        if (!name.endsWith("/")) {
+            throw new IllegalArgumentException("Directory name must end with /");
+        }
+        this.jarOutput = jarOutput;
+        this.entry = new JarEntry(name);
+        entry.setMethod(ZipEntry.STORED);
+        entry.setSize(0);
+        entry.setCompressedSize(0);
+        entry.setCrc(0);
+        jarOutput.putNextEntry(entry);
+    }
+
+    public void close() throws IOException {
+        if (!closed) {
+            closed = true;
+            jarOutput.closeEntry();
+        }
+    }
+
+    public void setLastModifiedTime(final FileTime time) {
+        entry.setLastModifiedTime(time);
+    }
+
+    public void setLastAccessTime(final FileTime time) {
+        entry.setLastAccessTime(time);
+    }
+
+    public void setCreationTime(final FileTime time) {
+        entry.setCreationTime(time);
+    }
+}

--- a/extensions/packaging/modular/spi/src/main/java/io/quarkus/modular/spi/JarEntryOutputStream.java
+++ b/extensions/packaging/modular/spi/src/main/java/io/quarkus/modular/spi/JarEntryOutputStream.java
@@ -1,0 +1,194 @@
+package io.quarkus.modular.spi;
+
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.RandomAccessFile;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.attribute.AclEntry;
+import java.nio.file.attribute.AclEntryPermission;
+import java.nio.file.attribute.AclEntryType;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.FileTime;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.zip.CRC32;
+import java.util.zip.ZipEntry;
+
+import io.smallrye.common.os.OS;
+
+final class JarEntryOutputStream extends OutputStream {
+    private final JarOutputStream jarOutput;
+    private final JarEntry entry;
+    private final CRC32 crc = new CRC32();
+    private final File tempFile;
+    private final RandomAccessFile raf;
+    private final OutputStream os;
+    private long written;
+    private boolean closed;
+    private static final FileAttribute<?> USER_ACCESS_ONLY;
+
+    static {
+        // todo: this blob should probably be in `smallrye-common-io` somewhere
+        if (OS.current() == OS.WINDOWS) {
+            List<AclEntry> aclList;
+            try {
+                aclList = List.of(AclEntry.newBuilder()
+                        .setType(AclEntryType.ALLOW)
+                        .setPermissions(EnumSet.allOf(AclEntryPermission.class))
+                        .setPrincipal(
+                                FileSystems.getDefault().getUserPrincipalLookupService().lookupPrincipalByName(
+                                        ProcessHandle.current().info().user().orElseGet(() -> System.getProperty("user.name"))))
+                        .build());
+            } catch (IOException e) {
+                throw new IllegalStateException("Cannot get ACL entries", e);
+            }
+            USER_ACCESS_ONLY = new FileAttribute<List<AclEntry>>() {
+                public String name() {
+                    return "acl:acl";
+                }
+
+                public List<AclEntry> value() {
+                    return aclList;
+                }
+            };
+        } else {
+            USER_ACCESS_ONLY = PosixFilePermissions
+                    .asFileAttribute(Set.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE));
+        }
+    }
+
+    JarEntryOutputStream(final JarOutputStream jarOutput, final String name, boolean compress, long estSize)
+            throws IOException {
+        if (name.endsWith("/")) {
+            throw new IllegalArgumentException("Entry file name must not end with /");
+        }
+        this.jarOutput = jarOutput;
+        entry = new JarEntry(name);
+        if (compress) {
+            // they do the work for us; write directly
+            entry.setMethod(ZipEntry.DEFLATED);
+            os = jarOutput;
+            raf = null;
+            tempFile = null;
+            jarOutput.putNextEntry(entry);
+        } else {
+            // we have to precompute CRC, size etc.
+            // this is because ZipOutputStream does not support setting general flag bit 3 for STORED entries;
+            // this flag indicates that CRC and size info go into the data descriptor at the end instead.
+            // this is due to PKZIP 2.04g for DOS only supporting this for STORED. that's from 1993...
+            // but ZipInputStream also does not support it now, so it is what it is.
+            if (estSize >= 0 && estSize < 8192) {
+                tempFile = null;
+                raf = null;
+                os = new ByteArrayOutputStream((int) estSize);
+            } else {
+                tempFile = Files.createTempFile("quarkus-", "", USER_ACCESS_ONLY).toFile();
+                raf = new RandomAccessFile(tempFile, "rw");
+                try {
+                    os = new FileOutputStream(raf.getFD());
+                } catch (IOException e) {
+                    try {
+                        raf.close();
+                    } catch (IOException e2) {
+                        e.addSuppressed(e2);
+                    }
+                    throw e;
+                }
+            }
+            entry.setMethod(ZipEntry.STORED);
+        }
+    }
+
+    JarEntryOutputStream(final JarOutputStream jarOutput, final String name) throws IOException {
+        this(jarOutput, name, false, -1);
+    }
+
+    public void write(final byte[] b) throws IOException {
+        check();
+        os.write(b);
+        crc.update(b);
+        written += b.length;
+    }
+
+    public void write(final byte[] b, final int off, final int len) throws IOException {
+        check();
+        os.write(b, off, len);
+        crc.update(b, off, len);
+        written += len;
+    }
+
+    public void write(final int b) throws IOException {
+        check();
+        os.write(b);
+        crc.update(b);
+        written++;
+    }
+
+    public void flush() throws IOException {
+        check();
+    }
+
+    public void close() throws IOException {
+        if (!closed) {
+            closed = true;
+            if (entry.getMethod() == ZipEntry.STORED) {
+                try (Closeable ignored = jarOutput::closeEntry) {
+                    if (raf != null) {
+                        // it's in a temp file
+                        try (os) {
+                            try (raf) {
+                                try (Closeable ignored2 = tempFile::delete) {
+                                    entry.setCrc(crc.getValue());
+                                    entry.setSize(written);
+                                    entry.setCompressedSize(written);
+                                    jarOutput.putNextEntry(entry);
+                                    raf.seek(0);
+                                    try (FileInputStream is = new FileInputStream(raf.getFD())) {
+                                        is.transferTo(jarOutput);
+                                    }
+                                }
+                            }
+                        }
+                    } else {
+                        entry.setCrc(crc.getValue());
+                        entry.setSize(written);
+                        entry.setCompressedSize(written);
+                        jarOutput.putNextEntry(entry);
+                        jarOutput.write(((ByteArrayOutputStream) os).toByteArray());
+                    }
+                }
+            } else {
+                jarOutput.closeEntry();
+            }
+        }
+    }
+
+    public void setLastModifiedTime(final FileTime time) {
+        entry.setLastModifiedTime(time);
+    }
+
+    public void setLastAccessTime(final FileTime time) {
+        entry.setLastAccessTime(time);
+    }
+
+    public void setCreationTime(final FileTime time) {
+        entry.setCreationTime(time);
+    }
+
+    private void check() throws IOException {
+        if (closed) {
+            throw new IOException("Entry closed");
+        }
+    }
+}

--- a/extensions/packaging/modular/spi/src/main/java/io/quarkus/modular/spi/ModuleWriter.java
+++ b/extensions/packaging/modular/spi/src/main/java/io/quarkus/modular/spi/ModuleWriter.java
@@ -1,0 +1,541 @@
+package io.quarkus.modular.spi;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.lang.constant.ClassDesc;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributeView;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import java.util.stream.Collectors;
+
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.maven.dependency.ResolvedDependency;
+import io.quarkus.modular.spi.model.AutoDependencyGroup;
+import io.quarkus.modular.spi.model.DependencyInfo;
+import io.quarkus.modular.spi.model.ModuleInfo;
+import io.quarkus.paths.PathTree;
+import io.smallrye.classfile.Annotation;
+import io.smallrye.classfile.AnnotationElement;
+import io.smallrye.classfile.AnnotationValue;
+import io.smallrye.classfile.ClassFile;
+import io.smallrye.classfile.attribute.ModuleAttribute;
+import io.smallrye.classfile.attribute.ModuleMainClassAttribute;
+import io.smallrye.classfile.attribute.ModulePackagesAttribute;
+import io.smallrye.classfile.attribute.RuntimeInvisibleAnnotationsAttribute;
+import io.smallrye.classfile.extras.constant.ModuleDesc;
+import io.smallrye.classfile.extras.constant.PackageDesc;
+import io.smallrye.classfile.extras.reflect.AccessFlag;
+import io.smallrye.common.constraint.Assert;
+import io.smallrye.common.resource.Resource;
+import io.smallrye.modules.desc.Dependency;
+import io.smallrye.modules.desc.ModuleDescriptor;
+import io.smallrye.modules.desc.PackageAccess;
+import io.smallrye.modules.desc.PackageInfo;
+
+/**
+ * Utility to help write patched and curated module files to a destination path.
+ */
+public final class ModuleWriter {
+    private static final Logger log = Logger.getLogger("io.quarkus.modular.spi");
+
+    private ModuleWriter() {
+    }
+
+    /**
+     * Write a patched module to the given output directory.
+     *
+     * @param moduleInfo the module information (must not be {@code null})
+     * @param outputDirectory the output directory (must not be {@code null})
+     * @param manifest the JAR manifest (must not be {@code null})
+     * @param bootModule {@code true} if this module is a boot module (and thus requires a {@code module-info.class})
+     * @return the path of the written module
+     * @throws IOException if writing fails for some reason
+     */
+    public static Path writeModule(ModuleInfo moduleInfo, Path outputDirectory, Manifest manifest, final boolean bootModule)
+            throws IOException {
+        Assert.checkNotNullParam("moduleInfo", moduleInfo);
+        Assert.checkNotNullParam("outputDirectory", outputDirectory);
+        Assert.checkNotNullParam("manifest", manifest);
+        log.debugf("Writing module %s", moduleInfo.name());
+        ResolvedDependency artifact = moduleInfo.resolvedArtifact();
+        // get an index of all generated/transformed resources
+        Map<String, Resource> generated = moduleInfo.generated().stream().collect(
+                Collectors.toMap(Resource::pathName, Function.identity()));
+        // compute the file name from the artifact info
+        final String fileName = artifact.getArtifactId() + "-" + artifact.getVersion() + "-patched.jar";
+        // Create the artifact
+        Files.createDirectories(outputDirectory);
+        PathTree contentTree = artifact.getContentTree();
+        Set<String> directories = new HashSet<>();
+        directories.add("META-INF");
+        Path outputPath = outputDirectory.resolve(fileName);
+        try (OutputStream fos = Files.newOutputStream(outputPath)) {
+            try (JarOutputStream jarOutput = new JarOutputStream(fos)) {
+                // start with the Manifest
+                try (JarDirEntry dir = new JarDirEntry(jarOutput, "META-INF/")) {
+                    // todo: set dates & times based on original resource
+                }
+                try (JarEntryOutputStream os = new JarEntryOutputStream(jarOutput, "META-INF/MANIFEST.MF")) {
+                    manifest.write(os);
+                }
+                // next, write module descriptor
+                if (bootModule) {
+                    // descriptor for "normal" module
+                    byte[] moduleInfoClass = getModuleInfoClass(moduleInfo);
+                    try (JarEntryOutputStream os = new JarEntryOutputStream(jarOutput, "module-info.class", false,
+                            moduleInfoClass.length)) {
+                        os.write(moduleInfoClass);
+                    }
+                } else {
+                    // write XML for automatic module
+                    try (JarEntryOutputStream os = new JarEntryOutputStream(jarOutput, "module.xml")) {
+                        try (OutputStreamWriter osw = new OutputStreamWriter(os, StandardCharsets.UTF_8)) {
+                            try (BufferedWriter bw = new BufferedWriter(osw)) {
+                                XMLOutputFactory xmlOutputFactory = XMLOutputFactory.newDefaultFactory();
+                                xmlOutputFactory.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, Boolean.TRUE);
+                                XMLStreamWriter xml = xmlOutputFactory.createXMLStreamWriter(bw);
+                                try (XmlCloser ignored = xml::close) {
+                                    writeModuleXml(new FormattingXMLStreamWriter(xml), moduleInfo);
+                                }
+                            } catch (XMLStreamException e) {
+                                throw new IOException(e);
+                            }
+                        }
+                    }
+                }
+                // write all resources
+                for (Resource resource : moduleInfo.generated()) {
+                    if (resource.isDirectory()) {
+                        continue;
+                    }
+                    // todo: create parent directories
+                    try (JarEntryOutputStream os = new JarEntryOutputStream(jarOutput, resource.pathName(), false,
+                            resource.size())) {
+                        try (InputStream is = resource.openStream()) {
+                            is.transferTo(os);
+                        }
+                    }
+                }
+                // now, find and process all files using our own walker
+                contentTree.walk(visited -> {
+                    String rp = visited.getResourceName();
+                    if (generated.containsKey(rp)) {
+                        // skip it until the end
+                        return;
+                    }
+                    BasicFileAttributes attr;
+                    try {
+                        attr = Files.getFileAttributeView(visited.getPath(), BasicFileAttributeView.class).readAttributes();
+                    } catch (IOException e) {
+                        throw sneak(e);
+                    }
+                    if (attr.isDirectory()) {
+                        if (rp.isEmpty()) {
+                            // skip base directory entry
+                            return;
+                        }
+                        if (directories.add(rp)) {
+                            try (JarDirEntry dir = new JarDirEntry(jarOutput, rp + "/")) {
+                                dir.setCreationTime(attr.creationTime());
+                                dir.setLastModifiedTime(attr.lastModifiedTime());
+                                dir.setLastAccessTime(attr.lastAccessTime());
+                            } catch (IOException e) {
+                                throw sneak(e);
+                            }
+                        }
+                    } else {
+                        if (rp.equals("META-INF/MANIFEST.MF") || rp.equals("module-info.class")
+                                || rp.endsWith("/module-info.class")) {
+                            // skip
+                            return;
+                        }
+                        int idx = rp.lastIndexOf('/');
+                        if (idx != -1) {
+                            // make sure the directory exists
+                            // todo: recurse to parents, extract to method for reuse
+                            String dirName = rp.substring(0, idx);
+                            if (directories.add(dirName)) {
+                                try (JarDirEntry dir = new JarDirEntry(jarOutput, dirName)) {
+                                    // todo: default date & time
+                                } catch (IOException e) {
+                                    throw sneak(e);
+                                }
+                            }
+                        }
+                        // copy the content
+                        try (JarEntryOutputStream os = new JarEntryOutputStream(jarOutput, rp, false, attr.size())) {
+                            os.setCreationTime(attr.creationTime());
+                            os.setLastModifiedTime(attr.lastModifiedTime());
+                            os.setLastAccessTime(attr.lastAccessTime());
+                            Files.copy(visited.getPath(), os);
+                        } catch (IOException ioe) {
+                            throw sneak(ioe);
+                        }
+                    }
+                });
+            }
+        } catch (Throwable t) {
+            // don't leave a half-written file around
+            try {
+                Files.delete(outputPath);
+            } catch (Throwable t2) {
+                t.addSuppressed(t2);
+            }
+            throw t;
+        }
+        return outputPath;
+    }
+
+    /**
+     * Get a {@code module-info.class} for the given module.
+     * Note that this might lose some information, so this should only be used when necessary.
+     *
+     * @param moduleInfo the module information (must not be {@code null})
+     * @return the {@code module-info.class} bytes (not {@code null})
+     */
+    private static byte[] getModuleInfoClass(final ModuleInfo moduleInfo) {
+        return ClassFile.of().buildModule(ModuleAttribute.of(
+                ModuleDesc.of(moduleInfo.name()),
+                mab -> {
+                    boolean automatic = moduleInfo.modifiers().contains(ModuleDescriptor.Modifier.AUTOMATIC);
+                    if (automatic) {
+                        log.warnf("Generating module-info for automatic module %s", moduleInfo.name());
+                    }
+                    boolean open = automatic || moduleInfo.modifiers().contains(ModuleDescriptor.Modifier.OPEN);
+                    int bits = 0;
+                    if (open) {
+                        bits |= AccessFlag.OPEN.mask();
+                    }
+                    mab.moduleFlags(bits);
+                    String version = moduleInfo.version();
+                    if (version != null) {
+                        mab.moduleVersion(version);
+                    }
+                    for (Map.Entry<String, PackageInfo> e : moduleInfo.packages().entrySet()) {
+                        String pn = e.getKey();
+                        if (pn.isEmpty()) {
+                            // skip default package
+                            continue;
+                        }
+                        PackageInfo info = e.getValue();
+                        switch (info.packageAccess()) {
+                            case EXPORTED -> mab.exports(PackageDesc.of(pn), Set.of(),
+                                    info.exportTargets().stream().map(ModuleDesc::of).toArray(ModuleDesc[]::new));
+                            case OPEN -> mab.opens(PackageDesc.of(pn), Set.of(),
+                                    info.openTargets().stream().map(ModuleDesc::of).toArray(ModuleDesc[]::new));
+                        }
+                    }
+                    if (automatic) {
+                        // todo: scrape the module for uses (needs analyzer framework)
+                    }
+                    for (String used : moduleInfo.uses()) {
+                        mab.uses(ClassDesc.of(used));
+                    }
+                    for (Map.Entry<String, List<String>> e : moduleInfo.provides().entrySet()) {
+                        String serviceName = e.getKey();
+                        List<String> serviceImpls = e.getValue();
+                        mab.provides(ClassDesc.of(serviceName),
+                                serviceImpls.stream().map(ClassDesc::of).toArray(ClassDesc[]::new));
+                    }
+                    for (DependencyInfo depInfo : moduleInfo.dependencies()) {
+                        processDep(mab, depInfo);
+                    }
+                    for (AutoDependencyGroup grp : moduleInfo.autoDependencies()) {
+                        for (DependencyInfo depInfo : grp.dependencies()) {
+                            processDep(mab, depInfo);
+                        }
+                    }
+                }), zb -> {
+                    zb.withVersion(ClassFile.JAVA_17_VERSION, 0);
+                    if (moduleInfo.mainClassName() != null) {
+                        zb.with(ModuleMainClassAttribute.of(ClassDesc.of(moduleInfo.mainClassName())));
+                    }
+                    zb.with(ModulePackagesAttribute.of(
+                            moduleInfo.packages().keySet().stream().map(n -> zb.constantPool().packageEntry(PackageDesc.of(n)))
+                                    .toList()));
+                    List<Annotation> annotations = new ArrayList<>();
+                    if (moduleInfo.modifiers().contains(ModuleDescriptor.Modifier.NATIVE_ACCESS)) {
+                        annotations.add(Annotation.of(ClassDesc.of("io.smallrye.common.annotation.NativeAccess")));
+                    }
+                    List<Annotation> addOpens = new ArrayList<>();
+                    List<Annotation> addExports = new ArrayList<>();
+                    for (DependencyInfo depInfo : moduleInfo.dependencies()) {
+                        processDepAnnotations(depInfo, addExports, addOpens);
+                    }
+                    // now, automatic module deps
+                    for (AutoDependencyGroup grp : moduleInfo.autoDependencies()) {
+                        for (DependencyInfo depInfo : grp.dependencies()) {
+                            processDepAnnotations(depInfo, addExports, addOpens);
+                        }
+                    }
+                    switch (addOpens.size()) {
+                        case 0 -> {
+                        }
+                        case 1 -> annotations.add(addOpens.get(0));
+                        default -> annotations.add(Annotation.of(ClassDesc.of("io.smallrye.common.annotation.AddOpens$List"),
+                                addOpens.stream().map(a -> AnnotationElement.ofAnnotation("value", a)).toList()));
+                    }
+                    switch (addExports.size()) {
+                        case 0 -> {
+                        }
+                        case 1 -> annotations.add(addExports.get(0));
+                        default -> annotations.add(Annotation.of(ClassDesc.of("io.smallrye.common.annotation.AddExports$List"),
+                                addExports.stream().map(a -> AnnotationElement.ofAnnotation("value", a)).toList()));
+                    }
+                    if (!annotations.isEmpty()) {
+                        zb.with(RuntimeInvisibleAnnotationsAttribute.of(annotations));
+                    }
+                });
+    }
+
+    private static void processDep(final ModuleAttribute.ModuleAttributeBuilder mab, final DependencyInfo depInfo) {
+        int bits;
+        bits = 0;
+        if (!depInfo.modifiers().containsAny(Dependency.Modifier.LINKED, Dependency.Modifier.READ)) {
+            // skip it
+            return;
+        }
+        if (depInfo.modifiers().contains(Dependency.Modifier.OPTIONAL)) {
+            bits |= AccessFlag.STATIC_PHASE.mask();
+        }
+        if (depInfo.modifiers().contains(Dependency.Modifier.MANDATED)) {
+            bits |= AccessFlag.MANDATED.mask();
+        }
+        if (depInfo.modifiers().contains(Dependency.Modifier.SYNTHETIC)) {
+            bits |= AccessFlag.SYNTHETIC.mask();
+        }
+        if (depInfo.modifiers().contains(Dependency.Modifier.TRANSITIVE)) {
+            bits |= AccessFlag.TRANSITIVE.mask();
+        }
+        mab.requires(ModuleDesc.of(depInfo.moduleName()), bits, null);
+    }
+
+    private static void processDepAnnotations(final DependencyInfo depInfo, final List<Annotation> addExports,
+            final List<Annotation> addOpens) {
+        if (depInfo.packageAccesses().isEmpty()) {
+            return;
+        }
+        List<String> opens = new ArrayList<>();
+        List<String> exports = new ArrayList<>();
+        String moduleName = depInfo.moduleName();
+        for (Map.Entry<String, PackageAccess> e : depInfo.packageAccesses().entrySet()) {
+            String pn = e.getKey();
+            PackageAccess access = e.getValue();
+            switch (access) {
+                case EXPORTED -> exports.add(pn);
+                case OPEN -> opens.add(pn);
+            }
+        }
+        if (!exports.isEmpty()) {
+            addExports.add(Annotation.of(ClassDesc.of("io.smallrye.common.annotation.AddExports"),
+                    AnnotationElement.ofString("module", moduleName),
+                    AnnotationElement.ofArray("packages",
+                            exports.stream().map(AnnotationValue::ofString).toArray(AnnotationValue[]::new))));
+        }
+        if (!opens.isEmpty()) {
+            addOpens.add(Annotation.of(ClassDesc.of("io.smallrye.common.annotation.AddOpens"),
+                    AnnotationElement.ofString("module", moduleName),
+                    AnnotationElement.ofArray("packages",
+                            opens.stream().map(AnnotationValue::ofString).toArray(AnnotationValue[]::new))));
+        }
+    }
+
+    private static final String NS = "urn:jboss:module:3.0";
+
+    interface XmlCloser extends AutoCloseable {
+        void close() throws XMLStreamException;
+    }
+
+    private static void writeModuleXml(final XMLStreamWriter xml, final ModuleInfo moduleInfo)
+            throws XMLStreamException {
+        xml.writeStartDocument();
+        xml.setDefaultNamespace(NS);
+        xml.writeStartElement("module");
+        xml.writeAttribute("name", moduleInfo.name());
+        String version = moduleInfo.version();
+        if (version != null) {
+            xml.writeAttribute("version", version);
+        }
+        if (moduleInfo.modifiers().contains(ModuleDescriptor.Modifier.AUTOMATIC)) {
+            xml.writeAttribute("automatic", "true");
+        }
+        if (moduleInfo.modifiers().contains(ModuleDescriptor.Modifier.NATIVE_ACCESS)) {
+            xml.writeAttribute("native-access", "true");
+        }
+        if (moduleInfo.modifiers().contains(ModuleDescriptor.Modifier.OPEN)) {
+            xml.writeAttribute("open", "true");
+        }
+        if (moduleInfo.modifiers().contains(ModuleDescriptor.Modifier.UNNAMED)) {
+            xml.writeAttribute("unnamed", "true");
+        }
+        if (moduleInfo.mainClassName() != null) {
+            xml.writeEmptyElement("main-class");
+            xml.writeAttribute("name", moduleInfo.mainClassName());
+        }
+        List<DependencyInfo> deps = moduleInfo.dependencies();
+        List<AutoDependencyGroup> autoDeps = moduleInfo.autoDependencies();
+        if (deps.isEmpty() && autoDeps.isEmpty()) {
+            xml.writeEmptyElement("dependencies");
+        } else {
+            xml.writeStartElement("dependencies");
+            for (DependencyInfo dep : deps) {
+                writeDependencyElement(xml, dep);
+            }
+            for (AutoDependencyGroup autoDep : autoDeps) {
+                xml.writeCharacters("\n");
+                xml.writeComment("dependencies of " + autoDep.hostModuleName());
+                for (DependencyInfo dep : autoDep.dependencies()) {
+                    writeDependencyElement(xml, dep);
+                }
+            }
+            xml.writeEndElement();
+        }
+        // gather package list
+        Map<String, PackageInfo> packages = moduleInfo.packages();
+        if (!packages.isEmpty()) {
+            xml.writeStartElement("packages");
+            String[] pkgArray = packages.keySet().toArray(String[]::new);
+            Arrays.sort(pkgArray);
+            for (String pkg : pkgArray) {
+                if (pkg.isEmpty()) {
+                    // skip default package
+                    continue;
+                }
+                PackageInfo pi = packages.get(pkg);
+                switch (pi.packageAccess()) {
+                    case PRIVATE -> {
+                        if (pi.openTargets().isEmpty() && pi.exportTargets().isEmpty()) {
+                            xml.writeEmptyElement("private");
+                            xml.writeAttribute("package", pkg);
+                        } else {
+                            xml.writeStartElement("export");
+                            xml.writeAttribute("package", pkg);
+                            for (String exportTarget : pi.exportTargets()) {
+                                xml.writeEmptyElement("export-to");
+                                xml.writeAttribute("module", exportTarget);
+                            }
+                            for (String openTarget : pi.openTargets()) {
+                                xml.writeEmptyElement("open-to");
+                                xml.writeAttribute("module", openTarget);
+                            }
+                            xml.writeEndElement();
+                        }
+                    }
+                    case EXPORTED -> {
+                        if (pi.openTargets().isEmpty()) {
+                            xml.writeEmptyElement("export");
+                            xml.writeAttribute("package", pkg);
+                        } else {
+                            xml.writeStartElement("export");
+                            xml.writeAttribute("package", pkg);
+                            for (String openTarget : pi.openTargets()) {
+                                xml.writeEmptyElement("open-to");
+                                xml.writeAttribute("module", openTarget);
+                            }
+                            xml.writeEndElement();
+                        }
+                    }
+                    case OPEN -> {
+                        xml.writeEmptyElement("open");
+                        xml.writeAttribute("package", pkg);
+                    }
+                }
+            }
+            xml.writeEndElement(); // packages
+        }
+        if (!moduleInfo.uses().isEmpty()) {
+            xml.writeStartElement("uses");
+            for (String name : moduleInfo.uses()) {
+                xml.writeEmptyElement("use");
+                xml.writeAttribute("name", name);
+            }
+            xml.writeEndElement(); // uses
+        }
+        // ---
+        // provides
+        Map<String, List<String>> provided = moduleInfo.provides();
+        if (!provided.isEmpty()) {
+            xml.writeStartElement("provides");
+            for (Map.Entry<String, List<String>> entry : provided.entrySet()) {
+                String svc = entry.getKey();
+                xml.writeStartElement("provide");
+                xml.writeAttribute("name", svc);
+                for (String impl : entry.getValue()) {
+                    xml.writeEmptyElement("with");
+                    xml.writeAttribute("name", impl);
+                }
+                xml.writeEndElement(); // provide
+            }
+            xml.writeEndElement(); // provides
+        }
+        xml.writeEndElement(); // module
+        xml.writeEndDocument();
+    }
+
+    private static void writeDependencyElement(final XMLStreamWriter xml, final DependencyInfo depInfo)
+            throws XMLStreamException {
+        Map<String, PackageAccess> accesses = depInfo.packageAccesses();
+        String depName = depInfo.moduleName();
+        boolean empty = accesses.isEmpty();
+        if (depName.equals("java.base") && empty) {
+            // skip it (it's implied)
+            return;
+        }
+        if (empty) {
+            xml.writeEmptyElement("dependency");
+        } else {
+            xml.writeStartElement("dependency");
+        }
+        xml.writeAttribute("name", depName);
+        if (depInfo.modifiers().contains(Dependency.Modifier.OPTIONAL)) {
+            xml.writeAttribute("optional", "true");
+        }
+        if (depInfo.modifiers().contains(Dependency.Modifier.TRANSITIVE)) {
+            xml.writeAttribute("transitive", "true");
+        }
+        if (!depInfo.modifiers().contains(Dependency.Modifier.LINKED)) {
+            xml.writeAttribute("linked", "false");
+        }
+        if (!depInfo.modifiers().contains(Dependency.Modifier.READ)) {
+            xml.writeAttribute("read", "false");
+        }
+        if (!empty) {
+            for (String pn : accesses.keySet()) {
+                switch (accesses.get(pn)) {
+                    case EXPORTED -> xml.writeEmptyElement("add-exports");
+                    case OPEN -> xml.writeEmptyElement("add-opens");
+                    default -> {
+                        // do not emit
+                        continue;
+                    }
+                }
+                xml.writeAttribute("name", pn);
+            }
+            xml.writeEndElement(); // dependency
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <E extends Throwable> RuntimeException sneak(Throwable t) throws E {
+        throw (E) t;
+    }
+}

--- a/extensions/packaging/modular/spi/src/main/java/io/quarkus/modular/spi/items/AddDependencyBuildItem.java
+++ b/extensions/packaging/modular/spi/src/main/java/io/quarkus/modular/spi/items/AddDependencyBuildItem.java
@@ -1,0 +1,49 @@
+package io.quarkus.modular.spi.items;
+
+import io.quarkus.builder.item.MultiBuildItem;
+import io.smallrye.common.constraint.Assert;
+import io.smallrye.modules.desc.Dependency;
+
+/**
+ * A build item which adds an extra dependency between modules.
+ */
+public final class AddDependencyBuildItem extends MultiBuildItem {
+    private final String module;
+    private final String targetModule;
+    private final Dependency.Modifier.Set modifiers;
+
+    /**
+     * Construct a new instance.
+     *
+     * @param module the dependent module name (must not be {@code null})
+     * @param targetModule the dependency module name (must not be {@code null})
+     * @param modifiers the dependency modifiers (must not be {@code null})
+     */
+    public AddDependencyBuildItem(final String module, final String targetModule,
+            final Dependency.Modifier.Set modifiers) {
+        this.module = Assert.checkNotNullParam("module", module);
+        this.targetModule = Assert.checkNotNullParam("targetModule", targetModule);
+        this.modifiers = Assert.checkNotNullParam("modifiers", modifiers);
+    }
+
+    /**
+     * {@return the dependent module name (not {@code null})}
+     */
+    public String module() {
+        return module;
+    }
+
+    /**
+     * {@return the dependency module name (not {@code null})}
+     */
+    public String targetModule() {
+        return targetModule;
+    }
+
+    /**
+     * {@return the dependency modifiers to apply (not {@code null})}
+     */
+    public Dependency.Modifier.Set modifiers() {
+        return modifiers;
+    }
+}

--- a/extensions/packaging/modular/spi/src/main/java/io/quarkus/modular/spi/items/ApplicationModuleInfoBuildItem.java
+++ b/extensions/packaging/modular/spi/src/main/java/io/quarkus/modular/spi/items/ApplicationModuleInfoBuildItem.java
@@ -1,0 +1,17 @@
+package io.quarkus.modular.spi.items;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+import io.quarkus.modular.spi.model.AppModuleModel;
+import io.smallrye.common.constraint.Assert;
+
+public final class ApplicationModuleInfoBuildItem extends SimpleBuildItem {
+    private final AppModuleModel model;
+
+    public ApplicationModuleInfoBuildItem(final AppModuleModel model) {
+        this.model = Assert.checkNotNullParam("model", model);
+    }
+
+    public AppModuleModel model() {
+        return model;
+    }
+}

--- a/extensions/packaging/modular/spi/src/main/java/io/quarkus/modular/spi/items/BootModulePathBuildItem.java
+++ b/extensions/packaging/modular/spi/src/main/java/io/quarkus/modular/spi/items/BootModulePathBuildItem.java
@@ -1,0 +1,27 @@
+package io.quarkus.modular.spi.items;
+
+import io.quarkus.builder.item.MultiBuildItem;
+import io.smallrye.common.constraint.Assert;
+
+/**
+ * Indicates that the named module must be a part of the boot module path.
+ */
+public final class BootModulePathBuildItem extends MultiBuildItem {
+    private final String moduleName;
+
+    /**
+     * Construct a new instance.
+     *
+     * @param moduleName the module name for the boot path (must not be {@code null})
+     */
+    public BootModulePathBuildItem(final String moduleName) {
+        this.moduleName = Assert.checkNotNullParam("moduleName", moduleName);
+    }
+
+    /**
+     * {@return the module name}
+     */
+    public String moduleName() {
+        return moduleName;
+    }
+}

--- a/extensions/packaging/modular/spi/src/main/java/io/quarkus/modular/spi/model/AppModuleModel.java
+++ b/extensions/packaging/modular/spi/src/main/java/io/quarkus/modular/spi/model/AppModuleModel.java
@@ -1,0 +1,123 @@
+package io.quarkus.modular.spi.model;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import io.quarkus.maven.dependency.ArtifactKey;
+import io.smallrye.common.constraint.Assert;
+
+public final class AppModuleModel {
+    private final ModuleInfo appModuleInfo;
+    private final Map<String, ModuleInfo> modulesByName;
+    private final Map<ArtifactKey, ModuleInfo> modulesByKey;
+    private final List<String> jdkModulesUsed;
+    private final Set<String> bootModules;
+
+    private AppModuleModel(final Builder builder) {
+        appModuleInfo = Assert.checkNotNullParam("builder.appModuleInfo", builder.appModuleInfo);
+        modulesByName = Map.copyOf(builder.modulesByName);
+        modulesByKey = Map.copyOf(builder.modulesByKey);
+        jdkModulesUsed = List.copyOf(builder.jdkModulesUsed);
+        bootModules = Set.copyOf(builder.bootModules);
+    }
+
+    public ModuleInfo appModuleInfo() {
+        return appModuleInfo;
+    }
+
+    public Map<String, ModuleInfo> modulesByName() {
+        return modulesByName;
+    }
+
+    public Map<ArtifactKey, ModuleInfo> modulesByKey() {
+        return modulesByKey;
+    }
+
+    public List<String> jdkModulesUsed() {
+        return jdkModulesUsed;
+    }
+
+    public Set<String> bootModules() {
+        return bootModules;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private ModuleInfo appModuleInfo;
+        private Map<String, ModuleInfo> modulesByName = Map.of();
+        private Map<ArtifactKey, ModuleInfo> modulesByKey = Map.of();
+        private List<String> jdkModulesUsed = List.of();
+        private Set<String> bootModules = Set.of();
+
+        private Builder() {
+        }
+
+        public Builder appModuleInfo(final ModuleInfo appModuleInfo) {
+            this.appModuleInfo = Assert.checkNotNullParam("appModuleInfo", appModuleInfo);
+            // make sure it's indexed
+            moduleInfo(appModuleInfo);
+            return this;
+        }
+
+        public Builder moduleInfo(final ModuleInfo moduleInfo) {
+            Assert.checkNotNullParam("moduleInfo", moduleInfo);
+            String name = moduleInfo.name();
+            ArtifactKey key = moduleInfo.key();
+            if (modulesByName.isEmpty()) {
+                modulesByName = new HashMap<>();
+            }
+            modulesByName.put(name, moduleInfo);
+            if (modulesByKey.isEmpty()) {
+                modulesByKey = new HashMap<>();
+            }
+            modulesByKey.put(key, moduleInfo);
+            return this;
+        }
+
+        public Builder jdkModuleUsed(String moduleName) {
+            Assert.checkNotNullParam("moduleName", moduleName);
+            if (moduleName.startsWith("java.") || moduleName.startsWith("jdk.") || moduleName.startsWith("ibm.")) {
+                if (jdkModulesUsed.isEmpty()) {
+                    jdkModulesUsed = new ArrayList<>();
+                }
+                int idx = Collections.binarySearch(jdkModulesUsed, moduleName);
+                if (idx < 0) {
+                    jdkModulesUsed.add(-idx - 1, moduleName);
+                }
+            }
+            // else ignore
+            return this;
+        }
+
+        public Builder bootModules(Set<String> moduleNames) {
+            Assert.checkNotNullParam("moduleNames", moduleNames);
+            if (bootModules.isEmpty()) {
+                bootModules = new HashSet<>(moduleNames);
+            } else {
+                bootModules.addAll(moduleNames);
+            }
+            return this;
+        }
+
+        public Builder bootModule(String moduleName) {
+            Assert.checkNotNullParam("moduleName", moduleName);
+            if (bootModules.isEmpty()) {
+                bootModules = new HashSet<>();
+            }
+            bootModules.add(moduleName);
+            return this;
+        }
+
+        public AppModuleModel build() {
+            return new AppModuleModel(this);
+        }
+    }
+}

--- a/extensions/packaging/modular/spi/src/main/java/io/quarkus/modular/spi/model/AutoDependencyGroup.java
+++ b/extensions/packaging/modular/spi/src/main/java/io/quarkus/modular/spi/model/AutoDependencyGroup.java
@@ -1,0 +1,15 @@
+package io.quarkus.modular.spi.model;
+
+import java.util.List;
+
+import io.smallrye.common.constraint.Assert;
+
+public record AutoDependencyGroup(
+        String hostModuleName,
+        List<DependencyInfo> dependencies) {
+
+    public AutoDependencyGroup {
+        Assert.checkNotNullParam("hostModuleName", hostModuleName);
+        dependencies = List.copyOf(Assert.checkNotNullParam("dependencies", dependencies));
+    }
+}

--- a/extensions/packaging/modular/spi/src/main/java/io/quarkus/modular/spi/model/DependencyInfo.java
+++ b/extensions/packaging/modular/spi/src/main/java/io/quarkus/modular/spi/model/DependencyInfo.java
@@ -1,0 +1,36 @@
+package io.quarkus.modular.spi.model;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.smallrye.common.constraint.Assert;
+import io.smallrye.modules.desc.Dependency;
+import io.smallrye.modules.desc.PackageAccess;
+
+public record DependencyInfo(
+        String moduleName,
+        Dependency.Modifier.Set modifiers,
+        Map<String, PackageAccess> packageAccesses) {
+    public DependencyInfo {
+        Assert.checkNotNullParam("moduleName", moduleName);
+        Assert.checkNotNullParam("modifiers", modifiers);
+        packageAccesses = Map.copyOf(Assert.checkNotNullParam("packageAccesses", packageAccesses));
+    }
+
+    public static DependencyInfo merge(DependencyInfo a, DependencyInfo b) {
+        String moduleName = a.moduleName;
+        if (!moduleName.equals(b.moduleName)) {
+            throw new IllegalArgumentException("Cannot merge dependencies with different module names");
+        }
+        // merge modifiers but non-synthetic takes priority over synthetic
+        Dependency.Modifier.Set modifiers = a.modifiers.xor(Dependency.Modifier.SYNTHETIC)
+                .withAll(b.modifiers.xor(Dependency.Modifier.SYNTHETIC))
+                .xor(Dependency.Modifier.SYNTHETIC);
+        Map<String, PackageAccess> packageAccesses = Stream.concat(
+                a.packageAccesses.entrySet().stream(),
+                b.packageAccesses.entrySet().stream())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, PackageAccess::max));
+        return new DependencyInfo(moduleName, modifiers, packageAccesses);
+    }
+}

--- a/extensions/packaging/modular/spi/src/main/java/io/quarkus/modular/spi/model/ModuleInfo.java
+++ b/extensions/packaging/modular/spi/src/main/java/io/quarkus/modular/spi/model/ModuleInfo.java
@@ -1,0 +1,193 @@
+package io.quarkus.modular.spi.model;
+
+import static io.smallrye.common.constraint.Assert.checkNotNullParam;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.ResolvedDependency;
+import io.smallrye.common.resource.Resource;
+import io.smallrye.modules.desc.ModuleDescriptor;
+import io.smallrye.modules.desc.PackageInfo;
+
+/**
+ * Information about a single module in the project.
+ */
+public record ModuleInfo(
+        String name,
+        String version,
+        ModuleDescriptor.Modifier.Set modifiers,
+        ResolvedDependency resolvedArtifact,
+        String mainClassName,
+        Map<String, PackageInfo> packages,
+        List<DependencyInfo> dependencies,
+        List<AutoDependencyGroup> autoDependencies,
+        Set<String> uses,
+        Map<String, List<String>> provides,
+        List<Resource> generated) {
+
+    public ModuleInfo {
+        checkNotNullParam("name", name);
+        checkNotNullParam("modifiers", modifiers);
+        checkNotNullParam("resolvedArtifact", resolvedArtifact);
+        packages = Map.copyOf(checkNotNullParam("packages", packages));
+        dependencies = List.copyOf(checkNotNullParam("dependencies", dependencies));
+        autoDependencies = List.copyOf(checkNotNullParam("autoDependencies", autoDependencies));
+        uses = Set.copyOf(checkNotNullParam("uses", uses));
+        provides = deepCopy(checkNotNullParam("provides", provides), List::copyOf);
+        generated = List.copyOf(checkNotNullParam("generated", generated));
+    }
+
+    private <K, V> Map<K, V> deepCopy(final Map<K, V> map, final UnaryOperator<V> copier) {
+        return Map.copyOf(map.entrySet().stream()
+                .map(e -> Map.entry(e.getKey(), copier.apply(e.getValue())))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+    }
+
+    public ArtifactKey key() {
+        // todo: cache (this is one reason why records are difficult)
+        return ArtifactKey.ga(resolvedArtifact.getGroupId(), resolvedArtifact.getArtifactId());
+    }
+
+    public ModuleInfo withModifier(ModuleDescriptor.Modifier modifier) {
+        if (modifiers.contains(modifier)) {
+            return this;
+        } else {
+            return new ModuleInfo(
+                    name,
+                    version,
+                    modifiers.with(modifier),
+                    resolvedArtifact,
+                    mainClassName,
+                    packages,
+                    dependencies,
+                    autoDependencies,
+                    uses,
+                    provides,
+                    generated);
+        }
+    }
+
+    public ModuleInfo withMainClass(final String mainClassName) {
+        if (Objects.equals(mainClassName, this.mainClassName)) {
+            return this;
+        }
+        return new ModuleInfo(
+                name,
+                version,
+                modifiers,
+                resolvedArtifact,
+                mainClassName,
+                packages,
+                dependencies,
+                autoDependencies,
+                uses,
+                provides,
+                generated);
+    }
+
+    public ModuleInfo withMorePackages(final Map<String, PackageInfo> morePackages) {
+        if (morePackages.isEmpty()) {
+            return this;
+        }
+        return new ModuleInfo(
+                name,
+                version,
+                modifiers,
+                resolvedArtifact,
+                mainClassName,
+                Stream.concat(packages.entrySet().stream(), morePackages.entrySet().stream())
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, PackageInfo::mergedWith)),
+                dependencies,
+                autoDependencies,
+                uses,
+                provides,
+                generated);
+    }
+
+    public ModuleInfo withMoreServices(final Map<String, List<String>> moreServices) {
+        if (moreServices.isEmpty()) {
+            return this;
+        }
+        return new ModuleInfo(
+                name,
+                version,
+                modifiers,
+                resolvedArtifact,
+                mainClassName,
+                packages,
+                dependencies,
+                autoDependencies,
+                uses,
+                Stream.concat(provides.entrySet().stream(), moreServices.entrySet().stream())
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue,
+                                (a, b) -> Stream.concat(a.stream(), b.stream()).toList())),
+                generated);
+    }
+
+    public ModuleInfo withMoreDependencies(final List<DependencyInfo> moreDependencies) {
+        if (moreDependencies.isEmpty()) {
+            return this;
+        }
+        // index the new dependencies
+        Map<String, DependencyInfo> index1 = dependencies.stream()
+                .collect(Collectors.toMap(DependencyInfo::moduleName, UnaryOperator.identity()));
+        Map<String, DependencyInfo> index2 = moreDependencies.stream()
+                .collect(Collectors.toMap(DependencyInfo::moduleName, UnaryOperator.identity()));
+        // now emit the dependencies in order
+        ArrayList<DependencyInfo> newDeps = new ArrayList<>(index1.size() + index2.size());
+        for (DependencyInfo dep : dependencies) {
+            if (index2.containsKey(dep.moduleName())) {
+                // merge it
+                newDeps.add(DependencyInfo.merge(dep, index2.get(dep.moduleName())));
+            } else {
+                // add it
+                newDeps.add(dep);
+            }
+        }
+        for (DependencyInfo dep : moreDependencies) {
+            if (index1.containsKey(dep.moduleName())) {
+                // we already added it; skip
+            } else {
+                newDeps.add(dep);
+            }
+        }
+        return new ModuleInfo(
+                name,
+                version,
+                modifiers,
+                resolvedArtifact,
+                mainClassName,
+                packages,
+                newDeps,
+                autoDependencies,
+                uses,
+                provides,
+                generated);
+    }
+
+    public ModuleInfo withMoreResources(final List<Resource> moreResources) {
+        if (moreResources.isEmpty()) {
+            return this;
+        }
+        return new ModuleInfo(
+                name,
+                version,
+                modifiers,
+                resolvedArtifact,
+                mainClassName,
+                packages,
+                dependencies,
+                autoDependencies,
+                uses,
+                provides,
+                Stream.concat(generated.stream(), moreResources.stream()).toList());
+    }
+}

--- a/extensions/packaging/modular/spi/src/test/java/io/quarkus/modular/spi/FormattingXMLStreamWriterTest.java
+++ b/extensions/packaging/modular/spi/src/test/java/io/quarkus/modular/spi/FormattingXMLStreamWriterTest.java
@@ -1,0 +1,112 @@
+package io.quarkus.modular.spi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.StringWriter;
+
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamWriter;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link FormattingXMLStreamWriter}.
+ */
+class FormattingXMLStreamWriterTest {
+
+    private FormattingXMLStreamWriter create(StringWriter sw) throws Exception {
+        XMLStreamWriter delegate = XMLOutputFactory.newDefaultFactory().createXMLStreamWriter(sw);
+        return new FormattingXMLStreamWriter(delegate);
+    }
+
+    @Test
+    void writeStartDocumentAddsNewlines() throws Exception {
+        StringWriter sw = new StringWriter();
+        FormattingXMLStreamWriter xml = create(sw);
+        xml.writeStartDocument();
+        xml.flush();
+        String output = sw.toString();
+        // should end with two newlines after the XML declaration
+        assertThat(output).endsWith("\n\n");
+    }
+
+    @Test
+    void nestedElementsProduceCorrectIndentation() throws Exception {
+        StringWriter sw = new StringWriter();
+        FormattingXMLStreamWriter xml = create(sw);
+        xml.writeStartElement("root");
+        xml.writeStartElement("child");
+        xml.writeEndElement(); // child
+        xml.writeEndElement(); // root
+        xml.flush();
+        String output = sw.toString();
+        // child should be indented by 4 spaces (level 1)
+        assertThat(output).contains("    <child");
+        // closing root should not be indented
+        assertThat(output).contains("</root>");
+    }
+
+    @Test
+    void writeEmptyElementIndentsWithoutLevelChange() throws Exception {
+        StringWriter sw = new StringWriter();
+        FormattingXMLStreamWriter xml = create(sw);
+        xml.writeStartElement("root");
+        xml.writeEmptyElement("empty");
+        xml.writeStartElement("sibling");
+        xml.writeEndElement(); // sibling
+        xml.writeEndElement(); // root
+        xml.flush();
+        String output = sw.toString();
+        // both empty and sibling should be at same indentation (level 1 = 4 spaces)
+        assertThat(output).contains("    <empty");
+        assertThat(output).contains("    <sibling");
+    }
+
+    @Test
+    void writeAttributePassesThrough() throws Exception {
+        StringWriter sw = new StringWriter();
+        FormattingXMLStreamWriter xml = create(sw);
+        xml.writeStartElement("root");
+        xml.writeAttribute("name", "value");
+        xml.writeEndElement();
+        xml.flush();
+        String output = sw.toString();
+        assertThat(output).contains("name=\"value\"");
+    }
+
+    @Test
+    void writeCommentIndentsAndBreaks() throws Exception {
+        StringWriter sw = new StringWriter();
+        FormattingXMLStreamWriter xml = create(sw);
+        xml.writeStartElement("root");
+        xml.writeComment(" a comment ");
+        xml.writeEndElement();
+        xml.flush();
+        String output = sw.toString();
+        assertThat(output).contains("    <!-- a comment -->");
+    }
+
+    @Test
+    void fullNestedScenario() throws Exception {
+        StringWriter sw = new StringWriter();
+        FormattingXMLStreamWriter xml = create(sw);
+        xml.writeStartDocument();
+        xml.writeStartElement("module");
+        xml.writeAttribute("name", "test");
+        xml.writeStartElement("dependencies");
+        xml.writeEmptyElement("dependency");
+        xml.writeAttribute("name", "java.base");
+        xml.writeEndElement(); // dependencies
+        xml.writeEndElement(); // module
+        xml.writeEndDocument();
+        xml.flush();
+        String output = sw.toString();
+
+        // verify structure: module at level 0, dependencies at level 1, dependency at level 2
+        assertThat(output).contains("<module name=\"test\">");
+        assertThat(output).contains("    <dependencies>");
+        assertThat(output).contains("        <dependency name=\"java.base\"/>");
+        assertThat(output).contains("    </dependencies>");
+        assertThat(output).contains("</module>");
+    }
+}

--- a/extensions/packaging/modular/spi/src/test/java/io/quarkus/modular/spi/JarDirEntryTest.java
+++ b/extensions/packaging/modular/spi/src/test/java/io/quarkus/modular/spi/JarDirEntryTest.java
@@ -1,0 +1,56 @@
+package io.quarkus.modular.spi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.jar.JarInputStream;
+import java.util.jar.JarOutputStream;
+import java.util.zip.ZipEntry;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link JarDirEntry}.
+ */
+class JarDirEntryTest {
+
+    @Test
+    void rejectsNameWithoutTrailingSlash() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (JarOutputStream jos = new JarOutputStream(baos)) {
+            assertThatThrownBy(() -> new JarDirEntry(jos, "foo"))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Directory name must end with /");
+        }
+    }
+
+    @Test
+    void acceptsNameWithTrailingSlash() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (JarOutputStream jos = new JarOutputStream(baos)) {
+            try (JarDirEntry dir = new JarDirEntry(jos, "foo/")) {
+                // should succeed without exception
+            }
+        }
+        // verify the entry exists and is STORED with zero size
+        try (JarInputStream jis = new JarInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
+            ZipEntry entry = jis.getNextEntry();
+            assertThat(entry).isNotNull();
+            assertThat(entry.getName()).isEqualTo("foo/");
+            assertThat(entry.getMethod()).isEqualTo(ZipEntry.STORED);
+            assertThat(entry.getSize()).isZero();
+        }
+    }
+
+    @Test
+    void closeIsIdempotent() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (JarOutputStream jos = new JarOutputStream(baos)) {
+            JarDirEntry dir = new JarDirEntry(jos, "bar/");
+            dir.close();
+            dir.close(); // second close should not throw
+        }
+    }
+}

--- a/extensions/packaging/modular/spi/src/test/java/io/quarkus/modular/spi/JarEntryOutputStreamTest.java
+++ b/extensions/packaging/modular/spi/src/test/java/io/quarkus/modular/spi/JarEntryOutputStreamTest.java
@@ -1,0 +1,154 @@
+package io.quarkus.modular.spi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.jar.JarInputStream;
+import java.util.jar.JarOutputStream;
+import java.util.zip.CRC32;
+import java.util.zip.ZipEntry;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link JarEntryOutputStream}.
+ */
+class JarEntryOutputStreamTest {
+
+    @Test
+    void rejectsNameEndingWithSlash() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (JarOutputStream jos = new JarOutputStream(baos)) {
+            assertThatThrownBy(() -> new JarEntryOutputStream(jos, "foo/"))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Entry file name must not end with /");
+        }
+    }
+
+    @Test
+    void writeAndCloseSmallUncompressed() throws Exception {
+        byte[] data = "Hello, world!".getBytes();
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (JarOutputStream jos = new JarOutputStream(baos)) {
+            try (JarEntryOutputStream os = new JarEntryOutputStream(jos, "test.txt", false, data.length)) {
+                os.write(data);
+            }
+        }
+        // read back and verify
+        try (JarInputStream jis = new JarInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
+            ZipEntry entry = jis.getNextEntry();
+            assertThat(entry).isNotNull();
+            assertThat(entry.getName()).isEqualTo("test.txt");
+            assertThat(entry.getMethod()).isEqualTo(ZipEntry.STORED);
+            byte[] read = jis.readAllBytes();
+            assertThat(read).isEqualTo(data);
+        }
+    }
+
+    @Test
+    void writeAndCloseLargeUncompressed() throws Exception {
+        // >8KB to exercise the temp file path
+        byte[] data = new byte[16384];
+        Arrays.fill(data, (byte) 'x');
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (JarOutputStream jos = new JarOutputStream(baos)) {
+            try (JarEntryOutputStream os = new JarEntryOutputStream(jos, "large.bin", false, data.length)) {
+                os.write(data);
+            }
+        }
+        // read back and verify
+        try (JarInputStream jis = new JarInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
+            ZipEntry entry = jis.getNextEntry();
+            assertThat(entry).isNotNull();
+            assertThat(entry.getName()).isEqualTo("large.bin");
+            assertThat(entry.getMethod()).isEqualTo(ZipEntry.STORED);
+            byte[] read = jis.readAllBytes();
+            assertThat(read).isEqualTo(data);
+        }
+    }
+
+    @Test
+    void writeAndCloseCompressed() throws Exception {
+        byte[] data = "Compressed content for testing".getBytes();
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (JarOutputStream jos = new JarOutputStream(baos)) {
+            try (JarEntryOutputStream os = new JarEntryOutputStream(jos, "compressed.txt", true, data.length)) {
+                os.write(data);
+            }
+        }
+        // read back and verify
+        try (JarInputStream jis = new JarInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
+            ZipEntry entry = jis.getNextEntry();
+            assertThat(entry).isNotNull();
+            assertThat(entry.getName()).isEqualTo("compressed.txt");
+            assertThat(entry.getMethod()).isEqualTo(ZipEntry.DEFLATED);
+            byte[] read = jis.readAllBytes();
+            assertThat(read).isEqualTo(data);
+        }
+    }
+
+    @Test
+    void closeIsIdempotent() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (JarOutputStream jos = new JarOutputStream(baos)) {
+            JarEntryOutputStream os = new JarEntryOutputStream(jos, "test.txt");
+            os.write("data".getBytes());
+            os.close();
+            os.close(); // second close should not throw
+        }
+    }
+
+    @Test
+    void writeAfterCloseThrows() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (JarOutputStream jos = new JarOutputStream(baos)) {
+            JarEntryOutputStream os = new JarEntryOutputStream(jos, "test.txt");
+            os.close();
+            assertThatThrownBy(() -> os.write(42))
+                    .isInstanceOf(IOException.class)
+                    .hasMessageContaining("Entry closed");
+        }
+    }
+
+    @Test
+    void crcIsCorrectForStoredEntry() throws Exception {
+        byte[] data = "Known data for CRC verification".getBytes();
+        CRC32 expected = new CRC32();
+        expected.update(data);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (JarOutputStream jos = new JarOutputStream(baos)) {
+            try (JarEntryOutputStream os = new JarEntryOutputStream(jos, "crc.txt", false, data.length)) {
+                os.write(data);
+            }
+        }
+        // read back and verify CRC
+        try (JarInputStream jis = new JarInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
+            ZipEntry entry = jis.getNextEntry();
+            jis.readAllBytes(); // consume the entry so CRC is computed
+            assertThat(entry.getCrc()).isEqualTo(expected.getValue());
+        }
+    }
+
+    @Test
+    void writeMethodVariantsAllWork() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (JarOutputStream jos = new JarOutputStream(baos)) {
+            try (JarEntryOutputStream os = new JarEntryOutputStream(jos, "multi.txt", false, 100)) {
+                os.write('A');
+                os.write("BC".getBytes());
+                os.write("xDEx".getBytes(), 1, 2);
+            }
+        }
+        try (JarInputStream jis = new JarInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
+            ZipEntry entry = jis.getNextEntry();
+            assertThat(entry).isNotNull();
+            byte[] read = jis.readAllBytes();
+            assertThat(new String(read)).isEqualTo("ABCDE");
+        }
+    }
+}

--- a/extensions/packaging/modular/spi/src/test/java/io/quarkus/modular/spi/model/AppModuleModelBuilderTest.java
+++ b/extensions/packaging/modular/spi/src/test/java/io/quarkus/modular/spi/model/AppModuleModelBuilderTest.java
@@ -1,0 +1,189 @@
+package io.quarkus.modular.spi.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.ResolvedDependency;
+import io.smallrye.modules.desc.ModuleDescriptor;
+
+/**
+ * Tests for {@link AppModuleModel.Builder}.
+ */
+class AppModuleModelBuilderTest {
+
+    private ModuleInfo moduleInfo(String groupId, String artifactId, String name) {
+        ResolvedDependency rd = TestResolvedDependency.create(groupId, artifactId, "1.0");
+        return new ModuleInfo(
+                name, "1.0", ModuleDescriptor.Modifier.Set.of(), rd, null,
+                Map.of(), List.of(), List.of(), Set.of(), Map.of(), List.of());
+    }
+
+    @Test
+    void appModuleInfoIsIndexedInMaps() {
+        ModuleInfo appModule = moduleInfo("org.app", "app", "app.module");
+        AppModuleModel model = AppModuleModel.builder()
+                .appModuleInfo(appModule)
+                .build();
+
+        assertThat(model.appModuleInfo()).isSameAs(appModule);
+        assertThat(model.modulesByName()).containsKey("app.module");
+        assertThat(model.modulesByKey()).containsKey(ArtifactKey.ga("org.app", "app"));
+    }
+
+    @Test
+    void moduleInfoAddsToMaps() {
+        ModuleInfo appModule = moduleInfo("org.app", "app", "app.module");
+        ModuleInfo libModule = moduleInfo("org.lib", "lib", "lib.module");
+        AppModuleModel model = AppModuleModel.builder()
+                .appModuleInfo(appModule)
+                .moduleInfo(libModule)
+                .build();
+
+        assertThat(model.modulesByName()).containsKeys("app.module", "lib.module");
+        assertThat(model.modulesByKey()).containsKeys(
+                ArtifactKey.ga("org.app", "app"),
+                ArtifactKey.ga("org.lib", "lib"));
+    }
+
+    @Test
+    void laterModuleInfoOverwritesEarlierForSameName() {
+        ModuleInfo first = moduleInfo("org.v1", "lib", "lib.module");
+        ModuleInfo second = moduleInfo("org.v2", "lib2", "lib.module");
+        ModuleInfo appModule = moduleInfo("org.app", "app", "app.module");
+        AppModuleModel model = AppModuleModel.builder()
+                .appModuleInfo(appModule)
+                .moduleInfo(first)
+                .moduleInfo(second)
+                .build();
+
+        assertThat(model.modulesByName().get("lib.module").key())
+                .isEqualTo(ArtifactKey.ga("org.v2", "lib2"));
+    }
+
+    // -- JDK module filtering and sorting --
+
+    @Test
+    void jdkModuleUsedAcceptsJavaPrefix() {
+        ModuleInfo appModule = moduleInfo("org.app", "app", "app.module");
+        AppModuleModel model = AppModuleModel.builder()
+                .appModuleInfo(appModule)
+                .jdkModuleUsed("java.base")
+                .build();
+        assertThat(model.jdkModulesUsed()).containsExactly("java.base");
+    }
+
+    @Test
+    void jdkModuleUsedAcceptsJdkPrefix() {
+        ModuleInfo appModule = moduleInfo("org.app", "app", "app.module");
+        AppModuleModel model = AppModuleModel.builder()
+                .appModuleInfo(appModule)
+                .jdkModuleUsed("jdk.management")
+                .build();
+        assertThat(model.jdkModulesUsed()).containsExactly("jdk.management");
+    }
+
+    @Test
+    void jdkModuleUsedAcceptsIbmPrefix() {
+        ModuleInfo appModule = moduleInfo("org.app", "app", "app.module");
+        AppModuleModel model = AppModuleModel.builder()
+                .appModuleInfo(appModule)
+                .jdkModuleUsed("ibm.jsse2")
+                .build();
+        assertThat(model.jdkModulesUsed()).containsExactly("ibm.jsse2");
+    }
+
+    @Test
+    void jdkModuleUsedIgnoresNonJdkModules() {
+        ModuleInfo appModule = moduleInfo("org.app", "app", "app.module");
+        AppModuleModel model = AppModuleModel.builder()
+                .appModuleInfo(appModule)
+                .jdkModuleUsed("org.foo")
+                .build();
+        assertThat(model.jdkModulesUsed()).isEmpty();
+    }
+
+    @Test
+    void jdkModuleUsedMaintainsSortedOrder() {
+        ModuleInfo appModule = moduleInfo("org.app", "app", "app.module");
+        AppModuleModel model = AppModuleModel.builder()
+                .appModuleInfo(appModule)
+                .jdkModuleUsed("java.sql")
+                .jdkModuleUsed("java.base")
+                .jdkModuleUsed("java.net.http")
+                .build();
+        assertThat(model.jdkModulesUsed()).containsExactly("java.base", "java.net.http", "java.sql");
+    }
+
+    @Test
+    void jdkModuleUsedIgnoresDuplicates() {
+        ModuleInfo appModule = moduleInfo("org.app", "app", "app.module");
+        AppModuleModel model = AppModuleModel.builder()
+                .appModuleInfo(appModule)
+                .jdkModuleUsed("java.base")
+                .jdkModuleUsed("java.base")
+                .build();
+        assertThat(model.jdkModulesUsed()).containsExactly("java.base");
+    }
+
+    // -- boot modules --
+
+    @Test
+    void bootModuleAddsSingleModule() {
+        ModuleInfo appModule = moduleInfo("org.app", "app", "app.module");
+        AppModuleModel model = AppModuleModel.builder()
+                .appModuleInfo(appModule)
+                .bootModule("boot.a")
+                .build();
+        assertThat(model.bootModules()).containsExactly("boot.a");
+    }
+
+    @Test
+    void bootModulesAddsMultipleModules() {
+        ModuleInfo appModule = moduleInfo("org.app", "app", "app.module");
+        AppModuleModel model = AppModuleModel.builder()
+                .appModuleInfo(appModule)
+                .bootModules(Set.of("boot.a", "boot.b"))
+                .build();
+        assertThat(model.bootModules()).containsExactlyInAnyOrder("boot.a", "boot.b");
+    }
+
+    @Test
+    void bootModulesAccumulatesAcrossCalls() {
+        ModuleInfo appModule = moduleInfo("org.app", "app", "app.module");
+        AppModuleModel model = AppModuleModel.builder()
+                .appModuleInfo(appModule)
+                .bootModule("boot.a")
+                .bootModules(Set.of("boot.b", "boot.c"))
+                .bootModule("boot.d")
+                .build();
+        assertThat(model.bootModules()).containsExactlyInAnyOrder("boot.a", "boot.b", "boot.c", "boot.d");
+    }
+
+    // -- immutability --
+
+    @Test
+    void builtModelHasImmutableCollections() {
+        ModuleInfo appModule = moduleInfo("org.app", "app", "app.module");
+        AppModuleModel model = AppModuleModel.builder()
+                .appModuleInfo(appModule)
+                .jdkModuleUsed("java.base")
+                .bootModule("boot.a")
+                .build();
+
+        assertThatThrownBy(() -> model.modulesByName().put("foo", appModule))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> model.modulesByKey().put(ArtifactKey.ga("a", "b"), appModule))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> model.jdkModulesUsed().add("java.sql"))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> model.bootModules().add("boot.b"))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+}

--- a/extensions/packaging/modular/spi/src/test/java/io/quarkus/modular/spi/model/DependencyInfoTest.java
+++ b/extensions/packaging/modular/spi/src/test/java/io/quarkus/modular/spi/model/DependencyInfoTest.java
@@ -1,0 +1,108 @@
+package io.quarkus.modular.spi.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.modules.desc.Dependency;
+import io.smallrye.modules.desc.PackageAccess;
+
+/**
+ * Tests for {@link DependencyInfo}, focusing on the {@code merge()} logic.
+ */
+class DependencyInfoTest {
+
+    @Test
+    void constructorMakesDefensiveCopyOfPackageAccesses() {
+        HashMap<String, PackageAccess> original = new HashMap<>();
+        original.put("com.foo", PackageAccess.EXPORTED);
+        DependencyInfo info = new DependencyInfo("mod.a", Dependency.Modifier.Set.of(), original);
+        original.put("com.bar", PackageAccess.OPEN);
+        assertThat(info.packageAccesses()).doesNotContainKey("com.bar");
+    }
+
+    @Test
+    void mergeWithMatchingNamesPreservesModuleName() {
+        DependencyInfo a = new DependencyInfo("mod.a", Dependency.Modifier.Set.of(Dependency.Modifier.LINKED), Map.of());
+        DependencyInfo b = new DependencyInfo("mod.a", Dependency.Modifier.Set.of(Dependency.Modifier.READ), Map.of());
+        DependencyInfo merged = DependencyInfo.merge(a, b);
+        assertThat(merged.moduleName()).isEqualTo("mod.a");
+    }
+
+    @Test
+    void mergeThrowsOnDifferentModuleNames() {
+        DependencyInfo a = new DependencyInfo("mod.a", Dependency.Modifier.Set.of(), Map.of());
+        DependencyInfo b = new DependencyInfo("mod.b", Dependency.Modifier.Set.of(), Map.of());
+        assertThatThrownBy(() -> DependencyInfo.merge(a, b))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void mergeNonSyntheticTakesPriorityOverSynthetic() {
+        // when a has SYNTHETIC + LINKED and b has LINKED (non-synthetic), result should have LINKED without SYNTHETIC
+        DependencyInfo a = new DependencyInfo("mod.a",
+                Dependency.Modifier.Set.of(Dependency.Modifier.SYNTHETIC, Dependency.Modifier.LINKED), Map.of());
+        DependencyInfo b = new DependencyInfo("mod.a",
+                Dependency.Modifier.Set.of(Dependency.Modifier.LINKED), Map.of());
+        DependencyInfo merged = DependencyInfo.merge(a, b);
+        assertThat(merged.modifiers().contains(Dependency.Modifier.LINKED)).isTrue();
+        assertThat(merged.modifiers().contains(Dependency.Modifier.SYNTHETIC)).isFalse();
+    }
+
+    @Test
+    void mergeBothSyntheticRemainsSynthetic() {
+        DependencyInfo a = new DependencyInfo("mod.a",
+                Dependency.Modifier.Set.of(Dependency.Modifier.SYNTHETIC, Dependency.Modifier.LINKED), Map.of());
+        DependencyInfo b = new DependencyInfo("mod.a",
+                Dependency.Modifier.Set.of(Dependency.Modifier.SYNTHETIC, Dependency.Modifier.READ), Map.of());
+        DependencyInfo merged = DependencyInfo.merge(a, b);
+        assertThat(merged.modifiers().contains(Dependency.Modifier.SYNTHETIC)).isTrue();
+        assertThat(merged.modifiers().contains(Dependency.Modifier.LINKED)).isTrue();
+        assertThat(merged.modifiers().contains(Dependency.Modifier.READ)).isTrue();
+    }
+
+    @Test
+    void mergeNeitherSyntheticRemainsNonSynthetic() {
+        DependencyInfo a = new DependencyInfo("mod.a",
+                Dependency.Modifier.Set.of(Dependency.Modifier.LINKED), Map.of());
+        DependencyInfo b = new DependencyInfo("mod.a",
+                Dependency.Modifier.Set.of(Dependency.Modifier.READ), Map.of());
+        DependencyInfo merged = DependencyInfo.merge(a, b);
+        assertThat(merged.modifiers().contains(Dependency.Modifier.SYNTHETIC)).isFalse();
+        assertThat(merged.modifiers().contains(Dependency.Modifier.LINKED)).isTrue();
+        assertThat(merged.modifiers().contains(Dependency.Modifier.READ)).isTrue();
+    }
+
+    @Test
+    void mergePackageAccessesTakesMax() {
+        DependencyInfo a = new DependencyInfo("mod.a", Dependency.Modifier.Set.of(),
+                Map.of("com.foo", PackageAccess.PRIVATE));
+        DependencyInfo b = new DependencyInfo("mod.a", Dependency.Modifier.Set.of(),
+                Map.of("com.foo", PackageAccess.EXPORTED));
+        DependencyInfo merged = DependencyInfo.merge(a, b);
+        assertThat(merged.packageAccesses().get("com.foo")).isEqualTo(PackageAccess.EXPORTED);
+    }
+
+    @Test
+    void mergePackageAccessesUnionsDisjointKeys() {
+        DependencyInfo a = new DependencyInfo("mod.a", Dependency.Modifier.Set.of(),
+                Map.of("com.foo", PackageAccess.EXPORTED));
+        DependencyInfo b = new DependencyInfo("mod.a", Dependency.Modifier.Set.of(),
+                Map.of("com.bar", PackageAccess.OPEN));
+        DependencyInfo merged = DependencyInfo.merge(a, b);
+        assertThat(merged.packageAccesses()).containsEntry("com.foo", PackageAccess.EXPORTED);
+        assertThat(merged.packageAccesses()).containsEntry("com.bar", PackageAccess.OPEN);
+    }
+
+    @Test
+    void mergeEmptyPackageAccesses() {
+        DependencyInfo a = new DependencyInfo("mod.a", Dependency.Modifier.Set.of(), Map.of());
+        DependencyInfo b = new DependencyInfo("mod.a", Dependency.Modifier.Set.of(), Map.of());
+        DependencyInfo merged = DependencyInfo.merge(a, b);
+        assertThat(merged.packageAccesses()).isEmpty();
+    }
+}

--- a/extensions/packaging/modular/spi/src/test/java/io/quarkus/modular/spi/model/ModuleInfoTest.java
+++ b/extensions/packaging/modular/spi/src/test/java/io/quarkus/modular/spi/model/ModuleInfoTest.java
@@ -1,0 +1,252 @@
+package io.quarkus.modular.spi.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.ResolvedDependency;
+import io.smallrye.common.resource.MemoryResource;
+import io.smallrye.common.resource.Resource;
+import io.smallrye.modules.desc.Dependency;
+import io.smallrye.modules.desc.ModuleDescriptor;
+import io.smallrye.modules.desc.PackageAccess;
+import io.smallrye.modules.desc.PackageInfo;
+
+/**
+ * Tests for {@link ModuleInfo}, focusing on copy-on-write transformation methods.
+ */
+class ModuleInfoTest {
+
+    private static final ResolvedDependency ARTIFACT = TestResolvedDependency.create("org.test", "test-lib", "1.0");
+
+    private ModuleInfo base() {
+        return new ModuleInfo(
+                "test.module",
+                "1.0",
+                ModuleDescriptor.Modifier.Set.of(),
+                ARTIFACT,
+                null,
+                Map.of(),
+                List.of(),
+                List.of(),
+                Set.of(),
+                Map.of(),
+                List.of());
+    }
+
+    @Test
+    void keyReturnsCorrectArtifactKey() {
+        ModuleInfo info = base();
+        ArtifactKey key = info.key();
+        assertThat(key.getGroupId()).isEqualTo("org.test");
+        assertThat(key.getArtifactId()).isEqualTo("test-lib");
+    }
+
+    @Test
+    void constructorMakesDefensiveCopies() {
+        HashMap<String, PackageInfo> packages = new HashMap<>();
+        packages.put("com.foo", new PackageInfo(PackageAccess.EXPORTED, Set.of(), Set.of()));
+        ArrayList<DependencyInfo> deps = new ArrayList<>();
+        deps.add(new DependencyInfo("dep.a", Dependency.Modifier.Set.of(), Map.of()));
+        ArrayList<Resource> resources = new ArrayList<>();
+        resources.add(new MemoryResource("test.txt", new byte[0]));
+
+        ModuleInfo info = new ModuleInfo(
+                "test.module", "1.0", ModuleDescriptor.Modifier.Set.of(), ARTIFACT, null,
+                packages, deps, List.of(), Set.of(), Map.of(), resources);
+
+        // mutating originals should not affect the record
+        packages.put("com.bar", new PackageInfo(PackageAccess.PRIVATE, Set.of(), Set.of()));
+        deps.add(new DependencyInfo("dep.b", Dependency.Modifier.Set.of(), Map.of()));
+        resources.add(new MemoryResource("test2.txt", new byte[0]));
+
+        assertThat(info.packages()).doesNotContainKey("com.bar");
+        assertThat(info.dependencies()).hasSize(1);
+        assertThat(info.generated()).hasSize(1);
+    }
+
+    // -- withModifier --
+
+    @Test
+    void withModifierAddsNewModifier() {
+        ModuleInfo info = base();
+        ModuleInfo result = info.withModifier(ModuleDescriptor.Modifier.OPEN);
+        assertThat(result).isNotSameAs(info);
+        assertThat(result.modifiers().contains(ModuleDescriptor.Modifier.OPEN)).isTrue();
+    }
+
+    @Test
+    void withModifierReturnsSameInstanceIfAlreadyPresent() {
+        ModuleInfo info = new ModuleInfo(
+                "test.module", "1.0", ModuleDescriptor.Modifier.Set.of(ModuleDescriptor.Modifier.OPEN),
+                ARTIFACT, null, Map.of(), List.of(), List.of(), Set.of(), Map.of(), List.of());
+        ModuleInfo result = info.withModifier(ModuleDescriptor.Modifier.OPEN);
+        assertThat(result).isSameAs(info);
+    }
+
+    // -- withMainClass --
+
+    @Test
+    void withMainClassChangesMainClass() {
+        ModuleInfo info = base();
+        ModuleInfo result = info.withMainClass("com.example.Main");
+        assertThat(result).isNotSameAs(info);
+        assertThat(result.mainClassName()).isEqualTo("com.example.Main");
+    }
+
+    @Test
+    void withMainClassReturnsSameInstanceIfUnchanged() {
+        ModuleInfo info = new ModuleInfo(
+                "test.module", "1.0", ModuleDescriptor.Modifier.Set.of(), ARTIFACT, "com.example.Main",
+                Map.of(), List.of(), List.of(), Set.of(), Map.of(), List.of());
+        ModuleInfo result = info.withMainClass("com.example.Main");
+        assertThat(result).isSameAs(info);
+    }
+
+    @Test
+    void withMainClassHandlesNullToNonNull() {
+        ModuleInfo info = base();
+        assertThat(info.mainClassName()).isNull();
+        ModuleInfo result = info.withMainClass("com.example.Main");
+        assertThat(result).isNotSameAs(info);
+        assertThat(result.mainClassName()).isEqualTo("com.example.Main");
+    }
+
+    // -- withMorePackages --
+
+    @Test
+    void withMorePackagesAddsNewPackages() {
+        ModuleInfo info = base();
+        PackageInfo pi = new PackageInfo(PackageAccess.EXPORTED, Set.of(), Set.of());
+        ModuleInfo result = info.withMorePackages(Map.of("com.foo", pi));
+        assertThat(result).isNotSameAs(info);
+        assertThat(result.packages()).containsKey("com.foo");
+        assertThat(result.packages().get("com.foo")).isEqualTo(pi);
+    }
+
+    @Test
+    void withMorePackagesReturnsSameInstanceIfEmpty() {
+        ModuleInfo info = base();
+        ModuleInfo result = info.withMorePackages(Map.of());
+        assertThat(result).isSameAs(info);
+    }
+
+    @Test
+    void withMorePackagesMergesOverlappingKeys() {
+        PackageInfo existing = new PackageInfo(PackageAccess.PRIVATE, Set.of(), Set.of());
+        ModuleInfo info = new ModuleInfo(
+                "test.module", "1.0", ModuleDescriptor.Modifier.Set.of(), ARTIFACT, null,
+                Map.of("com.foo", existing), List.of(), List.of(), Set.of(), Map.of(), List.of());
+        PackageInfo incoming = new PackageInfo(PackageAccess.EXPORTED, Set.of(), Set.of());
+        ModuleInfo result = info.withMorePackages(Map.of("com.foo", incoming));
+        // mergedWith should have been called; the result depends on PackageInfo.mergedWith() semantics
+        assertThat(result.packages()).containsKey("com.foo");
+        assertThat(result).isNotSameAs(info);
+    }
+
+    // -- withMoreServices --
+
+    @Test
+    void withMoreServicesAddsNewProviders() {
+        ModuleInfo info = base();
+        ModuleInfo result = info.withMoreServices(Map.of("com.svc.Svc", List.of("com.svc.Impl")));
+        assertThat(result).isNotSameAs(info);
+        assertThat(result.provides()).containsKey("com.svc.Svc");
+        assertThat(result.provides().get("com.svc.Svc")).containsExactly("com.svc.Impl");
+    }
+
+    @Test
+    void withMoreServicesReturnsSameInstanceIfEmpty() {
+        ModuleInfo info = base();
+        ModuleInfo result = info.withMoreServices(Map.of());
+        assertThat(result).isSameAs(info);
+    }
+
+    @Test
+    void withMoreServicesMergesOverlappingKeys() {
+        ModuleInfo info = new ModuleInfo(
+                "test.module", "1.0", ModuleDescriptor.Modifier.Set.of(), ARTIFACT, null,
+                Map.of(), List.of(), List.of(), Set.of(),
+                Map.of("com.svc.Svc", List.of("com.svc.Impl1")), List.of());
+        ModuleInfo result = info.withMoreServices(Map.of("com.svc.Svc", List.of("com.svc.Impl2")));
+        assertThat(result.provides().get("com.svc.Svc")).containsExactly("com.svc.Impl1", "com.svc.Impl2");
+    }
+
+    // -- withMoreDependencies --
+
+    @Test
+    void withMoreDependenciesAddsNewDependencies() {
+        ModuleInfo info = base();
+        DependencyInfo dep = new DependencyInfo("dep.a", Dependency.Modifier.Set.of(Dependency.Modifier.LINKED), Map.of());
+        ModuleInfo result = info.withMoreDependencies(List.of(dep));
+        assertThat(result).isNotSameAs(info);
+        assertThat(result.dependencies()).hasSize(1);
+        assertThat(result.dependencies().get(0).moduleName()).isEqualTo("dep.a");
+    }
+
+    @Test
+    void withMoreDependenciesReturnsSameInstanceIfEmpty() {
+        ModuleInfo info = base();
+        ModuleInfo result = info.withMoreDependencies(List.of());
+        assertThat(result).isSameAs(info);
+    }
+
+    @Test
+    void withMoreDependenciesMergesExistingByModuleName() {
+        DependencyInfo existing = new DependencyInfo("dep.a",
+                Dependency.Modifier.Set.of(Dependency.Modifier.LINKED), Map.of());
+        ModuleInfo info = new ModuleInfo(
+                "test.module", "1.0", ModuleDescriptor.Modifier.Set.of(), ARTIFACT, null,
+                Map.of(), List.of(existing), List.of(), Set.of(), Map.of(), List.of());
+        DependencyInfo incoming = new DependencyInfo("dep.a",
+                Dependency.Modifier.Set.of(Dependency.Modifier.READ), Map.of());
+        ModuleInfo result = info.withMoreDependencies(List.of(incoming));
+        // should be merged, not duplicated
+        assertThat(result.dependencies()).hasSize(1);
+        DependencyInfo merged = result.dependencies().get(0);
+        assertThat(merged.modifiers().contains(Dependency.Modifier.LINKED)).isTrue();
+        assertThat(merged.modifiers().contains(Dependency.Modifier.READ)).isTrue();
+    }
+
+    @Test
+    void withMoreDependenciesPreservesOrder() {
+        DependencyInfo dep1 = new DependencyInfo("dep.a", Dependency.Modifier.Set.of(), Map.of());
+        DependencyInfo dep2 = new DependencyInfo("dep.b", Dependency.Modifier.Set.of(), Map.of());
+        ModuleInfo info = new ModuleInfo(
+                "test.module", "1.0", ModuleDescriptor.Modifier.Set.of(), ARTIFACT, null,
+                Map.of(), List.of(dep1), List.of(), Set.of(), Map.of(), List.of());
+        ModuleInfo result = info.withMoreDependencies(List.of(dep2));
+        assertThat(result.dependencies()).hasSize(2);
+        assertThat(result.dependencies().get(0).moduleName()).isEqualTo("dep.a");
+        assertThat(result.dependencies().get(1).moduleName()).isEqualTo("dep.b");
+    }
+
+    // -- withMoreResources --
+
+    @Test
+    void withMoreResourcesAppendsResources() {
+        Resource r1 = new MemoryResource("a.txt", new byte[] { 1 });
+        ModuleInfo info = new ModuleInfo(
+                "test.module", "1.0", ModuleDescriptor.Modifier.Set.of(), ARTIFACT, null,
+                Map.of(), List.of(), List.of(), Set.of(), Map.of(), List.of(r1));
+        Resource r2 = new MemoryResource("b.txt", new byte[] { 2 });
+        ModuleInfo result = info.withMoreResources(List.of(r2));
+        assertThat(result.generated()).hasSize(2);
+        assertThat(result.generated().get(0).pathName()).isEqualTo("a.txt");
+        assertThat(result.generated().get(1).pathName()).isEqualTo("b.txt");
+    }
+
+    @Test
+    void withMoreResourcesReturnsSameInstanceIfEmpty() {
+        ModuleInfo info = base();
+        ModuleInfo result = info.withMoreResources(List.of());
+        assertThat(result).isSameAs(info);
+    }
+}

--- a/extensions/packaging/modular/spi/src/test/java/io/quarkus/modular/spi/model/TestResolvedDependency.java
+++ b/extensions/packaging/modular/spi/src/test/java/io/quarkus/modular/spi/model/TestResolvedDependency.java
@@ -1,0 +1,32 @@
+package io.quarkus.modular.spi.model;
+
+import java.nio.file.Path;
+
+import io.quarkus.maven.dependency.ResolvedDependency;
+import io.quarkus.maven.dependency.ResolvedDependencyBuilder;
+
+/**
+ * Factory for creating {@link ResolvedDependency} instances in tests.
+ */
+final class TestResolvedDependency {
+
+    private TestResolvedDependency() {
+    }
+
+    /**
+     * Create a minimal resolved dependency for testing.
+     *
+     * @param groupId the group ID (must not be {@code null})
+     * @param artifactId the artifact ID (must not be {@code null})
+     * @param version the version (must not be {@code null})
+     * @return the resolved dependency (not {@code null})
+     */
+    static ResolvedDependency create(String groupId, String artifactId, String version) {
+        return ResolvedDependencyBuilder.newInstance()
+                .setGroupId(groupId)
+                .setArtifactId(artifactId)
+                .setVersion(version)
+                .setResolvedPath(Path.of("/tmp/fake/" + artifactId + "-" + version + ".jar"))
+                .build();
+    }
+}

--- a/extensions/packaging/pom.xml
+++ b/extensions/packaging/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-extensions-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-packaging-parent</artifactId>
+
+    <name>Quarkus - Packaging</name>
+    <description>The parent POM for packaging types</description>
+
+    <packaging>pom</packaging>
+
+    <modules>
+        <!-- The common modular extension -->
+        <module>modular</module>
+
+        <!-- Packaging types (alphabetical) -->
+        <module>jlink</module>
+    </modules>
+</project>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -25,6 +25,7 @@
         <module>jaxp</module>
         <module>smallrye-stork</module>
         <module>signals</module>
+        <module>packaging</module>
 
         <!-- Configuration -->
         <module>config-yaml</module>

--- a/independent-projects/bootstrap/app-model/pom.xml
+++ b/independent-projects/bootstrap/app-model/pom.xml
@@ -41,6 +41,10 @@
             <artifactId>jboss-logging</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.smallrye.classfile</groupId>
+            <artifactId>jdk-classfile-backport</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>commons-logging-jboss-logging</artifactId>
             <scope>runtime</scope>

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/LogHolder.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/LogHolder.java
@@ -1,0 +1,10 @@
+package io.quarkus.maven.dependency;
+
+import org.jboss.logging.Logger;
+
+final class LogHolder {
+    private LogHolder() {
+    }
+
+    static final Logger log = Logger.getLogger("io.quarkus.maven.dependency");
+}

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ResolvedArtifactDependency.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ResolvedArtifactDependency.java
@@ -22,6 +22,7 @@ public class ResolvedArtifactDependency extends ArtifactDependency implements Re
     private final Collection<ArtifactCoords> deps;
     private final Collection<Dependency> directDeps;
     private volatile transient PathTree contentTree;
+    private transient String moduleName;
 
     public ResolvedArtifactDependency(ArtifactCoords coords) {
         this(coords, (PathCollection) null);
@@ -88,6 +89,14 @@ public class ResolvedArtifactDependency extends ArtifactDependency implements Re
     @Override
     public Collection<Dependency> getDirectDependencies() {
         return directDeps;
+    }
+
+    public String getModuleName() {
+        String moduleName = this.moduleName;
+        if (moduleName == null) {
+            moduleName = this.moduleName = ResolvedDependency.computeModuleName(this);
+        }
+        return moduleName;
     }
 
     @Override

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ResolvedDependency.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ResolvedDependency.java
@@ -1,16 +1,25 @@
 package io.quarkus.maven.dependency;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
 
 import io.quarkus.bootstrap.workspace.ArtifactSources;
 import io.quarkus.bootstrap.workspace.WorkspaceModule;
 import io.quarkus.paths.EmptyPathTree;
 import io.quarkus.paths.FilteredPathTree;
+import io.quarkus.paths.ManifestAttributes;
 import io.quarkus.paths.MultiRootPathTree;
 import io.quarkus.paths.PathCollection;
 import io.quarkus.paths.PathFilter;
 import io.quarkus.paths.PathTree;
+import io.smallrye.classfile.Attributes;
+import io.smallrye.classfile.ClassFile;
+import io.smallrye.classfile.ClassModel;
+import io.smallrye.classfile.attribute.ModuleAttribute;
 
 public interface ResolvedDependency extends Dependency {
 
@@ -39,6 +48,11 @@ public interface ResolvedDependency extends Dependency {
      * @return all the direct dependencies of the artifact of this dependency
      */
     Collection<Dependency> getDirectDependencies();
+
+    /**
+     * {@return the module name for this resolved dependency's artifact (not {@code null})}
+     */
+    String getModuleName();
 
     default boolean isResolved() {
         final PathCollection paths = getResolvedPaths();
@@ -78,5 +92,117 @@ public interface ResolvedDependency extends Dependency {
             trees[i++] = PathTree.ofDirectoryOrArchive(p, pathFilter);
         }
         return new MultiRootPathTree(trees);
+    }
+
+    static String computeModuleName(ResolvedDependency dep) {
+        // first, see if there is a descriptor
+        PathTree contentTree = dep.getContentTree();
+        if (contentTree.contains("module-info.class")) {
+            ClassModel cm = contentTree.apply("module-info.class", pv -> {
+                try {
+                    return ClassFile.of().parse(Files.readAllBytes(pv.getPath()));
+                } catch (IOException e) {
+                    throw new IllegalStateException("Failed to read or parse module-info.class", e);
+                }
+            });
+            Optional<ModuleAttribute> optModAttr = cm.findAttribute(Attributes.module());
+            if (optModAttr.isPresent()) {
+                return optModAttr.get().moduleName().name().stringValue();
+            }
+        }
+        // next, see if there is an explicit automatic module name in the manifest
+        ManifestAttributes ma = contentTree.getManifestAttributes();
+        if (ma != null) {
+            String moduleName = ma.automaticModuleName();
+            if (moduleName != null) {
+                return moduleName;
+            }
+        }
+        // next, see if we have a (temporary) policy-defined module name for this artifact
+        String groupId = dep.getGroupId();
+        String artifactId = dep.getArtifactId();
+        String classifier = dep.getClassifier();
+        // XXX MANUAL AUTOMATIC MODULE NAME FIXUPS
+        String moduleName = switch (groupId) {
+            case "io.quarkus" -> switch (artifactId) {
+                case "quarkus-arc" -> "io.quarkus.arc.runtime";
+                default -> null;
+            };
+            case "io.smallrye.config" -> switch (artifactId) {
+                case "smallrye-config-core" -> "io.smallrye.config";
+                case "smallrye-config" -> "io.smallrye.config.inject";
+                default -> null;
+            };
+            case "io.smallrye.certs" -> switch (artifactId) {
+                // https://github.com/smallrye/smallrye-certificate-generator/issues/41
+                case "smallrye-private-key-pem-parser" -> "io.smallrye.certs.pem.private_keys";
+                default -> null;
+            };
+            case "org.jboss.logging" -> switch (artifactId) {
+                // https://github.com/jboss-logging/commons-logging-jboss-logging/issues/20
+                case "commons-logging-jboss-logging" -> "org.apache.commons.logging";
+                default -> null;
+            };
+            case "org.jboss.slf4j" -> switch (artifactId) {
+                // https://github.com/jboss-logging/slf4j-jboss-logmanager/issues/69
+                case "slf4j-jboss-logmanager" -> "org.jboss.logmanager.slf4j";
+                default -> null;
+            };
+            case "org.eclipse.microprofile.config" -> switch (artifactId) {
+                // https://github.com/microprofile/microprofile-config/issues/768
+                case "microprofile-config-api" -> "org.eclipse.microprofile.config";
+                default -> null;
+            };
+            case "org.eclipse.microprofile.rest.client" -> switch (artifactId) {
+                // https://github.com/microprofile/microprofile-rest-client/issues/397
+                case "microprofile-rest-client-api" -> "org.eclipse.microprofile.rest.client";
+                default -> null;
+            };
+            case "org.eclipse.microprofile.context-propagation" -> switch (artifactId) {
+                // https://github.com/microprofile/microprofile-context-propagation/issues/221
+                case "microprofile-context-propagation-api" -> "org.eclipse.microprofile.context";
+                default -> null;
+            };
+            default -> null;
+        };
+        if (moduleName == null) {
+            // Generate an automatic module name using a the groupId:artifactId (instead of just the artifactId)
+            List<String> groupParts = List.of(groupId.split("[-_.]"));
+            List<String> artifactParts = List.of(artifactId.split("[-_.]"));
+            StringBuilder finalNameBuilder = new StringBuilder(
+                    groupId.length() + artifactId.length() + 1);
+            int groupSize = groupParts.size();
+            for (int idx = 0; idx < groupSize; idx++) {
+                // fast check
+                if (groupParts.get(idx).equals(artifactParts.get(0))) {
+                    // slower check
+                    int overlap = groupSize - idx;
+                    if (groupParts.subList(idx, groupSize).equals(artifactParts.subList(0, overlap))) {
+                        // cut out the overlapping parts from the artifact list
+                        artifactParts = artifactParts.subList(overlap, artifactParts.size());
+                        break;
+                    }
+                }
+            }
+            finalNameBuilder.append(groupParts.get(0));
+            for (int i = 1; i < groupSize; i++) {
+                finalNameBuilder.append('.').append(groupParts.get(i));
+            }
+            for (String artifactPart : artifactParts) {
+                finalNameBuilder.append('.').append(artifactPart);
+            }
+            if (classifier != null && !classifier.isEmpty()) {
+                finalNameBuilder.append('.').append(classifier);
+            }
+            moduleName = finalNameBuilder.toString();
+        }
+        if (classifier != null && !classifier.isEmpty()) {
+            LogHolder.log.warnf("Artifact %s:%s:%s does not have a defined module name; using computed name %s", groupId,
+                    artifactId, classifier, moduleName);
+        } else {
+            LogHolder.log.warnf("Artifact %s:%s does not have a defined module name; using computed name %s", groupId,
+                    artifactId, moduleName);
+        }
+        return moduleName;
     }
 }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ResolvedDependencyBuilder.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ResolvedDependencyBuilder.java
@@ -159,6 +159,10 @@ public class ResolvedDependencyBuilder extends AbstractDependencyBuilder<Resolve
         return directDeps;
     }
 
+    public String getModuleName() {
+        throw new UnsupportedOperationException("Module name not supported while building");
+    }
+
     @Override
     public ResolvedDependency build() {
         return new ResolvedArtifactDependency(this);

--- a/independent-projects/bootstrap/bom/pom.xml
+++ b/independent-projects/bootstrap/bom/pom.xml
@@ -509,6 +509,11 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <dependency>
+                <groupId>io.smallrye.classfile</groupId>
+                <artifactId>jdk-classfile-backport</artifactId>
+                <version>${smallrye-classfile.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -71,6 +71,7 @@
         <plexus-sec-dispatcher.version>2.0</plexus-sec-dispatcher.version>
         <plexus-utils.version>3.6.1</plexus-utils.version>
         <smallrye-common.version>2.18.1</smallrye-common.version>
+        <smallrye-classfile.version>26</smallrye-classfile.version>
         <smallrye-beanbag.version>1.6.1</smallrye-beanbag.version>
         <gradle-tooling.version>9.5.1</gradle-tooling.version>
         <quarkus-fs-util.version>1.3.0</quarkus-fs-util.version>


### PR DESCRIPTION
Introduce two new extensions:

* `quarkus-modular` - this extension contains steps and utilities necessary to assemble a modularized application based on a modularity app model; the extension produces nothing by itself
* `quarkus-jlink` - this extension produces a simple modularized `jlink`-ed application based on the modular model.

When the `quarkus-jlink` extension is present, the default JAR packaging is disabled by default.

Not yet supported:

* Container builds with `jlink`
* Cross-architecture builds with `jlink`
* AOT with `jlink`
* Modular testing

See #51583.