### PR TITLE
Docs: dev services for OIDC https required note

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -443,17 +443,17 @@ Whichever user you choose, no password is required.
 
 Possible solutions:
 
-Include localhost with port bindings - A common solution is to update your docker compose file to include your local loopback address when binding ports for keycloak.
+*Include localhost with port bindings* - A common solution is to update your docker compose file to use a private IPv4 addresse, such as localhost.
 ```
     ports:
       - "127.0.0.1:8081:8080"
 ```
-
-Force localhost when binding ports - Be aware that this change is applied to all docker containers, and may have unforseen side affects. These instructions only apply to docker desktop. 
+*Alternatively,*
+You can change the default behaviour within docker desktop to use localhost when binding ports but be aware that this change is applied to all docker containers, and may have unforseen side affects.
 
 Inside docker desktop go to `Settings > Resources > Network > Port Binding Behaviour` and change it to  `localhost by default`. If you do not see the option mentioned, try updating to the latest version of docker.
 
-Disable SSLRequired - Run the following inside your container everytime it restarts:
+*Disable SSLRequired* - Run the following inside your container everytime it restarts:
 ```
 kcadm.sh update realms/master -s sslRequired=NONE
 ```

--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -449,7 +449,7 @@ Include localhost with port bindings - A common solution is to update your docke
       - "127.0.0.1:8081:8080"
 ```
 
-Force docker desktop to use localhost when binding ports - Be aware that this change is applied to all containers, and may have unforseen side affects. These instructions only apply to docker desktop. 
+Force localhost when binding ports - Be aware that this change is applied to all docker containers, and may have unforseen side affects. These instructions only apply to docker desktop. 
 
 Inside docker desktop go to `Settings > Resources > Network > Port Binding Behaviour = localhost by default` 
 

--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -309,30 +309,29 @@ quarkus.keycloak.devservices.resource-mappings.policies=/opt/keycloak/providers/
 Policy jars can also be located in the file system.
 <2> The policies jar is mapped to the `/opt/keycloak/providers/policies.jar` container location.
 
-== Keycloak Troubleshooting "HTTPS required"
-If you are seeing `java.lang.RuntimeException: {"error":"invalid_request","error_description":"HTTPS required"}` or, `We are sorry, https required.` You might be facing a docker issue that mainly affects MacOS users attempting to use keycloak locally where the ports dont automatically bind to localhost.
+[NOTE]
+====
+`java.lang.RuntimeException: {"error":"invalid_request","error_description":"HTTPS required"}` or, `We are sorry, https required.` You might be facing a docker issue that mainly affects MacOS users attempting to use keycloak locally where the ports dont automatically bind to localhost.
 
-> External requests Users can interact with Keycloak without SSL so long as they stick to private IPv4 addresses such as localhost, 127.0.0.1, 10.x.x.x, 192.168.x.x, 172.16.x.x or IPv6 link-local and unique-local addresses. If you try to access Keycloak without SSL from a non-private IP address, you will get an error.
+Possible solutions:
 
-=== Include localhost with port bindings
-A common solution is to update your docker compose file to include your local loopback address when binding ports for keycloak.
+Include localhost with port bindings - A common solution is to update your docker compose file to include your local loopback address when binding ports for keycloak.
 ```
     ports:
       - "127.0.0.1:8081:8080"
 ```
 
-=== Force docker desktop to use localhost when binding ports
-Be aware that this change is applied to all containers, and may have unforseen side affects. These instructions only apply to docker desktop. 
+Force docker desktop to use localhost when binding ports - Be aware that this change is applied to all containers, and may have unforseen side affects. These instructions only apply to docker desktop. 
 
 Inside docker desktop go to `Settings > Resources > Network > Port Binding Behaviour = localhost by default` 
 
 NOTE: If you do not see the option mentioned, try updating to the latest version of docker.
 
-=== Disable SSLRequired
-Run the following inside your container everytime it restarts:
+Disable SSLRequired - Run the following inside your container everytime it restarts:
 ```
 kcadm.sh update realms/master -s sslRequired=NONE
 ```
+====
 
 == Disable Dev Services for Keycloak
 

--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -309,6 +309,31 @@ quarkus.keycloak.devservices.resource-mappings.policies=/opt/keycloak/providers/
 Policy jars can also be located in the file system.
 <2> The policies jar is mapped to the `/opt/keycloak/providers/policies.jar` container location.
 
+== Keycloak Troubleshooting "HTTPS required"
+If you are seeing `java.lang.RuntimeException: {"error":"invalid_request","error_description":"HTTPS required"}` or, `We are sorry, https required.` You might be facing a docker issue that mainly affects MacOS users attempting to use keycloak locally where the ports dont automatically bind to localhost.
+
+> External requests Users can interact with Keycloak without SSL so long as they stick to private IPv4 addresses such as localhost, 127.0.0.1, 10.x.x.x, 192.168.x.x, 172.16.x.x or IPv6 link-local and unique-local addresses. If you try to access Keycloak without SSL from a non-private IP address, you will get an error.
+
+=== Include localhost with port bindings
+A common solution is to update your docker compose file to include your local loopback address when binding ports for keycloak.
+```
+    ports:
+      - "127.0.0.1:8081:8080"
+```
+
+=== Force docker desktop to use localhost when binding ports
+Be aware that this change is applied to all containers, and may have unforseen side affects. These instructions only apply to docker desktop. 
+
+Inside docker desktop go to `Settings > Resources > Network > Port Binding Behaviour = localhost by default` 
+
+NOTE: If you do not see the option mentioned, try updating to the latest version of docker.
+
+=== Disable SSLRequired
+Run the following inside your container everytime it restarts:
+```
+kcadm.sh update realms/master -s sslRequired=NONE
+```
+
 == Disable Dev Services for Keycloak
 
 Dev Services for Keycloak is not activated if either `quarkus.oidc.auth-server-url` is already initialized or the default OIDC tenant is disabled with `quarkus.oidc.tenant.enabled=false`, regardless of whether you work with Keycloak or not.
@@ -436,11 +461,6 @@ Another option is log in as a custom user with the username and roles of your ch
 image::dev-ui-oidc-dev-svc-login-for-custom-users.png[alt=Dev Services for OIDC custom user login,role="center"]
 
 Whichever user you choose, no password is required.
-
-== Troubleshooting "HTTPS required"
-If you are seeing `java.lang.RuntimeException: {"error":"invalid_request","error_description":"HTTPS required"}` or, `We are sorry, https required.` You might be facing a docker issue that mainly affects MacOS users. 
-
-A few solutions are listed below:
 
 == Configuration reference
 

--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -309,30 +309,6 @@ quarkus.keycloak.devservices.resource-mappings.policies=/opt/keycloak/providers/
 Policy jars can also be located in the file system.
 <2> The policies jar is mapped to the `/opt/keycloak/providers/policies.jar` container location.
 
-[NOTE]
-====
-`java.lang.RuntimeException: {"error":"invalid_request","error_description":"HTTPS required"}` or, `We are sorry, https required.` You might be facing a docker issue that mainly affects MacOS users attempting to use keycloak locally where the ports dont automatically bind to localhost.
-
-Possible solutions:
-
-Include localhost with port bindings - A common solution is to update your docker compose file to include your local loopback address when binding ports for keycloak.
-```
-    ports:
-      - "127.0.0.1:8081:8080"
-```
-
-Force docker desktop to use localhost when binding ports - Be aware that this change is applied to all containers, and may have unforseen side affects. These instructions only apply to docker desktop. 
-
-Inside docker desktop go to `Settings > Resources > Network > Port Binding Behaviour = localhost by default` 
-
-NOTE: If you do not see the option mentioned, try updating to the latest version of docker.
-
-Disable SSLRequired - Run the following inside your container everytime it restarts:
-```
-kcadm.sh update realms/master -s sslRequired=NONE
-```
-====
-
 == Disable Dev Services for Keycloak
 
 Dev Services for Keycloak is not activated if either `quarkus.oidc.auth-server-url` is already initialized or the default OIDC tenant is disabled with `quarkus.oidc.tenant.enabled=false`, regardless of whether you work with Keycloak or not.
@@ -460,6 +436,30 @@ Another option is log in as a custom user with the username and roles of your ch
 image::dev-ui-oidc-dev-svc-login-for-custom-users.png[alt=Dev Services for OIDC custom user login,role="center"]
 
 Whichever user you choose, no password is required.
+
+[NOTE]
+====
+`java.lang.RuntimeException: {"error":"invalid_request","error_description":"HTTPS required"}` or, `We are sorry, https required.` You might be facing a docker issue that mainly affects MacOS users attempting to use keycloak locally where the ports dont automatically bind to localhost.
+
+Possible solutions:
+
+Include localhost with port bindings - A common solution is to update your docker compose file to include your local loopback address when binding ports for keycloak.
+```
+    ports:
+      - "127.0.0.1:8081:8080"
+```
+
+Force docker desktop to use localhost when binding ports - Be aware that this change is applied to all containers, and may have unforseen side affects. These instructions only apply to docker desktop. 
+
+Inside docker desktop go to `Settings > Resources > Network > Port Binding Behaviour = localhost by default` 
+
+NOTE: If you do not see the option mentioned, try updating to the latest version of docker.
+
+Disable SSLRequired - Run the following inside your container everytime it restarts:
+```
+kcadm.sh update realms/master -s sslRequired=NONE
+```
+====
 
 == Configuration reference
 

--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -437,6 +437,11 @@ image::dev-ui-oidc-dev-svc-login-for-custom-users.png[alt=Dev Services for OIDC 
 
 Whichever user you choose, no password is required.
 
+== Troubleshooting "HTTPS required"
+If you are seeing `java.lang.RuntimeException: {"error":"invalid_request","error_description":"HTTPS required"}` or, `We are sorry, https required.` You might be facing a docker issue that mainly affects MacOS users. 
+
+A few solutions are listed below:
+
 == Configuration reference
 
 include::{generated-dir}/config/quarkus-devservices-keycloak_quarkus.keycloak.adoc[opts=optional, leveloffset=+1]

--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -451,7 +451,7 @@ Include localhost with port bindings - A common solution is to update your docke
 
 Force localhost when binding ports - Be aware that this change is applied to all docker containers, and may have unforseen side affects. These instructions only apply to docker desktop. 
 
-Inside docker desktop go to `Settings > Resources > Network > Port Binding Behaviour = localhost by default` 
+Inside docker desktop go to `Settings > Resources > Network > Port Binding Behaviour` and change it to  `localhost by default` 
 
 NOTE: If you do not see the option mentioned, try updating to the latest version of docker.
 

--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -453,7 +453,7 @@ Force localhost when binding ports - Be aware that this change is applied to all
 
 Inside docker desktop go to `Settings > Resources > Network > Port Binding Behaviour` and change it to  `localhost by default` 
 
-NOTE: If you do not see the option mentioned, try updating to the latest version of docker.
+If you do not see the option mentioned, try updating to the latest version of docker.
 
 Disable SSLRequired - Run the following inside your container everytime it restarts:
 ```

