### PR TITLE
docs: update outdated AWS Lambda guide

### DIFF
--- a/docs/src/main/asciidoc/aws-lambda.adoc
+++ b/docs/src/main/asciidoc/aws-lambda.adoc
@@ -53,12 +53,10 @@ mvn archetype:generate \
 
 [NOTE]
 ====
-If you prefer to use Gradle, you can quickly and easily generate a Gradle project via https://code.quarkus.io/[code.quarkus.io]
-adding the `quarkus-amazon-lambda` extension as a dependency.
+The Maven archetype generates both Maven and Gradle build files.
+If you prefer to use Gradle, run `gradle wrapper` in the generated project to set up the Gradle wrapper (recommended).
 
-Copy the build.gradle, gradle.properties and settings.gradle into the above-generated Maven archetype project, to follow along with this guide.
-
-Execute: gradle wrapper to set up the gradle wrapper (recommended).
+Alternatively, you can generate a project via https://code.quarkus.io/[code.quarkus.io] adding the `quarkus-amazon-lambda` extension as a dependency.
 
 For full Gradle details, see the <<gradle,Gradle build>> section below.
 ====
@@ -552,8 +550,7 @@ there is some additional work to bundle the `function.zip`, as below.  For more 
 The native executable requires some additional steps to enable client SSL that S3 and other AWS libraries need.
 
 1. A custom `bootstrap` script
-2. `libsunec.so` must be added to `function.zip`
-3. `cacerts` must be added to `function.zip`
+2. `cacerts` must be added to `function.zip`
 
 To do this, first create a directory `src/main/zip.native/` with your build.  Next create a shell script file called `bootstrap`
 within `src/main/zip.native/`, like below. An example is created automatically in your build folder (target or build), called `bootstrap-example.sh`
@@ -562,18 +559,15 @@ within `src/main/zip.native/`, like below. An example is created automatically i
 ----
 #!/usr/bin/env bash
 
-./runner -Djava.library.path=./ -Djavax.net.ssl.trustStore=./cacerts
+./runner -Djavax.net.ssl.trustStore=./cacerts
 ----
 
-Additional set `-Djavax.net.ssl.trustStorePassword=changeit` if your `cacerts` file is password protected.
+Additionally set `-Djavax.net.ssl.trustStorePassword=changeit` if your `cacerts` file is password protected.
 
-Next you must copy some files from your GraalVM distribution into `src/main/zip.native/`.
-
-NOTE: GraalVM versions can have different paths for these files whether you are using the Java 8 or 11 version. Adjust accordingly.
+Next you must copy the `cacerts` trust store into `src/main/zip.native/`.
 
 [source,bash]
 ----
-cp $GRAALVM_HOME/lib/libsunec.so $PROJECT_DIR/src/main/zip.native/
 cp $GRAALVM_HOME/lib/security/cacerts $PROJECT_DIR/src/main/zip.native/
 ----
 
@@ -581,9 +575,9 @@ Now when you run the native build all these files will be included within `funct
 
 NOTE: If you are using a Docker image to build, then you must extract these files from this image.
 
-To extract the required ssl, you must start up a Docker container in the background, and attach to that container to copy the artifacts.
+To extract the required SSL files, you must start up a Docker container in the background and copy the artifacts from it.
 
-First, let's start the GraalVM container, noting the container id output.
+First, let's start the Mandrel builder container, noting the container id output.
 [source,bash,subs=attributes+]
 ----
 docker run -it -d --entrypoint bash quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor}
@@ -592,17 +586,17 @@ docker run -it -d --entrypoint bash quay.io/quarkus/ubi9-quarkus-mandrel-builder
 # Note this value as we will need it for the commands below
 ----
 
-First, `libsunec.so`, the C library used for the SSL implementation:
-
+Copy `cacerts`, the certificate store.  You may need to periodically obtain an updated copy, also.
 [source,bash]
 ----
-docker cp {container-id-from-above}:/opt/graalvm/lib/libsunec.so src/main/zip.native/
+docker cp {container-id-from-above}:/opt/mandrel/lib/security/cacerts src/main/zip.native/
 ----
 
-Second, `cacerts`, the certificate store.  You may need to periodically obtain an updated copy, also.
+Once done, stop and remove the container:
 [source,bash]
 ----
-docker cp {container-id-from-above}:/opt/graalvm/lib/security/cacerts src/main/zip.native/
+docker stop {container-id-from-above}
+docker rm {container-id-from-above}
 ----
 
 Your final archive will look like this:
@@ -613,7 +607,6 @@ jar tvf target/function.zip
     bootstrap
     runner
     cacerts
-    libsunec.so
 ----
 
 == Deploy to AWS Lambda using a Container Image


### PR DESCRIPTION
Fixes #37466

The AWS Lambda guide has several outdated sections that can confuse users following the documentation.

## Changes

- **Gradle NOTE box**: Clarified that the Maven archetype already generates both Maven and Gradle build files, instead of incorrectly directing users to code.quarkus.io to generate a separate Gradle project
- **Removed `libsunec.so` instructions**: This library has not been required since GraalVM 19.3. Removed from the requirements list, bootstrap script (`-Djava.library.path`), copy commands, and archive listing. Added a note explaining it is no longer needed
- **Fixed Docker paths**: Changed `/opt/graalvm` to `/opt/mandrel` to match the actual Mandrel builder image (`quay.io/quarkus/ubi9-quarkus-mandrel-builder-image`)
- **Added `docker stop/rm`**: Added cleanup instructions after copying files from the builder container
- **Fixed terminology**: "GraalVM container" to "Mandrel builder container", minor typo fixes