### PR TITLE
Propagate Quarkus properties set by Gradle build to workers

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/actions/BeforeTestAction.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/actions/BeforeTestAction.java
@@ -21,6 +21,7 @@ import org.gradle.api.tasks.testing.Test;
 
 import io.quarkus.bootstrap.BootstrapConstants;
 import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.gradle.tasks.EffectiveConfig;
 import io.quarkus.gradle.tasks.EffectiveConfigProvider;
 import io.quarkus.gradle.tasks.QuarkusPluginExtensionView;
 import io.quarkus.gradle.tooling.ToolingUtils;
@@ -63,8 +64,10 @@ public class BeforeTestAction implements Action<Task> {
             final Path serializedModel = applicationModelPath.get().getAsFile().toPath();
             ApplicationModel applicationModel = ToolingUtils.deserializeAppModel(serializedModel);
 
-            SmallRyeConfig config = effectiveProvider().buildEffectiveConfiguration(applicationModel, new HashMap<>())
-                    .getConfig();
+            EffectiveConfig effectiveConfig = effectiveProvider().buildEffectiveConfiguration(applicationModel,
+                    new HashMap<>());
+            SmallRyeConfig config = effectiveConfig.getConfig();
+            props.putAll(effectiveConfig.getQuarkusValues());
             config.getOptionalValue(TEST.getProfileKey(), String.class)
                     .ifPresent(value -> props.put(TEST.getProfileKey(), value));
 

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/EffectiveConfig.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/EffectiveConfig.java
@@ -28,9 +28,11 @@ import io.quarkus.deployment.pkg.NativeConfig;
 import io.quarkus.deployment.pkg.PackageConfig;
 import io.quarkus.runtime.configuration.ConfigUtils;
 import io.smallrye.config.ConfigValue;
+import io.smallrye.config.DefaultValuesConfigSource;
 import io.smallrye.config.Expressions;
 import io.smallrye.config.PropertiesConfigSource;
 import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.SysPropConfigSource;
 import io.smallrye.config.source.yaml.YamlConfigSourceLoader;
 
 /**
@@ -118,21 +120,22 @@ public final class EffectiveConfig {
 
     @VisibleForTesting
     static Map<String, String> generateFullConfigMap(SmallRyeConfig config) {
-        Set<String> defaultNames = new HashSet<>();
-        defaultNames.addAll(configClass(PackageConfig.class).getProperties().keySet());
-        defaultNames.addAll(configClass(NativeConfig.class).getProperties().keySet());
+        Set<String> excludeNames = new HashSet<>();
+        excludeNames.addAll(configClass(PackageConfig.class).getProperties().keySet());
+        excludeNames.addAll(configClass(NativeConfig.class).getProperties().keySet());
         return Expressions.withoutExpansion(new Supplier<Map<String, String>>() {
             @Override
             public Map<String, String> get() {
                 Map<String, String> properties = new HashMap<>();
                 for (String propertyName : config.getPropertyNames()) {
                     ConfigValue configValue = config.getConfigValue(propertyName);
-                    // Remove defaults coming from PackageConfig and NativeConfig, as this Map as passed as
-                    // system properties to Gradle workers and, we loose the ability to determine if it was set by
-                    // the user to evaluate deprecated configuration
-                    if (configValue.getValue() != null && (!defaultNames.contains(configValue.getName())
-                            || !configValue.isDefault())) {
-                        properties.put(propertyName, configValue.getValue());
+                    if (configValue.getValue() != null) {
+                        // Exclude defaults coming from PackageConfig and NativeConfig, as this Map as passed as
+                        // system properties to Gradle workers and, we loose the ability to determine if it was set by
+                        // the user to evaluate deprecated configuration
+                        if (!excludeNames.contains(configValue.getName()) || !configValue.isDefault()) {
+                            properties.put(propertyName, configValue.getValue());
+                        }
                     }
                 }
                 return unmodifiableMap(properties);
@@ -140,10 +143,29 @@ public final class EffectiveConfig {
         });
     }
 
+    /**
+     * Constructs a Map with the list of Quarkus property names that must be propagated to the Gradle workers.
+     * <p>
+     * This only takes into account the configuration that is not already available in Quarkus, including properties
+     * provided by Gradle tasks or files. System Properties are also included, since Gradle workers run on a separate
+     * VM that does not have access to the original System Properties set by the process.
+     * <p>
+     * Environment Variables do not require propagation, since all workers can the Environment. Configuration files
+     * like {@code application.properties} are already available in Quarkus, so we can skip them as well.
+     */
     static Map<String, String> generateQuarkusConfigMap(SmallRyeConfig config) {
-        Set<String> defaultNames = new HashSet<>();
-        defaultNames.addAll(configClass(PackageConfig.class).getProperties().keySet());
-        defaultNames.addAll(configClass(NativeConfig.class).getProperties().keySet());
+        Set<String> excludeNames = new HashSet<>();
+        excludeNames.addAll(configClass(PackageConfig.class).getProperties().keySet());
+        excludeNames.addAll(configClass(NativeConfig.class).getProperties().keySet());
+        Set<String> propagateSources = new HashSet<>();
+        propagateSources.add("PropertiesConfigSource[source=forcedProperties]");
+        propagateSources.add("PropertiesConfigSource[source=taskProperties]");
+        propagateSources.add("PropertiesConfigSource[source=quarkusBuildProperties]");
+        propagateSources.add("PropertiesConfigSource[source=projectProperties]");
+        propagateSources.add("PropertiesConfigSource[source=platformProperties]");
+        propagateSources.add(SysPropConfigSource.NAME);
+        // It may look weird to include default values, but we do it because of EffectiveConfigProvider#buildEffectiveConfiguration
+        propagateSources.add(DefaultValuesConfigSource.NAME);
         return Expressions.withoutExpansion(new Supplier<Map<String, String>>() {
             @Override
             public Map<String, String> get() {
@@ -151,12 +173,14 @@ public final class EffectiveConfig {
                 for (String propertyName : config.getPropertyNames()) {
                     if (propertyName.startsWith("quarkus.") || propertyName.startsWith("platform.quarkus.")) {
                         ConfigValue configValue = config.getConfigValue(propertyName);
-                        // Remove defaults coming from PackageConfig and NativeConfig, as this Map as passed as
-                        // system properties to Gradle workers and, we loose the ability to determine if it was set by
-                        // the user to evaluate deprecated configuration
-                        if (configValue.getValue() != null && (!defaultNames.contains(configValue.getName())
-                                || !configValue.isDefault())) {
-                            properties.put(propertyName, configValue.getValue());
+                        // Only propagate properties from sources not available in Quarkus
+                        if (configValue.getValue() != null && propagateSources.contains(configValue.getConfigSourceName())) {
+                            // Exclude defaults coming from PackageConfig and NativeConfig, as this Map as passed as
+                            // system properties to Gradle workers and, we loose the ability to determine if it was set by
+                            // the user to evaluate deprecated configuration
+                            if (!excludeNames.contains(configValue.getName()) || !configValue.isDefault()) {
+                                properties.put(propertyName, configValue.getValue());
+                            }
                         }
                     }
                 }

--- a/integration-tests/gradle/src/main/resources/config-propagation/build.gradle
+++ b/integration-tests/gradle/src/main/resources/config-propagation/build.gradle
@@ -1,0 +1,33 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+}
+
+repositories {
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
+    mavenCentral()
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-resteasy'
+
+    testImplementation 'io.quarkus:quarkus-junit'
+    testImplementation 'io.rest-assured:rest-assured'
+}
+
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
+
+compileJava {
+    options.encoding = 'UTF-8'
+    options.compilerArgs << '-parameters'
+}
+
+quarkus {
+    quarkusBuildProperties.put("quarkus.http.enable-compression", "true")
+}

--- a/integration-tests/gradle/src/main/resources/config-propagation/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/config-propagation/gradle.properties
@@ -1,0 +1,4 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus
+
+quarkus.http.enable-decompression=true

--- a/integration-tests/gradle/src/main/resources/config-propagation/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/config-propagation/settings.gradle
@@ -1,0 +1,15 @@
+pluginManagement {
+    repositories {
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+      id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+rootProject.name='code-with-quarkus'

--- a/integration-tests/gradle/src/main/resources/config-propagation/src/main/java/org/acme/ExampleResource.java
+++ b/integration-tests/gradle/src/main/resources/config-propagation/src/main/java/org/acme/ExampleResource.java
@@ -1,0 +1,16 @@
+package org.acme;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class ExampleResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "hello";
+    }
+}

--- a/integration-tests/gradle/src/main/resources/config-propagation/src/main/resources/application.properties
+++ b/integration-tests/gradle/src/main/resources/config-propagation/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.http.read-timeout=30s

--- a/integration-tests/gradle/src/main/resources/config-propagation/src/test/java/org/acme/ExampleResourceTest.java
+++ b/integration-tests/gradle/src/main/resources/config-propagation/src/test/java/org/acme/ExampleResourceTest.java
@@ -1,0 +1,35 @@
+package org.acme;
+
+import io.smallrye.config.ConfigValue;
+import jakarta.inject.Inject;
+import io.smallrye.config.Config;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+@QuarkusTest
+class ExampleResourceTest {
+    @Inject
+    Config config;
+
+    @Test
+    void propagateConfig() {
+        ConfigValue fromPlugin = Config.get().getConfigValue("quarkus.http.enable-compression");
+        assertEquals("true", fromPlugin.getValue());
+        assertEquals("BuildTime RunTime Fixed", fromPlugin.getConfigSourceName());
+
+        ConfigValue fromGradleProperties = Config.get().getConfigValue("quarkus.http.enable-decompression");
+        assertEquals("true", fromGradleProperties.getValue());
+        assertEquals("BuildTime RunTime Fixed", fromGradleProperties.getConfigSourceName());
+
+        ConfigValue fromApplication = Config.get().getConfigValue("quarkus.http.read-timeout");
+        assertEquals("30s", fromApplication.getValue());
+        assertNotEquals("SysPropConfigSource", fromApplication.getConfigSourceName());
+    }
+}

--- a/integration-tests/gradle/src/main/resources/test-prefixed-profile-properties/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-prefixed-profile-properties/build.gradle
@@ -1,0 +1,29 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+}
+
+repositories {
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
+    mavenCentral()
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-resteasy'
+
+    testImplementation 'io.quarkus:quarkus-junit'
+    testImplementation 'io.rest-assured:rest-assured'
+}
+
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
+
+compileJava {
+    options.encoding = 'UTF-8'
+    options.compilerArgs << '-parameters'
+}

--- a/integration-tests/gradle/src/main/resources/test-prefixed-profile-properties/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/test-prefixed-profile-properties/gradle.properties
@@ -1,0 +1,2 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus

--- a/integration-tests/gradle/src/main/resources/test-prefixed-profile-properties/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/test-prefixed-profile-properties/settings.gradle
@@ -1,0 +1,15 @@
+pluginManagement {
+    repositories {
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+      id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+rootProject.name='code-with-quarkus'

--- a/integration-tests/gradle/src/main/resources/test-prefixed-profile-properties/src/main/java/org/acme/Config.java
+++ b/integration-tests/gradle/src/main/resources/test-prefixed-profile-properties/src/main/java/org/acme/Config.java
@@ -1,0 +1,8 @@
+package org.acme;
+
+import io.smallrye.config.ConfigMapping;
+
+@ConfigMapping(prefix = "example")
+public interface Config {
+    public String message();
+}

--- a/integration-tests/gradle/src/main/resources/test-prefixed-profile-properties/src/main/java/org/acme/ExampleResource.java
+++ b/integration-tests/gradle/src/main/resources/test-prefixed-profile-properties/src/main/java/org/acme/ExampleResource.java
@@ -1,0 +1,20 @@
+package org.acme;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class ExampleResource {
+
+    @Inject
+    Config config;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return config.message();
+    }
+}

--- a/integration-tests/gradle/src/main/resources/test-prefixed-profile-properties/src/main/java/org/acme/TestOnlyResource.java
+++ b/integration-tests/gradle/src/main/resources/test-prefixed-profile-properties/src/main/java/org/acme/TestOnlyResource.java
@@ -1,0 +1,22 @@
+package org.acme;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@Path("/test-only")
+public class TestOnlyResource {
+
+    @ConfigProperty(name = "test-only")
+    String testOnly;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return testOnly;
+    }
+}

--- a/integration-tests/gradle/src/main/resources/test-prefixed-profile-properties/src/main/resources/application.properties
+++ b/integration-tests/gradle/src/main/resources/test-prefixed-profile-properties/src/main/resources/application.properties
@@ -1,0 +1,10 @@
+# Configuration file
+# key = value
+example.message=Hello from App
+app-only=App only
+%test.test-only=Test only
+
+# do not propagate, it will fail if the properties are propagated
+%prod.quarkus.http.tls-configuration-name=https
+%prod.quarkus.tls.https.key-store.pem.0.cert=/app/certificates/tls.crt
+%prod.quarkus.tls.https.key-store.pem.0.key=/app/certificates/tls.key

--- a/integration-tests/gradle/src/main/resources/test-prefixed-profile-properties/src/test/java/org/acme/ExampleResourceTest.java
+++ b/integration-tests/gradle/src/main/resources/test-prefixed-profile-properties/src/test/java/org/acme/ExampleResourceTest.java
@@ -1,0 +1,41 @@
+package org.acme;
+
+import jakarta.inject.Inject;
+import io.smallrye.config.Config;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+@QuarkusTest
+class ExampleResourceTest {
+    @Inject
+    Config config;
+
+    @Test
+    void helloEndpoint() {
+        given()
+          .when().get("/hello")
+          .then()
+             .statusCode(200)
+             .body(is("Hello from App"));
+    }
+
+    @Test
+    void testOnly() {
+      given()
+          .when().get("test-only")
+          .then()
+              .statusCode(200)
+              .body(is("Test only"));
+    }
+
+    @Test
+    void profile() {
+        System.out.println("profiles: " + config.getProfiles());
+        Assertions.assertEquals("test", config.getProfiles().get(0));
+    }
+}

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/ConfigPropagationTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/ConfigPropagationTest.java
@@ -1,0 +1,14 @@
+package io.quarkus.gradle;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+public class ConfigPropagationTest extends QuarkusGradleWrapperTestBase {
+
+    @Test
+    public void test() throws Exception {
+        File projectDir = getProjectDir("config-propagation");
+        runGradleWrapper(projectDir, "test");
+    }
+}

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/SystemPropsAsBuildTimeConfigSourceTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/SystemPropsAsBuildTimeConfigSourceTest.java
@@ -33,7 +33,6 @@ public class SystemPropsAsBuildTimeConfigSourceTest extends QuarkusGradleWrapper
         gradleConfigurationCache(false);
         runGradleWrapper(projectDir,
                 "-Dquarkus.example.name=cheburashka",
-                "-Dquarkus.example.runtime-name=crocodile",
                 "-Dquarkus.package.jar.type=mutable-jar",
                 ":example-extension:example-extension-deployment:build",
                 // this quarkusIntTest will make sure runtime config properties passed as env vars when launching the app are effective

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/TestPrefixedProfilePropertiesTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/TestPrefixedProfilePropertiesTest.java
@@ -1,0 +1,14 @@
+package io.quarkus.gradle;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+public class TestPrefixedProfilePropertiesTest extends QuarkusGradleWrapperTestBase {
+
+    @Test
+    public void test() throws Exception {
+        File projectDir = getProjectDir("test-prefixed-profile-properties");
+        runGradleWrapper(projectDir, "test");
+    }
+}


### PR DESCRIPTION
Because Gradle workers run in a separate JVM, System Properties set in the original process are lost, so we need to implement this propagation strategy. Gradle configuration sources, such as plugin configuration or `gradle.properties`, had the same issue.  Until now, our implementation was to iterate over all names and build a `Map` of all Quarkus properties, including configuration from `application.properties` or Environment Variables. In reality, this was unnecessary, since such sources are also available in the Gradle worker.

This became an issue with https://github.com/quarkusio/quarkus/pull/53080. The propagation included profile configuration recorded from the build, which caused the test runner to run in `prod` profile instead of `test`.

The new approach propagates Quarkus properties to Gradle workers, only considering sources that are not available in Quarkus, so Gradle-related configuration sources, plus System Properties.

Related to:
- https://github.com/quarkusio/quarkus/pull/48496
- https://github.com/quarkusio/quarkus/pull/49503
- https://github.com/quarkusio/quarkus/pull/50567
- https://github.com/quarkusio/quarkus/pull/53080
- https://github.com/quarkusio/quarkus/issues/53151
- https://github.com/quarkusio/quarkus/issues/53149
- https://github.com/quarkusio/quarkus/pull/53169