### PR TITLE
Fix ClassCastException when mocking interface type on class bean 

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ClientProxyGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ClientProxyGenerator.java
@@ -116,7 +116,8 @@ public class ClientProxyGenerator extends AbstractGenerator {
             boolean transformUnproxyableClasses, String generatedName, String targetPackage) {
 
         Type providerType = bean.getProviderType();
-        ClassInfo providerClass = getClassByName(bean.getDeployment().getBeanArchiveIndex(), providerType.name());
+        IndexView index = bean.getDeployment().getBeanArchiveIndex();
+        ClassInfo providerClass = getClassByName(index, providerType.name());
         ClassDesc providerClassDesc = classDescOf(providerClass);
 
         boolean isInterface = providerClass.isInterface();
@@ -145,7 +146,7 @@ public class ClientProxyGenerator extends AbstractGenerator {
                 mockField = cc.field(MOCK_FIELD, fc -> {
                     fc.private_();
                     fc.volatile_();
-                    fc.setType(providerClassDesc);
+                    fc.setType(Object.class);
                 });
             } else {
                 mockField = null;
@@ -187,14 +188,10 @@ public class ClientProxyGenerator extends AbstractGenerator {
             MethodDesc delegateMethod = cc.method(DELEGATE_METHOD_NAME, mc -> {
                 mc.private_();
                 mc.returning(providerClassDesc);
+                // Mock dispatch is handled per-method rather than here to avoid a VerifyError:
+                // returning Object (the mock field type) from a method declaring a class return type
+                // is rejected by the JVM verifier.
                 mc.body(b0 -> {
-                    if (mockable) {
-                        // if mockable and mocked just return the mock
-                        b0.ifNotNull(cc.this_().field(mockField), b1 -> {
-                            b1.return_(cc.this_().field(mockField));
-                        });
-                    }
-
                     Expr ret;
                     if (BuiltinScope.APPLICATION.is(bean.getScope())) {
                         // Application context is stored in a field and is always active
@@ -256,6 +253,48 @@ public class ClientProxyGenerator extends AbstractGenerator {
                     }
 
                     mc.body(bc -> {
+                        if (mockable) {
+                            // Use invokeinterface where possible: the JVM verifier is lenient about
+                            // invokeinterface receiver types (checked at runtime), unlike invokevirtual.
+                            // This allows mocks that only implement the interface without extending the bean class.
+                            final ClassDesc mockDispatchDesc;
+                            final boolean dispatchViaInterface;
+                            if (isInterface) {
+                                mockDispatchDesc = providerClassDesc;
+                                dispatchViaInterface = true;
+                            } else if (Methods.isObjectToString(method)) {
+                                mockDispatchDesc = CD_Object;
+                                dispatchViaInterface = false;
+                            } else {
+                                ClassInfo declaringIface = findDeclaringInterface(providerClass, method, index);
+                                if (declaringIface != null) {
+                                    mockDispatchDesc = classDescOf(declaringIface);
+                                    dispatchViaInterface = true;
+                                } else {
+                                    mockDispatchDesc = providerClassDesc;
+                                    dispatchViaInterface = false;
+                                }
+                            }
+                            bc.ifNotNull(cc.this_().field(mockField), b1 -> {
+                                Expr mockExpr = dispatchViaInterface
+                                        ? b1.uncheckedCast(cc.this_().field(mockField), mockDispatchDesc)
+                                        : b1.cast(cc.this_().field(mockField), mockDispatchDesc);
+                                Expr mockRet;
+                                if (dispatchViaInterface) {
+                                    mockRet = b1.invokeInterface(
+                                            InterfaceMethodDesc.of(mockDispatchDesc, originalMethodDesc.name(),
+                                                    originalMethodDesc.type()),
+                                            mockExpr, params);
+                                } else {
+                                    mockRet = b1.invokeVirtual(
+                                            ClassMethodDesc.of(mockDispatchDesc, originalMethodDesc.name(),
+                                                    originalMethodDesc.type()),
+                                            mockExpr, params);
+                                }
+                                b1.return_(mockRet);
+                            });
+                        }
+
                         if (!superClass.equals(CD_Object)) {
                             // Skip delegation if proxy is not constructed yet
                             // This is not necessary for producers of interfaces, because interfaces cannot have constructors
@@ -357,6 +396,34 @@ public class ClientProxyGenerator extends AbstractGenerator {
                         new Methods.RemoveFinalFromMethod(entry.getValue())));
             }
         }
+    }
+
+    /**
+     * Finds the first interface in the class hierarchy of {@code classInfo} that declares
+     * a method with the same name and parameter types as {@code method}.
+     * Returns {@code null} if no such interface exists.
+     */
+    private ClassInfo findDeclaringInterface(ClassInfo classInfo, MethodInfo method, IndexView index) {
+        if (classInfo == null) {
+            return null;
+        }
+        for (DotName ifaceName : classInfo.interfaceNames()) {
+            ClassInfo iface = getClassByName(index, ifaceName);
+            if (iface == null) {
+                continue;
+            }
+            if (iface.method(method.name(), method.parameterTypes().toArray(Type[]::new)) != null) {
+                return iface;
+            }
+            ClassInfo found = findDeclaringInterface(iface, method, index);
+            if (found != null) {
+                return found;
+            }
+        }
+        if (classInfo.superName() != null && !classInfo.superName().equals(DotNames.OBJECT)) {
+            return findDeclaringInterface(getClassByName(index, classInfo.superName()), method, index);
+        }
+        return null;
     }
 
     private DotName getApplicationClassTestName(BeanInfo bean) {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/ArcTestContainer.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/ArcTestContainer.java
@@ -496,6 +496,7 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
                 builder.addRemovalExclusion(exclusion);
             }
             builder.setAlternativePriorities(alternativePriorities);
+            builder.setAllowMocking(testMode);
 
             BeanProcessor beanProcessor = builder.build();
 

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/mocking/MockInterfaceTypeTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/mocking/MockInterfaceTypeTest.java
@@ -1,0 +1,74 @@
+package io.quarkus.arc.test.mocking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.impl.Mockable;
+import io.quarkus.arc.test.ArcTestContainer;
+
+/**
+ * Reproduces: installing a mock for an interface type when the bean is a concrete implementation fails with
+ * ClassCastException because the generated client proxy types the mock field to the concrete class,
+ * not to the interface.
+ *
+ * @see <a href="https://github.com/quarkusio/quarkus/issues/53051">GitHub issue #53051</a>
+ */
+public class MockInterfaceTypeTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(MyInterface.class, ProdImpl.class, ConsumerBean.class)
+            .testMode(true)
+            .build();
+
+    @Test
+    public void testMockByInterfaceType() {
+        // Get the proxy for the interface type
+        MyInterface proxy = Arc.container().select(MyInterface.class).get();
+        assertInstanceOf(Mockable.class, proxy);
+
+        // Install a mock implementation — this should NOT throw ClassCastException
+        Mockable mockable = (Mockable) proxy;
+        mockable.arc$setMock(new TestImpl());
+
+        // Verify the mock is used
+        assertEquals("mock", proxy.hello());
+
+        // Clear the mock — original impl should be restored
+        mockable.arc$clearMock();
+        assertEquals("prod", proxy.hello());
+    }
+
+    interface MyInterface {
+        String hello();
+    }
+
+    @ApplicationScoped
+    static class ProdImpl implements MyInterface {
+        @Override
+        public String hello() {
+            return "prod";
+        }
+    }
+
+    static class TestImpl implements MyInterface {
+        @Override
+        public String hello() {
+            return "mock";
+        }
+    }
+
+    @ApplicationScoped
+    static class ConsumerBean {
+        // Inject by interface to ensure a client proxy is generated for the interface
+        @Inject
+        MyInterface iface;
+    }
+}


### PR DESCRIPTION
  When installing a mock for a bean looked up by interface type, the generated
  client proxy would fail with ClassCastException (or VerifyError after the
  partial fix) because arc$delegate() typed the mock field as the concrete class.

  - Type the mock field as Object to accept any mock implementation
  - Move mock dispatch out of arc$delegate() and into each delegating method, using invokeinterface on the declaring interface rather than invokevirtual on the concrete class — the JVM verifier is lenient about invokeinterface receiver types, allowing mocks that only implement the interface
  - Add findDeclaringInterface() to walk the class and interface hierarchy to find the correct interface for dispatch
  - Fix ArcTestContainer to pass testMode to setAllowMocking()
  - Add MockInterfaceTypeTest to reproduce and verify the fix

-----

- Fixes: #53051