### PR TITLE
Fix typo in enableMcpFuctionByDefault and MCP resource parsing regex

### DIFF
--- a/docs/src/main/asciidoc/dev-mcp.adoc
+++ b/docs/src/main/asciidoc/dev-mcp.adoc
@@ -86,7 +86,7 @@ BuildTimeActionBuildItem createBuildTimeActions() {
 <3> Set a human‑readable description.
 <4> Provide the runtime value returned by your recorder.
 
-By default this resource will be disabled, and the user has to enable it in Dev UI. You can change this default by adding `.enableMcpFuctionByDefault()` in the builder method.
+By default this resource will be disabled, and the user has to enable it in Dev UI. You can change this default by adding `.enableMcpFunctionByDefault()` in the builder method.
 
 === MCP tools
 
@@ -159,7 +159,7 @@ BuildTimeActionBuildItem createBuildTimeActions() {
 
 The code in the `function` runs on the deployment classpath. The function can return a plain value, a `CompletionStage` or `CompletableFuture` for asynchronous work.
 
-By default this tool will be disabled, and the user has to enable it in Dev UI. You can change this default by adding `.enableMcpFuctionByDefault()` in the builder method.
+By default this tool will be disabled, and the user has to enable it in Dev UI. You can change this default by adding `.enableMcpFunctionByDefault()` in the builder method.
 
 === JSON‑RPC usage
 

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/BuildTimeActionBuildItem.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/BuildTimeActionBuildItem.java
@@ -151,9 +151,17 @@ public final class BuildTimeActionBuildItem extends AbstractDevUIBuildItem {
             return this;
         }
 
-        public ActionBuilder enableMcpFuctionByDefault() {
+        public ActionBuilder enableMcpFunctionByDefault() {
             this.mcpEnabledByDefault = true;
             return this;
+        }
+
+        /**
+         * @deprecated Use {@link #enableMcpFunctionByDefault()} instead.
+         */
+        @Deprecated(forRemoval = true)
+        public ActionBuilder enableMcpFuctionByDefault() {
+            return enableMcpFunctionByDefault();
         }
 
         public <T> ActionBuilder function(Function<Map<String, String>, T> function) {
@@ -245,9 +253,17 @@ public final class BuildTimeActionBuildItem extends AbstractDevUIBuildItem {
             return this;
         }
 
-        public SubscriptionBuilder enableMcpFuctionByDefault() {
+        public SubscriptionBuilder enableMcpFunctionByDefault() {
             this.mcpEnabledByDefault = true;
             return this;
+        }
+
+        /**
+         * @deprecated Use {@link #enableMcpFunctionByDefault()} instead.
+         */
+        @Deprecated(forRemoval = true)
+        public SubscriptionBuilder enableMcpFuctionByDefault() {
+            return enableMcpFunctionByDefault();
         }
 
         public <T> SubscriptionBuilder function(Function<Map<String, String>, T> function) {

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/logstream/LogStreamProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/logstream/LogStreamProcessor.java
@@ -62,7 +62,7 @@ public class LogStreamProcessor {
                     RuntimeUpdatesProcessor.INSTANCE.doScan(true, true);
                     return Map.of();
                 })
-                .enableMcpFuctionByDefault()
+                .enableMcpFunctionByDefault()
                 .build();
 
         keyStrokeActions.actionBuilder()

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/ConfigurationProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/ConfigurationProcessor.java
@@ -126,7 +126,7 @@ public class ConfigurationProcessor {
                     updateConfig(name, value, profile, target);
                     return true;
                 })
-                .enableMcpFuctionByDefault()
+                .enableMcpFunctionByDefault()
                 .build();
 
         configActions.actionBuilder()

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/ContinuousTestingProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/ContinuousTestingProcessor.java
@@ -113,7 +113,7 @@ public class ContinuousTestingProcessor {
                         throw new RuntimeException(e);
                     }
                 })
-                .enableMcpFuctionByDefault()
+                .enableMcpFunctionByDefault()
                 .build();
     }
 
@@ -139,7 +139,7 @@ public class ContinuousTestingProcessor {
                         throw new RuntimeException(e);
                     }
                 })
-                .enableMcpFuctionByDefault()
+                .enableMcpFunctionByDefault()
                 .build();
     }
 
@@ -160,7 +160,7 @@ public class ContinuousTestingProcessor {
                         throw new RuntimeException(e);
                     }
                 })
-                .enableMcpFuctionByDefault()
+                .enableMcpFunctionByDefault()
                 .build();
     }
 
@@ -262,7 +262,7 @@ public class ContinuousTestingProcessor {
                         throw new RuntimeException(e);
                     }
                 })
-                .enableMcpFuctionByDefault()
+                .enableMcpFunctionByDefault()
                 .build();
     }
 
