### PR TITLE
Dev MCP: Add single-test execution tool for agents

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
@@ -724,6 +724,21 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
         return ret;
     }
 
+    /**
+     * Compile and detect changed application and test classes for one-shot test execution.
+     * Returns a merged ClassScanResult, or null if no changes were detected.
+     */
+    public ClassScanResult checkForChangedClassesForTests() {
+        ClassScanResult appChanges = checkForChangedClasses(compiler, DevModeContext.ModuleInfo::getMain, false, test, true);
+        ClassScanResult testChanges = new ClassScanResult();
+        if (testSupport != null && testSupport.getCompiler() != null) {
+            testChanges = checkForChangedClasses(testSupport.getCompiler(),
+                    s -> s.getTest().orElse(DevModeContext.EMPTY_COMPILATION_UNIT), false, test, true);
+        }
+        ClassScanResult merged = ClassScanResult.merge(testChanges, appChanges);
+        return merged.isChanged() ? merged : null;
+    }
+
     private void collectRecompilationTargets(DotName changedDependency, Set<DotName> knownRecompilationTargets) {
         Deque<DotName> toResolve = new ArrayDeque<>();
         toResolve.add(changedDependency);

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/ModuleTestRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/ModuleTestRunner.java
@@ -38,6 +38,11 @@ public class ModuleTestRunner {
     }
 
     Runnable prepare(ClassScanResult classScanResult, boolean reRunFailures, long runId, TestRunListener listener) {
+        return prepare(classScanResult, reRunFailures, runId, listener, null);
+    }
+
+    Runnable prepare(ClassScanResult classScanResult, boolean reRunFailures, long runId, TestRunListener listener,
+            String specificSelection) {
 
         var old = Thread.currentThread().getContextClassLoader();
         Thread.currentThread().setContextClassLoader(testApplication.getOrCreateAugmentClassLoader());
@@ -56,7 +61,7 @@ public class ModuleTestRunner {
                         .setExcludeTags(testSupport.excludeTags)
                         .setInclude(testSupport.include)
                         .setExclude(testSupport.exclude)
-                        .setSpecificSelection(testSupport.specificSelection)
+                        .setSpecificSelection(specificSelection != null ? specificSelection : testSupport.specificSelection)
                         .setIncludeEngines(testSupport.includeEngines)
                         .setExcludeEngines(testSupport.excludeEngines)
                         .setTestType(testSupport.testType)
@@ -103,5 +108,9 @@ public class ModuleTestRunner {
 
     public TestState getTestState() {
         return testState;
+    }
+
+    public boolean hasTestClassUsageData() {
+        return testClassUsages.hasData();
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestClassUsages.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestClassUsages.java
@@ -38,6 +38,10 @@ public class TestClassUsages implements Serializable {
         classNames.putAll(newData.classNames);
     }
 
+    public synchronized boolean hasData() {
+        return !classNames.isEmpty();
+    }
+
     public synchronized PostDiscoveryFilter getTestsToRun(Set<String> changedClasses, TestState testState) {
 
         Set<UniqueId> touchedIds = new HashSet<>();

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestSupport.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestSupport.java
@@ -30,6 +30,7 @@ import io.quarkus.bootstrap.app.QuarkusBootstrap.Mode;
 import io.quarkus.bootstrap.classloading.ClassPathElement;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.bootstrap.utils.BuildToolHelper;
 import io.quarkus.deployment.dev.ClassScanResult;
 import io.quarkus.deployment.dev.CompilationProvider;
 import io.quarkus.deployment.dev.DevModeContext;
@@ -484,6 +485,132 @@ public class TestSupport implements TestController {
             }
         }
 
+    }
+
+    /**
+     * Run all tests synchronously on the calling thread and return the results.
+     * Initializes test infrastructure if needed, without requiring continuous testing to be started.
+     */
+    public TestRunResults runAllTestsSynchronously() {
+        return runTestsSynchronouslyInternal(null, null);
+    }
+
+    /**
+     * Run tests affected by recent code changes synchronously and return the results.
+     * Uses RuntimeUpdatesProcessor to detect changed classes and TestClassUsages to filter affected tests.
+     * On cold start (no prior test run), falls back to running all tests.
+     */
+    public TestRunResults runAffectedTestsSynchronously() {
+        ClassScanResult classScanResult = RuntimeUpdatesProcessor.INSTANCE.checkForChangedClassesForTests();
+        if (classScanResult != null) {
+            return runTestsSynchronouslyInternal(classScanResult, null);
+        }
+        // no changes detected, run all
+        return runTestsSynchronouslyInternal(null, null);
+    }
+
+    /**
+     * Run a specific test synchronously and return the results.
+     *
+     * @param testSelection test class name (e.g. com.example.MyTest) or class+method (e.g. com.example.MyTest#myMethod)
+     */
+    public TestRunResults runSpecificTestSynchronously(String testSelection) {
+        String prefix = "maven:";
+        if (context.getProjectDir() != null) {
+            Path projectDir = context.getProjectDir().toPath();
+            if (BuildToolHelper.BuildTool.GRADLE.exists(projectDir)) {
+                prefix = "gradle:";
+            }
+        }
+        String selection = prefix + testSelection;
+        return runTestsSynchronouslyInternal(null, selection);
+    }
+
+    private synchronized TestRunResults runTestsSynchronouslyInternal(ClassScanResult classScanResult,
+            String specificSelection) {
+        init();
+        final ClassScanResult effectiveScanResult = classScanResult;
+        final long runId = COUNTER.incrementAndGet();
+        handleApplicationPropertiesChange();
+        List<Runnable> runnables = new ArrayList<>();
+        List<TestRunListener> testRunListeners = new ArrayList<>();
+        for (var i : testListeners) {
+            i.testRunStarted(testRunListeners::add);
+        }
+        long start = System.currentTimeMillis();
+        final AtomicLong testCount = new AtomicLong();
+        List<TestRunResults> allResults = new ArrayList<>();
+        for (var module : moduleRunners) {
+            runnables.add(module.prepare(effectiveScanResult, false, runId, new TestRunListener() {
+                @Override
+                public void runStarted(long toRun) {
+                    testCount.addAndGet(toRun);
+                }
+
+                @Override
+                public void testComplete(TestResult result) {
+                    for (var i : testRunListeners) {
+                        i.testComplete(result);
+                    }
+                }
+
+                @Override
+                public void runComplete(TestRunResults results) {
+                    allResults.add(results);
+                }
+
+                @Override
+                public void runAborted() {
+                    for (var i : testRunListeners) {
+                        i.runAborted();
+                    }
+                }
+
+                @Override
+                public void testStarted(TestIdentifier testIdentifier, String className) {
+                    for (var i : testRunListeners) {
+                        i.testStarted(testIdentifier, className);
+                    }
+                }
+
+            }, specificSelection));
+        }
+        for (var i : testRunListeners) {
+            i.runStarted(testCount.get());
+        }
+        for (var i : runnables) {
+            try {
+                i.run();
+            } catch (Exception e) {
+                log.error("Failed to run test module", e);
+            }
+        }
+        Map<String, TestClassResult> aggregate = new HashMap<>();
+        for (var i : allResults) {
+            aggregate.putAll(i.getResults());
+        }
+        TestRunResults results = new TestRunResults(runId, effectiveScanResult, effectiveScanResult == null, start,
+                System.currentTimeMillis(), aggregate);
+        testRunResults = results;
+        if (!closed) {
+            for (var i : testRunListeners) {
+                i.runComplete(results);
+            }
+        }
+        return results;
+    }
+
+    /**
+     * Check if test class usage data has been populated from a prior test run.
+     * When false, runAffectedTests will fall back to running all tests.
+     */
+    public boolean hasTestClassUsageData() {
+        for (var module : moduleRunners) {
+            if (module.hasTestClassUsageData()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public void addListener(TestListener listener) {

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/ContinuousTestingProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/ContinuousTestingProcessor.java
@@ -113,7 +113,6 @@ public class ContinuousTestingProcessor {
                         throw new RuntimeException(e);
                     }
                 })
-                .enableMcpFunctionByDefault()
                 .build();
     }
 
@@ -139,7 +138,6 @@ public class ContinuousTestingProcessor {
                         throw new RuntimeException(e);
                     }
                 })
-                .enableMcpFunctionByDefault()
                 .build();
     }
 
@@ -160,7 +158,6 @@ public class ContinuousTestingProcessor {
                         throw new RuntimeException(e);
                     }
                 })