--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -451,9 +451,7 @@ Include localhost with port bindings - A common solution is to update your docke
 
 Force localhost when binding ports - Be aware that this change is applied to all docker containers, and may have unforseen side affects. These instructions only apply to docker desktop. 
 
-Inside docker desktop go to `Settings > Resources > Network > Port Binding Behaviour` and change it to  `localhost by default` 
-
-If you do not see the option mentioned, try updating to the latest version of docker.
+Inside docker desktop go to `Settings > Resources > Network > Port Binding Behaviour` and change it to  `localhost by default`. If you do not see the option mentioned, try updating to the latest version of docker.
 
 Disable SSLRequired - Run the following inside your container everytime it restarts:
 ```


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->
# Https Required Note
<!--Please describe here what your change is about-->
Updated the documentation to address a common issue that macos users seem to be running into; https required. The documentation update adds a note added to the Dev services for oidc section, suggested by @sberyozkin. I tested common solutions mentioned in the issue #48905 to make sure that I could replicate the fixes and follow along with the steps I had described. 

I tried to keep the note as meaningful as possible, and as condenced as I could make it; It is still a large note but no larger than some of the other notes on [security-openid-connect-dev-services.adoc](https://github.com/quarkusio/quarkus/compare/main...zer0origin:quarkus-document-mac-issue:zer0origin-Dev-services-for-oidc-https-required-note?expand=1#diff-1a233076c11ab9674b25dc23c8ed2acd07c8e5aab181b6b0321b5632508e2115)

Fixes #48905
