### PR TITLE
Remove unnecessary GraalVM `@Delete`

### DIFF
--- a/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/KubernetesClientProcessor.java
+++ b/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/KubernetesClientProcessor.java
@@ -22,7 +22,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.CustomResource;
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.VersionInfo;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.extension.ExtensionAdapter;
@@ -194,7 +193,7 @@ public class KubernetesClientProcessor {
                 .methods().build());
 
         reflectiveClasses.produce(
-                ReflectiveClassBuildItem.builder(KubernetesClientImpl.class, DefaultKubernetesClient.class, VersionInfo.class)
+                ReflectiveClassBuildItem.builder(KubernetesClientImpl.class, VersionInfo.class)
                         .reason(getClass().getName())
                         .methods().fields().build());
         reflectiveClasses.produce(ReflectiveClassBuildItem

--- a/extensions/kubernetes-client/runtime/src/main/java/io/quarkus/kubernetes/client/runtime/graal/Fabric8VertxHttpClientFactoryDelete.java
+++ b/extensions/kubernetes-client/runtime/src/main/java/io/quarkus/kubernetes/client/runtime/graal/Fabric8VertxHttpClientFactoryDelete.java
@@ -1,9 +1,0 @@
-package io.quarkus.kubernetes.client.runtime.graal;
-
-import com.oracle.svm.core.annotate.Delete;
-import com.oracle.svm.core.annotate.TargetClass;
-
-@TargetClass(className = "io.fabric8.kubernetes.client.vertx.VertxHttpClientFactory")
-@Delete
-public final class Fabric8VertxHttpClientFactoryDelete {
-}

--- a/extensions/openshift-client/deployment/src/main/java/io/quarkus/openshift/client/deployment/OpenShiftClientProcessor.java
+++ b/extensions/openshift-client/deployment/src/main/java/io/quarkus/openshift/client/deployment/OpenShiftClientProcessor.java
@@ -4,7 +4,6 @@ import java.util.Collections;
 
 import org.jboss.jandex.DotName;
 
-import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.impl.OpenShiftClientImpl;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.IgnoreSplitPackageBuildItem;
@@ -55,7 +54,7 @@ public class OpenShiftClientProcessor {
                 .reason(getClass().getName())
                 .methods().build());
 
-        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(OpenShiftClientImpl.class, DefaultOpenShiftClient.class)
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(OpenShiftClientImpl.class)
                 .reason(getClass().getName())
                 .methods().fields().build());
     }


### PR DESCRIPTION
This shouldn't be necessary as we already delete
the Service Loader file that brings in the client

Moreover, this seems to be causing problems
with the bytecode parsing in GraalVM

- Fixes: #53165