### PR TITLE
Conditionally register DefaultJwtValidator for reflection

### DIFF
--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
@@ -222,6 +222,7 @@ public class KafkaProcessor {
             CombinedIndexBuildItem indexBuildItem,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<ReflectiveMethodBuildItem> reflectiveMethod,
+            BuildProducer<ReflectiveClassConditionBuildItem> reflectiveClassCondition,
             BuildProducer<ServiceProviderBuildItem> serviceProviders,
             BuildProducer<NativeImageProxyDefinitionBuildItem> proxies,
             Capabilities capabilities,
@@ -249,9 +250,11 @@ public class KafkaProcessor {
                 .reason(getClass().getName() + " OAuthBearerSaslClient classes")
                 .build());
 
-        // This is done to avoid loading jose4j classes when not needed, as DefaultJwtValidator is the default validator used by Kafka clients if no other validator is specified.
-        reflectiveMethod.produce(new ReflectiveMethodBuildItem(getClass().getName() + " DefaultJwtValidator class",
-                DefaultJwtValidator.class.getName(), "<init>", new String[0]));
+        // Register DefaultJwtValidator only when jose4j is present to avoid NoClassDefFoundError
+        // with GraalVM 25's --future-defaults=complete-reflection-types flag
+        reflectiveClassCondition.produce(new ReflectiveClassConditionBuildItem(
+                DefaultJwtValidator.class.getName(),
+                "org.jose4j.keys.resolvers.VerificationKeyResolver"));
 
         for (Class<?> i : BUILT_INS) {
             reflectiveClass.produce(ReflectiveClassBuildItem.builder(i.getName())


### PR DESCRIPTION
Fixes #53162

Only register DefaultJwtValidator for reflection when jose4j is present on the classpath. This prevents NoClassDefFoundError when building native images with GraalVM 25's --future-defaults=complete-reflection-types flag, which analyzes all constructors including those with optional dependencies.

The fix uses ReflectiveClassConditionBuildItem instead of ReflectiveMethodBuildItem to make the reflection registration conditional on the presence of org.jose4j.keys.resolvers.VerificationKeyResolver.

Testing:
- Created minimal reproducer with kafka-client extension
- Verified build fails with --future-defaults=complete-reflection-types (before fix)
- Applied fix and rebuilt Quarkus
- Verified build succeeds with --future-defaults=complete-reflection-types (after fix)
- Confirmed backward compatibility: build still succeeds without the flag

