### PR TITLE
Fix JFR capability configuration

### DIFF
--- a/extensions/jfr/deployment/src/main/java/io/quarkus/jfr/deployment/JfrProcessor.java
+++ b/extensions/jfr/deployment/src/main/java/io/quarkus/jfr/deployment/JfrProcessor.java
@@ -15,7 +15,6 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
-import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.jfr.runtime.internal.JfrRecorder;
@@ -38,11 +37,6 @@ public class JfrProcessor {
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(Feature.JFR);
-    }
-
-    @BuildStep
-    CapabilityBuildItem capability() {
-        return new CapabilityBuildItem(Capability.JFR);
     }
 
     @BuildStep

--- a/extensions/jfr/runtime/pom.xml
+++ b/extensions/jfr/runtime/pom.xml
@@ -45,19 +45,11 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-extension-maven-plugin</artifactId>
-                <version>${project.version}</version>
-                <executions>
-                    <execution>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>extension-descriptor</goal>
-                        </goals>
-                        <configuration>
-                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}
-                            </deployment>
-                        </configuration>
-                    </execution>
-                </executions>
+                <configuration>
+                    <capabilities>
+                        <provides>io.quarkus.jfr</provides>
+                    </capabilities>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
Additionally, remove unnecessary Maven configuration

This came to my attention because I saw:

```
[WARNING] [io.quarkus.deployment.steps.CapabilityAggregationStep] The following capabilities were found to be missing from the processed extension descriptors:
 - io.quarkus.jfr provided by io.quarkus.jfr.deployment.JfrProcessor
Please report this issue to the extension maintainers to get it fixed in the future releases.
```

with the previous version of the code