### PR TITLE
Simple Map support for Spring @ConfigurationProperties

### DIFF
--- a/extensions/spring-boot-properties/deployment/pom.xml
+++ b/extensions/spring-boot-properties/deployment/pom.xml
@@ -21,6 +21,18 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc-deployment</artifactId>
         </dependency>
+
+        <!-- Testing dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/spring-boot-properties/deployment/src/main/java/io/quarkus/spring/boot/properties/deployment/ClassConfigurationPropertiesUtil.java
+++ b/extensions/spring-boot-properties/deployment/src/main/java/io/quarkus/spring/boot/properties/deployment/ClassConfigurationPropertiesUtil.java
@@ -15,7 +15,6 @@ import jakarta.enterprise.inject.Produces;
 import jakarta.enterprise.inject.spi.DeploymentException;
 import jakarta.inject.Inject;
 
-import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
@@ -47,6 +46,7 @@ import io.quarkus.runtime.StartupEvent;
 import io.quarkus.runtime.util.HashUtil;
 import io.quarkus.runtime.util.StringUtil;
 import io.quarkus.spring.boot.properties.deployment.ConfigurationPropertiesUtil.ReadOptionalResponse;
+import io.smallrye.config.Config;
 import io.smallrye.config.ConfigMapping;
 
 final class ClassConfigurationPropertiesUtil {
@@ -287,11 +287,11 @@ final class ClassConfigurationPropertiesUtil {
                  */
                 DotName fieldTypeDotName = fieldType.name();
                 ClassInfo fieldTypeClassInfo = applicationIndex.getClassByName(fieldType.name());
-                ResultHandle mpConfig = methodCreator.getMethodParam(0);
+                ResultHandle config = methodCreator.getMethodParam(0);
                 if (fieldTypeClassInfo != null) {
                     if (DotNames.ENUM.equals(fieldTypeClassInfo.superName())) {
                         populateTypicalProperty(methodCreator, configObject, configPropertyBuildItemCandidates,
-                                currentClassInHierarchy, field, useFieldAccess, fieldType, setter, mpConfig,
+                                currentClassInHierarchy, field, useFieldAccess, fieldType, setter, config,
                                 getFullConfigName(prefixStr, namingStrategy, field));
 
                         // we need to register the 'valueOf' method of the enum for reflection because
@@ -336,7 +336,7 @@ final class ClassConfigurationPropertiesUtil {
                             ResultHandle setterValue = methodCreator.invokeInterfaceMethod(
                                     MethodDescriptor.ofMethod(Config.class, "getOptionalValue", Optional.class, String.class,
                                             Class.class),
-                                    mpConfig, methodCreator.load(fullConfigName),
+                                    config, methodCreator.load(fullConfigName),
                                     methodCreator.loadClassFromTCCL(genericType.name().toString()));
                             createWriteValue(methodCreator, configObject, field, setter, useFieldAccess, setterValue);
                         } else {
@@ -344,7 +344,7 @@ final class ClassConfigurationPropertiesUtil {
                             ReadOptionalResponse readOptionalResponse = ConfigurationPropertiesUtil
                                     .createReadOptionalValueAndConvertIfNeeded(
                                             fullConfigName,
-                                            genericType, field.declaringClass().name(), methodCreator, mpConfig);
+                                            genericType, field.declaringClass().name(), methodCreator, config);
                             createWriteValue(readOptionalResponse.getIsPresentTrue(), configObject, field, setter,
                                     useFieldAccess,
                                     readOptionalResponse.getIsPresentTrue().invokeStaticMethod(
@@ -364,13 +364,13 @@ final class ClassConfigurationPropertiesUtil {
                                             + field.name() + "' of class '" + field.declaringClass().name().toString());
                         }
                         ResultHandle setterValue = yamlListObjectHandler.handle(new YamlListObjectHandler.FieldMember(field),
-                                methodCreator, mpConfig,
+                                methodCreator, config,
                                 getEffectiveConfigName(namingStrategy, field), fullConfigName);
                         createWriteValue(methodCreator, configObject, field, setter, useFieldAccess, setterValue);
                     } else {
                         ConfigurationPropertiesUtil.registerImplicitConverter(fieldType, reflectiveClasses);
                         populateTypicalProperty(methodCreator, configObject, configPropertyBuildItemCandidates,
-                                currentClassInHierarchy, field, useFieldAccess, fieldType, setter, mpConfig,
+                                currentClassInHierarchy, field, useFieldAccess, fieldType, setter, config,
                                 fullConfigName);
                     }
                 }
@@ -410,7 +410,7 @@ final class ClassConfigurationPropertiesUtil {
     private static void populateTypicalProperty(MethodCreator methodCreator, ResultHandle configObject,
             List<ConfigPropertyBuildItemCandidate> configPropertyBuildItemCandidates, ClassInfo currentClassInHierarchy,
             FieldInfo field, boolean useFieldAccess, Type fieldType, MethodInfo setter,
-            ResultHandle mpConfig, String fullConfigName) {
+            ResultHandle config, String fullConfigName) {
         /*
          * We want to support cases where the Config class defines a default value for fields
          * by simply specifying the default value in its constructor
@@ -421,7 +421,7 @@ final class ClassConfigurationPropertiesUtil {
         if (shouldCheckForDefaultValue(currentClassInHierarchy, field)) {
             ReadOptionalResponse readOptionalResponse = ConfigurationPropertiesUtil.createReadOptionalValueAndConvertIfNeeded(
                     fullConfigName,
-                    fieldType, field.declaringClass().name(), methodCreator, mpConfig);
+                    fieldType, field.declaringClass().name(), methodCreator, config);
 
             // call the setter if the optional contained data
             createWriteValue(readOptionalResponse.getIsPresentTrue(), configObject, field, setter,
@@ -434,7 +434,7 @@ final class ClassConfigurationPropertiesUtil {
              */
             ResultHandle setterValue = ConfigurationPropertiesUtil.createReadMandatoryValueAndConvertIfNeeded(
                     fullConfigName, fieldType,
-                    field.declaringClass().name(), methodCreator, mpConfig);
+                    field.declaringClass().name(), methodCreator, config);
             createWriteValue(methodCreator, configObject, field, setter, useFieldAccess, setterValue);
 
         }

--- a/extensions/spring-boot-properties/deployment/src/main/java/io/quarkus/spring/boot/properties/deployment/ConfigurationPropertiesUtil.java
+++ b/extensions/spring-boot-properties/deployment/src/main/java/io/quarkus/spring/boot/properties/deployment/ConfigurationPropertiesUtil.java
@@ -1,15 +1,14 @@
 package io.quarkus.spring.boot.properties.deployment;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.IntFunction;
 
-import jakarta.enterprise.inject.spi.DeploymentException;
-
-import org.eclipse.microprofile.config.Config;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
+import org.jboss.jandex.Type.Kind;
 
 import io.quarkus.arc.deployment.ConfigBuildStep;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -20,11 +19,24 @@ import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.runtime.configuration.ArrayListFactory;
 import io.quarkus.runtime.configuration.HashSetFactory;
-import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.Config;
 
 final class ConfigurationPropertiesUtil {
 
     static final String PACKAGE_TO_PLACE_GENERATED_CLASSES = "io.quarkus.spring.boot.properties.runtime.config";
+
+    private static final MethodDescriptor CONFIG_GET_VALUES_MAP = MethodDescriptor.ofMethod(
+            Config.class, "getValues", Map.class, String.class, Class.class, Class.class);
+    private static final MethodDescriptor CONFIG_GET_OPTIONAL_VALUES_MAP = MethodDescriptor.ofMethod(
+            Config.class, "getOptionalValues", Optional.class, String.class, Class.class, Class.class);
+    private static final MethodDescriptor CONFIG_GET_VALUES_COLLECTION = MethodDescriptor.ofMethod(
+            Config.class, "getValues", Collection.class, String.class, Class.class, IntFunction.class);
+    private static final MethodDescriptor CONFIG_GET_OPTIONAL_VALUES_COLLECTION = MethodDescriptor.ofMethod(
+            Config.class, "getOptionalValues", Optional.class, String.class, Class.class, IntFunction.class);
+    private static final MethodDescriptor CONFIG_GET_VALUE = MethodDescriptor.ofMethod(
+            Config.class, "getValue", Object.class, String.class, Class.class);
+    private static final MethodDescriptor CONFIG_GET_OPTIONAL_VALUE = MethodDescriptor.ofMethod(
+            Config.class, "getOptionalValue", Optional.class, String.class, Class.class);
 
     private ConfigurationPropertiesUtil() {
     }
@@ -39,32 +51,44 @@ final class ConfigurationPropertiesUtil {
      * @param bytecodeCreator Where the bytecode will be generated
      * @param config Reference to the MP config object
      */
-    static ResultHandle createReadMandatoryValueAndConvertIfNeeded(String propertyName,
+    static ResultHandle createReadMandatoryValueAndConvertIfNeeded(
+            String propertyName,
             Type resultType,
             DotName declaringClass,
-            BytecodeCreator bytecodeCreator, ResultHandle config) {
+            BytecodeCreator bytecodeCreator,
+            ResultHandle config) {
 
         if (isMap(resultType)) {
-            throw new DeploymentException(
-                    "Using a Map is not supported for classes annotated with '@ConfigProperties'. Consider using https://quarkus.io/guides/config-mappings instead.");
-        }
-        if (isCollection(resultType)) {
-            ResultHandle smallryeConfig = bytecodeCreator.checkCast(config, SmallRyeConfig.class);
+            if (resultType.kind() != Kind.PARAMETERIZED_TYPE) {
+                throw new IllegalArgumentException("Unable to resolve Map parameter types for " + propertyName);
+            }
 
+            ParameterizedType parameterizedType = resultType.asParameterizedType();
+            String keyType = parameterizedType.arguments().get(0).name().toString();
+            String valueType = parameterizedType.arguments().get(1).name().toString();
+
+            // Only support Map#value with Converter
+            // We don't have a way to validate, so it will fail at runtime (with a proper error message from SR Config)
+            return bytecodeCreator.invokeInterfaceMethod(
+                    CONFIG_GET_VALUES_MAP,
+                    config,
+                    bytecodeCreator.load(propertyName),
+                    bytecodeCreator.loadClassFromTCCL(keyType),
+                    bytecodeCreator.loadClassFromTCCL(valueType));
+        } else if (isCollection(resultType)) {
             Class<?> factoryToUse = DotNames.SET.equals(resultType.name()) ? HashSetFactory.class : ArrayListFactory.class;
             ResultHandle collectionFactory = bytecodeCreator.invokeStaticMethod(
                     MethodDescriptor.ofMethod(factoryToUse, "getInstance", factoryToUse));
 
-            return bytecodeCreator.invokeVirtualMethod(
-                    MethodDescriptor.ofMethod(SmallRyeConfig.class, "getValues", Collection.class, String.class,
-                            Class.class, IntFunction.class),
-                    smallryeConfig,
+            return bytecodeCreator.invokeInterfaceMethod(
+                    CONFIG_GET_VALUES_COLLECTION,
+                    config,
                     bytecodeCreator.load(propertyName),
                     bytecodeCreator.loadClassFromTCCL(determineSingleGenericType(resultType, declaringClass).name().toString()),
                     collectionFactory);
         } else {
             return bytecodeCreator.invokeInterfaceMethod(
-                    MethodDescriptor.ofMethod(Config.class, "getValue", Object.class, String.class, Class.class),
+                    CONFIG_GET_VALUE,
                     config, bytecodeCreator.load(propertyName),
                     bytecodeCreator.loadClassFromTCCL(resultType.name().toString()));
         }
@@ -80,33 +104,45 @@ final class ConfigurationPropertiesUtil {
      * @param bytecodeCreator Where the bytecode will be generated
      * @param config Reference to the MP config object
      */
-    static ReadOptionalResponse createReadOptionalValueAndConvertIfNeeded(String propertyName, Type resultType,
+    static ReadOptionalResponse createReadOptionalValueAndConvertIfNeeded(
+            String propertyName,
+            Type resultType,
             DotName declaringClass,
-            BytecodeCreator bytecodeCreator, ResultHandle config) {
+            BytecodeCreator bytecodeCreator,
+            ResultHandle config) {
 
         ResultHandle optionalValue;
         if (isMap(resultType)) {
-            throw new DeploymentException(
-                    "Using a Map is not supported for classes annotated with '@ConfigProperties'. Consider using https://quarkus.io/guides/config-mappings instead.");
-        }
-        if (isCollection(resultType)) {
-            ResultHandle smallryeConfig = bytecodeCreator.checkCast(config, SmallRyeConfig.class);
+            if (resultType.kind() != Kind.PARAMETERIZED_TYPE) {
+                throw new IllegalArgumentException("Unable to resolve Map parameter types for " + propertyName);
+            }
 
+            ParameterizedType parameterizedType = resultType.asParameterizedType();
+            String keyType = parameterizedType.arguments().get(0).name().toString();
+            String valueType = parameterizedType.arguments().get(1).name().toString();
+
+            // Only support Map#value with Converter
+            // We don't have a way to validate, so it will fail at runtime (with a proper error message from SR Config)
+            optionalValue = bytecodeCreator.invokeInterfaceMethod(
+                    CONFIG_GET_OPTIONAL_VALUES_MAP,
+                    config,
+                    bytecodeCreator.load(propertyName),
+                    bytecodeCreator.loadClassFromTCCL(keyType),
+                    bytecodeCreator.loadClassFromTCCL(valueType));
+        } else if (isCollection(resultType)) {
             Class<?> factoryToUse = DotNames.SET.equals(resultType.name()) ? HashSetFactory.class : ArrayListFactory.class;
             ResultHandle collectionFactory = bytecodeCreator.invokeStaticMethod(
                     MethodDescriptor.ofMethod(factoryToUse, "getInstance", factoryToUse));
 
-            optionalValue = bytecodeCreator.invokeVirtualMethod(
-                    MethodDescriptor.ofMethod(SmallRyeConfig.class, "getOptionalValues", Optional.class, String.class,
-                            Class.class, IntFunction.class),
-                    smallryeConfig,
+            optionalValue = bytecodeCreator.invokeInterfaceMethod(
+                    CONFIG_GET_OPTIONAL_VALUES_COLLECTION,
+                    config,
                     bytecodeCreator.load(propertyName),
                     bytecodeCreator.loadClassFromTCCL(determineSingleGenericType(resultType, declaringClass).name().toString()),
                     collectionFactory);
         } else {
             optionalValue = bytecodeCreator.invokeInterfaceMethod(
-                    MethodDescriptor.ofMethod(Config.class, "getOptionalValue", Optional.class, String.class,
-                            Class.class),
+                    CONFIG_GET_OPTIONAL_VALUE,
                     config, bytecodeCreator.load(propertyName),
                     bytecodeCreator.loadClassFromTCCL(resultType.name().toString()));
         }

--- a/extensions/spring-boot-properties/deployment/src/main/java/io/quarkus/spring/boot/properties/deployment/DotNames.java
+++ b/extensions/spring-boot-properties/deployment/src/main/java/io/quarkus/spring/boot/properties/deployment/DotNames.java
@@ -24,7 +24,5 @@ final class DotNames {
     static final DotName MAP = DotName.createSimple(Map.class.getName());
     static final DotName HASH_MAP = DotName.createSimple(HashMap.class.getName());
     static final DotName ENUM = DotName.createSimple(Enum.class.getName());
-    static final DotName MP_CONFIG_PROPERTIES = DotName
-            .createSimple(org.eclipse.microprofile.config.inject.ConfigProperties.class.getName());
     static final DotName CONFIG_PROPERTY = DotName.createSimple(ConfigProperty.class.getName());
 }

--- a/extensions/spring-boot-properties/deployment/src/main/java/io/quarkus/spring/boot/properties/deployment/InterfaceConfigurationPropertiesUtil.java
+++ b/extensions/spring-boot-properties/deployment/src/main/java/io/quarkus/spring/boot/properties/deployment/InterfaceConfigurationPropertiesUtil.java
@@ -13,7 +13,6 @@ import java.util.Set;
 import jakarta.enterprise.inject.Produces;
 import jakarta.enterprise.inject.spi.DeploymentException;
 
-import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
@@ -41,6 +40,7 @@ import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.runtime.util.HashUtil;
+import io.smallrye.config.Config;
 import io.smallrye.config.ConfigMapping;
 
 final class InterfaceConfigurationPropertiesUtil {
@@ -125,7 +125,7 @@ final class InterfaceConfigurationPropertiesUtil {
                     .setModifiers(Modifier.PRIVATE)
                     .getFieldDescriptor();
 
-            // generate a constructor that takes MP Config as an argument
+            // generate a constructor that takes Config as an argument
             try (MethodCreator ctor = interfaceImplClassCreator.getMethodCreator("<init>", void.class, Config.class)) {
                 ctor.setModifiers(Modifier.PUBLIC);
                 ctor.invokeSpecialMethod(MethodDescriptor.ofConstructor(Object.class), ctor.getThis());

--- a/extensions/spring-boot-properties/deployment/src/test/java/io/quarkus/spring/boot/properties/deployment/ConfigurationPropertiesTest.java
+++ b/extensions/spring-boot-properties/deployment/src/test/java/io/quarkus/spring/boot/properties/deployment/ConfigurationPropertiesTest.java
@@ -1,0 +1,129 @@
+package io.quarkus.spring.boot.properties.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.config.spi.Converter;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+class ConfigurationPropertiesTest {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsServiceProvider(Converter.class, ServerConverter.class)
+                    .addAsResource(new StringAsset(
+                            """
+                                    config.spring.map.one=one
+                                    config.spring.map.two=two
+                                    config.spring.servers.one=host: localhost, port: 8080
+                                    config.spring.required.one=one
+                                    """), "application.properties"));
+
+    @Inject
+    MapConfig mapConfig;
+    @Inject
+    MapInterfaceConfig mapInterfaceConfig;
+
+    @Test
+    void config() {
+        assertFalse(mapConfig.getMap().isEmpty());
+        assertEquals("one", mapConfig.getMap().get("one"));
+        assertEquals("two", mapConfig.getMap().get("two"));
+        assertEquals("localhost", mapConfig.getServers().get("one").getHost());
+        assertEquals(8080, mapConfig.getServers().get("one").getPort());
+        assertEquals("one", mapConfig.required.get("one"));
+
+        assertFalse(mapInterfaceConfig.map().isEmpty());
+        assertEquals("one", mapInterfaceConfig.map().get("one"));
+        assertEquals("two", mapInterfaceConfig.map().get("two"));
+        assertEquals("localhost", mapInterfaceConfig.servers().get("one").getHost());
+        assertEquals(8080, mapInterfaceConfig.servers().get("one").getPort());
+        assertEquals("one", mapInterfaceConfig.required().get("one"));
+    }
+
+    @ConfigurationProperties("config.spring")
+    public static final class MapConfig {
+        private Map<String, String> map = new HashMap<>();
+        private Map<String, Server> servers = new HashMap<>();
+
+        private Map<String, String> required = new HashMap<>();
+
+        public Map<String, String> getMap() {
+            return map;
+        }
+
+        public void setMap(Map<String, String> map) {
+            this.map = map;
+        }
+
+        public Map<String, Server> getServers() {
+            return servers;
+        }
+
+        public void setServers(Map<String, Server> servers) {
+            this.servers = servers;
+        }
+
+        public void setRequired(Map<String, String> required) {
+            this.required = required;
+        }
+    }
+
+    @ConfigurationProperties("config.spring")
+    public interface MapInterfaceConfig {
+        Map<String, String> map();
+
+        Map<String, Server> servers();
+
+        Map<String, String> required();
+    }
+
+    public static final class Server {
+        private String host;
+        private int port;
+
+        public String getHost() {
+            return host;
+        }
+
+        public Server setHost(String host) {
+            this.host = host;
+            return this;
+        }
+
+        public int getPort() {
+            return port;
+        }
+
+        public Server setPort(int port) {
+            this.port = port;
+            return this;
+        }
+    }
+
+    public static final class ServerConverter implements Converter<Server> {
+        @Override
+        public Server convert(String value) throws IllegalArgumentException, NullPointerException {
+            Map<String, String> map = new HashMap<>();
+            String[] values = value.split(",");
+            for (String element : values) {
+                String[] entry = element.trim().split(":");
+                map.put(entry[0].trim(), entry[1].trim());
+            }
+
+            return new Server().setHost(map.get("host")).setPort(Integer.parseInt(map.get("port")));
+        }
+    }
+}


### PR DESCRIPTION
Adds simple `Map` support for Spring `@ConfigurationProperties`. Only for types that can be converted by a `Converter`.