### PR TITLE
Revert "Propagate Quarkus properties for Gradle Test tasks"

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/actions/BeforeTestAction.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/actions/BeforeTestAction.java
@@ -21,7 +21,6 @@ import org.gradle.api.tasks.testing.Test;
 
 import io.quarkus.bootstrap.BootstrapConstants;
 import io.quarkus.bootstrap.model.ApplicationModel;
-import io.quarkus.gradle.tasks.EffectiveConfig;
 import io.quarkus.gradle.tasks.EffectiveConfigProvider;
 import io.quarkus.gradle.tasks.QuarkusPluginExtensionView;
 import io.quarkus.gradle.tooling.ToolingUtils;
@@ -64,12 +63,10 @@ public class BeforeTestAction implements Action<Task> {
             final Path serializedModel = applicationModelPath.get().getAsFile().toPath();
             ApplicationModel applicationModel = ToolingUtils.deserializeAppModel(serializedModel);
 
-            EffectiveConfig effectiveConfig = effectiveProvider().buildEffectiveConfiguration(applicationModel,
-                    new HashMap<>());
-            SmallRyeConfig config = effectiveConfig.getConfig();
+            SmallRyeConfig config = effectiveProvider().buildEffectiveConfiguration(applicationModel, new HashMap<>())
+                    .getConfig();
             config.getOptionalValue(TEST.getProfileKey(), String.class)
                     .ifPresent(value -> props.put(TEST.getProfileKey(), value));
-            props.putAll(effectiveConfig.getQuarkusValues());
 
             props.put(BootstrapConstants.SERIALIZED_TEST_APP_MODEL, serializedModel.toString());
 

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/SystemPropsAsBuildTimeConfigSourceTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/SystemPropsAsBuildTimeConfigSourceTest.java
@@ -33,6 +33,7 @@ public class SystemPropsAsBuildTimeConfigSourceTest extends QuarkusGradleWrapper
         gradleConfigurationCache(false);
         runGradleWrapper(projectDir,
                 "-Dquarkus.example.name=cheburashka",
+                "-Dquarkus.example.runtime-name=crocodile",
                 "-Dquarkus.package.jar.type=mutable-jar",
                 ":example-extension:example-extension-deployment:build",
                 // this quarkusIntTest will make sure runtime config properties passed as env vars when launching the app are effective


### PR DESCRIPTION
This reverts commit 1833a6e17054d7fa5aaa27033456e5e7c520379c.

Fixes https://github.com/quarkusio/quarkus/issues/53151 (well, not really, but that's the best we have for now...)