### PR TITLE
Do not create a public key in devmode when 'smallrye.jwt.verify.key.location' is set

### DIFF
--- a/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallryeJwtDevModeProcessor.java
+++ b/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallryeJwtDevModeProcessor.java
@@ -37,6 +37,7 @@ public class SmallryeJwtDevModeProcessor {
     private static final Logger LOGGER = Logger.getLogger(SmallryeJwtDevModeProcessor.class);
 
     public static final String MP_JWT_VERIFY_PUBLIC_KEY = "mp.jwt.verify.publickey";
+    public static final String SMALLRYE_JWT_VERIFY_KEY_LOCATION = "smallrye.jwt.verify.key.location";
     private static final String MP_JWT_VERIFY_ISSUER = "mp.jwt.verify.issuer";
     private static final String SMALLRYE_JWT_DECRYPT_KEY = "smallrye.jwt.decrypt.key"; // no MP equivalent
     private static final String MP_JWT_DECRYPT_KEY_LOCATION = "mp.jwt.decrypt.key.location";
@@ -54,6 +55,7 @@ public class SmallryeJwtDevModeProcessor {
 
     private static final Set<String> JWT_SIGN_KEY_PROPERTIES = Set.of(
             MP_JWT_VERIFY_KEY_LOCATION,
+            SMALLRYE_JWT_VERIFY_KEY_LOCATION,
             MP_JWT_VERIFY_PUBLIC_KEY,
             SMALLRYE_JWT_DECRYPT_KEY,
             MP_JWT_DECRYPT_KEY_LOCATION,

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/dev/SmallryeJwtEncryptLocationDevModeTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/dev/SmallryeJwtEncryptLocationDevModeTest.java
@@ -1,0 +1,62 @@
+package io.quarkus.jwt.test.dev;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SmallryeJwtEncryptLocationDevModeTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset(
+                            """
+                                    smallrye.jwt.encrypt.key.location=/publicKey.pem
+                                    mp.jwt.decrypt.key.location=/privateKey.pem
+                                    """), "application.properties")
+                    .addAsResource("publicKey.pem")
+                    .addAsResource("privateKey.pem"))
+            .addBuildChainCustomizer(new Consumer<BuildChainBuilder>() {
+                @Override
+                public void accept(BuildChainBuilder chain) {
+                    chain.addBuildStep(new BuildStep() {
+                        @Override
+                        public void execute(BuildContext context) {
+                            List<DevServicesResultBuildItem> buildItems = context
+                                    .consumeMulti(DevServicesResultBuildItem.class);
+                            assertThat(buildItems).filteredOn(item -> item.getName().equals("smallrye-jwt"))
+                                    .first()
+                                    .satisfies(item -> {
+                                        assertThat(item.getConfig())
+                                                .containsEntry("mp.jwt.verify.publickey", "NONE")
+                                                .containsEntry("smallrye.jwt.sign.key", "NONE");
+                                    });
+                            context.produce(new FeatureBuildItem("dummy"));
+                        }
+                    })
+                            .consumes(DevServicesResultBuildItem.class)
+                            .produces(FeatureBuildItem.class)
+                            .build();
+                }
+            });
+
+    @Test
+    void shouldNotConfigureAutomatically() {
+        assertThat(true).isTrue();
+    }
+
+}

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/dev/SmallryeJwtSignLocationDevModeTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/dev/SmallryeJwtSignLocationDevModeTest.java
@@ -18,15 +18,14 @@ import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.test.QuarkusUnitTest;
 
-public class SmallryeJwtLocationDevModeTest {
+public class SmallryeJwtSignLocationDevModeTest {
 
     @RegisterExtension
     static QuarkusUnitTest unitTest = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addAsResource(new StringAsset(
                             """
-                                    smallrye.jwt.encrypt.key.location=/publicKey.pem
-                                    mp.jwt.decrypt.key.location=/privateKey.pem
+                                    smallrye.jwt.verify.key.location=/publicKey.pem
                                     """), "application.properties")
                     .addAsResource("publicKey.pem")
                     .addAsResource("privateKey.pem"))


### PR DESCRIPTION
SmallRye JWT extension creates a public key pair in devmode if it does not detect any configured key material, and 'smallrye.jwt.verify.key.location' property was missed.