### PR TITLE
Vert.x: do not disable websockets extensions init if websockets-next is present

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
@@ -561,7 +561,9 @@ class VertxHttpProcessor {
                 eventLoopCount.getEventLoopCount(),
                 websocketSubProtocols.stream().map(bi -> bi.getWebsocketSubProtocols())
                         .collect(Collectors.toList()),
-                launchMode.isAuxiliaryApplication(), !capabilities.isPresent(Capability.VERTX_WEBSOCKETS));
+                launchMode.isAuxiliaryApplication(),
+                !capabilities.isPresent(Capability.VERTX_WEBSOCKETS)
+                        && !capabilities.isPresent(Capability.WEBSOCKETS_NEXT));
     }
 
     @BuildStep


### PR DESCRIPTION
- there's an optimization introduced in #31715 that disables WebSockets extensions initialization if the legacy quarkus-websocket is not present, it should be quarkus-websocket && quarkus-websocket-next
- fixes #53159