### PR TITLE
Dev MCP: Add skill aggregation mechanism for extensions

### DIFF
--- a/devtools/extension-skills/pom.xml
+++ b/devtools/extension-skills/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>quarkus-build-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../../build-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-extension-skills</artifactId>
+    <name>Quarkus - Extension Skills</name>
+    <description>Aggregated extension skill files for AI coding agents, following the Agent Skills specification</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <executions>
+                    <!-- Disable the default extension-descriptor goal -->
+                    <execution>
+                        <id>generate-extension-descriptor</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>aggregate-extension-skills</id>
+                        <goals>
+                            <goal>aggregate-skills</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/devtools/pom.xml
+++ b/devtools/pom.xml
@@ -28,5 +28,6 @@
         <module>cli-common</module>
         <module>cli</module>
         <module>config-doc-maven-plugin</module>
+        <module>extension-skills</module>
     </modules>
 </project>

--- a/docs/src/main/asciidoc/dev-mcp.adoc
+++ b/docs/src/main/asciidoc/dev-mcp.adoc
@@ -88,6 +88,88 @@ BuildTimeActionBuildItem createBuildTimeActions() {
 
 By default this resource will be disabled, and the user has to enable it in Dev UI. You can change this default by adding `.enableMcpFunctionByDefault()` in the builder method.
 
+=== Extension skills
+
+Extensions can ship a `quarkus-skill.md` file to provide AI coding agents with extension-specific coding guidelines, testing patterns, and common pitfalls. During the Quarkus build, all skill files are automatically discovered, composed with extension metadata (name, description, guide URL), and aggregated into a single `io.quarkus:quarkus-extension-skills` JAR following the https://agentskills.io/specification[Agent Skills specification]. This JAR is published to Maven Central with each Quarkus release and is compatible with https://www.skillsjars.com[SkillsJars].
+
+==== Adding a skill file to your extension
+
+Place a `quarkus-skill.md` file in your extension's deployment module at:
+
+[source]
+----
+my-extension/deployment/src/main/resources/META-INF/quarkus-skill.md
+----
+
+That's it. No pom.xml changes are needed. The Quarkus build automatically discovers all `quarkus-skill.md` files across all extensions and aggregates them into the `quarkus-extension-skills` artifact.
+
+If your extension's runtime module has a `description` field in `META-INF/quarkus-extension.yaml`, it will be included in the composed skill's YAML frontmatter to help AI agents discover and understand your extension. While optional, providing a description is recommended:
+
+[source,yaml]
+----
+name: "My Extension"
+description: "A concise description of what this extension does"
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+metadata:
+  guide: "https://quarkus.io/guides/my-extension"
+----
+
+The file should contain concise, actionable Markdown content. Focus on what an AI agent needs to know to use your extension correctly:
+
+- **Key patterns** — how to use the main APIs, annotations, and CDI beans.
+- **Testing** — how to write tests using `@QuarkusTest`, Dev Services, and extension-specific test utilities.
+- **Common pitfalls** — mistakes that agents (and developers) frequently make.
+
+Example for a hypothetical extension:
+
+[source,markdown]
+----
+### Data Access
+
+- Inject `MyClient` with `@Inject` — it is an `@ApplicationScoped` CDI bean.
+- Use `client.query("...")` for read operations.
+- Always wrap write operations in `@Transactional`.
+
+### Testing
+
+- Use `@QuarkusTest` — Dev Services starts a backing service automatically.
+- Inject `MyClient` in tests for direct assertions.
+
+### Common Pitfalls
+
+- Do NOT create `MyClient` manually with `new` — always let CDI inject it.
+- Do NOT set the connection URL without a `%prod.` profile prefix — this disables Dev Services.
+----
+
+==== What gets composed
+
+The skill file content is **not** shipped as-is. During the Quarkus build, the `aggregate-skills` goal scans the source tree for all `quarkus-skill.md` files and composes each one with extension metadata to produce a `SKILL.md` file at `META-INF/skills/{extension-name}/SKILL.md` inside the aggregated JAR. The composed document follows the https://agentskills.io/specification[Agent Skills specification] and includes:
+
+1. **YAML frontmatter** — the skill name, extension description from `quarkus-extension.yaml`, license, and guide URL as structured metadata for agent discovery.
+2. **Skill body** — the patterns, testing guidelines, and pitfalls authored by the extension developer.
+
+Example of a composed `SKILL.md`:
+
+[source,markdown]
+----
+---
+name: quarkus-my-extension
+description: "A brief description of the extension from quarkus-extension.yaml"
+license: Apache-2.0
+metadata:
+  guide: https://quarkus.io/guides/my-extension
+---
+
+### Data Access
+...
+----
+
+==== What NOT to put in the skill file
+
+- **Extension description or guide links** — these are automatically added from `quarkus-extension.yaml`.
+- **Configuration properties** — reference the guide instead. A link is auto-generated.
+- **Obvious instructions** — focus on Quarkus-specific patterns and gotchas, not generic advice.
+
 === MCP tools
 
 A tool corresponds to a method that a client can call. Any JSON‑RPC method can be exposed as a tool by supplying descriptions on the method and its parameters.

--- a/independent-projects/extension-maven-plugin/src/main/java/io/quarkus/maven/AggregateSkillsMojo.java
+++ b/independent-projects/extension-maven-plugin/src/main/java/io/quarkus/maven/AggregateSkillsMojo.java
@@ -1,0 +1,253 @@
+package io.quarkus.maven;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.quarkus.devtools.utils.SkillComposer;
+
+/**
+ * Aggregates all extension skill files from the Quarkus source tree into a single JAR.
+ * <p>
+ * This goal walks the {@code extensionsDir} looking for
+ * {@code {ext}/deployment/src/main/resources/META-INF/quarkus-skill.md} files.
+ * For each one found, it reads the corresponding runtime extension metadata from
+ * {@code {ext}/runtime/src/main/resources/META-INF/quarkus-extension.yaml},
+ * composes them into a {@code SKILL.md} with YAML frontmatter per the
+ * <a href="https://agentskills.io/specification">Agent Skills specification</a>,
+ * and writes the result to {@code target/classes/META-INF/skills/{name}/SKILL.md}.
+ * <p>
+ * Extension developers only need to create a {@code quarkus-skill.md} file in their
+ * deployment module's resources — no pom.xml configuration is required. This mojo
+ * discovers all skill files automatically by scanning the source tree.
+ */
+@Mojo(name = "aggregate-skills", defaultPhase = LifecyclePhase.GENERATE_RESOURCES, threadSafe = true)
+public class AggregateSkillsMojo extends AbstractMojo {
+
+    private static final String DEPLOYMENT = "deployment";
+    private static final String RUNTIME = "runtime";
+
+    @Parameter(readonly = true, required = true, defaultValue = "${project.build.outputDirectory}")
+    private File outputDirectory;
+
+    /**
+     * Root directory containing Quarkus extensions.
+     * Defaults to {@code ../../extensions} relative to the project base directory
+     * (i.e. from {@code devtools/extension-skills/}).
+     */
+    @Parameter(defaultValue = "${project.basedir}/../../extensions", property = "extensionsDir")
+    private File extensionsDir;
+
+    @Override
+    public void execute() throws MojoExecutionException {
+        final Path extRoot = extensionsDir.toPath().normalize();
+        if (!Files.isDirectory(extRoot)) {
+            getLog().warn("Extensions directory does not exist: " + extRoot);
+            return;
+        }
+
+        final List<SkillEntry> entries = discoverSkillFiles(extRoot);
+        if (entries.isEmpty()) {
+            getLog().info("No extension skill files found");
+            return;
+        }
+
+        int composed = 0;
+        for (SkillEntry entry : entries) {
+            try {
+                composeAndWrite(entry);
+                composed++;
+            } catch (IOException e) {
+                getLog().warn("Failed to compose skill for " + entry.skillFile + ": " + e.getMessage());
+            }
+        }
+        getLog().info("Aggregated " + composed + " extension skills from " + extRoot);
+    }
+
+    private List<SkillEntry> discoverSkillFiles(Path extRoot) throws MojoExecutionException {
+        final List<SkillEntry> entries = new ArrayList<>();
+
+        try {
+            Files.walkFileTree(extRoot, new SimpleFileVisitor<>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                    // Match: **/deployment/src/main/resources/META-INF/quarkus-skill.md
+                    if (file.getFileName().toString().equals("quarkus-skill.md")
+                            && file.getParent() != null
+                            && file.getParent().getFileName().toString().equals("META-INF")
+                            && isDeploymentResourcePath(file)) {
+
+                        Path runtimeYaml = resolveRuntimeMetadata(file);
+                        if (runtimeYaml != null && Files.isRegularFile(runtimeYaml)) {
+                            entries.add(new SkillEntry(file, runtimeYaml));
+                        } else {
+                            getLog().debug("No runtime quarkus-extension.yaml found for: " + file);
+                        }
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                    // Skip target directories for performance
+                    if (dir.getFileName().toString().equals("target")) {
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (IOException e) {
+            throw new MojoExecutionException("Failed to scan extensions directory: " + extRoot, e);
+        }
+
+        return entries;
+    }
+
+    /**
+     * Checks that the file is under a {@code deployment/src/main/resources/META-INF/} path.
+     */
+    private boolean isDeploymentResourcePath(Path file) {
+        // Walk up from quarkus-skill.md: META-INF / resources / main / src / deployment
+        Path current = file.getParent(); // META-INF
+        if (current == null)
+            return false;
+        current = current.getParent(); // resources
+        if (current == null || !current.getFileName().toString().equals("resources"))
+            return false;
+        current = current.getParent(); // main
+        if (current == null || !current.getFileName().toString().equals("main"))
+            return false;
+        current = current.getParent(); // src
+        if (current == null || !current.getFileName().toString().equals("src"))
+            return false;
+        current = current.getParent(); // deployment
+        return current != null && current.getFileName().toString().equals(DEPLOYMENT);
+    }
+
+    /**
+     * Resolves the runtime module's {@code quarkus-extension.yaml} relative to the
+     * deployment module that contains the skill file.
+     * <p>
+     * First tries the conventional sibling {@code runtime} module. If not found,
+     * scans other sibling directories for a {@code quarkus-extension.yaml} — this
+     * handles extensions like Lambda (common-runtime) and other non-standard layouts.
+     */
+    private Path resolveRuntimeMetadata(Path skillFile) {
+        // Navigate up to the deployment module directory
+        // skillFile: .../extensions/{ext}/deployment/src/main/resources/META-INF/quarkus-skill.md
+        Path deploymentDir = skillFile.getParent() // META-INF
+                .getParent() // resources
+                .getParent() // main
+                .getParent() // src
+                .getParent(); // deployment
+
+        if (deploymentDir == null || !deploymentDir.getFileName().toString().equals(DEPLOYMENT)) {
+            return null;
+        }
+
+        Path extensionDir = deploymentDir.getParent();
+        if (extensionDir == null) {
+            return null;
+        }
+
+        // Try conventional sibling "runtime" first
+        Path runtimeYaml = extensionDir.resolve(RUNTIME)
+                .resolve("src/main/resources")
+                .resolve(SkillComposer.EXTENSION_METADATA_PATH);
+        if (Files.isRegularFile(runtimeYaml)) {
+            return runtimeYaml;
+        }
+
+        // Fall back: scan sibling directories for quarkus-extension.yaml
+        // (handles extensions like Lambda with common-runtime, or other non-standard layouts)
+        try (var siblings = Files.list(extensionDir)) {
+            return siblings
+                    .filter(Files::isDirectory)
+                    .filter(d -> !d.getFileName().toString().equals(DEPLOYMENT))
+                    .map(d -> d.resolve("src/main/resources").resolve(SkillComposer.EXTENSION_METADATA_PATH))
+                    .filter(Files::isRegularFile)
+                    .findFirst()
+                    .orElse(null);
+        } catch (IOException e) {
+            getLog().debug("Failed to scan siblings of " + extensionDir + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    private void composeAndWrite(SkillEntry entry) throws IOException {
+        final String rawContent = Files.readString(entry.skillFile, StandardCharsets.UTF_8);
+
+        final ObjectNode extMeta;
+        try (InputStream is = Files.newInputStream(entry.runtimeYaml)) {
+            extMeta = SkillComposer.parseExtensionMetadata(is);
+        }
+
+        // Derive skill name from the runtime module's pom.xml artifactId
+        Path runtimeDir = entry.runtimeYaml.getParent() // META-INF
+                .getParent() // resources
+                .getParent() // main
+                .getParent() // src
+                .getParent(); // runtime
+        String skillName = readArtifactIdFromPom(runtimeDir.resolve("pom.xml"));
+        if (skillName == null) {
+            // Fallback to directory name
+            Path extensionDir = runtimeDir.getParent();
+            skillName = extensionDir != null ? extensionDir.getFileName().toString() : "unknown";
+        }
+
+        final String composed = SkillComposer.compose(extMeta, rawContent, skillName);
+        final Path outputPath = outputDirectory.toPath()
+                .resolve(SkillComposer.outputSkillPath(skillName));
+        Files.createDirectories(outputPath.getParent());
+        Files.writeString(outputPath, composed, StandardCharsets.UTF_8);
+
+        getLog().debug("Composed skill: " + skillName + " from " + entry.skillFile);
+    }
+
+    /**
+     * Reads the {@code <artifactId>} from a pom.xml file using the Maven model reader.
+     */
+    private String readArtifactIdFromPom(Path pomFile) {
+        if (!Files.isRegularFile(pomFile)) {
+            return null;
+        }
+        try (Reader reader = Files.newBufferedReader(pomFile, StandardCharsets.UTF_8)) {
+            // TODO: MavenXpp3Reader is Maven 3 specific; will need migration for Maven 4
+            Model model = new MavenXpp3Reader().read(reader);
+            return model.getArtifactId();
+        } catch (IOException | XmlPullParserException e) {
+            getLog().debug("Failed to read pom.xml: " + pomFile + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    private static class SkillEntry {
+        final Path skillFile;
+        final Path runtimeYaml;
+
+        SkillEntry(Path skillFile, Path runtimeYaml) {
+            this.skillFile = skillFile;
+            this.runtimeYaml = runtimeYaml;
+        }
+    }
+}

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/utils/SkillComposer.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/utils/SkillComposer.java
@@ -1,0 +1,164 @@
+package io.quarkus.devtools.utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+/**
+ * Shared utility for composing skill files with extension metadata,
+ * following the <a href="https://agentskills.io/specification">Agent Skills</a> format.
+ * Used by both the Maven Mojo and the Gradle task.
+ */
+public final class SkillComposer {
+
+    /** Path where extension developers place the raw skill source in deployment modules. */
+    public static final String SOURCE_SKILL_PATH = "META-INF/quarkus-skill.md";
+
+    public static final String EXTENSION_METADATA_PATH = "META-INF/quarkus-extension.yaml";
+
+    private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory())
+            .setPropertyNamingStrategy(PropertyNamingStrategies.KEBAB_CASE);
+
+    private SkillComposer() {
+    }
+
+    /**
+     * Returns the output path for a composed skill file inside the deployment JAR,
+     * following the Agent Skills directory convention.
+     *
+     * @param skillName the skill identifier (e.g. {@code quarkus-arc})
+     */
+    public static String outputSkillPath(String skillName) {
+        return "META-INF/skills/" + skillName + "/SKILL.md";
+    }
+
+    /**
+     * Parses a {@code quarkus-extension.yaml} from the given input stream.
+     *
+     * @throws IOException if the stream cannot be read, the YAML is malformed, or the file is empty
+     */
+    public static ObjectNode parseExtensionMetadata(InputStream is) throws IOException {
+        final ObjectNode result = YAML_MAPPER.readValue(is, ObjectNode.class);
+        if (result == null) {
+            throw new IOException("quarkus-extension.yaml is empty or contains no object");
+        }
+        return result;
+    }
+
+    /**
+     * Composes a skill document from extension metadata and raw skill content,
+     * producing a {@code SKILL.md} file with YAML frontmatter per the
+     * <a href="https://agentskills.io/specification">Agent Skills specification</a>.
+     *
+     * @param extMeta the parsed {@code quarkus-extension.yaml} as an {@link ObjectNode}
+     * @param rawContent the raw skill file content authored by the extension developer
+     * @param skillName the skill identifier used in the frontmatter {@code name} field
+     *        (e.g. {@code quarkus-arc}, derived from the runtime artifact name)
+     * @param license the SPDX license identifier (e.g. {@code Apache-2.0}), may be {@code null}
+     */
+    public static String compose(ObjectNode extMeta, String rawContent, String skillName, String license) {
+        Objects.requireNonNull(extMeta, "extMeta must not be null");
+        Objects.requireNonNull(rawContent, "rawContent must not be null");
+        Objects.requireNonNull(skillName, "skillName must not be null");
+
+        final StringBuilder sb = new StringBuilder();
+
+        // YAML frontmatter
+        sb.append("---\n");
+        sb.append("name: \"").append(escapeYamlString(skillName)).append("\"\n");
+
+        final String description = getTextValue(extMeta, "description");
+        if (description != null && !description.isBlank()) {
+            sb.append("description: \"").append(escapeYamlString(description)).append("\"\n");
+        }
+
+        if (license != null && !license.isBlank()) {
+            sb.append("license: \"").append(escapeYamlString(license)).append("\"\n");
+        }
+
+        final String guide = getNestedTextValue(extMeta, "metadata", "guide");
+        if (guide != null && !guide.isBlank()) {
+            sb.append("metadata:\n");
+            sb.append("  guide: \"").append(escapeYamlString(guide)).append("\"\n");
+        }
+
+        sb.append("---\n\n");
+
+        // Skill body
+        sb.append(rawContent.trim()).append("\n");
+
+        return sb.toString();
+    }
+
+    /**
+     * Overload that defaults to {@code Apache-2.0} license for Quarkus core extensions.
+     */
+    public static String compose(ObjectNode extMeta, String rawContent, String skillName) {
+        return compose(extMeta, rawContent, skillName, "Apache-2.0");
+    }
+
+    /**
+     * Safely extracts a text value from a JSON node, returning {@code null} if
+     * the field is missing, null, or not a textual type.
+     */
+    private static String getTextValue(ObjectNode node, String field) {
+        var child = node.get(field);
+        if (child == null || child.isNull() || !child.isTextual()) {
+            return null;
+        }
+        return child.asText();
+    }
+
+    /**
+     * Safely extracts a nested text value (e.g. {@code metadata.guide}),
+     * returning {@code null} if any part of the path is missing or not the expected type.
+     */
+    private static String getNestedTextValue(ObjectNode node, String parent, String field) {
+        var parentNode = node.get(parent);
+        if (parentNode == null || parentNode.isNull() || !parentNode.isObject()) {
+            return null;
+        }
+        return getTextValue((ObjectNode) parentNode, field);
+    }
+
+    private static String escapeYamlString(String value) {
+        final StringBuilder sb = new StringBuilder(value.length());
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '\\':
+                    sb.append("\\\\");
+                    break;
+                case '"':
+                    sb.append("\\\"");
+                    break;
+                case '\n':
+                    sb.append("\\n");
+                    break;
+                case '\r':
+                    sb.append("\\r");
+                    break;
+                case '\t':
+                    sb.append("\\t");
+                    break;
+                case '\0':
+                    sb.append("\\0");
+                    break;
+                default:
+                    if (c < 0x20) {
+                        // Escape non-printable control characters as Unicode
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+                    break;
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/independent-projects/tools/devtools-common/src/test/java/io/quarkus/devtools/utils/SkillComposerTest.java
+++ b/independent-projects/tools/devtools-common/src/test/java/io/quarkus/devtools/utils/SkillComposerTest.java
@@ -1,0 +1,189 @@
+package io.quarkus.devtools.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public class SkillComposerTest {
+
+    @Test
+    public void outputSkillPathProducesCorrectLayout() {
+        assertEquals("META-INF/skills/quarkus-arc/SKILL.md",
+                SkillComposer.outputSkillPath("quarkus-arc"));
+    }
+
+    @Test
+    public void parseExtensionMetadataReadsYaml() throws IOException {
+        String yaml = "name: \"My Extension\"\ndescription: \"Does things\"\n";
+        try (var is = new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8))) {
+            ObjectNode node = SkillComposer.parseExtensionMetadata(is);
+            assertNotNull(node);
+            assertEquals("My Extension", node.path("name").asText());
+            assertEquals("Does things", node.path("description").asText());
+        }
+    }
+
+    @Test
+    public void parseExtensionMetadataThrowsOnEmptyStream() {
+        // Empty YAML should throw
+        assertThrows(Exception.class, () -> {
+            try (var is = new ByteArrayInputStream(new byte[0])) {
+                SkillComposer.parseExtensionMetadata(is);
+            }
+        });
+    }
+
+    @Test
+    public void composeWithFullMetadata() throws IOException {
+        String yaml = "name: \"REST\"\n"
+                + "description: \"Build RESTful APIs\"\n"
+                + "metadata:\n"
+                + "  guide: https://quarkus.io/guides/rest\n";
+        ObjectNode meta = parseYaml(yaml);
+
+        String result = SkillComposer.compose(meta, "### Endpoints\n- Use @GET\n", "quarkus-rest");
+
+        assertTrue(result.startsWith("---\n"));
+        assertTrue(result.contains("name: \"quarkus-rest\"\n"));
+        assertTrue(result.contains("description: \"Build RESTful APIs\"\n"));
+        assertTrue(result.contains("license: \"Apache-2.0\"\n"));
+        assertTrue(result.contains("  guide: \"https://quarkus.io/guides/rest\"\n"));
+        assertTrue(result.contains("### Endpoints"));
+        assertTrue(result.contains("- Use @GET"));
+        // Ends with closing frontmatter separator, blank line, then body
+        assertTrue(result.contains("---\n\n### Endpoints"));
+    }
+
+    @Test
+    public void composeWithoutDescriptionOmitsField() throws IOException {
+        String yaml = "name: \"Minimal\"\n";
+        ObjectNode meta = parseYaml(yaml);
+
+        String result = SkillComposer.compose(meta, "content", "quarkus-minimal");
+
+        assertTrue(result.contains("name: \"quarkus-minimal\"\n"));
+        assertTrue(!result.contains("description:"));
+        assertTrue(result.contains("license: \"Apache-2.0\"\n"));
+    }
+
+    @Test
+    public void composeWithBlankDescriptionOmitsField() throws IOException {
+        String yaml = "name: \"Blank\"\ndescription: \"   \"\n";
+        ObjectNode meta = parseYaml(yaml);
+
+        String result = SkillComposer.compose(meta, "content", "quarkus-blank");
+
+        assertTrue(!result.contains("description:"));
+    }
+
+    @Test
+    public void composeWithoutGuideOmitsMetadataBlock() throws IOException {
+        String yaml = "name: \"No Guide\"\ndescription: \"Something\"\n";
+        ObjectNode meta = parseYaml(yaml);
+
+        String result = SkillComposer.compose(meta, "body", "quarkus-noguide");
+
+        assertTrue(!result.contains("metadata:"));
+        assertTrue(!result.contains("guide:"));
+    }
+
+    @Test
+    public void composeEscapesQuotesInDescription() throws IOException {
+        String yaml = "name: \"Quoted\"\ndescription: 'Say \"hello\" world'\n";
+        ObjectNode meta = parseYaml(yaml);
+
+        String result = SkillComposer.compose(meta, "body", "quarkus-quoted");
+
+        assertTrue(result.contains("description: \"Say \\\"hello\\\" world\"\n"));
+    }
+
+    @Test
+    public void composeTrimsRawContent() throws IOException {
+        String yaml = "name: \"Trim\"\ndescription: \"desc\"\n";
+        ObjectNode meta = parseYaml(yaml);
+
+        String result = SkillComposer.compose(meta, "\n  content with whitespace  \n\n", "quarkus-trim");
+
+        // Body should be trimmed and end with single newline
+        assertTrue(result.endsWith("content with whitespace\n"));
+    }
+
+    @Test
+    public void composeWithCustomLicense() throws IOException {
+        String yaml = "name: \"Custom\"\ndescription: \"desc\"\n";
+        ObjectNode meta = parseYaml(yaml);
+
+        String result = SkillComposer.compose(meta, "body", "my-ext", "MIT");
+
+        assertTrue(result.contains("license: \"MIT\"\n"));
+        assertTrue(!result.contains("Apache-2.0"));
+    }
+
+    @Test
+    public void composeWithNullLicenseOmitsField() throws IOException {
+        String yaml = "name: \"NoLicense\"\ndescription: \"desc\"\n";
+        ObjectNode meta = parseYaml(yaml);
+
+        String result = SkillComposer.compose(meta, "body", "my-ext", null);
+
+        assertTrue(!result.contains("license:"));
+    }
+
+    @Test
+    public void composeIgnoresNonTextualDescription() throws IOException {
+        // description is an object, not a string — should be treated as missing
+        String yaml = "name: \"Bad\"\ndescription:\n  nested: value\n";
+        ObjectNode meta = parseYaml(yaml);
+
+        String result = SkillComposer.compose(meta, "body", "quarkus-bad");
+
+        assertTrue(!result.contains("description:"));
+    }
+
+    @Test
+    public void composeEscapesNonPrintableInDescription() throws IOException {
+        // Use a description containing a null byte and a control character
+        String yaml = "name: \"Esc\"\ndescription: \"has ctrl\"\n";
+        ObjectNode meta = parseYaml(yaml);
+        // Manually set description with non-printable chars
+        meta.put("description", "before\0after\u0007bell");
+
+        String result = SkillComposer.compose(meta, "body", "quarkus-esc");
+
+        assertTrue(result.contains("description: \"before\\0after\\u0007bell\"\n"));
+    }
+
+    @Test
+    public void composeQuotesNameWithSpecialChars() throws IOException {
+        String yaml = "name: \"Special\"\ndescription: \"desc\"\n";
+        ObjectNode meta = parseYaml(yaml);
+
+        String result = SkillComposer.compose(meta, "body", "my-ext: special");
+
+        assertTrue(result.contains("name: \"my-ext: special\"\n"));
+    }
+
+    @Test
+    public void composeThrowsOnNullArgs() throws IOException {
+        ObjectNode meta = parseYaml("name: x\n");
+
+        assertThrows(NullPointerException.class, () -> SkillComposer.compose(null, "c", "n"));
+        assertThrows(NullPointerException.class, () -> SkillComposer.compose(meta, null, "n"));
+        assertThrows(NullPointerException.class, () -> SkillComposer.compose(meta, "c", null));
+    }
+
+    private static ObjectNode parseYaml(String yaml) throws IOException {
+        try (var is = new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8))) {
+            return SkillComposer.parseExtensionMetadata(is);
+        }
+    }
+}


### PR DESCRIPTION
Adds a frictionless skill mechanism for Quarkus extensions to ship coding
guidelines, testing patterns, and common pitfalls to AI coding agents. Extension
developers just drop a `quarkus-skill.md` file in their deployment module's
resources — no pom.xml changes needed. All skills are automatically discovered
and aggregated into a single `io.quarkus:quarkus-extension-skills` JAR following
the [Agent Skills specification](https://agentskills.io/specification),
compatible with [SkillsJars](https://www.skillsjars.com).

How extension developers opt in:

1. Place a `quarkus-skill.md` in the deployment module at
   `deployment/src/main/resources/META-INF/quarkus-skill.md`
2. Add a `description` field to the runtime module's `quarkus-extension.yaml`

The build does the rest:
- `AggregateSkillsMojo` (goal: `aggregate-skills`) walks the extensions source
  tree, discovers all skill files, reads the corresponding runtime
  `quarkus-extension.yaml` for metadata, and composes `SKILL.md` files with
  YAML frontmatter
- `SkillComposer` utility handles the composition logic per the Agent Skills spec
- `devtools/extension-skills/` module produces the aggregated JAR with all
  composed skills at `META-INF/skills/{extension-name}/SKILL.md`

Documentation added to `dev-mcp.adoc`.

Related: Skill files for individual extensions in #53196.