@@ -282,7 +282,7 @@ public class ContinuousTestingProcessor {
         actions.actionBuilder()
                 .methodName("getTestResults")
                 .description("Get the results of a Continuous testing test run")
-                .enableMcpFuctionByDefault()
+                .enableMcpFunctionByDefault()
                 .function(ignored -> {
                     TestRunResults continuousTestingResults = continuousTestingResults(launchModeBuildItem);
                     if (continuousTestingResults != null) {

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/DevServicesProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/DevServicesProcessor.java
@@ -90,7 +90,7 @@ public class DevServicesProcessor {
                 .function(ignored -> CompletableFuture.supplyAsync(() -> getServices(devServiceDescriptions, otherDevServices)))
                 .description(
                         "Get all the DevServices started by this Quarkus app, including information on container (if any) and the config that is being set automatically")
-                .enableMcpFuctionByDefault()
+                .enableMcpFunctionByDefault()
                 .build();
     }
 

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/ExtensionsProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/ExtensionsProcessor.java
@@ -137,7 +137,7 @@ public class ExtensionsProcessor {
                         return filtered;
                     });
                 })
-                .enableMcpFuctionByDefault()
+                .enableMcpFunctionByDefault()
                 .build();
     }
 
@@ -221,7 +221,7 @@ public class ExtensionsProcessor {
                         }
                     });
                 })
-                .enableMcpFuctionByDefault()
+                .enableMcpFunctionByDefault()
                 .build();
     }
 
@@ -247,7 +247,7 @@ public class ExtensionsProcessor {
                         }
                     });
                 })
-                .enableMcpFuctionByDefault()
+                .enableMcpFunctionByDefault()
                 .build();
     }
 

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/WorkspaceProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/WorkspaceProcessor.java
@@ -189,7 +189,7 @@ public class WorkspaceProcessor {
                     .function((t) -> {
                         return workspaceBuildItem.get().getWorkspaceItems();
                     })
-                    .enableMcpFuctionByDefault()
+                    .enableMcpFunctionByDefault()
                     .build();
 
             buildItemActions.actionBuilder()
@@ -251,7 +251,7 @@ public class WorkspaceProcessor {
                         }
                         return null;
                     })
-                    .enableMcpFuctionByDefault()
+                    .enableMcpFunctionByDefault()
                     .build();
 
             buildItemActions.actionBuilder()
@@ -270,7 +270,7 @@ public class WorkspaceProcessor {
                         }
                         return new SavedResult(null, false, "Invalid input");
                     })
-                    .enableMcpFuctionByDefault()
+                    .enableMcpFunctionByDefault()
                     .build();
 
             buildTimeActionProducer.produce(buildItemActions);

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpResourcesService.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpResourcesService.java
@@ -248,18 +248,25 @@ public class McpResourcesService {
     }
 
     private String getBuildTimeDataConstValue(String jsContent, String constName) {
-        String patternString = "export const " + Pattern.quote(constName) + "\\s*=\\s*([^;]+);";
-        Pattern pattern = Pattern.compile(patternString, Pattern.DOTALL);
+        // Match the full value including any semicolons inside JSON strings.
+        // Values are always on a single physical line (newlines are escaped in JSON strings).
+        String patternString = "export const " + Pattern.quote(constName) + "\\s*=\\s*(.+)";
+        Pattern pattern = Pattern.compile(patternString);
         Matcher matcher = pattern.matcher(jsContent);
 
         if (matcher.find()) {
-            return matcher.group(1).trim();
+            String value = matcher.group(1).trim();
+            // Strip the trailing semicolon
+            if (value.endsWith(";")) {
+                value = value.substring(0, value.length() - 1).trim();
+            }
+            return value;
         }
 
         return "Error: Data not found for " + constName;
     }
 
-    private static final Pattern BTD_PATTERN = Pattern.compile("export const (\\w+)\\s*=\\s*([^;]+);", Pattern.DOTALL);
+    private static final Pattern BTD_PATTERN = Pattern.compile("export const (\\w+)\\s*=\\s*(.+)");
 
     private static final String URI_SCHEME = "quarkus://resource/";
     private static final String SUB_SCHEME_BUILD_TIME = "build-time/";

--- a/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/InfoProcessor.java
+++ b/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/InfoProcessor.java
@@ -307,7 +307,7 @@ public class InfoProcessor {
                         "Information about the environment where this Quarkus application is running. "
                                 + "Things like Operating System, Java version Git information and application details is available")
                 .runtime(finalBuildInfo)
-                .enableMcpFuctionByDefault()
+                .enableMcpFunctionByDefault()
                 .build());
 
         return RouteBuildItem.newManagementRoute(buildTimeConfig.path())


### PR DESCRIPTION
## Summary

- Renamed `enableMcpFuctionByDefault()` to `enableMcpFunctionByDefault()` (typo fix) with a `@Deprecated(forRemoval = true)` bridge method for backwards compatibility
- Fixed regex in `McpResourcesService.getBuildTimeDataConstValue()` that failed to parse build-time data values containing semicolons inside JSON strings
- Updated all callers to use the corrected method name
- Fixed the same typo in `dev-mcp.adoc`