### PR TITLE
Gradle: do not propagate quarkus.profile to Test JVM from effective config

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/actions/BeforeTestAction.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/actions/BeforeTestAction.java
@@ -70,6 +70,9 @@ public class BeforeTestAction implements Action<Task> {
             config.getOptionalValue(TEST.getProfileKey(), String.class)
                     .ifPresent(value -> props.put(TEST.getProfileKey(), value));
             props.putAll(effectiveConfig.getQuarkusValues());
+            // Do not propagate quarkus.profile: effective config is resolved with Gradle's default profile (often prod),
+            // but the test JVM must use LaunchMode.TEST so @QuarkusTest and DevServices see the correct profile.
+            props.remove("quarkus.profile");
 
             props.put(BootstrapConstants.SERIALIZED_TEST_APP_MODEL, serializedModel.toString());
 


### PR DESCRIPTION
### Problem
`BeforeTestAction` propagates `effectiveConfig.getQuarkusValues()` into the Gradle `Test` task. The effective Gradle config is often resolved with default profile `prod` (`EffectiveConfigProvider#getQuarkusProfile`). That injects `quarkus.profile=prod` into the test JVM and overrides `@QuarkusTest` / `LaunchMode.TEST`, breaking profile-scoped config (e.g. DevServices JDBC URLs vs `%prod` datasource URLs). Observed when upgrading to **3.32.4** (related to propagating all Quarkus values to Test, commit 9127896669e).

### Change
After merging propagated Quarkus properties, remove `quarkus.profile` so the test runtime keeps the correct TEST launch profile.

### Notes
Pipestream stays on **3.32.3** until this is fixed in a 3.32.x release. Happy to add an integration test under `integration-tests/gradle` if desired.

cc @radcortez (config / Gradle)