### PR TITLE
Optimize Beans#getCallbacks()

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
@@ -852,8 +852,7 @@ public class BeanGenerator extends AbstractGenerator {
         class PostConstructGenerator {
             void generate(BlockCreator bc, Var instance) {
                 if (!bean.isInterceptor()) {
-                    List<MethodInfo> postConstructCallbacks = Beans.getCallbacks(bean.getTarget().get().asClass(),
-                            DotNames.POST_CONSTRUCT, bean.getDeployment().getBeanArchiveIndex());
+                    List<MethodInfo> postConstructCallbacks = bean.getPostConstructCallbacks();
 
                     for (MethodInfo callback : postConstructCallbacks) {
                         if (isReflectionFallbackNeeded(callback, targetPackage)) {
@@ -1480,9 +1479,7 @@ public class BeanGenerator extends AbstractGenerator {
                                     void generate(BlockCreator bc, Var instance) {
                                         // PreDestroy callbacks
                                         // possibly wrapped into Runnable so that PreDestroy interceptors can proceed() correctly
-                                        List<MethodInfo> preDestroyCallbacks = Beans.getCallbacks(
-                                                bean.getTarget().get().asClass(), DotNames.PRE_DESTROY,
-                                                bean.getDeployment().getBeanArchiveIndex());
+                                        List<MethodInfo> preDestroyCallbacks = bean.getPreDestroyCallbacks();
                                         for (MethodInfo callback : preDestroyCallbacks) {
                                             if (isReflectionFallbackNeeded(callback, targetPackage)) {
                                                 if (Modifier.isPrivate(callback.flags())) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
@@ -87,6 +87,10 @@ public class BeanInfo implements InjectionTargetInfo {
 
     private final List<MethodInfo> aroundInvokes;
 
+    private final List<MethodInfo> postConstructCallbacks;
+
+    private final List<MethodInfo> preDestroyCallbacks;
+
     private final InterceptionProxyInfo interceptionProxy;
 
     // Following fields are only used by synthetic beans
@@ -173,6 +177,15 @@ public class BeanInfo implements InjectionTargetInfo {
         this.targetPackageName = targetPackageName;
         this.startupPriority = startupPriority;
         this.aroundInvokes = isInterceptor() || isDecorator() ? List.of() : Beans.getAroundInvokes(implClazz, beanDeployment);
+        if (isClassBean() && !isInterceptor()) {
+            this.postConstructCallbacks = Beans.getCallbacks(target.asClass(), DotNames.POST_CONSTRUCT,
+                    beanDeployment.getBeanArchiveIndex());
+            this.preDestroyCallbacks = Beans.getCallbacks(target.asClass(), DotNames.PRE_DESTROY,
+                    beanDeployment.getBeanArchiveIndex());
+        } else {
+            this.postConstructCallbacks = List.of();
+            this.preDestroyCallbacks = List.of();
+        }
     }
 
     @Override
@@ -457,8 +470,7 @@ public class BeanInfo implements InjectionTargetInfo {
         }
         // test class bean with @PreDestroy interceptor or callback
         return isClassBean() && (!getLifecycleInterceptors(InterceptionType.PRE_DESTROY).isEmpty()
-                || !Beans.getCallbacks(target.get().asClass(), DotNames.PRE_DESTROY, beanDeployment.getBeanArchiveIndex())
-                        .isEmpty());
+                || !preDestroyCallbacks.isEmpty());
     }
 
     public boolean isForceApplicationClass() {
@@ -531,6 +543,22 @@ public class BeanInfo implements InjectionTargetInfo {
             }
         }
         return false;
+    }
+
+    /**
+     *
+     * @return the list of {@code @PostConstruct} callback methods declared in the hierarchy of a bean class
+     */
+    List<MethodInfo> getPostConstructCallbacks() {
+        return postConstructCallbacks;
+    }
+
+    /**
+     *
+     * @return the list of {@code @PreDestroy} callback methods declared in the hierarchy of a bean class
+     */
+    List<MethodInfo> getPreDestroyCallbacks() {
+        return preDestroyCallbacks;
     }
 
     /**

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
@@ -762,7 +762,7 @@ public final class Beans {
         List<MethodInfo> callbacks = new ArrayList<>();
         collectCallbacks(beanClass, callbacks, annotation, index, new HashSet<>(), interceptionType);
         Collections.reverse(callbacks);
-        return callbacks;
+        return callbacks.isEmpty() ? List.of() : Collections.unmodifiableList(callbacks);
     }
 
     static List<MethodInfo> getAroundInvokes(ClassInfo beanClass, BeanDeployment deployment) {


### PR DESCRIPTION
I only added caching of the callbacks because I don't think we can replace method iteration with `ClassInfo#annotations` (see https://github.com/quarkusio/quarkus/issues/49653#issuecomment-4089249807) nor am I aware of any other Jandex way that would be simpler. We still need to mark all the methods to account for overrides.

- Closes: #49653 