### PR TITLE
OpenShift Internal Registry Container Image Name

### DIFF
--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/ApplyImageNameDecorator.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/ApplyImageNameDecorator.java
@@ -1,0 +1,25 @@
+package io.quarkus.container.image.openshift.deployment;
+
+import io.dekorate.kubernetes.decorator.NamedResourceDecorator;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectMetaFluent;
+
+/**
+ * Responsible for finding an ImageStream with the given name and renaming it. This allows
+ * changing the name of the output image when saving to the internal registry.
+ */
+public class ApplyImageNameDecorator extends NamedResourceDecorator<ObjectMetaFluent<?>> {
+
+    private final String newName;
+
+    public ApplyImageNameDecorator(String currentName, String newName) {
+        super("ImageStream", currentName);
+        this.newName = newName;
+    }
+
+    @Override
+    public void andThenVisit(ObjectMetaFluent<?> meta, ObjectMeta resourceMeta) {
+        meta.withName(newName);
+    }
+
+}

--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/ApplyImageStreamNameToBuildConfigDecorator.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/ApplyImageStreamNameToBuildConfigDecorator.java
@@ -1,0 +1,28 @@
+package io.quarkus.container.image.openshift.deployment;
+
+import io.dekorate.kubernetes.decorator.NamedResourceDecorator;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.openshift.api.model.BuildOutputFluent;
+
+/**
+ * Allows conformity between the configuration and output resources when it comes to the name of the image stream and
+ * the image stream tag for local openshift builds.
+ */
+public class ApplyImageStreamNameToBuildConfigDecorator extends NamedResourceDecorator<BuildOutputFluent<?>> {
+
+    final String imageStreamName;
+    final String imageStreamTag;
+
+    public ApplyImageStreamNameToBuildConfigDecorator(String buildConfigName, String imageStreamName, String imageStreamTag) {
+        super(buildConfigName);
+        this.imageStreamName = imageStreamName;
+        this.imageStreamTag = imageStreamTag;
+    }
+
+    public void andThenVisit(BuildOutputFluent<?> output, ObjectMeta objectMeta) {
+        output.withNewTo()
+                .withKind("ImageStreamTag")
+                .withName(String.format("%s:%s", imageStreamName, imageStreamTag))
+                .endTo();
+    }
+}

--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftProcessor.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftProcessor.java
@@ -210,6 +210,7 @@ public class OpenshiftProcessor {
             BuildProducer<DecoratorBuildItem> decorator) {
         containerImageInfo.registry.ifPresent(registry -> {
             final String name = applicationInfo.getName();
+            final String imageStreamName = Optional.ofNullable(containerImageInfo.getName()).orElse(name);
             final String serviceAccountName = applicationInfo.getName();
             String repositoryWithRegistry = registry + "/" + containerImageInfo.getRepository();
 
@@ -219,7 +220,11 @@ public class OpenshiftProcessor {
                 decorator.produce(new DecoratorBuildItem(OPENSHIFT, new ApplyDockerImageOutputToBuildConfigDecorator(
                         applicationInfo.getName(), containerImageInfo.getImage(), imagePushSecret)));
             } else if (registry.contains(OPENSHIFT_INTERNAL_REGISTRY)) {
-                //no special handling of secrets is really needed.
+                // when using an internal registry ensure that the build config and image stream
+                // are in sync with the configuration given in `quarkus.container-image.image` or `quarkus.container-image.name`
+                decorator.produce(new DecoratorBuildItem(OPENSHIFT, new ApplyImageNameDecorator(name, imageStreamName)));
+                decorator.produce(new DecoratorBuildItem(OPENSHIFT,
+                        new ApplyImageStreamNameToBuildConfigDecorator(name, imageStreamName, containerImageInfo.getTag())));
             } else if (containerImageInfo.username.isPresent() && containerImageInfo.password.isPresent()) {
                 String imagePushSecret = applicationInfo.getName() + "-push-secret";
                 decorator.produce(new DecoratorBuildItem(OPENSHIFT,

--- a/extensions/container-image/spi/src/main/java/io/quarkus/container/spi/ContainerImageInfoBuildItem.java
+++ b/extensions/container-image/spi/src/main/java/io/quarkus/container/spi/ContainerImageInfoBuildItem.java
@@ -23,6 +23,7 @@ public final class ContainerImageInfoBuildItem extends SimpleBuildItem {
 
     private final String imagePrefix;
     private final String repository;
+    private final String name;
 
     private final String tag;
 
@@ -34,6 +35,7 @@ public final class ContainerImageInfoBuildItem extends SimpleBuildItem {
         this.username = username;
         this.password = password;
         this.repository = repository;
+        this.name = repository.contains(SLASH) ? repository.substring(repository.lastIndexOf(SLASH) + 1) : repository;
 
         StringBuilder sb = new StringBuilder();
         registry.ifPresent(r -> sb.append(r).append(SLASH));
@@ -49,6 +51,7 @@ public final class ContainerImageInfoBuildItem extends SimpleBuildItem {
         this.registry = registry;
         this.username = username;
         this.password = password;
+        this.name = name;
 
         StringBuilder imagePrefixSB = new StringBuilder();
         StringBuilder repositorySB = new StringBuilder();
@@ -94,5 +97,9 @@ public final class ContainerImageInfoBuildItem extends SimpleBuildItem {
 
     public String getGroup() {
         return repository == null ? null : repository.split("/")[0];
+    }
+
+    public String getName() {
+        return name;
     }
 }


### PR DESCRIPTION
Adds decorators for when the OpenShift internal registry is being used so that the configuration items for `quarkus.container-image.name` and `quarkus.container-image.image` are effective in the same way that they would be when pushing to an external image repository and so that the naming is consistent between the BuildConfig, ImageStream, and ImageStreamTag.

- Fixes: #53121