-                .enableMcpFunctionByDefault()
                 .build();
     }
 
@@ -262,7 +259,6 @@ public class ContinuousTestingProcessor {
                         throw new RuntimeException(e);
                     }
                 })
-                .enableMcpFunctionByDefault()
                 .build();
     }
 
@@ -282,7 +278,6 @@ public class ContinuousTestingProcessor {
         actions.actionBuilder()
                 .methodName("getTestResults")
                 .description("Get the results of a Continuous testing test run")
-                .enableMcpFunctionByDefault()
                 .function(ignored -> {
                     TestRunResults continuousTestingResults = continuousTestingResults(launchModeBuildItem);
                     if (continuousTestingResults != null) {

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/OneShotTestingProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/OneShotTestingProcessor.java
@@ -1,0 +1,141 @@
+package io.quarkus.devui.deployment.menu;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import io.quarkus.deployment.IsLocalDevelopment;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.deployment.dev.ClassScanResult;
+import io.quarkus.deployment.dev.RuntimeUpdatesProcessor;
+import io.quarkus.deployment.dev.testing.TestRunResults;
+import io.quarkus.deployment.dev.testing.TestSupport;
+import io.quarkus.dev.spi.DevModeType;
+import io.quarkus.devui.spi.buildtime.BuildTimeActionBuildItem;
+
+/**
+ * Registers one-shot synchronous testing tools for AI coding agents.
+ * These tools run tests on demand and return results directly,
+ * without requiring continuous testing to be started.
+ */
+public class OneShotTestingProcessor {
+
+    private static final String NAMESPACE = "devui-testing";
+    private static final long TEST_TIMEOUT_MINUTES = 5;
+    private static final ExecutorService executor = Executors.newCachedThreadPool(r -> {
+        Thread t = new Thread(r, "oneshot-test-runner");
+        t.setDaemon(true);
+        return t;
+    });
+
+    @BuildStep(onlyIf = IsLocalDevelopment.class)
+    void registerOneShotTestingActions(LaunchModeBuildItem launchModeBuildItem,
+            BuildProducer<BuildTimeActionBuildItem> buildTimeActionProducer) {
+
+        BuildTimeActionBuildItem actions = new BuildTimeActionBuildItem(NAMESPACE);
+        registerRunTestsMethod(launchModeBuildItem, actions);
+        registerRunAffectedTestsMethod(launchModeBuildItem, actions);
+        registerRunTestMethod(launchModeBuildItem, actions);
+        buildTimeActionProducer.produce(actions);
+    }
+
+    private boolean testsDisabled(LaunchModeBuildItem launchModeBuildItem, Optional<TestSupport> ts) {
+        return ts.isEmpty() || launchModeBuildItem.getDevModeType().orElse(null) != DevModeType.LOCAL;
+    }
+
+    /**
+     * Compile any changed main and test source files before running tests.
+     * This is necessary because the one-shot test tools do not use continuous testing,
+     * so test sources written after the app started would not be compiled otherwise.
+     * Returns the ClassScanResult so the test runner knows which classes changed.
+     */
+    private static ClassScanResult compileTestSources() {
+        if (RuntimeUpdatesProcessor.INSTANCE != null) {
+            return RuntimeUpdatesProcessor.INSTANCE.checkForChangedClassesForTests();
+        }
+        return null;
+    }
+
+    private void registerRunTestsMethod(LaunchModeBuildItem launchModeBuildItem, BuildTimeActionBuildItem actions) {
+        actions.actionBuilder()
+                .methodName("runTests")
+                .description("Run all tests synchronously and return the results. "
+                        + "Does not require continuous testing to be started.")
+                .function(ignored -> {
+                    Optional<TestSupport> ts = TestSupport.instance();
+                    if (testsDisabled(launchModeBuildItem, ts)) {
+                        return CompletableFuture.completedFuture(null);
+                    }
+                    return CompletableFuture.supplyAsync(() -> {
+                        compileTestSources();
+                        TestRunResults results = ts.get().runAllTestsSynchronously();
+                        return results != null ? new TrimmedTestRunResult(results) : null;
+                    }, executor).orTimeout(TEST_TIMEOUT_MINUTES, TimeUnit.MINUTES);
+                })
+                .enableMcpFunctionByDefault()
+                .build();
+    }
+
+    private void registerRunAffectedTestsMethod(LaunchModeBuildItem launchModeBuildItem,
+            BuildTimeActionBuildItem actions) {
+        actions.actionBuilder()
+                .methodName("runAffectedTests")
+                .description("Run tests affected by recent code changes synchronously and return the results. "
+                        + "On first call (no prior test data), runs all tests to populate tracing data. "
+                        + "Subsequent calls intelligently filter to only affected tests.")
+                .function(ignored -> {
+                    Optional<TestSupport> ts = TestSupport.instance();
+                    if (testsDisabled(launchModeBuildItem, ts)) {
+                        return CompletableFuture.completedFuture(null);
+                    }
+                    return CompletableFuture.supplyAsync(() -> {
+                        compileTestSources();
+                        TestSupport testSupport = ts.get();
+                        boolean usageDataAvailable = testSupport.hasTestClassUsageData();
+                        TestRunResults results = testSupport.runAffectedTestsSynchronously();
+                        return results != null ? new TrimmedTestRunResult(results, usageDataAvailable) : null;
+                    }, executor).orTimeout(TEST_TIMEOUT_MINUTES, TimeUnit.MINUTES);
+                })
+                .enableMcpFunctionByDefault()
+                .build();
+    }
+
+    private void registerRunTestMethod(LaunchModeBuildItem launchModeBuildItem, BuildTimeActionBuildItem actions) {
+        actions.actionBuilder()
+                .methodName("runTest")
+                .description("Run a specific test synchronously and return the results. "
+                        + "Accepts a test class name (e.g. com.example.MyTest) "
+                        + "or class and method (e.g. com.example.MyTest#myMethod).")
+                .parameter("className", "The fully qualified test class name, e.g. com.example.MyTest")
+                .parameter("methodName",
+                        "The test method name to run. If not provided, all tests in the class are run.",
+                        false)
+                .function(params -> {
+                    Optional<TestSupport> ts = TestSupport.instance();
+                    if (testsDisabled(launchModeBuildItem, ts)) {
+                        return CompletableFuture.completedFuture(null);
+                    }
+                    String className = params.get("className");
+                    if (className == null || className.isBlank()) {
+                        throw new IllegalArgumentException("className parameter is required");
+                    }
+                    String methodName = params.get("methodName");
+                    String testSelection = className;
+                    if (methodName != null && !methodName.isBlank()) {
+                        testSelection = className + "#" + methodName;
+                    }
+                    final String selection = testSelection;
+                    return CompletableFuture.supplyAsync(() -> {
+                        compileTestSources();
+                        TestRunResults results = ts.get().runSpecificTestSynchronously(selection);
+                        return results != null ? new TrimmedTestRunResult(results) : null;
+                    }, executor).orTimeout(TEST_TIMEOUT_MINUTES, TimeUnit.MINUTES);
+                })
+                .enableMcpFunctionByDefault()
+                .build();
+    }
+}

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/TrimmedTestRunResult.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/TrimmedTestRunResult.java
@@ -1,30 +1,22 @@
 package io.quarkus.devui.deployment.menu;
 
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import io.quarkus.deployment.dev.testing.TestClassResult;
+import io.quarkus.deployment.dev.testing.TestResult;
 import io.quarkus.deployment.dev.testing.TestRunResults;
 
 public class TrimmedTestRunResult {
 
-    /**
-     * The run id
-     */
     private final long id;
-
-    /**
-     * If this ran all tests, or just the modified ones
-     */
     private final boolean full;
-
     private final long started;
     private final long completed;
-
-    private final Map<String, TestClassResult> currentFailing = new HashMap<>();
-    private final Map<String, TestClassResult> historicFailing = new HashMap<>();
-    private final Map<String, TestClassResult> currentPassing = new HashMap<>();
-    private final Map<String, TestClassResult> historicPassing = new HashMap<>();
 
     private final long passedCount;
     private final long failedCount;
@@ -32,22 +24,55 @@ public class TrimmedTestRunResult {
     private final long currentPassedCount;
     private final long currentFailedCount;
     private final long currentSkippedCount;
+    private final boolean usageDataAvailable;
+
+    private final List<TrimmedTestResult> failing;
+    private final List<TrimmedTestResult> passing;
+    private final List<TrimmedTestResult> skipped;
 
     public TrimmedTestRunResult(TestRunResults testRunResults) {
+        this(testRunResults, true);
+    }
+
+    public TrimmedTestRunResult(TestRunResults testRunResults, boolean usageDataAvailable) {
         this.id = testRunResults.getId();
         this.full = testRunResults.isFull();
         this.started = testRunResults.getStartedTime();
         this.completed = testRunResults.getCompletedTime();
-        this.currentFailing.putAll(testRunResults.getCurrentFailing());
-        this.historicFailing.putAll(testRunResults.getHistoricFailing());
-        this.currentPassing.putAll(testRunResults.getCurrentPassing());
-        this.historicPassing.putAll(testRunResults.getHistoricPassing());
         this.passedCount = testRunResults.getPassedCount();
         this.failedCount = testRunResults.getFailedCount();
         this.skippedCount = testRunResults.getSkippedCount();
         this.currentPassedCount = testRunResults.getCurrentPassedCount();
         this.currentFailedCount = testRunResults.getCurrentFailedCount();
         this.currentSkippedCount = testRunResults.getCurrentSkippedCount();
+        this.usageDataAvailable = usageDataAvailable;
+
+        this.failing = extractResults(testRunResults.getCurrentFailing(), TestState.FAILED);
+        this.passing = extractResults(testRunResults.getCurrentPassing(), TestState.PASSED);
+        this.skipped = extractResults(testRunResults.getResults(), TestState.SKIPPED);
+    }
+
+    private enum TestState {
+        FAILED,
+        PASSED,
+        SKIPPED
+    }
+
+    private static List<TrimmedTestResult> extractResults(Map<String, TestClassResult> classResults, TestState filterState) {
+        List<TrimmedTestResult> results = new ArrayList<>();
+        for (TestClassResult classResult : classResults.values()) {
+            List<TestResult> tests = switch (filterState) {
+                case FAILED -> classResult.getFailing();
+                case SKIPPED -> classResult.getSkipped();
+                case PASSED -> classResult.getPassing();
+            };
+            for (TestResult test : tests) {
+                if (test.isTest()) {
+                    results.add(new TrimmedTestResult(test));
+                }
+            }
+        }
+        return results;
     }
 
     public long getId() {
@@ -56,22 +81,6 @@ public class TrimmedTestRunResult {
 
     public boolean isFull() {
         return full;
-    }
-
-    public Map<String, TestClassResult> getCurrentFailing() {
-        return currentFailing;
-    }
-
-    public Map<String, TestClassResult> getHistoricFailing() {
-        return historicFailing;
-    }
-
-    public Map<String, TestClassResult> getCurrentPassing() {
-        return currentPassing;
-    }
-
-    public Map<String, TestClassResult> getHistoricPassing() {
-        return historicPassing;
     }
 
     public long getStartedTime() {
@@ -110,4 +119,74 @@ public class TrimmedTestRunResult {
         return currentSkippedCount;
     }
 
+    public boolean isUsageDataAvailable() {
+        return usageDataAvailable;
+    }
+
+    public List<TrimmedTestResult> getFailing() {
+        return failing;
+    }
+
+    public List<TrimmedTestResult> getPassing() {
+        return passing;
+    }
+
+    public List<TrimmedTestResult> getSkipped() {
+        return skipped;
+    }
+
+    public static class TrimmedTestResult {
+        private final String displayName;
+        private final String className;
+        private final String state;
+        private final String message;
+        private final long time;
+
+        public TrimmedTestResult(TestResult testResult) {
+            this.displayName = testResult.getDisplayName();
+            this.className = testResult.getTestClass();
+            this.state = testResult.getTestExecutionResult().getStatus().name();
+            this.time = testResult.getTime();
+
+            Throwable throwable = testResult.getTestExecutionResult().getThrowable().orElse(null);
+            if (throwable != null) {
+                this.message = getRootMessage(throwable);
+            } else {
+                this.message = null;
+            }
+        }
+
+        private static String getRootMessage(Throwable throwable) {
+            Set<Throwable> seen = Collections.newSetFromMap(new IdentityHashMap<>());
+            Throwable root = throwable;
+            while (root.getCause() != null && seen.add(root)) {
+                root = root.getCause();
+            }
+            String msg = root.getMessage();
+            if (msg == null) {
+                msg = root.getClass().getName();
+            }
+            return msg;
+        }
+
+        public String getDisplayName() {
+            return displayName;
+        }
+
+        public String getClassName() {
+            return className;
+        }
+
+        public String getState() {
+            return state;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public long getTime() {
+            return time;
+        }
+    }
 }

--- a/extensions/devui/deployment/src/test/java/io/quarkus/devui/devmcp/DevMcpTestToolsTest.java
+++ b/extensions/devui/deployment/src/test/java/io/quarkus/devui/devmcp/DevMcpTestToolsTest.java
@@ -1,0 +1,133 @@
+package io.quarkus.devui.devmcp;
+
+import org.hamcrest.CoreMatchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.devui.testrunner.HelloResource;
+import io.quarkus.devui.testrunner.SimpleET;
+import io.quarkus.devui.testrunner.UnitET;
+import io.quarkus.devui.testrunner.UnitService;
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
+public class DevMcpTestToolsTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(HelloResource.class, UnitService.class)
+                    .add(new StringAsset(
+                            "quarkus.test.continuous-testing=disabled\nquarkus.console.basic=true\nquarkus.console.disable-input=true\nquarkus.dev-mcp.enabled=true\n"),
+                            "application.properties"))
+            .setTestArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(SimpleET.class, UnitET.class));
+
+    @Test
+    public void testNewTestToolsInToolsList() {
+        String jsonBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 1,
+                      "method": "initialize",
+                      "params": {
+                        "protocolVersion": "2025-03-26",
+                        "capabilities": {},
+                        "clientInfo": {
+                          "name": "JUnitTestClient",
+                          "version": "1.0.0"
+                        }
+                      }
+                    }
+                """;
+
+        RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .body(jsonBody)
+                .when()
+                .post("/q/dev-mcp")
+                .then()
+                .statusCode(200);
+
+        jsonBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 2,
+                      "method": "tools/list"
+                    }
+                """;
+
+        RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .body(jsonBody)
+                .when()
+                .post("/q/dev-mcp")
+                .then()
+                .statusCode(200)
+                .body("result.tools.name", CoreMatchers.hasItem("devui-testing_runTests"))
+                .body("result.tools.name", CoreMatchers.hasItem("devui-testing_runTest"))
+                .body("result.tools.name", CoreMatchers.hasItem("devui-testing_runAffectedTests"));
+    }
+
+    @Test
+    public void testRunTestsViaMcp() {
+        // Initialize first
+        String initBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 1,
+                      "method": "initialize",
+                      "params": {
+                        "protocolVersion": "2025-03-26",
+                        "capabilities": {},
+                        "clientInfo": {
+                          "name": "JUnitTestClient",
+                          "version": "1.0.0"
+                        }
+                      }
+                    }
+                """;
+
+        RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .body(initBody)
+                .when()
+                .post("/q/dev-mcp")
+                .then()
+                .statusCode(200);
+
+        // Call runTests
+        String callBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 3,
+                      "method": "tools/call",
+                      "params": {
+                        "name": "devui-testing_runTests",
+                        "arguments": {}
+                      }
+                    }
+                """;
+
+        RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .body(callBody)
+                .when()
+                .post("/q/dev-mcp")
+                .then()
+                .statusCode(200)
+                .body("id", CoreMatchers.equalTo(3))
+                .body("result.content[0].type", CoreMatchers.equalTo("text"))
+                .body("result.content[0].text", CoreMatchers.containsString("\"passedCount\""))
+                .body("result.content[0].text", CoreMatchers.containsString("\"failedCount\""))
+                .body("result.content[0].text", CoreMatchers.containsString("\"passing\""));
+    }
+}

--- a/extensions/devui/deployment/src/test/java/io/quarkus/devui/testrunner/TestRunnerOneShotTestCase.java
+++ b/extensions/devui/deployment/src/test/java/io/quarkus/devui/testrunner/TestRunnerOneShotTestCase.java
@@ -1,0 +1,120 @@
+package io.quarkus.devui.testrunner;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.quarkus.devui.tests.DevUIJsonRPCTest;
+import io.quarkus.test.QuarkusDevModeTest;
+
+public class TestRunnerOneShotTestCase extends DevUIJsonRPCTest {
+
+    @RegisterExtension
+    static QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class).addClasses(HelloResource.class, UnitService.class)
+                            .add(new StringAsset(
+                                    "quarkus.test.continuous-testing=disabled\nquarkus.console.basic=true\nquarkus.console.disable-input=true\n"),
+                                    "application.properties");
+                }
+            })
+            .setTestArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class).addClasses(SimpleET.class, UnitET.class);
+                }
+            });
+
+    public TestRunnerOneShotTestCase() {
+        super("devui-testing");
+    }
+
+    @Test
+    public void testRunTests() throws Exception {
+        JsonNode result = super.executeJsonRPCMethod("runTests");
+        Assertions.assertNotNull(result, "runTests should return a result");
+
+        Assertions.assertTrue(result.has("passedCount"), "Result should have passedCount");
+        Assertions.assertTrue(result.has("failedCount"), "Result should have failedCount");
+        Assertions.assertTrue(result.has("skippedCount"), "Result should have skippedCount");
+        Assertions.assertTrue(result.has("failing"), "Result should have failing list");
+        Assertions.assertTrue(result.has("passing"), "Result should have passing list");
+        Assertions.assertTrue(result.has("skipped"), "Result should have skipped list");
+
+        // The tests include SimpleET (2 tests) and UnitET (2 tests)
+        // SimpleET.testHelloEndpoint will fail (no /hello route initially)
+        // SimpleET.testGreetingEndpoint will pass
+        // UnitET tests will fail (expects "UNIT" but gets "unit", expects "Hi" but gets "hello")
+        long totalTests = result.get("passedCount").asLong() + result.get("failedCount").asLong()
+                + result.get("skippedCount").asLong();
+        Assertions.assertTrue(totalTests > 0, "Should have run at least one test");
+
+        // Verify the result has timing info
+        Assertions.assertTrue(result.has("startedTime"), "Result should have startedTime");
+        Assertions.assertTrue(result.has("completedTime"), "Result should have completedTime");
+        Assertions.assertTrue(result.has("totalTime"), "Result should have totalTime");
+        Assertions.assertTrue(result.get("totalTime").asLong() > 0, "Total time should be positive");
+    }
+
+    @Test
+    public void testRunTestWithClassName() throws Exception {
+        JsonNode result = super.executeJsonRPCMethod("runTest",
+                Map.of("className", "io.quarkus.devui.testrunner.UnitET"));
+        Assertions.assertNotNull(result, "runTest should return a result");
+
+        // Should only contain results for UnitET
+        long totalTests = result.get("passedCount").asLong() + result.get("failedCount").asLong()
+                + result.get("skippedCount").asLong();
+        Assertions.assertTrue(totalTests > 0, "Should have run at least one test");
+
+        // All results should be from UnitET
+        assertAllResultsFromClass(result.get("failing"), "io.quarkus.devui.testrunner.UnitET");
+        assertAllResultsFromClass(result.get("passing"), "io.quarkus.devui.testrunner.UnitET");
+        assertAllResultsFromClass(result.get("skipped"), "io.quarkus.devui.testrunner.UnitET");
+    }
+
+    @Test
+    public void testRunTestWithMethodName() throws Exception {
+        JsonNode result = super.executeJsonRPCMethod("runTest",
+                Map.of("className", "io.quarkus.devui.testrunner.SimpleET",
+                        "methodName", "testGreetingEndpoint"));
+        Assertions.assertNotNull(result, "runTest should return a result");
+
+        // Should only have run one test method
+        long totalTests = result.get("passedCount").asLong() + result.get("failedCount").asLong()
+                + result.get("skippedCount").asLong();
+        Assertions.assertEquals(1, totalTests, "Should have run exactly one test");
+    }
+
+    @Test
+    public void testRunAffectedTests() throws Exception {
+        JsonNode result = super.executeJsonRPCMethod("runAffectedTests");
+        Assertions.assertNotNull(result, "runAffectedTests should return a result");
+
+        Assertions.assertTrue(result.has("usageDataAvailable"), "Result should have usageDataAvailable");
+        Assertions.assertTrue(result.has("passedCount"), "Result should have passedCount");
+
+        long totalTests = result.get("passedCount").asLong() + result.get("failedCount").asLong()
+                + result.get("skippedCount").asLong();
+        Assertions.assertTrue(totalTests > 0, "Should have run at least one test");
+    }
+
+    private void assertAllResultsFromClass(JsonNode results, String expectedClassName) {
+        if (results != null && results.isArray()) {
+            for (JsonNode testResult : results) {
+                Assertions.assertEquals(expectedClassName, testResult.get("className").asText(),
+                        "Test result should be from " + expectedClassName);
+            }
+        }
+    }
+}


### PR DESCRIPTION
The existing Dev MCP continuous testing tools require a multi-step orchestration
(start → poll → get results → stop) that doesn't suit AI coding agents. Agents
need one-shot, synchronous test execution with results returned directly.

Adds a dedicated test execution tool that lets agents run all tests or a specific
test class in a single call, without needing to manage the continuous testing
lifecycle.

- Fixes: #53123