### PR TITLE
Make QuarkusArtifactHandler back to being @Singleton

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/components/QuarkusArtifactHandler.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/components/QuarkusArtifactHandler.java
@@ -1,11 +1,11 @@
 package io.quarkus.maven.components;
 
 import javax.inject.Named;
+import javax.inject.Singleton;
 
-import org.apache.maven.SessionScoped;
 import org.apache.maven.artifact.handler.ArtifactHandler;
 
-@SessionScoped
+@Singleton
 @Named("quarkus")
 public class QuarkusArtifactHandler implements ArtifactHandler {
 


### PR DESCRIPTION
This was changed in:
https://github.com/quarkusio/quarkus/pull/52016
together with a bunch of other components.

But this particular component needs to exist even if not in a session as demonstrated in https://github.com/kordamp/pomchecker/issues/38 .
