### PR TITLE
DevStar: Adds a way to enable dev mcp for the current app only

### DIFF
--- a/extensions/devui/runtime/pom.xml
+++ b/extensions/devui/runtime/pom.xml
@@ -39,6 +39,23 @@
                     </capabilities>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.quarkus</groupId>
+                                    <artifactId>quarkus-extension-processor</artifactId>
+                                    <version>${project.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/DevMcpConfig.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/DevMcpConfig.java
@@ -1,0 +1,18 @@
+package io.quarkus.devui.runtime.mcp;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+@ConfigMapping(prefix = "quarkus.dev-mcp")
+public interface DevMcpConfig {
+
+    /**
+     * Enable/Disable the Dev MCP server.
+     * This overrides the value in ~/.quarkus/dev-mcp.properties.
+     */
+    Optional<Boolean> enabled();
+}

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpDevUIJsonRpcService.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpDevUIJsonRpcService.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
 
 import org.jboss.logging.Logger;
 
@@ -38,9 +39,16 @@ public class McpDevUIJsonRpcService {
     private final Set<McpClientInfo> connectedClients = new HashSet<>();
     private McpServerConfiguration mcpServerConfiguration;
 
+    @Inject
+    DevMcpConfig devMcpConfig;
+
     @PostConstruct
     public void init() {
         this.mcpServerConfiguration = new McpServerConfiguration(loadConfiguration());
+
+        // Allow SmallRye Config sources (system properties, env vars, application.properties)
+        // to override the ~/.quarkus/dev-mcp.properties file setting
+        devMcpConfig.enabled().ifPresent(this.mcpServerConfiguration::setEnable);
     }
 
     public Set<McpClientInfo> getConnectedClients() {


### PR DESCRIPTION
**Summary**
                                                                                                                                                                              
- Adds support for enabling/disabling Dev MCP via standard MicroProfile Config sources (-Dquarkus.dev mcp.enabled=true, QUARKUS_DEV_MCP_ENABLED=true, or application.properties), in addition to the existing ~/.quarkus/dev-mcp.properties file
- Config source values override the properties file setting but do not persist — removing the override reverts to the file's value
- This is needed by the Quarkus Agent MCP project, which starts Quarkus apps as child processes and needs to enable Dev MCP without modifying the user's global config
                                                                                                                                                                              
**How it works**
                                                                                                                                                                              
On startup, McpDevUIJsonRpcService first loads ~/.quarkus/dev-mcp.properties as before. It then checks SmallRye Config for quarkus.dev-mcp.enabled — if present, it overrides the in-memory value without writing back to the file.

- Fixes: #53094