### PR TITLE
Warn when dev mode port is shadowed by another process on 0.0.0.0

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -16,13 +16,20 @@ import static io.quarkus.vertx.http.runtime.options.HttpServerTlsConfig.getHttpS
 import java.io.File;
 import java.io.IOException;
 import java.net.BindException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.NetworkInterface;
+import java.net.Socket;
+import java.net.SocketException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -149,6 +156,10 @@ public class VertxHttpRecorder {
     public static final String MAX_REQUEST_SIZE_KEY = "io.quarkus.max-request-size";
 
     private static final String DISABLE_WEBSOCKETS_PROP_NAME = "vertx.disableWebsockets";
+
+    private static final int PORT_SHADOW_CHECK_TIMEOUT_MS = 500;
+
+    private static final Set<String> LOOPBACK_HOSTS = Set.of("localhost", "127.0.0.1", "::1");
 
     private static final Logger LOGGER = Logger.getLogger(VertxHttpRecorder.class.getName());
 
@@ -1420,6 +1431,7 @@ public class VertxHttpRecorder {
                                     // Compatibility with test.url
                                     valueRegistry.register(RuntimeKey.key("test.url"), localBaseUri.toString());
                                 }
+                                checkPortShadowedByAnotherProcess(options.getHost(), actualPort);
                             }
                         }
 
@@ -1491,6 +1503,55 @@ public class VertxHttpRecorder {
                         path.deleteCharAt(path.length() - 1);
                     }
                     return URI.create(scheme + "://" + host + ":" + actualPort + path);
+                }
+
+                private void checkPortShadowedByAnotherProcess(String host, int port) {
+                    if (!launchMode.isDevOrTest()) {
+                        return;
+                    }
+                    if (!LOOPBACK_HOSTS.contains(host)) {
+                        return;
+                    }
+                    InetAddress nonLoopback = findNonLoopbackAddress();
+                    if (nonLoopback == null) {
+                        LOGGER.debug("No non-loopback address found, skipping port shadow check");
+                        return;
+                    }
+                    vertx.executeBlocking(() -> {
+                        try (Socket socket = new Socket()) {
+                            socket.connect(new InetSocketAddress(nonLoopback, port), PORT_SHADOW_CHECK_TIMEOUT_MS);
+                            LOGGER.warnf("Port %d is also in use on network interface %s, possibly by a container. "
+                                    + "Quarkus is listening on %s only, which may shadow the other process. "
+                                    + "Use 'quarkus.http.host=0.0.0.0' to listen on all interfaces.",
+                                    port, nonLoopback.getHostAddress(), host);
+                        } catch (IOException e) {
+                            LOGGER.debugf("Port shadow check on %s:%d found no conflict: %s",
+                                    nonLoopback.getHostAddress(), port, e.getMessage());
+                        }
+                        return null;
+                    });
+                }
+
+                private InetAddress findNonLoopbackAddress() {
+                    try {
+                        Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+                        while (interfaces.hasMoreElements()) {
+                            NetworkInterface ni = interfaces.nextElement();
+                            if (ni.isLoopback() || !ni.isUp()) {
+                                continue;
+                            }
+                            Enumeration<InetAddress> addresses = ni.getInetAddresses();
+                            while (addresses.hasMoreElements()) {
+                                InetAddress addr = addresses.nextElement();
+                                if (!addr.isLoopbackAddress()) {
+                                    return addr;
+                                }
+                            }
+                        }
+                    } catch (SocketException e) {
+                        LOGGER.debugf("Failed to enumerate network interfaces: %s", e.getMessage());
+                    }
+                    return null;
                 }
             });
         }

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/PortShadowDetectionTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/PortShadowDetectionTest.java
@@ -1,0 +1,104 @@
+package io.quarkus.vertx.http.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.NetworkInterface;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketException;
+import java.util.Enumeration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+public class PortShadowDetectionTest {
+
+    private static final int TIMEOUT_MS = 500;
+
+    @Test
+    void detectShadowOnWildcardIPv4() throws IOException {
+        try (ServerSocket server = new ServerSocket()) {
+            server.setReuseAddress(true);
+            server.bind(new InetSocketAddress("0.0.0.0", 0));
+            int port = server.getLocalPort();
+
+            InetAddress nonLoopback = findNonLoopbackAddress();
+            if (nonLoopback == null) {
+                return;
+            }
+
+            try (Socket socket = new Socket()) {
+                socket.connect(new InetSocketAddress(nonLoopback, port), TIMEOUT_MS);
+                assertTrue(socket.isConnected(), "Should detect process on wildcard via non-loopback IP");
+            }
+        }
+    }
+
+    @Test
+    @EnabledOnOs({ OS.LINUX, OS.MAC })
+    void detectShadowOnWildcardIPv6() throws IOException {
+        try (ServerSocket server = new ServerSocket()) {
+            server.setReuseAddress(true);
+            server.bind(new InetSocketAddress("::", 0));
+            int port = server.getLocalPort();
+
+            InetAddress nonLoopback = findNonLoopbackAddress();
+            if (nonLoopback == null) {
+                return;
+            }
+
+            try (Socket socket = new Socket()) {
+                socket.connect(new InetSocketAddress(nonLoopback, port), TIMEOUT_MS);
+                assertTrue(socket.isConnected(), "Should detect process on IPv6 wildcard via non-loopback IP");
+            }
+        }
+    }
+
+    @Test
+    void noFalsePositiveOnLoopbackOnly() throws IOException {
+        try (ServerSocket server = new ServerSocket()) {
+            server.setReuseAddress(true);
+            server.bind(new InetSocketAddress("127.0.0.1", 0));
+            int port = server.getLocalPort();
+
+            InetAddress nonLoopback = findNonLoopbackAddress();
+            if (nonLoopback == null) {
+                return;
+            }
+
+            try (Socket socket = new Socket()) {
+                socket.connect(new InetSocketAddress(nonLoopback, port), TIMEOUT_MS);
+                fail("Should not connect to loopback-only server via non-loopback IP");
+            } catch (IOException expected) {
+                // Connection refused — confirms no false positive for loopback-only binding
+            }
+        }
+    }
+
+    private InetAddress findNonLoopbackAddress() {
+        try {
+            Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+            while (interfaces.hasMoreElements()) {
+                NetworkInterface ni = interfaces.nextElement();
+                if (ni.isLoopback() || !ni.isUp()) {
+                    continue;
+                }
+                Enumeration<InetAddress> addresses = ni.getInetAddresses();
+                while (addresses.hasMoreElements()) {
+                    InetAddress addr = addresses.nextElement();
+                    if (!addr.isLoopbackAddress()) {
+                        return addr;
+                    }
+                }
+            }
+        } catch (SocketException e) {
+            return null;
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary

- In dev mode, Quarkus binds to `localhost` by default while Docker/Podman containers bind to `0.0.0.0`. Since these are different interfaces, no `BindException` is thrown and the container silently shadows Quarkus (#17950).
- After a successful HTTP bind in dev/test mode on `localhost`, attempt a socket connection to `0.0.0.0` on the same port. If it succeeds, log a warning suggesting `quarkus.http.host=0.0.0.0`.
- The check runs via `vertx.executeBlocking()` to avoid blocking the event loop, with a 200ms socket timeout.

Fixes #17950

## Test plan

- [ ] Start a Docker container on port 8080: `docker run -d -p 8080:80 nginx:alpine`
- [ ] Run `quarkus dev` — verify the new warning appears in logs
- [ ] Stop the container, restart Quarkus — verify no warning appears
- [ ] Run existing tests: `mvn test -pl extensions/vertx-http/deployment`