### PR TITLE
Introduce new CLI module inspired by PicoCLI

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -3643,6 +3643,16 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-quickcli</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-quickcli-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-web-dependency-locator</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/devtools/bom-descriptor-json/pom.xml
+++ b/devtools/bom-descriptor-json/pom.xml
@@ -2041,6 +2041,19 @@
                 </dependency>
                 <dependency>
                     <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-quickcli</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-qute</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>

--- a/devtools/cli-common/pom.xml
+++ b/devtools/cli-common/pom.xml
@@ -16,8 +16,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>info.picocli</groupId>
-            <artifactId>picocli</artifactId>
+            <groupId>io.quarkus.quickcli</groupId>
+            <artifactId>quickcli-core</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/devtools/cli-common/src/main/java/io/quarkus/cli/common/BuildOptions.java
+++ b/devtools/cli-common/src/main/java/io/quarkus/cli/common/BuildOptions.java
@@ -1,27 +1,27 @@
 package io.quarkus.cli.common;
 
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.Option;
 
 public class BuildOptions {
-    @CommandLine.Option(order = 3, names = {
+    @Option(order = 3, names = {
             "--clean" }, description = "Perform clean as part of build. False by default.", negatable = true)
     public boolean clean = false;
 
-    @CommandLine.Option(order = 4, names = { "--native" }, description = "Build native executable.", defaultValue = "false")
+    @Option(order = 4, names = { "--native" }, description = "Build native executable.", defaultValue = "false")
     public boolean buildNative = false;
 
-    @CommandLine.Option(order = 5, names = { "--offline" }, description = "Work offline.", defaultValue = "false")
+    @Option(order = 5, names = { "--offline" }, description = "Work offline.", defaultValue = "false")
     public boolean offline = false;
 
-    @CommandLine.Option(order = 6, names = {
+    @Option(order = 6, names = {
             "--no-tests" }, description = "Run tests.", negatable = true, defaultValue = "false")
     public boolean skipTests = false;
 
-    @CommandLine.Option(order = 7, names = {
+    @Option(order = 7, names = {
             "--report" }, description = "Generate build report.", negatable = true, defaultValue = "false")
     public boolean generateBuildReport = false;
 
-    @CommandLine.Option(order = 8, names = {
+    @Option(order = 8, names = {
             "--ext-capture" }, description = "Enable extended capture for build metrics.", negatable = true, defaultValue = "false")
     public boolean buildExtendedCapture = false;
 

--- a/devtools/cli-common/src/main/java/io/quarkus/cli/common/BuildToolDelegatingCommand.java
+++ b/devtools/cli-common/src/main/java/io/quarkus/cli/common/BuildToolDelegatingCommand.java
@@ -13,9 +13,12 @@ import io.quarkus.cli.common.build.BuildSystemRunner;
 import io.quarkus.cli.common.gradle.GradleInitScript;
 import io.quarkus.cli.common.registry.ToggleRegistryClientMixin;
 import io.quarkus.devtools.project.BuildTool;
-import picocli.CommandLine;
-import picocli.CommandLine.ExitCode;
-import picocli.CommandLine.Parameters;
+import io.quarkus.quickcli.CommandSpec;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.quickcli.annotations.ArgGroup;
+import io.quarkus.quickcli.annotations.Mixin;
+import io.quarkus.quickcli.annotations.Parameters;
+import io.quarkus.quickcli.annotations.Spec;
 
 /**
  * A cli command that delegates to the quarkus build system.
@@ -25,25 +28,25 @@ public class BuildToolDelegatingCommand implements Callable<Integer> {
     private static final String GRADLE_NO_BUILD_CACHE = "--no-build-cache";
     private static final String GRADLE_NO_DAEMON = "--no-daemon";
 
-    @CommandLine.Spec
-    protected CommandLine.Model.CommandSpec spec;
+    @Spec
+    protected CommandSpec spec;
 
-    @CommandLine.Mixin(name = "output")
+    @Mixin(name = "output")
     protected OutputOptionMixin output;
 
-    @CommandLine.Mixin
+    @Mixin
     protected ToggleRegistryClientMixin registryClient;
 
-    @CommandLine.Mixin
+    @Mixin
     protected HelpOption helpOption;
 
-    @CommandLine.ArgGroup(exclusive = false, validate = false)
+    @ArgGroup(exclusive = false, validate = false)
     protected PropertiesOptions propertiesOptions = new PropertiesOptions();
 
-    @CommandLine.Mixin
+    @Mixin
     private RunModeOption runMode;
 
-    @CommandLine.ArgGroup(order = 1, exclusive = false, validate = false, heading = "%nBuild options:%n")
+    @ArgGroup(order = 1, exclusive = false, validate = false, heading = "%nBuild options:%n")
     private BuildOptions buildOptions = new BuildOptions();
 
     @Parameters(description = "Additional parameters passed to the build system")

--- a/devtools/cli-common/src/main/java/io/quarkus/cli/common/CategoryListFormatOptions.java
+++ b/devtools/cli-common/src/main/java/io/quarkus/cli/common/CategoryListFormatOptions.java
@@ -1,15 +1,15 @@
 package io.quarkus.cli.common;
 
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.Option;
 
 public class CategoryListFormatOptions {
-    @CommandLine.Option(names = { "--id" }, order = 1, description = "Display categoryId column only. (default)")
+    @Option(names = { "--id" }, order = 1, description = "Display categoryId column only. (default)")
     boolean id = false;
 
-    @CommandLine.Option(names = { "--concise" }, order = 2, description = "Display categoryId and name columns.")
+    @Option(names = { "--concise" }, order = 2, description = "Display categoryId and name columns.")
     boolean concise = false;
 
-    @CommandLine.Option(names = { "--full" }, order = 3, description = "Display categoryId, name and description columns.")
+    @Option(names = { "--full" }, order = 3, description = "Display categoryId, name and description columns.")
     boolean full = false;
 
     public String getFormatString() {

--- a/devtools/cli-common/src/main/java/io/quarkus/cli/common/DataOptions.java
+++ b/devtools/cli-common/src/main/java/io/quarkus/cli/common/DataOptions.java
@@ -3,14 +3,14 @@ package io.quarkus.cli.common;
 import java.util.HashMap;
 import java.util.Map;
 
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.Option;
 
 public class DataOptions {
 
     public Map<String, String> data = new HashMap<>();
 
-    @CommandLine.Option(names = "--data", mapFallbackValue = "", description = "Additional data")
-    void setData(Map<String, String> data) {
+    @Option(names = "--data", mapFallbackValue = "", description = "Additional data")
+    public void setData(Map<String, String> data) {
         this.data = data;
     }
 

--- a/devtools/cli-common/src/main/java/io/quarkus/cli/common/DebugOptions.java
+++ b/devtools/cli-common/src/main/java/io/quarkus/cli/common/DebugOptions.java
@@ -2,7 +2,7 @@ package io.quarkus.cli.common;
 
 import java.util.Collection;
 
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.Option;
 
 public class DebugOptions {
     final static String LOCALHOST = "localhost";
@@ -13,23 +13,23 @@ public class DebugOptions {
         listen
     }
 
-    @CommandLine.Option(order = 7, names = {
+    @Option(order = 7, names = {
             "--no-debug" }, description = "Toggle debug mode. Enabled by default.", negatable = true)
     public boolean debug = true;
 
-    @CommandLine.Option(order = 8, names = {
+    @Option(order = 8, names = {
             "--debug-host" }, description = "Debug host, e.g. localhost or 0.0.0.0", defaultValue = LOCALHOST)
     public String host = LOCALHOST;
 
-    @CommandLine.Option(order = 9, names = {
+    @Option(order = 9, names = {
             "--debug-mode" }, description = "Valid values: ${COMPLETION-CANDIDATES}.%nEither connect to or listen on <host>:<port>.", defaultValue = "listen")
     public DebugMode mode = DebugMode.listen;
 
-    @CommandLine.Option(order = 10, names = {
+    @Option(order = 10, names = {
             "--debug-port" }, description = "Debug port (must be a number > 0).", defaultValue = "" + DEFAULT_PORT)
     public int port = DEFAULT_PORT;
 
-    @CommandLine.Option(order = 11, names = {
+    @Option(order = 11, names = {
             "--suspend" }, description = "In listen mode, suspend until a debugger is attached. Disabled by default.", negatable = true)
     public boolean suspend = false;
 

--- a/devtools/cli-common/src/main/java/io/quarkus/cli/common/DevOptions.java
+++ b/devtools/cli-common/src/main/java/io/quarkus/cli/common/DevOptions.java
@@ -1,28 +1,28 @@
 package io.quarkus.cli.common;
 
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.Option;
 
 public class DevOptions {
 
-    @CommandLine.Option(names = { "-B", "--batch-mode" }, description = "Run in non-interactive (batch) mode.")
+    @Option(names = { "-B", "--batch-mode" }, description = "Run in non-interactive (batch) mode.")
     boolean batchMode;
 
-    @CommandLine.Option(order = 2, names = { "--dry-run" }, description = "Show actions that would be taken.")
+    @Option(order = 2, names = { "--dry-run" }, description = "Show actions that would be taken.")
     boolean dryRun = false;
 
     // Allow the option variant, but don't crowd help
-    @CommandLine.Option(names = { "--dryrun" }, hidden = true)
+    @Option(names = { "--dryrun" }, hidden = true)
     boolean dryRun2 = false;
 
-    @CommandLine.Option(order = 3, names = {
+    @Option(order = 3, names = {
             "--clean" }, description = "Perform clean as part of build. False by default.", negatable = true)
     public boolean clean = false;
 
     // Invalid w/ continuous test mode. Leave for compat (hidden)
-    @CommandLine.Option(order = 4, names = { "--no-tests" }, negatable = true, hidden = true)
+    @Option(order = 4, names = { "--no-tests" }, negatable = true, hidden = true)
     public boolean runTests = true;
 
-    @CommandLine.Option(order = 5, names = { "--offline" }, description = "Work offline.", defaultValue = "false")
+    @Option(order = 5, names = { "--offline" }, description = "Work offline.", defaultValue = "false")
     public boolean offline = false;
 
     public boolean skipTests() {

--- a/devtools/cli-common/src/main/java/io/quarkus/cli/common/HelpOption.java
+++ b/devtools/cli-common/src/main/java/io/quarkus/cli/common/HelpOption.java
@@ -1,8 +1,8 @@
 package io.quarkus.cli.common;
 
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.Option;
 
 public class HelpOption {
-    @CommandLine.Option(names = { "-h", "--help" }, usageHelp = true, description = "Display this help message.")
+    @Option(names = { "-h", "--help" }, usageHelp = true, description = "Display this help message.")
     public boolean help;
 }

--- a/devtools/cli-common/src/main/java/io/quarkus/cli/common/ListFormatOptions.java
+++ b/devtools/cli-common/src/main/java/io/quarkus/cli/common/ListFormatOptions.java
@@ -1,27 +1,27 @@
 package io.quarkus.cli.common;
 
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.Option;
 
 public class ListFormatOptions {
 
-    @CommandLine.Option(names = { "--id" }, order = 4, description = "Display extension artifactId only. (default)")
+    @Option(names = { "--id" }, order = 4, description = "Display extension artifactId only. (default)")
     boolean id = false;
 
-    @CommandLine.Option(names = { "--name" }, hidden = true, description = "Display extension artifactId only. (deprecated)")
+    @Option(names = { "--name" }, hidden = true, description = "Display extension artifactId only. (deprecated)")
     boolean name = false;
 
-    @CommandLine.Option(names = { "--concise" }, order = 5, description = "Display extension artifactId and name.")
+    @Option(names = { "--concise" }, order = 5, description = "Display extension artifactId and name.")
     boolean concise = false;
 
-    @CommandLine.Option(names = {
+    @Option(names = {
             "--full" }, order = 6, description = "Display extension artifactId, name, version, platform origin, and other information.")
     boolean full = false;
 
-    @CommandLine.Option(names = {
+    @Option(names = {
             "--origins" }, order = 7, description = "Display extension artifactId, name, version, and platform origins.")
     boolean origins = false;
 
-    @CommandLine.Option(names = {
+    @Option(names = {
             "--support-scope" }, order = 7, description = "Display extension artifactId, name, version, and support scope in case it's associated with an extension.")
     boolean supportScope = false;
 

--- a/devtools/cli-common/src/main/java/io/quarkus/cli/common/OutputOptionMixin.java
+++ b/devtools/cli-common/src/main/java/io/quarkus/cli/common/OutputOptionMixin.java
@@ -9,50 +9,50 @@ import java.nio.file.Paths;
 import java.util.List;
 
 import io.quarkus.devtools.messagewriter.MessageWriter;
-import picocli.CommandLine;
-import picocli.CommandLine.Help.ColorScheme;
-import picocli.CommandLine.Model.CommandSpec;
+import io.quarkus.quickcli.Ansi;
+import io.quarkus.quickcli.CommandLine;
+import io.quarkus.quickcli.CommandSpec;
+import io.quarkus.quickcli.Help;
+import io.quarkus.quickcli.annotations.Option;
+import io.quarkus.quickcli.annotations.Spec;
 
 public class OutputOptionMixin implements MessageWriter {
 
-    static final boolean picocliDebugEnabled = "DEBUG".equalsIgnoreCase(System.getProperty("picocli.trace"));
+    static final boolean quickcliDebugEnabled = "DEBUG".equalsIgnoreCase(System.getProperty("quickcli.trace"));
 
     boolean verbose = false;
 
-    @CommandLine.Option(names = { "-e", "--errors" }, description = "Print more context on errors and exceptions.")
+    @Option(names = { "-e", "--errors" }, description = "Print more context on errors and exceptions.")
     boolean showErrors;
 
-    @CommandLine.Option(names = {
+    @Option(names = {
             "--cli-test" }, hidden = true, description = "Manually set output streams for unit test purposes.")
     boolean cliTestMode;
 
     Path testProjectRoot;
 
-    @CommandLine.Option(names = { "--cli-test-dir" }, hidden = true)
+    @Option(names = { "--cli-test-dir" }, hidden = true)
     void setTestProjectRoot(String path) {
         // Allow the starting/project directory to be specified. Used during test.
         testProjectRoot = Paths.get(path).toAbsolutePath();
     }
 
-    @CommandLine.Spec(CommandLine.Spec.Target.MIXEE)
+    @Spec(Spec.Target.MIXEE)
     CommandSpec mixee;
 
-    ColorScheme scheme;
     PrintWriter out;
     PrintWriter err;
 
-    ColorScheme colorScheme() {
-        ColorScheme colors = scheme;
-        if (colors == null) {
-            colors = scheme = mixee.commandLine().getColorScheme();
-        }
-        return colors;
+    Help.ColorScheme colorScheme() {
+        return Help.ColorScheme.DEFAULT;
     }
 
     public PrintWriter out() {
         PrintWriter o = out;
         if (o == null) {
-            o = out = mixee.commandLine().getOut();
+            o = out = (mixee != null && mixee.commandLine() != null)
+                    ? mixee.commandLine().getOut()
+                    : new PrintWriter(System.out, true);
         }
         return o;
     }
@@ -60,21 +60,23 @@ public class OutputOptionMixin implements MessageWriter {
     public PrintWriter err() {
         PrintWriter e = err;
         if (e == null) {
-            e = err = mixee.commandLine().getErr();
+            e = err = (mixee != null && mixee.commandLine() != null)
+                    ? mixee.commandLine().getErr()
+                    : new PrintWriter(System.err, true);
         }
         return e;
     }
 
     public boolean isShowErrors() {
-        return showErrors || picocliDebugEnabled;
+        return showErrors || quickcliDebugEnabled;
     }
 
     private static OutputOptionMixin getOutput(CommandSpec commandSpec) {
         return ((OutputProvider) commandSpec.root().userObject()).getOutput();
     }
 
-    @CommandLine.Option(names = { "--verbose" }, description = "Verbose mode.")
-    public void setVerbose(boolean verbose) {
+    @Option(names = { "--verbose" }, description = "Verbose mode.")
+    void setVerbose(boolean verbose) {
         getOutput(mixee).verbose = verbose;
     }
 
@@ -83,7 +85,7 @@ public class OutputOptionMixin implements MessageWriter {
     }
 
     public boolean isVerbose() {
-        return getVerbose() || picocliDebugEnabled;
+        return getVerbose() || quickcliDebugEnabled;
     }
 
     public boolean isCliTest() {
@@ -91,12 +93,12 @@ public class OutputOptionMixin implements MessageWriter {
     }
 
     public boolean isAnsiEnabled() {
-        return CommandLine.Help.Ansi.AUTO.enabled();
+        return Ansi.AUTO.enabled();
     }
 
     public void printText(String... text) {
         for (String line : text) {
-            out().println(colorScheme().ansi().new Text(line, colorScheme()));
+            out().println(new Ansi.Text(line, null));
         }
     }
 
@@ -121,7 +123,7 @@ public class OutputOptionMixin implements MessageWriter {
 
     @Override
     public void info(String msg) {
-        out().println(colorScheme().ansi().new Text(msg, colorScheme()));
+        out().println(new Ansi.Text(msg, null));
     }
 
     @Override
@@ -137,20 +139,20 @@ public class OutputOptionMixin implements MessageWriter {
     @Override
     public void debug(String msg) {
         if (isVerbose()) {
-            out().println(colorScheme().ansi().new Text("@|faint [DEBUG] " + msg + "|@", colorScheme()));
+            out().println(new Ansi.Text("@|faint [DEBUG] " + msg + "|@", null));
         }
     }
 
     @Override
     public void warn(String msg) {
-        out().println(colorScheme().ansi().new Text("@|yellow " + WARN_ICON + " " + msg + "|@", colorScheme()));
+        out().println(new Ansi.Text("@|yellow " + WARN_ICON + " " + msg + "|@", null));
     }
 
     // CommandLine must be passed in (forwarded commands)
     public void throwIfUnmatchedArguments(CommandLine cmd) {
         List<String> unmatchedArguments = cmd.getUnmatchedArguments();
         if (!unmatchedArguments.isEmpty()) {
-            throw new CommandLine.UnmatchedArgumentException(cmd, unmatchedArguments);
+            throw new CommandLine.UnmatchedArgumentException("Unmatched arguments: " + unmatchedArguments);
         }
     }
 
@@ -158,7 +160,7 @@ public class OutputOptionMixin implements MessageWriter {
         CommandLine cmd = mixee.commandLine();
         printStackTrace(ex);
         if (ex instanceof CommandLine.ParameterException) {
-            CommandLine.UnmatchedArgumentException.printSuggestions((CommandLine.ParameterException) ex, out());
+            // suggestion printing not supported
         }
         error(message);
 

--- a/devtools/cli-common/src/main/java/io/quarkus/cli/common/PropertiesOptions.java
+++ b/devtools/cli-common/src/main/java/io/quarkus/cli/common/PropertiesOptions.java
@@ -5,13 +5,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.Option;
 
 public class PropertiesOptions {
     public Map<String, String> properties = new HashMap<>();
 
-    @CommandLine.Option(names = "-D", mapFallbackValue = "", description = "Java properties")
-    void setProperty(Map<String, String> props) {
+    @Option(names = "-D", mapFallbackValue = "", description = "Java properties")
+    public void setProperty(Map<String, String> props) {
         this.properties = props;
     }
 

--- a/devtools/cli-common/src/main/java/io/quarkus/cli/common/RunModeOption.java
+++ b/devtools/cli-common/src/main/java/io/quarkus/cli/common/RunModeOption.java
@@ -1,18 +1,18 @@
 package io.quarkus.cli.common;
 
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.Option;
 
 public class RunModeOption {
 
-    @CommandLine.Option(names = { "-B",
+    @Option(names = { "-B",
             "--batch-mode" }, description = "Run in non-interactive (batch) mode.")
     boolean batchMode;
 
     // Allow the option variant, but don't crowd help
-    @CommandLine.Option(names = { "--dryrun" }, hidden = true)
+    @Option(names = { "--dryrun" }, hidden = true)
     boolean dryRun2 = false;
 
-    @CommandLine.Option(names = { "--dry-run" }, description = "Show actions that would be taken.")
+    @Option(names = { "--dry-run" }, description = "Show actions that would be taken.")
     boolean dryRun = false;
 
     public boolean isBatchMode() {

--- a/devtools/cli-common/src/main/java/io/quarkus/cli/common/TargetQuarkusPlatformGroup.java
+++ b/devtools/cli-common/src/main/java/io/quarkus/cli/common/TargetQuarkusPlatformGroup.java
@@ -2,9 +2,10 @@ package io.quarkus.cli.common;
 
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.platform.tools.ToolsConstants;
+import io.quarkus.quickcli.CommandSpec;
+import io.quarkus.quickcli.annotations.Option;
+import io.quarkus.quickcli.annotations.Spec;
 import io.quarkus.registry.catalog.PlatformStreamCoords;
-import picocli.CommandLine;
-import picocli.CommandLine.Model.CommandSpec;
 
 public class TargetQuarkusPlatformGroup {
     static final String FULL_EXAMPLE = ToolsConstants.DEFAULT_PLATFORM_BOM_GROUP_ID + ":"
@@ -15,33 +16,33 @@ public class TargetQuarkusPlatformGroup {
     ArtifactCoords platformBom = null;
     String validPlatformBom = null;
 
-    @CommandLine.Spec
+    @Spec
     CommandSpec spec;
 
-    @CommandLine.Option(paramLabel = "platformKey:streamId", names = { "-S",
+    @Option(paramLabel = "platformKey:streamId", names = { "-S",
             "--stream" }, description = "A target stream, for example:%n  3.15 or io.quarkus.platform:3.15")
-    void setStream(String stream) {
+    public void setStream(String stream) {
         stream = stream.trim();
         if (!stream.isEmpty()) {
             try {
                 streamCoords = PlatformStreamCoords.fromString(stream);
                 validStream = stream;
             } catch (IllegalArgumentException iex) {
-                throw new CommandLine.ParameterException(spec.commandLine(),
+                throw new io.quarkus.quickcli.CommandLine.ParameterException(
                         String.format("Invalid value '%s' for option '--stream'. " +
                                 "Value should be specified as 'platformKey:streamId'. %s", stream, iex.getMessage()));
             }
         }
     }
 
-    @CommandLine.Option(paramLabel = "groupId:artifactId:version", names = { "-P",
+    @Option(paramLabel = "groupId:artifactId:version", names = { "-P",
             "--platform-bom" }, description = "A specific Quarkus platform BOM, for example:%n"
                     + "  " + FULL_EXAMPLE + "%n"
                     + "  io.quarkus::999-SNAPSHOT"
                     + "  3.15.2%n"
                     + "Default groupId: " + ToolsConstants.DEFAULT_PLATFORM_BOM_GROUP_ID + "%n"
                     + "Default artifactId: " + ToolsConstants.DEFAULT_PLATFORM_BOM_ARTIFACT_ID + "%n")
-    void setPlatformBom(String bom) {
+    public void setPlatformBom(String bom) {
         bom = bom.replaceFirst("^::", "").trim();
         if (!bom.isEmpty()) {
             try {
@@ -74,7 +75,7 @@ public class TargetQuarkusPlatformGroup {
                     validPlatformBom = bom; // keep original (valid) string (dryrun)
                 }
             } catch (IllegalArgumentException iex) {
-                throw new CommandLine.ParameterException(spec.commandLine(),
+                throw new io.quarkus.quickcli.CommandLine.ParameterException(
                         String.format("Invalid value '%s' for option '--platform-bom'. " +
                                 "Value should be specified as 'GROUP-ID:ARTIFACT-ID:VERSION'. %s", bom, iex.getMessage()));
             }

--- a/devtools/cli-common/src/main/java/io/quarkus/cli/common/TargetQuarkusVersionGroup.java
+++ b/devtools/cli-common/src/main/java/io/quarkus/cli/common/TargetQuarkusVersionGroup.java
@@ -1,19 +1,19 @@
 package io.quarkus.cli.common;
 
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.Option;
 
 public class TargetQuarkusVersionGroup {
 
-    @CommandLine.Option(paramLabel = "targetStream", names = { "-S",
+    @Option(paramLabel = "targetStream", names = { "-S",
             "--stream" }, description = "A target stream, for example:%n  3.15")
     public String streamId;
 
-    @CommandLine.Option(paramLabel = "targetPlatformVersion", names = { "-P",
+    @Option(paramLabel = "targetPlatformVersion", names = { "-P",
             "--platform-version" }, description = "A specific target Quarkus platform version, for example:%n"
                     + "  3.15.2%n")
     public String platformVersion;
 
-    //@CommandLine.Option(names = { "-L",
+    //@Option(names = { "-L",
     //        "--latest" }, description = "Use the latest Quarkus platform version")
     //public boolean latest;
 }

--- a/devtools/cli-common/src/main/java/io/quarkus/cli/common/build/BuildSystemRunner.java
+++ b/devtools/cli-common/src/main/java/io/quarkus/cli/common/build/BuildSystemRunner.java
@@ -23,7 +23,7 @@ import io.quarkus.cli.common.TargetQuarkusVersionGroup;
 import io.quarkus.cli.common.registry.RegistryClientMixin;
 import io.quarkus.cli.common.update.RewriteGroup;
 import io.quarkus.devtools.project.BuildTool;
-import picocli.CommandLine;
+import io.quarkus.quickcli.ExitCode;
 
 public interface BuildSystemRunner {
 
@@ -51,7 +51,7 @@ public interface BuildSystemRunner {
         } catch (IOException | InterruptedException e) {
             getOutput().error("Command failed. " + e.getMessage());
             getOutput().printStackTrace(e);
-            return CommandLine.ExitCode.SOFTWARE;
+            return ExitCode.SOFTWARE;
         }
     }
 

--- a/devtools/cli-common/src/main/java/io/quarkus/cli/common/build/ExecuteUtil.java
+++ b/devtools/cli-common/src/main/java/io/quarkus/cli/common/build/ExecuteUtil.java
@@ -1,7 +1,7 @@
 package io.quarkus.cli.common.build;
 
-import static picocli.CommandLine.ExitCode.OK;
-import static picocli.CommandLine.ExitCode.SOFTWARE;
+import static io.quarkus.quickcli.ExitCode.OK;
+import static io.quarkus.quickcli.ExitCode.SOFTWARE;
 
 import java.io.File;
 import java.io.IOException;

--- a/devtools/cli-common/src/main/java/io/quarkus/cli/common/build/MavenRunner.java
+++ b/devtools/cli-common/src/main/java/io/quarkus/cli/common/build/MavenRunner.java
@@ -35,9 +35,9 @@ import io.quarkus.devtools.project.QuarkusProjectHelper;
 import io.quarkus.devtools.project.buildfile.MavenProjectBuildFile;
 import io.quarkus.platform.tools.ToolsConstants;
 import io.quarkus.platform.tools.ToolsUtils;
+import io.quarkus.quickcli.ExitCode;
 import io.quarkus.registry.catalog.ExtensionCatalog;
 import io.quarkus.registry.config.RegistriesConfigLocator;
-import picocli.CommandLine;
 
 public class MavenRunner implements BuildSystemRunner {
     public static String MAVEN_SETTINGS = "maven.settings";
@@ -100,7 +100,7 @@ public class MavenRunner implements BuildSystemRunner {
                 .batchMode(runMode.isBatchMode())
                 .execute();
 
-        return outcome.isSuccess() ? CommandLine.ExitCode.OK : CommandLine.ExitCode.SOFTWARE;
+        return outcome.isSuccess() ? ExitCode.OK : ExitCode.SOFTWARE;
     }
 
     @Override
@@ -119,21 +119,21 @@ public class MavenRunner implements BuildSystemRunner {
                 .batchMode(runMode.isBatchMode())
                 .execute();
 
-        return outcome.isSuccess() ? CommandLine.ExitCode.OK : CommandLine.ExitCode.SOFTWARE;
+        return outcome.isSuccess() ? ExitCode.OK : ExitCode.SOFTWARE;
     }
 
     @Override
     public Integer addExtension(RunModeOption runMode, Set<String> extensions) throws Exception {
         AddExtensions invoker = new AddExtensions(quarkusProject());
         invoker.extensions(extensions);
-        return invoker.execute().isSuccess() ? CommandLine.ExitCode.OK : CommandLine.ExitCode.SOFTWARE;
+        return invoker.execute().isSuccess() ? ExitCode.OK : ExitCode.SOFTWARE;
     }
 
     @Override
     public Integer removeExtension(RunModeOption runMode, Set<String> extensions) throws Exception {
         RemoveExtensions invoker = new RemoveExtensions(quarkusProject());
         invoker.extensions(extensions);
-        return invoker.execute().isSuccess() ? CommandLine.ExitCode.OK : CommandLine.ExitCode.SOFTWARE;
+        return invoker.execute().isSuccess() ? ExitCode.OK : ExitCode.SOFTWARE;
     }
 
     @Override

--- a/devtools/cli-common/src/main/java/io/quarkus/cli/common/registry/RegistryClientMixin.java
+++ b/devtools/cli-common/src/main/java/io/quarkus/cli/common/registry/RegistryClientMixin.java
@@ -15,11 +15,11 @@ import io.quarkus.devtools.project.QuarkusProjectHelper;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.platform.tools.ToolsConstants;
 import io.quarkus.platform.tools.ToolsUtils;
+import io.quarkus.quickcli.annotations.Option;
 import io.quarkus.registry.ExtensionCatalogResolver;
 import io.quarkus.registry.RegistryResolutionException;
 import io.quarkus.registry.catalog.ExtensionCatalog;
 import io.quarkus.registry.config.RegistriesConfig;
-import picocli.CommandLine;
 
 public class RegistryClientMixin {
     static final boolean VALIDATE = !Boolean.parseBoolean(System.getenv("REGISTRY_CLIENT_TEST"));
@@ -29,11 +29,11 @@ public class RegistryClientMixin {
         return "-DquarkusRegistryClient=" + enabled();
     }
 
-    @CommandLine.Option(names = {
+    @Option(names = {
             "--refresh" }, description = "Refresh the local Quarkus extension registry cache", defaultValue = "false")
     boolean refresh = false;
 
-    @CommandLine.Option(paramLabel = "CONFIG", names = { "--config" }, description = "Configuration file")
+    @Option(paramLabel = "CONFIG", names = { "--config" }, description = "Configuration file")
     String config;
 
     public boolean enabled() {

--- a/devtools/cli-common/src/main/java/io/quarkus/cli/common/registry/ToggleRegistryClientMixin.java
+++ b/devtools/cli-common/src/main/java/io/quarkus/cli/common/registry/ToggleRegistryClientMixin.java
@@ -1,13 +1,13 @@
 package io.quarkus.cli.common.registry;
 
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.Option;
 
 public class ToggleRegistryClientMixin extends RegistryClientMixin {
 
     boolean useRegistryClient = true;
 
-    @CommandLine.Option(names = { "--registry-client" }, description = "Use the Quarkus extension catalog", negatable = true)
-    void setRegistryClient(boolean enabled) {
+    @Option(names = { "--registry-client" }, description = "Use the Quarkus extension catalog", negatable = true)
+    public void setRegistryClient(boolean enabled) {
         System.setProperty("quarkusRegistryClient", Boolean.toString(enabled));
         useRegistryClient = enabled;
     }

--- a/devtools/cli-common/src/main/java/io/quarkus/cli/common/update/RewriteGroup.java
+++ b/devtools/cli-common/src/main/java/io/quarkus/cli/common/update/RewriteGroup.java
@@ -1,37 +1,38 @@
 package io.quarkus.cli.common.update;
 
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.ArgGroup;
+import io.quarkus.quickcli.annotations.Option;
 
 public class RewriteGroup {
 
-    @CommandLine.ArgGroup(exclusive = true)
+    @ArgGroup(exclusive = true)
     public RewriteRun run;
 
-    @CommandLine.Option(order = 0, names = {
+    @Option(order = 0, names = {
             "--quarkus-update-recipes" }, description = "Use custom io.quarkus:quarkus-update-recipes:LATEST artifact (GAV) or just provide the version. This artifact should contain the base Quarkus update recipes to update a project.")
     public String quarkusUpdateRecipes;
 
-    @CommandLine.Option(order = 1, names = {
+    @Option(order = 1, names = {
             "--rewrite-plugin-version" }, description = "Use a custom OpenRewrite plugin version.")
     public String pluginVersion;
 
-    @CommandLine.Option(order = 2, names = {
+    @Option(order = 2, names = {
             "--additional-update-recipes" }, description = "Specify a list of additional artifacts (GAV) containing rewrite recipes.")
     public String additionalUpdateRecipes;
 
     public static class RewriteRun {
-        @CommandLine.Option(order = 3, names = {
+        @Option(order = 3, names = {
                 "--yes",
                 "-y" }, description = "Run the suggested update recipe for this project.", defaultValue = "false")
         public boolean yes = false;
 
-        @CommandLine.Option(order = 5, names = {
+        @Option(order = 5, names = {
                 "--dry-run",
                 "-n"
         }, description = "Do a dry run of the suggested update recipe for this project and create a patch file.", defaultValue = "false")
         public boolean dryRun = false;
 
-        @CommandLine.Option(order = 4, names = {
+        @Option(order = 4, names = {
                 "--no",
                 "--no-rewrite",
                 "-N" }, description = "Do NOT run the update.", defaultValue = "false")

--- a/devtools/cli/pom.xml
+++ b/devtools/cli/pom.xml
@@ -20,7 +20,7 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-picocli</artifactId>
+            <artifactId>quarkus-quickcli</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -72,6 +72,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
@@ -89,7 +94,7 @@
         <!-- This dependency is here to make sure the build order is correct-->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-picocli-deployment</artifactId>
+            <artifactId>quarkus-quickcli-deployment</artifactId>
             <type>pom</type>
             <scope>test</scope>
             <version>${project.version}</version>
@@ -167,10 +172,17 @@
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>default</id>
                         <goals>
-                            <goal>build</goal>
                             <goal>generate-code</goal>
                             <goal>generate-code-tests</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>build</id>
+                        <phase>process-test-classes</phase>
+                        <goals>
+                            <goal>build</goal>
                         </goals>
                         <configuration>
                             <skipOriginalJarRename>true</skipOriginalJarRename>
@@ -188,6 +200,16 @@
                     <environmentVariables>
                         <JBANG_REPO>${settings.localRepository}</JBANG_REPO>
                     </environmentVariables>
+                    <!-- Each test class gets a fresh JVM fork to prevent Maven's
+                         in-memory resolution cache from causing cross-test failures
+                         (especially for RegistryClientBuilderTestBase subclasses) -->
+                    <reuseForks>false</reuseForks>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <useIncrementalCompilation>false</useIncrementalCompilation>
                 </configuration>
             </plugin>
             <!-- copy the Maven wrapper to make sure we don't inherit the configuration from the root .mvn in the nested projects -->

--- a/devtools/cli/src/main/java/io/quarkus/cli/BaseBuildCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/BaseBuildCommand.java
@@ -10,22 +10,25 @@ import io.quarkus.cli.common.build.BuildSystemRunner;
 import io.quarkus.cli.common.registry.ToggleRegistryClientMixin;
 import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.project.QuarkusProjectHelper;
-import picocli.CommandLine;
+import io.quarkus.quickcli.CommandSpec;
+import io.quarkus.quickcli.annotations.ArgGroup;
+import io.quarkus.quickcli.annotations.Mixin;
+import io.quarkus.quickcli.annotations.Spec;
 
 public class BaseBuildCommand {
-    @CommandLine.Spec
-    protected CommandLine.Model.CommandSpec spec;
+    @Spec
+    protected CommandSpec spec;
 
-    @CommandLine.Mixin(name = "output")
+    @Mixin(name = "output")
     protected OutputOptionMixin output;
 
-    @CommandLine.Mixin
+    @Mixin
     protected ToggleRegistryClientMixin registryClient;
 
-    @CommandLine.Mixin
+    @Mixin
     protected HelpOption helpOption;
 
-    @CommandLine.ArgGroup(exclusive = false, validate = false)
+    @ArgGroup(exclusive = false, validate = false)
     protected PropertiesOptions propertiesOptions = new PropertiesOptions();
 
     Path projectRoot;

--- a/devtools/cli/src/main/java/io/quarkus/cli/Build.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Build.java
@@ -10,16 +10,20 @@ import io.quarkus.cli.common.BuildOptions;
 import io.quarkus.cli.common.RunModeOption;
 import io.quarkus.cli.common.build.BuildSystemRunner;
 import io.quarkus.devtools.project.BuildTool;
-import picocli.CommandLine;
-import picocli.CommandLine.Parameters;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.quickcli.Help;
+import io.quarkus.quickcli.annotations.ArgGroup;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Mixin;
+import io.quarkus.quickcli.annotations.Parameters;
 
-@CommandLine.Command(name = "build", showEndOfOptionsDelimiterInUsageHelp = true, header = "Build the current project.")
+@Command(name = "build", showEndOfOptionsDelimiterInUsageHelp = true, header = "Build the current project.")
 public class Build extends BaseBuildCommand implements Callable<Integer> {
 
-    @CommandLine.Mixin
+    @Mixin
     protected RunModeOption runMode;
 
-    @CommandLine.ArgGroup(order = 1, exclusive = false, validate = false, heading = "%nBuild options:%n")
+    @ArgGroup(order = 1, exclusive = false, validate = false, heading = "%nBuild options:%n")
     BuildOptions buildOptions = new BuildOptions();
 
     @Parameters(description = "Additional parameters passed to the build system")
@@ -42,11 +46,11 @@ public class Build extends BaseBuildCommand implements Callable<Integer> {
 
             if (runMode.isDryRun()) {
                 dryRunBuild(spec.commandLine().getHelp(), runner.getBuildTool(), commandArgs);
-                return CommandLine.ExitCode.OK;
+                return ExitCode.OK;
             }
 
             int exitCode = runner.run(commandArgs);
-            if (exitCode == CommandLine.ExitCode.OK && buildOptions.generateBuildReport) {
+            if (exitCode == ExitCode.OK && buildOptions.generateBuildReport) {
                 output.printText(new String[] {
                         "\nBuild report available: " + new BuildReport(runner).generate().toPath().toAbsolutePath().toString()
                                 + "\n"
@@ -59,7 +63,7 @@ public class Build extends BaseBuildCommand implements Callable<Integer> {
         }
     }
 
-    void dryRunBuild(CommandLine.Help help, BuildTool buildTool, BuildSystemRunner.BuildCommandArgs args) {
+    void dryRunBuild(Help help, BuildTool buildTool, BuildSystemRunner.BuildCommandArgs args) {
         output.printText(new String[] {
                 "\nBuild current project\n",
                 "\t" + projectRoot().toString()

--- a/devtools/cli/src/main/java/io/quarkus/cli/CliPlugins.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/CliPlugins.java
@@ -9,11 +9,15 @@ import io.quarkus.cli.plugin.CliPluginsAdd;
 import io.quarkus.cli.plugin.CliPluginsList;
 import io.quarkus.cli.plugin.CliPluginsRemove;
 import io.quarkus.cli.plugin.CliPluginsSync;
-import picocli.CommandLine;
-import picocli.CommandLine.ParseResult;
-import picocli.CommandLine.Unmatched;
+import io.quarkus.quickcli.CommandLine;
+import io.quarkus.quickcli.CommandSpec;
+import io.quarkus.quickcli.ParseResult;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Mixin;
+import io.quarkus.quickcli.annotations.Spec;
+import io.quarkus.quickcli.annotations.Unmatched;
 
-@CommandLine.Command(name = "plugin", aliases = { "plug" }, header = "Configure plugins of the Quarkus CLI.", subcommands = {
+@Command(name = "plugin", aliases = { "plug" }, header = "Configure plugins of the Quarkus CLI.", subcommands = {
         CliPluginsList.class,
         CliPluginsAdd.class,
         CliPluginsRemove.class,
@@ -21,11 +25,11 @@ import picocli.CommandLine.Unmatched;
 })
 public class CliPlugins implements Callable<Integer> {
 
-    @CommandLine.Mixin(name = "output")
+    @Mixin(name = "output")
     protected OutputOptionMixin output;
 
-    @CommandLine.Spec
-    protected CommandLine.Model.CommandSpec spec;
+    @Spec
+    protected CommandSpec spec;
 
     @Unmatched // avoids throwing errors for unmatched arguments
     List<String> unmatchedArgs;
@@ -36,7 +40,7 @@ public class CliPlugins implements Callable<Integer> {
         ParseResult result = spec.commandLine().getParseResult();
         List<String> args = result.originalArgs().stream().filter(x -> !"plugin".equals(x) && !"plug".equals(x))
                 .collect(Collectors.toList());
-        CommandLine listCommand = spec.subcommands().get("list");
+        CommandLine listCommand = spec.commandLine().getSubcommands().get("list");
         return listCommand.execute(args.toArray(new String[0]));
     }
 }

--- a/devtools/cli/src/main/java/io/quarkus/cli/Completion.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Completion.java
@@ -1,10 +1,30 @@
 package io.quarkus.cli;
 
-import picocli.AutoComplete.GenerateCompletion;
-import picocli.CommandLine;
+import java.util.concurrent.Callable;
 
-@CommandLine.Command(name = "completion", version = "generate-completion "
+import io.quarkus.quickcli.AutoComplete;
+import io.quarkus.quickcli.CommandLine;
+import io.quarkus.quickcli.CommandSpec;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Spec;
+
+@Command(name = "completion", version = "generate-completion "
         + CommandLine.VERSION, header = "bash/zsh completion:  source <(${PARENT-COMMAND-FULL-NAME:-$PARENTCOMMAND} ${COMMAND-NAME})", helpCommand = true)
-public class Completion extends GenerateCompletion {
+public class Completion implements Callable<Integer> {
 
+    @Spec
+    CommandSpec spec;
+
+    @Override
+    public Integer call() {
+        String script = AutoComplete.bash(
+                spec.root().name(),
+                spec.root());
+        // not println: scripts with Windows line separators fail in strange ways
+        System.out.print(script);
+        System.out.print('\n');
+        System.out.flush();
+        return ExitCode.OK;
+    }
 }

--- a/devtools/cli/src/main/java/io/quarkus/cli/Config.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Config.java
@@ -9,27 +9,30 @@ import io.quarkus.cli.config.Decrypt;
 import io.quarkus.cli.config.Encrypt;
 import io.quarkus.cli.config.RemoveConfig;
 import io.quarkus.cli.config.SetConfig;
-import picocli.CommandLine;
-import picocli.CommandLine.Command;
+import io.quarkus.quickcli.CommandSpec;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Mixin;
+import io.quarkus.quickcli.annotations.Spec;
+import io.quarkus.quickcli.annotations.Unmatched;
 
 @Command(name = "config", header = "Manage Quarkus configuration", subcommands = { SetConfig.class, RemoveConfig.class,
         Encrypt.class, Decrypt.class })
 public class Config implements Callable<Integer> {
-    @CommandLine.Mixin(name = "output")
+    @Mixin(name = "output")
     protected OutputOptionMixin output;
 
-    @CommandLine.Mixin
+    @Mixin
     protected HelpOption helpOption;
 
-    @CommandLine.Spec
-    protected CommandLine.Model.CommandSpec spec;
+    @Spec
+    protected CommandSpec spec;
 
-    @CommandLine.Unmatched // avoids throwing errors for unmatched arguments
+    @Unmatched // avoids throwing errors for unmatched arguments
     List<String> unmatchedArgs;
 
     @Override
     public Integer call() throws Exception {
-        spec.commandLine().usage(System.out);
+        spec.commandLine().usage(output.out());
         return 0;
     }
 }

--- a/devtools/cli/src/main/java/io/quarkus/cli/Create.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Create.java
@@ -5,24 +5,28 @@ import java.util.concurrent.Callable;
 
 import io.quarkus.cli.common.HelpOption;
 import io.quarkus.cli.common.OutputOptionMixin;
-import picocli.CommandLine;
-import picocli.CommandLine.ParseResult;
-import picocli.CommandLine.Unmatched;
+import io.quarkus.quickcli.CommandLine;
+import io.quarkus.quickcli.CommandSpec;
+import io.quarkus.quickcli.ParseResult;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Mixin;
+import io.quarkus.quickcli.annotations.Spec;
+import io.quarkus.quickcli.annotations.Unmatched;
 
-@CommandLine.Command(name = "create", header = "Create a new project.", subcommands = {
+@Command(name = "create", header = "Create a new project.", subcommands = {
         CreateApp.class,
         CreateCli.class,
         CreateExtension.class })
 public class Create implements Callable<Integer> {
 
-    @CommandLine.Mixin(name = "output")
+    @Mixin(name = "output")
     protected OutputOptionMixin output;
 
-    @CommandLine.Mixin
+    @Mixin
     protected HelpOption helpOption;
 
-    @CommandLine.Spec
-    protected CommandLine.Model.CommandSpec spec;
+    @Spec
+    protected CommandSpec spec;
 
     @Unmatched // avoids throwing errors for unmatched arguments
     List<String> unmatchedArgs;
@@ -31,7 +35,7 @@ public class Create implements Callable<Integer> {
         output.info("Creating an app (default project type, see --help).");
 
         ParseResult result = spec.commandLine().getParseResult();
-        CommandLine appCommand = spec.subcommands().get("app");
+        CommandLine appCommand = spec.commandLine().getSubcommands().get("app");
         return appCommand.execute(result.originalArgs().stream().filter(x -> !"create".equals(x)).toArray(String[]::new));
     }
 }

--- a/devtools/cli/src/main/java/io/quarkus/cli/CreateApp.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/CreateApp.java
@@ -17,44 +17,48 @@ import io.quarkus.devtools.commands.handlers.CreateJBangProjectCommandHandler;
 import io.quarkus.devtools.commands.handlers.CreateProjectCommandHandler;
 import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.project.SourceType;
-import picocli.CommandLine;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.quickcli.annotations.ArgGroup;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Mixin;
+import io.quarkus.quickcli.annotations.Option;
 
-@CommandLine.Command(name = "app", header = "Create a Quarkus application project.", description = "%n"
+@Command(name = "app", header = "Create a Quarkus application project.", description = "%n"
         + "This command will create a Java project in a new ARTIFACT-ID directory", footer = { "%n"
                 + "For example (using default values), a new Java project will be created in a 'code-with-quarkus' directory; "
                 + "it will use Maven to build an artifact with GROUP-ID='org.acme', ARTIFACT-ID='code-with-quarkus', and VERSION='1.0.0-SNAPSHOT'."
                 + "%n" })
 public class CreateApp extends BaseCreateCommand {
-    @CommandLine.Mixin
+    @Mixin
     TargetGAVGroup gav = new TargetGAVGroup();
 
-    @CommandLine.Option(order = 1, paramLabel = "EXTENSION", names = { "-x",
+    @Option(order = 1, paramLabel = "EXTENSION", names = { "-x",
             "--extension", "--extensions" }, description = "Extension(s) to add to the project.", split = ",")
     Set<String> extensions = new HashSet<>();
 
-    @CommandLine.Option(order = 2, paramLabel = "NAME", names = { "--name" }, description = "Name of the project.")
+    @Option(order = 2, paramLabel = "NAME", names = { "--name" }, description = "Name of the project.")
     String name;
 
-    @CommandLine.Option(order = 3, paramLabel = "DESCRIPTION", names = {
+    @Option(order = 3, paramLabel = "DESCRIPTION", names = {
             "--description" }, description = "Description of the project.")
     String description;
 
-    @CommandLine.ArgGroup(order = 4, heading = "%nQuarkus version:%n")
+    @ArgGroup(order = 4, heading = "%nQuarkus version:%n")
     TargetQuarkusPlatformGroup targetQuarkusVersion = new TargetQuarkusPlatformGroup();
 
-    @CommandLine.ArgGroup(order = 5, heading = "%nBuild tool (Maven):%n")
+    @ArgGroup(order = 5, heading = "%nBuild tool (Maven):%n")
     TargetBuildToolGroup targetBuildTool = new TargetBuildToolGroup();
 
-    @CommandLine.ArgGroup(order = 6, exclusive = false, heading = "%nTarget language:%n")
+    @ArgGroup(order = 6, exclusive = false, heading = "%nTarget language:%n")
     TargetLanguageGroup targetLanguage = new TargetLanguageGroup();
 
-    @CommandLine.ArgGroup(order = 7, exclusive = false, heading = "%nCode Generation:%n")
+    @ArgGroup(order = 7, exclusive = false, heading = "%nCode Generation:%n")
     CodeGenerationGroup codeGeneration = new CodeGenerationGroup();
 
-    @CommandLine.ArgGroup(order = 8, exclusive = false, validate = false)
+    @ArgGroup(order = 8, exclusive = false, validate = false)
     DataOptions dataOptions = new DataOptions();
 
-    @CommandLine.ArgGroup(order = 9, exclusive = false, validate = false)
+    @ArgGroup(order = 9, exclusive = false, validate = false)
     PropertiesOptions propertiesOptions = new PropertiesOptions();
 
     @Override
@@ -66,7 +70,7 @@ public class CreateApp extends BaseCreateCommand {
             setSingleProjectGAV(gav);
             setTestOutputDirectory(output.getTestDirectory());
             if (checkProjectRootAlreadyExists(runMode.isDryRun())) {
-                return CommandLine.ExitCode.USAGE;
+                return ExitCode.USAGE;
             }
 
             BuildTool buildTool = targetBuildTool.getBuildTool(BuildTool.MAVEN);
@@ -96,9 +100,9 @@ public class CreateApp extends BaseCreateCommand {
                     output.info(
                             "Navigate into this directory and get started: " + spec.root().qualifiedName() + " dev");
                 }
-                return CommandLine.ExitCode.OK;
+                return ExitCode.OK;
             }
-            return CommandLine.ExitCode.SOFTWARE;
+            return ExitCode.SOFTWARE;
         } catch (Exception e) {
             return output.handleCommandException(e,
                     "Unable to create project: " + e.getLocalizedMessage());

--- a/devtools/cli/src/main/java/io/quarkus/cli/CreateCli.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/CreateCli.java
@@ -17,44 +17,48 @@ import io.quarkus.devtools.commands.handlers.CreateJBangProjectCommandHandler;
 import io.quarkus.devtools.commands.handlers.CreateProjectCommandHandler;
 import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.project.SourceType;
-import picocli.CommandLine;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.quickcli.annotations.ArgGroup;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Mixin;
+import io.quarkus.quickcli.annotations.Option;
 
-@CommandLine.Command(name = "cli", header = "Create a Quarkus command-line project.", description = "%n"
+@Command(name = "cli", header = "Create a Quarkus command-line project.", description = "%n"
         + "This command will create a Java project in a new ARTIFACT-ID directory.", footer = { "%n"
                 + "For example (using default values), a new Java project will be created in a 'code-with-quarkus' directory; "
                 + "it will use Maven to build an artifact with GROUP-ID='org.acme', ARTIFACT-ID='code-with-quarkus', and VERSION='1.0.0-SNAPSHOT'."
                 + "%n" })
 public class CreateCli extends BaseCreateCommand {
-    @CommandLine.Mixin
+    @Mixin
     TargetGAVGroup gav = new TargetGAVGroup();
 
-    @CommandLine.Option(order = 1, paramLabel = "EXTENSION", names = { "-x",
+    @Option(order = 1, paramLabel = "EXTENSION", names = { "-x",
             "--extension", "--extensions" }, description = "Extension(s) to add to the project.", split = ",")
     Set<String> extensions = new HashSet<>();
 
-    @CommandLine.Option(order = 2, paramLabel = "NAME", names = { "--name" }, description = "Name of the project.")
+    @Option(order = 2, paramLabel = "NAME", names = { "--name" }, description = "Name of the project.")
     String name;
 
-    @CommandLine.Option(order = 3, paramLabel = "DESCRIPTION", names = {
+    @Option(order = 3, paramLabel = "DESCRIPTION", names = {
             "--description" }, description = "Description of the project.")
     String description;
 
-    @CommandLine.ArgGroup(order = 4, heading = "%nQuarkus version:%n")
+    @ArgGroup(order = 4, heading = "%nQuarkus version:%n")
     TargetQuarkusPlatformGroup targetQuarkusVersion = new TargetQuarkusPlatformGroup();
 
-    @CommandLine.ArgGroup(order = 5, heading = "%nBuild tool (Maven):%n")
+    @ArgGroup(order = 5, heading = "%nBuild tool (Maven):%n")
     TargetBuildToolGroup targetBuildTool = new TargetBuildToolGroup();
 
-    @CommandLine.ArgGroup(order = 6, exclusive = false, heading = "%nTarget language:%n")
+    @ArgGroup(order = 6, exclusive = false, heading = "%nTarget language:%n")
     TargetLanguageGroup targetLanguage = new TargetLanguageGroup();
 
-    @CommandLine.ArgGroup(order = 7, exclusive = false, heading = "%nCode Generation:%n")
+    @ArgGroup(order = 7, exclusive = false, heading = "%nCode Generation:%n")
     CodeGenerationGroup codeGeneration = new CodeGenerationGroup();
 
-    @CommandLine.ArgGroup(order = 8, exclusive = false, validate = false)
+    @ArgGroup(order = 8, exclusive = false, validate = false)
     DataOptions dataOptions = new DataOptions();
 
-    @CommandLine.ArgGroup(order = 9, exclusive = false, validate = false)
+    @ArgGroup(order = 9, exclusive = false, validate = false)
     PropertiesOptions propertiesOptions = new PropertiesOptions();
 
     @Override
@@ -68,7 +72,7 @@ public class CreateCli extends BaseCreateCommand {
             setSingleProjectGAV(gav);
             setTestOutputDirectory(output.getTestDirectory());
             if (checkProjectRootAlreadyExists(false)) {
-                return CommandLine.ExitCode.USAGE;
+                return ExitCode.USAGE;
             }
 
             BuildTool buildTool = targetBuildTool.getBuildTool(BuildTool.MAVEN);
@@ -97,9 +101,9 @@ public class CreateCli extends BaseCreateCommand {
                     output.info(
                             "Navigate into this directory and get started: " + spec.root().qualifiedName() + " dev");
                 }
-                return CommandLine.ExitCode.OK;
+                return ExitCode.OK;
             }
-            return CommandLine.ExitCode.SOFTWARE;
+            return ExitCode.SOFTWARE;
         } catch (Exception e) {
             return output.handleCommandException(e,
                     "Unable to create project: " + e.getMessage());

--- a/devtools/cli/src/main/java/io/quarkus/cli/CreateExtension.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/CreateExtension.java
@@ -18,10 +18,15 @@ import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.project.JavaVersion;
 import io.quarkus.devtools.project.QuarkusProject;
 import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.quickcli.Help;
+import io.quarkus.quickcli.annotations.ArgGroup;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Mixin;
+import io.quarkus.quickcli.annotations.Option;
 import io.quarkus.registry.catalog.ExtensionCatalog;
-import picocli.CommandLine;
 
-@CommandLine.Command(name = "extension", header = "Create a Quarkus extension project", description = "%n"
+@Command(name = "extension", header = "Create a Quarkus extension project", description = "%n"
         + "Quarkus extensions are built from multiple modules: runtime, deployment, integration-test and "
         + "docs. This command will generate a Maven multi-module project in a directory called EXTENSION-ID "
         + "by applying naming conventions to the specified EXTENSION-ID.", footer = { "%nDefault Naming conventions%n",
@@ -77,27 +82,24 @@ public class CreateExtension extends BaseCreateCommand {
         }
     }
 
-    @CommandLine.Spec
-    protected CommandLine.Model.CommandSpec spec;
-
-    @CommandLine.Mixin
+    @Mixin
     ExtensionGAVMixin gav = new ExtensionGAVMixin();
 
-    @CommandLine.ArgGroup(order = 1, heading = "%nQuarkus version:%n")
+    @ArgGroup(order = 1, heading = "%nQuarkus version:%n")
     TargetQuarkusPlatformGroup targetQuarkusVersion = new TargetQuarkusPlatformGroup();
 
     // Ideally we should use TargetLanguageGroup once we support creating extensions with Kotlin
-    @CommandLine.Option(names = {
+    @Option(names = {
             "--java" }, description = "Target Java version.\n  Valid values: ${COMPLETION-CANDIDATES}", completionCandidates = VersionCandidates.class, defaultValue = JavaVersion.DEFAULT_JAVA_VERSION_FOR_EXTENSION)
     String javaVersion;
 
-    @CommandLine.ArgGroup(order = 2, exclusive = false, heading = "%nGenerated artifacts%n")
+    @ArgGroup(order = 2, exclusive = false, heading = "%nGenerated artifacts%n")
     ExtensionNameGenerationGroup nameGeneration = new ExtensionNameGenerationGroup();
 
-    @CommandLine.ArgGroup(order = 3, exclusive = false, heading = "%nCode Generation (Optional):%n")
+    @ArgGroup(order = 3, exclusive = false, heading = "%nCode Generation (Optional):%n")
     ExtensionCodeGenerationGroup codeGeneration = new ExtensionCodeGenerationGroup();
 
-    @CommandLine.ArgGroup(order = 4, exclusive = false, validate = false)
+    @ArgGroup(order = 4, exclusive = false, validate = false)
     PropertiesOptions propertiesOptions = new PropertiesOptions();
 
     @Override
@@ -109,7 +111,7 @@ public class CreateExtension extends BaseCreateCommand {
             setExtensionId(gav.getExtensionId());
             setTestOutputDirectory(output.getTestDirectory());
             if (checkProjectRootAlreadyExists(runMode.isDryRun())) {
-                return CommandLine.ExitCode.USAGE;
+                return ExitCode.USAGE;
             }
 
             BuildTool buildTool = BuildTool.MAVEN;
@@ -151,9 +153,9 @@ public class CreateExtension extends BaseCreateCommand {
                     output.info(
                             "Navigate into this directory and get started: " + spec.root().qualifiedName() + " build");
                 }
-                return CommandLine.ExitCode.OK;
+                return ExitCode.OK;
             }
-            return CommandLine.ExitCode.SOFTWARE;
+            return ExitCode.SOFTWARE;
         } catch (Exception e) {
             output.error("Extension creation failed, " + e.getMessage());
             return output.handleCommandException(e,
@@ -162,7 +164,7 @@ public class CreateExtension extends BaseCreateCommand {
     }
 
     public void dryRun(BuildTool buildTool, CreateExtensionCommandHandler invocation, OutputOptionMixin output) {
-        CommandLine.Help help = spec.commandLine().getHelp();
+        Help help = spec.commandLine().getHelp();
         output.printText(new String[] {
                 "\nA new extension would have been created in",
                 "\t" + outputDirectory().toString(),

--- a/devtools/cli/src/main/java/io/quarkus/cli/Deploy.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Deploy.java
@@ -9,9 +9,9 @@ import io.quarkus.cli.deploy.Kubernetes;
 import io.quarkus.cli.deploy.Minikube;
 import io.quarkus.cli.deploy.Openshift;
 import io.quarkus.devtools.project.BuildTool;
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.Command;
 
-@CommandLine.Command(name = "deploy", sortOptions = false, mixinStandardHelpOptions = false, header = "Deploy application.", subcommands = {
+@Command(name = "deploy", sortOptions = false, mixinStandardHelpOptions = false, header = "Deploy application.", subcommands = {
         Kubernetes.class, Openshift.class, Knative.class, Kind.class, Minikube.class,
 }, headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", optionListHeading = "%nOptions:%n")
 public class Deploy extends BuildToolDelegatingCommand {

--- a/devtools/cli/src/main/java/io/quarkus/cli/Dev.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Dev.java
@@ -11,16 +11,19 @@ import io.quarkus.cli.common.DebugOptions;
 import io.quarkus.cli.common.DevOptions;
 import io.quarkus.cli.common.build.BuildSystemRunner;
 import io.quarkus.devtools.project.BuildTool;
-import picocli.CommandLine;
-import picocli.CommandLine.Parameters;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.quickcli.Help;
+import io.quarkus.quickcli.annotations.ArgGroup;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Parameters;
 
-@CommandLine.Command(name = "dev", showEndOfOptionsDelimiterInUsageHelp = true, header = "Run the current project in dev (live coding) mode.")
+@Command(name = "dev", showEndOfOptionsDelimiterInUsageHelp = true, header = "Run the current project in dev (live coding) mode.")
 public class Dev extends BaseBuildCommand implements Callable<Integer> {
 
-    @CommandLine.ArgGroup(order = 1, exclusive = false, heading = "%nDev Mode options:%n")
+    @ArgGroup(order = 1, exclusive = false, heading = "%nDev Mode options:%n")
     DevOptions devOptions = new DevOptions();
 
-    @CommandLine.ArgGroup(order = 3, exclusive = false, validate = true, heading = "%nDebug options:%n")
+    @ArgGroup(order = 3, exclusive = false, validate = true, heading = "%nDebug options:%n")
     DebugOptions debugOptions = new DebugOptions();
 
     @Parameters(description = "Parameters passed to the application.")
@@ -38,7 +41,7 @@ public class Dev extends BaseBuildCommand implements Callable<Integer> {
 
             if (devOptions.isDryRun()) {
                 dryRunDev(spec.commandLine().getHelp(), runner.getBuildTool(), commandArgs.iterator().next().get());
-                return CommandLine.ExitCode.OK;
+                return ExitCode.OK;
             }
             Integer ret = 1;
             for (Supplier<BuildSystemRunner.BuildCommandArgs> i : commandArgs) {
@@ -54,7 +57,7 @@ public class Dev extends BaseBuildCommand implements Callable<Integer> {
         }
     }
 
-    void dryRunDev(CommandLine.Help help, BuildTool buildTool, BuildSystemRunner.BuildCommandArgs args) {
+    void dryRunDev(Help help, BuildTool buildTool, BuildSystemRunner.BuildCommandArgs args) {
         output.printText(new String[] {
                 "\nRun current project in dev mode\n",
                 "\t" + projectRoot().toString()

--- a/devtools/cli/src/main/java/io/quarkus/cli/Image.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Image.java
@@ -7,30 +7,34 @@ import io.quarkus.cli.common.HelpOption;
 import io.quarkus.cli.common.OutputOptionMixin;
 import io.quarkus.cli.image.Build;
 import io.quarkus.cli.image.Push;
-import picocli.CommandLine;
-import picocli.CommandLine.ParseResult;
-import picocli.CommandLine.Unmatched;
+import io.quarkus.quickcli.CommandLine;
+import io.quarkus.quickcli.CommandSpec;
+import io.quarkus.quickcli.ParseResult;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Mixin;
+import io.quarkus.quickcli.annotations.Spec;
+import io.quarkus.quickcli.annotations.Unmatched;
 
-@CommandLine.Command(name = "image", sortOptions = false, mixinStandardHelpOptions = false, header = "Build or push project container image.", subcommands = {
+@Command(name = "image", sortOptions = false, mixinStandardHelpOptions = false, header = "Build or push project container image.", subcommands = {
         Build.class, Push.class
 }, headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", optionListHeading = "%nOptions:%n")
 public class Image implements Callable<Integer> {
 
-    @CommandLine.Mixin(name = "output")
+    @Mixin(name = "output")
     protected OutputOptionMixin output;
 
-    @CommandLine.Mixin
+    @Mixin
     protected HelpOption helpOption;
 
-    @CommandLine.Spec
-    protected CommandLine.Model.CommandSpec spec;
+    @Spec
+    protected CommandSpec spec;
 
     @Unmatched // avoids throwing errors for unmatched arguments
     List<String> unmatchedArgs;
 
     public Integer call() throws Exception {
         ParseResult result = spec.commandLine().getParseResult();
-        CommandLine buildCommand = spec.subcommands().get("build");
+        CommandLine buildCommand = spec.commandLine().getSubcommands().get("build");
         return buildCommand.execute(result.originalArgs().stream().filter(x -> !"image".equals(x)).toArray(String[]::new));
     }
 }

--- a/devtools/cli/src/main/java/io/quarkus/cli/Info.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Info.java
@@ -3,12 +3,13 @@ package io.quarkus.cli;
 import java.util.concurrent.Callable;
 
 import io.quarkus.cli.common.build.BuildSystemRunner;
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Option;
 
-@CommandLine.Command(name = "info", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Display project information and verify versions health (platform and extensions).", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "%nOptions:%n")
+@Command(name = "info", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Display project information and verify versions health (platform and extensions).", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "%nOptions:%n")
 public class Info extends BaseBuildCommand implements Callable<Integer> {
 
-    @CommandLine.Option(names = { "--per-module" }, description = "Display information per project module.")
+    @Option(names = { "--per-module" }, description = "Display information per project module.")
     public boolean perModule = false;
 
     @Override

--- a/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensions.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensions.java
@@ -5,11 +5,15 @@ import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
 import io.quarkus.cli.common.OutputOptionMixin;
-import picocli.CommandLine;
-import picocli.CommandLine.ParseResult;
-import picocli.CommandLine.Unmatched;
+import io.quarkus.quickcli.CommandLine;
+import io.quarkus.quickcli.CommandSpec;
+import io.quarkus.quickcli.ParseResult;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Mixin;
+import io.quarkus.quickcli.annotations.Spec;
+import io.quarkus.quickcli.annotations.Unmatched;
 
-@CommandLine.Command(name = "extension", aliases = {
+@Command(name = "extension", aliases = {
         "ext" }, header = "Configure extensions of an existing project.", subcommands = {
                 ProjectExtensionsList.class,
                 ProjectExtensionsCategories.class,
@@ -17,11 +21,11 @@ import picocli.CommandLine.Unmatched;
                 ProjectExtensionsRemove.class })
 public class ProjectExtensions implements Callable<Integer> {
 
-    @CommandLine.Mixin(name = "output")
+    @Mixin(name = "output")
     protected OutputOptionMixin output;
 
-    @CommandLine.Spec
-    protected CommandLine.Model.CommandSpec spec;
+    @Spec
+    protected CommandSpec spec;
 
     @Unmatched // avoids throwing errors for unmatched arguments
     List<String> unmatchedArgs;
@@ -33,7 +37,7 @@ public class ProjectExtensions implements Callable<Integer> {
         ParseResult result = spec.commandLine().getParseResult();
         List<String> args = result.originalArgs().stream().filter(x -> !"extension".equals(x) && !"ext".equals(x))
                 .collect(Collectors.toList());
-        CommandLine listCommand = spec.subcommands().get("list");
+        CommandLine listCommand = spec.commandLine().getSubcommands().get("list");
         return listCommand.execute(args.toArray(new String[0]));
     }
 }

--- a/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsAdd.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsAdd.java
@@ -8,15 +8,19 @@ import java.util.concurrent.Callable;
 import io.quarkus.cli.common.RunModeOption;
 import io.quarkus.cli.common.build.BuildSystemRunner;
 import io.quarkus.devtools.project.BuildTool;
-import picocli.CommandLine;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.quickcli.Help;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Mixin;
+import io.quarkus.quickcli.annotations.Parameters;
 
-@CommandLine.Command(name = "add", header = "Add extension(s) to this project.")
+@Command(name = "add", header = "Add extension(s) to this project.")
 public class ProjectExtensionsAdd extends BaseBuildCommand implements Callable<Integer> {
 
-    @CommandLine.Mixin
+    @Mixin
     RunModeOption runMode;
 
-    @CommandLine.Parameters(arity = "1", paramLabel = "EXTENSION", description = "extensions to add to this project", split = ",")
+    @Parameters(arity = "1", paramLabel = "EXTENSION", description = "extensions to add to this project", split = ",")
     Set<String> extensions;
 
     @Override
@@ -28,7 +32,7 @@ public class ProjectExtensionsAdd extends BaseBuildCommand implements Callable<I
             BuildSystemRunner runner = getRunner();
             if (runMode.isDryRun()) {
                 dryRunAdd(spec.commandLine().getHelp(), runner.getBuildTool());
-                return CommandLine.ExitCode.OK;
+                return ExitCode.OK;
             }
 
             return runner.addExtension(runMode, extensions);
@@ -38,7 +42,7 @@ public class ProjectExtensionsAdd extends BaseBuildCommand implements Callable<I
         }
     }
 
-    void dryRunAdd(CommandLine.Help help, BuildTool buildTool) {
+    void dryRunAdd(Help help, BuildTool buildTool) {
         output.printText(new String[] {
                 "\nAdd extensions to the current project\n",
                 "\t" + projectRoot().toString()

--- a/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsCategories.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsCategories.java
@@ -14,19 +14,23 @@ import io.quarkus.devtools.commands.data.QuarkusCommandOutcome;
 import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.project.QuarkusProject;
 import io.quarkus.devtools.project.QuarkusProjectHelper;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.quickcli.Help;
+import io.quarkus.quickcli.annotations.ArgGroup;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Mixin;
 import io.quarkus.registry.RegistryResolutionException;
-import picocli.CommandLine;
 
-@CommandLine.Command(name = "categories", aliases = "cat", header = "List extension categories.")
+@Command(name = "categories", aliases = "cat", header = "List extension categories.")
 public class ProjectExtensionsCategories extends BaseBuildCommand implements Callable<Integer> {
 
-    @CommandLine.Mixin
+    @Mixin
     RunModeOption runMode;
 
-    @CommandLine.ArgGroup(heading = "%nOutput format:%n")
+    @ArgGroup(heading = "%nOutput format:%n")
     CategoryListFormatOptions format = new CategoryListFormatOptions();
 
-    @CommandLine.ArgGroup(order = 2, heading = "%nQuarkus version:%n")
+    @ArgGroup(order = 2, heading = "%nQuarkus version:%n")
     TargetQuarkusPlatformGroup targetQuarkusVersion = new TargetQuarkusPlatformGroup();
 
     @Override
@@ -62,7 +66,7 @@ public class ProjectExtensionsCategories extends BaseBuildCommand implements Cal
         }
     }
 
-    Integer dryRunList(CommandLine.Help help, BuildTool buildTool) {
+    Integer dryRunList(Help help, BuildTool buildTool) {
         Map<String, String> dryRunOutput = new TreeMap<>();
 
         if (buildTool == null) {
@@ -82,7 +86,7 @@ public class ProjectExtensionsCategories extends BaseBuildCommand implements Cal
         dryRunOutput.put("List format", format.getFormatString());
 
         output.info(help.createTextTable(dryRunOutput).toString());
-        return CommandLine.ExitCode.OK;
+        return ExitCode.OK;
     }
 
     Integer listPlatformCategories() throws QuarkusCommandException, RegistryResolutionException {
@@ -95,7 +99,7 @@ public class ProjectExtensionsCategories extends BaseBuildCommand implements Cal
                 .batchMode(runMode.isBatchMode())
                 .execute();
 
-        return outcome.isSuccess() ? CommandLine.ExitCode.OK : CommandLine.ExitCode.SOFTWARE;
+        return outcome.isSuccess() ? ExitCode.OK : ExitCode.SOFTWARE;
     }
 
     private void printHints(boolean formatHint, boolean extensionListHint) {

--- a/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsList.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsList.java
@@ -14,10 +14,15 @@ import io.quarkus.devtools.commands.data.QuarkusCommandOutcome;
 import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.project.QuarkusProject;
 import io.quarkus.devtools.project.QuarkusProjectHelper;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.quickcli.Help;
+import io.quarkus.quickcli.annotations.ArgGroup;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Mixin;
+import io.quarkus.quickcli.annotations.Option;
 import io.quarkus.registry.RegistryResolutionException;
-import picocli.CommandLine;
 
-@CommandLine.Command(name = "list", aliases = "ls", header = "List platforms and extensions. ", footer = {
+@Command(name = "list", aliases = "ls", header = "List platforms and extensions. ", footer = {
         "%nList modes:%n",
         "(relative). Active when invoked within a project unless an explicit release is specified. " +
                 "The current project configuration will determine what extensions are listed, " +
@@ -27,25 +32,25 @@ import picocli.CommandLine;
                 "The CLI release will be used if this command is invoked outside of a project and no other release is specified.%n" })
 public class ProjectExtensionsList extends BaseBuildCommand implements Callable<Integer> {
 
-    @CommandLine.Mixin
+    @Mixin
     RunModeOption runMode;
 
-    @CommandLine.ArgGroup(order = 2, heading = "%nQuarkus version (absolute):%n")
+    @ArgGroup(order = 2, heading = "%nQuarkus version (absolute):%n")
     TargetQuarkusPlatformGroup targetQuarkusVersion = new TargetQuarkusPlatformGroup();
 
-    @CommandLine.Option(names = { "-i",
+    @Option(names = { "-i",
             "--installable" }, defaultValue = "false", order = 2, description = "List extensions that can be installed (relative)")
     boolean installable = false;
 
-    @CommandLine.Option(names = { "-s",
+    @Option(names = { "-s",
             "--search" }, defaultValue = "*", paramLabel = "PATTERN", order = 3, description = "Search for matching extensions (simple glob using '*' and '?').")
     String searchPattern;
 
-    @CommandLine.Option(names = { "-c",
+    @Option(names = { "-c",
             "--category" }, defaultValue = "", paramLabel = "CATEGORY_ID", order = 4, description = "Only list extensions from the specified category.")
     String category;
 
-    @CommandLine.ArgGroup(heading = "%nOutput format:%n")
+    @ArgGroup(heading = "%nOutput format:%n")
     ListFormatOptions format = new ListFormatOptions();
 
     @Override
@@ -88,7 +93,7 @@ public class ProjectExtensionsList extends BaseBuildCommand implements Callable<
         }
     }
 
-    Integer dryRunList(CommandLine.Help help, BuildTool buildTool) {
+    Integer dryRunList(Help help, BuildTool buildTool) {
         Map<String, String> dryRunOutput = new TreeMap<>();
 
         if (buildTool == null) {
@@ -112,7 +117,7 @@ public class ProjectExtensionsList extends BaseBuildCommand implements Callable<
         dryRunOutput.put("Registry Client", Boolean.toString(registryClient.enabled()));
 
         output.info(help.createTextTable(dryRunOutput).toString());
-        return CommandLine.ExitCode.OK;
+        return ExitCode.OK;
     }
 
     Integer listPlatformExtensions() throws QuarkusCommandException, RegistryResolutionException {
@@ -128,7 +133,7 @@ public class ProjectExtensionsList extends BaseBuildCommand implements Callable<
                 .batchMode(runMode.isBatchMode())
                 .execute();
 
-        return outcome.isSuccess() ? CommandLine.ExitCode.OK : CommandLine.ExitCode.SOFTWARE;
+        return outcome.isSuccess() ? ExitCode.OK : ExitCode.SOFTWARE;
     }
 
     private void printHints(BuildTool buildTool, boolean formatHint, boolean filterHint, boolean addExtensionHint) {

--- a/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsRemove.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsRemove.java
@@ -8,15 +8,19 @@ import java.util.concurrent.Callable;
 import io.quarkus.cli.common.RunModeOption;
 import io.quarkus.cli.common.build.BuildSystemRunner;
 import io.quarkus.devtools.project.BuildTool;
-import picocli.CommandLine;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.quickcli.Help;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Mixin;
+import io.quarkus.quickcli.annotations.Parameters;
 
-@CommandLine.Command(name = "remove", aliases = "rm", header = "Remove extension(s) from this project.")
+@Command(name = "remove", aliases = "rm", header = "Remove extension(s) from this project.")
 public class ProjectExtensionsRemove extends BaseBuildCommand implements Callable<Integer> {
 
-    @CommandLine.Mixin
+    @Mixin
     RunModeOption runMode;
 
-    @CommandLine.Parameters(arity = "1", paramLabel = "EXTENSION", description = "Extension(s) to remove from this project.", split = ",")
+    @Parameters(arity = "1", paramLabel = "EXTENSION", description = "Extension(s) to remove from this project.", split = ",")
     Set<String> extensions;
 
     @Override
@@ -28,7 +32,7 @@ public class ProjectExtensionsRemove extends BaseBuildCommand implements Callabl
             BuildSystemRunner runner = getRunner();
             if (runMode.isDryRun()) {
                 dryRunRemove(spec.commandLine().getHelp(), runner.getBuildTool());
-                return CommandLine.ExitCode.OK;
+                return ExitCode.OK;
             }
 
             return runner.removeExtension(runMode, extensions);
@@ -38,7 +42,7 @@ public class ProjectExtensionsRemove extends BaseBuildCommand implements Callabl
         }
     }
 
-    void dryRunRemove(CommandLine.Help help, BuildTool buildTool) {
+    void dryRunRemove(Help help, BuildTool buildTool) {
         output.printText(new String[] {
                 "\nRemove extensions to the current project in \n",
                 "\t" + projectRoot().toString()

--- a/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
@@ -1,6 +1,6 @@
 package io.quarkus.cli;
 
-import static picocli.CommandLine.Model.UsageMessageSpec.SECTION_KEY_COMMAND_LIST;
+import static io.quarkus.quickcli.UsageMessageSpec.SECTION_KEY_COMMAND_LIST;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -34,21 +34,21 @@ import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.project.QuarkusProject;
 import io.quarkus.devtools.project.QuarkusProjectHelper;
 import io.quarkus.devtools.utils.Prompt;
+import io.quarkus.quickcli.CommandLine;
+import io.quarkus.quickcli.CommandSpec;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.quickcli.Help;
+import io.quarkus.quickcli.ParseResult;
+import io.quarkus.quickcli.ScopeType;
+import io.quarkus.quickcli.UsageMessageSpec;
+import io.quarkus.quickcli.annotations.ArgGroup;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Mixin;
+import io.quarkus.quickcli.annotations.Option;
+import io.quarkus.quickcli.annotations.Spec;
 import io.quarkus.runtime.QuarkusApplication;
-import picocli.CommandLine;
-import picocli.CommandLine.ExitCode;
-import picocli.CommandLine.Help;
-import picocli.CommandLine.IHelpSectionRenderer;
-import picocli.CommandLine.IParameterExceptionHandler;
-import picocli.CommandLine.Model.CommandSpec;
-import picocli.CommandLine.Model.UsageMessageSpec;
-import picocli.CommandLine.MutuallyExclusiveArgsException;
-import picocli.CommandLine.ParameterException;
-import picocli.CommandLine.ParseResult;
-import picocli.CommandLine.ScopeType;
-import picocli.CommandLine.UnmatchedArgumentException;
 
-@CommandLine.Command(name = "quarkus", subcommands = {
+@Command(name = "quarkus", subcommands = {
         Create.class,
         Build.class,
         Dev.class,
@@ -72,25 +72,25 @@ public class QuarkusCli implements QuarkusApplication, OutputProvider, Callable<
     private static final Set<String> CATCH_ALL_COMMANDS = Set.of("create", "image", "extension", "ext", "plugin", "plug");
 
     @Inject
-    CommandLine.IFactory factory;
+    CommandLine.Factory factory;
 
-    @CommandLine.Mixin
+    @Mixin
     protected RegistryClientMixin registryClient;
 
-    @CommandLine.Mixin
+    @Mixin
     protected HelpOption helpOption;
 
-    @CommandLine.Option(names = { "-v",
+    @Option(names = { "-v",
             "--version" }, versionHelp = true, description = "Print CLI version information and exit.")
     public boolean showVersion;
 
-    @CommandLine.Mixin(name = "output")
+    @Mixin(name = "output")
     OutputOptionMixin output;
 
-    @CommandLine.Spec
-    protected CommandLine.Model.CommandSpec spec;
+    @Spec
+    protected CommandSpec spec;
 
-    @CommandLine.ArgGroup(exclusive = false, validate = false)
+    @ArgGroup(exclusive = false, validate = false)
     protected PropertiesOptions propertiesOptions = new PropertiesOptions();
 
     public OutputOptionMixin getOutput() {
@@ -151,7 +151,7 @@ public class QuarkusCli implements QuarkusApplication, OutputProvider, Callable<
                     output.error("Unable to match command `%s` and a corresponding plugin couldn't be installed.", m);
                 }
             });
-        } catch (MutuallyExclusiveArgsException e) {
+        } catch (CommandLine.MutuallyExclusiveArgsException e) {
             return ExitCode.USAGE;
         }
         return cmd.execute(args);
@@ -198,7 +198,7 @@ public class QuarkusCli implements QuarkusApplication, OutputProvider, Callable<
             } while (currentParseResult != null);
 
             return Optional.empty();
-        } catch (UnmatchedArgumentException e) {
+        } catch (CommandLine.UnmatchedArgumentException e) {
             // the first element was matched so it's not missing
             if (e.getCommandLine() != root) {
                 return Optional.empty();
@@ -243,15 +243,15 @@ public class QuarkusCli implements QuarkusApplication, OutputProvider, Callable<
         return spec.exitCodeOnUsageHelp();
     }
 
-    class ShortErrorMessageHandler implements IParameterExceptionHandler {
-        public int handleParseException(ParameterException ex, String[] args) {
+    class ShortErrorMessageHandler implements CommandLine.ParameterExceptionHandler {
+        public int handleParseException(CommandLine.ParameterException ex, String[] args) {
             CommandLine cmd = ex.getCommandLine();
             CommandSpec spec = cmd.getCommandSpec();
 
             output.error(ex.getMessage()); // bold red
             output.printStackTrace(ex);
 
-            UnmatchedArgumentException.printSuggestions(ex, output.err());
+            CommandLine.UnmatchedArgumentException.printSuggestions(ex, System.err);
             output.err().println(cmd.getHelp().fullSynopsis()); // normal text to error stream
 
             if (spec.equals(spec.root())) {
@@ -265,7 +265,7 @@ public class QuarkusCli implements QuarkusApplication, OutputProvider, Callable<
         }
     }
 
-    class SubCommandListRenderer implements IHelpSectionRenderer {
+    class SubCommandListRenderer implements CommandLine.HelpSectionRenderer {
         // @Override
         public String render(Help help) {
             CommandSpec spec = help.commandSpec();
@@ -273,27 +273,22 @@ public class QuarkusCli implements QuarkusApplication, OutputProvider, Callable<
                 return "";
             }
 
-            Help.Column commands = new Help.Column(24, 2, CommandLine.Help.Column.Overflow.SPAN);
-            Help.Column descriptions = new Help.Column(spec.usageMessage().width() - 24, 2,
-                    CommandLine.Help.Column.Overflow.WRAP);
-            Help.TextTable textTable = Help.TextTable.forColumns(help.colorScheme(), commands, descriptions);
-            textTable.setAdjustLineBreaksForWideCJKCharacters(spec.usageMessage().adjustLineBreaksForWideCJKCharacters());
-
-            addHierarchy(spec.subcommands().values(), textTable, "");
-            return textTable.toString();
+            StringBuilder sb = new StringBuilder();
+            addHierarchy(spec.subcommands().values(), sb, "");
+            return sb.toString();
         }
 
-        private void addHierarchy(Collection<CommandLine> collection, Help.TextTable textTable,
+        private void addHierarchy(Collection<CommandSpec> collection, StringBuilder sb,
                 String indent) {
-            collection.stream().distinct().forEach(subcommand -> {
+            collection.stream().distinct().forEach(subSpec -> {
                 // create comma-separated list of command name and aliases
-                String names = String.join(", ", subcommand.getCommandSpec().names());
-                String description = description(subcommand.getCommandSpec().usageMessage());
-                textTable.addRowValues(indent + names, description);
+                String names = String.join(", ", subSpec.names());
+                String description = description(subSpec.usageMessage());
+                sb.append(String.format("  %s%-24s %s%n", indent, names, description));
 
-                Map<String, CommandLine> subcommands = subcommand.getSubcommands();
+                Map<String, CommandSpec> subcommands = subSpec.subcommands();
                 if (!subcommands.isEmpty()) {
-                    addHierarchy(subcommands.values(), textTable, indent + "  ");
+                    addHierarchy(subcommands.values(), sb, indent + "  ");
                 }
             });
         }

--- a/devtools/cli/src/main/java/io/quarkus/cli/Registry.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Registry.java
@@ -5,30 +5,35 @@ import java.util.concurrent.Callable;
 
 import io.quarkus.cli.common.HelpOption;
 import io.quarkus.cli.common.OutputOptionMixin;
-import picocli.CommandLine;
-import picocli.CommandLine.ParseResult;
+import io.quarkus.quickcli.CommandLine;
+import io.quarkus.quickcli.CommandSpec;
+import io.quarkus.quickcli.ParseResult;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Mixin;
+import io.quarkus.quickcli.annotations.Spec;
+import io.quarkus.quickcli.annotations.Unmatched;
 
-@CommandLine.Command(name = "registry", header = "Configure Quarkus registry client", subcommands = {
+@Command(name = "registry", header = "Configure Quarkus registry client", subcommands = {
         RegistryListCommand.class,
         RegistryAddCommand.class,
         RegistryRemoveCommand.class })
 public class Registry implements Callable<Integer> {
 
-    @CommandLine.Mixin(name = "output")
+    @Mixin(name = "output")
     protected OutputOptionMixin output;
 
-    @CommandLine.Mixin
+    @Mixin
     protected HelpOption helpOption;
 
-    @CommandLine.Spec
-    protected CommandLine.Model.CommandSpec spec;
+    @Spec
+    protected CommandSpec spec;
 
-    @CommandLine.Unmatched // avoids throwing errors for unmatched arguments
+    @Unmatched // avoids throwing errors for unmatched arguments
     List<String> unmatchedArgs;
 
     public Integer call() throws Exception {
         final ParseResult result = spec.commandLine().getParseResult();
-        final CommandLine appCommand = spec.subcommands().get("list");
+        final CommandLine appCommand = spec.commandLine().getSubcommands().get("list");
         return appCommand.execute(result.originalArgs().stream().filter(x -> !"registry".equals(x)).toArray(String[]::new));
     }
 }

--- a/devtools/cli/src/main/java/io/quarkus/cli/RegistryAddCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/RegistryAddCommand.java
@@ -8,15 +8,17 @@ import java.nio.file.Paths;
 import java.util.List;
 
 import io.quarkus.cli.registry.BaseRegistryCommand;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Parameters;
 import io.quarkus.registry.config.RegistriesConfig;
 import io.quarkus.registry.config.RegistryConfig;
-import picocli.CommandLine;
 
-@CommandLine.Command(name = "add", header = "Add a Quarkus extension registry", description = "%n"
+@Command(name = "add", header = "Add a Quarkus extension registry", description = "%n"
         + "This command will add a Quarkus extension registry to the registry client configuration unless it's already present.")
 public class RegistryAddCommand extends BaseRegistryCommand {
 
-    @CommandLine.Parameters(arity = "1..*", split = ",", paramLabel = "REGISTRY-ID[,REGISTRY-ID]", description = "Registry ID to add to the registry client configuration%n"
+    @Parameters(arity = "1..*", split = ",", paramLabel = "REGISTRY-ID[,REGISTRY-ID]", description = "Registry ID to add to the registry client configuration%n"
             + "  Example:%n"
             + "    registry.quarkus.io%n"
             + "    registry.quarkus.acme.com,registry.quarkus.io%n")
@@ -67,6 +69,6 @@ public class RegistryAddCommand extends BaseRegistryCommand {
                 config.persist();
             }
         }
-        return CommandLine.ExitCode.OK;
+        return ExitCode.OK;
     }
 }

--- a/devtools/cli/src/main/java/io/quarkus/cli/RegistryListCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/RegistryListCommand.java
@@ -1,19 +1,21 @@
 package io.quarkus.cli;
 
 import io.quarkus.cli.registry.BaseRegistryCommand;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Option;
 import io.quarkus.registry.ExtensionCatalogResolver;
 import io.quarkus.registry.catalog.Platform;
 import io.quarkus.registry.catalog.PlatformCatalog;
 import io.quarkus.registry.catalog.PlatformStream;
 import io.quarkus.registry.config.RegistriesConfig;
 import io.quarkus.registry.config.RegistryConfig;
-import picocli.CommandLine;
 
-@CommandLine.Command(name = "list", header = "List enabled Quarkus registries", description = "%n"
+@Command(name = "list", header = "List enabled Quarkus registries", description = "%n"
         + "This command will list currently enabled Quarkus extension registries.")
 public class RegistryListCommand extends BaseRegistryCommand {
 
-    @CommandLine.Option(names = {
+    @Option(names = {
             "--streams" }, description = "List currently recommended platform streams", defaultValue = "false")
     boolean streams;
 
@@ -50,6 +52,6 @@ public class RegistryListCommand extends BaseRegistryCommand {
 
         output.info("(Config source: " + config.getSource().describe() + ")");
 
-        return CommandLine.ExitCode.OK;
+        return ExitCode.OK;
     }
 }

--- a/devtools/cli/src/main/java/io/quarkus/cli/RegistryRemoveCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/RegistryRemoveCommand.java
@@ -6,15 +6,17 @@ import java.nio.file.Paths;
 import java.util.List;
 
 import io.quarkus.cli.registry.BaseRegistryCommand;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Parameters;
 import io.quarkus.registry.config.RegistriesConfig;
 import io.quarkus.registry.config.RegistryConfig;
-import picocli.CommandLine;
 
-@CommandLine.Command(name = "remove", aliases = "rm", header = "Remove a Quarkus extension registry", description = "%n"
+@Command(name = "remove", aliases = "rm", header = "Remove a Quarkus extension registry", description = "%n"
         + "This command will remove a Quarkus extension registry from the registry client configuration.")
 public class RegistryRemoveCommand extends BaseRegistryCommand {
 
-    @CommandLine.Parameters(arity = "1..*", split = ",", paramLabel = "REGISTRY-ID[,REGISTRY-ID]", description = "Registry ID to remove from the registry client configuration%n"
+    @Parameters(arity = "1..*", split = ",", paramLabel = "REGISTRY-ID[,REGISTRY-ID]", description = "Registry ID to remove from the registry client configuration%n"
             + "  Example:%n"
             + "    registry.quarkus.io%n"
             + "    registry.quarkus.acme.com,registry.quarkus.io%n")
@@ -56,6 +58,6 @@ public class RegistryRemoveCommand extends BaseRegistryCommand {
                 config.persist();
             }
         }
-        return CommandLine.ExitCode.OK;
+        return ExitCode.OK;
     }
 }

--- a/devtools/cli/src/main/java/io/quarkus/cli/Run.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Run.java
@@ -5,15 +5,16 @@ import java.util.Map;
 import io.quarkus.cli.common.BuildToolContext;
 import io.quarkus.cli.common.BuildToolDelegatingCommand;
 import io.quarkus.devtools.project.BuildTool;
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Option;
 
-@CommandLine.Command(name = "run", sortOptions = false, mixinStandardHelpOptions = false, header = "Run application.")
+@Command(name = "run", sortOptions = false, mixinStandardHelpOptions = false, header = "Run application.")
 public class Run extends BuildToolDelegatingCommand {
 
     private static final Map<BuildTool, String> ACTION_MAPPING = Map.of(BuildTool.MAVEN, "quarkus:run",
             BuildTool.GRADLE, "quarkusRun", BuildTool.GRADLE_KOTLIN_DSL, "quarkusRun");
 
-    @CommandLine.Option(names = { "--target" }, description = "Run target.")
+    @Option(names = { "--target" }, description = "Run target.")
     String target;
 
     @Override

--- a/devtools/cli/src/main/java/io/quarkus/cli/Test.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Test.java
@@ -14,22 +14,26 @@ import io.quarkus.cli.common.RunModeOption;
 import io.quarkus.cli.common.build.BuildSystemRunner;
 import io.quarkus.cli.common.build.BuildSystemRunner.BuildCommandArgs;
 import io.quarkus.devtools.project.BuildTool;
-import picocli.CommandLine;
-import picocli.CommandLine.Parameters;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.quickcli.Help;
+import io.quarkus.quickcli.annotations.ArgGroup;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Option;
+import io.quarkus.quickcli.annotations.Parameters;
 
-@CommandLine.Command(name = "test", showEndOfOptionsDelimiterInUsageHelp = true, header = "Run the current project in continuous testing mode.")
+@Command(name = "test", showEndOfOptionsDelimiterInUsageHelp = true, header = "Run the current project in continuous testing mode.")
 public class Test extends BaseBuildCommand implements Callable<Integer> {
 
-    @CommandLine.ArgGroup(order = 1, exclusive = false, heading = "%nContinuous Test Mode options:%n")
+    @ArgGroup(order = 1, exclusive = false, heading = "%nContinuous Test Mode options:%n")
     DevOptions testOptions = new DevOptions();
 
-    @CommandLine.ArgGroup(order = 3, exclusive = false, validate = true, heading = "%nDebug options:%n")
+    @ArgGroup(order = 3, exclusive = false, validate = true, heading = "%nDebug options:%n")
     DebugOptions debugOptions = new DebugOptions();
 
-    @CommandLine.Option(names = "--once", description = "Run the test suite with continuous mode disabled.")
+    @Option(names = "--once", description = "Run the test suite with continuous mode disabled.")
     boolean runOnce = false;
 
-    @CommandLine.Option(names = "--filter", description = { "Run a subset of the test suite that matches the given filter.",
+    @Option(names = "--filter", description = { "Run a subset of the test suite that matches the given filter.",
             "If continuous testing is enabled then the value is a regular expression that is matched against the test class name.",
             "If continuous testing is disabled then the value is passed as-is to the underlying build tool." })
     String filter;
@@ -53,7 +57,7 @@ public class Test extends BaseBuildCommand implements Callable<Integer> {
                 BuildCommandArgs commandArgs = runner.prepareTest(buildOptions, new RunModeOption(), params, filter);
                 if (testOptions.isDryRun()) {
                     dryRunTest(spec.commandLine().getHelp(), runner.getBuildTool(), commandArgs, false);
-                    return CommandLine.ExitCode.OK;
+                    return ExitCode.OK;
                 }
                 return runner.run(commandArgs);
             }
@@ -66,7 +70,7 @@ public class Test extends BaseBuildCommand implements Callable<Integer> {
 
             if (testOptions.isDryRun()) {
                 dryRunTest(spec.commandLine().getHelp(), runner.getBuildTool(), commandArgs.iterator().next().get(), true);
-                return CommandLine.ExitCode.OK;
+                return ExitCode.OK;
             }
             int ret = 1;
             for (Supplier<BuildSystemRunner.BuildCommandArgs> i : commandArgs) {
@@ -82,7 +86,7 @@ public class Test extends BaseBuildCommand implements Callable<Integer> {
         }
     }
 
-    void dryRunTest(CommandLine.Help help, BuildTool buildTool, BuildSystemRunner.BuildCommandArgs args, boolean isContinuous) {
+    void dryRunTest(Help help, BuildTool buildTool, BuildSystemRunner.BuildCommandArgs args, boolean isContinuous) {
         output.printText("\nRun current project in" + (isContinuous ? " continuous" : "") + " test mode\n",
                 "\t" + projectRoot().toString());
         Map<String, String> dryRunOutput = new TreeMap<>();

--- a/devtools/cli/src/main/java/io/quarkus/cli/Update.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Update.java
@@ -5,16 +5,17 @@ import java.util.concurrent.Callable;
 import io.quarkus.cli.common.TargetQuarkusVersionGroup;
 import io.quarkus.cli.common.build.BuildSystemRunner;
 import io.quarkus.cli.common.update.RewriteGroup;
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.ArgGroup;
+import io.quarkus.quickcli.annotations.Command;
 
-@CommandLine.Command(name = "update", aliases = { "up",
+@Command(name = "update", aliases = { "up",
         "upgrade" }, sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Suggest project updates and create a recipe with the possibility to apply it.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "%nOptions:%n")
 public class Update extends BaseBuildCommand implements Callable<Integer> {
 
-    @CommandLine.ArgGroup(order = 0, heading = "%nTarget Quarkus version:%n", multiplicity = "0..1")
+    @ArgGroup(order = 0, heading = "%nTarget Quarkus version:%n", multiplicity = "0..1")
     TargetQuarkusVersionGroup targetQuarkusVersion = new TargetQuarkusVersionGroup();
 
-    @CommandLine.ArgGroup(order = 1, heading = "%nRewrite (interactive by default):%n", exclusive = false)
+    @ArgGroup(order = 1, heading = "%nRewrite (interactive by default):%n", exclusive = false)
     RewriteGroup rewrite = new RewriteGroup();
 
     @Override

--- a/devtools/cli/src/main/java/io/quarkus/cli/Version.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Version.java
@@ -7,31 +7,36 @@ import java.util.concurrent.Callable;
 import io.quarkus.cli.common.HelpOption;
 import io.quarkus.cli.common.OutputOptionMixin;
 import io.quarkus.cli.common.PropertiesOptions;
-import picocli.CommandLine;
-import picocli.CommandLine.Model.CommandSpec;
+import io.quarkus.quickcli.CommandSpec;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.quickcli.VersionProvider;
+import io.quarkus.quickcli.annotations.ArgGroup;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Mixin;
+import io.quarkus.quickcli.annotations.Spec;
 
-@CommandLine.Command(name = "version", header = "Display CLI version information.", hidden = true)
-public class Version implements CommandLine.IVersionProvider, Callable<Integer> {
+@Command(name = "version", header = "Display CLI version information.", hidden = true)
+public class Version implements VersionProvider, Callable<Integer> {
 
     private static String version;
 
-    @CommandLine.Mixin(name = "output")
+    @Mixin(name = "output")
     OutputOptionMixin output;
 
-    @CommandLine.Mixin
+    @Mixin
     HelpOption helpOption;
 
-    @CommandLine.ArgGroup(exclusive = false, validate = false)
+    @ArgGroup(exclusive = false, validate = false)
     protected PropertiesOptions propertiesOptions = new PropertiesOptions();
 
-    @CommandLine.Spec
+    @Spec
     CommandSpec spec;
 
     @Override
     public Integer call() throws Exception {
-        // Gather/interpolate the usual version information via IVersionProvider handling
+        // Gather/interpolate the usual version information via VersionProvider handling
         output.printText(getVersion());
-        return CommandLine.ExitCode.OK;
+        return ExitCode.OK;
     }
 
     @Override

--- a/devtools/cli/src/main/java/io/quarkus/cli/config/BaseConfigCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/config/BaseConfigCommand.java
@@ -7,18 +7,20 @@ import java.util.List;
 
 import io.quarkus.cli.common.HelpOption;
 import io.quarkus.cli.common.OutputOptionMixin;
+import io.quarkus.quickcli.CommandSpec;
+import io.quarkus.quickcli.annotations.Mixin;
+import io.quarkus.quickcli.annotations.Spec;
 import io.smallrye.config.ConfigValue;
-import picocli.CommandLine;
 
 public class BaseConfigCommand {
-    @CommandLine.Mixin(name = "output")
+    @Mixin(name = "output")
     protected OutputOptionMixin output;
 
-    @CommandLine.Mixin
+    @Mixin
     protected HelpOption helpOption;
 
-    @CommandLine.Spec
-    protected CommandLine.Model.CommandSpec spec;
+    @Spec
+    protected CommandSpec spec;
 
     Path projectRoot;
 

--- a/devtools/cli/src/main/java/io/quarkus/cli/config/Decrypt.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/config/Decrypt.java
@@ -13,9 +13,9 @@ import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
 import io.quarkus.cli.config.Encrypt.KeyFormat;
-import picocli.CommandLine.Command;
-import picocli.CommandLine.Option;
-import picocli.CommandLine.Parameters;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Option;
+import io.quarkus.quickcli.annotations.Parameters;
 
 @Command(name = "decrypt", aliases = "dec", header = "Decrypt Secrets", description = "Decrypt a Secret value using the AES/GCM/NoPadding algorithm as a default.")
 public class Decrypt extends BaseConfigCommand implements Callable<Integer> {

--- a/devtools/cli/src/main/java/io/quarkus/cli/config/Encrypt.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/config/Encrypt.java
@@ -15,9 +15,9 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
-import picocli.CommandLine.Command;
-import picocli.CommandLine.Option;
-import picocli.CommandLine.Parameters;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Option;
+import io.quarkus.quickcli.annotations.Parameters;
 
 @Command(name = "encrypt", aliases = "enc", header = "Encrypt Secrets", description = "Encrypt a Secret value using the AES/GCM/NoPadding algorithm as a default. The encryption key is generated unless a specific key is set with the --key option.")
 public class Encrypt extends BaseConfigCommand implements Callable<Integer> {

--- a/devtools/cli/src/main/java/io/quarkus/cli/config/RemoveConfig.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/config/RemoveConfig.java
@@ -8,12 +8,14 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.Callable;
 
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Parameters;
 import io.smallrye.config.ConfigValue;
-import picocli.CommandLine;
 
-@CommandLine.Command(name = "remove", header = "Removes a configuration from application.properties")
+@Command(name = "remove", header = "Removes a configuration from application.properties")
 public class RemoveConfig extends BaseConfigCommand implements Callable<Integer> {
-    @CommandLine.Parameters(index = "0", arity = "1", paramLabel = "NAME", description = "Configuration name")
+    @Parameters(index = "0", arity = "1", paramLabel = "NAME", description = "Configuration name")
     String name;
 
     @Override
@@ -42,6 +44,6 @@ public class RemoveConfig extends BaseConfigCommand implements Callable<Integer>
             }
         }
 
-        return CommandLine.ExitCode.OK;
+        return ExitCode.OK;
     }
 }

--- a/devtools/cli/src/main/java/io/quarkus/cli/config/SetConfig.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/config/SetConfig.java
@@ -9,12 +9,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 
+import io.quarkus.quickcli.CommandLine;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Option;
+import io.quarkus.quickcli.annotations.Parameters;
 import io.smallrye.config.ConfigValue;
 import io.smallrye.config.Converters;
-import picocli.CommandLine;
-import picocli.CommandLine.Command;
-import picocli.CommandLine.Option;
-import picocli.CommandLine.Parameters;
 
 @Command(name = "set", header = "Sets a configuration in application.properties")
 public class SetConfig extends BaseConfigCommand implements Callable<Integer> {
@@ -89,6 +90,6 @@ public class SetConfig extends BaseConfigCommand implements Callable<Integer> {
             }
         }
 
-        return CommandLine.ExitCode.OK;
+        return ExitCode.OK;
     }
 }

--- a/devtools/cli/src/main/java/io/quarkus/cli/create/BaseCreateCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/create/BaseCreateCommand.java
@@ -21,27 +21,31 @@ import io.quarkus.devtools.commands.data.QuarkusCommandInvocation;
 import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.project.QuarkusProject;
 import io.quarkus.devtools.project.SourceType;
+import io.quarkus.quickcli.CommandSpec;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.quickcli.Help;
+import io.quarkus.quickcli.annotations.Mixin;
+import io.quarkus.quickcli.annotations.Option;
+import io.quarkus.quickcli.annotations.Spec;
 import io.quarkus.registry.RegistryResolutionException;
-import picocli.CommandLine;
-import picocli.CommandLine.Model.CommandSpec;
 
 public class BaseCreateCommand implements Callable<Integer> {
-    @CommandLine.Mixin
+    @Mixin
     protected RunModeOption runMode;
 
-    @CommandLine.Mixin(name = "output")
+    @Mixin(name = "output")
     protected OutputOptionMixin output;
 
-    @CommandLine.Mixin
+    @Mixin
     ToggleRegistryClientMixin registryClient;
 
-    @CommandLine.Mixin
+    @Mixin
     protected HelpOption helpOption;
 
-    @CommandLine.Spec
+    @Spec
     protected CommandSpec spec;
 
-    @CommandLine.Option(paramLabel = "OUTPUT-DIR", names = { "-o",
+    @Option(paramLabel = "OUTPUT-DIR", names = { "-o",
             "--output-directory" }, description = "The directory to create the new project in.")
     String targetDirectory;
 
@@ -239,7 +243,7 @@ public class BaseCreateCommand implements Callable<Integer> {
     @Override
     public Integer call() throws Exception {
         spec.commandLine().usage(output.out());
-        return CommandLine.ExitCode.OK;
+        return ExitCode.OK;
     }
 
     public String toString() {
@@ -253,7 +257,7 @@ public class BaseCreateCommand implements Callable<Integer> {
     }
 
     public void dryRun(BuildTool buildTool, QuarkusCommandInvocation invocation, OutputOptionMixin output) {
-        CommandLine.Help help = spec.commandLine().getHelp();
+        Help help = spec.commandLine().getHelp();
         output.printText(new String[] {
                 "\nA new project would have been created in",
                 "\t" + projectRoot().toString(),

--- a/devtools/cli/src/main/java/io/quarkus/cli/create/CodeGenerationGroup.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/create/CodeGenerationGroup.java
@@ -5,13 +5,13 @@ import java.util.Map;
 
 import io.quarkus.devtools.commands.CreateProjectHelper;
 import io.quarkus.platform.tools.ToolsUtils;
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.Option;
 
 public class CodeGenerationGroup {
     String packageName;
     Map<String, String> appConfig = Collections.emptyMap();
 
-    @CommandLine.Option(paramLabel = "PACKAGE-NAME", names = {
+    @Option(paramLabel = "PACKAGE-NAME", names = {
             "--package-name" }, description = "Base package for generated classes")
     void setPackageName(String name) {
         this.packageName = CreateProjectHelper.checkPackageName(name);
@@ -21,19 +21,19 @@ public class CodeGenerationGroup {
         return packageName;
     }
 
-    @CommandLine.Option(names = {
+    @Option(names = {
             "--no-wrapper" }, description = "Include a buildtool wrapper (e.g. mvnw, gradlew)", negatable = true)
     public boolean includeWrapper = true;
 
-    @CommandLine.Option(names = {
+    @Option(names = {
             "--no-code" }, description = "Include starter code provided by extensions or generate an empty project", negatable = true)
     public boolean includeCode = true;
 
-    @CommandLine.Option(names = {
+    @Option(names = {
             "--no-dockerfiles" }, description = "Include standard dockerfiles", negatable = true)
     public boolean includeDockerfiles = true;
 
-    @CommandLine.Option(names = { "-c",
+    @Option(names = { "-c",
             "--app-config" }, description = "Configuration attributes to be set in the application.properties/yml file. Specify as 'key1=value1,key2=value2'")
     void setAppConfig(String config) {
         if (config.trim().length() > 0) {

--- a/devtools/cli/src/main/java/io/quarkus/cli/create/ExtensionCodeGenerationGroup.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/create/ExtensionCodeGenerationGroup.java
@@ -2,25 +2,25 @@ package io.quarkus.cli.create;
 
 import java.util.Optional;
 
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.Option;
 
 public class ExtensionCodeGenerationGroup {
-    @CommandLine.Option(names = { "-C",
+    @Option(names = { "-C",
             "--codestart" }, description = "Generate extension codestart", negatable = true)
     boolean codestart = false;
 
-    @CommandLine.Option(names = { "--no-unit-test" }, description = "Generate unit tests", negatable = true)
+    @Option(names = { "--no-unit-test" }, description = "Generate unit tests", negatable = true)
     boolean unitTest = true;
 
-    @CommandLine.Option(names = {
+    @Option(names = {
             "--no-it-test" }, description = "Generate integration test", negatable = true)
     boolean integrationTests = true;
 
-    @CommandLine.Option(names = {
+    @Option(names = {
             "--no-devmode-test" }, description = "Generate dev mode tests", negatable = true)
     boolean devModeTest = true;
 
-    @CommandLine.Option(names = {
+    @Option(names = {
             "--without-tests" }, description = "Do not generate any tests (disable all)")
     Optional<Boolean> withoutTests;
 

--- a/devtools/cli/src/main/java/io/quarkus/cli/create/ExtensionGAVMixin.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/create/ExtensionGAVMixin.java
@@ -4,7 +4,7 @@ import static io.quarkus.devtools.commands.CreateExtension.extractQuarkiverseExt
 import static io.quarkus.devtools.commands.CreateExtension.isQuarkiverseGroupId;
 
 import io.quarkus.devtools.commands.CreateExtension;
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.Parameters;
 
 public class ExtensionGAVMixin {
     static final String DEFAULT_EXTENSION_ID = "custom";
@@ -15,7 +15,7 @@ public class ExtensionGAVMixin {
     String extensionId = null;
     String version = null;
 
-    @CommandLine.Parameters(arity = "0..1", paramLabel = "[GROUP-ID:]EXTENSION-ID[:VERSION]", description = "Quarkus extension project identifiers%n"
+    @Parameters(arity = "0..1", paramLabel = "[GROUP-ID:]EXTENSION-ID[:VERSION]", description = "Quarkus extension project identifiers%n"
             + "  " + EXAMPLE_GAV + "%n"
             + "  Examples:%n"
             + "     my-extension%n"

--- a/devtools/cli/src/main/java/io/quarkus/cli/create/ExtensionNameGenerationGroup.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/create/ExtensionNameGenerationGroup.java
@@ -1,27 +1,27 @@
 package io.quarkus.cli.create;
 
 import io.quarkus.devtools.commands.CreateProjectHelper;
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.Option;
 
 public class ExtensionNameGenerationGroup {
     String packageName;
 
-    @CommandLine.Option(paramLabel = "NAMESPACE-ID", names = { "-N",
+    @Option(paramLabel = "NAMESPACE-ID", names = { "-N",
             "--namespace-id" }, description = "A common prefix for all module artifactIds")
     String namespaceId;
 
-    @CommandLine.Option(paramLabel = "EXTENSION-NAME", names = { "--extension-name" }, description = "Extension name")
+    @Option(paramLabel = "EXTENSION-NAME", names = { "--extension-name" }, description = "Extension name")
     String extensionName;
 
-    @CommandLine.Option(paramLabel = "EXTENSION-DESCRIPTION", names = {
+    @Option(paramLabel = "EXTENSION-DESCRIPTION", names = {
             "--extension-description" }, description = "Extension description")
     String extensionDescription;
 
-    @CommandLine.Option(paramLabel = "NAMESPACE-NAME", names = {
+    @Option(paramLabel = "NAMESPACE-NAME", names = {
             "--namespace-name" }, description = "A common prefix for all module names")
     String namespaceName;
 
-    @CommandLine.Option(paramLabel = "PACKAGE-NAME", names = {
+    @Option(paramLabel = "PACKAGE-NAME", names = {
             "--package-name" }, description = "Base package for generated classes")
     void setPackageName(String name) {
         this.packageName = CreateProjectHelper.checkPackageName(name);

--- a/devtools/cli/src/main/java/io/quarkus/cli/create/TargetBuildToolGroup.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/create/TargetBuildToolGroup.java
@@ -1,19 +1,19 @@
 package io.quarkus.cli.create;
 
 import io.quarkus.devtools.project.BuildTool;
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.Option;
 
 public class TargetBuildToolGroup {
-    @CommandLine.Option(names = { "--jbang" }, description = "Use JBang (Java only)")
+    @Option(names = { "--jbang" }, description = "Use JBang (Java only)")
     boolean jbang = false;
 
-    @CommandLine.Option(names = { "--maven" }, description = "Use Maven")
+    @Option(names = { "--maven" }, description = "Use Maven")
     boolean maven = false;
 
-    @CommandLine.Option(names = { "--gradle" }, description = "Use Gradle")
+    @Option(names = { "--gradle" }, description = "Use Gradle")
     boolean gradle = false;
 
-    @CommandLine.Option(names = { "--gradle-kotlin-dsl" }, description = "Use Gradle with Kotlin DSL")
+    @Option(names = { "--gradle-kotlin-dsl" }, description = "Use Gradle with Kotlin DSL")
     boolean gradleKotlinDsl = false;
 
     public boolean isBuildless() {

--- a/devtools/cli/src/main/java/io/quarkus/cli/create/TargetGAVGroup.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/create/TargetGAVGroup.java
@@ -3,8 +3,8 @@ package io.quarkus.cli.create;
 import java.util.regex.Pattern;
 
 import io.quarkus.devtools.commands.CreateProjectHelper;
-import picocli.CommandLine;
-import picocli.CommandLine.TypeConversionException;
+import io.quarkus.quickcli.CommandLine.TypeConversionException;
+import io.quarkus.quickcli.annotations.Parameters;
 
 public class TargetGAVGroup {
     static final String BAD_IDENTIFIER = "The specified %s identifier (%s) contains invalid characters. Valid characters are alphanumeric characters (A-Za-z0-9), underscores, dashes and dots.";
@@ -18,7 +18,7 @@ public class TargetGAVGroup {
     String artifactId = CreateProjectHelper.DEFAULT_ARTIFACT_ID;
     String version = CreateProjectHelper.DEFAULT_VERSION;
 
-    @CommandLine.Parameters(arity = "0..1", paramLabel = "[GROUP-ID:]ARTIFACT-ID[:VERSION]", description = "Java project identifiers%n"
+    @Parameters(arity = "0..1", paramLabel = "[GROUP-ID:]ARTIFACT-ID[:VERSION]", description = "Java project identifiers%n"
             + "  default: " + DEFAULT_GAV + "%n"
             + "  Examples:%n"
             + "     my-project%n"

--- a/devtools/cli/src/main/java/io/quarkus/cli/create/TargetLanguageGroup.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/create/TargetLanguageGroup.java
@@ -8,9 +8,9 @@ import io.quarkus.cli.common.OutputOptionMixin;
 import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.project.JavaVersion;
 import io.quarkus.devtools.project.SourceType;
-import picocli.CommandLine;
-import picocli.CommandLine.Model.CommandSpec;
-import picocli.CommandLine.ParameterException;
+import io.quarkus.quickcli.CommandLine.ParameterException;
+import io.quarkus.quickcli.CommandSpec;
+import io.quarkus.quickcli.annotations.Option;
 
 public class TargetLanguageGroup {
     SourceType sourceType;
@@ -21,20 +21,21 @@ public class TargetLanguageGroup {
         }
     }
 
-    @CommandLine.Option(names = {
+    @Option(names = {
             "--java" }, description = "Target Java version.\n  Valid values: ${COMPLETION-CANDIDATES}", completionCandidates = VersionCandidates.class, defaultValue = JavaVersion.DETECT_JAVA_RUNTIME_VERSION)
     String javaVersion = JavaVersion.DETECT_JAVA_RUNTIME_VERSION;
 
-    @CommandLine.Option(names = { "--kotlin" }, description = "Use Kotlin")
+    @Option(names = { "--kotlin" }, description = "Use Kotlin")
     boolean kotlin = false;
 
-    @CommandLine.Option(names = { "--scala" }, description = "Use Scala")
+    @Option(names = { "--scala" }, description = "Use Scala")
     boolean scala = false;
 
     public SourceType getSourceType(CommandSpec spec, BuildTool buildTool, Set<String> extensions, OutputOptionMixin output) {
         if (kotlin && scala) {
-            throw new ParameterException(spec.commandLine(),
-                    "Invalid source type. Projects can target either Kotlin (--kotlin) or Scala (--scala), not both.");
+            throw new ParameterException(
+                    "Invalid source type. Projects can target either Kotlin (--kotlin) or Scala (--scala), not both.",
+                    spec.commandLine());
         }
 
         if (sourceType == null) {

--- a/devtools/cli/src/main/java/io/quarkus/cli/deploy/BaseKubernetesDeployCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/deploy/BaseKubernetesDeployCommand.java
@@ -9,8 +9,8 @@ import java.util.stream.Collectors;
 import io.quarkus.cli.Deploy;
 import io.quarkus.cli.common.BuildToolContext;
 import io.quarkus.cli.common.BuildToolDelegatingCommand;
-import picocli.CommandLine;
-import picocli.CommandLine.ParentCommand;
+import io.quarkus.quickcli.annotations.ArgGroup;
+import io.quarkus.quickcli.annotations.ParentCommand;
 
 public class BaseKubernetesDeployCommand extends BuildToolDelegatingCommand {
 
@@ -19,7 +19,7 @@ public class BaseKubernetesDeployCommand extends BuildToolDelegatingCommand {
     static final String QUARKUS_CONTAINER_IMAGE_BUILDER = "quarkus.container-image.builder";
     static final String DEFAULT_IMAGE_BUILDER = "docker";
 
-    @CommandLine.ArgGroup(order = 2, exclusive = false, validate = false, heading = "%nKubernetes options:%n")
+    @ArgGroup(order = 2, exclusive = false, validate = false, heading = "%nKubernetes options:%n")
     KubernetesOptions kubernetesOptions = new KubernetesOptions();
 
     @ParentCommand

--- a/devtools/cli/src/main/java/io/quarkus/cli/deploy/Kind.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/deploy/Kind.java
@@ -3,9 +3,10 @@ package io.quarkus.cli.deploy;
 import java.util.Optional;
 
 import io.quarkus.cli.common.BuildToolContext;
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Option;
 
-@CommandLine.Command(name = "kind", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Perform the deploy action on Kind.", description = "%n"
+@Command(name = "kind", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Perform the deploy action on Kind.", description = "%n"
         + "The command will deploy the application on Kind.", footer = "%n"
                 + "For example (using default values), it will create a Deployment named '<project.artifactId>' using the image with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>' and will deploy it to the target cluster.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
 public class Kind extends BaseKubernetesDeployCommand {
@@ -21,7 +22,7 @@ public class Kind extends BaseKubernetesDeployCommand {
         Job
     }
 
-    @CommandLine.Option(names = { "--deployment-kind" }, description = "The kind of resource to generate and deploy")
+    @Option(names = { "--deployment-kind" }, description = "The kind of resource to generate and deploy")
     public Optional<DeploymentKind> kind;
 
     @Override

--- a/devtools/cli/src/main/java/io/quarkus/cli/deploy/Knative.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/deploy/Knative.java
@@ -1,9 +1,9 @@
 package io.quarkus.cli.deploy;
 
 import io.quarkus.cli.common.BuildToolContext;
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.Command;
 
-@CommandLine.Command(name = "knative", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Perform the deploy action on Knative.", description = "%n"
+@Command(name = "knative", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Perform the deploy action on Knative.", description = "%n"
         + "The command will deploy the application on Knative.", footer = "%n"
                 + "For example (using default values), it will create a Deployment named '<project.artifactId>' using the image with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>' and will deploy it to the target cluster.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
 public class Knative extends BaseKubernetesDeployCommand {

--- a/devtools/cli/src/main/java/io/quarkus/cli/deploy/Kubernetes.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/deploy/Kubernetes.java
@@ -3,9 +3,10 @@ package io.quarkus.cli.deploy;
 import java.util.Optional;
 
 import io.quarkus.cli.common.BuildToolContext;
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Option;
 
-@CommandLine.Command(name = "kubernetes", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Perform the deploy action on Kubernetes.", description = "%n"
+@Command(name = "kubernetes", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Perform the deploy action on Kubernetes.", description = "%n"
         + "The command will deploy the application on Kubernetes.", footer = "%n"
                 + "For example (using default values), it will create a Deployment named '<project.artifactId>' using the image with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>' and will deploy it to the target cluster.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
 public class Kubernetes extends BaseKubernetesDeployCommand {
@@ -21,7 +22,7 @@ public class Kubernetes extends BaseKubernetesDeployCommand {
         Job
     }
 
-    @CommandLine.Option(names = { "--deployment-kind" }, description = "The kind of resource to generate and deploy")
+    @Option(names = { "--deployment-kind" }, description = "The kind of resource to generate and deploy")
     public Optional<DeploymentKind> kind;
 
     @Override

--- a/devtools/cli/src/main/java/io/quarkus/cli/deploy/KubernetesOptions.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/deploy/KubernetesOptions.java
@@ -2,78 +2,78 @@ package io.quarkus.cli.deploy;
 
 import java.util.Optional;
 
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.Option;
 
 public class KubernetesOptions {
 
-    @CommandLine.Option(order = 3, names = { "--api-server-url" }, description = "The URL of the kubernetes API server")
+    @Option(order = 3, names = { "--api-server-url" }, description = "The URL of the kubernetes API server")
     public Optional<String> masterUrl;
 
-    @CommandLine.Option(order = 4, names = { "--username" }, description = "Kubernetes username")
+    @Option(order = 4, names = { "--username" }, description = "Kubernetes username")
     public Optional<String> username = Optional.empty();
 
-    @CommandLine.Option(order = 5, names = {
+    @Option(order = 5, names = {
             "--password" }, description = "Kubernetes password")
     public Optional<String> password = Optional.empty();
 
-    @CommandLine.Option(order = 6, names = {
+    @Option(order = 6, names = {
             "--token" }, description = "Kubernetes oAuth token")
     public Optional<String> token = Optional.empty();
 
-    @CommandLine.Option(order = 7, names = {
+    @Option(order = 7, names = {
             "--trust-certs" }, description = "Flag to trust self-signed certificates")
     public Optional<Boolean> trustCerts = Optional.empty();
 
-    @CommandLine.Option(order = 8, names = { "--namespace" }, description = "The Kubernetes namespace")
+    @Option(order = 8, names = { "--namespace" }, description = "The Kubernetes namespace")
     public Optional<String> namespace = Optional.empty();
 
-    @CommandLine.Option(order = 9, names = { "--ca-cert-file" }, description = "The CA certificate file")
+    @Option(order = 9, names = { "--ca-cert-file" }, description = "The CA certificate file")
     public Optional<String> caCertFile = Optional.empty();
 
-    @CommandLine.Option(order = 10, names = { "--ca-cert-data" }, description = "The CA certificate data")
+    @Option(order = 10, names = { "--ca-cert-data" }, description = "The CA certificate data")
     public Optional<String> caCertData = Optional.empty();
 
-    @CommandLine.Option(order = 11, names = { "--client-cert-file" }, description = "The client certificate file")
+    @Option(order = 11, names = { "--client-cert-file" }, description = "The client certificate file")
     public Optional<String> clientCertFile = Optional.empty();
 
-    @CommandLine.Option(order = 12, names = { "--client-cert-data" }, description = "The client certificate data")
+    @Option(order = 12, names = { "--client-cert-data" }, description = "The client certificate data")
     public Optional<String> clientCertData = Optional.empty();
 
-    @CommandLine.Option(order = 13, names = { "--client-key-file" }, description = "The client key file")
+    @Option(order = 13, names = { "--client-key-file" }, description = "The client key file")
     public Optional<String> clientKeyFile = Optional.empty();
 
-    @CommandLine.Option(order = 14, names = { "--client-key-data" }, description = "The client key data")
+    @Option(order = 14, names = { "--client-key-data" }, description = "The client key data")
     public Optional<String> clientKeyData = Optional.empty();
 
-    @CommandLine.Option(order = 15, names = { "--client-key-algo" }, description = "The client key algorithm")
+    @Option(order = 15, names = { "--client-key-algo" }, description = "The client key algorithm")
     public Optional<String> clientKeyAlgo = Optional.empty();
 
-    @CommandLine.Option(order = 16, names = { "--client-key-passphrase" }, description = "The client key passphrase")
+    @Option(order = 16, names = { "--client-key-passphrase" }, description = "The client key passphrase")
     public Optional<String> clientKeyPassphrase = Optional.empty();
 
-    @CommandLine.Option(order = 17, names = {
+    @Option(order = 17, names = {
             "--http-proxy" }, description = "HTTP proxy used to access the Kubernetes API server")
     public Optional<String> httpProxy = Optional.empty();
 
-    @CommandLine.Option(order = 18, names = {
+    @Option(order = 18, names = {
             "--https-proxy" }, description = "HTTPS proxy used to access the Kubernetes API server")
     public Optional<String> httpsProxy = Optional.empty();
 
-    @CommandLine.Option(order = 18, names = { "--proxy-username" }, description = "Proxy username")
+    @Option(order = 18, names = { "--proxy-username" }, description = "Proxy username")
     public Optional<String> proxyUsername = Optional.empty();
 
-    @CommandLine.Option(order = 19, names = { "--proxy-password" }, description = "Proxy password")
+    @Option(order = 19, names = { "--proxy-password" }, description = "Proxy password")
     public Optional<String> proxyPassword = Optional.empty();
 
-    @CommandLine.Option(order = 19, names = {
+    @Option(order = 19, names = {
             "--no-proxy" }, arity = "0..*", description = "IP addresses or hosts to exclude from proxying")
     public String[] noProxy = new String[0];
 
-    @CommandLine.Option(order = 20, names = {
+    @Option(order = 20, names = {
             "--image-build" }, description = "Perform an image build using the selected builder before deployment")
     public boolean imageBuild;
 
-    @CommandLine.Option(order = 21, names = {
+    @Option(order = 21, names = {
             "--image-builder" }, description = "Perform an image build using the selected builder before deployment")
     public Optional<String> imageBuilder = Optional.empty();
 

--- a/devtools/cli/src/main/java/io/quarkus/cli/deploy/Minikube.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/deploy/Minikube.java
@@ -3,9 +3,10 @@ package io.quarkus.cli.deploy;
 import java.util.Optional;
 
 import io.quarkus.cli.common.BuildToolContext;
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Option;
 
-@CommandLine.Command(name = "minikube", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Perform the deploy action on minikube.", description = "%n"
+@Command(name = "minikube", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Perform the deploy action on minikube.", description = "%n"
         + "The command will deploy the application on minikube.", footer = "%n"
                 + "For example (using default values), it will create a Deployment named '<project.artifactId>' using the image with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>' and will deploy it to the target cluster.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
 public class Minikube extends BaseKubernetesDeployCommand {
@@ -21,7 +22,7 @@ public class Minikube extends BaseKubernetesDeployCommand {
         Job
     }
 
-    @CommandLine.Option(names = { "--deployment-kind" }, description = "The kind of resource to generate and deploy")
+    @Option(names = { "--deployment-kind" }, description = "The kind of resource to generate and deploy")
     public Optional<DeploymentKind> kind;
 
     @Override

--- a/devtools/cli/src/main/java/io/quarkus/cli/deploy/Openshift.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/deploy/Openshift.java
@@ -3,9 +3,10 @@ package io.quarkus.cli.deploy;
 import java.util.Optional;
 
 import io.quarkus.cli.common.BuildToolContext;
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Option;
 
-@CommandLine.Command(name = "openshift", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Perform the deploy action on OpenShift.", description = "%n"
+@Command(name = "openshift", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Perform the deploy action on OpenShift.", description = "%n"
         + "The command will deploy the application on OpenShift.", footer = "%n"
                 + "For example (using default values), it will create a Deployment named '<project.artifactId>' using the image with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>' and will deploy it to the target cluster.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
 public class Openshift extends BaseKubernetesDeployCommand {
@@ -21,7 +22,7 @@ public class Openshift extends BaseKubernetesDeployCommand {
         Job
     }
 
-    @CommandLine.Option(names = { "--deployment-kind" }, description = "The kind of resource to generate and deploy")
+    @Option(names = { "--deployment-kind" }, description = "The kind of resource to generate and deploy")
     public Optional<DeploymentKind> kind;
 
     @Override

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/BaseImageCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/BaseImageCommand.java
@@ -5,7 +5,7 @@ import java.util.concurrent.Callable;
 
 import io.quarkus.cli.common.BuildToolContext;
 import io.quarkus.cli.common.BuildToolDelegatingCommand;
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.ArgGroup;
 
 public class BaseImageCommand extends BuildToolDelegatingCommand implements Callable<Integer> {
 
@@ -17,7 +17,7 @@ public class BaseImageCommand extends BuildToolDelegatingCommand implements Call
     protected static final String QUARKUS_CONTAINER_IMAGE_BUILDER = "quarkus.container-image.builder";
     protected static final String QUARKUS_CONTAINER_IMAGE_REGISTRY = "quarkus.container-image.registry";
 
-    @CommandLine.ArgGroup(order = 2, exclusive = false, validate = false, heading = "%nImage options:%n")
+    @ArgGroup(order = 2, exclusive = false, validate = false, heading = "%nImage options:%n")
     ImageOptions imageOptions = new ImageOptions();
 
     public void populateContext(BuildToolContext context) {

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/BaseImageSubCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/BaseImageSubCommand.java
@@ -3,7 +3,7 @@ package io.quarkus.cli.image;
 import java.util.Optional;
 
 import io.quarkus.cli.common.BuildToolDelegatingCommand;
-import picocli.CommandLine.ParentCommand;
+import io.quarkus.quickcli.annotations.ParentCommand;
 
 public class BaseImageSubCommand extends BaseImageCommand {
 

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/Build.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/Build.java
@@ -5,9 +5,9 @@ import java.util.Optional;
 
 import io.quarkus.cli.common.BuildToolContext;
 import io.quarkus.devtools.project.BuildTool;
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.Command;
 
-@CommandLine.Command(name = "build", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Build a container image.", description = "%n"
+@Command(name = "build", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Build a container image.", description = "%n"
         + "This command will build a container image for the project.", subcommands = { Docker.class,
                 Podman.class,
                 Buildpack.class,

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/Buildpack.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/Buildpack.java
@@ -5,9 +5,10 @@ import java.util.Map;
 import java.util.Optional;
 
 import io.quarkus.cli.common.BuildToolContext;
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Option;
 
-@CommandLine.Command(name = "buildpack", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Build a container image using Buildpack.", description = "%n"
+@Command(name = "buildpack", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Build a container image using Buildpack.", description = "%n"
         + "This command will build or push a container image for the project, using Buildpack.", footer = "%n"
                 + "For example (using default values), it will create a container image using with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>'.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
 public class Buildpack extends BaseImageSubCommand {
@@ -23,28 +24,28 @@ public class Buildpack extends BaseImageSubCommand {
     private static final String BUILDER_ENV = "builder-env";
     private static final String DOCKER_HOST = "docker-host";
 
-    @CommandLine.Option(order = 7, names = { "--builder-image" }, description = "The builder image to use.")
+    @Option(order = 7, names = { "--builder-image" }, description = "The builder image to use.")
     public Optional<String> builderImage = Optional.empty();
 
-    @CommandLine.Option(order = 8, names = {
+    @Option(order = 8, names = {
             "--builder-registry-username" }, description = "The builder image registry username.")
     public Optional<String> builderRegistryUsername = Optional.empty();
 
-    @CommandLine.Option(order = 9, names = {
+    @Option(order = 9, names = {
             "--builder-registry-password" }, description = "The builder image registry password.")
     public Optional<String> builderRegistryPassword = Optional.empty();
 
-    @CommandLine.Option(order = 10, names = {
+    @Option(order = 10, names = {
             "--pull-image-timeout" }, description = "The amount of time to wait in seconds for pulling the builder image.")
     public Optional<Integer> pullTimeout = Optional.empty();
 
-    @CommandLine.Option(order = 11, names = { "--run-image" }, description = "The run image to use.")
+    @Option(order = 11, names = { "--run-image" }, description = "The run image to use.")
     public Optional<String> runImage = Optional.empty();
 
-    @CommandLine.Option(order = 12, names = { "--docker-host" }, description = "The docker host.")
+    @Option(order = 12, names = { "--docker-host" }, description = "The docker host.")
     public Optional<String> dockerHost = Optional.empty();
 
-    @CommandLine.Option(order = 13, names = { "--build-env" }, description = "A build environment variable.")
+    @Option(order = 13, names = { "--build-env" }, description = "A build environment variable.")
     public Map<String, String> buildEnv = new HashMap<>();
 
     @Override

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/Docker.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/Docker.java
@@ -4,9 +4,10 @@ import java.util.Map;
 import java.util.Optional;
 
 import io.quarkus.cli.common.BuildToolContext;
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Option;
 
-@CommandLine.Command(name = "docker", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Build a container image using Docker.", description = "%n"
+@Command(name = "docker", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Build a container image using Docker.", description = "%n"
         + "This command will build or push a container image for the project, using Docker.", footer = "%n"
                 + "For example (using default values), it will create a container image using with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>'.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
 public class Docker extends BaseImageSubCommand {
@@ -16,7 +17,7 @@ public class Docker extends BaseImageSubCommand {
     private static final String DOCKERFILE_JVM_PATH = "dockerfile-jvm-path";
     private static final String DOCKERFILE_NATIVE_PATH = "dockerfile-native-path";
 
-    @CommandLine.Option(order = 7, names = { "--dockerfile" }, description = "The path to the Dockerfile.")
+    @Option(order = 7, names = { "--dockerfile" }, description = "The path to the Dockerfile.")
     public Optional<String> dockerFile;
 
     @Override

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/ImageOptions.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/ImageOptions.java
@@ -3,23 +3,23 @@ package io.quarkus.cli.image;
 
 import java.util.Optional;
 
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.Option;
 
 public class ImageOptions {
 
-    @CommandLine.Option(order = 3, names = {
+    @Option(order = 3, names = {
             "--group" }, description = "The group part of the container image. Defaults to the ${user.name}.")
     public Optional<String> group = Optional.empty();
 
-    @CommandLine.Option(order = 4, names = {
+    @Option(order = 4, names = {
             "--name" }, description = "The name part of the container image. Defaults to the ${project.artifactId}.")
     public Optional<String> name = Optional.empty();
 
-    @CommandLine.Option(order = 5, names = {
+    @Option(order = 5, names = {
             "--tag" }, description = "The tag part of the container image. Defaults to the ${project.version}.")
     public Optional<String> tag = Optional.empty();
 
-    @CommandLine.Option(order = 6, names = {
+    @Option(order = 6, names = {
             "--registry" }, description = "The registry part of the container image. Empty by default.")
     public Optional<String> registry = Optional.empty();
 

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/Jib.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/Jib.java
@@ -10,9 +10,10 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import io.quarkus.cli.common.BuildToolContext;
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Option;
 
-@CommandLine.Command(name = "jib", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Build a container image using Jib.", description = "%n"
+@Command(name = "jib", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Build a container image using Jib.", description = "%n"
         + "This command will build or push a container image for the project, using Jib.", footer = "%n"
                 + "For example (using default values), it will create a container image using with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>'.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
 public class Jib extends BaseImageSubCommand {
@@ -35,41 +36,41 @@ public class Jib extends BaseImageSubCommand {
 
     private static final String USER = "user";
 
-    @CommandLine.Option(order = 7, names = { "--base-image" }, description = "The base image to use.")
+    @Option(order = 7, names = { "--base-image" }, description = "The base image to use.")
     public Optional<String> baseImage;
 
-    @CommandLine.Option(order = 8, names = {
+    @Option(order = 8, names = {
             "--arg" }, description = "Additional argument to pass when starting the application.")
     public List<String> arguments = new ArrayList<>();
 
-    @CommandLine.Option(order = 9, names = { "--entrypoint" }, description = "The entrypoint of the container image.")
+    @Option(order = 9, names = { "--entrypoint" }, description = "The entrypoint of the container image.")
     public List<String> entrypoint = new ArrayList<>();
 
-    @CommandLine.Option(order = 10, names = { "--env" }, description = "Environment variables to add to the container image.")
+    @Option(order = 10, names = { "--env" }, description = "Environment variables to add to the container image.")
     public Map<String, String> environmentVariables = new HashMap<>();
 
-    @CommandLine.Option(order = 11, names = { "--label" }, description = "Custom labels to add to the generated image.")
+    @Option(order = 11, names = { "--label" }, description = "Custom labels to add to the generated image.")
     public Map<String, String> labels = new HashMap<>();
 
-    @CommandLine.Option(order = 12, names = { "--port" }, description = "The ports to expose.")
+    @Option(order = 12, names = { "--port" }, description = "The ports to expose.")
     public List<Integer> ports = new ArrayList<>();
 
-    @CommandLine.Option(order = 13, names = { "--user" }, description = "The user in the generated image.")
+    @Option(order = 13, names = { "--user" }, description = "The user in the generated image.")
     public String user;
 
-    @CommandLine.Option(order = 14, names = {
+    @Option(order = 14, names = {
             "--always-cache-base-image" }, description = "Controls the optimization which skips downloading base image layers that exist in a target registry.")
     public boolean alwaysCacheBaseImage;
 
-    @CommandLine.Option(order = 15, names = {
+    @Option(order = 15, names = {
             "--platform" }, description = "The target platforms defined using the pattern <os>[/arch][/variant]|<os>/<arch>[/variant]")
     public Set<String> platforms = new HashSet<>();
 
-    @CommandLine.Option(order = 16, names = {
+    @Option(order = 16, names = {
             "--image-digest-file" }, description = "The path of a file that will be written containing the digest of the generated image.")
     public String imageDigestFile;
 
-    @CommandLine.Option(order = 17, names = {
+    @Option(order = 17, names = {
             "--image-id-file" }, description = "The path of a file that will be written containing the id of the generated image.")
     public String imageIdFile;
 

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/Openshift.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/Openshift.java
@@ -8,9 +8,10 @@ import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
 import io.quarkus.cli.common.BuildToolContext;
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Option;
 
-@CommandLine.Command(name = "openshift", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Build a container image using OpenShift.", description = "%n"
+@Command(name = "openshift", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Build a container image using OpenShift.", description = "%n"
         + "This command will build or push a container image for the project, using Openshift.", footer = "%n"
                 + "For example (using default values), it will create a container image in OpenShift using the docker build strategy with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>'.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
 public class Openshift extends BaseImageSubCommand implements Callable<Integer> {
@@ -32,27 +33,27 @@ public class Openshift extends BaseImageSubCommand implements Callable<Integer> 
     private static final String BUILD_STRATEGY = "build-strategy";
     private static final String BUILD_TIMEOUT = "build-timeout";
 
-    @CommandLine.Option(order = 7, names = { "--build-strategy" }, description = "The build strategy to use (docker or s2i).")
+    @Option(order = 7, names = { "--build-strategy" }, description = "The build strategy to use (docker or s2i).")
     public Optional<String> buildStrategy;
 
-    @CommandLine.Option(order = 8, names = { "--base-image" }, description = "The base image to use.")
+    @Option(order = 8, names = { "--base-image" }, description = "The base image to use.")
     public Optional<String> baseImage = Optional.empty();
 
-    @CommandLine.Option(order = 9, names = {
+    @Option(order = 9, names = {
             "--arg" }, description = "Additional argument to pass when starting the application.")
     public List<String> arguments = new ArrayList<>();
 
-    @CommandLine.Option(order = 10, names = { "--dockerfile" }, description = "The dockerfile of the container image.")
+    @Option(order = 10, names = { "--dockerfile" }, description = "The dockerfile of the container image.")
     public String dockerfile;
 
-    @CommandLine.Option(order = 11, names = {
+    @Option(order = 11, names = {
             "--artifact-directory" }, description = "The directory where the jar/native binary is added during the assemble phase.")
     public String artifactDirectory;
 
-    @CommandLine.Option(order = 12, names = { "--artifact-filename" }, description = "The filename of the jar/native binary.")
+    @Option(order = 12, names = { "--artifact-filename" }, description = "The filename of the jar/native binary.")
     public String artifactFilename;
 
-    @CommandLine.Option(order = 13, names = { "--build-timeout" }, description = "The build timeout.")
+    @Option(order = 13, names = { "--build-timeout" }, description = "The build timeout.")
     public String buildTimeout;
 
     @Override

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/Podman.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/Podman.java
@@ -3,9 +3,10 @@ package io.quarkus.cli.image;
 import java.util.Optional;
 
 import io.quarkus.cli.common.BuildToolContext;
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Option;
 
-@CommandLine.Command(name = "podman", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Build a container image using Podman.", description = "%n"
+@Command(name = "podman", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Build a container image using Podman.", description = "%n"
         + "This command will build or push a container image for the project, using Podman.", footer = "%n"
                 + "For example (using default values), it will create a container image using with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>'.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
 public class Podman extends BaseImageSubCommand {
@@ -15,7 +16,7 @@ public class Podman extends BaseImageSubCommand {
     private static final String DOCKERFILE_JVM_PATH = "dockerfile-jvm-path";
     private static final String DOCKERFILE_NATIVE_PATH = "dockerfile-native-path";
 
-    @CommandLine.Option(order = 7, names = { "--dockerfile" }, description = "The path to the Dockerfile.")
+    @Option(order = 7, names = { "--dockerfile" }, description = "The path to the Dockerfile.")
     public Optional<String> dockerFile;
 
     @Override

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/Push.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/Push.java
@@ -5,9 +5,10 @@ import java.util.Optional;
 
 import io.quarkus.cli.common.BuildToolContext;
 import io.quarkus.devtools.project.BuildTool;
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Option;
 
-@CommandLine.Command(name = "push", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Push a container image.", description = "%n"
+@Command(name = "push", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Push a container image.", description = "%n"
         + "This command will build and push a container image for the project.", footer = "%n", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
 public class Push extends BaseImageCommand {
 
@@ -19,19 +20,19 @@ public class Push extends BaseImageCommand {
     private static final String QUARKUS_CONTAINER_IMAGE_USERNAME = "quarkus.container-image.username";
     private static final String QUARKUS_CONTAINER_IMAGE_PASSWORD = "quarkus.container-image.password";
 
-    @CommandLine.Option(order = 8, names = {
+    @Option(order = 8, names = {
             "--registry-username" }, description = "The image registry username.")
     public Optional<String> registryUsername = Optional.empty();
 
-    @CommandLine.Option(order = 9, names = {
+    @Option(order = 9, names = {
             "--registry-password" }, description = "The image registry password.")
     public Optional<String> registryPassword = Optional.empty();
 
-    @CommandLine.Option(order = 10, names = {
+    @Option(order = 10, names = {
             "--registry-password-stdin" }, description = "Read the image registry password from stdin.")
     public boolean registryPasswordStdin;
 
-    @CommandLine.Option(order = 11, names = {
+    @Option(order = 11, names = {
             "--also-build" }, description = "(Re)build the image before pushing.")
     public boolean alsoBuild;
 

--- a/devtools/cli/src/main/java/io/quarkus/cli/plugin/CliPluginsAdd.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/plugin/CliPluginsAdd.java
@@ -8,19 +8,24 @@ import java.util.TreeMap;
 import java.util.concurrent.Callable;
 
 import io.quarkus.cli.common.RunModeOption;
-import picocli.CommandLine;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.quickcli.Help;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Mixin;
+import io.quarkus.quickcli.annotations.Option;
+import io.quarkus.quickcli.annotations.Parameters;
 
-@CommandLine.Command(name = "add", header = "Add plugin(s) to the Quarkus CLI.")
+@Command(name = "add", header = "Add plugin(s) to the Quarkus CLI.")
 public class CliPluginsAdd extends CliPluginsBase implements Callable<Integer> {
 
-    @CommandLine.Mixin
+    @Mixin
     RunModeOption runMode;
 
-    @CommandLine.Option(names = { "-d",
+    @Option(names = { "-d",
             "--description" }, paramLabel = "Plugin description", order = 5, description = "The plugin description")
     Optional<String> description;
 
-    @CommandLine.Parameters(arity = "1", paramLabel = "PLUGIN_NAME", description = " The plugin name or location (e.g. url, path or maven coordinates in GACTV form)")
+    @Parameters(arity = "1", paramLabel = "PLUGIN_NAME", description = " The plugin name or location (e.g. url, path or maven coordinates in GACTV form)")
     String nameOrLocation;
 
     @Override
@@ -31,7 +36,7 @@ public class CliPluginsAdd extends CliPluginsBase implements Callable<Integer> {
 
             if (runMode.isDryRun()) {
                 dryRunAdd(spec.commandLine().getHelp());
-                return CommandLine.ExitCode.OK;
+                return ExitCode.OK;
             }
 
             return addPlugin();
@@ -63,11 +68,11 @@ public class CliPluginsAdd extends CliPluginsBase implements Callable<Integer> {
                         "Plugin was added in the user scope, but another with the same name exists in the project scope!\nThe project scoped one will take precedence when invoked from within the project!");
             }
 
-            return CommandLine.ExitCode.OK;
+            return ExitCode.OK;
         }).orElseGet(() -> {
             output.error("No plugin available at: " + this.nameOrLocation);
             printHints(true);
-            return CommandLine.ExitCode.USAGE;
+            return ExitCode.USAGE;
         });
     }
 
@@ -80,7 +85,7 @@ public class CliPluginsAdd extends CliPluginsBase implements Callable<Integer> {
         }
     }
 
-    void dryRunAdd(CommandLine.Help help) {
+    void dryRunAdd(Help help) {
         output.printText(new String[] {
                 "\nAdd plugin to the CLI\n",
                 "\t" + projectRoot().toString()

--- a/devtools/cli/src/main/java/io/quarkus/cli/plugin/CliPluginsBase.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/plugin/CliPluginsBase.java
@@ -7,18 +7,19 @@ import java.util.function.Predicate;
 import io.quarkus.cli.BaseBuildCommand;
 import io.quarkus.cli.common.TargetQuarkusPlatformGroup;
 import io.quarkus.devtools.project.QuarkusProject;
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.ArgGroup;
+import io.quarkus.quickcli.annotations.Option;
 
 public class CliPluginsBase extends BaseBuildCommand {
 
-    @CommandLine.Option(names = { "-t",
+    @Option(names = { "-t",
             "--type" }, paramLabel = "PLUGIN_TYPE", order = 3, description = "Only list plugins from the specified type.")
     Optional<PluginType> type = Optional.empty();
 
-    @CommandLine.ArgGroup(order = 2, heading = "%nQuarkus version (absolute):%n")
+    @ArgGroup(order = 2, heading = "%nQuarkus version (absolute):%n")
     TargetQuarkusPlatformGroup targetQuarkusVersion = new TargetQuarkusPlatformGroup();
 
-    @CommandLine.ArgGroup(order = 3, heading = "%nCatalog:%n")
+    @ArgGroup(order = 3, heading = "%nCatalog:%n")
     PluginCatalogOptions catalogOptions = new PluginCatalogOptions();
 
     public Optional<QuarkusProject> quarkusProject() {

--- a/devtools/cli/src/main/java/io/quarkus/cli/plugin/CliPluginsList.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/plugin/CliPluginsList.java
@@ -13,24 +13,28 @@ import java.util.stream.Collectors;
 
 import io.quarkus.cli.common.RunModeOption;
 import io.quarkus.devtools.project.BuildTool;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.quickcli.Help;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Mixin;
+import io.quarkus.quickcli.annotations.Option;
 import io.quarkus.runtime.util.StringUtil;
-import picocli.CommandLine;
 
-@CommandLine.Command(name = "list", aliases = "ls", header = "List CLI plugins. ")
+@Command(name = "list", aliases = "ls", header = "List CLI plugins. ")
 public class CliPluginsList extends CliPluginsBase implements Callable<Integer> {
 
-    @CommandLine.Mixin
+    @Mixin
     RunModeOption runMode;
 
-    @CommandLine.Option(names = { "-i",
+    @Option(names = { "-i",
             "--installable" }, defaultValue = "false", order = 4, description = "List plugins that can be installed")
     boolean installable = false;
 
-    @CommandLine.Option(names = { "-s",
+    @Option(names = { "-s",
             "--search" }, defaultValue = "*", order = 5, paramLabel = "PATTERN", description = "Search for matching plugins (simple glob using '*' and '?').")
     String searchPattern;
 
-    @CommandLine.Option(names = { "-c",
+    @Option(names = { "-c",
             "--show-command" }, defaultValue = "false", order = 6, description = "Show the command that corresponds to the plugin")
     boolean showCommand = false;
 
@@ -54,7 +58,7 @@ public class CliPluginsList extends CliPluginsBase implements Callable<Integer> 
         }
     }
 
-    Integer dryRunList(CommandLine.Help help, BuildTool buildTool) {
+    Integer dryRunList(Help help, BuildTool buildTool) {
         Map<String, String> dryRunOutput = new TreeMap<>();
         output.printText(new String[] { "\nList plugins\n" });
         dryRunOutput.put("Search pattern", searchPattern);
@@ -63,7 +67,7 @@ public class CliPluginsList extends CliPluginsBase implements Callable<Integer> 
         dryRunOutput.put("Only user", String.valueOf(catalogOptions.user));
 
         output.info(help.createTextTable(dryRunOutput).toString());
-        return CommandLine.ExitCode.OK;
+        return ExitCode.OK;
     }
 
     Integer listPluigns() {
@@ -95,7 +99,7 @@ public class CliPluginsList extends CliPluginsBase implements Callable<Integer> 
                     items.values().stream().filter(this::filter).collect(Collectors.toList()), showCommand);
             output.info(table.getContent());
         }
-        return CommandLine.ExitCode.OK;
+        return ExitCode.OK;
     }
 
     private void printHints(boolean installableHint, boolean remoteHint) {

--- a/devtools/cli/src/main/java/io/quarkus/cli/plugin/CliPluginsRemove.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/plugin/CliPluginsRemove.java
@@ -8,15 +8,19 @@ import java.util.TreeMap;
 import java.util.concurrent.Callable;
 
 import io.quarkus.cli.common.RunModeOption;
-import picocli.CommandLine;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.quickcli.Help;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Mixin;
+import io.quarkus.quickcli.annotations.Parameters;
 
-@CommandLine.Command(name = "remove", header = "Remove plugin(s) to the Quarkus CLI.")
+@Command(name = "remove", header = "Remove plugin(s) to the Quarkus CLI.")
 public class CliPluginsRemove extends CliPluginsBase implements Callable<Integer> {
 
-    @CommandLine.Mixin
+    @Mixin
     RunModeOption runMode;
 
-    @CommandLine.Parameters(arity = "1", paramLabel = "PLUGIN_NAME", description = "Plugin name to remove from the CLI")
+    @Parameters(arity = "1", paramLabel = "PLUGIN_NAME", description = "Plugin name to remove from the CLI")
     String name;
 
     @Override
@@ -27,7 +31,7 @@ public class CliPluginsRemove extends CliPluginsBase implements Callable<Integer
 
             if (runMode.isDryRun()) {
                 dryRunRemove(spec.commandLine().getHelp());
-                return CommandLine.ExitCode.OK;
+                return ExitCode.OK;
             }
 
             return removePlugin();
@@ -55,14 +59,14 @@ public class CliPluginsRemove extends CliPluginsBase implements Callable<Integer
                             "The removed plugin was available both in user and project scopes. It was removed from the user but will remain available in the project scope!");
                 }
             }
-            return CommandLine.ExitCode.OK;
+            return ExitCode.OK;
         }).orElseGet(() -> {
             output.error("Plugin: " + name + " not found in catalog!");
-            return CommandLine.ExitCode.USAGE;
+            return ExitCode.USAGE;
         });
     }
 
-    void dryRunRemove(CommandLine.Help help) {
+    void dryRunRemove(Help help) {
         output.printText(new String[] {
                 "\nRemove plugin from the CLI\n",
                 "\t" + projectRoot().toString()

--- a/devtools/cli/src/main/java/io/quarkus/cli/plugin/CliPluginsSync.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/plugin/CliPluginsSync.java
@@ -7,12 +7,15 @@ import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
 import io.quarkus.cli.common.RunModeOption;
-import picocli.CommandLine;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.quickcli.Help;
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Mixin;
 
-@CommandLine.Command(name = "sync", header = "Sync (discover / purge) CLI Plugins.")
+@Command(name = "sync", header = "Sync (discover / purge) CLI Plugins.")
 public class CliPluginsSync extends CliPluginsBase implements Callable<Integer> {
 
-    @CommandLine.Mixin
+    @Mixin
     RunModeOption runMode;
 
     @Override
@@ -21,7 +24,7 @@ public class CliPluginsSync extends CliPluginsBase implements Callable<Integer> 
 
         if (runMode.isDryRun()) {
             dryRunAdd(spec.commandLine().getHelp());
-            return CommandLine.ExitCode.OK;
+            return ExitCode.OK;
         }
 
         PluginManager pluginManager = pluginManager();
@@ -43,10 +46,10 @@ public class CliPluginsSync extends CliPluginsBase implements Callable<Integer> 
         } else {
             output.info("Nothing to sync (no plugins were added or removed).");
         }
-        return CommandLine.ExitCode.OK;
+        return ExitCode.OK;
     }
 
-    void dryRunAdd(CommandLine.Help help) {
+    void dryRunAdd(Help help) {
         output.printText(new String[] {
                 "\tSync plugin to the CLI\n",
                 "\t" + projectRoot().toString()

--- a/devtools/cli/src/main/java/io/quarkus/cli/plugin/JBangCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/plugin/JBangCommand.java
@@ -4,8 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import io.quarkus.cli.common.OutputOptionMixin;
-import picocli.CommandLine.Command;
-import picocli.CommandLine.ExitCode;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.quickcli.annotations.Command;
 
 @Command
 public class JBangCommand implements PluginCommand {

--- a/devtools/cli/src/main/java/io/quarkus/cli/plugin/PluginCatalogOptions.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/plugin/PluginCatalogOptions.java
@@ -3,16 +3,16 @@ package io.quarkus.cli.plugin;
 import java.nio.file.Path;
 import java.util.Optional;
 
-import picocli.CommandLine;
+import io.quarkus.quickcli.annotations.Option;
 
 public class PluginCatalogOptions {
 
-    @CommandLine.Option(names = {
+    @Option(names = {
             "--user" }, defaultValue = "", paramLabel = "USER", order = 4, description = "Use the user catalog.")
     boolean user;
 
-    @CommandLine.Option(names = {
+    @Option(names = {
             "--user-dir" }, paramLabel = "USER_DIR", order = 5, description = "Use the user catalog directory.")
-    Optional<Path> userDirectory = Optional.empty();
+    public Optional<Path> userDirectory = Optional.empty();
 
 }

--- a/devtools/cli/src/main/java/io/quarkus/cli/plugin/PluginCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/plugin/PluginCommand.java
@@ -8,8 +8,9 @@ import java.util.concurrent.Callable;
 
 import io.quarkus.cli.common.OutputOptionMixin;
 import io.quarkus.cli.common.build.ExecuteUtil;
+import io.quarkus.quickcli.UsesArguments;
 
-public interface PluginCommand extends Callable<Integer> {
+public interface PluginCommand extends Callable<Integer>, UsesArguments {
 
     List<String> getCommand();
 

--- a/devtools/cli/src/main/java/io/quarkus/cli/plugin/PluginCommandFactory.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/plugin/PluginCommandFactory.java
@@ -1,7 +1,6 @@
 package io.quarkus.cli.plugin;
 
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -11,11 +10,9 @@ import java.util.stream.Collectors;
 
 import io.quarkus.cli.common.OutputOptionMixin;
 import io.quarkus.maven.dependency.GACTV;
+import io.quarkus.quickcli.CommandLine;
+import io.quarkus.quickcli.CommandSpec;
 import io.quarkus.runtime.util.StringUtil;
-import picocli.CommandLine;
-import picocli.CommandLine.Model.CommandSpec;
-import picocli.CommandLine.Model.ISetter;
-import picocli.CommandLine.Model.PositionalParamSpec;
 
 public class PluginCommandFactory {
 
@@ -60,26 +57,12 @@ public class PluginCommandFactory {
 
     public Function<PluginCommand, CommandSpec> createCommandSpec(String description) {
         return command -> {
-            CommandSpec spec = CommandSpec.wrapWithoutInspection(command);
+            CommandSpec spec = CommandSpec.create("plugin-cmd", command.getClass());
+            spec.setCommandInstance(command);
+            spec.setHasUnmatchedField(true);
             if (!StringUtil.isNullOrEmpty(description)) {
                 spec.usageMessage().description(description);
             }
-            spec.parser().unmatchedArgumentsAllowed(true);
-            spec.parser().unmatchedOptionsArePositionalParams(true);
-            spec.add(PositionalParamSpec.builder().type(String[].class).arity("0..*").description("Positional arguments")
-                    .setter(new ISetter() {
-                        @Override
-                        public <T> T set(T value) throws Exception {
-                            if (value == null) {
-                                return value;
-                            }
-                            if (value instanceof String[]) {
-                                String[] array = (String[]) value;
-                                command.useArguments(Arrays.asList(array));
-                            }
-                            return value;
-                        }
-                    }).build());
             return spec;
         };
     }

--- a/devtools/cli/src/main/java/io/quarkus/cli/plugin/ShellCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/plugin/ShellCommand.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.concurrent.Callable;
 
 import io.quarkus.cli.common.OutputOptionMixin;
-import picocli.CommandLine.Command;
+import io.quarkus.quickcli.annotations.Command;
 
 @Command
 public class ShellCommand implements PluginCommand, Callable<Integer> {

--- a/devtools/cli/src/main/java/io/quarkus/cli/registry/BaseRegistryCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/registry/BaseRegistryCommand.java
@@ -5,26 +5,28 @@ import java.util.concurrent.Callable;
 import io.quarkus.cli.common.HelpOption;
 import io.quarkus.cli.common.OutputOptionMixin;
 import io.quarkus.cli.common.registry.RegistryClientMixin;
-import picocli.CommandLine;
-import picocli.CommandLine.Model.CommandSpec;
+import io.quarkus.quickcli.CommandSpec;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.quickcli.annotations.Mixin;
+import io.quarkus.quickcli.annotations.Spec;
 
 public class BaseRegistryCommand implements Callable<Integer> {
 
-    @CommandLine.Mixin(name = "output")
+    @Mixin(name = "output")
     protected OutputOptionMixin output;
 
-    @CommandLine.Mixin
+    @Mixin
     protected RegistryClientMixin registryClient;
 
-    @CommandLine.Mixin
+    @Mixin
     protected HelpOption helpOption;
 
-    @CommandLine.Spec
+    @Spec
     protected CommandSpec spec;
 
     @Override
     public Integer call() throws Exception {
         spec.commandLine().usage(output.out());
-        return CommandLine.ExitCode.OK;
+        return ExitCode.OK;
     }
 }

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliCreateExtensionTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliCreateExtensionTest.java
@@ -11,11 +11,14 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.devtools.commands.CreateExtension;
 import io.quarkus.devtools.testing.RegistryClientTestHelper;
-import picocli.CommandLine;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.test.junit.main.QuarkusMainLauncher;
+import io.quarkus.test.junit.main.QuarkusMainTest;
 
+@QuarkusMainTest
 public class CliCreateExtensionTest {
     static final Path testProjectRoot = Paths.get(System.getProperty("user.dir")).toAbsolutePath()
-            .resolve("target/test-classes/test-project/");
+            .resolve("target/test-project/");
     static final Path workspaceRoot = testProjectRoot.resolve("CliCreateExtensionTest");
     Path project;
 
@@ -36,7 +39,8 @@ public class CliCreateExtensionTest {
     }
 
     @Test
-    public void testCreateDryRun() throws Exception {
+    public void testCreateDryRun(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "extension", "--dry-run");
         String noSpaces = result.stdout.replaceAll("[\\s\\p{Z}]", "");
         Assertions.assertTrue(noSpaces.contains("SkipDev-modeTestfalse"),
@@ -48,7 +52,8 @@ public class CliCreateExtensionTest {
     }
 
     @Test
-    public void testCreateDryRunWithoutTests() throws Exception {
+    public void testCreateDryRunWithoutTests(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "extension", "--dry-run", "--without-tests");
         String noSpaces = result.stdout.replaceAll("[\\s\\p{Z}]", "");
         Assertions.assertTrue(noSpaces.contains("SkipDev-modeTesttrue"),
@@ -60,7 +65,8 @@ public class CliCreateExtensionTest {
     }
 
     @Test
-    public void testCreateDryRunNoTests() throws Exception {
+    public void testCreateDryRunNoTests(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "extension", "--dry-run",
                 "--no-unit-test", "--no-it-test", "--no-devmode-test");
         String noSpaces = result.stdout.replaceAll("[\\s\\p{Z}]", "");
@@ -73,10 +79,11 @@ public class CliCreateExtensionTest {
     }
 
     @Test
-    public void testCreateExtensionDefaults() throws Exception {
+    public void testCreateExtensionDefaults(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         // Create a Quarkiverse extension by default
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "extension", "-e", "-B", "--verbose");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code." + result);
         Assertions.assertTrue(result.stdout.contains("generated"),
                 "Expected confirmation that the project has been created." + result);
 
@@ -129,12 +136,13 @@ public class CliCreateExtensionTest {
     }
 
     @Test
-    public void testCreateExtension() throws Exception {
+    public void testCreateExtension(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         // Create a standalone extension w/ specified names
         project = workspaceRoot.resolve("something");
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "extension", "-e", "-B", "--verbose",
                 "org.my:something:0.1");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code." + result);
         Assertions.assertTrue(result.stdout.contains("generated"),
                 "Expected confirmation that the project has been created." + result);
 

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliDriver.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliDriver.java
@@ -23,7 +23,9 @@ import java.util.function.UnaryOperator;
 
 import org.junit.jupiter.api.Assertions;
 
-import picocli.CommandLine;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.test.junit.main.LaunchResult;
+import io.quarkus.test.junit.main.QuarkusMainLauncher;
 
 public class CliDriver {
     static final PrintStream stdout = System.out;
@@ -32,12 +34,23 @@ public class CliDriver {
     private static final UnaryOperator<String> REPO_ARG_FORMATTER = value -> ARG_FORMATTER.apply(LOCAL_REPO_PROPERTY, value);
     private static final UnaryOperator<String> SETTINGS_ARG_FORMATTER = value -> ARG_FORMATTER.apply(MAVEN_SETTINGS, value);
 
+    private static final ThreadLocal<QuarkusMainLauncher> CURRENT_LAUNCHER = new ThreadLocal<>();
+
+    public static void setLauncher(QuarkusMainLauncher launcher) {
+        CURRENT_LAUNCHER.set(launcher);
+    }
+
+    public static void clearLauncher() {
+        CURRENT_LAUNCHER.remove();
+    }
+
     public static class CliDriverBuilder {
 
         private Path startingDir;
         private final List<String> args = new ArrayList<>();
         private String mavenLocalRepo;
         private String mavenSettings;
+        private QuarkusMainLauncher launcher;
 
         private CliDriverBuilder() {
         }
@@ -62,6 +75,11 @@ public class CliDriver {
             return this;
         }
 
+        public CliDriverBuilder setLauncher(QuarkusMainLauncher launcher) {
+            this.launcher = launcher;
+            return this;
+        }
+
         public Result execute() throws Exception {
             List<String> newArgs = args;
 
@@ -83,6 +101,15 @@ public class CliDriver {
             newArgs.addAll(looseArgs); // re-add arguments
 
             System.out.println("$ quarkus " + String.join(" ", newArgs));
+
+            if (launcher != null) {
+                LaunchResult launchResult = launcher.launch(newArgs.toArray(String[]::new));
+                Result result = new Result();
+                result.exitCode = launchResult.exitCode();
+                result.stdout = launchResult.getOutput();
+                result.stderr = launchResult.getErrorOutput();
+                return result;
+            }
 
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             PrintStream outPs = new PrintStream(out);
@@ -146,6 +173,12 @@ public class CliDriver {
         return new CliDriverBuilder();
     }
 
+    public static CliDriverBuilder builder(QuarkusMainLauncher launcher) {
+        CliDriverBuilder b = new CliDriverBuilder();
+        b.launcher = launcher;
+        return b;
+    }
+
     public static void preserveLocalRepoSettings(Collection<String> args) {
         getMavenLocalRepoProperty().map(REPO_ARG_FORMATTER).ifPresent(args::add);
         getMavenSettingsProperty().map(SETTINGS_ARG_FORMATTER).ifPresent(args::add);
@@ -174,7 +207,12 @@ public class CliDriver {
     }
 
     public static Result execute(Path startingDir, String... args) throws Exception {
-        return builder().setStartingDir(startingDir).addArgs(args).execute();
+        CliDriverBuilder b = builder();
+        QuarkusMainLauncher launcher = CURRENT_LAUNCHER.get();
+        if (launcher != null) {
+            b.setLauncher(launcher);
+        }
+        return b.setStartingDir(startingDir).addArgs(args).execute();
     }
 
     public static void println(String msg) {
@@ -264,7 +302,7 @@ public class CliDriver {
     public static Result invokeValidateExtensionList(Path projectRoot) throws Exception {
         Result result = execute(projectRoot, "extension", "list", "-e", "-B", "--verbose");
 
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
 
         Assertions.assertFalse(result.stdout.contains("camel-"),
@@ -276,7 +314,7 @@ public class CliDriver {
     public static Result invokeExtensionAddQute(Path projectRoot, Path file) throws Exception {
         // add the qute extension
         Result result = execute(projectRoot, "extension", "add", "qute", "-e", "-B", "--verbose");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
 
         // list all extensions, make sure qute is present
@@ -294,7 +332,7 @@ public class CliDriver {
     public static Result invokeExtensionRemoveQute(Path projectRoot, Path file) throws Exception {
         // remove the qute extension
         Result result = execute(projectRoot, "extension", "remove", "qute", "-e", "-B", "--verbose");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
 
         // list all extensions, make sure qute is present
@@ -312,7 +350,7 @@ public class CliDriver {
     public static Result invokeExtensionAddMultiple(Path projectRoot, Path file) throws Exception {
         // add amazon-lambda-http and jackson extensions
         Result result = execute(projectRoot, "extension", "add", "amazon-lambda-http", "jackson", "-e", "-B", "--verbose");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
 
         // list all extensions, make sure all are present
@@ -338,7 +376,7 @@ public class CliDriver {
     public static Result invokeExtensionRemoveMultiple(Path projectRoot, Path file) throws Exception {
         // remove amazon-lambda-http and jackson extensions
         Result result = execute(projectRoot, "extension", "remove", "amazon-lambda-http", "jackson", "-e", "-B", "--verbose");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
 
         // list all extensions, make sure all are present
@@ -364,7 +402,7 @@ public class CliDriver {
     public static Result invokeExtensionAddMultipleCommas(Path projectRoot, Path file) throws Exception {
         Result result = execute(projectRoot, "extension", "add",
                 "quarkus-rest-jsonb,quarkus-rest-jackson", "-e", "-B", "--verbose");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
 
         result = invokeValidateExtensionList(projectRoot);
@@ -389,7 +427,7 @@ public class CliDriver {
     public static Result invokeExtensionRemoveMultipleCommas(Path projectRoot, Path file) throws Exception {
         Result result = execute(projectRoot, "extension", "remove",
                 "quarkus-rest-jsonb,quarkus-rest-jackson", "-e", "-B", "--verbose");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
 
         result = invokeValidateExtensionList(projectRoot);
@@ -409,7 +447,7 @@ public class CliDriver {
 
     public static Result invokeExtensionListInstallable(Path projectRoot) throws Exception {
         Result result = CliDriver.execute(projectRoot, "extension", "list", "-e", "-B", "--verbose", "-i");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
         Assertions.assertTrue(result.stdout.contains("quarkus-hibernate-orm"),
                 "quarkus-hibernate-orm should be listed as an installable extension. Found:\n" + result);
@@ -420,7 +458,7 @@ public class CliDriver {
 
     public static Result invokeExtensionListInstallableSearch(Path projectRoot) throws Exception {
         Result result = CliDriver.execute(projectRoot, "extension", "list", "-e", "-B", "--verbose", "-i", "--search=vertx-*");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
 
         Assertions.assertTrue(result.stdout.contains("quarkus-reactive-routes"),
@@ -433,7 +471,7 @@ public class CliDriver {
 
     public static void invokeExtensionListFormatting(Path projectRoot) throws Exception {
         Result result = CliDriver.execute(projectRoot, "extension", "list", "-e", "-B", "--verbose", "-i", "--concise");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
         Assertions.assertTrue(result.stdout.contains("quarkus-reactive-routes"),
                 "quarkus-reactive-routes should be returned in result. Found:\n" + result);
@@ -441,25 +479,25 @@ public class CliDriver {
                 "'Reactive Routes' descriptive name should be returned in results. Found:\n" + result);
 
         result = CliDriver.execute(projectRoot, "extension", "list", "-e", "-B", "--verbose", "-i", "--full");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
         // TODO
 
         result = CliDriver.execute(projectRoot, "extension", "list", "-e", "-B", "--verbose", "-i", "--origins");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
         // TODO
 
         // Two different output options can not be specified together
         result = CliDriver.execute(projectRoot, "extension", "list", "-e", "-B", "--verbose", "-i", "--origins", "--name");
-        Assertions.assertEquals(CommandLine.ExitCode.USAGE, result.exitCode,
+        Assertions.assertEquals(ExitCode.USAGE, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
         // TODO
     }
 
     public static Result invokeExtensionAddRedundantQute(Path projectRoot) throws Exception {
         Result result = execute(projectRoot, "extension", "add", "-e", "-B", "--verbose", "qute");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
         return result;
     }
@@ -473,7 +511,7 @@ public class CliDriver {
     public static Result invokeValidateDryRunBuild(Path projectRoot) throws Exception {
         Result result = execute(projectRoot, "build", "-e", "-B", "--dryrun",
                 "-Dproperty=value1", "-Dproperty2=value2");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
         Assertions.assertTrue(result.stdout.contains("Command line"),
                 "--dry-run should echo command line");
@@ -483,7 +521,7 @@ public class CliDriver {
     public static Result invokeValidateBuild(Path projectRoot) throws Exception {
         Result result = execute(projectRoot, "build", "-e", "-B", "--clean",
                 "-Dproperty=value1", "-Dproperty2=value2");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
         return result;
     }

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliHelpTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliHelpTest.java
@@ -15,17 +15,21 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import io.quarkus.devtools.messagewriter.MessageIcons;
 import io.quarkus.devtools.messagewriter.MessageWriter;
+import io.quarkus.test.junit.main.QuarkusMainLauncher;
+import io.quarkus.test.junit.main.QuarkusMainTest;
 
 /**
  * This is ordered to make output easier to view (as it effectively dumps help)
  */
 @TestMethodOrder(OrderAnnotation.class)
+@QuarkusMainTest
 public class CliHelpTest {
     static Path workspaceRoot = Paths.get(System.getProperty("user.dir")).toAbsolutePath().resolve("target/test-project");
 
     @Test
     @Order(1)
-    public void testCommandHelp() throws Exception {
+    public void testCommandHelp(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "--help");
         result.echoSystemOut();
         assertThat(result.stdout).contains("Usage");
@@ -38,7 +42,8 @@ public class CliHelpTest {
 
     @Test
     @Order(10)
-    public void testCreateHelp() throws Exception {
+    public void testCreateHelp(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "--help");
         result.echoSystemOut();
         assertThat(result.stdout).contains("Usage");
@@ -46,7 +51,8 @@ public class CliHelpTest {
 
     @Test
     @Order(11)
-    public void testCreateAppHelp() throws Exception {
+    public void testCreateAppHelp(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--help");
         result.echoSystemOut();
         assertThat(result.stdout).contains("Usage");
@@ -54,7 +60,8 @@ public class CliHelpTest {
 
     @Test
     @Order(12)
-    public void testCreateCliHelp() throws Exception {
+    public void testCreateCliHelp(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "cli", "--help");
         result.echoSystemOut();
         assertThat(result.stdout).contains("Usage");
@@ -62,7 +69,8 @@ public class CliHelpTest {
 
     @Test
     @Order(13)
-    public void testCreateExtensionHelp() throws Exception {
+    public void testCreateExtensionHelp(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "extension", "--help");
         result.echoSystemOut();
         assertThat(result.stdout).contains("Usage");
@@ -70,7 +78,8 @@ public class CliHelpTest {
 
     @Test
     @Order(20)
-    public void testBuildHelp() throws Exception {
+    public void testBuildHelp(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "build", "--help");
         result.echoSystemOut();
         assertThat(result.stdout).contains("Usage");
@@ -78,7 +87,8 @@ public class CliHelpTest {
 
     @Test
     @Order(30)
-    public void testDevHelp() throws Exception {
+    public void testDevHelp(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "dev", "--help");
         result.echoSystemOut();
         assertThat(result.stdout).contains("Usage");
@@ -87,7 +97,8 @@ public class CliHelpTest {
 
     @Test
     @Order(40)
-    public void testExtHelp() throws Exception {
+    public void testExtHelp(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "ext", "--help");
         result.echoSystemOut();
         assertThat(result.stdout).contains("Usage");
@@ -99,7 +110,8 @@ public class CliHelpTest {
 
     @Test
     @Order(41)
-    public void testExtCatHelp() throws Exception {
+    public void testExtCatHelp(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "ext", "cat", "--help");
         result.echoSystemOut();
         assertThat(result.stdout).contains("Usage");
@@ -111,7 +123,8 @@ public class CliHelpTest {
 
     @Test
     @Order(42)
-    public void testExtListHelp() throws Exception {
+    public void testExtListHelp(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "ext", "ls", "--help");
         result.echoSystemOut();
         assertThat(result.stdout).contains("Usage");
@@ -123,7 +136,8 @@ public class CliHelpTest {
 
     @Test
     @Order(43)
-    public void testExtAddHelp() throws Exception {
+    public void testExtAddHelp(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "ext", "add", "--help");
         result.echoSystemOut();
         assertThat(result.stdout).contains("Usage");
@@ -131,7 +145,8 @@ public class CliHelpTest {
 
     @Test
     @Order(44)
-    public void testExtRemoveHelp() throws Exception {
+    public void testExtRemoveHelp(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "ext", "rm", "--help");
         result.echoSystemOut();
         assertThat(result.stdout).contains("Usage");
@@ -143,7 +158,8 @@ public class CliHelpTest {
 
     @Test
     @Order(50)
-    public void testRegistryHelp() throws Exception {
+    public void testRegistryHelp(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "registry", "--help");
         result.echoSystemOut();
         assertThat(result.stdout).contains("Usage");
@@ -151,7 +167,8 @@ public class CliHelpTest {
 
     @Test
     @Order(51)
-    public void testRegistryListHelp() throws Exception {
+    public void testRegistryListHelp(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "registry", "list", "--help");
         result.echoSystemOut();
         assertThat(result.stdout).contains("Usage");
@@ -159,7 +176,8 @@ public class CliHelpTest {
 
     @Test
     @Order(51)
-    public void testRegistryAddHelp() throws Exception {
+    public void testRegistryAddHelp(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "registry", "add", "--help");
         result.echoSystemOut();
         assertThat(result.stdout).contains("Usage");
@@ -167,7 +185,8 @@ public class CliHelpTest {
 
     @Test
     @Order(52)
-    public void testRegistryRemoveHelp() throws Exception {
+    public void testRegistryRemoveHelp(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "registry", "rm", "--help");
         result.echoSystemOut();
         assertThat(result.stdout).contains("Usage");
@@ -175,7 +194,8 @@ public class CliHelpTest {
 
     @Order(60)
     @Test
-    public void testGenerateCompletionHelp() throws Exception {
+    public void testGenerateCompletionHelp(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "completion", "--help");
         result.echoSystemOut();
         assertThat(result.stdout).contains("Usage");
@@ -183,7 +203,8 @@ public class CliHelpTest {
 
     @Test
     @Order(70)
-    public void testCommandVersion() throws Exception {
+    public void testCommandVersion(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "version", "--help");
         result.echoSystemOut();
         assertThat(result.stdout).contains("Usage");
@@ -191,7 +212,8 @@ public class CliHelpTest {
 
     @Test
     @Order(80)
-    public void testMessageFlags() throws Exception {
+    public void testMessageFlags(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         MessageWriter writer = MessageWriter.debug();
         writer.error("error"); // has emoji
         writer.warn("warn"); // has emoji
@@ -203,7 +225,8 @@ public class CliHelpTest {
 
     @Test
     @Order(90)
-    public void testImageHelp() throws Exception {
+    public void testImageHelp(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "image", "--help");
         result.echoSystemOut();
         assertThat(result.stdout).contains("Usage");
@@ -214,7 +237,8 @@ public class CliHelpTest {
 
     @Test
     @Order(92)
-    public void testImageBuildHelp() throws Exception {
+    public void testImageBuildHelp(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "image", "build", "--help");
         result.echoSystemOut();
         assertThat(result.stdout).contains("Usage");
@@ -230,7 +254,8 @@ public class CliHelpTest {
     @ParameterizedTest
     @Order(93)
     @ValueSource(strings = { "docker", "podman", "jib", "openshift", "buildpack" })
-    public void testImageBuildBuilderHelp(String builder) throws Exception {
+    public void testImageBuildBuilderHelp(String builder, QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "image", "build", builder, "--help");
         result.echoSystemOut();
         assertThat(result.stdout).contains("Usage");
@@ -238,7 +263,8 @@ public class CliHelpTest {
 
     @Test
     @Order(96)
-    public void testImagePushHelp() throws Exception {
+    public void testImagePushHelp(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "image", "push", "--help");
         result.echoSystemOut();
         assertThat(result.stdout).contains("Usage");
@@ -251,7 +277,8 @@ public class CliHelpTest {
     @ParameterizedTest
     @Order(97)
     @ValueSource(strings = { "docker", "podman", "jib", "openshift", "buildpack" })
-    public void testImagePushBuilderHelp(String builder) throws Exception {
+    public void testImagePushBuilderHelp(String builder, QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "image", "push", builder, "--help");
         result.echoSystemOut();
         assertThat(result.stdout).contains("Usage");
@@ -259,7 +286,8 @@ public class CliHelpTest {
 
     @Test
     @Order(101)
-    public void testDeployHelp() throws Exception {
+    public void testDeployHelp(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "deploy", "--help");
         result.echoSystemOut();
         assertThat(result.stdout).contains("Usage");
@@ -267,7 +295,8 @@ public class CliHelpTest {
 
     @Test
     @Order(102)
-    public void testDeployKubernetesHelp() throws Exception {
+    public void testDeployKubernetesHelp(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "deploy", "kubernetes", "--help");
         result.echoSystemOut();
         assertThat(result.stdout).contains("Usage");
@@ -279,7 +308,8 @@ public class CliHelpTest {
 
     @Test
     @Order(103)
-    public void testDeployOpenshiftHelp() throws Exception {
+    public void testDeployOpenshiftHelp(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "deploy", "openshift", "--help");
         result.echoSystemOut();
         assertThat(result.stdout).contains("Usage");
@@ -291,7 +321,8 @@ public class CliHelpTest {
 
     @Test
     @Order(104)
-    public void testDeployKnativeHelp() throws Exception {
+    public void testDeployKnativeHelp(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "deploy", "knative", "--help");
         result.echoSystemOut();
         assertThat(result.stdout).contains("Usage");
@@ -301,7 +332,8 @@ public class CliHelpTest {
     }
 
     @Order(105)
-    public void testPluginHelp() throws Exception {
+    public void testPluginHelp(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "plug", "--help");
         result.echoSystemOut();
         assertThat(result.stdout).contains("Usage");
@@ -313,7 +345,8 @@ public class CliHelpTest {
 
     @Test
     @Order(106)
-    public void testPlugnListHelp() throws Exception {
+    public void testPlugnListHelp(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "plug", "list", "--help");
         result.echoSystemOut();
         assertThat(result.stdout).contains("Usage");
@@ -325,7 +358,8 @@ public class CliHelpTest {
 
     @Test
     @Order(107)
-    public void testPlugnAddHelp() throws Exception {
+    public void testPlugnAddHelp(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "plug", "add", "--help");
         result.echoSystemOut();
         assertThat(result.stdout).contains("Usage");
@@ -337,7 +371,8 @@ public class CliHelpTest {
 
     @Test
     @Order(108)
-    public void testPlugnRemoveHelp() throws Exception {
+    public void testPlugnRemoveHelp(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "plug", "remove", "--help");
         result.echoSystemOut();
         assertThat(result.stdout).contains("Usage");

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliNonProjectTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliNonProjectTest.java
@@ -19,9 +19,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.devtools.testing.RegistryClientTestHelper;
+import io.quarkus.quickcli.ExitCode;
 import io.quarkus.registry.config.RegistriesConfig;
-import picocli.CommandLine;
+import io.quarkus.test.junit.main.QuarkusMainLauncher;
+import io.quarkus.test.junit.main.QuarkusMainTest;
 
+@QuarkusMainTest
 public class CliNonProjectTest {
     private static final String TEST_QUARKUS_REGISTRY = "test.quarkus.registry";
     static Path workspaceRoot;
@@ -29,7 +32,7 @@ public class CliNonProjectTest {
     @BeforeAll
     public static void initial() throws Exception {
         workspaceRoot = Paths.get(System.getProperty("user.dir")).toAbsolutePath()
-                .resolve("target/test-classes/test-project/CliNonProjectTest");
+                .resolve("target/test-project/CliNonProjectTest");
         CliDriver.deleteDir(workspaceRoot);
         Files.createDirectories(workspaceRoot);
     }
@@ -50,20 +53,22 @@ public class CliNonProjectTest {
     }
 
     @Test
-    public void testListOutsideOfProject() throws Exception {
+    public void testListOutsideOfProject(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "ext", "-e");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code." + result);
         Assertions.assertTrue(result.stdout.contains("Jackson"),
                 "Should contain 'Jackson' in the list of extensions, found: " + result.stdout);
     }
 
     @Test
-    public void testListPlatformExtensions() throws Exception {
+    public void testListPlatformExtensions(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         // List extensions of a specified platform version
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "ext", "list", "-P=io.quarkus:quarkus-bom:2.0.0.CR3", "-e",
                 "--origins");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code." + result);
         Assertions.assertTrue(result.stdout.contains("Jackson"),
                 "Should contain 'Jackson' in the list of extensions, found: " + result.stdout);
@@ -72,11 +77,12 @@ public class CliNonProjectTest {
     }
 
     @Test
-    public void testListPlatformExtensionsRegistryClient() throws Exception {
+    public void testListPlatformExtensionsRegistryClient(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         // Dry run: Make sure registry-client system property is true
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "ext", "list", "-e",
                 "--dry-run", "--registry-client");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code." + result);
 
         String noSpaces = result.stdout.replaceAll("[\\s\\p{Z}]", "");
@@ -88,7 +94,7 @@ public class CliNonProjectTest {
         // Dry run: Make sure registry-client system property is false
         result = CliDriver.execute(workspaceRoot, "ext", "list", "-e",
                 "--dry-run", "--no-registry-client");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code." + result);
 
         noSpaces = result.stdout.replaceAll("[\\s\\p{Z}]", "");
@@ -100,7 +106,7 @@ public class CliNonProjectTest {
         // Dry run: Make sure registry client property is set (default = false) TODO
         result = CliDriver.execute(workspaceRoot, "ext", "list", "-e",
                 "--dry-run");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code." + result);
 
         noSpaces = result.stdout.replaceAll("[\\s\\p{Z}]", "");
@@ -111,24 +117,27 @@ public class CliNonProjectTest {
     }
 
     @Test
-    public void testBuildOutsideOfProject() throws Exception {
+    public void testBuildOutsideOfProject(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "build", "-e");
-        Assertions.assertEquals(CommandLine.ExitCode.USAGE, result.exitCode,
+        Assertions.assertEquals(ExitCode.USAGE, result.exitCode,
                 "'quarkus build' should fail outside of a quarkus project directory:\n" + result);
     }
 
     @Test
-    public void testDevOutsideOfProject() throws Exception {
+    public void testDevOutsideOfProject(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "dev", "-e");
-        Assertions.assertEquals(CommandLine.ExitCode.USAGE, result.exitCode,
+        Assertions.assertEquals(ExitCode.USAGE, result.exitCode,
                 "'quarkus dev' should fail outside of a quarkus project directory:\n" + result);
     }
 
     @Test
-    public void testCreateAppDryRun() throws Exception {
+    public void testCreateAppDryRun(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         // A dry run of create should not create any files or directories
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "--dry-run", "-e");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code." + result);
         Assertions.assertTrue(result.stdout.contains("project would have been created"),
                 "Should contain 'project would have been created', found: " + result.stdout);
@@ -139,13 +148,14 @@ public class CliNonProjectTest {
     }
 
     @Test
-    public void testRegistryStreams() throws Exception {
+    public void testRegistryStreams(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
 
         CliDriver.Result result;
 
         // refresh the local cache and list the registries
         result = CliDriver.execute(workspaceRoot, "registry", "--streams", "-e");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code." + result);
 
         try (BufferedReader reader = new BufferedReader(new StringReader(result.stdout))) {
@@ -169,18 +179,19 @@ public class CliNonProjectTest {
     }
 
     @Test
-    public void testRegistryRefresh() throws Exception {
+    public void testRegistryRefresh(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result;
 
         // refresh the local cache and list the registries
         result = CliDriver.execute(workspaceRoot, "registry", "--refresh", "-e");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code." + result);
 
         Path configPath = resolveConfigPath("enabledConfig.yml");
         result = CliDriver.execute(workspaceRoot, "registry", "--refresh", "-e",
                 "--config", configPath.toAbsolutePath().toString());
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code." + result);
         Assertions.assertTrue(result.stdout.contains(configPath.toString()),
                 "Should contain path to config file, found: " + result.stdout);
@@ -192,7 +203,7 @@ public class CliNonProjectTest {
         configPath = resolveConfigPath("disabledConfig.yml");
         result = CliDriver.execute(workspaceRoot, "registry", "--refresh", "-e",
                 "--config", configPath.toAbsolutePath().toString());
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code." + result);
         Assertions.assertTrue(result.stdout.contains(configPath.toString()),
                 "Should contain path to config file, found: " + result.stdout);
@@ -203,7 +214,8 @@ public class CliNonProjectTest {
     }
 
     @Test
-    public void testRegistryAddRemove() throws Exception {
+    public void testRegistryAddRemove(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result;
 
         final Path testConfigYaml = workspaceRoot.resolve("test-registry-add-remove.yaml").toAbsolutePath();
@@ -211,7 +223,7 @@ public class CliNonProjectTest {
 
         assertThat(testConfigYaml).doesNotExist();
         result = CliDriver.execute(workspaceRoot, "registry", "add", "one,two", "--config", testConfigYaml.toString());
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code." + result);
 
         assertThat(testConfigYaml).exists();
@@ -221,7 +233,7 @@ public class CliNonProjectTest {
         assertThat(testConfig.getRegistries().get(1).getId()).isEqualTo("two");
 
         result = CliDriver.execute(workspaceRoot, "registry", "add", "two,three", "--config", testConfigYaml.toString());
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code." + result);
 
         testConfig = RegistriesConfig.fromFile(testConfigYaml);
@@ -231,7 +243,7 @@ public class CliNonProjectTest {
         assertThat(testConfig.getRegistries().get(2).getId()).isEqualTo("three");
 
         result = CliDriver.execute(workspaceRoot, "registry", "remove", "one,two", "--config", testConfigYaml.toString());
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code." + result);
 
         testConfig = RegistriesConfig.fromFile(testConfigYaml);
@@ -239,7 +251,7 @@ public class CliNonProjectTest {
         assertThat(testConfig.getRegistries().get(0).getId()).isEqualTo("three");
 
         result = CliDriver.execute(workspaceRoot, "registry", "add", "four", "--config", testConfigYaml.toString());
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code." + result);
 
         testConfig = RegistriesConfig.fromFile(testConfigYaml);
@@ -249,7 +261,7 @@ public class CliNonProjectTest {
 
         result = CliDriver.execute(workspaceRoot, "registry", "remove", "three,four,five", "--config",
                 testConfigYaml.toString());
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code." + result);
 
         String contents = Files.readString(testConfigYaml);

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliProjectGradleTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliProjectGradleTest.java
@@ -18,19 +18,23 @@ import io.quarkus.cli.common.build.ExecuteUtil;
 import io.quarkus.cli.common.build.GradleRunner;
 import io.quarkus.devtools.commands.CreateProjectHelper;
 import io.quarkus.devtools.testing.RegistryClientTestHelper;
-import picocli.CommandLine;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.test.junit.main.QuarkusMainLauncher;
+import io.quarkus.test.junit.main.QuarkusMainTest;
 
 /**
  * Similar to CliProjectMavenTest ..
  */
+@QuarkusMainTest
 public class CliProjectGradleTest {
     static final Path testProjectRoot = Paths.get(System.getProperty("user.dir")).toAbsolutePath()
-            .resolve("target/test-classes/test-project/");
+            .resolve("target/test-project/");
     static final Path workspaceRoot = testProjectRoot.resolve("CliProjectGradleTest");
     static final Path wrapperRoot = testProjectRoot.resolve("gradle-wrapper");
 
     Path project;
     static File gradle;
+    static boolean gradleDaemonStarted = false;
 
     @BeforeAll
     public static void setupTestRegistry() {
@@ -48,15 +52,18 @@ public class CliProjectGradleTest {
         project = workspaceRoot.resolve("code-with-quarkus");
     }
 
-    @BeforeAll
-    static void startGradleDaemon() throws Exception {
+    static void ensureGradleDaemon(QuarkusMainLauncher launcher) throws Exception {
+        if (gradleDaemonStarted) {
+            return;
+        }
         CliDriver.deleteDir(wrapperRoot);
+        CliDriver.setLauncher(launcher);
 
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--gradle", "--verbose", "-e", "-B",
                 "--no-code",
                 "-o", testProjectRoot.toString(),
                 "gradle-wrapper");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code." + result);
         Assertions.assertTrue(result.stdout.contains("SUCCESS"),
                 "Expected confirmation that the project has been created." + result);
 
@@ -69,6 +76,7 @@ public class CliProjectGradleTest {
 
         result = CliDriver.executeArbitraryCommand(wrapperRoot, args.toArray(new String[0]));
         Assertions.assertEquals(0, result.exitCode, "Gradle daemon should start properly");
+        gradleDaemonStarted = true;
     }
 
     @AfterAll
@@ -82,10 +90,13 @@ public class CliProjectGradleTest {
             CliDriver.Result result = CliDriver.executeArbitraryCommand(wrapperRoot, args.toArray(new String[0]));
             Assertions.assertEquals(0, result.exitCode, "Gradle daemon should stop properly");
         }
+        gradleDaemonStarted = false;
     }
 
     @Test
-    public void testNoCode() throws Exception {
+    public void testNoCode(QuarkusMainLauncher launcher) throws Exception {
+        ensureGradleDaemon(launcher);
+        CliDriver.setLauncher(launcher);
         // Inspect the no-code project created to hold the gradle wrapper
         Assertions.assertTrue(gradle.exists(), "Wrapper should exist");
 
@@ -99,9 +110,11 @@ public class CliProjectGradleTest {
     }
 
     @Test
-    public void testCreateAppDefaults() throws Exception {
+    public void testCreateAppDefaults(QuarkusMainLauncher launcher) throws Exception {
+        ensureGradleDaemon(launcher);
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--gradle", "--verbose", "-e", "-B");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code." + result);
         Assertions.assertTrue(result.stdout.contains("SUCCESS"),
                 "Expected confirmation that the project has been created." + result);
 
@@ -121,10 +134,12 @@ public class CliProjectGradleTest {
     }
 
     @Test
-    public void testCreateAppWithoutDockerfiles() throws Exception {
+    public void testCreateAppWithoutDockerfiles(QuarkusMainLauncher launcher) throws Exception {
+        ensureGradleDaemon(launcher);
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--no-dockerfiles", "-e", "-B",
                 "--verbose");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code." + result);
         Assertions.assertTrue(result.stdout.contains("SUCCESS"),
                 "Expected confirmation that the project has been created." + result);
         Assertions.assertFalse(Files.exists(project.resolve("src/main/docker")),
@@ -132,10 +147,12 @@ public class CliProjectGradleTest {
     }
 
     @Test
-    public void testCreateAppDefaultsWithKotlinDSL() throws Exception {
+    public void testCreateAppDefaultsWithKotlinDSL(QuarkusMainLauncher launcher) throws Exception {
+        ensureGradleDaemon(launcher);
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--gradle-kotlin-dsl", "--verbose", "-e",
                 "-B");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code." + result);
         Assertions.assertTrue(result.stdout.contains("SUCCESS"),
                 "Expected confirmation that the project has been created." + result);
 
@@ -157,7 +174,9 @@ public class CliProjectGradleTest {
     }
 
     @Test
-    public void testCreateAppOverrides() throws Exception {
+    public void testCreateAppOverrides(QuarkusMainLauncher launcher) throws Exception {
+        ensureGradleDaemon(launcher);
+        CliDriver.setLauncher(launcher);
         Path nested = workspaceRoot.resolve("cli-nested");
         project = nested.resolve("my-project");
 
@@ -173,7 +192,7 @@ public class CliProjectGradleTest {
 
         // TODO: would love a test that doesn't use a wrapper, but CI path..
 
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code." + result);
         Assertions.assertTrue(result.stdout.contains("SUCCESS"),
                 "Expected confirmation that the project has been created." + result);
 
@@ -194,9 +213,11 @@ public class CliProjectGradleTest {
     }
 
     @Test
-    public void testCreateCliDefaults() throws Exception {
+    public void testCreateCliDefaults(QuarkusMainLauncher launcher) throws Exception {
+        ensureGradleDaemon(launcher);
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "cli", "--gradle", "--verbose", "-e", "-B");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code." + result);
         Assertions.assertTrue(result.stdout.contains("SUCCESS"),
                 "Expected confirmation that the project has been created." + result);
 
@@ -216,9 +237,11 @@ public class CliProjectGradleTest {
     }
 
     @Test
-    public void testExtensionList() throws Exception {
+    public void testExtensionList(QuarkusMainLauncher launcher) throws Exception {
+        ensureGradleDaemon(launcher);
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--gradle", "--verbose", "-e", "-B");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code." + result);
 
         Path buildGradle = project.resolve("build.gradle");
         String buildGradleContent = CliDriver.readFileAsString(buildGradle);
@@ -237,20 +260,22 @@ public class CliProjectGradleTest {
 
         // TODO: Maven and Gradle give different return codes
         result = CliDriver.invokeExtensionRemoveNonexistent(project);
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
     }
 
     @Test
-    public void testBuildOptions() throws Exception {
+    public void testBuildOptions(QuarkusMainLauncher launcher) throws Exception {
+        ensureGradleDaemon(launcher);
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--gradle", "-e", "-B", "--verbose");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code." + result);
 
         // 1 --clean --tests --native --offline
         result = CliDriver.execute(project, "build", "-e", "-B", "--dry-run",
                 "--clean", "--tests", "--native", "--offline");
 
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
 
         Assertions.assertTrue(result.stdout.contains(" clean"),
@@ -283,15 +308,17 @@ public class CliProjectGradleTest {
     }
 
     @Test
-    public void testDevOptions() throws Exception {
+    public void testDevOptions(QuarkusMainLauncher launcher) throws Exception {
+        ensureGradleDaemon(launcher);
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--gradle", "-e", "-B", "--verbose");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code." + result);
 
         // 1 --clean --tests --suspend --offline
         result = CliDriver.execute(project, "dev", "-e", "--dry-run",
                 "--clean", "--tests", "--debug", "--suspend", "--debug-mode=listen", "--offline");
 
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
         Assertions.assertTrue(result.stdout.contains("GRADLE"),
                 "gradle command should specify 'GRADLE'\n" + result);
@@ -315,7 +342,7 @@ public class CliProjectGradleTest {
         result = CliDriver.execute(project, "dev", "-e", "--dry-run",
                 "--no-clean", "--no-tests", "--no-debug");
 
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
         Assertions.assertTrue(result.stdout.contains("GRADLE"),
                 "gradle command should specify 'GRADLE'\n" + result);
@@ -336,7 +363,7 @@ public class CliProjectGradleTest {
         result = CliDriver.execute(project, "dev", "-e", "--dry-run",
                 "--no-suspend", "--debug-host=0.0.0.0", "--debug-port=8008", "--debug-mode=connect", "--", "arg1", "arg2");
 
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
         Assertions.assertTrue(result.stdout.contains("GRADLE"),
                 "gradle command should specify 'GRADLE'\n" + result);
@@ -354,7 +381,7 @@ public class CliProjectGradleTest {
         // 4 TEST MODE: test --clean --debug --suspend --offline
         result = CliDriver.execute(project, "test", "-e", "--dry-run",
                 "--clean", "--debug", "--suspend", "--debug-mode=listen", "--offline", "--filter=FooTest");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
         Assertions.assertTrue(result.stdout.contains("Run current project in continuous test mode"), result.toString());
         Assertions.assertTrue(result.stdout.contains("-Dquarkus.test.include-pattern=FooTest"), result.toString());
@@ -362,7 +389,7 @@ public class CliProjectGradleTest {
         // 5 TEST MODE - run once: test --once --offline
         result = CliDriver.execute(project, "test", "-e", "--dry-run",
                 "--once", "--offline", "--filter=FooTest");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
         Assertions.assertTrue(result.stdout.contains("Run current project in test mode"), result.toString());
         Assertions.assertTrue(result.stdout.contains("--tests FooTest"), result.toString());
@@ -376,7 +403,9 @@ public class CliProjectGradleTest {
     }
 
     @Test
-    public void testCreateArgPassthrough() throws Exception {
+    public void testCreateArgPassthrough(QuarkusMainLauncher launcher) throws Exception {
+        ensureGradleDaemon(launcher);
+        CliDriver.setLauncher(launcher);
         Path nested = workspaceRoot.resolve("cli-nested");
         project = nested.resolve("my-project");
 
@@ -387,7 +416,7 @@ public class CliProjectGradleTest {
                 "silly:my-project:0.1.0");
 
         // We don't need to retest this, just need to make sure all the arguments were passed through
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code." + result);
 
         Assertions.assertTrue(result.stdout.contains("Creating an app"),
                 "Should contain 'Creating an app', found: " + result.stdout);
@@ -407,13 +436,15 @@ public class CliProjectGradleTest {
     }
 
     @Test
-    public void testCreateArgJava17() throws Exception {
+    public void testCreateArgJava17(QuarkusMainLauncher launcher) throws Exception {
+        ensureGradleDaemon(launcher);
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--gradle",
                 "-e", "-B", "--verbose",
                 "--java", "17");
 
         // We don't need to retest this, just need to make sure all the arguments were passed through
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code." + result);
 
         Path buildGradle = project.resolve("build.gradle");
         String buildGradleContent = CliDriver.readFileAsString(buildGradle);
@@ -423,13 +454,15 @@ public class CliProjectGradleTest {
     }
 
     @Test
-    public void testCreateArgJava21() throws Exception {
+    public void testCreateArgJava21(QuarkusMainLauncher launcher) throws Exception {
+        ensureGradleDaemon(launcher);
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--gradle",
                 "-e", "-B", "--verbose",
                 "--java", "21");
 
         // We don't need to retest this, just need to make sure all the arguments were passed through
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code." + result);
 
         Path buildGradle = project.resolve("build.gradle");
         String buildGradleContent = CliDriver.readFileAsString(buildGradle);
@@ -439,13 +472,15 @@ public class CliProjectGradleTest {
     }
 
     @Test
-    public void testCreateArgJava25() throws Exception {
+    public void testCreateArgJava25(QuarkusMainLauncher launcher) throws Exception {
+        ensureGradleDaemon(launcher);
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--gradle",
                 "-e", "-B", "--verbose",
                 "--java", "25");
 
         // We don't need to retest this, just need to make sure all the arguments were passed through
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code." + result);
 
         Path buildGradle = project.resolve("build.gradle");
         String buildGradleContent = CliDriver.readFileAsString(buildGradle);

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliProjectJBangTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliProjectJBangTest.java
@@ -13,11 +13,14 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.devtools.commands.CreateProjectHelper;
 import io.quarkus.devtools.testing.RegistryClientTestHelper;
-import picocli.CommandLine;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.test.junit.main.QuarkusMainLauncher;
+import io.quarkus.test.junit.main.QuarkusMainTest;
 
+@QuarkusMainTest
 public class CliProjectJBangTest {
     static Path workspaceRoot = Paths.get(System.getProperty("user.dir")).toAbsolutePath()
-            .resolve("target/test-classes/test-project/CliProjectJBangTest");
+            .resolve("target/test-project/CliProjectJBangTest");
 
     Path project;
 
@@ -38,9 +41,10 @@ public class CliProjectJBangTest {
     }
 
     @Test
-    public void testCreateAppDefaults() throws Exception {
+    public void testCreateAppDefaults(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--jbang", "--verbose", "-e", "-B");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code." + result);
         Assertions.assertTrue(result.stdout.contains("SUCCESS"),
                 "Expected confirmation that the project has been created." + result);
 
@@ -65,7 +69,8 @@ public class CliProjectJBangTest {
     }
 
     @Test
-    public void testCreateAppOverrides() throws Exception {
+    public void testCreateAppOverrides(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         Path nested = workspaceRoot.resolve("cli-nested");
         project = nested.resolve("my-project");
 
@@ -79,7 +84,7 @@ public class CliProjectJBangTest {
                 "-x reactive-routes",
                 "silly:my-project:0.1.0");
 
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code." + result);
         Assertions.assertTrue(result.stdout.contains("SUCCESS"),
                 "Expected confirmation that the project has been created." + result);
 
@@ -99,9 +104,10 @@ public class CliProjectJBangTest {
     }
 
     @Test
-    public void testCreateCliDefaults() throws Exception {
+    public void testCreateCliDefaults(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "cli", "--jbang", "--verbose", "-e", "-B");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code." + result);
         Assertions.assertTrue(result.stdout.contains("SUCCESS"),
                 "Expected confirmation that the project has been created." + result);
 
@@ -124,20 +130,21 @@ public class CliProjectJBangTest {
 
         result = CliDriver.execute(project, "build", "-e", "-B", "--clean", "--verbose",
                 "-Dproperty=value1", "-Dproperty2=value2");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
     }
 
     @Test
-    public void testBuildOptions() throws Exception {
+    public void testBuildOptions(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--jbang", "-e", "-B", "--verbose");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code." + result);
 
         // 1 --clean --tests --native --offline
         result = CliDriver.execute(project, "build", "-e", "-B", "--dry-run",
                 "--clean", "--tests", "--native", "--offline");
 
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
 
         Assertions.assertTrue(result.stdout.contains("--fresh"),
@@ -168,13 +175,14 @@ public class CliProjectJBangTest {
     }
 
     @Test
-    public void testCreateArgJava17() throws Exception {
+    public void testCreateArgJava17(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--jbang",
                 "-e", "-B", "--verbose",
                 "--java", "17");
 
         // We don't need to retest this, just need to make sure all the arguments were passed through
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code." + result);
 
         Path javaMain = validateJBangSourcePackage(project, ""); // no package name
         String source = CliDriver.readFileAsString(javaMain);
@@ -183,13 +191,14 @@ public class CliProjectJBangTest {
     }
 
     @Test
-    public void testCreateArgJava21() throws Exception {
+    public void testCreateArgJava21(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--jbang",
                 "-e", "-B", "--verbose",
                 "--java", "21");
 
         // We don't need to retest this, just need to make sure all the arguments were passed through
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code." + result);
 
         Path javaMain = validateJBangSourcePackage(project, ""); // no package name
         String source = CliDriver.readFileAsString(javaMain);
@@ -198,13 +207,14 @@ public class CliProjectJBangTest {
     }
 
     @Test
-    public void testCreateArgJava25() throws Exception {
+    public void testCreateArgJava25(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--jbang",
                 "-e", "-B", "--verbose",
                 "--java", "25");
 
         // We don't need to retest this, just need to make sure all the arguments were passed through
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code." + result);
 
         Path javaMain = validateJBangSourcePackage(project, ""); // no package name
         String source = CliDriver.readFileAsString(javaMain);

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliProjectMavenTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliProjectMavenTest.java
@@ -14,14 +14,17 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.devtools.commands.CreateProjectHelper;
 import io.quarkus.devtools.testing.RegistryClientTestHelper;
-import picocli.CommandLine;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.test.junit.main.QuarkusMainLauncher;
+import io.quarkus.test.junit.main.QuarkusMainTest;
 
 /**
  * Similar to CliProjectGradleTest ..
  */
+@QuarkusMainTest
 public class CliProjectMavenTest {
     static Path workspaceRoot = Paths.get(System.getProperty("user.dir")).toAbsolutePath()
-            .resolve("target/test-classes/test-project/CliProjectMavenTest");
+            .resolve("target/test-project/CliProjectMavenTest");
     Path project;
 
     @BeforeAll
@@ -41,9 +44,10 @@ public class CliProjectMavenTest {
     }
 
     @Test
-    public void testCreateAppDefaults() throws Exception {
+    public void testCreateAppDefaults(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "-e", "-B", "--verbose");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code." + result);
         Assertions.assertTrue(result.stdout.contains("SUCCESS"),
                 "Expected confirmation that the project has been created." + result);
 
@@ -76,10 +80,11 @@ public class CliProjectMavenTest {
     }
 
     @Test
-    public void testCreateAppWithoutDockerfiles() throws Exception {
+    public void testCreateAppWithoutDockerfiles(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--no-dockerfiles", "-e", "-B",
                 "--verbose");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code." + result);
         Assertions.assertTrue(result.stdout.contains("SUCCESS"),
                 "Expected confirmation that the project has been created." + result);
         Assertions.assertFalse(Files.exists(project.resolve("src/main/docker")),
@@ -87,7 +92,8 @@ public class CliProjectMavenTest {
     }
 
     @Test
-    public void testCreateAppOverrides() throws Exception {
+    public void testCreateAppOverrides(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         Path nested = workspaceRoot.resolve("cli-nested");
         project = nested.resolve("my-project");
 
@@ -103,7 +109,7 @@ public class CliProjectMavenTest {
                 "-x rest,micrometer-registry-prometheus",
                 "silly:my-project:0.1.0");
 
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code." + result);
         Assertions.assertTrue(result.stdout.contains("SUCCESS"),
                 "Expected confirmation that the project has been created." + result);
 
@@ -125,7 +131,7 @@ public class CliProjectMavenTest {
         result = CliDriver.execute(workspaceRoot, "create", "app", "--dry-run", "--verbose", "-e", "-B",
                 "--output-directory=" + nested,
                 "silly:my-project:0.1.0");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code. " + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code. " + result);
         Assertions.assertTrue(result.stdout.contains("WARN"),
                 "Expected a warning that the directory already exists. " + result);
 
@@ -134,9 +140,10 @@ public class CliProjectMavenTest {
     }
 
     @Test
-    public void testExtensionList() throws Exception {
+    public void testExtensionList(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "-e", "-B", "--verbose");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code." + result);
 
         Path pom = project.resolve("pom.xml");
         String pomContent = CliDriver.readFileAsString(pom);
@@ -157,19 +164,20 @@ public class CliProjectMavenTest {
 
         // TODO: Maven and Gradle give different return codes
         result = CliDriver.invokeExtensionRemoveNonexistent(project);
-        Assertions.assertEquals(CommandLine.ExitCode.SOFTWARE, result.exitCode,
+        Assertions.assertEquals(ExitCode.SOFTWARE, result.exitCode,
                 "Expected error return code. Result:\n" + result);
     }
 
     @Test
-    public void testBuildOptions() throws Exception {
+    public void testBuildOptions(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "-e", "-B", "--verbose");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code." + result);
 
         // 1 --clean --tests --native --offline
         result = CliDriver.execute(project, "build", "-e", "-B", "--dry-run",
                 "--clean", "--tests", "--native", "--offline");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
 
         Assertions.assertTrue(result.stdout.contains(" clean"),
@@ -206,15 +214,16 @@ public class CliProjectMavenTest {
     }
 
     @Test
-    public void testDevTestOptions() throws Exception {
+    public void testDevTestOptions(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "-e", "-B", "--verbose");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code." + result);
 
         // 1 --clean --tests --suspend --offline
         result = CliDriver.execute(project, "dev", "-e", "--dry-run",
                 "--clean", "--tests", "--debug", "--suspend", "--debug-mode=listen", "--offline");
 
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
         Assertions.assertTrue(result.stdout.contains("MAVEN"),
                 "quarkus command should specify 'MAVEN'\n" + result);
@@ -240,7 +249,7 @@ public class CliProjectMavenTest {
         result = CliDriver.execute(project, "dev", "-e", "--dry-run",
                 "--no-clean", "--no-tests", "--no-debug");
 
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
         Assertions.assertTrue(result.stdout.contains("MAVEN"),
                 "quarkus command should specify 'MAVEN'\n" + result);
@@ -263,7 +272,7 @@ public class CliProjectMavenTest {
         result = CliDriver.execute(project, "dev", "-e", "--dry-run",
                 "--no-suspend", "--debug-host=0.0.0.0", "--debug-port=8008", "--debug-mode=connect", "--", "arg1", "arg2");
 
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
         Assertions.assertTrue(result.stdout.contains("MAVEN"),
                 "quarkus command should specify 'MAVEN'\n" + result);
@@ -281,7 +290,7 @@ public class CliProjectMavenTest {
         // 4 TEST MODE: test --clean --debug --suspend --offline
         result = CliDriver.execute(project, "test", "-e", "--dry-run",
                 "--clean", "--debug", "--suspend", "--debug-mode=listen", "--offline", "--filter=FooTest");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
         Assertions.assertTrue(result.stdout.contains("Run current project in continuous test mode"), result.toString());
         Assertions.assertTrue(result.stdout.contains("-Dquarkus.test.include-pattern=FooTest"), result.toString());
@@ -289,7 +298,7 @@ public class CliProjectMavenTest {
         // 5 TEST MODE - run once: test --once --offline
         result = CliDriver.execute(project, "test", "-e", "--dry-run",
                 "--once", "--offline", "--filter=FooTest");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+        Assertions.assertEquals(ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
         Assertions.assertTrue(result.stdout.contains("Run current project in test mode"), result.toString());
         Assertions.assertTrue(result.stdout.contains("-Dtest=FooTest"), result.toString());
@@ -303,9 +312,10 @@ public class CliProjectMavenTest {
     }
 
     @Test
-    public void testCreateCliDefaults() throws Exception {
+    public void testCreateCliDefaults(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "cli", "-e", "-B", "--verbose");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code." + result);
         Assertions.assertTrue(result.stdout.contains("SUCCESS"),
                 "Expected confirmation that the project has been created." + result);
 
@@ -327,7 +337,8 @@ public class CliProjectMavenTest {
     }
 
     @Test
-    public void testCreateArgPassthrough() throws Exception {
+    public void testCreateArgPassthrough(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         Path nested = workspaceRoot.resolve("cli-nested");
         project = nested.resolve("my-project");
 
@@ -340,7 +351,7 @@ public class CliProjectMavenTest {
                 "silly:my-project:0.1.0");
 
         // We don't need to retest this, just need to make sure all the arguments were passed through
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code." + result);
 
         Assertions.assertTrue(result.stdout.contains("Creating an app"),
                 "Should contain 'Creating an app', found: " + result.stdout);
@@ -360,13 +371,14 @@ public class CliProjectMavenTest {
     }
 
     @Test
-    public void testCreateArgJava17() throws Exception {
+    public void testCreateArgJava17(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app",
                 "-e", "-B", "--verbose",
                 "--java", "17");
 
         // We don't need to retest this, just need to make sure all the arguments were passed through
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code." + result);
 
         Path pom = project.resolve("pom.xml");
         String pomContent = CliDriver.readFileAsString(pom);
@@ -376,13 +388,14 @@ public class CliProjectMavenTest {
     }
 
     @Test
-    public void testCreateArgJava21() throws Exception {
+    public void testCreateArgJava21(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app",
                 "-e", "-B", "--verbose",
                 "--java", "21");
 
         // We don't need to retest this, just need to make sure all the arguments were passed through
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code." + result);
 
         Path pom = project.resolve("pom.xml");
         String pomContent = CliDriver.readFileAsString(pom);
@@ -392,13 +405,14 @@ public class CliProjectMavenTest {
     }
 
     @Test
-    public void testCreateArgJava25() throws Exception {
+    public void testCreateArgJava25(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app",
                 "-e", "-B", "--verbose",
                 "--java", "25");
 
         // We don't need to retest this, just need to make sure all the arguments were passed through
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code." + result);
 
         Path pom = project.resolve("pom.xml");
         String pomContent = CliDriver.readFileAsString(pom);
@@ -408,10 +422,11 @@ public class CliProjectMavenTest {
     }
 
     @Test
-    public void testCreateNameDescription() throws Exception {
+    public void testCreateNameDescription(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--name", "My name", "--description",
                 "My description");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.exitCode, "Expected OK return code." + result);
         Assertions.assertTrue(result.stdout.contains("SUCCESS"),
                 "Expected confirmation that the project has been created." + result);
 

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliVersionTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliVersionTest.java
@@ -6,12 +6,16 @@ import java.nio.file.Paths;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.test.junit.main.QuarkusMainLauncher;
+import io.quarkus.test.junit.main.QuarkusMainTest;
+
+@QuarkusMainTest
 public class CliVersionTest {
     static Path workspaceRoot = Paths.get(System.getProperty("user.dir")).toAbsolutePath().resolve("target/test-project");
 
     @Test
-    public void testCommandVersion() throws Exception {
-
+    public void testCommandVersion(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "-v");
         result.echoSystemOut();
         Assertions.assertEquals(result.stdout.trim(), System.getProperty("project.version"),

--- a/devtools/cli/src/test/java/io/quarkus/cli/MavenProjectCreateForPlatformTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/MavenProjectCreateForPlatformTest.java
@@ -17,8 +17,11 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.bootstrap.resolver.maven.workspace.ModelUtils;
 import io.quarkus.devtools.testing.registry.client.TestRegistryClientBuilder;
 import io.quarkus.maven.dependency.ArtifactCoords;
-import picocli.CommandLine;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.test.junit.main.QuarkusMainLauncher;
+import io.quarkus.test.junit.main.QuarkusMainTest;
 
+@QuarkusMainTest
 public class MavenProjectCreateForPlatformTest extends RegistryClientBuilderTestBase {
 
     @BeforeAll
@@ -77,13 +80,14 @@ public class MavenProjectCreateForPlatformTest extends RegistryClientBuilderTest
     }
 
     @Test
-    void testCreateForPlatformWithUpstream() throws Exception {
+    void testCreateForPlatformWithUpstream(QuarkusMainLauncher launcher) throws Exception {
+        this.currentLauncher = launcher;
 
         final CliDriver.Result createResult = run(workDir(), "create", "app", "create-for-platform",
                 "-P com.acme.quarkus.platform:acme-supersonic-bom:8.0.0", "-x supersonic,subatomic");
         createResult.echoSystemOut();
         createResult.echoSystemErr();
-        assertThat(createResult.exitCode).isEqualTo(CommandLine.ExitCode.OK)
+        assertThat(createResult.exitCode).isEqualTo(ExitCode.OK)
                 .as(() -> "Expected OK return code." + createResult);
         assertThat(createResult.stdout).contains("SUCCESS")
                 .as(() -> "Expected confirmation that the project has been created." + createResult);

--- a/devtools/cli/src/test/java/io/quarkus/cli/MavenProjectInfoAndUpdateTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/MavenProjectInfoAndUpdateTest.java
@@ -13,8 +13,11 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.devtools.testing.registry.client.TestRegistryClientBuilder;
 import io.quarkus.maven.dependency.ArtifactCoords;
-import picocli.CommandLine;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.test.junit.main.QuarkusMainLauncher;
+import io.quarkus.test.junit.main.QuarkusMainTest;
 
+@QuarkusMainTest
 public class MavenProjectInfoAndUpdateTest extends RegistryClientBuilderTestBase {
 
     @BeforeAll
@@ -49,11 +52,12 @@ public class MavenProjectInfoAndUpdateTest extends RegistryClientBuilderTestBase
     }
 
     @Test
-    void testClean() throws Exception {
+    void testClean(QuarkusMainLauncher launcher) throws Exception {
+        this.currentLauncher = launcher;
 
         final CliDriver.Result createResult = run(workDir(), "create", "app", "acme-clean",
                 "-x supersonic,acme-quarkiverse-extension");
-        assertThat(createResult.exitCode).isEqualTo(CommandLine.ExitCode.OK)
+        assertThat(createResult.exitCode).isEqualTo(ExitCode.OK)
                 .as(() -> "Expected OK return code." + createResult);
         assertThat(createResult.stdout).contains("SUCCESS")
                 .as(() -> "Expected confirmation that the project has been created." + createResult);
@@ -81,11 +85,12 @@ public class MavenProjectInfoAndUpdateTest extends RegistryClientBuilderTestBase
     }
 
     @Test
-    void testMisalignedPlatformExtensionVersion() throws Exception {
+    void testMisalignedPlatformExtensionVersion(QuarkusMainLauncher launcher) throws Exception {
+        this.currentLauncher = launcher;
 
         final CliDriver.Result createResult = run(workDir(), "create", "app", "acme-misaligned-ext-version",
                 "-x supersonic,acme-quarkiverse-extension,org.acme.quarkus.platform:acme-quarkus-subatomic:1.0.0");
-        assertThat(createResult.exitCode).isEqualTo(CommandLine.ExitCode.OK)
+        assertThat(createResult.exitCode).isEqualTo(ExitCode.OK)
                 .as(() -> "Expected OK return code." + createResult);
         assertThat(createResult.stdout).contains("SUCCESS")
                 .as(() -> "Expected confirmation that the project has been created." + createResult);

--- a/devtools/cli/src/test/java/io/quarkus/cli/NotRegisteredExtensionWithCodestartTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/NotRegisteredExtensionWithCodestartTest.java
@@ -8,8 +8,11 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.devtools.testing.registry.client.TestRegistryClientBuilder;
-import picocli.CommandLine;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.test.junit.main.QuarkusMainLauncher;
+import io.quarkus.test.junit.main.QuarkusMainTest;
 
+@QuarkusMainTest
 public class NotRegisteredExtensionWithCodestartTest extends RegistryClientBuilderTestBase {
 
     @BeforeAll
@@ -32,10 +35,11 @@ public class NotRegisteredExtensionWithCodestartTest extends RegistryClientBuild
     }
 
     @Test
-    void test() throws Exception {
+    void test(QuarkusMainLauncher launcher) throws Exception {
+        this.currentLauncher = launcher;
         final CliDriver.Result createResult = run(workDir(), "create", "app", "acme-outlaw-codestart",
                 "-x org.acme.quarkus:acme-outlaw:6.6.6");
-        assertThat(createResult.exitCode).isEqualTo(CommandLine.ExitCode.OK)
+        assertThat(createResult.exitCode).isEqualTo(ExitCode.OK)
                 .as(() -> "Expected OK return code." + createResult);
         assertThat(createResult.stdout).contains("SUCCESS")
                 .as(() -> "Expected confirmation that the project has been created." + createResult);

--- a/devtools/cli/src/test/java/io/quarkus/cli/RegistryClientBuilderTestBase.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/RegistryClientBuilderTestBase.java
@@ -22,8 +22,11 @@ import io.quarkus.bootstrap.resolver.maven.BootstrapMavenException;
 import io.quarkus.devtools.project.QuarkusProjectHelper;
 import io.quarkus.devtools.testing.registry.client.TestRegistryClientBuilder;
 import io.quarkus.registry.config.RegistriesConfigLocator;
+import io.quarkus.test.junit.main.QuarkusMainLauncher;
 
 public abstract class RegistryClientBuilderTestBase {
+
+    protected QuarkusMainLauncher currentLauncher;
 
     private static Path workDir;
     private static Path settingsXml;
@@ -33,7 +36,7 @@ public abstract class RegistryClientBuilderTestBase {
 
     static Path workDir() {
         if (workDir == null) {
-            var p = Path.of(System.getProperty("user.dir")).resolve("target").resolve("test-classes").resolve("test-work-dir");
+            var p = Path.of(System.getProperty("user.dir")).resolve("target").resolve("test-work-dir");
             try {
                 Files.createDirectories(p);
             } catch (IOException e) {
@@ -132,11 +135,15 @@ public abstract class RegistryClientBuilderTestBase {
     }
 
     protected CliDriver.Result run(Path dir, String... args) throws Exception {
-        return CliDriver.builder()
+        CliDriver.CliDriverBuilder b = CliDriver.builder()
                 .setStartingDir(dir)
                 .setMavenRepoLocal(testRepo.toString())
                 .setMavenSettings(settingsXml.toString())
-                .addArgs(args)
-                .execute();
+                .addArgs(args);
+        QuarkusMainLauncher launcher = currentLauncher;
+        if (launcher != null) {
+            b.setLauncher(launcher);
+        }
+        return b.execute();
     }
 }

--- a/devtools/cli/src/test/java/io/quarkus/cli/config/DecryptTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/config/DecryptTest.java
@@ -11,14 +11,18 @@ import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
 import io.quarkus.cli.CliDriver;
+import io.quarkus.test.junit.main.QuarkusMainLauncher;
+import io.quarkus.test.junit.main.QuarkusMainTest;
 
 @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Parsing the stdout is not working on Github Windows, maybe because of the console formatting. I did try it in a Windows box and it works fine.")
+@QuarkusMainTest
 public class DecryptTest {
     @TempDir
     Path tempDir;
 
     @Test
-    void decryptPlain() throws Exception {
+    void decryptPlain(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(tempDir, "config", "decrypt",
                 "DPZqAC4GZNAXi6_43A4O2SBmaQssGkq6PS7rz8tzHDt1", "somearbitrarycrazystringthatdoesnotmatter", "-f=plain");
         Scanner scanner = new Scanner(result.getStdout());
@@ -28,7 +32,8 @@ public class DecryptTest {
     }
 
     @Test
-    void decryptBase64() throws Exception {
+    void decryptBase64(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(tempDir, "config", "decrypt",
                 "DJNrZ6LfpupFv6QbXyXhvzD8eVDnDa_kTliQBpuzTobDZxlg", "c29tZWFyYml0cmFyeWNyYXp5c3RyaW5ndGhhdGRvZXNub3RtYXR0ZXI");
         Scanner scanner = new Scanner(result.getStdout());

--- a/devtools/cli/src/test/java/io/quarkus/cli/config/EncryptTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/config/EncryptTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
 import io.quarkus.cli.CliDriver;
+import io.quarkus.test.junit.main.QuarkusMainLauncher;
+import io.quarkus.test.junit.main.QuarkusMainTest;
 import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.config.SmallRyeConfigBuilder;
 
@@ -18,12 +20,14 @@ import io.smallrye.config.SmallRyeConfigBuilder;
         +
         "I did try it in a Windows box and it works fine. Regardless, this commands is tested indirectly" +
         " in SetConfigTest, which is still enabled in Windows ")
+@QuarkusMainTest
 class EncryptTest {
     @TempDir
     Path tempDir;
 
     @Test
-    void encrypt() throws Exception {
+    void encrypt(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(tempDir, "config", "encrypt", "12345678");
         Scanner scanner = new Scanner(result.getStdout());
         String[] split = scanner.nextLine().split(" ");
@@ -41,7 +45,8 @@ class EncryptTest {
     }
 
     @Test
-    void keyPlain() throws Exception {
+    void keyPlain(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(tempDir, "config", "encrypt", "12345678", "-f=plain",
                 "--key=12345678");
         Scanner scanner = new Scanner(result.getStdout());
@@ -69,7 +74,8 @@ class EncryptTest {
     }
 
     @Test
-    void keyBase64() throws Exception {
+    void keyBase64(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(tempDir, "config", "encrypt", "12345678", "--key=12345678");
         Scanner scanner = new Scanner(result.getStdout());
         String[] split = scanner.nextLine().split(" ");

--- a/devtools/cli/src/test/java/io/quarkus/cli/config/RemoveConfigTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/config/RemoveConfigTest.java
@@ -14,10 +14,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import io.quarkus.cli.CliDriver;
+import io.quarkus.test.junit.main.QuarkusMainLauncher;
+import io.quarkus.test.junit.main.QuarkusMainTest;
 import io.smallrye.config.PropertiesConfigSource;
 import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.config.SmallRyeConfigBuilder;
 
+@QuarkusMainTest
 public class RemoveConfigTest {
     @TempDir
     Path tempDir;
@@ -30,7 +33,8 @@ public class RemoveConfigTest {
     }
 
     @Test
-    void removeConfiguration() throws Exception {
+    void removeConfiguration(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         Path propertiesFile = tempDir.resolve("src/main/resources/application.properties");
         Properties properties = new Properties();
         try (InputStream inputStream = propertiesFile.toUri().toURL().openStream()) {

--- a/devtools/cli/src/test/java/io/quarkus/cli/config/SetConfigTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/config/SetConfigTest.java
@@ -15,10 +15,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import io.quarkus.cli.CliDriver;
+import io.quarkus.test.junit.main.QuarkusMainLauncher;
+import io.quarkus.test.junit.main.QuarkusMainTest;
 import io.smallrye.config.PropertiesConfigSource;
 import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.config.SmallRyeConfigBuilder;
 
+@QuarkusMainTest
 class SetConfigTest {
     @TempDir
     Path tempDir;
@@ -31,14 +34,16 @@ class SetConfigTest {
     }
 
     @Test
-    void addConfiguration() throws Exception {
+    void addConfiguration(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(tempDir, "config", "set", "foo.bar", "1234");
         assertEquals(0, result.getExitCode());
         assertEquals("1234", config().getConfigValue("foo.bar").getValue());
     }
 
     @Test
-    void setConfiguration() throws Exception {
+    void setConfiguration(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         Path propertiesFile = tempDir.resolve("src/main/resources/application.properties");
         Properties properties = new Properties();
         try (InputStream inputStream = propertiesFile.toUri().toURL().openStream()) {
@@ -54,7 +59,8 @@ class SetConfigTest {
     }
 
     @Test
-    void addEncryptedConfiguration() throws Exception {
+    void addEncryptedConfiguration(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(tempDir, "config", "set", "foo.bar", "1234", "-k");
         assertEquals(0, result.getExitCode());
 
@@ -75,7 +81,8 @@ class SetConfigTest {
     }
 
     @Test
-    void setEncryptedConfiguration() throws Exception {
+    void setEncryptedConfiguration(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         Path propertiesFile = tempDir.resolve("src/main/resources/application.properties");
         Properties properties = new Properties();
         try (InputStream inputStream = propertiesFile.toUri().toURL().openStream()) {

--- a/devtools/cli/src/test/java/io/quarkus/cli/create/TargetGAVGroupTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/create/TargetGAVGroupTest.java
@@ -4,8 +4,11 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.devtools.commands.CreateProjectHelper;
-import picocli.CommandLine.TypeConversionException;
+import io.quarkus.quickcli.CommandLine.TypeConversionException;
+import io.quarkus.test.junit.main.QuarkusMainLauncher;
+import io.quarkus.test.junit.main.QuarkusMainTest;
 
+@QuarkusMainTest
 public class TargetGAVGroupTest {
 
     TargetGAVGroup gav = new TargetGAVGroup();
@@ -21,7 +24,7 @@ public class TargetGAVGroupTest {
     //     my-group:: -- use defaults for artifact id and version (rare)
 
     @Test
-    void testArtifactId() {
+    void testArtifactId(QuarkusMainLauncher launcher) {
         gav.gav = "a";
 
         Assertions.assertEquals(CreateProjectHelper.DEFAULT_GROUP_ID, gav.getGroupId());
@@ -30,7 +33,7 @@ public class TargetGAVGroupTest {
     }
 
     @Test
-    void testArtifactIdLonger() {
+    void testArtifactIdLonger(QuarkusMainLauncher launcher) {
         gav.gav = ":a:";
 
         Assertions.assertEquals(CreateProjectHelper.DEFAULT_GROUP_ID, gav.getGroupId());
@@ -39,7 +42,7 @@ public class TargetGAVGroupTest {
     }
 
     @Test
-    void testGroupIdArtifactId() {
+    void testGroupIdArtifactId(QuarkusMainLauncher launcher) {
         gav.gav = "g:a";
 
         Assertions.assertEquals("g", gav.getGroupId());
@@ -48,7 +51,7 @@ public class TargetGAVGroupTest {
     }
 
     @Test
-    void testGroupIdArtifactIdLonger() {
+    void testGroupIdArtifactIdLonger(QuarkusMainLauncher launcher) {
         gav.gav = "g:a:";
 
         Assertions.assertEquals("g", gav.getGroupId());
@@ -57,7 +60,7 @@ public class TargetGAVGroupTest {
     }
 
     @Test
-    void testGroupIdArtifactIdVersion() {
+    void testGroupIdArtifactIdVersion(QuarkusMainLauncher launcher) {
         gav.gav = "g:a:v";
 
         Assertions.assertEquals("g", gav.getGroupId());
@@ -66,7 +69,7 @@ public class TargetGAVGroupTest {
     }
 
     @Test
-    void testArtifactIdVersion() {
+    void testArtifactIdVersion(QuarkusMainLauncher launcher) {
         gav.gav = ":a:v";
 
         Assertions.assertEquals(CreateProjectHelper.DEFAULT_GROUP_ID, gav.getGroupId());
@@ -75,7 +78,7 @@ public class TargetGAVGroupTest {
     }
 
     @Test
-    void testGroupId() {
+    void testGroupId(QuarkusMainLauncher launcher) {
         gav.gav = "g::";
 
         Assertions.assertEquals("g", gav.getGroupId());
@@ -84,7 +87,7 @@ public class TargetGAVGroupTest {
     }
 
     @Test
-    void testOldParameters() {
+    void testOldParameters(QuarkusMainLauncher launcher) {
         gav.groupId = "g";
         gav.artifactId = "a";
         gav.version = "v";
@@ -95,13 +98,13 @@ public class TargetGAVGroupTest {
     }
 
     @Test
-    void testBadArtifactId() {
+    void testBadArtifactId(QuarkusMainLauncher launcher) {
         gav.gav = "g:a/x:v";
         Assertions.assertThrows(TypeConversionException.class, () -> gav.getArtifactId());
     }
 
     @Test
-    void testBadGroupId() {
+    void testBadGroupId(QuarkusMainLauncher launcher) {
         gav.gav = "g,x:a:v";
         Assertions.assertThrows(TypeConversionException.class, () -> gav.getGroupId());
     }

--- a/devtools/cli/src/test/java/io/quarkus/cli/deploy/CliDeployGradleTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/deploy/CliDeployGradleTest.java
@@ -20,20 +20,24 @@ import io.quarkus.cli.CliDriver;
 import io.quarkus.cli.common.build.ExecuteUtil;
 import io.quarkus.cli.common.build.GradleRunner;
 import io.quarkus.devtools.testing.RegistryClientTestHelper;
-import picocli.CommandLine;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.test.junit.main.QuarkusMainLauncher;
+import io.quarkus.test.junit.main.QuarkusMainTest;
 
 /**
  * Similar to CliProjecGradleTest ..
  */
+@QuarkusMainTest
 public class CliDeployGradleTest {
 
     static final Path testProjectRoot = Paths.get(System.getProperty("user.dir")).toAbsolutePath()
-            .resolve("target/test-classes/test-project/");
+            .resolve("target/test-project/");
     static final Path workspaceRoot = testProjectRoot.resolve("CliImageGradleTest");
     static final Path wrapperRoot = testProjectRoot.resolve("gradle-wrapper");
 
     Path project;
     static File gradle;
+    static boolean gradleDaemonStarted = false;
 
     @BeforeAll
     public static void setupTestRegistry() {
@@ -51,15 +55,18 @@ public class CliDeployGradleTest {
         project = workspaceRoot.resolve("code-with-quarkus");
     }
 
-    @BeforeAll
-    static void startGradleDaemon() throws Exception {
+    static void ensureGradleDaemon(QuarkusMainLauncher launcher) throws Exception {
+        if (gradleDaemonStarted) {
+            return;
+        }
         CliDriver.deleteDir(wrapperRoot);
+        CliDriver.setLauncher(launcher);
 
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--gradle", "--verbose", "-e", "-B",
                 "--no-code",
                 "-o", testProjectRoot.toString(),
                 "gradle-wrapper");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
         Assertions.assertTrue(result.getStdout().contains("SUCCESS"),
                 "Expected confirmation that the project has been created." + result);
 
@@ -72,6 +79,7 @@ public class CliDeployGradleTest {
 
         result = CliDriver.executeArbitraryCommand(wrapperRoot, args.toArray(new String[0]));
         Assertions.assertEquals(0, result.getExitCode(), "Gradle daemon should start properly");
+        gradleDaemonStarted = true;
     }
 
     @AfterAll
@@ -85,15 +93,18 @@ public class CliDeployGradleTest {
             CliDriver.Result result = CliDriver.executeArbitraryCommand(wrapperRoot, args.toArray(new String[0]));
             Assertions.assertEquals(0, result.getExitCode(), "Gradle daemon should stop properly");
         }
+        gradleDaemonStarted = false;
     }
 
     @Test
-    public void testUsage() throws Exception {
+    public void testUsage(QuarkusMainLauncher launcher) throws Exception {
+        ensureGradleDaemon(launcher);
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--gradle", "--verbose", "-e", "-B");
-        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertEquals(ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
 
         result = CliDriver.execute(project, "deploy", "--dry-run");
-        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertEquals(ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
         assertTrue(result.getStdout().contains("deploy"));
         assertTrue(result.getStdout().contains("--no-daemon"));
         assertTrue(result.getStdout().contains("--no-build-cache"));
@@ -108,7 +119,7 @@ public class CliDeployGradleTest {
 
     protected void testDeployer(String deployer, String configGroup, String defaultImageBuilder) throws Exception {
         CliDriver.Result result = CliDriver.execute(project, "deploy", deployer, "--dry-run");
-        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertEquals(ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
         assertTrue(result.getStdout().contains("deploy"));
         assertTrue(result.getStdout().contains("--no-daemon"));
         assertTrue(result.getStdout().contains("--no-build-cache"));
@@ -117,7 +128,7 @@ public class CliDeployGradleTest {
         assertFalse(result.getStdout().contains("-Dquarkus." + configGroup + ".deployment-kind"));
 
         result = CliDriver.execute(project, "deploy", deployer, "--image-build", "--dry-run");
-        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertEquals(ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
         assertTrue(result.getStdout().contains("deploy"));
         assertTrue(result.getStdout().contains("--no-daemon"));
         assertTrue(result.getStdout().contains("--no-build-cache"));
@@ -127,7 +138,7 @@ public class CliDeployGradleTest {
         assertFalse(result.getStdout().contains("-Dquarkus." + configGroup + ".deployment-kind"));
 
         result = CliDriver.execute(project, "deploy", deployer, "--image-builder=jib", "--dry-run");
-        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertEquals(ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
         assertTrue(result.getStdout().contains("deploy"));
         assertTrue(result.getStdout().contains("--no-daemon"));
         assertTrue(result.getStdout().contains("--no-build-cache"));
@@ -141,7 +152,7 @@ public class CliDeployGradleTest {
         }
         result = CliDriver.execute(project, "deploy", deployer, "--deployment-kind", "Deployment",
                 "--dry-run");
-        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertEquals(ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
         assertTrue(result.getStdout().contains("deploy"));
         assertTrue(result.getStdout().contains("--no-daemon"));
         assertTrue(result.getStdout().contains("--no-build-cache"));

--- a/devtools/cli/src/test/java/io/quarkus/cli/deploy/CliDeployMavenTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/deploy/CliDeployMavenTest.java
@@ -14,14 +14,17 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.cli.CliDriver;
 import io.quarkus.devtools.testing.RegistryClientTestHelper;
-import picocli.CommandLine;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.test.junit.main.QuarkusMainLauncher;
+import io.quarkus.test.junit.main.QuarkusMainTest;
 
 /**
  * Similar to CliProjecMavenTest ..
  */
+@QuarkusMainTest
 public class CliDeployMavenTest {
     static Path workspaceRoot = Paths.get(System.getProperty("user.dir")).toAbsolutePath()
-            .resolve("target/test-classes/test-project/CliDeployMavenTest");
+            .resolve("target/test-project/CliDeployMavenTest");
     Path project;
 
     @BeforeAll
@@ -41,13 +44,14 @@ public class CliDeployMavenTest {
     }
 
     @Test
-    public void testUsage() throws Exception {
+    public void testUsage(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "-e", "-B", "--verbose");
-        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertEquals(ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
 
         // 1 deploy --dry-run
         result = CliDriver.execute(project, "deploy", "--dry-run");
-        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertEquals(ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
 
         testDeployer("kubernetes", "kubernetes", "docker");
         testDeployer("minikube", "kubernetes", "docker");
@@ -58,14 +62,14 @@ public class CliDeployMavenTest {
 
     protected void testDeployer(String deployer, String configGroup, String defaultImageBuilder) throws Exception {
         CliDriver.Result result = CliDriver.execute(project, "deploy", deployer, "--dry-run");
-        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertEquals(ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
         assertTrue(result.getStdout().contains("quarkus:deploy"));
         assertTrue(result.getStdout().contains("-Dquarkus." + deployer + ".deploy=true"));
         assertTrue(result.getStdout().contains("-Dquarkus.container-image.build=false"));
         assertFalse(result.getStdout().contains("-Dquarkus." + configGroup + ".deployment-kind"));
 
         result = CliDriver.execute(project, "deploy", deployer, "--image-build", "--dry-run");
-        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertEquals(ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
         assertTrue(result.getStdout().contains("quarkus:deploy"));
         assertTrue(result.getStdout().contains("-Dquarkus." + deployer + ".deploy=true"));
         assertTrue(result.getStdout().contains("-Dquarkus.container-image.builder=" + defaultImageBuilder));
@@ -73,7 +77,7 @@ public class CliDeployMavenTest {
         assertFalse(result.getStdout().contains("-Dquarkus." + configGroup + ".deployment-kind"));
 
         result = CliDriver.execute(project, "deploy", deployer, "--image-builder=jib", "--dry-run");
-        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertEquals(ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
         assertTrue(result.getStdout().contains("quarkus:deploy"));
         assertTrue(result.getStdout().contains("-Dquarkus." + deployer + ".deploy=true"));
         assertTrue(result.getStdout().contains("-Dquarkus.container-image.builder=jib"));
@@ -84,7 +88,7 @@ public class CliDeployMavenTest {
             return;
         }
         result = CliDriver.execute(project, "deploy", deployer, "--deployment-kind", "Deployment", "--dry-run");
-        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertEquals(ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
         assertTrue(result.getStdout().contains("quarkus:deploy"));
         assertTrue(result.getStdout().contains("-Dquarkus." + deployer + ".deploy=true"));
         assertTrue(result.getStdout().contains("-Dquarkus.container-image.build=false"));

--- a/devtools/cli/src/test/java/io/quarkus/cli/image/CliImageGradleTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/image/CliImageGradleTest.java
@@ -20,20 +20,24 @@ import io.quarkus.cli.CliDriver;
 import io.quarkus.cli.common.build.ExecuteUtil;
 import io.quarkus.cli.common.build.GradleRunner;
 import io.quarkus.devtools.testing.RegistryClientTestHelper;
-import picocli.CommandLine;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.test.junit.main.QuarkusMainLauncher;
+import io.quarkus.test.junit.main.QuarkusMainTest;
 
 /**
  * Similar to CliProjecGradleTest ..
  */
+@QuarkusMainTest
 public class CliImageGradleTest {
 
     static final Path testProjectRoot = Paths.get(System.getProperty("user.dir")).toAbsolutePath()
-            .resolve("target/test-classes/test-project/");
+            .resolve("target/test-project/");
     static final Path workspaceRoot = testProjectRoot.resolve("CliImageGradleTest");
     static final Path wrapperRoot = testProjectRoot.resolve("gradle-wrapper");
 
     Path project;
     static File gradle;
+    static boolean gradleDaemonStarted = false;
 
     @BeforeAll
     public static void setupTestRegistry() {
@@ -51,15 +55,18 @@ public class CliImageGradleTest {
         project = workspaceRoot.resolve("code-with-quarkus");
     }
 
-    @BeforeAll
-    static void startGradleDaemon() throws Exception {
+    static void ensureGradleDaemon(QuarkusMainLauncher launcher) throws Exception {
+        if (gradleDaemonStarted) {
+            return;
+        }
         CliDriver.deleteDir(wrapperRoot);
+        CliDriver.setLauncher(launcher);
 
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--gradle", "--verbose", "-e", "-B",
                 "--no-code",
                 "-o", testProjectRoot.toString(),
                 "gradle-wrapper");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        Assertions.assertEquals(ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
         Assertions.assertTrue(result.getStdout().contains("SUCCESS"),
                 "Expected confirmation that the project has been created." + result);
 
@@ -72,6 +79,7 @@ public class CliImageGradleTest {
 
         result = CliDriver.executeArbitraryCommand(wrapperRoot, args.toArray(new String[0]));
         Assertions.assertEquals(0, result.getExitCode(), "Gradle daemon should start properly");
+        gradleDaemonStarted = true;
     }
 
     @AfterAll
@@ -85,55 +93,58 @@ public class CliImageGradleTest {
             CliDriver.Result result = CliDriver.executeArbitraryCommand(wrapperRoot, args.toArray(new String[0]));
             Assertions.assertEquals(0, result.getExitCode(), "Gradle daemon should stop properly");
         }
+        gradleDaemonStarted = false;
     }
 
     @Test
-    public void testUsage() throws Exception {
+    public void testUsage(QuarkusMainLauncher launcher) throws Exception {
+        ensureGradleDaemon(launcher);
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--gradle", "--verbose", "-e", "-B");
-        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertEquals(ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
 
         // 1 image --dry-run
         result = CliDriver.execute(project, "image", "--dry-run");
-        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertEquals(ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
         assertFalse(result.getStdout().contains("-Dquarkus.native.enabled=true"));
         result = CliDriver.execute(project, "image", "--native", "--dry-run");
-        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertEquals(ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
         assertTrue(result.getStdout().contains("-Dquarkus.native.enabled=true"));
 
         // 2 image build --dry-run
         result = CliDriver.execute(project, "image", "build", "--dry-run");
-        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertEquals(ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
         assertTrue(result.getStdout().contains("--builder=docker")); // Should fallback to docker
         assertTrue(result.getStdout().contains("--init-script="));
 
         result = CliDriver.execute(project, "image", "build", "docker", "--dry-run");
-        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertEquals(ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
         assertTrue(result.getStdout().contains("--builder=docker"));
         assertTrue(result.getStdout().contains("--init-script="));
 
         result = CliDriver.execute(project, "image", "build", "podman", "--dry-run");
-        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertEquals(ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
         assertTrue(result.getStdout().contains("--builder=podman"));
         assertTrue(result.getStdout().contains("--init-script="));
 
         result = CliDriver.execute(project, "image", "build", "jib", "--dry-run");
-        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertEquals(ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
         assertTrue(result.getStdout().contains("--builder=jib"));
         assertTrue(result.getStdout().contains("--init-script="));
 
         result = CliDriver.execute(project, "image", "build", "buildpack", "--dry-run");
-        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertEquals(ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
         assertTrue(result.getStdout().contains("--builder=buildpack"));
         assertTrue(result.getStdout().contains("--init-script="));
 
         result = CliDriver.execute(project, "image", "build", "openshift", "--dry-run");
-        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertEquals(ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
         assertTrue(result.getStdout().contains("--builder=openshift"));
         assertTrue(result.getStdout().contains("--init-script="));
 
         result = CliDriver.execute(project, "image", "build", "--group=mygroup", "--name=myname", "--tag=1.0", "--native",
                 "--dry-run");
-        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertEquals(ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
         assertTrue(result.getStdout().contains("-Dquarkus.container-image.group=mygroup"));
         assertTrue(result.getStdout().contains("-Dquarkus.container-image.name=myname"));
         assertTrue(result.getStdout().contains("-Dquarkus.container-image.tag=1.0"));
@@ -141,13 +152,13 @@ public class CliImageGradleTest {
 
         // 3 image push --dry-run
         result = CliDriver.execute(project, "image", "push", "--dry-run");
-        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertEquals(ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
         assertTrue(result.getStdout().contains("-Dquarkus.container-image.build=false"));
         assertTrue(result.getStdout().contains("--init-script="));
 
         // 4 image push --also-build --dry-run --registry=quay.io
         result = CliDriver.execute(project, "image", "push", "--also-build", "--dry-run", "--registry=quay.io");
-        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertEquals(ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
         assertTrue(result.getStdout().contains("-Dquarkus.container-image.build=true"));
         assertTrue(result.getStdout().contains("-Dquarkus.container-image.registry=quay.io"));
     }

--- a/devtools/cli/src/test/java/io/quarkus/cli/image/CliImageMavenTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/image/CliImageMavenTest.java
@@ -14,14 +14,17 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.cli.CliDriver;
 import io.quarkus.devtools.testing.RegistryClientTestHelper;
-import picocli.CommandLine;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.test.junit.main.QuarkusMainLauncher;
+import io.quarkus.test.junit.main.QuarkusMainTest;
 
 /**
  * Similar to CliProjecMavenTest ..
  */
+@QuarkusMainTest
 public class CliImageMavenTest {
     static Path workspaceRoot = Paths.get(System.getProperty("user.dir")).toAbsolutePath()
-            .resolve("target/test-classes/test-project/CliImageMavenTest");
+            .resolve("target/test-project/CliImageMavenTest");
     Path project;
 
     @BeforeAll
@@ -41,13 +44,14 @@ public class CliImageMavenTest {
     }
 
     @Test
-    public void testUsage() throws Exception {
+    public void testUsage(QuarkusMainLauncher launcher) throws Exception {
+        CliDriver.setLauncher(launcher);
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "-e", "-B", "--verbose");
-        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertEquals(ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
 
         // 1 image --dry-run
         result = CliDriver.execute(project, "image", "--dry-run");
-        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertEquals(ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
         assertTrue(result.getStdout().contains("quarkus:image-build"));
         assertFalse(result.getStdout().contains("-Dnative"));
         result = CliDriver.execute(project, "image", "--native", "--dry-run");
@@ -55,10 +59,10 @@ public class CliImageMavenTest {
 
         // 2 image build --dry-run
         result = CliDriver.execute(project, "image", "build", "--dry-run");
-        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertEquals(ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
         result = CliDriver.execute(project, "image", "build", "--group=mygroup", "--name=myname", "--tag=1.0", "--native",
                 "--dry-run");
-        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertEquals(ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
         assertTrue(result.getStdout().contains("-Dquarkus.container-image.group=mygroup"));
         assertTrue(result.getStdout().contains("-Dquarkus.container-image.name=myname"));
         assertTrue(result.getStdout().contains("-Dquarkus.container-image.tag=1.0"));
@@ -66,12 +70,12 @@ public class CliImageMavenTest {
 
         // 3 image push --dry-run
         result = CliDriver.execute(project, "image", "push", "--dry-run");
-        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertEquals(ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
         assertTrue(result.getStdout().contains("-Dquarkus.container-image.build=false"));
 
         // 4 image push --also-build --dry-run --registry=quay.io
         result = CliDriver.execute(project, "image", "push", "--also-build", "--dry-run", "--registry=quay.io");
-        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertEquals(ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
         assertTrue(result.getStdout().contains("-Dquarkus.container-image.build=true"));
         assertTrue(result.getStdout().contains("-Dquarkus.container-image.registry=quay.io"));
 

--- a/devtools/cli/src/test/java/io/quarkus/cli/plugin/PluginCommandFactoryTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/plugin/PluginCommandFactoryTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
-import picocli.CommandLine;
+import io.quarkus.quickcli.CommandLine;
 
 public class PluginCommandFactoryTest {
 

--- a/devtools/cli/src/test/java/io/quarkus/cli/plugin/TestCommand.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/plugin/TestCommand.java
@@ -4,8 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import io.quarkus.cli.common.OutputOptionMixin;
-import picocli.CommandLine;
-import picocli.CommandLine.Command;
+import io.quarkus.quickcli.ExitCode;
+import io.quarkus.quickcli.annotations.Command;
 
 @Command
 public class TestCommand implements PluginCommand {
@@ -26,7 +26,7 @@ public class TestCommand implements PluginCommand {
     @Override
     public Integer call() throws Exception {
         System.out.println("Calling " + cmd + " " + String.join(" ", arguments));
-        return CommandLine.ExitCode.OK;
+        return ExitCode.OK;
     }
 
     @Override

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -2005,6 +2005,19 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-quickcli-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-qute-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -218,6 +218,7 @@
 
         <!-- Command line -->
         <module>picocli</module>
+        <module>quickcli</module>
         <module>google-cloud-functions-http</module>
         <module>google-cloud-functions</module>
         <module>grpc-common</module>

--- a/extensions/quickcli/deployment/pom.xml
+++ b/extensions/quickcli/deployment/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-quickcli-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-quickcli-deployment</artifactId>
+    <name>Quarkus - QuickCLI - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-quickcli</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.quarkus</groupId>
+                                    <artifactId>quarkus-extension-processor</artifactId>
+                                    <version>${project.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/quickcli/deployment/src/main/java/io/quarkus/quickcli/deployment/CommandModelGenerator.java
+++ b/extensions/quickcli/deployment/src/main/java/io/quarkus/quickcli/deployment/CommandModelGenerator.java
@@ -1,0 +1,1571 @@
+package io.quarkus.quickcli.deployment;
+
+import java.lang.constant.ClassDesc;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.ParameterizedType;
+import org.jboss.jandex.Type;
+
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
+import io.quarkus.gizmo2.Const;
+import io.quarkus.gizmo2.Expr;
+import io.quarkus.gizmo2.Gizmo;
+import io.quarkus.gizmo2.LocalVar;
+import io.quarkus.gizmo2.This;
+import io.quarkus.gizmo2.creator.BlockCreator;
+import io.quarkus.gizmo2.creator.ClassCreator;
+import io.quarkus.gizmo2.desc.ClassMethodDesc;
+import io.quarkus.gizmo2.desc.ConstructorDesc;
+import io.quarkus.gizmo2.desc.FieldDesc;
+import io.quarkus.gizmo2.desc.MethodDesc;
+import io.quarkus.quickcli.CommandSpec;
+import io.quarkus.quickcli.ScopeType;
+import io.quarkus.quickcli.model.BuiltCommandModel;
+import io.quarkus.quickcli.model.CommandModelRegistry;
+import io.quarkus.quickcli.model.FieldAccessor;
+
+/**
+ * Generates {@code *_QuickCliModel} classes using Gizmo2 at Quarkus build time.
+ * <p>
+ * For each {@code @Command} class, generates a single class that:
+ * <ul>
+ * <li>Implements {@link FieldAccessor} (dispatches by field index)</li>
+ * <li>Implements {@link Supplier} (creates command instances)</li>
+ * <li>Has a static initializer that builds and registers a {@link BuiltCommandModel}</li>
+ * </ul>
+ */
+class CommandModelGenerator {
+
+    private static final DotName COMMAND = DotName.createSimple("io.quarkus.quickcli.annotations.Command");
+    private static final DotName OPTION = DotName.createSimple("io.quarkus.quickcli.annotations.Option");
+    private static final DotName PARAMETERS = DotName.createSimple("io.quarkus.quickcli.annotations.Parameters");
+    private static final DotName MIXIN = DotName.createSimple("io.quarkus.quickcli.annotations.Mixin");
+    private static final DotName ARG_GROUP = DotName.createSimple("io.quarkus.quickcli.annotations.ArgGroup");
+    private static final DotName SPEC = DotName.createSimple("io.quarkus.quickcli.annotations.Spec");
+    private static final DotName PARENT_COMMAND = DotName.createSimple("io.quarkus.quickcli.annotations.ParentCommand");
+    private static final DotName UNMATCHED = DotName.createSimple("io.quarkus.quickcli.annotations.Unmatched");
+
+    private static final DotName LIST = DotName.createSimple(java.util.List.class.getName());
+    private static final DotName SET = DotName.createSimple(java.util.Set.class.getName());
+    private static final DotName MAP = DotName.createSimple(java.util.Map.class.getName());
+    private static final DotName OPTIONAL = DotName.createSimple(Optional.class.getName());
+
+    private final IndexView index;
+
+    CommandModelGenerator(IndexView index) {
+        this.index = index;
+    }
+
+    void generateAll(BuildProducer<GeneratedClassBuildItem> generatedClass) {
+        Set<DotName> generated = new HashSet<>();
+        for (AnnotationInstance ann : index.getAnnotations(COMMAND)) {
+            if (ann.target().kind() != AnnotationTarget.Kind.CLASS) {
+                continue;
+            }
+            ClassInfo classInfo = ann.target().asClass();
+            if (generated.add(classInfo.name())) {
+                generate(classInfo, generatedClass);
+            }
+        }
+    }
+
+    private void generate(ClassInfo commandClass, BuildProducer<GeneratedClassBuildItem> generatedClass) {
+        String commandClassName = commandClass.name().toString();
+        String modelClassName = commandClassName + "_QuickCliModel";
+        String commandPkg = packageOf(commandClassName);
+
+        // Collect all field metadata
+        CommandData data = collectCommandData(commandClass);
+
+        io.quarkus.gizmo2.ClassOutput classOutput = createClassOutput(generatedClass);
+
+        // Generate accessor classes in cross-package superclass packages.
+        // This avoids reflection: each accessor is in the same package as the fields it accesses.
+        List<FieldSetInfo> allFields = collectAllFieldSetInfos(data, commandClassName);
+        Map<String, String> accessorClassNames = generateCrossPackageAccessors(
+                allFields, commandClassName, commandPkg, classOutput);
+
+        Gizmo gizmo = Gizmo.create(classOutput);
+        gizmo.class_(modelClassName, cc -> {
+            cc.implements_(FieldAccessor.class);
+            cc.implements_(Supplier.class);
+
+            This this_ = cc.this_();
+
+            // Field: int fieldIndex
+            FieldDesc fieldIndexField = cc.field("fieldIndex", fc -> {
+                fc.private_();
+                fc.final_();
+                fc.setType(int.class);
+            });
+
+            // Constructor(int fieldIndex)
+            cc.constructor(mc -> {
+                var fieldIndex = mc.parameter("fieldIndex", int.class);
+                mc.body(bc -> {
+                    bc.invokeSpecial(ConstructorDesc.of(Object.class), this_);
+                    bc.set(this_.field(fieldIndexField), fieldIndex);
+                    bc.return_();
+                });
+            });
+
+            // Supplier.get() -> new CommandClass()
+            cc.method("get", mc -> {
+                mc.public_();
+                mc.returning(Object.class);
+                mc.body(bc -> bc.return_(bc.new_(ClassDesc.of(commandClassName))));
+            });
+
+            // FieldAccessor.set(Object instance, Object value) - dispatch by fieldIndex
+            generateSetMethod(cc, this_, fieldIndexField, commandClassName, data);
+
+            // Static initializer: build and register the model
+            generateStaticInitializer(cc, modelClassName, commandClassName, data, accessorClassNames);
+        });
+    }
+
+    private static io.quarkus.gizmo2.ClassOutput createClassOutput(
+            BuildProducer<GeneratedClassBuildItem> generatedClass) {
+        return (resourceName, bytes) -> {
+            if (resourceName.endsWith(".class")) {
+                String cn = resourceName.substring(0, resourceName.length() - 6).replace('/', '.');
+                generatedClass.produce(new GeneratedClassBuildItem(true, cn, bytes));
+            }
+        };
+    }
+
+    // --- Field metadata collection via Jandex ---
+
+    private CommandData collectCommandData(ClassInfo commandClass) {
+        AnnotationInstance cmdAnn = commandClass.annotation(COMMAND);
+        CommandData data = new CommandData();
+        data.commandClassName = commandClass.name().toString();
+
+        // @Command attributes
+        data.name = annotationString(cmdAnn, "name", "");
+        if (data.name.isEmpty()) {
+            data.name = commandClass.simpleName().toLowerCase();
+        }
+        data.description = annotationStringArray(cmdAnn, "description");
+        data.version = annotationStringArray(cmdAnn, "version");
+        data.mixinStandardHelpOptions = annotationBool(cmdAnn, "mixinStandardHelpOptions", false);
+        data.header = annotationStringArray(cmdAnn, "header");
+        data.footer = annotationStringArray(cmdAnn, "footer");
+        data.scope = annotationEnum(cmdAnn, "scope", ScopeType.class, ScopeType.LOCAL);
+        data.aliases = annotationStringArray(cmdAnn, "aliases");
+        data.showDefaultValues = annotationBool(cmdAnn, "showDefaultValues", false);
+        data.commandListHeading = annotationString(cmdAnn, "commandListHeading", "Commands:%n");
+        data.synopsisHeading = annotationString(cmdAnn, "synopsisHeading", "Usage: ");
+        data.optionListHeading = annotationString(cmdAnn, "optionListHeading", "Options:%n");
+        data.headerHeading = annotationString(cmdAnn, "headerHeading", "");
+        data.parameterListHeading = annotationString(cmdAnn, "parameterListHeading", "%n");
+
+        // Version provider
+        AnnotationValue vpValue = cmdAnn.value("versionProvider");
+        if (vpValue != null) {
+            data.versionProviderClassName = vpValue.asClass().name().toString();
+        }
+
+        // Subcommands
+        AnnotationValue subValue = cmdAnn.value("subcommands");
+        if (subValue != null) {
+            for (Type t : subValue.asClassArray()) {
+                data.subcommandClassNames.add(t.name().toString());
+            }
+        }
+
+        int fieldIndex = 0;
+
+        // Scan this class for annotated fields
+        fieldIndex = scanClassFields(commandClass, data, null, fieldIndex, false);
+
+        // Scan superclasses
+        String commandPkg = packageOf(commandClass.name().toString());
+        Type superType = commandClass.superClassType();
+        while (superType != null && !superType.name().equals(DotName.createSimple("java.lang.Object"))) {
+            ClassInfo superClass = index.getClassByName(superType.name());
+            if (superClass == null) {
+                break;
+            }
+            boolean crossPackage = !commandPkg.equals(packageOf(superClass.name().toString()));
+            fieldIndex = scanClassFields(superClass, data, superClass.name().toString(), fieldIndex, crossPackage);
+            superType = superClass.superClassType();
+        }
+
+        // Sort parameters by explicit index so help output and value assignment are correct
+        data.parameters.sort(java.util.Comparator.comparingInt(p -> p.paramIndex));
+
+        return data;
+    }
+
+    private int scanClassFields(ClassInfo classInfo, CommandData data, String declaringClass,
+            int fieldIndex, boolean crossPackage) {
+
+        for (FieldInfo field : classInfo.fields()) {
+            AnnotationInstance optionAnn = field.annotation(OPTION);
+            AnnotationInstance paramsAnn = field.annotation(PARAMETERS);
+            AnnotationInstance mixinAnn = field.annotation(MIXIN);
+            AnnotationInstance argGroupAnn = field.annotation(ARG_GROUP);
+            AnnotationInstance specAnn = field.annotation(SPEC);
+            AnnotationInstance parentAnn = field.annotation(PARENT_COMMAND);
+            AnnotationInstance unmatchedAnn = field.annotation(UNMATCHED);
+
+            if (optionAnn == null && paramsAnn == null && mixinAnn == null
+                    && argGroupAnn == null && specAnn == null && parentAnn == null
+                    && unmatchedAnn == null) {
+                continue;
+            }
+
+            boolean isPublic = Modifier.isPublic(field.flags());
+            // Reflection fallback is needed for non-public fields on cross-package superclasses.
+            // Private fields on the command class itself are bytecode-transformed to package-private,
+            // so PUTFIELD works without reflection. Same approach as Arc.
+            boolean needsReflection = crossPackage && !isPublic;
+            String fieldTypeName = fieldTypeClassName(field.type());
+            BuiltCommandModel.FieldKind fieldKind = detectFieldKind(field.type());
+            String componentTypeName = detectComponentType(field.type());
+            String optionalInnerTypeName = fieldKind == BuiltCommandModel.FieldKind.OPTIONAL
+                    ? detectOptionalInnerType(field.type())
+                    : null;
+
+            if (optionAnn != null) {
+                OptionData od = createOptionData(optionAnn, fieldIndex++, field.name(),
+                        fieldTypeName, fieldKind, componentTypeName, optionalInnerTypeName,
+                        needsReflection, declaringClass, null, null);
+                data.options.add(od);
+            }
+
+            if (paramsAnn != null) {
+                ParameterData pd = createParameterData(paramsAnn, fieldIndex++, field.name(),
+                        fieldTypeName, fieldKind, componentTypeName,
+                        needsReflection, declaringClass, null, null, data);
+                data.parameters.add(pd);
+            }
+
+            if (mixinAnn != null) {
+                MixinData md = new MixinData();
+                md.fieldIndex = fieldIndex++;
+                md.fieldName = field.name();
+                md.mixinTypeName = fieldTypeName;
+                md.isPrivate = needsReflection;
+                md.declaringClassName = declaringClass;
+                data.mixins.add(md);
+
+                // Scan mixin type for @Option and @Parameters fields
+                ClassInfo mixinClass = index.getClassByName(field.type().name());
+                if (mixinClass != null) {
+                    fieldIndex = scanMixinOrArgGroupFields(mixinClass, data, field.name(),
+                            fieldTypeName, fieldIndex, false);
+
+                    // Check for @Spec(MIXEE) fields in the mixin
+                    for (FieldInfo mixinField : mixinClass.fields()) {
+                        AnnotationInstance mixinSpec = mixinField.annotation(SPEC);
+                        if (mixinSpec != null) {
+                            AnnotationValue targetValue = mixinSpec.value("value");
+                            String target = targetValue != null ? targetValue.asEnum() : "SELF";
+                            if ("MIXEE".equals(target)) {
+                                MixeeSpecData msd = new MixeeSpecData();
+                                msd.fieldIndex = fieldIndex++;
+                                msd.mixinFieldName = field.name();
+                                msd.mixinTypeName = fieldTypeName;
+                                msd.specFieldName = mixinField.name();
+                                msd.isPrivate = Modifier.isPrivate(mixinField.flags());
+                                data.mixeeSpecs.add(msd);
+                            }
+                        }
+                    }
+                } else {
+                    throw new IllegalStateException(
+                            "Mixin class " + fieldTypeName + " is not in the Jandex index. "
+                                    + "Add an IndexDependencyBuildItem for the library containing this class.");
+                }
+            }
+
+            if (argGroupAnn != null) {
+                ArgGroupData agd = new ArgGroupData();
+                agd.fieldIndex = fieldIndex++;
+                agd.fieldName = field.name();
+                agd.argGroupTypeName = fieldTypeName;
+                agd.isPrivate = needsReflection;
+                agd.declaringClassName = declaringClass;
+                data.argGroups.add(agd);
+
+                ClassInfo argGroupClass = index.getClassByName(field.type().name());
+                if (argGroupClass != null) {
+                    boolean exclusive = annotationBool(argGroupAnn, "exclusive", true);
+                    if (exclusive) {
+                        // Collect exclusive group option names
+                        List<String> groupOptionNames = new ArrayList<>();
+                        for (FieldInfo agField : argGroupClass.fields()) {
+                            AnnotationInstance agOption = agField.annotation(OPTION);
+                            if (agOption != null) {
+                                String[] names = annotationStringArray(agOption, "names");
+                                if (names.length > 0) {
+                                    groupOptionNames.add(names[names.length - 1]); // longest name
+                                }
+                            }
+                        }
+                        if (!groupOptionNames.isEmpty()) {
+                            data.exclusiveGroups.add(groupOptionNames);
+                        }
+                    }
+                    fieldIndex = scanMixinOrArgGroupFields(argGroupClass, data, field.name(),
+                            fieldTypeName, fieldIndex, false);
+                } else {
+                    throw new IllegalStateException(
+                            "ArgGroup class " + fieldTypeName + " is not in the Jandex index. "
+                                    + "Add an IndexDependencyBuildItem for the library containing this class.");
+                }
+            }
+
+            if (specAnn != null) {
+                String target = "SELF";
+                AnnotationValue targetVal = specAnn.value();
+                if (targetVal != null) {
+                    target = targetVal.asString();
+                }
+                if ("SELF".equals(target)) {
+                    data.specFieldIndex = fieldIndex++;
+                    data.specFieldName = field.name();
+                    data.specIsPrivate = needsReflection;
+                    data.specDeclaringClassName = declaringClass;
+                }
+            }
+
+            if (parentAnn != null) {
+                data.parentCommandFieldIndex = fieldIndex++;
+                data.parentCommandFieldName = field.name();
+                data.parentCommandIsPrivate = needsReflection;
+                data.parentCommandTypeName = fieldTypeName;
+                data.parentCommandDeclaringClassName = declaringClass;
+            }
+
+            if (unmatchedAnn != null) {
+                data.unmatchedFieldIndex = fieldIndex++;
+                data.unmatchedFieldName = field.name();
+                data.unmatchedIsPrivate = needsReflection;
+                data.unmatchedDeclaringClassName = declaringClass;
+            }
+        }
+
+        // Scan methods for @Option annotations (e.g., setter methods like setProperty(Map))
+        fieldIndex = scanMethodOptions(classInfo, data, declaringClass, fieldIndex, crossPackage, null, null);
+
+        return fieldIndex;
+    }
+
+    private int scanMixinOrArgGroupFields(ClassInfo ownerClass, CommandData data,
+            String ownerFieldName, String ownerTypeName, int fieldIndex, boolean crossPackage) {
+        String cmdPkg = packageOf(data.commandClassName);
+
+        for (FieldInfo field : ownerClass.fields()) {
+            AnnotationInstance optionAnn = field.annotation(OPTION);
+            AnnotationInstance paramsAnn = field.annotation(PARAMETERS);
+            AnnotationInstance nestedArgGroupAnn = field.annotation(ARG_GROUP);
+
+            if (optionAnn == null && paramsAnn == null && nestedArgGroupAnn == null) {
+                continue;
+            }
+
+            // Handle nested @ArgGroup fields inside a mixin or arg group
+            if (nestedArgGroupAnn != null) {
+                String nestedTypeName = fieldTypeClassName(field.type());
+                ArgGroupData agd = new ArgGroupData();
+                agd.fieldIndex = fieldIndex++;
+                agd.fieldName = field.name();
+                agd.argGroupTypeName = nestedTypeName;
+                agd.isPrivate = false;
+                agd.ownerPath = ownerFieldName;
+                agd.ownerTypeName = ownerTypeName;
+                data.argGroups.add(agd);
+
+                ClassInfo nestedArgGroupClass = index.getClassByName(field.type().name());
+                if (nestedArgGroupClass != null) {
+                    boolean exclusive = annotationBool(nestedArgGroupAnn, "exclusive", true);
+                    if (exclusive) {
+                        List<String> groupOptionNames = new ArrayList<>();
+                        for (FieldInfo agField : nestedArgGroupClass.fields()) {
+                            AnnotationInstance agOption = agField.annotation(OPTION);
+                            if (agOption != null) {
+                                String[] names = annotationStringArray(agOption, "names");
+                                if (names.length > 0) {
+                                    groupOptionNames.add(names[names.length - 1]);
+                                }
+                            }
+                        }
+                        if (!groupOptionNames.isEmpty()) {
+                            data.exclusiveGroups.add(groupOptionNames);
+                        }
+                    }
+                    String nestedOwnerPath = ownerFieldName != null
+                            ? ownerFieldName + "." + field.name()
+                            : field.name();
+                    fieldIndex = scanMixinOrArgGroupFields(nestedArgGroupClass, data, nestedOwnerPath,
+                            nestedTypeName, fieldIndex, false);
+                } else {
+                    throw new IllegalStateException(
+                            "ArgGroup class " + nestedTypeName + " is not in the Jandex index. "
+                                    + "Add an IndexDependencyBuildItem for the library containing this class.");
+                }
+                continue;
+            }
+
+            String fieldTypeName = fieldTypeClassName(field.type());
+            BuiltCommandModel.FieldKind fieldKind = detectFieldKind(field.type());
+            String componentTypeName = detectComponentType(field.type());
+            String optionalInnerTypeName = fieldKind == BuiltCommandModel.FieldKind.OPTIONAL
+                    ? detectOptionalInnerType(field.type())
+                    : null;
+
+            if (optionAnn != null) {
+                OptionData od = createOptionData(optionAnn, fieldIndex++, field.name(),
+                        fieldTypeName, fieldKind, componentTypeName, optionalInnerTypeName,
+                        false, null, ownerFieldName, ownerTypeName);
+                data.options.add(od);
+            }
+
+            if (paramsAnn != null) {
+                ParameterData pd = createParameterData(paramsAnn, fieldIndex++, field.name(),
+                        fieldTypeName, fieldKind, componentTypeName,
+                        false, null, ownerFieldName, ownerTypeName, data);
+                data.parameters.add(pd);
+            }
+        }
+
+        // Scan methods for @Option annotations in mixin/arggroup classes
+        fieldIndex = scanMethodOptions(ownerClass, data, null, fieldIndex, crossPackage,
+                ownerFieldName, ownerTypeName);
+
+        return fieldIndex;
+    }
+
+    /**
+     * Scans methods of a class for @Option annotations (setter-style options).
+     * For method-level options, the type is derived from the method's single parameter.
+     */
+    private int scanMethodOptions(ClassInfo classInfo, CommandData data, String declaringClass,
+            int fieldIndex, boolean crossPackage, String ownerFieldName, String ownerTypeName) {
+        for (MethodInfo method : classInfo.methods()) {
+            AnnotationInstance optionAnn = method.annotation(OPTION);
+            if (optionAnn == null) {
+                continue;
+            }
+            if (method.parametersCount() != 1) {
+                throw new IllegalStateException("@Option on method " + classInfo.name() + "." + method.name()
+                        + " must have exactly one parameter");
+            }
+
+            Type paramType = method.parameterType(0);
+            String paramTypeName = fieldTypeClassName(paramType);
+            BuiltCommandModel.FieldKind fieldKind = detectFieldKind(paramType);
+            String componentTypeName = detectComponentType(paramType);
+            String optionalInnerTypeName = fieldKind == BuiltCommandModel.FieldKind.OPTIONAL
+                    ? detectOptionalInnerType(paramType)
+                    : null;
+
+            OptionData od = createOptionData(optionAnn, fieldIndex++, method.name(),
+                    paramTypeName, fieldKind, componentTypeName, optionalInnerTypeName,
+                    false, declaringClass, ownerFieldName, ownerTypeName);
+            od.setterMethodName = method.name();
+            od.setterMethodParamType = paramTypeName;
+            data.options.add(od);
+        }
+        return fieldIndex;
+    }
+
+    private OptionData createOptionData(AnnotationInstance optionAnn, int fieldIndex, String fieldName,
+            String typeName, BuiltCommandModel.FieldKind fieldKind,
+            String componentTypeName, String optionalInnerTypeName,
+            boolean isPrivate, String declaringClassName, String ownerPath, String ownerTypeName) {
+        OptionData od = new OptionData();
+        od.fieldIndex = fieldIndex;
+        od.fieldName = fieldName;
+        od.names = annotationStringArray(optionAnn, "names");
+        od.description = joinDescriptionArray(annotationStringArray(optionAnn, "description"));
+        od.typeName = typeName;
+        od.required = annotationBool(optionAnn, "required", false);
+        od.defaultValue = annotationString(optionAnn, "defaultValue", "");
+        od.arity = annotationString(optionAnn, "arity", "");
+        od.hidden = annotationBool(optionAnn, "hidden", false);
+        od.paramLabel = annotationString(optionAnn, "paramLabel", "");
+        od.versionHelp = annotationBool(optionAnn, "versionHelp", false);
+        od.usageHelp = annotationBool(optionAnn, "usageHelp", false);
+        od.negatable = annotationBool(optionAnn, "negatable", false);
+        od.order = annotationInt(optionAnn, "order", -1);
+        od.fieldKind = fieldKind;
+        od.componentTypeName = componentTypeName;
+        od.optionalInnerTypeName = optionalInnerTypeName;
+        od.split = annotationString(optionAnn, "split", "");
+        od.mapFallbackValue = annotationString(optionAnn, "mapFallbackValue", "");
+        od.isPrivate = isPrivate;
+        od.declaringClassName = declaringClassName;
+        od.ownerPath = ownerPath;
+        od.ownerTypeName = ownerTypeName;
+        return od;
+    }
+
+    private ParameterData createParameterData(AnnotationInstance paramsAnn, int fieldIndex, String fieldName,
+            String typeName, BuiltCommandModel.FieldKind fieldKind, String componentTypeName,
+            boolean isPrivate, String declaringClassName, String ownerPath, String ownerTypeName,
+            CommandData data) {
+        ParameterData pd = new ParameterData();
+        pd.fieldIndex = fieldIndex;
+        pd.fieldName = fieldName;
+        pd.typeName = typeName;
+        pd.description = annotationString(paramsAnn, "description", "");
+        pd.defaultValue = annotationString(paramsAnn, "defaultValue", "");
+        pd.arity = annotationString(paramsAnn, "arity", "");
+        pd.hidden = annotationBool(paramsAnn, "hidden", false);
+        pd.paramLabel = annotationString(paramsAnn, "paramLabel", "");
+        pd.split = annotationString(paramsAnn, "split", "");
+        pd.isMultiValue = fieldKind == BuiltCommandModel.FieldKind.LIST
+                || fieldKind == BuiltCommandModel.FieldKind.SET
+                || fieldKind == BuiltCommandModel.FieldKind.ARRAY;
+        pd.fieldKind = fieldKind;
+        pd.componentTypeName = componentTypeName;
+        pd.isPrivate = isPrivate;
+        pd.declaringClassName = declaringClassName;
+        pd.ownerPath = ownerPath;
+        pd.ownerTypeName = ownerTypeName;
+        String indexStr = annotationString(paramsAnn, "index", "");
+        if (!indexStr.isEmpty()) {
+            int dotPos = indexStr.indexOf('.');
+            pd.paramIndex = Integer.parseInt(dotPos > 0 ? indexStr.substring(0, dotPos) : indexStr);
+        } else {
+            pd.paramIndex = data.nextParamIndex++;
+        }
+        return pd;
+    }
+
+    // --- Gizmo2 generation ---
+
+    /**
+     * Generates accessor classes in cross-package superclass packages so that non-public
+     * fields can be accessed via direct PUTFIELD without reflection.
+     *
+     * @return map of declaring class name -> generated accessor class name
+     */
+    private Map<String, String> generateCrossPackageAccessors(
+            List<FieldSetInfo> allFields, String commandClassName, String commandPkg,
+            io.quarkus.gizmo2.ClassOutput classOutput) {
+
+        // Group cross-package fields by their declaring class
+        Map<String, List<FieldSetInfo>> fieldsByDeclaringClass = new HashMap<>();
+        for (FieldSetInfo fsi : allFields) {
+            if (!fsi.useReflection()) {
+                continue;
+            }
+            // Determine which class declares the field that needs cross-package access
+            String declaringClass;
+            if (fsi.ownerPath() != null && fsi.ownerDeclaringClassName() != null) {
+                // The owner field (mixin/arggroup) is on a cross-package superclass
+                declaringClass = fsi.ownerDeclaringClassName();
+            } else if (fsi.declaringClassName() != null) {
+                declaringClass = fsi.declaringClassName();
+            } else {
+                continue;
+            }
+            fieldsByDeclaringClass.computeIfAbsent(declaringClass, k -> new ArrayList<>()).add(fsi);
+        }
+
+        Map<String, String> accessorClassNames = new HashMap<>();
+        for (Map.Entry<String, List<FieldSetInfo>> entry : fieldsByDeclaringClass.entrySet()) {
+            String declaringClass = entry.getKey();
+            List<FieldSetInfo> fields = entry.getValue();
+            // Generate accessor in the declaring class's package, named after both
+            // the command and declaring class to avoid conflicts when multiple commands
+            // share the same superclass. Use full command class name (dots → underscores)
+            // to handle same-named classes in different packages.
+            String commandId = commandClassName.replace('.', '_');
+            String accessorClassName = declaringClass + "_" + commandId + "_Accessor";
+            accessorClassNames.put(declaringClass, accessorClassName);
+
+            generateAccessorClass(classOutput, accessorClassName, commandClassName, declaringClass, fields);
+        }
+        return accessorClassNames;
+    }
+
+    /**
+     * Generates a FieldAccessor class in the declaring class's package.
+     * Being in the same package allows direct PUTFIELD/GETFIELD on package-private and protected fields.
+     */
+    private void generateAccessorClass(io.quarkus.gizmo2.ClassOutput classOutput,
+            String accessorClassName, String commandClassName, String declaringClass,
+            List<FieldSetInfo> fields) {
+
+        Gizmo gizmo = Gizmo.create(classOutput);
+        gizmo.class_(accessorClassName, cc -> {
+            cc.implements_(FieldAccessor.class);
+
+            This this_ = cc.this_();
+
+            FieldDesc fieldIndexField = cc.field("fieldIndex", fc -> {
+                fc.private_();
+                fc.final_();
+                fc.setType(int.class);
+            });
+
+            // Constructor(int fieldIndex)
+            cc.constructor(mc -> {
+                var fieldIndex = mc.parameter("fieldIndex", int.class);
+                mc.body(bc -> {
+                    bc.invokeSpecial(ConstructorDesc.of(Object.class), this_);
+                    bc.set(this_.field(fieldIndexField), fieldIndex);
+                    bc.return_();
+                });
+            });
+
+            // FieldAccessor.set(Object instance, Object value)
+            cc.method("set", mc -> {
+                mc.public_();
+                mc.returning(void.class);
+                var instance = mc.parameter("instance", Object.class);
+                var value = mc.parameter("value", Object.class);
+                mc.body(bc -> {
+                    LocalVar fieldIndexExpr = bc.localVar("fieldIndex", this_.field(fieldIndexField));
+                    LocalVar cmd = bc.localVar("cmd", bc.cast(instance, ClassDesc.of(commandClassName)));
+
+                    for (FieldSetInfo fsi : fields) {
+                        bc.if_(bc.eq(fieldIndexExpr, Const.of(fsi.fieldIndex())), tb -> {
+                            if (fsi.ownerPath() != null) {
+                                // Read the owner field (mixin/arggroup) — same package, direct access works
+                                Expr owner = cmd.field(ClassDesc.of(declaringClass),
+                                        fsi.ownerPath(), classDesc(fsi.ownerTypeName()));
+                                if (fsi.setterMethodName() != null) {
+                                    Expr castedValue = castValue(tb, value, fsi.fieldTypeName());
+                                    tb.invokeVirtual(
+                                            ClassMethodDesc.of(classDesc(fsi.ownerTypeName()),
+                                                    fsi.setterMethodName(), ClassDesc.ofDescriptor("V"),
+                                                    classDesc(fsi.setterMethodParamType())),
+                                            owner, castedValue);
+                                } else {
+                                    Expr castedValue = castValue(tb, value, fsi.fieldTypeName());
+                                    tb.set(owner.field(classDesc(fsi.ownerTypeName()),
+                                            fsi.fieldName(), classDesc(fsi.fieldTypeName())), castedValue);
+                                }
+                            } else {
+                                // Direct field on the declaring class
+                                if (fsi.setterMethodName() != null) {
+                                    Expr castedValue = castValue(tb, value, fsi.fieldTypeName());
+                                    tb.invokeVirtual(
+                                            ClassMethodDesc.of(ClassDesc.of(declaringClass),
+                                                    fsi.setterMethodName(), ClassDesc.ofDescriptor("V"),
+                                                    classDesc(fsi.setterMethodParamType())),
+                                            cmd, castedValue);
+                                } else {
+                                    Expr castedValue = castValue(tb, value, fsi.fieldTypeName());
+                                    tb.set(cmd.field(ClassDesc.of(declaringClass),
+                                            fsi.fieldName(), classDesc(fsi.fieldTypeName())), castedValue);
+                                }
+                            }
+                            tb.return_();
+                        });
+                    }
+                    bc.return_();
+                });
+            });
+        });
+    }
+
+    private void generateSetMethod(ClassCreator cc, This this_, FieldDesc fieldIndexField,
+            String commandClassName, CommandData data) {
+        cc.method("set", mc -> {
+            mc.public_();
+            mc.returning(void.class);
+            var instance = mc.parameter("instance", Object.class);
+            var value = mc.parameter("value", Object.class);
+            mc.body(bc -> {
+                LocalVar fieldIndexExpr = bc.localVar("fieldIndex", this_.field(fieldIndexField));
+                LocalVar cmd = bc.localVar("cmd", bc.cast(instance, ClassDesc.of(commandClassName)));
+
+                // Generate if-else chain for each field index.
+                // Cross-package fields are handled by separate accessor classes, so skip them here.
+                List<FieldSetInfo> allFields = collectAllFieldSetInfos(data, commandClassName);
+                for (FieldSetInfo fsi : allFields) {
+                    if (fsi.useReflection()) {
+                        continue; // handled by cross-package accessor class
+                    }
+                    bc.if_(bc.eq(fieldIndexExpr, Const.of(fsi.fieldIndex)), tb -> {
+                        if (fsi.ownerPath() != null) {
+                            // Navigate through mixin/arggroup chain
+                            Expr owner;
+                            String ownerType;
+                            if (fsi.ownerPath().contains(".")) {
+                                // Multi-level path (e.g. "rewrite.run")
+                                String[] segments = fsi.ownerPath().split("\\.");
+                                Expr current = cmd;
+                                String currentType = commandClassName;
+                                for (int s = 0; s < segments.length; s++) {
+                                    String segType = findFieldType(data, segments, s, commandClassName);
+                                    current = current.field(ClassDesc.of(currentType),
+                                            segments[s], ClassDesc.of(segType));
+                                    currentType = segType;
+                                }
+                                owner = current;
+                                ownerType = currentType;
+                            } else {
+                                owner = cmd.field(ClassDesc.of(commandClassName),
+                                        fsi.ownerPath(), classDesc(fsi.ownerTypeName()));
+                                ownerType = fsi.ownerTypeName();
+                            }
+                            if (fsi.setterMethodName() != null) {
+                                Expr castedValue = castValue(tb, value, fsi.fieldTypeName());
+                                tb.invokeVirtual(
+                                        ClassMethodDesc.of(classDesc(ownerType),
+                                                fsi.setterMethodName(), ClassDesc.ofDescriptor("V"),
+                                                classDesc(fsi.setterMethodParamType())),
+                                        owner, castedValue);
+                            } else {
+                                Expr castedValue = castValue(tb, value, fsi.fieldTypeName());
+                                tb.set(owner.field(classDesc(fsi.ownerTypeName()),
+                                        fsi.fieldName(), classDesc(fsi.fieldTypeName())), castedValue);
+                            }
+                        } else {
+                            // Direct field or method on command class
+                            String targetClass = fsi.declaringClassName() != null
+                                    ? fsi.declaringClassName()
+                                    : commandClassName;
+                            if (fsi.setterMethodName() != null) {
+                                Expr castedValue = castValue(tb, value, fsi.fieldTypeName());
+                                tb.invokeVirtual(
+                                        ClassMethodDesc.of(ClassDesc.of(targetClass),
+                                                fsi.setterMethodName(), ClassDesc.ofDescriptor("V"),
+                                                classDesc(fsi.setterMethodParamType())),
+                                        cmd, castedValue);
+                            } else {
+                                Expr castedValue = castValue(tb, value, fsi.fieldTypeName());
+                                tb.set(cmd.field(ClassDesc.of(targetClass),
+                                        fsi.fieldName(), classDesc(fsi.fieldTypeName())), castedValue);
+                            }
+                        }
+                        tb.return_();
+                    });
+                }
+
+                bc.return_(); // fallthrough
+            });
+        });
+    }
+
+    private void generateStaticInitializer(ClassCreator cc, String modelClassName,
+            String commandClassName, CommandData data,
+            Map<String, String> accessorClassNames) {
+        cc.staticInitializer(bc -> {
+            ClassDesc modelClassDesc = ClassDesc.of(modelClassName);
+
+            // Supplier<Object> supplier = new ModelClass(0); (fieldIndex doesn't matter for get())
+            LocalVar supplier = bc.localVar("supplier",
+                    bc.new_(ConstructorDesc.of(modelClassDesc, int.class), Const.of(-1)));
+
+            // BuiltCommandModel.Builder builder = BuiltCommandModel.builder(CommandClass.class, supplier);
+            LocalVar builder = bc.localVar("builder", bc.invokeStatic(
+                    MethodDesc.of(BuiltCommandModel.class, "builder",
+                            BuiltCommandModel.Builder.class, Class.class, Supplier.class),
+                    Const.of(ClassDesc.of(commandClassName)), supplier));
+
+            // Set command metadata
+            bc.invokeVirtual(m("name", String.class), builder, Const.of(data.name));
+            invokeBuilderStringArray(bc, builder, "description", data.description);
+            invokeBuilderStringArray(bc, builder, "version", data.version);
+            bc.invokeVirtual(m("mixinStandardHelpOptions", boolean.class), builder,
+                    Const.of(data.mixinStandardHelpOptions));
+            invokeBuilderStringArray(bc, builder, "header", data.header);
+            invokeBuilderStringArray(bc, builder, "footer", data.footer);
+            invokeBuilderStringArray(bc, builder, "aliases", data.aliases);
+            bc.invokeVirtual(m("showDefaultValues", boolean.class), builder,
+                    Const.of(data.showDefaultValues));
+            bc.invokeVirtual(m("commandListHeading", String.class), builder,
+                    Const.of(data.commandListHeading));
+            bc.invokeVirtual(m("synopsisHeading", String.class), builder,
+                    Const.of(data.synopsisHeading));
+            bc.invokeVirtual(m("optionListHeading", String.class), builder,
+                    Const.of(data.optionListHeading));
+            bc.invokeVirtual(m("headerHeading", String.class), builder,
+                    Const.of(data.headerHeading));
+            bc.invokeVirtual(m("parameterListHeading", String.class), builder,
+                    Const.of(data.parameterListHeading));
+
+            // Scope
+            LocalVar scopeValue = bc.localVar("scope",
+                    bc.get(Expr.staticField(FieldDesc.of(ScopeType.class, data.scope.name()))));
+            bc.invokeVirtual(m("scope", ScopeType.class), builder, scopeValue);
+
+            // Version provider
+            if (data.versionProviderClassName != null
+                    && !"io.quarkus.quickcli.VersionProvider.NoVersionProvider".equals(data.versionProviderClassName)
+                    && !"io.quarkus.quickcli.VersionProvider$NoVersionProvider"
+                            .equals(data.versionProviderClassName)) {
+                bc.invokeVirtual(m("versionProviderClass", Class.class),
+                        builder, Const.of(ClassDesc.of(data.versionProviderClassName)));
+            }
+
+            // HasUnmatchedField / HasSpecField
+            bc.invokeVirtual(m("hasUnmatchedField", boolean.class),
+                    builder, Const.of(data.unmatchedFieldName != null));
+            bc.invokeVirtual(m("hasSpecField", boolean.class),
+                    builder, Const.of(data.specFieldName != null));
+
+            // Build owner-declaring-class map for accessor resolution.
+            // Only includes entries where the owner field needs cross-package access (isPrivate).
+            Map<String, String> ownerDeclaring = new HashMap<>();
+            for (MixinData md : data.mixins) {
+                if (md.isPrivate && md.declaringClassName != null) {
+                    ownerDeclaring.put(md.fieldName, md.declaringClassName);
+                }
+            }
+            for (ArgGroupData agd : data.argGroups) {
+                if (agd.isPrivate && agd.ownerPath == null && agd.declaringClassName != null) {
+                    ownerDeclaring.put(agd.fieldName, agd.declaringClassName);
+                }
+            }
+
+            // Options
+            for (OptionData od : data.options) {
+                String ownerDecl = od.ownerPath != null ? ownerDeclaring.get(firstSegment(od.ownerPath)) : null;
+                boolean needsAccessor = od.isPrivate || ownerDecl != null;
+                String accClass = needsAccessor
+                        ? accessorClass(modelClassName, ownerDecl != null ? ownerDecl : od.declaringClassName,
+                                accessorClassNames)
+                        : modelClassName;
+                LocalVar accessor = bc.localVar("accessor",
+                        bc.new_(ConstructorDesc.of(ClassDesc.of(accClass), int.class),
+                                Const.of(od.fieldIndex)));
+                LocalVar namesArr = bc.localVar("namesArr", createStringArray(bc, od.names));
+                LocalVar fieldKind = bc.localVar("fieldKind", bc.get(Expr.staticField(
+                        FieldDesc.of(BuiltCommandModel.FieldKind.class, od.fieldKind.name()))));
+                Expr componentType = od.componentTypeName != null
+                        ? classConstExpr(od.componentTypeName)
+                        : Const.ofNull(Class.class);
+                Expr optionalInnerType = od.optionalInnerTypeName != null
+                        ? classConstExpr(od.optionalInnerTypeName)
+                        : Const.ofNull(Class.class);
+
+                LocalVar binding = bc.localVar("binding", bc.new_(
+                        ConstructorDesc.of(BuiltCommandModel.OptionBinding.class,
+                                String[].class, String.class, Class.class, boolean.class, String.class,
+                                String.class, boolean.class, String.class, String.class, boolean.class,
+                                boolean.class, boolean.class, int.class, BuiltCommandModel.FieldKind.class,
+                                Class.class, Class.class, String.class, String.class, FieldAccessor.class),
+                        namesArr, Const.of(od.description), classConstExpr(od.typeName),
+                        Const.of(od.required),
+                        Const.of(od.defaultValue), Const.of(od.arity), Const.of(od.hidden),
+                        Const.of(od.paramLabel), Const.of(od.fieldName), Const.of(od.versionHelp),
+                        Const.of(od.usageHelp), Const.of(od.negatable), Const.of(od.order),
+                        fieldKind, componentType, optionalInnerType, Const.of(od.split),
+                        Const.of(od.mapFallbackValue), accessor));
+
+                bc.invokeVirtual(
+                        MethodDesc.of(BuiltCommandModel.Builder.class, "addOption",
+                                BuiltCommandModel.Builder.class, BuiltCommandModel.OptionBinding.class),
+                        builder, binding);
+            }
+
+            // Parameters
+            for (ParameterData pd : data.parameters) {
+                String pdOwnerDecl = pd.ownerPath != null ? ownerDeclaring.get(firstSegment(pd.ownerPath)) : null;
+                boolean pdNeedsAccessor = pd.isPrivate || pdOwnerDecl != null;
+                String accClass = pdNeedsAccessor
+                        ? accessorClass(modelClassName,
+                                pdOwnerDecl != null ? pdOwnerDecl : pd.declaringClassName, accessorClassNames)
+                        : modelClassName;
+                LocalVar accessor = bc.localVar("accessor",
+                        bc.new_(ConstructorDesc.of(ClassDesc.of(accClass), int.class),
+                                Const.of(pd.fieldIndex)));
+                LocalVar fieldKind = bc.localVar("fieldKind", bc.get(Expr.staticField(
+                        FieldDesc.of(BuiltCommandModel.FieldKind.class, pd.fieldKind.name()))));
+                Expr componentType = pd.componentTypeName != null
+                        ? classConstExpr(pd.componentTypeName)
+                        : Const.ofNull(Class.class);
+
+                LocalVar binding = bc.localVar("binding", bc.new_(
+                        ConstructorDesc.of(BuiltCommandModel.ParameterBinding.class,
+                                int.class, String.class, Class.class, String.class, String.class,
+                                boolean.class, String.class, String.class, boolean.class,
+                                BuiltCommandModel.FieldKind.class, Class.class,
+                                FieldAccessor.class, String.class),
+                        Const.of(pd.paramIndex), Const.of(pd.description),
+                        classConstExpr(pd.typeName),
+                        Const.of(pd.defaultValue), Const.of(pd.arity), Const.of(pd.hidden),
+                        Const.of(pd.paramLabel), Const.of(pd.fieldName), Const.of(pd.isMultiValue),
+                        fieldKind, componentType, accessor, Const.of(pd.split)));
+
+                bc.invokeVirtual(
+                        MethodDesc.of(BuiltCommandModel.Builder.class, "addParameter",
+                                BuiltCommandModel.Builder.class, BuiltCommandModel.ParameterBinding.class),
+                        builder, binding);
+            }
+
+            // Subcommands
+            for (String subCls : data.subcommandClassNames) {
+                bc.invokeVirtual(
+                        MethodDesc.of(BuiltCommandModel.Builder.class, "addSubcommand",
+                                BuiltCommandModel.Builder.class, Class.class),
+                        builder, Const.of(ClassDesc.of(subCls)));
+            }
+
+            // Mixins
+            for (MixinData md : data.mixins) {
+                String accClass = md.isPrivate
+                        ? accessorClass(modelClassName, md.declaringClassName, accessorClassNames)
+                        : modelClassName;
+                LocalVar accessor = bc.localVar("accessor",
+                        bc.new_(ConstructorDesc.of(ClassDesc.of(accClass), int.class),
+                                Const.of(md.fieldIndex)));
+                LocalVar binding = bc.localVar("binding", bc.new_(
+                        ConstructorDesc.of(BuiltCommandModel.MixinBinding.class,
+                                String.class, Class.class, FieldAccessor.class),
+                        Const.of(md.fieldName), Const.of(ClassDesc.of(md.mixinTypeName)), accessor));
+                bc.invokeVirtual(
+                        MethodDesc.of(BuiltCommandModel.Builder.class, "addMixin",
+                                BuiltCommandModel.Builder.class, BuiltCommandModel.MixinBinding.class),
+                        builder, binding);
+            }
+
+            // ArgGroups
+            for (ArgGroupData agd : data.argGroups) {
+                String accClass = agd.isPrivate
+                        ? accessorClass(modelClassName, agd.declaringClassName, accessorClassNames)
+                        : modelClassName;
+                LocalVar accessor = bc.localVar("accessor",
+                        bc.new_(ConstructorDesc.of(ClassDesc.of(accClass), int.class),
+                                Const.of(agd.fieldIndex)));
+                LocalVar binding = bc.localVar("binding", bc.new_(
+                        ConstructorDesc.of(BuiltCommandModel.ArgGroupBinding.class,
+                                String.class, Class.class, FieldAccessor.class),
+                        Const.of(agd.fieldName), Const.of(ClassDesc.of(agd.argGroupTypeName)), accessor));
+                bc.invokeVirtual(
+                        MethodDesc.of(BuiltCommandModel.Builder.class, "addArgGroup",
+                                BuiltCommandModel.Builder.class, BuiltCommandModel.ArgGroupBinding.class),
+                        builder, binding);
+            }
+
+            // Exclusive groups
+            for (List<String> group : data.exclusiveGroups) {
+                LocalVar arr = bc.localVar("arr", createStringArray(bc, group.toArray(new String[0])));
+                LocalVar list = bc.localVar("list", bc.invokeStatic(
+                        MethodDesc.of(Arrays.class, "asList", java.util.List.class, Object[].class),
+                        arr));
+                bc.invokeVirtual(
+                        MethodDesc.of(BuiltCommandModel.Builder.class, "addExclusiveGroup",
+                                BuiltCommandModel.Builder.class, java.util.List.class),
+                        builder, list);
+            }
+
+            // Parent command accessor
+            if (data.parentCommandFieldName != null) {
+                String accClass = data.parentCommandIsPrivate
+                        ? accessorClass(modelClassName, data.parentCommandDeclaringClassName, accessorClassNames)
+                        : modelClassName;
+                LocalVar accessor = bc.localVar("accessor",
+                        bc.new_(ConstructorDesc.of(ClassDesc.of(accClass), int.class),
+                                Const.of(data.parentCommandFieldIndex)));
+                bc.invokeVirtual(
+                        MethodDesc.of(BuiltCommandModel.Builder.class, "parentCommandAccessor",
+                                BuiltCommandModel.Builder.class, FieldAccessor.class),
+                        builder, accessor);
+            }
+
+            // Unmatched accessor
+            if (data.unmatchedFieldName != null) {
+                String accClass = data.unmatchedIsPrivate
+                        ? accessorClass(modelClassName, data.unmatchedDeclaringClassName, accessorClassNames)
+                        : modelClassName;
+                LocalVar accessor = bc.localVar("accessor",
+                        bc.new_(ConstructorDesc.of(ClassDesc.of(accClass), int.class),
+                                Const.of(data.unmatchedFieldIndex)));
+                bc.invokeVirtual(
+                        MethodDesc.of(BuiltCommandModel.Builder.class, "unmatchedAccessor",
+                                BuiltCommandModel.Builder.class, FieldAccessor.class),
+                        builder, accessor);
+            }
+
+            // Spec accessor
+            if (data.specFieldName != null) {
+                String accClass = data.specIsPrivate
+                        ? accessorClass(modelClassName, data.specDeclaringClassName, accessorClassNames)
+                        : modelClassName;
+                LocalVar accessor = bc.localVar("accessor",
+                        bc.new_(ConstructorDesc.of(ClassDesc.of(accClass), int.class),
+                                Const.of(data.specFieldIndex)));
+                bc.invokeVirtual(
+                        MethodDesc.of(BuiltCommandModel.Builder.class, "specAccessor",
+                                BuiltCommandModel.Builder.class, FieldAccessor.class),
+                        builder, accessor);
+            }
+
+            // Mixee spec accessors
+            for (MixeeSpecData msd : data.mixeeSpecs) {
+                String mixinOwnerDecl = null;
+                for (MixinData md : data.mixins) {
+                    if (md.fieldName.equals(msd.mixinFieldName)) {
+                        mixinOwnerDecl = md.declaringClassName;
+                        break;
+                    }
+                }
+                boolean msdNeedsAccessor = msd.isPrivate || mixinOwnerDecl != null;
+                String accClass = msdNeedsAccessor
+                        ? accessorClass(modelClassName, mixinOwnerDecl, accessorClassNames)
+                        : modelClassName;
+                LocalVar accessor = bc.localVar("accessor",
+                        bc.new_(ConstructorDesc.of(ClassDesc.of(accClass), int.class),
+                                Const.of(msd.fieldIndex)));
+                bc.invokeVirtual(
+                        MethodDesc.of(BuiltCommandModel.Builder.class, "addMixeeSpecAccessor",
+                                BuiltCommandModel.Builder.class, FieldAccessor.class),
+                        builder, accessor);
+            }
+
+            // Build and register
+            Expr model = bc.invokeVirtual(
+                    MethodDesc.of(BuiltCommandModel.Builder.class, "build", BuiltCommandModel.class),
+                    builder);
+            bc.invokeStatic(
+                    MethodDesc.of(CommandModelRegistry.class, "register", void.class,
+                            io.quarkus.quickcli.model.CommandModel.class),
+                    model);
+
+            // Register instance creators for mixin and arg group types
+            Set<String> registeredCreators = new HashSet<>();
+            for (MixinData md : data.mixins) {
+                if (registeredCreators.add(md.mixinTypeName)) {
+                    registerInstanceCreator(bc, md.mixinTypeName);
+                }
+            }
+            for (ArgGroupData agd : data.argGroups) {
+                if (registeredCreators.add(agd.argGroupTypeName)) {
+                    registerInstanceCreator(bc, agd.argGroupTypeName);
+                }
+            }
+        });
+    }
+
+    /**
+     * Generates bytecode to register an instance creator (Supplier) for a non-@Command class
+     * (mixin or arg group) so that Factory can instantiate it without reflection.
+     */
+    private void registerInstanceCreator(BlockCreator bc, String typeName) {
+        ClassDesc typeClassDesc = ClassDesc.of(typeName);
+        LocalVar supplierLambda = bc.localVar("supplier", bc.lambda(Supplier.class, lc -> {
+            lc.body(lbc -> lbc.return_(lbc.new_(typeClassDesc)));
+        }));
+        bc.invokeStatic(
+                MethodDesc.of(CommandModelRegistry.class, "registerInstanceCreator",
+                        void.class, Class.class, Supplier.class),
+                Const.of(typeClassDesc), supplierLambda);
+    }
+
+    // --- Helpers ---
+
+    private List<FieldSetInfo> collectAllFieldSetInfos(CommandData data, String commandClassName) {
+        List<FieldSetInfo> result = new ArrayList<>();
+
+        // Build a map of ownerPath -> declaring class for owner field navigation.
+        // Only includes entries where the owner field needs cross-package access (isPrivate).
+        Map<String, String> ownerDeclaring = new HashMap<>();
+        for (MixinData md : data.mixins) {
+            if (md.isPrivate) {
+                ownerDeclaring.put(md.fieldName, md.declaringClassName);
+            }
+        }
+        for (ArgGroupData agd : data.argGroups) {
+            if (agd.isPrivate && agd.ownerPath == null) {
+                ownerDeclaring.put(agd.fieldName, agd.declaringClassName);
+            }
+        }
+
+        for (OptionData od : data.options) {
+            String ownerDecl = od.ownerPath != null ? ownerDeclaring.get(firstSegment(od.ownerPath)) : null;
+            boolean needsAccessor = od.isPrivate || ownerDecl != null;
+            result.add(new FieldSetInfo(od.fieldIndex, od.fieldName, od.typeName,
+                    od.ownerPath, od.ownerTypeName, ownerDecl, od.declaringClassName,
+                    od.setterMethodName, od.setterMethodParamType, needsAccessor));
+        }
+        for (ParameterData pd : data.parameters) {
+            String ownerDecl = pd.ownerPath != null ? ownerDeclaring.get(firstSegment(pd.ownerPath)) : null;
+            boolean needsAccessor = pd.isPrivate || ownerDecl != null;
+            result.add(new FieldSetInfo(pd.fieldIndex, pd.fieldName, pd.typeName,
+                    pd.ownerPath, pd.ownerTypeName, ownerDecl, pd.declaringClassName,
+                    null, null, needsAccessor));
+        }
+        for (MixinData md : data.mixins) {
+            result.add(new FieldSetInfo(md.fieldIndex, md.fieldName, md.mixinTypeName,
+                    null, null, null, md.declaringClassName,
+                    null, null, md.isPrivate));
+        }
+        for (ArgGroupData agd : data.argGroups) {
+            String ownerDecl = agd.ownerPath != null ? ownerDeclaring.get(firstSegment(agd.ownerPath)) : null;
+            result.add(new FieldSetInfo(agd.fieldIndex, agd.fieldName, agd.argGroupTypeName,
+                    agd.ownerPath, agd.ownerTypeName, ownerDecl, agd.declaringClassName,
+                    null, null, agd.isPrivate));
+        }
+        if (data.parentCommandFieldName != null) {
+            result.add(new FieldSetInfo(data.parentCommandFieldIndex, data.parentCommandFieldName,
+                    data.parentCommandTypeName, null, null, data.parentCommandDeclaringClassName,
+                    data.parentCommandIsPrivate));
+        }
+        if (data.unmatchedFieldName != null) {
+            result.add(new FieldSetInfo(data.unmatchedFieldIndex, data.unmatchedFieldName,
+                    "java.util.List", null, null, data.unmatchedDeclaringClassName,
+                    data.unmatchedIsPrivate));
+        }
+        if (data.specFieldName != null) {
+            result.add(new FieldSetInfo(data.specFieldIndex, data.specFieldName,
+                    CommandSpec.class.getName(), null, null, data.specDeclaringClassName,
+                    data.specIsPrivate));
+        }
+        for (MixeeSpecData msd : data.mixeeSpecs) {
+            String ownerDecl = ownerDeclaring.get(msd.mixinFieldName);
+            // Route to accessor if either the spec field is private OR the mixin field
+            // is on a cross-package superclass (need same-package access to read the mixin field)
+            boolean needsAccessor = msd.isPrivate || ownerDecl != null;
+            result.add(new FieldSetInfo(msd.fieldIndex, msd.specFieldName,
+                    CommandSpec.class.getName(), msd.mixinFieldName, msd.mixinTypeName, ownerDecl,
+                    null, null, null, needsAccessor));
+        }
+        return result;
+    }
+
+    private static String firstSegment(String path) {
+        int dot = path.indexOf('.');
+        return dot > 0 ? path.substring(0, dot) : path;
+    }
+
+    /**
+     * Returns the accessor class name for a given declaring class. If the declaring class
+     * has a cross-package accessor, returns that; otherwise returns the model class name.
+     */
+    private String accessorClass(String modelClassName, String declaringClassName,
+            Map<String, String> accessorClassNames) {
+        if (declaringClassName != null) {
+            String accessor = accessorClassNames.get(declaringClassName);
+            if (accessor != null) {
+                return accessor;
+            }
+        }
+        return modelClassName;
+    }
+
+    private Expr castValue(BlockCreator bc, Expr value, String targetTypeName) {
+        return switch (targetTypeName) {
+            case "int" -> bc.invokeVirtual(
+                    MethodDesc.of(Integer.class, "intValue", int.class),
+                    bc.cast(value, Integer.class));
+            case "long" -> bc.invokeVirtual(
+                    MethodDesc.of(Long.class, "longValue", long.class),
+                    bc.cast(value, Long.class));
+            case "boolean" -> bc.invokeVirtual(
+                    MethodDesc.of(Boolean.class, "booleanValue", boolean.class),
+                    bc.cast(value, Boolean.class));
+            case "double" -> bc.invokeVirtual(
+                    MethodDesc.of(Double.class, "doubleValue", double.class),
+                    bc.cast(value, Double.class));
+            case "float" -> bc.invokeVirtual(
+                    MethodDesc.of(Float.class, "floatValue", float.class),
+                    bc.cast(value, Float.class));
+            case "short" -> bc.invokeVirtual(
+                    MethodDesc.of(Short.class, "shortValue", short.class),
+                    bc.cast(value, Short.class));
+            case "byte" -> bc.invokeVirtual(
+                    MethodDesc.of(Byte.class, "byteValue", byte.class),
+                    bc.cast(value, Byte.class));
+            case "char" -> bc.invokeVirtual(
+                    MethodDesc.of(Character.class, "charValue", char.class),
+                    bc.cast(value, Character.class));
+            default -> bc.cast(value, classDesc(targetTypeName));
+        };
+    }
+
+    /**
+     * Find the type of a field at a given depth in a dot-separated path by looking through
+     * mixin, argGroup, and option data.
+     */
+    private String findFieldType(CommandData data, String[] segments, int segIndex, String commandClassName) {
+        String fieldName = segments[segIndex];
+        String parentPath = segIndex == 0 ? null : String.join(".", java.util.Arrays.copyOf(segments, segIndex));
+
+        // Check mixins
+        for (MixinData md : data.mixins) {
+            if (md.fieldName.equals(fieldName) && (parentPath == null) == (md.declaringClassName == null)) {
+                return md.mixinTypeName;
+            }
+        }
+        // Check argGroups
+        for (ArgGroupData agd : data.argGroups) {
+            if (agd.fieldName.equals(fieldName)) {
+                if (segIndex == 0 && agd.ownerPath == null) {
+                    return agd.argGroupTypeName;
+                }
+                if (parentPath != null && parentPath.equals(agd.ownerPath)) {
+                    return agd.argGroupTypeName;
+                }
+            }
+        }
+        throw new IllegalStateException("Cannot find type for field '" + fieldName + "' at segment " + segIndex
+                + " in path '" + String.join(".", segments) + "'");
+    }
+
+    private void invokeBuilderStringArray(BlockCreator bc, Expr builder, String methodName, String[] values) {
+        LocalVar arr = bc.localVar("arr", createStringArray(bc, values));
+        bc.invokeVirtual(
+                MethodDesc.of(BuiltCommandModel.Builder.class, methodName,
+                        BuiltCommandModel.Builder.class, String[].class),
+                builder, arr);
+    }
+
+    private Expr createStringArray(BlockCreator bc, String[] values) {
+        return bc.newArray(String.class, java.util.Arrays.asList(values), Const::of);
+    }
+
+    private static MethodDesc m(String name, Class<?>... paramTypes) {
+        return MethodDesc.of(BuiltCommandModel.Builder.class, name, BuiltCommandModel.Builder.class, paramTypes);
+    }
+
+    /**
+     * Returns a {@link Const} expression that loads the {@link Class} for the given type name.
+     * For primitives, uses {@code Const.of(int.class)} etc. (generates {@code getstatic Integer.TYPE}),
+     * since {@code ldc} cannot load primitive class references.
+     */
+    private static Const classConstExpr(String typeName) {
+        return switch (typeName) {
+            case "int" -> Const.of(int.class);
+            case "long" -> Const.of(long.class);
+            case "boolean" -> Const.of(boolean.class);
+            case "double" -> Const.of(double.class);
+            case "float" -> Const.of(float.class);
+            case "short" -> Const.of(short.class);
+            case "byte" -> Const.of(byte.class);
+            case "char" -> Const.of(char.class);
+            default -> Const.of(classDesc(typeName));
+        };
+    }
+
+    /**
+     * Converts a type name string to a {@link ClassDesc}.
+     * Handles primitives, arrays (e.g., {@code [Ljava.lang.String;}), and regular class names.
+     */
+    private static ClassDesc classDesc(String typeName) {
+        return switch (typeName) {
+            case "int" -> ClassDesc.ofDescriptor("I");
+            case "long" -> ClassDesc.ofDescriptor("J");
+            case "boolean" -> ClassDesc.ofDescriptor("Z");
+            case "double" -> ClassDesc.ofDescriptor("D");
+            case "float" -> ClassDesc.ofDescriptor("F");
+            case "short" -> ClassDesc.ofDescriptor("S");
+            case "byte" -> ClassDesc.ofDescriptor("B");
+            case "char" -> ClassDesc.ofDescriptor("C");
+            case "void" -> ClassDesc.ofDescriptor("V");
+            default -> {
+                if (typeName.startsWith("[")) {
+                    // Array type like [Ljava.lang.String; — convert dots to slashes for JVM descriptor
+                    yield ClassDesc.ofDescriptor(typeName.replace('.', '/'));
+                }
+                yield ClassDesc.of(typeName);
+            }
+        };
+    }
+
+    // --- Type detection ---
+
+    private BuiltCommandModel.FieldKind detectFieldKind(Type type) {
+        if (type.kind() == Type.Kind.ARRAY) {
+            return BuiltCommandModel.FieldKind.ARRAY;
+        }
+        DotName typeName = type.name();
+        if (typeName.equals(LIST) || isSubtypeOf(typeName, LIST)) {
+            return BuiltCommandModel.FieldKind.LIST;
+        }
+        if (typeName.equals(SET) || isSubtypeOf(typeName, SET)) {
+            return BuiltCommandModel.FieldKind.SET;
+        }
+        if (typeName.equals(MAP) || isSubtypeOf(typeName, MAP)) {
+            return BuiltCommandModel.FieldKind.MAP;
+        }
+        if (typeName.equals(OPTIONAL)) {
+            return BuiltCommandModel.FieldKind.OPTIONAL;
+        }
+        return BuiltCommandModel.FieldKind.SINGLE;
+    }
+
+    private boolean isSubtypeOf(DotName typeName, DotName superTypeName) {
+        ClassInfo classInfo = index.getClassByName(typeName);
+        if (classInfo == null) {
+            return false;
+        }
+        for (DotName iface : classInfo.interfaceNames()) {
+            if (iface.equals(superTypeName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String detectComponentType(Type type) {
+        if (type.kind() == Type.Kind.ARRAY) {
+            return fieldTypeClassName(type.asArrayType().constituent());
+        }
+        if (type.kind() == Type.Kind.PARAMETERIZED_TYPE) {
+            ParameterizedType pt = type.asParameterizedType();
+            if (!pt.arguments().isEmpty()) {
+                return fieldTypeClassName(pt.arguments().get(0));
+            }
+        }
+        return "java.lang.String"; // default fallback
+    }
+
+    private String detectOptionalInnerType(Type type) {
+        if (type.kind() == Type.Kind.PARAMETERIZED_TYPE) {
+            ParameterizedType pt = type.asParameterizedType();
+            if (!pt.arguments().isEmpty()) {
+                return fieldTypeClassName(pt.arguments().get(0));
+            }
+        }
+        return "java.lang.String";
+    }
+
+    /**
+     * Returns the type name in a format that works with field descriptors.
+     * For arrays, uses JVM format like {@code [Ljava.lang.String;}.
+     */
+    private String fieldTypeClassName(Type type) {
+        switch (type.kind()) {
+            case PRIMITIVE:
+                return type.asPrimitiveType().primitive().name().toLowerCase();
+            case ARRAY:
+                return "[" + fieldTypeDescriptor(type.asArrayType().constituent());
+            case CLASS:
+            case PARAMETERIZED_TYPE:
+                return type.name().toString();
+            default:
+                return type.name().toString();
+        }
+    }
+
+    private String fieldTypeDescriptor(Type type) {
+        switch (type.kind()) {
+            case PRIMITIVE:
+                switch (type.asPrimitiveType().primitive()) {
+                    case BOOLEAN:
+                        return "Z";
+                    case BYTE:
+                        return "B";
+                    case CHAR:
+                        return "C";
+                    case DOUBLE:
+                        return "D";
+                    case FLOAT:
+                        return "F";
+                    case INT:
+                        return "I";
+                    case LONG:
+                        return "J";
+                    case SHORT:
+                        return "S";
+                    default:
+                        throw new IllegalArgumentException("Unknown primitive: " + type);
+                }
+            case ARRAY:
+                return "[" + fieldTypeDescriptor(type.asArrayType().constituent());
+            case CLASS:
+            case PARAMETERIZED_TYPE:
+                return "L" + type.name().toString() + ";";
+            default:
+                return "L" + type.name().toString() + ";";
+        }
+    }
+
+    // --- Annotation helpers ---
+
+    private static String annotationString(AnnotationInstance ann, String key, String defaultValue) {
+        AnnotationValue value = ann.value(key);
+        return value != null ? value.asString() : defaultValue;
+    }
+
+    private static String[] annotationStringArray(AnnotationInstance ann, String key) {
+        AnnotationValue value = ann.value(key);
+        return value != null ? value.asStringArray() : new String[0];
+    }
+
+    private static boolean annotationBool(AnnotationInstance ann, String key, boolean defaultValue) {
+        AnnotationValue value = ann.value(key);
+        return value != null ? value.asBoolean() : defaultValue;
+    }
+
+    private static int annotationInt(AnnotationInstance ann, String key, int defaultValue) {
+        AnnotationValue value = ann.value(key);
+        return value != null ? value.asInt() : defaultValue;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <E extends Enum<E>> E annotationEnum(AnnotationInstance ann, String key,
+            Class<E> enumClass, E defaultValue) {
+        AnnotationValue value = ann.value(key);
+        if (value != null) {
+            return Enum.valueOf(enumClass, value.asEnum());
+        }
+        return defaultValue;
+    }
+
+    private static String joinDescriptionArray(String[] arr) {
+        return arr.length == 0 ? "" : String.join(" ", arr);
+    }
+
+    private static String packageOf(String className) {
+        int dot = className.lastIndexOf('.');
+        return dot > 0 ? className.substring(0, dot) : "";
+    }
+
+    // --- Data classes ---
+
+    static class CommandData {
+        String commandClassName;
+        String name;
+        String[] description = new String[0];
+        String[] version = new String[0];
+        boolean mixinStandardHelpOptions;
+        String[] header = new String[0];
+        String[] footer = new String[0];
+        ScopeType scope = ScopeType.LOCAL;
+        String[] aliases = new String[0];
+        boolean showDefaultValues;
+        String commandListHeading = "Commands:%n";
+        String synopsisHeading = "Usage: ";
+        String optionListHeading = "Options:%n";
+        String headerHeading = "";
+        String parameterListHeading = "%n";
+        String versionProviderClassName;
+        List<String> subcommandClassNames = new ArrayList<>();
+        List<OptionData> options = new ArrayList<>();
+        List<ParameterData> parameters = new ArrayList<>();
+        List<MixinData> mixins = new ArrayList<>();
+        List<ArgGroupData> argGroups = new ArrayList<>();
+        List<MixeeSpecData> mixeeSpecs = new ArrayList<>();
+        List<List<String>> exclusiveGroups = new ArrayList<>();
+        int nextParamIndex;
+
+        // Special fields
+        String specFieldName;
+        int specFieldIndex = -1;
+        boolean specIsPrivate;
+        String specDeclaringClassName;
+        String parentCommandFieldName;
+        int parentCommandFieldIndex = -1;
+        boolean parentCommandIsPrivate;
+        String parentCommandTypeName;
+        String parentCommandDeclaringClassName;
+        String unmatchedFieldName;
+        int unmatchedFieldIndex = -1;
+        boolean unmatchedIsPrivate;
+        String unmatchedDeclaringClassName;
+    }
+
+    static class OptionData {
+        int fieldIndex;
+        String fieldName;
+        String[] names;
+        String description;
+        String typeName;
+        boolean required;
+        String defaultValue;
+        String arity;
+        boolean hidden;
+        String paramLabel;
+        boolean versionHelp;
+        boolean usageHelp;
+        boolean negatable;
+        int order;
+        BuiltCommandModel.FieldKind fieldKind;
+        String componentTypeName;
+        String optionalInnerTypeName;
+        String split;
+        String mapFallbackValue;
+        boolean isPrivate;
+        String declaringClassName;
+        String ownerPath; // null for direct fields, mixin/arggroup field name for navigated fields
+        String ownerTypeName;
+        String setterMethodName; // non-null for method-level @Option (e.g., "setProperty")
+        String setterMethodParamType; // parameter type descriptor for the setter method
+    }
+
+    static class ParameterData {
+        int fieldIndex;
+        String fieldName;
+        String typeName;
+        String description;
+        String defaultValue;
+        String arity;
+        boolean hidden;
+        String paramLabel;
+        boolean isMultiValue;
+        BuiltCommandModel.FieldKind fieldKind;
+        String componentTypeName;
+        boolean isPrivate;
+        String declaringClassName;
+        String ownerPath;
+        String ownerTypeName;
+        int paramIndex;
+        String split = "";
+    }
+
+    static class MixinData {
+        int fieldIndex;
+        String fieldName;
+        String mixinTypeName;
+        boolean isPrivate;
+        String declaringClassName;
+    }
+
+    static class ArgGroupData {
+        int fieldIndex;
+        String fieldName;
+        String argGroupTypeName;
+        boolean isPrivate;
+        String declaringClassName;
+        String ownerPath;
+        String ownerTypeName;
+    }
+
+    static class MixeeSpecData {
+        int fieldIndex;
+        String mixinFieldName;
+        String mixinTypeName;
+        String specFieldName;
+        boolean isPrivate;
+    }
+
+    record FieldSetInfo(int fieldIndex, String fieldName, String fieldTypeName,
+            String ownerPath, String ownerTypeName, String ownerDeclaringClassName,
+            String declaringClassName,
+            String setterMethodName, String setterMethodParamType, boolean useReflection) {
+
+        FieldSetInfo(int fieldIndex, String fieldName, String fieldTypeName,
+                String ownerPath, String ownerTypeName, String declaringClassName) {
+            this(fieldIndex, fieldName, fieldTypeName, ownerPath, ownerTypeName, null,
+                    declaringClassName, null, null, false);
+        }
+
+        FieldSetInfo(int fieldIndex, String fieldName, String fieldTypeName,
+                String ownerPath, String ownerTypeName, String declaringClassName,
+                boolean useReflection) {
+            this(fieldIndex, fieldName, fieldTypeName, ownerPath, ownerTypeName, null,
+                    declaringClassName, null, null, useReflection);
+        }
+    }
+}

--- a/extensions/quickcli/deployment/src/main/java/io/quarkus/quickcli/deployment/QuickCliProcessor.java
+++ b/extensions/quickcli/deployment/src/main/java/io/quarkus/quickcli/deployment/QuickCliProcessor.java
@@ -1,0 +1,309 @@
+package io.quarkus.quickcli.deployment;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.AnnotationTransformation;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.MethodInfo;
+import org.objectweb.asm.Opcodes;
+
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.deployment.AnnotationsTransformerBuildItem;
+import io.quarkus.arc.deployment.AutoAddScopeBuildItem;
+import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
+import io.quarkus.arc.processor.BuiltinScope;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.ApplicationIndexBuildItem;
+import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
+import io.quarkus.deployment.builditem.QuarkusApplicationClassBuildItem;
+import io.quarkus.deployment.builditem.RunTimeConfigBuilderBuildItem;
+import io.quarkus.gizmo.ClassTransformer;
+import io.quarkus.gizmo.FieldDescriptor;
+import io.quarkus.quickcli.runtime.DefaultQuickCliCommandLineFactory;
+import io.quarkus.quickcli.runtime.QuickCliConfigSourceBuilder;
+import io.quarkus.quickcli.runtime.QuickCliRunner;
+import io.quarkus.quickcli.runtime.annotations.TopCommand;
+import io.quarkus.runtime.annotations.QuarkusMain;
+
+class QuickCliProcessor {
+
+    private static final String FEATURE = "quickcli";
+    private static final DotName QUICKCLI_COMMAND = DotName.createSimple(
+            io.quarkus.quickcli.annotations.Command.class.getName());
+    private static final DotName TOP_COMMAND = DotName.createSimple(TopCommand.class.getName());
+    private static final DotName QUARKUS_MAIN = DotName.createSimple(QuarkusMain.class.getName());
+    private static final DotName QUICKCLI_OPTION = DotName.createSimple(
+            io.quarkus.quickcli.annotations.Option.class.getName());
+    private static final DotName QUICKCLI_PARAMETERS = DotName.createSimple(
+            io.quarkus.quickcli.annotations.Parameters.class.getName());
+    private static final DotName QUICKCLI_MIXIN = DotName.createSimple(
+            io.quarkus.quickcli.annotations.Mixin.class.getName());
+    private static final DotName QUICKCLI_PARENT_COMMAND = DotName.createSimple(
+            io.quarkus.quickcli.annotations.ParentCommand.class.getName());
+    private static final DotName QUICKCLI_SPEC = DotName.createSimple(
+            io.quarkus.quickcli.annotations.Spec.class.getName());
+    private static final DotName QUICKCLI_UNMATCHED = DotName.createSimple(
+            io.quarkus.quickcli.annotations.Unmatched.class.getName());
+    private static final DotName QUICKCLI_ARG_GROUP = DotName.createSimple(
+            io.quarkus.quickcli.annotations.ArgGroup.class.getName());
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
+
+    @BuildStep
+    void addScopeToCommands(BuildProducer<AutoAddScopeBuildItem> autoAddScope) {
+        // Add @Dependent to all @Command classes so they can participate in CDI
+        autoAddScope.produce(AutoAddScopeBuildItem.builder()
+                .isAnnotatedWith(QUICKCLI_COMMAND)
+                .defaultScope(BuiltinScope.DEPENDENT)
+                .unremovable()
+                .build());
+        // Add @Dependent to any class annotated with @TopCommand
+        autoAddScope.produce(AutoAddScopeBuildItem.builder()
+                .isAnnotatedWith(TOP_COMMAND)
+                .defaultScope(BuiltinScope.DEPENDENT)
+                .unremovable()
+                .build());
+    }
+
+    @BuildStep
+    void quickCliRunner(ApplicationIndexBuildItem applicationIndex,
+            CombinedIndexBuildItem combinedIndex,
+            BuildProducer<AdditionalBeanBuildItem> additionalBean,
+            BuildProducer<UnremovableBeanBuildItem> unremovableBean,
+            BuildProducer<QuarkusApplicationClassBuildItem> quarkusApplicationClass,
+            BuildProducer<AnnotationsTransformerBuildItem> annotationsTransformer) {
+
+        IndexView index = combinedIndex.getIndex();
+        Collection<DotName> topCommands = classesAnnotatedWith(index, TOP_COMMAND);
+
+        if (topCommands.isEmpty()) {
+            List<DotName> commands = classesAnnotatedWith(
+                    applicationIndex.getIndex(), QUICKCLI_COMMAND);
+            if (commands.size() == 1) {
+                // If there is exactly one @Command, automatically make it @TopCommand
+                DotName singleCommandClassName = commands.get(0);
+                annotationsTransformer.produce(new AnnotationsTransformerBuildItem(
+                        AnnotationTransformation.forClasses()
+                                .whenClass(singleCommandClassName)
+                                .priority(2000)
+                                .transform(ctx -> ctx.add(TopCommand.class))));
+            }
+        }
+
+        // Register all @Command classes as CDI beans so they can use @Inject
+        // Do NOT set a default scope here — AutoAddScopeBuildItem already handles it,
+        // and setting @Dependent here conflicts with QuarkusApplication's @ApplicationScoped.
+        List<DotName> allCommands = classesAnnotatedWith(index, QUICKCLI_COMMAND);
+        for (DotName commandClass : allCommands) {
+            additionalBean.produce(AdditionalBeanBuildItem.builder()
+                    .addBeanClass(commandClass.toString())
+                    .setUnremovable()
+                    .build());
+        }
+
+        if (index.getAnnotations(QUARKUS_MAIN).isEmpty()) {
+            additionalBean.produce(AdditionalBeanBuildItem.unremovableOf(QuickCliRunner.class));
+            additionalBean.produce(
+                    AdditionalBeanBuildItem.unremovableOf(DefaultQuickCliCommandLineFactory.class));
+            quarkusApplicationClass.produce(
+                    new QuarkusApplicationClassBuildItem(QuickCliRunner.class));
+        }
+
+        // Make VersionProvider implementations unremovable
+        unremovableBean.produce(UnremovableBeanBuildItem.beanTypes(
+                io.quarkus.quickcli.VersionProvider.class));
+    }
+
+    @BuildStep
+    void registerConfigSource(BuildProducer<RunTimeConfigBuilderBuildItem> runTimeConfigBuilder) {
+        runTimeConfigBuilder.produce(new RunTimeConfigBuilderBuildItem(QuickCliConfigSourceBuilder.class));
+    }
+
+    @BuildStep
+    void generateCommandModels(CombinedIndexBuildItem combinedIndex,
+            BuildProducer<GeneratedClassBuildItem> generatedClass) {
+        new CommandModelGenerator(combinedIndex.getIndex()).generateAll(generatedClass);
+    }
+
+    @BuildStep
+    void transformPrivateFields(CombinedIndexBuildItem combinedIndex,
+            BuildProducer<BytecodeTransformerBuildItem> transformers) {
+
+        IndexView index = combinedIndex.getIndex();
+
+        // Collect private annotated fields on @Command classes (and their superclasses)
+        // that need to be made package-private. The generated *_QuickCliModel class
+        // (same package) uses PUTFIELD to set fields directly.
+        Map<String, List<FieldInfo>> classFieldsToTransform = new HashMap<>();
+
+        for (DotName annotation : List.of(QUICKCLI_OPTION, QUICKCLI_PARAMETERS,
+                QUICKCLI_MIXIN, QUICKCLI_PARENT_COMMAND, QUICKCLI_SPEC,
+                QUICKCLI_UNMATCHED, QUICKCLI_ARG_GROUP)) {
+            for (var instance : index.getAnnotations(annotation)) {
+                if (instance.target().kind() != AnnotationTarget.Kind.FIELD) {
+                    continue;
+                }
+                FieldInfo field = instance.target().asField();
+                if ((field.flags() & Opcodes.ACC_PRIVATE) == 0) {
+                    continue;
+                }
+                String className = field.declaringClass().name().toString();
+                classFieldsToTransform
+                        .computeIfAbsent(className, k -> new java.util.ArrayList<>())
+                        .add(field);
+            }
+        }
+
+        // Also collect non-public annotated fields and methods on mixin/arggroup types
+        // that are used from commands in a different package. The model class navigates through
+        // the mixin field chain (e.g., cmd.output.showErrors), and needs the mixin type's
+        // members to be public for cross-package access. This is equivalent to picocli's reflection.
+        Map<String, List<MethodInfo>> classMethodsToTransform = new HashMap<>();
+        collectCrossPackageMixinMembers(index, classFieldsToTransform, classMethodsToTransform);
+
+        // Merge all class names that need transformation
+        java.util.Set<String> allClasses = new java.util.HashSet<>();
+        allClasses.addAll(classFieldsToTransform.keySet());
+        allClasses.addAll(classMethodsToTransform.keySet());
+
+        for (String className : allClasses) {
+            List<FieldInfo> fields = classFieldsToTransform.getOrDefault(className, List.of());
+            List<MethodInfo> methods = classMethodsToTransform.getOrDefault(className, List.of());
+
+            transformers.produce(new BytecodeTransformerBuildItem.Builder()
+                    .setClassToTransform(className)
+                    .setCacheable(true)
+                    .setVisitorFunction((name, classVisitor) -> {
+                        ClassTransformer transformer = new ClassTransformer(className);
+                        for (FieldInfo field : fields) {
+                            if ((field.flags() & Opcodes.ACC_PRIVATE) != 0) {
+                                // Private → package-private (same as Arc)
+                                transformer.modifyField(FieldDescriptor.of(field))
+                                        .removeModifiers(Opcodes.ACC_PRIVATE);
+                            } else if ((field.flags() & Opcodes.ACC_PUBLIC) == 0) {
+                                // Package-private or protected → public (for cross-package mixin access)
+                                transformer.modifyField(FieldDescriptor.of(field))
+                                        .removeModifiers(Opcodes.ACC_PROTECTED)
+                                        .addModifiers(Opcodes.ACC_PUBLIC);
+                            }
+                        }
+                        for (MethodInfo method : methods) {
+                            if ((method.flags() & Opcodes.ACC_PUBLIC) == 0) {
+                                String[] paramTypes = method.parameterTypes().stream()
+                                        .map(t -> t.name().toString())
+                                        .toArray(String[]::new);
+                                transformer.modifyMethod(
+                                        io.quarkus.gizmo.MethodDescriptor.ofMethod(
+                                                className, method.name(),
+                                                method.returnType().name().toString(),
+                                                paramTypes))
+                                        .removeModifiers(Opcodes.ACC_PRIVATE | Opcodes.ACC_PROTECTED)
+                                        .addModifiers(Opcodes.ACC_PUBLIC);
+                            }
+                        }
+                        return transformer.applyTo(classVisitor);
+                    })
+                    .build());
+        }
+    }
+
+    /**
+     * Finds non-public annotated fields and methods on mixin/arggroup types that are referenced
+     * from @Command classes in a different package. These members need to be made public
+     * so the generated model class can access them through the mixin field chain.
+     */
+    private void collectCrossPackageMixinMembers(IndexView index,
+            Map<String, List<FieldInfo>> classFieldsToTransform,
+            Map<String, List<MethodInfo>> classMethodsToTransform) {
+
+        // Find all @Command classes and their packages
+        java.util.Set<String> commandPackages = new java.util.HashSet<>();
+        for (var ann : index.getAnnotations(QUICKCLI_COMMAND)) {
+            if (ann.target().kind() == AnnotationTarget.Kind.CLASS) {
+                String className = ann.target().asClass().name().toString();
+                commandPackages.add(packageOf(className));
+            }
+        }
+
+        // Find mixin/arggroup types referenced from @Command classes
+        java.util.Set<String> mixinArgGroupTypes = new java.util.HashSet<>();
+        for (DotName annotation : List.of(QUICKCLI_MIXIN, QUICKCLI_ARG_GROUP)) {
+            for (var instance : index.getAnnotations(annotation)) {
+                if (instance.target().kind() != AnnotationTarget.Kind.FIELD) {
+                    continue;
+                }
+                FieldInfo field = instance.target().asField();
+                String mixinTypeName = field.type().name().toString();
+                String mixinPkg = packageOf(mixinTypeName);
+                for (String cmdPkg : commandPackages) {
+                    if (!cmdPkg.equals(mixinPkg)) {
+                        mixinArgGroupTypes.add(mixinTypeName);
+                        break;
+                    }
+                }
+            }
+        }
+
+        // For each cross-package mixin/arggroup type, collect non-public annotated members
+        for (String typeName : mixinArgGroupTypes) {
+            org.jboss.jandex.ClassInfo classInfo = index.getClassByName(typeName);
+            if (classInfo == null) {
+                continue;
+            }
+            for (FieldInfo field : classInfo.fields()) {
+                if ((field.flags() & Opcodes.ACC_PUBLIC) != 0) {
+                    continue;
+                }
+                boolean hasAnnotation = field.annotation(QUICKCLI_OPTION) != null
+                        || field.annotation(QUICKCLI_PARAMETERS) != null
+                        || field.annotation(QUICKCLI_MIXIN) != null
+                        || field.annotation(QUICKCLI_SPEC) != null
+                        || field.annotation(QUICKCLI_PARENT_COMMAND) != null
+                        || field.annotation(QUICKCLI_UNMATCHED) != null
+                        || field.annotation(QUICKCLI_ARG_GROUP) != null;
+                if (hasAnnotation) {
+                    classFieldsToTransform
+                            .computeIfAbsent(typeName, k -> new java.util.ArrayList<>())
+                            .add(field);
+                }
+            }
+            for (MethodInfo method : classInfo.methods()) {
+                if ((method.flags() & Opcodes.ACC_PUBLIC) != 0) {
+                    continue;
+                }
+                if (method.annotation(QUICKCLI_OPTION) != null) {
+                    classMethodsToTransform
+                            .computeIfAbsent(typeName, k -> new java.util.ArrayList<>())
+                            .add(method);
+                }
+            }
+        }
+    }
+
+    private static String packageOf(String className) {
+        int lastDot = className.lastIndexOf('.');
+        return lastDot > 0 ? className.substring(0, lastDot) : "";
+    }
+
+    private List<DotName> classesAnnotatedWith(IndexView indexView, DotName annotationName) {
+        return indexView.getAnnotations(annotationName)
+                .stream()
+                .filter(ann -> ann.target().kind() == AnnotationTarget.Kind.CLASS)
+                .map(ann -> ann.target().asClass().name())
+                .collect(Collectors.toList());
+    }
+}

--- a/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/CdiInjectionTest.java
+++ b/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/CdiInjectionTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.quickcli.deployment;
+
+import static io.quarkus.quickcli.deployment.TestUtils.createConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusProdModeTest;
+
+/**
+ * Tests that CDI injection works in QuickCLI commands via the QuickCliBeansFactory.
+ */
+public class CdiInjectionTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = createConfig("cdi-app",
+            InjectedCommand.class, GreetingService.class)
+            .setCommandLineParameters("--greeting", "Hello");
+
+    @Test
+    public void testCdiInjection() {
+        assertThat(config.getStartupConsoleOutput()).containsOnlyOnce("Hello from service!");
+        assertThat(config.getExitCode()).isZero();
+    }
+}

--- a/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/ConfigSourceCommand.java
+++ b/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/ConfigSourceCommand.java
@@ -1,0 +1,28 @@
+package io.quarkus.quickcli.deployment;
+
+import java.util.Optional;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Option;
+
+@Command(name = "config-test", description = "Tests config source integration")
+public class ConfigSourceCommand implements Runnable {
+
+    @Option(names = { "-p", "--server.port" }, description = "Server port")
+    String port;
+
+    @Option(names = { "--app.name" }, description = "App name")
+    String appName;
+
+    @Override
+    public void run() {
+        Optional<String> portFromConfig = ConfigProvider.getConfig().getOptionalValue("server.port", String.class);
+        Optional<String> nameFromConfig = ConfigProvider.getConfig().getOptionalValue("app.name", String.class);
+        System.out.println("option.port=" + port);
+        System.out.println("config.server.port=" + portFromConfig.orElse("MISSING"));
+        System.out.println("option.appName=" + appName);
+        System.out.println("config.app.name=" + nameFromConfig.orElse("MISSING"));
+    }
+}

--- a/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/ConfigSourceTest.java
+++ b/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/ConfigSourceTest.java
@@ -1,0 +1,29 @@
+package io.quarkus.quickcli.deployment;
+
+import static io.quarkus.quickcli.deployment.TestUtils.createConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusProdModeTest;
+
+/**
+ * Verifies that parsed CLI options are available as SmallRye Config properties.
+ */
+public class ConfigSourceTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = createConfig("config-source-app", ConfigSourceCommand.class)
+            .setCommandLineParameters("--server.port", "8080", "--app.name", "MyApp");
+
+    @Test
+    public void testCliOptionsAvailableAsConfigProperties() {
+        String output = config.getStartupConsoleOutput();
+        assertThat(output).contains("option.port=8080");
+        assertThat(output).contains("config.server.port=8080");
+        assertThat(output).contains("option.appName=MyApp");
+        assertThat(output).contains("config.app.name=MyApp");
+        assertThat(config.getExitCode()).isZero();
+    }
+}

--- a/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/DefaultCommandTest.java
+++ b/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/DefaultCommandTest.java
@@ -1,0 +1,24 @@
+package io.quarkus.quickcli.deployment;
+
+import static io.quarkus.quickcli.deployment.TestUtils.createConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusProdModeTest;
+
+/**
+ * Tests that a command works with default option values when no args are provided.
+ */
+public class DefaultCommandTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = createConfig("default-app", HelloCommand.class);
+
+    @Test
+    public void testDefaultValues() {
+        assertThat(config.getStartupConsoleOutput()).containsOnlyOnce("Hello World!");
+        assertThat(config.getExitCode()).isZero();
+    }
+}

--- a/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/ExitCodeTest.java
+++ b/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/ExitCodeTest.java
@@ -1,0 +1,24 @@
+package io.quarkus.quickcli.deployment;
+
+import static io.quarkus.quickcli.deployment.TestUtils.createConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusProdModeTest;
+
+/**
+ * Tests that exit codes from Callable commands are propagated correctly.
+ */
+public class ExitCodeTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = createConfig("exitcode-app", ExitCodeTestCommand.class)
+            .setCommandLineParameters("--code", "42");
+
+    @Test
+    public void testExitCode() {
+        assertThat(config.getExitCode()).isEqualTo(42);
+    }
+}

--- a/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/ExitCodeTestCommand.java
+++ b/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/ExitCodeTestCommand.java
@@ -1,0 +1,18 @@
+package io.quarkus.quickcli.deployment;
+
+import java.util.concurrent.Callable;
+
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Option;
+
+@Command(name = "exitcode", description = { "Returns a custom exit code" })
+public class ExitCodeTestCommand implements Callable<Integer> {
+
+    @Option(names = { "--code" }, description = "Exit code to return", defaultValue = "0")
+    int exitCode;
+
+    @Override
+    public Integer call() {
+        return exitCode;
+    }
+}

--- a/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/GoodbyeCommand.java
+++ b/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/GoodbyeCommand.java
@@ -1,0 +1,12 @@
+package io.quarkus.quickcli.deployment;
+
+import io.quarkus.quickcli.annotations.Command;
+
+@Command(name = "goodbye", description = { "A goodbye command" })
+public class GoodbyeCommand implements Runnable {
+
+    @Override
+    public void run() {
+        System.out.println("Goodbye was requested!");
+    }
+}

--- a/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/GreetingService.java
+++ b/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/GreetingService.java
@@ -1,0 +1,11 @@
+package io.quarkus.quickcli.deployment;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class GreetingService {
+
+    public String greet(String greeting) {
+        return greeting + " from service!";
+    }
+}

--- a/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/HelloCommand.java
+++ b/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/HelloCommand.java
@@ -1,0 +1,16 @@
+package io.quarkus.quickcli.deployment;
+
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Option;
+
+@Command(name = "hello", description = { "A hello command" })
+public class HelloCommand implements Runnable {
+
+    @Option(names = { "--name" }, description = "Name to greet", defaultValue = "World")
+    String name;
+
+    @Override
+    public void run() {
+        System.out.println("Hello " + name + "!");
+    }
+}

--- a/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/InjectedCommand.java
+++ b/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/InjectedCommand.java
@@ -1,0 +1,21 @@
+package io.quarkus.quickcli.deployment;
+
+import jakarta.inject.Inject;
+
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Option;
+
+@Command(name = "injected", description = { "Tests CDI injection in commands" })
+public class InjectedCommand implements Runnable {
+
+    @Option(names = { "--greeting" }, description = "Greeting text", defaultValue = "Hi")
+    String greeting;
+
+    @Inject
+    GreetingService greetingService;
+
+    @Override
+    public void run() {
+        System.out.println(greetingService.greet(greeting));
+    }
+}

--- a/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/MethodOptionCommand.java
+++ b/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/MethodOptionCommand.java
@@ -1,0 +1,27 @@
+package io.quarkus.quickcli.deployment;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Option;
+
+@Command(name = "method-opt", description = "Test method-level @Option")
+public class MethodOptionCommand implements Runnable {
+
+    public Map<String, String> properties = new HashMap<>();
+
+    @Option(names = "-D", mapFallbackValue = "", description = "Java properties")
+    public void setProperty(Map<String, String> props) {
+        this.properties = props;
+    }
+
+    @Override
+    public void run() {
+        if (properties.isEmpty()) {
+            System.out.println("No properties set");
+        } else {
+            properties.forEach((k, v) -> System.out.println(k + "=" + v));
+        }
+    }
+}

--- a/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/MethodOptionTest.java
+++ b/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/MethodOptionTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.quickcli.deployment;
+
+import static io.quarkus.quickcli.deployment.TestUtils.createConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusProdModeTest;
+
+/**
+ * Tests that @Option on a setter method works correctly.
+ */
+public class MethodOptionTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = createConfig("method-opt-app", MethodOptionCommand.class)
+            .setCommandLineParameters("-Dfoo=bar", "-Dbaz=qux");
+
+    @Test
+    public void testMethodOptionExecution() {
+        assertThat(config.getStartupConsoleOutput()).contains("foo=bar");
+        assertThat(config.getStartupConsoleOutput()).contains("baz=qux");
+        assertThat(config.getExitCode()).isZero();
+    }
+}

--- a/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/PrivateFieldTest.java
+++ b/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/PrivateFieldTest.java
@@ -1,0 +1,30 @@
+package io.quarkus.quickcli.deployment;
+
+import static io.quarkus.quickcli.deployment.TestUtils.createConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusProdModeTest;
+
+/**
+ * Tests that the Quarkus bytecode transformation properly handles private fields.
+ * The PrivateFieldTestCommand has private @Option and @Parameters fields
+ * without setters — the deployment processor should:
+ * 1. Remove ACC_PRIVATE from those fields
+ * 2. Replace _quickcli_set_* placeholder methods with putfield instructions
+ */
+public class PrivateFieldTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = createConfig("private-field-app",
+            PrivateFieldTestCommand.class)
+            .setCommandLineParameters("--name", "Secret", "greet");
+
+    @Test
+    public void testPrivateFieldsWork() {
+        assertThat(config.getStartupConsoleOutput()).containsOnlyOnce("greet: Secret");
+        assertThat(config.getExitCode()).isZero();
+    }
+}

--- a/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/PrivateFieldTestCommand.java
+++ b/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/PrivateFieldTestCommand.java
@@ -1,0 +1,28 @@
+package io.quarkus.quickcli.deployment;
+
+import java.util.concurrent.Callable;
+
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.annotations.Option;
+import io.quarkus.quickcli.annotations.Parameters;
+
+/**
+ * Tests that the Quarkus bytecode transform makes private fields accessible.
+ * No setters — relies on the deployment processor to remove ACC_PRIVATE
+ * and replace _quickcli_set_* placeholder methods.
+ */
+@Command(name = "private-test", description = { "Tests private field access in Quarkus" })
+public class PrivateFieldTestCommand implements Callable<Integer> {
+
+    @Option(names = { "-n", "--name" }, description = "Name", required = true)
+    private String name;
+
+    @Parameters(index = "0", description = "Action to perform")
+    private String action;
+
+    @Override
+    public Integer call() {
+        System.out.println(action + ": " + name);
+        return 0;
+    }
+}

--- a/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/SingleCommandTest.java
+++ b/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/SingleCommandTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.quickcli.deployment;
+
+import static io.quarkus.quickcli.deployment.TestUtils.createConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusProdModeTest;
+
+/**
+ * Tests that a single @Command class is automatically detected as the top command
+ * (auto-applied @TopCommand) and the app runs successfully.
+ */
+public class SingleCommandTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = createConfig("single-cmd-app", HelloCommand.class)
+            .setCommandLineParameters("--name", "Quarkus");
+
+    @Test
+    public void testSingleCommandExecution() {
+        assertThat(config.getStartupConsoleOutput()).containsOnlyOnce("Hello Quarkus!");
+        assertThat(config.getExitCode()).isZero();
+    }
+}

--- a/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/SubcommandTest.java
+++ b/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/SubcommandTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.quickcli.deployment;
+
+import static io.quarkus.quickcli.deployment.TestUtils.createConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusProdModeTest;
+
+/**
+ * Tests subcommand routing with a @TopCommand parent.
+ */
+public class SubcommandTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = createConfig("subcommand-app",
+            TopEntryCommand.class, GoodbyeCommand.class)
+            .setCommandLineParameters("goodbye");
+
+    @Test
+    public void testSubcommandExecution() {
+        assertThat(config.getStartupConsoleOutput()).containsOnlyOnce("Goodbye was requested!");
+        assertThat(config.getExitCode()).isZero();
+    }
+}

--- a/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/TestUtils.java
+++ b/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/TestUtils.java
@@ -1,0 +1,28 @@
+package io.quarkus.quickcli.deployment;
+
+import io.quarkus.test.QuarkusProdModeTest;
+
+class TestUtils {
+
+    private TestUtils() {
+    }
+
+    static QuarkusProdModeTest createConfig(String appName, Class<?>... classes) {
+        return new QuarkusProdModeTest()
+                .withApplicationRoot((jar) -> {
+                    jar.addClasses(classes);
+                    // Also add the generated QuickCLI model classes
+                    for (Class<?> cls : classes) {
+                        String modelName = cls.getName() + "_QuickCliModel";
+                        try {
+                            Class<?> modelClass = Class.forName(modelName);
+                            jar.addClass(modelClass);
+                        } catch (ClassNotFoundException e) {
+                            // Not a @Command class — no model generated, that's fine
+                        }
+                    }
+                })
+                .setApplicationName(appName).setApplicationVersion("0.1-SNAPSHOT")
+                .setExpectExit(true).setRun(true);
+    }
+}

--- a/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/TopCommandPropertyTest.java
+++ b/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/TopCommandPropertyTest.java
@@ -1,0 +1,29 @@
+package io.quarkus.quickcli.deployment;
+
+import static io.quarkus.quickcli.deployment.TestUtils.createConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusProdModeTest;
+
+/**
+ * Tests the quarkus.quickcli.top-command configuration property
+ * to select a specific command when multiple exist.
+ */
+public class TopCommandPropertyTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = createConfig("top-cmd-prop-app",
+            HelloCommand.class, GoodbyeCommand.class)
+            .overrideConfigKey("quarkus.quickcli.top-command",
+                    HelloCommand.class.getName())
+            .setCommandLineParameters("--name", "Config");
+
+    @Test
+    public void testTopCommandSelectedByProperty() {
+        assertThat(config.getStartupConsoleOutput()).containsOnlyOnce("Hello Config!");
+        assertThat(config.getExitCode()).isZero();
+    }
+}

--- a/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/TopEntryCommand.java
+++ b/extensions/quickcli/deployment/src/test/java/io/quarkus/quickcli/deployment/TopEntryCommand.java
@@ -1,0 +1,9 @@
+package io.quarkus.quickcli.deployment;
+
+import io.quarkus.quickcli.annotations.Command;
+import io.quarkus.quickcli.runtime.annotations.TopCommand;
+
+@TopCommand
+@Command(name = "app", description = { "Top-level command" }, subcommands = { GoodbyeCommand.class })
+public class TopEntryCommand {
+}

--- a/extensions/quickcli/pom.xml
+++ b/extensions/quickcli/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>quarkus-extensions-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-quickcli-parent</artifactId>
+    <name>Quarkus - QuickCLI</name>
+    <packaging>pom</packaging>
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+</project>

--- a/extensions/quickcli/runtime/pom.xml
+++ b/extensions/quickcli/runtime/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-quickcli-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-quickcli</artifactId>
+    <name>Quarkus - QuickCLI - Runtime</name>
+    <description>Develop command line applications with QuickCLI (build-time CLI framework)</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.quickcli</groupId>
+            <artifactId>quickcli-core</artifactId>
+            <version>999-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <configuration>
+                    <capabilities>
+                        <provides>io.quarkus.quickcli</provides>
+                    </capabilities>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.quarkus</groupId>
+                                    <artifactId>quarkus-extension-processor</artifactId>
+                                    <version>${project.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/quickcli/runtime/src/main/java/io/quarkus/quickcli/runtime/DefaultQuickCliCommandLineFactory.java
+++ b/extensions/quickcli/runtime/src/main/java/io/quarkus/quickcli/runtime/DefaultQuickCliCommandLineFactory.java
@@ -1,0 +1,47 @@
+package io.quarkus.quickcli.runtime;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.literal.NamedLiteral;
+
+import io.quarkus.quickcli.CommandLine;
+import io.quarkus.quickcli.runtime.annotations.TopCommand;
+
+@ApplicationScoped
+public class DefaultQuickCliCommandLineFactory implements QuickCliCommandLineFactory {
+
+    private final Instance<Object> topCommand;
+    private final QuickCliConfiguration configuration;
+    private final CommandLine.Factory factory;
+
+    public DefaultQuickCliCommandLineFactory(@TopCommand Instance<Object> topCommand,
+            QuickCliConfiguration configuration,
+            CommandLine.Factory factory) {
+        this.topCommand = topCommand;
+        this.configuration = configuration;
+        this.factory = factory;
+    }
+
+    private Class<?> classForName(String name) {
+        try {
+            return Class.forName(name, false, Thread.currentThread().getContextClassLoader());
+        } catch (ClassNotFoundException ex) {
+            throw new IllegalArgumentException(ex);
+        }
+    }
+
+    @Override
+    public CommandLine create() {
+        if (configuration.topCommand().isPresent()) {
+            String topCommandName = configuration.topCommand().get();
+
+            Instance<Object> namedTopCommand = topCommand.select(NamedLiteral.of(topCommandName));
+            if (namedTopCommand.isResolvable()) {
+                return new CommandLine(namedTopCommand.get().getClass(), factory);
+            }
+            return new CommandLine(classForName(topCommandName), factory);
+        }
+        Object topCmd = topCommand.get();
+        return new CommandLine(topCmd.getClass(), factory);
+    }
+}

--- a/extensions/quickcli/runtime/src/main/java/io/quarkus/quickcli/runtime/QuickCliBeansFactory.java
+++ b/extensions/quickcli/runtime/src/main/java/io/quarkus/quickcli/runtime/QuickCliBeansFactory.java
@@ -1,0 +1,42 @@
+package io.quarkus.quickcli.runtime;
+
+import java.util.function.Supplier;
+
+import jakarta.enterprise.inject.Any;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.quickcli.CommandLine;
+import io.quarkus.quickcli.model.CommandModel;
+import io.quarkus.quickcli.model.CommandModelRegistry;
+
+/**
+ * An {@link CommandLine.Factory} that first tries to resolve instances from the Quarkus Arc
+ * CDI container, falling back to the generated {@link CommandModel#createInstance()}
+ * which uses a direct {@code new} call. No reflection is used.
+ */
+class QuickCliBeansFactory implements CommandLine.Factory {
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K> K create(Class<K> aClass) throws Exception {
+        // Use @Any qualifier to match beans regardless of their qualifier (e.g. @TopCommand)
+        InstanceHandle<K> instance = Arc.container().instance(aClass, Any.Literal.INSTANCE);
+        if (instance.isAvailable()) {
+            return instance.get();
+        }
+        // Try CommandModel for @Command classes
+        try {
+            return (K) CommandModelRegistry.getModel(aClass).createInstance();
+        } catch (IllegalStateException ignored) {
+            // Not a @Command class — try instance creator for mixins/arg groups
+        }
+        // Try build-time generated instance creator for mixin/arg group types
+        Supplier<Object> creator = CommandModelRegistry.getInstanceCreator(aClass);
+        if (creator != null) {
+            return (K) creator.get();
+        }
+        throw new IllegalArgumentException(
+                "No CDI bean or CommandModel found for " + aClass.getName());
+    }
+}

--- a/extensions/quickcli/runtime/src/main/java/io/quarkus/quickcli/runtime/QuickCliCommandLineFactory.java
+++ b/extensions/quickcli/runtime/src/main/java/io/quarkus/quickcli/runtime/QuickCliCommandLineFactory.java
@@ -1,0 +1,12 @@
+package io.quarkus.quickcli.runtime;
+
+import io.quarkus.quickcli.CommandLine;
+
+/**
+ * Factory for creating QuickCLI CommandLine instances.
+ * Can be overridden by providing a custom CDI bean.
+ */
+@FunctionalInterface
+public interface QuickCliCommandLineFactory {
+    CommandLine create();
+}

--- a/extensions/quickcli/runtime/src/main/java/io/quarkus/quickcli/runtime/QuickCliCommandLineProducer.java
+++ b/extensions/quickcli/runtime/src/main/java/io/quarkus/quickcli/runtime/QuickCliCommandLineProducer.java
@@ -1,0 +1,32 @@
+package io.quarkus.quickcli.runtime;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+
+import io.quarkus.arc.DefaultBean;
+import io.quarkus.quickcli.CommandLine;
+import io.quarkus.quickcli.ParseResult;
+import io.quarkus.runtime.annotations.CommandLineArguments;
+
+@ApplicationScoped
+public class QuickCliCommandLineProducer {
+
+    @Produces
+    @Singleton
+    public CommandLine.Factory quickCliFactory() {
+        return new QuickCliBeansFactory();
+    }
+
+    @Produces
+    @DefaultBean
+    public CommandLine quickCliCommandLine(QuickCliCommandLineFactory commandLineFactory) {
+        return commandLineFactory.create();
+    }
+
+    @Produces
+    public ParseResult quickCliParseResult(CommandLine commandLine,
+            @CommandLineArguments String[] args) {
+        return commandLine.parse(args);
+    }
+}

--- a/extensions/quickcli/runtime/src/main/java/io/quarkus/quickcli/runtime/QuickCliConfigSource.java
+++ b/extensions/quickcli/runtime/src/main/java/io/quarkus/quickcli/runtime/QuickCliConfigSource.java
@@ -1,0 +1,54 @@
+package io.quarkus.quickcli.runtime;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+/**
+ * A {@link ConfigSource} that exposes parsed QuickCLI command-line options as
+ * SmallRye Config properties.
+ * <p>
+ * Registered early (empty) during config building, then populated after CLI
+ * parsing in {@link QuickCliRunner}. Option names are mapped by stripping
+ * leading dashes from the longest option name (e.g. {@code --server.port}
+ * becomes {@code server.port}).
+ */
+public class QuickCliConfigSource implements ConfigSource {
+
+    static final String NAME = "QuickCLI CLI Options";
+    static final int ORDINAL = 275;
+
+    private static final Map<String, String> properties = new ConcurrentHashMap<>();
+
+    public static void setProperties(Map<String, String> values) {
+        properties.clear();
+        properties.putAll(values);
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        return Map.copyOf(properties);
+    }
+
+    @Override
+    public Set<String> getPropertyNames() {
+        return properties.keySet();
+    }
+
+    @Override
+    public String getValue(String propertyName) {
+        return properties.get(propertyName);
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public int getOrdinal() {
+        return ORDINAL;
+    }
+}

--- a/extensions/quickcli/runtime/src/main/java/io/quarkus/quickcli/runtime/QuickCliConfigSourceBuilder.java
+++ b/extensions/quickcli/runtime/src/main/java/io/quarkus/quickcli/runtime/QuickCliConfigSourceBuilder.java
@@ -1,0 +1,11 @@
+package io.quarkus.quickcli.runtime;
+
+import io.quarkus.runtime.configuration.ConfigBuilder;
+import io.smallrye.config.SmallRyeConfigBuilder;
+
+public class QuickCliConfigSourceBuilder implements ConfigBuilder {
+    @Override
+    public SmallRyeConfigBuilder configBuilder(SmallRyeConfigBuilder builder) {
+        return builder.withSources(new QuickCliConfigSource());
+    }
+}

--- a/extensions/quickcli/runtime/src/main/java/io/quarkus/quickcli/runtime/QuickCliConfiguration.java
+++ b/extensions/quickcli/runtime/src/main/java/io/quarkus/quickcli/runtime/QuickCliConfiguration.java
@@ -1,0 +1,18 @@
+package io.quarkus.quickcli.runtime;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+@ConfigMapping(prefix = "quarkus.quickcli")
+public interface QuickCliConfiguration {
+    /**
+     * Name of bean annotated with {@link io.quarkus.quickcli.runtime.annotations.TopCommand}
+     * or FQCN of class which will be used as entry point for QuickCLI CommandLine instance.
+     * This class needs to be annotated with {@link io.quarkus.quickcli.annotations.Command}.
+     */
+    Optional<String> topCommand();
+}

--- a/extensions/quickcli/runtime/src/main/java/io/quarkus/quickcli/runtime/QuickCliRunner.java
+++ b/extensions/quickcli/runtime/src/main/java/io/quarkus/quickcli/runtime/QuickCliRunner.java
@@ -1,0 +1,82 @@
+package io.quarkus.quickcli.runtime;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.event.Event;
+
+import io.quarkus.quickcli.CommandLine;
+import io.quarkus.quickcli.CommandSpec;
+import io.quarkus.quickcli.OptionSpec;
+import io.quarkus.quickcli.ParseResult;
+import io.quarkus.runtime.QuarkusApplication;
+
+@Dependent
+public class QuickCliRunner implements QuarkusApplication {
+
+    private final CommandLine commandLine;
+    private final Event<ParseResult> parseResultEvent;
+
+    public QuickCliRunner(CommandLine commandLine, Event<ParseResult> parseResultEvent) {
+        this.commandLine = commandLine;
+        this.parseResultEvent = parseResultEvent;
+    }
+
+    @Override
+    public int run(String... args) throws Exception {
+        // Set a custom execution strategy that fires CDI events before execution
+        commandLine.setExecutionStrategy((parseResult, cmd) -> {
+            // Populate SmallRye Config with parsed CLI options before command execution
+            QuickCliConfigSource.setProperties(extractConfigProperties(parseResult));
+            parseResultEvent.fire(parseResult);
+            return new CommandLine.RunLastStrategy().execute(parseResult, cmd);
+        });
+
+        return commandLine.execute(args);
+    }
+
+    /**
+     * Extracts parsed option values as config properties from the entire parse
+     * result chain (including subcommands). Option names are mapped by stripping
+     * leading dashes from the longest name (e.g. {@code --server.port} becomes
+     * {@code server.port}).
+     */
+    static Map<String, String> extractConfigProperties(ParseResult parseResult) {
+        Map<String, String> properties = new LinkedHashMap<>();
+        collectOptions(parseResult, properties);
+        return properties;
+    }
+
+    private static void collectOptions(ParseResult parseResult, Map<String, String> properties) {
+        CommandSpec spec = parseResult.commandSpec();
+        for (OptionSpec option : spec.options()) {
+            if (option.isUsageHelp() || option.isVersionHelp()) {
+                continue;
+            }
+            if (!parseResult.hasOptionBySpec(option)) {
+                continue;
+            }
+            String configKey = toConfigKey(option.longestName());
+            List<String> values = parseResult.getOptionValues(option.longestName());
+            if (!values.isEmpty()) {
+                // For multi-value options, join with comma (SmallRye Config convention)
+                properties.put(configKey, String.join(",", values));
+            }
+        }
+        if (parseResult.subcommandResult() != null) {
+            collectOptions(parseResult.subcommandResult(), properties);
+        }
+    }
+
+    private static String toConfigKey(String optionName) {
+        // Strip leading dashes: --server.port -> server.port, -v -> v
+        if (optionName.startsWith("--")) {
+            return optionName.substring(2);
+        } else if (optionName.startsWith("-")) {
+            return optionName.substring(1);
+        }
+        return optionName;
+    }
+}

--- a/extensions/quickcli/runtime/src/main/java/io/quarkus/quickcli/runtime/annotations/TopCommand.java
+++ b/extensions/quickcli/runtime/src/main/java/io/quarkus/quickcli/runtime/annotations/TopCommand.java
@@ -1,0 +1,23 @@
+package io.quarkus.quickcli.runtime.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.inject.Qualifier;
+
+/**
+ * CDI qualifier marking the top-level command for the QuickCLI CommandLine instance.
+ * Can be used together with {@link jakarta.inject.Named} — use the runtime property
+ * {@code quarkus.quickcli.top-command} to specify which Named TopCommand to use.
+ */
+@Qualifier
+@Target({ FIELD, PARAMETER, TYPE, METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TopCommand {
+}

--- a/independent-projects/quickcli/pom.xml
+++ b/independent-projects/quickcli/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../parent/pom.xml</relativePath>
+    </parent>
+
+    <groupId>io.quarkus.quickcli</groupId>
+    <artifactId>quickcli-parent</artifactId>
+    <version>999-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>QuickCLI - Parent</name>
+    <description>A build-time CLI framework - like picocli but with compile-time annotation processing</description>
+
+    <modules>
+        <module>quickcli-core</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.quarkus.quickcli</groupId>
+                <artifactId>quickcli-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/independent-projects/quickcli/quickcli-core/pom.xml
+++ b/independent-projects/quickcli/quickcli-core/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus.quickcli</groupId>
+        <artifactId>quickcli-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quickcli-core</artifactId>
+    <name>QuickCLI - Core</name>
+    <description>Core annotations and runtime for QuickCLI</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.11.4</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/Ansi.java
+++ b/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/Ansi.java
@@ -1,0 +1,45 @@
+package io.quarkus.quickcli;
+
+/**
+ * ANSI text rendering support. Provides picocli-compatible API for styled console output.
+ * Strips @|style text|@ markup patterns and renders plain text.
+ */
+public enum Ansi {
+    AUTO,
+    ON,
+    OFF;
+
+    /** Whether ANSI escape codes should be emitted. */
+    public boolean enabled() {
+        if (this == OFF) return false;
+        if (this == ON) return true;
+        // AUTO: check if stdout is a terminal
+        return System.console() != null && !System.getenv().containsKey("NO_COLOR");
+    }
+
+    /** Styled text that strips @|style ...|@ markup for plain text output. */
+    public Text text(String value) {
+        return new Text(value, null);
+    }
+
+    /** Creates a Text instance, compatible with picocli's Ansi.Text pattern. */
+    public static class Text {
+        private final String raw;
+
+        public Text(String raw, Object colorScheme) {
+            this.raw = raw != null ? raw : "";
+        }
+
+        @Override
+        public String toString() {
+            return stripAnsiMarkup(raw);
+        }
+
+        /** Strips picocli-style @|style text|@ markup, leaving only the text content. */
+        static String stripAnsiMarkup(String text) {
+            if (text == null) return "";
+            // Strip @|style text|@ patterns → just the text
+            return text.replaceAll("@\\|[^\\s]+ ([^|]*?)\\|@", "$1");
+        }
+    }
+}

--- a/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/AutoComplete.java
+++ b/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/AutoComplete.java
@@ -1,0 +1,533 @@
+package io.quarkus.quickcli;
+
+import static java.lang.String.format;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Generates bash/zsh auto-completion scripts for QuickCLI-based applications.
+ * <p>
+ * Walks the {@link CommandSpec} hierarchy to produce a bash completion script
+ * that handles subcommands, options (flags and arg-taking), and positional
+ * parameters with file/hostname completion.
+ * </p>
+ */
+public final class AutoComplete {
+
+    private AutoComplete() {
+    }
+
+    /**
+     * Generates and returns the source code for a bash/zsh autocompletion script.
+     *
+     * @param scriptName  the name of the command (e.g. "quarkus")
+     * @param rootSpec    the root {@link CommandSpec}
+     * @return bash completion script source code
+     */
+    public static String bash(String scriptName, CommandSpec rootSpec) {
+        if (scriptName == null) {
+            throw new NullPointerException("scriptName");
+        }
+        if (rootSpec == null) {
+            throw new NullPointerException("rootSpec");
+        }
+        scriptName = sanitizeScriptName(scriptName);
+        StringBuilder result = new StringBuilder(4096);
+        result.append(format(SCRIPT_HEADER, scriptName, CommandLine.VERSION));
+
+        List<CommandDescriptor> hierarchy = createHierarchy(scriptName, rootSpec);
+        result.append(generateEntryPointFunction(scriptName, hierarchy));
+
+        for (CommandDescriptor descriptor : hierarchy) {
+            result.append(generateFunctionForCommand(descriptor.functionName,
+                    descriptor.commandName, descriptor.spec));
+        }
+        result.append(format(SCRIPT_FOOTER, scriptName));
+        return result.toString();
+    }
+
+    // --- internals ---
+
+    private static String sanitizeScriptName(String scriptName) {
+        return scriptName
+                .replaceAll("\\.sh", "")
+                .replaceAll("\\.bash", "")
+                .replaceAll("\\.\\/", "");
+    }
+
+    private static String bashify(CharSequence value) {
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (Character.isLetterOrDigit(c) || c == '_') {
+                builder.append(c);
+            } else if (Character.isSpaceChar(c)) {
+                builder.append('_');
+            }
+        }
+        if (builder.length() > 0 && Character.isDigit(builder.charAt(0))) {
+            builder.insert(0, "_");
+        }
+        return builder.toString();
+    }
+
+    // ---- hierarchy ----
+
+    private static final class CommandDescriptor {
+        final String functionName;
+        final String parentFunctionName;
+        final String parentWithoutTopLevelCommand;
+        final String commandName;
+        final CommandSpec spec;
+
+        CommandDescriptor(String functionName, String parentFunctionName,
+                          String parentWithoutTopLevelCommand, String commandName,
+                          CommandSpec spec) {
+            this.functionName = functionName;
+            this.parentFunctionName = parentFunctionName;
+            this.parentWithoutTopLevelCommand = parentWithoutTopLevelCommand;
+            this.commandName = commandName;
+            this.spec = spec;
+        }
+    }
+
+    private static List<CommandDescriptor> createHierarchy(String scriptName, CommandSpec rootSpec) {
+        List<CommandDescriptor> result = new ArrayList<>();
+        result.add(new CommandDescriptor("_picocli_" + scriptName, "", "",
+                scriptName, rootSpec));
+        createSubHierarchy(scriptName, "", rootSpec, result);
+        return result;
+    }
+
+    private static void createSubHierarchy(String scriptName,
+                                            String parentWithoutTopLevelCommand,
+                                            CommandSpec parentSpec,
+                                            List<CommandDescriptor> out) {
+        // breadth-first: add descriptors for each subcommand
+        for (Map.Entry<String, CommandSpec> entry : parentSpec.subcommands().entrySet()) {
+            String commandName = entry.getKey();
+            CommandSpec subSpec = entry.getValue();
+            String functionNameWithoutPrefix = bashify(
+                    concat("_", parentWithoutTopLevelCommand.replace(' ', '_'), commandName));
+            String functionName = concat("_", "_picocli", scriptName, functionNameWithoutPrefix);
+            String parentFunctionName = parentWithoutTopLevelCommand.isEmpty()
+                    ? concat("_", "_picocli", scriptName)
+                    : concat("_", "_picocli", scriptName,
+                    bashify(parentWithoutTopLevelCommand.replace(' ', '_')));
+            out.add(new CommandDescriptor(functionName, parentFunctionName,
+                    parentWithoutTopLevelCommand, commandName, subSpec));
+        }
+        // then recurse
+        for (Map.Entry<String, CommandSpec> entry : parentSpec.subcommands().entrySet()) {
+            String newParent = concat(" ", parentWithoutTopLevelCommand, entry.getKey());
+            createSubHierarchy(scriptName, newParent, entry.getValue(), out);
+        }
+    }
+
+    // ---- entry-point function ----
+
+    private static String generateEntryPointFunction(String scriptName,
+                                                      List<CommandDescriptor> hierarchy) {
+        StringBuilder buff = new StringBuilder(1024);
+        buff.append(format(
+                "# Bash completion entry point function.\n"
+                        + "function _complete_%1$s() {\n",
+                scriptName));
+
+        // Edge case lines
+        buff.append("  # Edge case: if command line has no space after subcommand, "
+                + "don't assume it is selected.\n");
+        for (CommandDescriptor descriptor : hierarchy.subList(1, hierarchy.size())) {
+            String withoutTopLevel = concat(" ",
+                    descriptor.parentWithoutTopLevelCommand, descriptor.commandName);
+            buff.append(format(
+                    "  if [ \"${COMP_LINE}\" = \"${COMP_WORDS[0]} %1$s\" ]; "
+                            + "then %2$s; return $?; fi\n",
+                    withoutTopLevel, descriptor.parentFunctionName));
+        }
+        buff.append("\n");
+
+        // CompWordsContainsArray calls (longest match first)
+        buff.append("  # Find the longest sequence of subcommands and call "
+                + "the bash function for that subcommand.\n");
+        List<String> functionCalls = new ArrayList<>();
+        for (CommandDescriptor descriptor : hierarchy.subList(1, hierarchy.size())) {
+            int count = functionCalls.size();
+            String withoutTopLevel = concat(" ",
+                    descriptor.parentWithoutTopLevelCommand, descriptor.commandName);
+            functionCalls.add(format(
+                    "  if CompWordsContainsArray \"${cmds%2$d[@]}\"; "
+                            + "then %1$s; return $?; fi\n",
+                    descriptor.functionName, count));
+            buff.append(format("  local cmds%2$d=(%1$s)\n", withoutTopLevel, count));
+        }
+        buff.append("\n");
+        Collections.reverse(functionCalls);
+        for (String fc : functionCalls) {
+            buff.append(fc);
+        }
+
+        buff.append(format(
+                "\n  # No subcommands were specified; generate completions for "
+                        + "the top-level command.\n"
+                        + "  _picocli_%1$s; return $?;\n"
+                        + "}\n",
+                scriptName));
+        return buff.toString();
+    }
+
+    // ---- per-command function ----
+
+    private static String generateFunctionForCommand(String functionName,
+                                                      String commandName,
+                                                      CommandSpec spec) {
+        // Classify options as flag (boolean) vs arg (takes a value)
+        List<OptionSpec> flagOptions = new ArrayList<>();
+        List<OptionSpec> argOptions = new ArrayList<>();
+        for (OptionSpec opt : spec.options()) {
+            if (opt.hidden()) {
+                continue;
+            }
+            if (opt.isBoolean()) {
+                flagOptions.add(opt);
+            } else {
+                argOptions.add(opt);
+            }
+        }
+
+        String flagOptionNames = optionNames(flagOptions);
+        String argOptionNames = optionNames(argOptions);
+
+        // Visible subcommand names
+        Set<String> subCmds = new LinkedHashSet<>();
+        for (String sub : spec.subcommands().keySet()) {
+            subCmds.add(sub);
+        }
+        String commands = String.join(" ", subCmds).trim();
+
+        StringBuilder buff = new StringBuilder(1024);
+        String sub = functionName.equals("_picocli_" + commandName) ? "" : "sub";
+        String previousWord = argOptions.isEmpty()
+                ? "" : "  local prev_word=${COMP_WORDS[COMP_CWORD-1]}\n";
+        buff.append(format(
+                "\n# Generates completions for the options and subcommands of `%s` %scommand.\n"
+                        + "function %s() {\n"
+                        + "  # Get completion data\n"
+                        + "  local curr_word=${COMP_WORDS[COMP_CWORD]}\n"
+                        + "%s"
+                        + "\n"
+                        + "  local commands=\"%s\"\n"
+                        + "  local flag_opts=\"%s\"\n"
+                        + "  local arg_opts=\"%s\"\n",
+                commandName, sub, functionName, previousWord,
+                commands, flagOptionNames, argOptionNames));
+
+        // case statement for arg-taking options
+        buff.append(generateOptionsSwitch(argOptions, spec));
+
+        // positional param support
+        String paramsCases = generatePositionalParamsCases(spec.parameters(), commandName);
+
+        String posParamsFooter = "";
+        if (!paramsCases.isEmpty()) {
+            posParamsFooter = format(
+                    "    local currIndex\n"
+                            + "    currIndex=$(currentPositionalIndex \"%s\" "
+                            + "\"${arg_opts}\" \"${flag_opts}\")\n"
+                            + "%s",
+                    commandName, paramsCases);
+        }
+        buff.append(format(
+                "\n"
+                        + "  if [[ \"${curr_word}\" == -* ]]; then\n"
+                        + "    COMPREPLY=( $(compgen -W \"${flag_opts} ${arg_opts}\" "
+                        + "-- \"${curr_word}\") )\n"
+                        + "  else\n"
+                        + "    local positionals=\"\"\n"
+                        + "%s"
+                        + "    local IFS=$'\\n'\n"
+                        + "    COMPREPLY=( $(compgen -W "
+                        + "\"${commands// /$'\\n'}${IFS}${positionals}\" "
+                        + "-- \"${curr_word}\") )\n"
+                        + "  fi\n"
+                        + "}\n",
+                posParamsFooter));
+        return buff.toString();
+    }
+
+    private static String generateOptionsSwitch(List<OptionSpec> argOptions,
+                                                 CommandSpec spec) {
+        if (argOptions.isEmpty()) {
+            return "";
+        }
+        StringBuilder cases = new StringBuilder();
+        for (OptionSpec option : argOptions) {
+            if (option.hidden()) {
+                continue;
+            }
+            Class<?> type = option.type();
+            String caseLabel = singleQuoteJoin(option.names());
+            if (isFileType(type)) {
+                cases.append(format("    %s)\n", caseLabel));
+                cases.append("      local IFS=$'\\n'\n");
+                cases.append("      type compopt &>/dev/null && compopt -o filenames\n");
+                cases.append("      COMPREPLY=( $( compgen -f -- \"${curr_word}\" ) ) # files\n");
+                cases.append("      return $?\n");
+                cases.append("      ;;\n");
+            } else {
+                cases.append(format("    %s)\n", caseLabel));
+                cases.append("      return\n");
+                cases.append("      ;;\n");
+            }
+        }
+        if (cases.isEmpty()) {
+            return "";
+        }
+        return "\n"
+                + "  type compopt &>/dev/null && compopt +o default\n\n"
+                + "  case ${prev_word} in\n"
+                + cases
+                + "  esac\n";
+    }
+
+    private static String generatePositionalParamsCases(List<ParameterSpec> params,
+                                                         String commandName) {
+        StringBuilder buff = new StringBuilder();
+        for (ParameterSpec param : params) {
+            if (param.hidden()) {
+                continue;
+            }
+            Class<?> type = param.type();
+            if (param.isMultiValue()) {
+                // for List<File>, the element type is likely String — skip special handling
+            }
+            if (isFileType(type)) {
+                String ifOrElif = buff.isEmpty() ? "if" : "elif";
+                int idx = param.index();
+                buff.append(format("    %s (( currIndex >= %d )); then\n", ifOrElif, idx));
+                buff.append("      local IFS=$'\\n'\n");
+                buff.append("      type compopt &>/dev/null && compopt -o filenames\n");
+                buff.append("      positionals=$( compgen -f -- \"${curr_word}\" ) # files\n");
+            }
+        }
+        if (!buff.isEmpty()) {
+            buff.append("    fi\n");
+        }
+        return buff.toString();
+    }
+
+    // ---- helpers ----
+
+    private static boolean isFileType(Class<?> type) {
+        return java.io.File.class.equals(type)
+                || "java.nio.file.Path".equals(type.getName());
+    }
+
+    private static String optionNames(List<OptionSpec> options) {
+        StringBuilder sb = new StringBuilder();
+        for (OptionSpec option : options) {
+            if (option.hidden()) {
+                continue;
+            }
+            for (String name : option.names()) {
+                if (!sb.isEmpty()) {
+                    sb.append(' ');
+                }
+                sb.append('\'').append(name).append('\'');
+            }
+        }
+        return sb.toString();
+    }
+
+    private static String singleQuoteJoin(String[] names) {
+        StringBuilder sb = new StringBuilder();
+        for (String name : names) {
+            if (!sb.isEmpty()) {
+                sb.append('|');
+            }
+            sb.append('\'').append(name).append('\'');
+        }
+        return sb.toString();
+    }
+
+    private static String concat(String infix, String... values) {
+        StringBuilder sb = new StringBuilder();
+        for (String val : values) {
+            if (val == null || val.isEmpty()) {
+                continue;
+            }
+            if (!sb.isEmpty()) {
+                sb.append(infix);
+            }
+            sb.append(val);
+        }
+        return sb.toString();
+    }
+
+    // ---- script templates ----
+
+    private static final String SCRIPT_HEADER = ""
+            + "#!/usr/bin/env bash\n"
+            + "#\n"
+            + "# %1$s Bash Completion\n"
+            + "# =======================\n"
+            + "#\n"
+            + "# Bash completion support for the `%1$s` command,\n"
+            + "# generated by [QuickCLI](https://quarkus.io/) version %2$s.\n"
+            + "#\n"
+            + "# Installation\n"
+            + "# ------------\n"
+            + "#\n"
+            + "# 1. Source all completion scripts in your .bash_profile\n"
+            + "#\n"
+            + "#   cd $YOUR_APP_HOME/bin\n"
+            + "#   for f in $(find . -name \"*_completion\"); do line=\". $(pwd)/$f\"; "
+            + "grep \"$line\" ~/.bash_profile || echo \"$line\" >> ~/.bash_profile; done\n"
+            + "#\n"
+            + "# 2. Open a new bash console, and type `%1$s [TAB][TAB]`\n"
+            + "#\n"
+            + "# 1a. Alternatively, if you have bash-completion installed:\n"
+            + "#     Place this file in a `bash-completion.d` folder:\n"
+            + "#\n"
+            + "#   * /etc/bash-completion.d\n"
+            + "#   * /usr/local/etc/bash-completion.d\n"
+            + "#   * ~/bash-completion.d\n"
+            + "#\n"
+            + "\n"
+            + "if [ -n \"$BASH_VERSION\" ]; then\n"
+            + "  # Enable programmable completion facilities when using bash\n"
+            + "  shopt -s progcomp\n"
+            + "elif [ -n \"$ZSH_VERSION\" ]; then\n"
+            + "  # Make alias a distinct command for completion purposes when using zsh\n"
+            + "  setopt COMPLETE_ALIASES\n"
+            + "  alias compopt=complete\n"
+            + "\n"
+            + "  # Enable bash completion in zsh\n"
+            + "  if ! type compdef > /dev/null; then\n"
+            + "    autoload -U +X compinit && compinit\n"
+            + "  fi\n"
+            + "  autoload -U +X bashcompinit && bashcompinit\n"
+            + "fi\n"
+            + "\n"
+            + "# CompWordsContainsArray takes an array and then checks\n"
+            + "# if all elements of this array are in the global COMP_WORDS array.\n"
+            + "#\n"
+            + "# Returns zero (no error) if all elements of the array are in the "
+            + "COMP_WORDS array,\n"
+            + "# otherwise returns 1 (error).\n"
+            + "function CompWordsContainsArray() {\n"
+            + "  declare -a localArray\n"
+            + "  localArray=(\"$@\")\n"
+            + "  local findme\n"
+            + "  for findme in \"${localArray[@]}\"; do\n"
+            + "    if ElementNotInCompWords \"$findme\"; then return 1; fi\n"
+            + "  done\n"
+            + "  return 0\n"
+            + "}\n"
+            + "function ElementNotInCompWords() {\n"
+            + "  local findme=\"$1\"\n"
+            + "  local element\n"
+            + "  for element in \"${COMP_WORDS[@]}\"; do\n"
+            + "    if [[ \"$findme\" = \"$element\" ]]; then return 1; fi\n"
+            + "  done\n"
+            + "  return 0\n"
+            + "}\n"
+            + "\n"
+            + "# The `currentPositionalIndex` function calculates the index of the "
+            + "current positional parameter.\n"
+            + "#\n"
+            + "# currentPositionalIndex takes three parameters:\n"
+            + "# the command name,\n"
+            + "# a space-separated string with the names of options that take a "
+            + "parameter, and\n"
+            + "# a space-separated string with the names of boolean options "
+            + "(that don't take any params).\n"
+            + "# When done, this function echos the current positional index to "
+            + "std_out.\n"
+            + "#\n"
+            + "# Example usage:\n"
+            + "# local currIndex=$(currentPositionalIndex \"mysubcommand\" "
+            + "\"$ARG_OPTS\" \"$FLAG_OPTS\")\n"
+            + "function currentPositionalIndex() {\n"
+            + "  local commandName=\"$1\"\n"
+            + "  local optionsWithArgs=\"$2\"\n"
+            + "  local booleanOptions=\"$3\"\n"
+            + "  local previousWord\n"
+            + "  local result=0\n"
+            + "\n"
+            + "  for i in $(seq $((COMP_CWORD - 1)) -1 0); do\n"
+            + "    previousWord=${COMP_WORDS[i]}\n"
+            + "    if [ \"${previousWord}\" = \"$commandName\" ]; then\n"
+            + "      break\n"
+            + "    fi\n"
+            + "    if [[ \"${optionsWithArgs}\" =~ ${previousWord} ]]; then\n"
+            + "      ((result-=2)) # Arg option and its value not counted as "
+            + "positional param\n"
+            + "    elif [[ \"${booleanOptions}\" =~ ${previousWord} ]]; then\n"
+            + "      ((result-=1)) # Flag option itself not counted as positional "
+            + "param\n"
+            + "    fi\n"
+            + "    ((result++))\n"
+            + "  done\n"
+            + "  echo \"$result\"\n"
+            + "}\n"
+            + "\n"
+            + "# compReplyArray generates a list of completion suggestions based on "
+            + "an array, ensuring all values are properly escaped.\n"
+            + "#\n"
+            + "# compReplyArray takes a single parameter: the array of options to be "
+            + "displayed\n"
+            + "#\n"
+            + "# The output is echoed to std_out, one option per line.\n"
+            + "#\n"
+            + "# Example usage:\n"
+            + "# local options=(\"foo\", \"bar\", \"baz\")\n"
+            + "# local IFS=$'\\n'\n"
+            + "# COMPREPLY=($(compReplyArray \"${options[@]}\"))\n"
+            + "function compReplyArray() {\n"
+            + "  declare -a options\n"
+            + "  options=(\"$@\")\n"
+            + "  local curr_word=${COMP_WORDS[COMP_CWORD]}\n"
+            + "  local i\n"
+            + "  local quoted\n"
+            + "  local optionList=()\n"
+            + "\n"
+            + "  for (( i=0; i<${#options[@]}; i++ )); do\n"
+            + "    # Double escape, since we want escaped values, but compgen -W "
+            + "expands the argument\n"
+            + "    printf -v quoted %%q \"${options[i]}\"\n"
+            + "    quoted=\\'${quoted//\\'/\\'\\\\\\'\\'}\\'\n"
+            + "\n"
+            + "    optionList[i]=$quoted\n"
+            + "  done\n"
+            + "\n"
+            + "  # We also have to add another round of escaping to $curr_word.\n"
+            + "  curr_word=${curr_word//\\\\/\\\\\\\\}\n"
+            + "  curr_word=${curr_word//\\'/\\\\\\'}\n"
+            + "\n"
+            + "  # Actually generate completions.\n"
+            + "  local IFS=$'\\n'\n"
+            + "  echo -e \"$(compgen -W \"${optionList[*]}\" -- \"$curr_word\")\"\n"
+            + "}\n"
+            + "\n";
+
+    private static final String SCRIPT_FOOTER = ""
+            + "\n"
+            + "# Define a completion specification (a compspec) for the\n"
+            + "# `%1$s`, `%1$s.sh`, and `%1$s.bash` commands.\n"
+            + "# Uses the bash `complete` builtin to specify that shell function\n"
+            + "# `_complete_%1$s` is responsible for generating possible completions "
+            + "for the\n"
+            + "# current word on the command line.\n"
+            + "# The `-o default` option means that if the function generated no "
+            + "matches, the\n"
+            + "# default Bash completions and the Readline default filename "
+            + "completions are performed.\n"
+            + "complete -F _complete_%1$s -o default %1$s %1$s.sh %1$s.bash\n";
+}

--- a/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/CommandLine.java
+++ b/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/CommandLine.java
@@ -1,0 +1,784 @@
+package io.quarkus.quickcli;
+
+import io.quarkus.quickcli.model.CommandModel;
+import io.quarkus.quickcli.model.CommandModelRegistry;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+/**
+ * Main entry point for QuickCLI. Creates a command line parser from a
+ * pre-generated command model (no runtime annotation scanning).
+ *
+ * <p>Usage:</p>
+ * <pre>
+ * int exitCode = new CommandLine(MyCommand.class).execute(args);
+ * System.exit(exitCode);
+ * </pre>
+ */
+public final class CommandLine {
+
+    /** QuickCLI version string. */
+    public static final String VERSION = "1.0.0";
+
+    private final CommandSpec spec;
+    private final CommandModel model;
+    private final io.quarkus.quickcli.Factory factory;
+    private final Map<String, CommandLine> subcommands = new LinkedHashMap<>();
+    private PrintStream out = System.out;
+    private PrintStream err = System.err;
+    private PrintWriter outWriter;
+    private PrintWriter errWriter;
+    private ExecutionStrategy executionStrategy = new RunLastStrategy();
+    private ParameterExceptionHandler parameterExceptionHandler;
+    private ExitCodeExceptionMapper exitCodeExceptionMapper;
+    private final Map<String, HelpSectionRenderer> helpSectionMap = new LinkedHashMap<>();
+    private final Help.ColorScheme colorScheme = Help.ColorScheme.DEFAULT;
+    private ParseResult lastParseResult;
+
+    /**
+     * Creates a CommandLine with the default factory.
+     */
+    public CommandLine(Class<?> commandClass) {
+        this(commandClass, new io.quarkus.quickcli.Factory.DefaultFactory());
+    }
+
+    /**
+     * Creates a CommandLine with a custom factory.
+     */
+    public CommandLine(Class<?> commandClass, io.quarkus.quickcli.Factory factory) {
+        this.factory = factory;
+        this.model = CommandModelRegistry.getModel(commandClass);
+        this.spec = model.buildSpec();
+        this.spec.setCommandLine(this);
+        resolveSubcommandModels(this.spec);
+        buildSubcommandMap();
+    }
+
+    /**
+     * Creates a CommandLine from an existing command instance (for pre-created objects).
+     */
+    public CommandLine(Object commandInstance) {
+        this(commandInstance, new io.quarkus.quickcli.Factory.DefaultFactory());
+    }
+
+    /**
+     * Creates a CommandLine from an existing command instance with a custom factory.
+     * Initializes the instance's mixins, arg groups, and spec so that error handlers
+     * can access them even if parsing fails.
+     */
+    public CommandLine(Object commandInstance, io.quarkus.quickcli.Factory factory) {
+        this(commandInstance.getClass(), factory);
+        // Pre-initialize the instance so fields like @Mixin output are available
+        // to error handlers even when parsing fails
+        if (this.model != null) {
+            try {
+                this.model.initMixins(commandInstance, factory);
+                this.model.initArgGroups(commandInstance, factory);
+                this.model.injectSpec(commandInstance, this.spec);
+                this.spec.setCommandInstance(commandInstance);
+            } catch (Exception e) {
+                throw new RuntimeException("QuickCLI: failed to pre-initialize command " + commandInstance.getClass().getName(), e);
+            }
+        }
+    }
+
+    /**
+     * Creates a CommandLine from a pre-built CommandSpec (for dynamic commands
+     * like plugins that are not annotation-processed).
+     */
+    public CommandLine(CommandSpec spec) {
+        this(spec, new io.quarkus.quickcli.Factory.DefaultFactory());
+    }
+
+    /**
+     * Creates a CommandLine from a pre-built CommandSpec with a custom factory.
+     * Preserves the spec's existing parent chain (unlike the Class-based constructor
+     * which builds a new spec hierarchy).
+     */
+    public CommandLine(CommandSpec spec, io.quarkus.quickcli.Factory factory) {
+        this.factory = factory;
+        // For pre-built specs (e.g., plugin commands), the model may not exist.
+        // This is fine — the spec is already fully constructed.
+        CommandModel m = null;
+        try {
+            m = CommandModelRegistry.getModel(spec.commandClass());
+        } catch (IllegalStateException ignored) {
+            // No model for dynamic/plugin commands — that's expected
+        }
+        this.model = m;
+        this.spec = spec;
+        this.spec.setCommandLine(this);
+    }
+
+    /**
+     * Set the output stream for help and version output.
+     */
+    public CommandLine setOut(PrintStream out) {
+        this.out = out;
+        return this;
+    }
+
+    /**
+     * Set the error stream.
+     */
+    public CommandLine setErr(PrintStream err) {
+        this.err = err;
+        return this;
+    }
+
+    /** Get the output writer. */
+    public PrintWriter getOut() {
+        if (outWriter == null) {
+            outWriter = new PrintWriter(out, true);
+        }
+        return outWriter;
+    }
+
+    /** Get the error writer. */
+    public PrintWriter getErr() {
+        if (errWriter == null) {
+            errWriter = new PrintWriter(err, true);
+        }
+        return errWriter;
+    }
+
+    /** Get the color scheme. */
+    public Help.ColorScheme getColorScheme() {
+        return colorScheme;
+    }
+
+    /** Get the last parse result from execute() or parseArgs(). */
+    public ParseResult getParseResult() {
+        return lastParseResult;
+    }
+
+    /** Get unmatched arguments from the last parse. */
+    public List<String> getUnmatchedArguments() {
+        return lastParseResult != null ? lastParseResult.unmatched() : Collections.emptyList();
+    }
+
+    /**
+     * Set the execution strategy.
+     */
+    public CommandLine setExecutionStrategy(ExecutionStrategy strategy) {
+        this.executionStrategy = strategy;
+        return this;
+    }
+
+    /**
+     * Get the command specification.
+     */
+    public CommandSpec getCommandSpec() {
+        return spec;
+    }
+
+    /** Get the command name. */
+    public String getCommandName() {
+        return spec.name();
+    }
+
+    /** Get the subcommands map (name -> CommandLine). */
+    public Map<String, CommandLine> getSubcommands() {
+        return Collections.unmodifiableMap(subcommands);
+    }
+
+    /** Add a subcommand at runtime (e.g., for plugin systems). */
+    public CommandLine addSubcommand(String name, CommandLine subcommandLine) {
+        subcommands.put(name, subcommandLine);
+        spec.addSubcommand(name, subcommandLine.getCommandSpec());
+        return this;
+    }
+
+    /** Add a subcommand at runtime from a CommandSpec (e.g., for plugin systems). */
+    public CommandLine addSubcommand(String name, CommandSpec subSpec) {
+        CommandLine subCmdLine = new CommandLine(subSpec);
+        return addSubcommand(name, subCmdLine);
+    }
+
+    /** Get the help section map for customization. */
+    public Map<String, HelpSectionRenderer> getHelpSectionMap() {
+        return helpSectionMap;
+    }
+
+    /** Set the parameter exception handler. */
+    public CommandLine setParameterExceptionHandler(ParameterExceptionHandler handler) {
+        this.parameterExceptionHandler = handler;
+        return this;
+    }
+
+    /** Get the exit code exception mapper. */
+    public ExitCodeExceptionMapper getExitCodeExceptionMapper() {
+        return exitCodeExceptionMapper;
+    }
+
+    /** Set the exit code exception mapper. */
+    public CommandLine setExitCodeExceptionMapper(ExitCodeExceptionMapper mapper) {
+        this.exitCodeExceptionMapper = mapper;
+        return this;
+    }
+
+    /** Get a Help object for this command. */
+    public Help getHelp() {
+        return new Help(spec);
+    }
+
+    /** Print usage/help to the given output stream. */
+    public void usage(PrintStream out) {
+        HelpFormatter.printHelp(spec, out);
+    }
+
+    /** Print usage/help to the given writer. */
+    public void usage(PrintWriter out) {
+        HelpFormatter.printHelp(spec, out);
+    }
+
+    /**
+     * Parse and execute the command with the given arguments.
+     *
+     * @return exit code (0 for success)
+     */
+    public int execute(String... args) {
+        try {
+            ParseResult result = parse(args);
+            return executionStrategy.execute(result, this);
+        } catch (ParameterException e) {
+            if (parameterExceptionHandler != null) {
+                return parameterExceptionHandler.handleParseException(e, args);
+            }
+            err.println("Error: " + e.getMessage());
+            err.println("Try '" + spec.qualifiedName() + " --help' for more information.");
+            return ExitCode.USAGE;
+        } catch (ExecutionException e) {
+            err.println("Error executing command: " + e.getCause().getMessage());
+            return ExitCode.SOFTWARE;
+        } catch (Exception e) {
+            err.println("Unexpected error: " + e.getMessage());
+            return ExitCode.SOFTWARE;
+        }
+    }
+
+    /**
+     * Parse arguments without executing the command.
+     * Alias for {@link #parse(String...)} for picocli compatibility.
+     */
+    public ParseResult parseArgs(String... args) {
+        return parse(args);
+    }
+
+    /**
+     * Parse arguments without executing the command.
+     */
+    public ParseResult parse(String... args) {
+        ParseResult result = parseArgsInternal(spec, Arrays.asList(args), 0);
+        this.lastParseResult = result;
+        return result;
+    }
+
+    /**
+     * For negatable options, determine the value when the --no-xxx (negative) form is used.
+     * Picocli behavior: negate the effective default value.
+     * - defaultValue="false" → returns "true" (negate false)
+     * - defaultValue="true" or null → returns "false" (negate true, or standard negative)
+     */
+    private static String negatableValueForNegativeForm(OptionSpec option) {
+        String defaultValue = option.defaultValue();
+        if ("false".equals(defaultValue)) {
+            return "true"; // negate "false" → "true"
+        }
+        return "false"; // standard negative form
+    }
+
+    /**
+     * For negatable options, determine the value when the --xxx (positive) form is used.
+     * Picocli behavior: affirm the effective default value.
+     * - defaultValue="false" → returns "false" (affirm false)
+     * - defaultValue="true" or null → returns "true" (affirm true, or standard positive)
+     */
+    private static String negatableValueForPositiveForm(OptionSpec option) {
+        String defaultValue = option.defaultValue();
+        if ("false".equals(defaultValue)) {
+            return "false"; // affirm "false"
+        }
+        return "true"; // standard positive form
+    }
+
+    private ParseResult parseArgsInternal(CommandSpec currentSpec, List<String> args, int startIndex) {
+        ParseResult result = new ParseResult(currentSpec, args);
+        boolean endOfOptions = false;
+        boolean hasUnmatched = currentSpec.hasUnmatchedField();
+
+        for (int i = startIndex; i < args.size(); i++) {
+            String arg = args.get(i);
+
+            if ("--".equals(arg)) {
+                endOfOptions = true;
+                continue;
+            }
+
+            // Check for help/version flags (always handle -h/--help)
+            if (!endOfOptions) {
+                if ("-h".equals(arg) || "--help".equals(arg)) {
+                    result.setHelpRequested(true);
+                    return result;
+                }
+                if (currentSpec.mixinStandardHelpOptions()
+                        && ("-V".equals(arg) || "--version".equals(arg))) {
+                    result.setVersionRequested(true);
+                    return result;
+                }
+            }
+
+            // Check for usageHelp / versionHelp options
+            if (!endOfOptions) {
+                OptionSpec specialOption = currentSpec.findOption(arg);
+                if (specialOption != null && specialOption.isVersionHelp()) {
+                    result.setVersionRequested(true);
+                    result.addOptionValue(specialOption.longestName(), "true");
+                    return result;
+                }
+                if (specialOption != null && specialOption.isUsageHelp()) {
+                    result.setHelpRequested(true);
+                    result.addOptionValue(specialOption.longestName(), "true");
+                    return result;
+                }
+            }
+
+            // Check for subcommand
+            if (!endOfOptions && currentSpec.subcommands().containsKey(arg)) {
+                CommandSpec subSpec = currentSpec.subcommands().get(arg);
+                ParseResult subResult = parseArgsInternal(subSpec, args, i + 1);
+                result.setSubcommandResult(subResult);
+                // Store parse result on the subcommand's CommandLine
+                if (subSpec.commandLine() != null) {
+                    subSpec.commandLine().lastParseResult = subResult;
+                }
+                return result;
+            }
+
+            // Check for option
+            if (!endOfOptions && arg.startsWith("-")) {
+                String optionName = arg;
+                String inlineValue = null;
+
+                // Handle --option=value syntax
+                int eqIndex = arg.indexOf('=');
+                if (eqIndex > 0) {
+                    optionName = arg.substring(0, eqIndex);
+                    inlineValue = arg.substring(eqIndex + 1);
+                }
+
+                OptionSpec option = currentSpec.findOption(optionName);
+                // Try prefix matching for attached-value options (e.g., -Dkey=value)
+                if (option == null && optionName.length() > 2 && optionName.startsWith("-")
+                        && !optionName.startsWith("--")) {
+                    // Try the first two chars as the option name (e.g., "-D" from "-Dkey")
+                    String prefix = optionName.substring(0, 2);
+                    OptionSpec prefixOption = currentSpec.findOption(prefix);
+                    if (prefixOption != null && !prefixOption.isBoolean()) {
+                        option = prefixOption;
+                        // The rest of the original arg (after the prefix) is the value
+                        String attached = arg.substring(2);
+                        inlineValue = attached;
+                    }
+                }
+                // Try negatable option matching
+                boolean negated = false;
+                if (option == null && optionName.startsWith("--no-")) {
+                    // --no-foo → try --foo (negatable=true)
+                    String positiveForm = "--" + optionName.substring(5);
+                    OptionSpec negatableOption = currentSpec.findOption(positiveForm);
+                    if (negatableOption != null && negatableOption.isNegatable()) {
+                        option = negatableOption;
+                        negated = true;
+                        inlineValue = negatableValueForNegativeForm(negatableOption);
+                    }
+                }
+                if (option == null && optionName.startsWith("--") && !optionName.startsWith("--no-")) {
+                    // --foo → try --no-foo (negatable=true, positive form of negated option)
+                    String negativeForm = "--no-" + optionName.substring(2);
+                    OptionSpec negatableOption = currentSpec.findOption(negativeForm);
+                    if (negatableOption != null && negatableOption.isNegatable()) {
+                        option = negatableOption;
+                        negated = true;
+                        inlineValue = negatableValueForPositiveForm(negatableOption);
+                    }
+                }
+                if (option == null) {
+                    if (hasUnmatched) {
+                        result.addUnmatched(arg);
+                        continue;
+                    }
+                    throw new ParameterException(
+                            "Unknown option: '" + optionName + "'", this);
+                }
+
+                if (option.isBoolean() && !option.isVersionHelp()) {
+                    if (inlineValue != null) {
+                        result.addOptionValue(option.longestName(), inlineValue);
+                    } else if (option.isNegatable() && optionName.startsWith("--no-")) {
+                        // Negatable option with --no- prefix matched directly
+                        result.addOptionValue(option.longestName(), negatableValueForNegativeForm(option));
+                    } else {
+                        result.addOptionValue(option.longestName(), "true");
+                    }
+                } else {
+                    String value;
+                    if (inlineValue != null) {
+                        value = inlineValue;
+                    } else if (i + 1 < args.size()) {
+                        value = args.get(++i);
+                    } else {
+                        throw new ParameterException(
+                                "Option " + optionName + " requires a value", this);
+                    }
+                    result.addOptionValue(option.longestName(), value);
+                }
+            } else {
+                if (hasUnmatched && !endOfOptions) {
+                    // For commands with @Unmatched, non-option args may also be unmatched
+                    // But only if there are no positional parameters defined
+                    if (currentSpec.parameters().isEmpty()) {
+                        result.addUnmatched(arg);
+                    } else {
+                        result.addPositionalValue(arg);
+                    }
+                } else {
+                    // Positional parameter
+                    result.addPositionalValue(arg);
+                }
+            }
+        }
+
+        // Validate required options
+        for (OptionSpec option : currentSpec.options()) {
+            if (option.required() && !result.hasOptionBySpec(option)) {
+                throw new ParameterException(
+                        "Missing required option: " + option.longestName(), this);
+            }
+        }
+
+        // Validate exclusive groups
+        for (List<String> group : currentSpec.exclusiveGroups()) {
+            List<String> matched = new java.util.ArrayList<>();
+            for (String optName : group) {
+                if (result.hasOption(optName)) {
+                    matched.add(optName);
+                }
+            }
+            if (matched.size() > 1) {
+                throw new ParameterException(
+                        "Error: " + matched.get(0) + " and " + matched.get(1)
+                                + " are mutually exclusive (specify only one)", this);
+            }
+        }
+
+        return result;
+    }
+
+    private void resolveSubcommandModels(CommandSpec parentSpec) {
+        for (Map.Entry<String, CommandSpec> entry : parentSpec.subcommands().entrySet()) {
+            resolveSubcommandModels(entry.getValue());
+        }
+    }
+
+    private void buildSubcommandMap() {
+        buildSubcommandMapForSpec(this);
+    }
+
+    private void buildSubcommandMapForSpec(CommandLine parentCmdLine) {
+        for (Map.Entry<String, CommandSpec> entry : parentCmdLine.spec.subcommands().entrySet()) {
+            String subName = entry.getKey();
+            CommandSpec subSpec = entry.getValue();
+            // Wrap the existing spec (preserving parent chain) instead of building a new one
+            CommandLine subCmdLine = new CommandLine(subSpec, factory);
+            parentCmdLine.subcommands.put(subName, subCmdLine);
+            subSpec.setCommandLine(subCmdLine);
+            // Recurse into sub-subcommands
+            buildSubcommandMapForSpec(subCmdLine);
+        }
+    }
+
+    // --- Inner classes and interfaces ---
+
+    /**
+     * Strategy for executing parsed commands.
+     */
+    @FunctionalInterface
+    public interface ExecutionStrategy {
+        int execute(ParseResult parseResult, CommandLine commandLine) throws Exception;
+    }
+
+    /**
+     * Handler for parameter parsing exceptions.
+     */
+    @FunctionalInterface
+    public interface ParameterExceptionHandler {
+        int handleParseException(ParameterException ex, String[] args);
+    }
+
+    /**
+     * Renders a section of the help message.
+     */
+    @FunctionalInterface
+    public interface HelpSectionRenderer {
+        String render(Help help);
+    }
+
+    /**
+     * Maps exceptions to exit codes.
+     */
+    @FunctionalInterface
+    public interface ExitCodeExceptionMapper {
+        int getExitCode(Throwable exception);
+    }
+
+    /**
+     * Version provider interface (re-export for convenience).
+     */
+    public interface VersionProvider extends io.quarkus.quickcli.VersionProvider {
+    }
+
+    /**
+     * Factory interface (re-export for convenience).
+     */
+    public interface Factory extends io.quarkus.quickcli.Factory {
+    }
+
+    /**
+     * Default strategy: executes the last (most specific) subcommand.
+     */
+    public static class RunLastStrategy implements ExecutionStrategy {
+        @Override
+        public int execute(ParseResult parseResult, CommandLine commandLine) throws Exception {
+            // Walk to the deepest subcommand
+            ParseResult current = parseResult;
+            while (current.subcommandResult() != null) {
+                current = current.subcommandResult();
+            }
+
+            return executeCommand(current, parseResult, commandLine);
+        }
+
+        private int executeCommand(ParseResult target, ParseResult root,
+                                    CommandLine commandLine) throws Exception {
+            CommandSpec spec = target.commandSpec();
+
+            // Handle help
+            if (target.isHelpRequested()) {
+                HelpFormatter.printHelp(spec, commandLine.out);
+                return 0;
+            }
+
+            // Handle version
+            if (target.isVersionRequested()) {
+                String[] versionStrings = spec.version();
+                if (versionStrings.length == 0 && spec.versionProviderClass() != null
+                        && spec.versionProviderClass() != io.quarkus.quickcli.VersionProvider.NoVersionProvider.class) {
+                    try {
+                        @SuppressWarnings("unchecked")
+                        io.quarkus.quickcli.VersionProvider provider = (io.quarkus.quickcli.VersionProvider) commandLine.factory
+                                .create((Class<Object>) (Class<?>) spec.versionProviderClass());
+                        versionStrings = provider.getVersion();
+                    } catch (Exception e) {
+                        commandLine.err.println("Error getting version: " + e.getMessage());
+                    }
+                }
+                for (String v : versionStrings) {
+                    commandLine.out.println(v);
+                }
+                return 0;
+            }
+
+            // If this command has subcommands and none was selected, show help
+            if (!spec.subcommands().isEmpty() && target.subcommandResult() == null
+                    && !isExecutable(spec.commandClass())) {
+                HelpFormatter.printHelp(spec, commandLine.out);
+                return 0;
+            }
+
+            // Create and execute the command
+            CommandModel model = null;
+            try {
+                model = CommandModelRegistry.getModel(spec.commandClass());
+            } catch (IllegalStateException e) {
+                // Dynamic commands (plugins) may not have a generated model — that's OK
+            }
+
+            // Dynamic commands (plugins) may have a pre-set instance and no model
+            if (model == null) {
+                Object presetInstance = spec.commandInstance();
+                if (presetInstance != null) {
+                    // Pass unmatched args to the instance if it supports them
+                    List<String> unmatched = target.unmatched();
+                    if (!unmatched.isEmpty() && presetInstance instanceof UsesArguments ua) {
+                        ua.useArguments(unmatched);
+                    }
+                    return executeInstance(presetInstance);
+                }
+                throw new ExecutionException(
+                        new IllegalStateException("No model for " + spec.commandClass().getName()));
+            }
+
+            // Ensure the spec has a CommandLine reference (subcommand specs
+            // created during buildSpec() may not have one yet)
+            if (spec.commandLine() == null) {
+                spec.setCommandLine(commandLine);
+            }
+
+            // Reuse pre-initialized instance (set during constructor) or create new
+            Object instance = spec.commandInstance();
+            if (instance == null) {
+                instance = commandLine.factory.create(spec.commandClass());
+                model.initMixins(instance, commandLine.factory);
+                model.initArgGroups(instance, commandLine.factory);
+                model.injectSpec(instance, spec);
+            }
+
+            // Set parent command if applicable
+            setParentChain(instance, model, root, target, commandLine);
+
+            // Apply parsed values
+            model.applyValues(instance, target);
+
+            // Set @Unmatched field
+            List<String> unmatched = target.unmatched();
+            model.setUnmatched(instance, unmatched);
+
+            // Pass unmatched args to UsesArguments instances (e.g. plugin commands)
+            if (!unmatched.isEmpty() && instance instanceof UsesArguments ua) {
+                ua.useArguments(unmatched);
+            }
+
+            // Execute
+            return executeInstance(instance);
+        }
+
+        private void setParentChain(Object instance, CommandModel model,
+                                     ParseResult root, ParseResult target,
+                                     CommandLine commandLine) throws Exception {
+            if (root == target) return;
+
+            // Find the parent parse result
+            ParseResult parent = root;
+            ParseResult child = root;
+            while (child != null && child != target) {
+                parent = child;
+                child = child.subcommandResult();
+            }
+
+            if (parent != null) {
+                CommandModel parentModel = CommandModelRegistry.getModel(
+                        parent.commandSpec().commandClass());
+                Object parentInstance = commandLine.factory.create(
+                        parent.commandSpec().commandClass());
+                parentModel.initMixins(parentInstance, commandLine.factory);
+                parentModel.initArgGroups(parentInstance, commandLine.factory);
+                parentModel.applyValues(parentInstance, parent);
+                model.setParentCommand(instance, parentInstance);
+            }
+        }
+
+        private boolean isExecutable(Class<?> cls) {
+            return Runnable.class.isAssignableFrom(cls)
+                    || Callable.class.isAssignableFrom(cls);
+        }
+
+        private int executeInstance(Object instance) throws Exception {
+            if (instance instanceof Callable<?> callable) {
+                Object result = callable.call();
+                if (result instanceof Integer exitCode) {
+                    return exitCode;
+                }
+                return 0;
+            } else if (instance instanceof Runnable runnable) {
+                runnable.run();
+                return 0;
+            }
+            return 0;
+        }
+    }
+
+    /**
+     * Thrown when there's a problem with command-line parameters.
+     */
+    public static class ParameterException extends RuntimeException {
+        private CommandLine commandLine;
+
+        public ParameterException(String message) {
+            super(message);
+        }
+
+        public ParameterException(String message, CommandLine commandLine) {
+            super(message);
+            this.commandLine = commandLine;
+        }
+
+        public CommandLine getCommandLine() {
+            return commandLine;
+        }
+    }
+
+    /**
+     * Thrown when an unmatched argument is encountered (and no @Unmatched field exists).
+     */
+    public static class UnmatchedArgumentException extends ParameterException {
+        public UnmatchedArgumentException(String message) {
+            super(message);
+        }
+
+        public UnmatchedArgumentException(String message, CommandLine commandLine) {
+            super(message, commandLine);
+        }
+
+        /** Print suggestions for unmatched arguments. */
+        public static void printSuggestions(ParameterException ex, PrintStream stream) {
+            // Simple implementation — could be enhanced with fuzzy matching
+            if (ex.getCommandLine() != null) {
+                CommandSpec spec = ex.getCommandLine().getCommandSpec();
+                stream.println("Possible solutions:");
+                for (String name : spec.subcommands().keySet()) {
+                    stream.println("  " + name);
+                }
+            }
+        }
+    }
+
+    /**
+     * Thrown when mutually exclusive arguments are used together.
+     */
+    public static class MutuallyExclusiveArgsException extends ParameterException {
+        public MutuallyExclusiveArgsException(String message) {
+            super(message);
+        }
+
+        public MutuallyExclusiveArgsException(String message, CommandLine commandLine) {
+            super(message, commandLine);
+        }
+    }
+
+    /**
+     * Thrown for type conversion errors.
+     */
+    public static class TypeConversionException extends ParameterException {
+        public TypeConversionException(String message) {
+            super(message);
+        }
+    }
+
+    /**
+     * Thrown when there's a problem executing a command.
+     */
+    public static class ExecutionException extends RuntimeException {
+        public ExecutionException(Throwable cause) {
+            super(cause);
+        }
+    }
+}

--- a/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/CommandSpec.java
+++ b/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/CommandSpec.java
@@ -1,0 +1,266 @@
+package io.quarkus.quickcli;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Complete specification of a command, built at compile time by the annotation processor.
+ * Contains all metadata needed to parse arguments and generate help without reflection.
+ */
+public final class CommandSpec {
+
+    private final String name;
+    private final String[] description;
+    private final String[] version;
+    private final boolean mixinStandardHelpOptions;
+    private final String[] header;
+    private final String[] footer;
+    private final Class<?> commandClass;
+
+    private final List<OptionSpec> options = new ArrayList<>();
+    private final List<ParameterSpec> parameters = new ArrayList<>();
+    private final Map<String, CommandSpec> subcommands = new LinkedHashMap<>();
+    private CommandSpec parent;
+    private CommandLine commandLine;
+    private final UsageMessageSpec usageMessage = new UsageMessageSpec();
+    private String[] aliases = {};
+    private boolean hasUnmatchedField;
+    private boolean hasSpecField;
+    private Object commandInstance;
+    private ScopeType scope = ScopeType.LOCAL;
+    private Class<? extends VersionProvider> versionProviderClass;
+    private final List<List<String>> exclusiveGroups = new ArrayList<>();
+
+    public CommandSpec(String name, String[] description, String[] version,
+                       boolean mixinStandardHelpOptions, String[] header,
+                       String[] footer, Class<?> commandClass) {
+        this.name = name;
+        this.description = description;
+        this.version = version;
+        this.mixinStandardHelpOptions = mixinStandardHelpOptions;
+        this.header = header;
+        this.footer = footer;
+        this.commandClass = commandClass;
+        // Sync with usage message
+        usageMessage.header(header);
+        usageMessage.description(description);
+        usageMessage.footer(footer);
+    }
+
+    /**
+     * Creates a bare CommandSpec for programmatic/dynamic command creation.
+     * Used for plugin commands that are not annotation-processed.
+     */
+    public static CommandSpec create(String name, Class<?> commandClass) {
+        return new CommandSpec(name, new String[0], new String[0], false,
+                new String[0], new String[0], commandClass);
+    }
+
+    /** Get the pre-created command instance (for dynamic commands). */
+    public Object commandInstance() {
+        return commandInstance;
+    }
+
+    /** Set a pre-created command instance (for dynamic commands). */
+    public void setCommandInstance(Object instance) {
+        this.commandInstance = instance;
+    }
+
+    /** Returns the user object (command instance) associated with this spec.
+     *  Picocli-compatible alias for commandInstance(). */
+    public Object userObject() {
+        return commandInstance;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    /** Returns all names: the primary name followed by aliases. */
+    public String[] names() {
+        if (aliases.length == 0) {
+            return new String[] { name };
+        }
+        String[] result = new String[1 + aliases.length];
+        result[0] = name;
+        System.arraycopy(aliases, 0, result, 1, aliases.length);
+        return result;
+    }
+
+    public String[] description() {
+        return description;
+    }
+
+    public String[] version() {
+        return version;
+    }
+
+    public boolean mixinStandardHelpOptions() {
+        return mixinStandardHelpOptions;
+    }
+
+    public String[] header() {
+        return header;
+    }
+
+    public String[] footer() {
+        return footer;
+    }
+
+    public Class<?> commandClass() {
+        return commandClass;
+    }
+
+    public void addOption(OptionSpec option) {
+        options.add(option);
+    }
+
+    public List<OptionSpec> options() {
+        return Collections.unmodifiableList(options);
+    }
+
+    public void addParameter(ParameterSpec parameter) {
+        parameters.add(parameter);
+    }
+
+    public List<ParameterSpec> parameters() {
+        return Collections.unmodifiableList(parameters);
+    }
+
+    public void addSubcommand(String name, CommandSpec subcommand) {
+        subcommand.parent = this;
+        subcommands.put(name, subcommand);
+        propagateInheritedOptions(subcommand);
+    }
+
+    private void propagateInheritedOptions(CommandSpec subcommand) {
+        CommandSpec current = this;
+        while (current != null) {
+            if (current.scope == ScopeType.INHERIT) {
+                for (OptionSpec parentOption : current.options) {
+                    if (subcommand.findOption(parentOption.longestName()) == null) {
+                        subcommand.addOption(parentOption);
+                    }
+                }
+                if (current.hasUnmatchedField && !subcommand.hasUnmatchedField) {
+                    subcommand.setHasUnmatchedField(true);
+                }
+            }
+            current = current.parent;
+        }
+        for (CommandSpec subSub : subcommand.subcommands.values()) {
+            propagateInheritedOptions(subSub);
+        }
+    }
+
+    public Map<String, CommandSpec> subcommands() {
+        return subcommands; // mutable for runtime additions
+    }
+
+    public CommandSpec parent() {
+        return parent;
+    }
+
+    /** Returns the root CommandSpec of the command hierarchy. */
+    public CommandSpec root() {
+        CommandSpec current = this;
+        while (current.parent != null) {
+            current = current.parent;
+        }
+        return current;
+    }
+
+    /** Get the CommandLine that owns this spec. */
+    public CommandLine commandLine() {
+        return commandLine;
+    }
+
+    /** Set the CommandLine that owns this spec. */
+    public void setCommandLine(CommandLine commandLine) {
+        this.commandLine = commandLine;
+    }
+
+    /** Get the usage message spec for help formatting. */
+    public UsageMessageSpec usageMessage() {
+        return usageMessage;
+    }
+
+    /** Exit code when help is requested (default 0). */
+    public int exitCodeOnUsageHelp() {
+        return 0;
+    }
+
+    /** Exit code when invalid input is provided (default 2). */
+    public int exitCodeOnInvalidInput() {
+        return 2;
+    }
+
+    /** Find an option by any of its names. */
+    public OptionSpec findOption(String name) {
+        for (OptionSpec option : options) {
+            if (option.matches(name)) {
+                return option;
+            }
+        }
+        return null;
+    }
+
+    /** Get the full command name including parent chain (e.g., "app sub-cmd"). */
+    public String qualifiedName() {
+        if (parent != null) {
+            return parent.qualifiedName() + " " + name;
+        }
+        return name;
+    }
+
+    public String[] aliases() {
+        return aliases;
+    }
+
+    public void setAliases(String... aliases) {
+        this.aliases = aliases;
+    }
+
+    public boolean hasUnmatchedField() {
+        return hasUnmatchedField;
+    }
+
+    public void setHasUnmatchedField(boolean hasUnmatchedField) {
+        this.hasUnmatchedField = hasUnmatchedField;
+    }
+
+    public boolean hasSpecField() {
+        return hasSpecField;
+    }
+
+    public void setHasSpecField(boolean hasSpecField) {
+        this.hasSpecField = hasSpecField;
+    }
+
+    public ScopeType scope() {
+        return scope;
+    }
+
+    public void setScope(ScopeType scope) {
+        this.scope = scope;
+    }
+
+    public void addExclusiveGroup(List<String> optionNames) {
+        exclusiveGroups.add(optionNames);
+    }
+
+    public List<List<String>> exclusiveGroups() {
+        return exclusiveGroups;
+    }
+
+    public Class<? extends VersionProvider> versionProviderClass() {
+        return versionProviderClass;
+    }
+
+    public void setVersionProviderClass(Class<? extends VersionProvider> versionProviderClass) {
+        this.versionProviderClass = versionProviderClass;
+    }
+}

--- a/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/ExitCode.java
+++ b/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/ExitCode.java
@@ -1,0 +1,16 @@
+package io.quarkus.quickcli;
+
+/**
+ * Standard exit codes for CLI applications.
+ */
+public final class ExitCode {
+    /** Successful execution. */
+    public static final int OK = 0;
+    /** Execution error in user code. */
+    public static final int SOFTWARE = 1;
+    /** Invalid command-line usage (bad options, missing arguments). */
+    public static final int USAGE = 2;
+
+    private ExitCode() {
+    }
+}

--- a/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/Factory.java
+++ b/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/Factory.java
@@ -1,0 +1,49 @@
+package io.quarkus.quickcli;
+
+import java.util.function.Supplier;
+
+import io.quarkus.quickcli.model.CommandModel;
+import io.quarkus.quickcli.model.CommandModelRegistry;
+
+/**
+ * Factory for creating command instances. Allows integration with dependency injection frameworks.
+ */
+public interface Factory {
+
+    /**
+     * Creates an instance of the specified class.
+     *
+     * @param cls the class to instantiate
+     * @return the new instance
+     * @throws Exception if instantiation fails
+     */
+    <T> T create(Class<T> cls) throws Exception;
+
+    /**
+     * Default factory that delegates to the generated {@link CommandModel#createInstance()}
+     * or a build-time registered instance creator. No reflection is used.
+     */
+    class DefaultFactory implements Factory {
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T create(Class<T> cls) throws Exception {
+            try {
+                CommandModel model = CommandModelRegistry.getModel(cls);
+                if (model != null) {
+                    return (T) model.createInstance();
+                }
+            } catch (IllegalStateException e) {
+                // Not a @Command class — fall through to instance creator lookup
+            }
+            // No CommandModel — this is a mixin or other non-@Command class.
+            // Use the build-time generated instance creator.
+            Supplier<Object> creator = CommandModelRegistry.getInstanceCreator(cls);
+            if (creator != null) {
+                return (T) creator.get();
+            }
+            throw new IllegalStateException(
+                    "No build-time generated instance creator for " + cls.getName()
+                            + ". Ensure the class is discovered during the Quarkus build.");
+        }
+    }
+}

--- a/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/Help.java
+++ b/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/Help.java
@@ -1,0 +1,182 @@
+package io.quarkus.quickcli;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Provides help rendering for commands. Supports customizable column layouts
+ * and hierarchical subcommand display.
+ */
+public final class Help {
+
+    private final CommandSpec spec;
+    private final ColorScheme colorScheme;
+
+    public Help(CommandSpec spec) {
+        this(spec, ColorScheme.DEFAULT);
+    }
+
+    public Help(CommandSpec spec, ColorScheme colorScheme) {
+        this.spec = spec;
+        this.colorScheme = colorScheme;
+    }
+
+    public CommandSpec commandSpec() {
+        return spec;
+    }
+
+    public ColorScheme colorScheme() {
+        return colorScheme;
+    }
+
+    /** Returns the full synopsis (usage line) for this command. */
+    public String fullSynopsis() {
+        StringBuilder sb = new StringBuilder();
+        UsageMessageSpec usage = spec.usageMessage();
+        sb.append(formatHeading(usage.synopsisHeading()));
+        sb.append(spec.qualifiedName());
+        if (!spec.options().isEmpty()) {
+            sb.append(" [OPTIONS]");
+        }
+        if (!spec.subcommands().isEmpty()) {
+            sb.append(" [COMMAND]");
+        }
+        for (ParameterSpec param : spec.parameters()) {
+            if (!param.hidden()) {
+                String label = param.paramLabel().isEmpty()
+                        ? "<" + param.fieldName() + ">"
+                        : param.paramLabel();
+                sb.append(" ").append(label);
+            }
+        }
+        sb.append(System.lineSeparator());
+        return sb.toString();
+    }
+
+    /** Returns formatted command list section. */
+    public String commandList() {
+        if (spec.subcommands().isEmpty()) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder();
+        UsageMessageSpec usage = spec.usageMessage();
+        sb.append(formatHeading(usage.commandListHeading()));
+        for (Map.Entry<String, CommandSpec> entry : spec.subcommands().entrySet()) {
+            CommandSpec sub = entry.getValue();
+            String desc = sub.description().length > 0 ? sub.description()[0] : "";
+            sb.append(String.format("  %-22s %s%n", entry.getKey(), desc));
+        }
+        return sb.toString();
+    }
+
+    /** Format a heading string, replacing %n with newlines. */
+    static String formatHeading(String heading) {
+        if (heading == null || heading.isEmpty()) {
+            return "";
+        }
+        return heading.replace("%n", System.lineSeparator());
+    }
+
+    // --- Column and TextTable ---
+
+    /** Defines a column in a text table. */
+    public static class Column {
+        public final int width;
+        public final int indent;
+        public final Overflow overflow;
+
+        public Column(int width, int indent, Overflow overflow) {
+            this.width = width;
+            this.indent = indent;
+            this.overflow = overflow;
+        }
+
+        public enum Overflow {
+            SPAN, WRAP, TRUNCATE
+        }
+    }
+
+    /** A simple text table for rendering aligned columns. */
+    public static class TextTable {
+        private final List<String[]> rows = new ArrayList<>();
+        private final Column[] columns;
+        private boolean adjustLineBreaksForWideCJKCharacters;
+
+        private TextTable(Column... columns) {
+            this.columns = columns;
+        }
+
+        public static TextTable forColumns(ColorScheme colorScheme, Column... columns) {
+            return new TextTable(columns);
+        }
+
+        public void setAdjustLineBreaksForWideCJKCharacters(boolean adjust) {
+            this.adjustLineBreaksForWideCJKCharacters = adjust;
+        }
+
+        public void addRowValues(String... values) {
+            rows.add(values);
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            for (String[] row : rows) {
+                StringBuilder line = new StringBuilder();
+                for (int i = 0; i < columns.length && i < row.length; i++) {
+                    String value = row[i] != null ? row[i] : "";
+                    Column col = columns[i];
+                    String indent = " ".repeat(col.indent);
+                    if (i == 0) {
+                        line.append(indent).append(value);
+                        int padding = col.width - indent.length() - value.length();
+                        if (padding > 0) {
+                            line.append(" ".repeat(padding));
+                        } else if (i + 1 < columns.length) {
+                            line.append(System.lineSeparator());
+                            line.append(" ".repeat(col.width));
+                        }
+                    } else {
+                        line.append(indent).append(value);
+                    }
+                }
+                sb.append(line.toString().stripTrailing()).append(System.lineSeparator());
+            }
+            return sb.toString();
+        }
+    }
+
+    /** Color scheme for help output. Provides picocli-compatible API. */
+    public static class ColorScheme {
+        public static final ColorScheme DEFAULT = new ColorScheme();
+
+        public Ansi ansi() {
+            return Ansi.AUTO;
+        }
+
+        /** Returns plain text with markup stripped. */
+        public String errorText(String text) {
+            return Ansi.Text.stripAnsiMarkup(text);
+        }
+
+        /** Returns a plain-text rendering of a stack trace. */
+        public String stackTraceText(Exception ex) {
+            java.io.StringWriter sw = new java.io.StringWriter();
+            ex.printStackTrace(new java.io.PrintWriter(sw));
+            return sw.toString();
+        }
+    }
+
+    /** Creates a formatted text table from a map (key-value pairs). */
+    public String createTextTable(java.util.Map<String, String> map) {
+        StringBuilder sb = new StringBuilder();
+        for (java.util.Map.Entry<String, String> entry : map.entrySet()) {
+            sb.append(String.format("  %-22s %s%n", entry.getKey(), entry.getValue()));
+        }
+        return sb.toString();
+    }
+}

--- a/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/HelpFormatter.java
+++ b/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/HelpFormatter.java
@@ -1,0 +1,170 @@
+package io.quarkus.quickcli;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.util.Map;
+
+/**
+ * Formats and prints help messages for commands.
+ */
+public final class HelpFormatter {
+
+    private static final int OPTION_COLUMN_WIDTH = 30;
+
+    private HelpFormatter() {
+    }
+
+    /**
+     * Print help for the given command spec to the output stream.
+     */
+    public static void printHelp(CommandSpec spec, PrintStream out) {
+        out.print(buildHelp(spec));
+        out.flush();
+    }
+
+    /**
+     * Print help for the given command spec to the writer.
+     */
+    public static void printHelp(CommandSpec spec, PrintWriter out) {
+        out.print(buildHelp(spec));
+        out.flush();
+    }
+
+    /**
+     * Build the help text for the given command spec.
+     */
+    public static String buildHelp(CommandSpec spec) {
+        StringBuilder out = new StringBuilder();
+
+        // Header
+        for (String line : spec.header()) {
+            out.append(line).append('\n');
+        }
+
+        // Usage line
+        out.append("Usage: ").append(spec.qualifiedName());
+        if (!spec.options().isEmpty()) {
+            out.append(" [OPTIONS]");
+        }
+        if (!spec.subcommands().isEmpty()) {
+            out.append(" [COMMAND]");
+        }
+        for (ParameterSpec param : spec.parameters()) {
+            if (!param.hidden()) {
+                String label = param.paramLabel().isEmpty()
+                        ? "<" + param.fieldName() + ">"
+                        : param.paramLabel();
+                out.append(' ').append(label);
+            }
+        }
+        out.append('\n');
+
+        // Description
+        if (spec.description().length > 0) {
+            out.append('\n');
+            for (String line : spec.description()) {
+                out.append("  ").append(line).append('\n');
+            }
+        }
+
+        // Parameters
+        boolean hasVisibleParams = spec.parameters().stream().anyMatch(p -> !p.hidden());
+        if (hasVisibleParams) {
+            out.append('\n');
+            out.append("Parameters:\n");
+            for (ParameterSpec param : spec.parameters()) {
+                if (param.hidden())
+                    continue;
+                String label = param.paramLabel().isEmpty()
+                        ? "<" + param.fieldName() + ">"
+                        : param.paramLabel();
+                appendDescriptionColumn(out, "  " + label, param.description());
+            }
+        }
+
+        // Options
+        boolean hasVisibleOptions = spec.options().stream().anyMatch(o -> !o.hidden());
+        if (hasVisibleOptions || spec.mixinStandardHelpOptions()) {
+            out.append('\n');
+            out.append("Options:\n");
+            for (OptionSpec option : spec.options()) {
+                if (option.hidden())
+                    continue;
+                appendOption(out, option);
+            }
+            if (spec.mixinStandardHelpOptions()) {
+                appendDescriptionColumn(out, "  -h, --help", "Show this help message and exit.");
+                appendDescriptionColumn(out, "  -V, --version", "Print version information and exit.");
+            }
+        }
+
+        // Subcommands
+        if (!spec.subcommands().isEmpty()) {
+            out.append('\n');
+            out.append("Commands:\n");
+            for (Map.Entry<String, CommandSpec> entry : spec.subcommands().entrySet()) {
+                CommandSpec sub = entry.getValue();
+                String desc = sub.description().length > 0 ? sub.description()[0] : "";
+                appendDescriptionColumn(out, "  " + entry.getKey(), desc);
+            }
+        }
+
+        // Footer
+        if (spec.footer().length > 0) {
+            out.append('\n');
+            for (String line : spec.footer()) {
+                out.append(line).append('\n');
+            }
+        }
+
+        return out.toString();
+    }
+
+    private static void appendOption(StringBuilder out, OptionSpec option) {
+        StringBuilder names = new StringBuilder("  ");
+        String shortName = null;
+        String longName = null;
+
+        for (String name : option.names()) {
+            if (name.startsWith("--")) {
+                longName = name;
+            } else {
+                shortName = name;
+            }
+        }
+
+        if (shortName != null) {
+            names.append(shortName);
+            if (longName != null) {
+                names.append(", ").append(longName);
+            }
+        } else if (longName != null) {
+            names.append("    ").append(longName);
+        }
+
+        if (!option.isBoolean()) {
+            String label = option.paramLabel().isEmpty()
+                    ? option.type().getSimpleName().toUpperCase()
+                    : option.paramLabel();
+            names.append("=<").append(label).append(">");
+        }
+
+        appendDescriptionColumn(out, names.toString(), option.description());
+    }
+
+    private static void appendDescriptionColumn(StringBuilder out, String left, String description) {
+        if (left.length() >= OPTION_COLUMN_WIDTH) {
+            out.append(left).append('\n');
+            if (!description.isEmpty()) {
+                out.append(" ".repeat(OPTION_COLUMN_WIDTH)).append(description).append('\n');
+            }
+        } else {
+            out.append(left);
+            if (!description.isEmpty()) {
+                out.append(" ".repeat(OPTION_COLUMN_WIDTH - left.length()));
+                out.append(description);
+            }
+            out.append('\n');
+        }
+    }
+}

--- a/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/OptionSpec.java
+++ b/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/OptionSpec.java
@@ -1,0 +1,147 @@
+package io.quarkus.quickcli;
+
+/**
+ * Metadata for a command-line option, built at compile time.
+ */
+public final class OptionSpec {
+
+    private final String[] names;
+    private final String description;
+    private final Class<?> type;
+    private final boolean required;
+    private final String defaultValue;
+    private final String arity;
+    private final boolean hidden;
+    private final String paramLabel;
+    private final String fieldName;
+    private final boolean isBoolean;
+    private final boolean versionHelp;
+    private final boolean usageHelp;
+    private final boolean negatable;
+    private final int order;
+    private Object value; // stores the matched value for matchedOption() access
+
+    public OptionSpec(String[] names, String description, Class<?> type,
+                      boolean required, String defaultValue, String arity,
+                      boolean hidden, String paramLabel, String fieldName) {
+        this(names, description, type, required, defaultValue, arity,
+                hidden, paramLabel, fieldName, false, -1);
+    }
+
+    public OptionSpec(String[] names, String description, Class<?> type,
+                      boolean required, String defaultValue, String arity,
+                      boolean hidden, String paramLabel, String fieldName,
+                      boolean versionHelp, int order) {
+        this(names, description, type, required, defaultValue, arity,
+                hidden, paramLabel, fieldName, versionHelp, false, false, order);
+    }
+
+    public OptionSpec(String[] names, String description, Class<?> type,
+                      boolean required, String defaultValue, String arity,
+                      boolean hidden, String paramLabel, String fieldName,
+                      boolean versionHelp, boolean usageHelp, boolean negatable,
+                      int order) {
+        this.names = names;
+        this.description = description;
+        this.type = type;
+        this.required = required;
+        this.defaultValue = defaultValue;
+        this.arity = arity;
+        this.hidden = hidden;
+        this.paramLabel = paramLabel;
+        this.fieldName = fieldName;
+        this.isBoolean = TypeConverter.isBooleanType(type);
+        this.versionHelp = versionHelp;
+        this.usageHelp = usageHelp;
+        this.negatable = negatable;
+        this.order = order;
+    }
+
+    public String[] names() {
+        return names;
+    }
+
+    /** Returns the longest name (typically the --long-form). */
+    public String longestName() {
+        String longest = names[0];
+        for (String name : names) {
+            if (name.length() > longest.length()) {
+                longest = name;
+            }
+        }
+        return longest;
+    }
+
+    public String description() {
+        return description;
+    }
+
+    public Class<?> type() {
+        return type;
+    }
+
+    public boolean required() {
+        return required;
+    }
+
+    public String defaultValue() {
+        return defaultValue;
+    }
+
+    public String arity() {
+        return arity;
+    }
+
+    public boolean hidden() {
+        return hidden;
+    }
+
+    public String paramLabel() {
+        return paramLabel;
+    }
+
+    public String fieldName() {
+        return fieldName;
+    }
+
+    public boolean isBoolean() {
+        return isBoolean;
+    }
+
+    public boolean isVersionHelp() {
+        return versionHelp;
+    }
+
+    public boolean isUsageHelp() {
+        return usageHelp;
+    }
+
+    public boolean isNegatable() {
+        return negatable;
+    }
+
+    public int order() {
+        return order;
+    }
+
+    /** Get the matched value (set during parsing). */
+    @SuppressWarnings("unchecked")
+    public <T> T getValue() {
+        return (T) value;
+    }
+
+    /** Set the matched value. */
+    public void setValue(Object value) {
+        this.value = value;
+    }
+
+    /** Check if the given argument matches any of this option's names. */
+    public boolean matches(String arg) {
+        for (String name : names) {
+            if (name.equals(arg)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/ParameterSpec.java
+++ b/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/ParameterSpec.java
@@ -1,0 +1,67 @@
+package io.quarkus.quickcli;
+
+/**
+ * Metadata for a positional parameter, built at compile time.
+ */
+public final class ParameterSpec {
+
+    private final int index;
+    private final String description;
+    private final Class<?> type;
+    private final String defaultValue;
+    private final String arity;
+    private final boolean hidden;
+    private final String paramLabel;
+    private final String fieldName;
+    private final boolean isMultiValue;
+
+    public ParameterSpec(int index, String description, Class<?> type,
+                         String defaultValue, String arity, boolean hidden,
+                         String paramLabel, String fieldName, boolean isMultiValue) {
+        this.index = index;
+        this.description = description;
+        this.type = type;
+        this.defaultValue = defaultValue;
+        this.arity = arity;
+        this.hidden = hidden;
+        this.paramLabel = paramLabel;
+        this.fieldName = fieldName;
+        this.isMultiValue = isMultiValue;
+    }
+
+    public int index() {
+        return index;
+    }
+
+    public String description() {
+        return description;
+    }
+
+    public Class<?> type() {
+        return type;
+    }
+
+    public String defaultValue() {
+        return defaultValue;
+    }
+
+    public String arity() {
+        return arity;
+    }
+
+    public boolean hidden() {
+        return hidden;
+    }
+
+    public String paramLabel() {
+        return paramLabel;
+    }
+
+    public String fieldName() {
+        return fieldName;
+    }
+
+    public boolean isMultiValue() {
+        return isMultiValue;
+    }
+}

--- a/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/ParseResult.java
+++ b/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/ParseResult.java
@@ -1,0 +1,136 @@
+package io.quarkus.quickcli;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Result of parsing command-line arguments. Contains matched options, parameters,
+ * unmatched arguments, and any subcommand parse results.
+ */
+public final class ParseResult {
+
+    private final CommandSpec commandSpec;
+    private final Map<String, List<String>> optionValues = new LinkedHashMap<>();
+    private final List<String> positionalValues = new ArrayList<>();
+    private final List<String> unmatchedArgs = new ArrayList<>();
+    private ParseResult subcommandResult;
+    private boolean helpRequested;
+    private boolean versionRequested;
+    private final List<String> originalArgs;
+
+    public ParseResult(CommandSpec commandSpec, List<String> originalArgs) {
+        this.commandSpec = commandSpec;
+        this.originalArgs = originalArgs;
+    }
+
+    public CommandSpec commandSpec() {
+        return commandSpec;
+    }
+
+    public void addOptionValue(String name, String value) {
+        optionValues.computeIfAbsent(name, k -> new ArrayList<>()).add(value);
+    }
+
+    public boolean hasOption(String name) {
+        return optionValues.containsKey(name);
+    }
+
+    public String getOptionValue(String name) {
+        List<String> values = optionValues.get(name);
+        return values != null && !values.isEmpty() ? values.get(0) : null;
+    }
+
+    public List<String> getOptionValues(String name) {
+        return optionValues.getOrDefault(name, List.of());
+    }
+
+    /** Returns the matched option value for the given option name (checking all aliases). */
+    public OptionSpec matchedOption(String name) {
+        // Find the OptionSpec that matches this name
+        for (OptionSpec option : commandSpec.options()) {
+            if (option.matches(name) || option.matches("--" + name)) {
+                if (hasOptionBySpec(option)) {
+                    return option;
+                }
+            }
+        }
+        return null;
+    }
+
+    public void addPositionalValue(String value) {
+        positionalValues.add(value);
+    }
+
+    public List<String> positionalValues() {
+        return positionalValues;
+    }
+
+    public String getPositionalValue(int index) {
+        return index < positionalValues.size() ? positionalValues.get(index) : null;
+    }
+
+    /** Returns the subcommand parse result (picocli-compatible alias for subcommandResult). */
+    public ParseResult subcommand() {
+        return subcommandResult;
+    }
+
+    public ParseResult subcommandResult() {
+        return subcommandResult;
+    }
+
+    public void setSubcommandResult(ParseResult subcommandResult) {
+        this.subcommandResult = subcommandResult;
+    }
+
+    public boolean isHelpRequested() {
+        return helpRequested;
+    }
+
+    public void setHelpRequested(boolean helpRequested) {
+        this.helpRequested = helpRequested;
+    }
+
+    public boolean isVersionRequested() {
+        return versionRequested;
+    }
+
+    public void setVersionRequested(boolean versionRequested) {
+        this.versionRequested = versionRequested;
+    }
+
+    public List<String> originalArgs() {
+        return originalArgs;
+    }
+
+    /** Returns unmatched arguments (only populated when @Unmatched is present). */
+    public List<String> unmatched() {
+        return unmatchedArgs;
+    }
+
+    public void addUnmatched(String arg) {
+        unmatchedArgs.add(arg);
+    }
+
+    /** Find the option value, checking all known aliases for the option. */
+    public String resolveOptionValue(OptionSpec option) {
+        for (String name : option.names()) {
+            String value = getOptionValue(name);
+            if (value != null) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    /** Check if any alias for the given option was specified. */
+    public boolean hasOptionBySpec(OptionSpec option) {
+        for (String name : option.names()) {
+            if (hasOption(name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/ScopeType.java
+++ b/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/ScopeType.java
@@ -1,0 +1,11 @@
+package io.quarkus.quickcli;
+
+/**
+ * Determines the scope of options defined in a command.
+ */
+public enum ScopeType {
+    /** Options apply only to the command where they are defined. */
+    LOCAL,
+    /** Options are inherited by all subcommands. */
+    INHERIT
+}

--- a/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/TypeConverter.java
+++ b/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/TypeConverter.java
@@ -1,0 +1,130 @@
+package io.quarkus.quickcli;
+
+import java.io.File;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Converts string arguments to typed values. Supports common Java types out of the box.
+ */
+public final class TypeConverter {
+
+    private static final Map<Class<?>, Function<String, Object>> CONVERTERS = new HashMap<>();
+
+    static {
+        // Primitives and wrappers
+        CONVERTERS.put(String.class, s -> s);
+        CONVERTERS.put(int.class, Integer::parseInt);
+        CONVERTERS.put(Integer.class, Integer::valueOf);
+        CONVERTERS.put(long.class, Long::parseLong);
+        CONVERTERS.put(Long.class, Long::valueOf);
+        CONVERTERS.put(short.class, Short::parseShort);
+        CONVERTERS.put(Short.class, Short::valueOf);
+        CONVERTERS.put(byte.class, Byte::parseByte);
+        CONVERTERS.put(Byte.class, Byte::valueOf);
+        CONVERTERS.put(float.class, Float::parseFloat);
+        CONVERTERS.put(Float.class, Float::valueOf);
+        CONVERTERS.put(double.class, Double::parseDouble);
+        CONVERTERS.put(Double.class, Double::valueOf);
+        CONVERTERS.put(boolean.class, TypeConverter::parseBoolean);
+        CONVERTERS.put(Boolean.class, TypeConverter::parseBoolean);
+        CONVERTERS.put(char.class, s -> s.charAt(0));
+        CONVERTERS.put(Character.class, s -> s.charAt(0));
+
+        // Common types
+        CONVERTERS.put(File.class, File::new);
+        CONVERTERS.put(Path.class, Path::of);
+        CONVERTERS.put(BigDecimal.class, BigDecimal::new);
+        CONVERTERS.put(BigInteger.class, BigInteger::new);
+        CONVERTERS.put(URI.class, URI::create);
+    }
+
+    private static final Map<Class<?>, Function<String, Object>> CUSTOM_CONVERTERS = new HashMap<>();
+
+    private TypeConverter() {
+    }
+
+    /**
+     * Register a custom converter for a type.
+     */
+    public static <T> void register(Class<T> type, Function<String, T> converter) {
+        @SuppressWarnings("unchecked")
+        Function<String, Object> fn = (Function<String, Object>) (Function<String, ?>) converter;
+        CUSTOM_CONVERTERS.put(type, fn);
+    }
+
+    /**
+     * Convert a string value to the target type.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T convert(String value, Class<T> targetType) {
+        if (value == null) {
+            return null;
+        }
+
+        // Check custom converters first
+        Function<String, Object> custom = CUSTOM_CONVERTERS.get(targetType);
+        if (custom != null) {
+            return (T) custom.apply(value);
+        }
+
+        // Built-in converters
+        Function<String, Object> converter = CONVERTERS.get(targetType);
+        if (converter != null) {
+            return (T) converter.apply(value);
+        }
+
+        // Enum types
+        if (targetType.isEnum()) {
+            @SuppressWarnings("rawtypes")
+            Class<? extends Enum> enumType = (Class<? extends Enum>) targetType;
+            return (T) Enum.valueOf(enumType, value);
+        }
+
+        // InetAddress
+        if (InetAddress.class.isAssignableFrom(targetType)) {
+            try {
+                return (T) InetAddress.getByName(value);
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Cannot resolve address: " + value, e);
+            }
+        }
+
+        throw new IllegalArgumentException(
+                "No converter registered for type: " + targetType.getName()
+                        + ". Register one via TypeConverter.register()");
+    }
+
+    /**
+     * Check if a type has a known converter.
+     */
+    public static boolean hasConverter(Class<?> type) {
+        return CONVERTERS.containsKey(type)
+                || CUSTOM_CONVERTERS.containsKey(type)
+                || type.isEnum()
+                || InetAddress.class.isAssignableFrom(type);
+    }
+
+    /**
+     * Check if a type is a boolean type (for flag options that don't need a value).
+     */
+    public static boolean isBooleanType(Class<?> type) {
+        return type == boolean.class || type == Boolean.class;
+    }
+
+    private static Boolean parseBoolean(String s) {
+        if ("true".equalsIgnoreCase(s) || "yes".equalsIgnoreCase(s) || "1".equals(s)) {
+            return Boolean.TRUE;
+        }
+        if ("false".equalsIgnoreCase(s) || "no".equalsIgnoreCase(s) || "0".equals(s)) {
+            return Boolean.FALSE;
+        }
+        throw new IllegalArgumentException("Not a boolean value: " + s);
+    }
+}

--- a/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/UsageMessageSpec.java
+++ b/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/UsageMessageSpec.java
@@ -1,0 +1,122 @@
+package io.quarkus.quickcli;
+
+/**
+ * Specification for usage/help message formatting. Stores headings,
+ * widths, and other formatting metadata from {@code @Command}.
+ */
+public final class UsageMessageSpec {
+
+    /** Section key for the command list in the help section map. */
+    public static final String SECTION_KEY_COMMAND_LIST = "commandList";
+
+    private String[] header = {};
+    private String[] description = {};
+    private String[] footer = {};
+    private String synopsisHeading = "Usage: ";
+    private String commandListHeading = "Commands:%n";
+    private String optionListHeading = "Options:%n";
+    private String parameterListHeading = "%n";
+    private String headerHeading = "";
+    private boolean showDefaultValues;
+    private int width = 80;
+    private boolean adjustLineBreaksForWideCJKCharacters;
+
+    public String[] header() {
+        return header;
+    }
+
+    public UsageMessageSpec header(String... header) {
+        this.header = header;
+        return this;
+    }
+
+    public String[] description() {
+        return description;
+    }
+
+    public UsageMessageSpec description(String... description) {
+        this.description = description;
+        return this;
+    }
+
+    public String[] footer() {
+        return footer;
+    }
+
+    public UsageMessageSpec footer(String... footer) {
+        this.footer = footer;
+        return this;
+    }
+
+    public String synopsisHeading() {
+        return synopsisHeading;
+    }
+
+    public UsageMessageSpec synopsisHeading(String synopsisHeading) {
+        this.synopsisHeading = synopsisHeading;
+        return this;
+    }
+
+    public String commandListHeading() {
+        return commandListHeading;
+    }
+
+    public UsageMessageSpec commandListHeading(String commandListHeading) {
+        this.commandListHeading = commandListHeading;
+        return this;
+    }
+
+    public String optionListHeading() {
+        return optionListHeading;
+    }
+
+    public UsageMessageSpec optionListHeading(String optionListHeading) {
+        this.optionListHeading = optionListHeading;
+        return this;
+    }
+
+    public String parameterListHeading() {
+        return parameterListHeading;
+    }
+
+    public UsageMessageSpec parameterListHeading(String parameterListHeading) {
+        this.parameterListHeading = parameterListHeading;
+        return this;
+    }
+
+    public String headerHeading() {
+        return headerHeading;
+    }
+
+    public UsageMessageSpec headerHeading(String headerHeading) {
+        this.headerHeading = headerHeading;
+        return this;
+    }
+
+    public boolean showDefaultValues() {
+        return showDefaultValues;
+    }
+
+    public UsageMessageSpec showDefaultValues(boolean showDefaultValues) {
+        this.showDefaultValues = showDefaultValues;
+        return this;
+    }
+
+    public int width() {
+        return width;
+    }
+
+    public UsageMessageSpec width(int width) {
+        this.width = width;
+        return this;
+    }
+
+    public boolean adjustLineBreaksForWideCJKCharacters() {
+        return adjustLineBreaksForWideCJKCharacters;
+    }
+
+    public UsageMessageSpec adjustLineBreaksForWideCJKCharacters(boolean adjust) {
+        this.adjustLineBreaksForWideCJKCharacters = adjust;
+        return this;
+    }
+}

--- a/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/UsesArguments.java
+++ b/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/UsesArguments.java
@@ -1,0 +1,12 @@
+package io.quarkus.quickcli;
+
+import java.util.List;
+
+/**
+ * Interface for dynamic commands (e.g. plugins) that accept unmatched arguments.
+ * Implement this instead of relying on reflective method lookup.
+ */
+public interface UsesArguments {
+
+    void useArguments(List<String> arguments);
+}

--- a/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/VersionProvider.java
+++ b/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/VersionProvider.java
@@ -1,0 +1,22 @@
+package io.quarkus.quickcli;
+
+/**
+ * Provides version information dynamically.
+ */
+public interface VersionProvider {
+
+    /**
+     * Returns version strings to display when --version is requested.
+     */
+    String[] getVersion() throws Exception;
+
+    /**
+     * Sentinel class indicating no version provider is configured.
+     */
+    final class NoVersionProvider implements VersionProvider {
+        @Override
+        public String[] getVersion() {
+            return new String[0];
+        }
+    }
+}

--- a/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/annotations/ArgGroup.java
+++ b/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/annotations/ArgGroup.java
@@ -1,0 +1,33 @@
+package io.quarkus.quickcli.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a field as an argument group, enabling mutually exclusive or co-occurring options.
+ * The field type should be a class containing {@code @Option} and/or {@code @Parameters} fields.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface ArgGroup {
+
+    /** Whether the options in this group are mutually exclusive. */
+    boolean exclusive() default true;
+
+    /**
+     * Multiplicity: how many times this group can/must occur.
+     * Examples: "0..1" (optional), "1" (required exactly once), "0..*" (any number).
+     */
+    String multiplicity() default "0..1";
+
+    /** Heading for this group in help output. */
+    String heading() default "";
+
+    /** Display order in help output. Lower values are shown first. */
+    int order() default -1;
+
+    /** Whether to validate group constraints. */
+    boolean validate() default true;
+}

--- a/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/annotations/Command.java
+++ b/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/annotations/Command.java
@@ -1,0 +1,83 @@
+package io.quarkus.quickcli.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.quarkus.quickcli.ScopeType;
+
+/**
+ * Marks a class as a CLI command. The annotation processor will generate
+ * a CommandModel at compile time, eliminating the need for runtime reflection.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Command {
+
+    /** The name of this command. Defaults to the class name in lowercase. */
+    String name() default "";
+
+    /** Description shown in help output. */
+    String[] description() default {};
+
+    /** Subcommand classes. */
+    Class<?>[] subcommands() default {};
+
+    /** Version strings shown when --version is requested. */
+    String[] version() default {};
+
+    /** If true, adds --help and --version options automatically. */
+    boolean mixinStandardHelpOptions() default false;
+
+    /** Custom version provider class. */
+    Class<? extends io.quarkus.quickcli.VersionProvider> versionProvider() default io.quarkus.quickcli.VersionProvider.NoVersionProvider.class;
+
+    /** Header lines shown before the description in help output. */
+    String[] header() default {};
+
+    /** Footer lines shown after the description in help output. */
+    String[] footer() default {};
+
+    /** Custom name for the synopsis in help output. */
+    String customSynopsis() default "";
+
+    /** Sort options alphabetically in help output. */
+    boolean sortOptions() default true;
+
+    /** Scope type for options. INHERIT means options propagate to subcommands. */
+    ScopeType scope() default ScopeType.LOCAL;
+
+    /** Whether to show default values in help output. */
+    boolean showDefaultValues() default false;
+
+    /** Heading for the command list section in help. */
+    String commandListHeading() default "Commands:%n";
+
+    /** Heading for the synopsis section in help. */
+    String synopsisHeading() default "Usage: ";
+
+    /** Heading for the option list section in help. */
+    String optionListHeading() default "Options:%n";
+
+    /** Heading before the header section. */
+    String headerHeading() default "";
+
+    /** Heading for the parameter list section in help. */
+    String parameterListHeading() default "%n";
+
+    /** Whether subcommands can be repeated. */
+    boolean subcommandsRepeatable() default false;
+
+    /** Aliases for this command. */
+    String[] aliases() default {};
+
+    /** Whether to show the end-of-options delimiter (--) in usage help. */
+    boolean showEndOfOptionsDelimiterInUsageHelp() default false;
+
+    /** Whether this command is hidden from help output. */
+    boolean hidden() default false;
+
+    /** Whether this is a help command (like 'help' or 'completion'). */
+    boolean helpCommand() default false;
+}

--- a/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/annotations/Mixin.java
+++ b/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/annotations/Mixin.java
@@ -1,0 +1,17 @@
+package io.quarkus.quickcli.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a field as a mixin, pulling in options and parameters from the mixin class.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface Mixin {
+
+    /** Optional name for the mixin. */
+    String name() default "";
+}

--- a/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/annotations/NullCompletionCandidates.java
+++ b/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/annotations/NullCompletionCandidates.java
@@ -1,0 +1,15 @@
+package io.quarkus.quickcli.annotations;
+
+import java.util.Collections;
+import java.util.Iterator;
+
+/**
+ * Default (no-op) completion candidates class used as the default value
+ * for {@link Option#completionCandidates()}.
+ */
+public class NullCompletionCandidates implements Iterable<String> {
+    @Override
+    public Iterator<String> iterator() {
+        return Collections.emptyIterator();
+    }
+}

--- a/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/annotations/Option.java
+++ b/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/annotations/Option.java
@@ -1,0 +1,65 @@
+package io.quarkus.quickcli.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.quarkus.quickcli.ScopeType;
+
+/**
+ * Marks a field as a command-line option (e.g., --name, -n).
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD})
+public @interface Option {
+
+    /** Option names, e.g., {"-n", "--name"}. At least one name is required. */
+    String[] names();
+
+    /** Description shown in help output. */
+    String[] description() default {};
+
+    /** Whether this option is required. */
+    boolean required() default false;
+
+    /** Default value as a string. Empty string means no default. */
+    String defaultValue() default "";
+
+    /**
+     * Arity: how many values this option accepts.
+     * Examples: "0" (flag), "1" (single value), "0..1" (optional), "1..*" (one or more).
+     * Empty string means auto-detect from the field type.
+     */
+    String arity() default "";
+
+    /** If true, this option is hidden from help output. */
+    boolean hidden() default false;
+
+    /** Parameter label shown in help, e.g., FILE, HOST. */
+    String paramLabel() default "";
+
+    /** Whether this is a negatable boolean option. */
+    boolean negatable() default false;
+
+    /** Whether this option triggers usage help display (like --help). */
+    boolean usageHelp() default false;
+
+    /** Whether this option triggers version display (like --version). */
+    boolean versionHelp() default false;
+
+    /** Display order in help output. Lower values are shown first. */
+    int order() default -1;
+
+    /** Regex to split multi-value options (e.g., "," for --names=a,b,c). */
+    String split() default "";
+
+    /** Scope type. INHERIT means this option is inherited by subcommands. */
+    ScopeType scope() default ScopeType.LOCAL;
+
+    /** Fallback value for map-type options when key is specified without a value. */
+    String mapFallbackValue() default "";
+
+    /** Class that provides completion candidates for this option. */
+    Class<? extends Iterable<String>> completionCandidates() default NullCompletionCandidates.class;
+}

--- a/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/annotations/Parameters.java
+++ b/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/annotations/Parameters.java
@@ -1,0 +1,38 @@
+package io.quarkus.quickcli.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a field as a positional parameter.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface Parameters {
+
+    /** The index of this positional parameter (e.g., "0", "1", "0..1", "0..*"). */
+    String index() default "";
+
+    /** Description shown in help output. */
+    String description() default "";
+
+    /** Default value as a string. */
+    String defaultValue() default "";
+
+    /**
+     * Arity: how many values this parameter accepts.
+     * Empty string means auto-detect from the field type.
+     */
+    String arity() default "";
+
+    /** Parameter label shown in help output. */
+    String paramLabel() default "";
+
+    /** Whether this parameter is hidden from help output. */
+    boolean hidden() default false;
+
+    /** Regex to split multi-value parameters (e.g., "," for a,b,c). */
+    String split() default "";
+}

--- a/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/annotations/ParentCommand.java
+++ b/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/annotations/ParentCommand.java
@@ -1,0 +1,14 @@
+package io.quarkus.quickcli.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a field that should be injected with a reference to the parent command instance.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface ParentCommand {
+}

--- a/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/annotations/Spec.java
+++ b/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/annotations/Spec.java
@@ -1,0 +1,30 @@
+package io.quarkus.quickcli.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a {@code CommandSpec} field for injection. The field will be populated with
+ * the command's specification before the command is executed. This allows commands
+ * to access their own metadata, print usage, and retrieve exit codes.
+ *
+ * <p>The annotation processor generates code to inject the spec at build time,
+ * so no runtime reflection is needed.</p>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface Spec {
+
+    /** The target of the spec injection. */
+    Spec.Target value() default Spec.Target.SELF;
+
+    /** Specifies which command spec to inject. */
+    enum Target {
+        /** Inject the spec of the command that declares this field. */
+        SELF,
+        /** Inject the spec of the command that uses this mixin (the "mixee"). */
+        MIXEE
+    }
+}

--- a/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/annotations/Unmatched.java
+++ b/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/annotations/Unmatched.java
@@ -1,0 +1,16 @@
+package io.quarkus.quickcli.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a {@code List<String>} field to capture any unmatched command-line arguments.
+ * When present, the parser will not throw an error for unknown options or arguments;
+ * instead they are collected into this field.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface Unmatched {
+}

--- a/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/model/BuiltCommandModel.java
+++ b/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/model/BuiltCommandModel.java
@@ -1,0 +1,601 @@
+package io.quarkus.quickcli.model;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import io.quarkus.quickcli.CommandSpec;
+import io.quarkus.quickcli.Factory;
+import io.quarkus.quickcli.VersionProvider;
+import io.quarkus.quickcli.OptionSpec;
+import io.quarkus.quickcli.ParameterSpec;
+import io.quarkus.quickcli.ParseResult;
+import io.quarkus.quickcli.ScopeType;
+import io.quarkus.quickcli.TypeConverter;
+
+/**
+ * Data-driven {@link CommandModel} implementation. Instead of generating a full
+ * model class per command, metadata is collected at Quarkus build time (via Jandex)
+ * and field accessors are generated with Gizmo. This class holds the metadata and
+ * delegates field writes to the generated accessors.
+ */
+public final class BuiltCommandModel implements CommandModel {
+
+    private final Class<?> commandClass;
+    private final Supplier<Object> instanceCreator;
+
+    // CommandSpec metadata
+    private final String name;
+    private final String[] description;
+    private final String[] version;
+    private final boolean mixinStandardHelpOptions;
+    private final String[] header;
+    private final String[] footer;
+    private final ScopeType scope;
+    private final String[] aliases;
+    private final boolean hasUnmatchedField;
+    private final boolean hasSpecField;
+    private final Class<? extends VersionProvider> versionProviderClass;
+    private final List<List<String>> exclusiveGroups;
+
+    // UsageMessage customization
+    private final String commandListHeading;
+    private final String synopsisHeading;
+    private final String optionListHeading;
+    private final String headerHeading;
+    private final String parameterListHeading;
+    private final boolean showDefaultValues;
+
+    // Bindings
+    private final List<OptionBinding> optionBindings;
+    private final List<ParameterBinding> parameterBindings;
+    private final List<Class<?>> subcommandClasses;
+    private final List<MixinBinding> mixinBindings;
+    private final List<ArgGroupBinding> argGroupBindings;
+    private final FieldAccessor parentCommandAccessor;
+    private final FieldAccessor unmatchedAccessor;
+    private final FieldAccessor specAccessor;
+    private final List<FieldAccessor> mixeeSpecAccessors;
+
+    private BuiltCommandModel(Builder builder) {
+        this.commandClass = builder.commandClass;
+        this.instanceCreator = builder.instanceCreator;
+        this.name = builder.name;
+        this.description = builder.description;
+        this.version = builder.version;
+        this.mixinStandardHelpOptions = builder.mixinStandardHelpOptions;
+        this.header = builder.header;
+        this.footer = builder.footer;
+        this.scope = builder.scope;
+        this.aliases = builder.aliases;
+        this.hasUnmatchedField = builder.hasUnmatchedField;
+        this.hasSpecField = builder.hasSpecField;
+        this.versionProviderClass = builder.versionProviderClass;
+        this.exclusiveGroups = builder.exclusiveGroups;
+        this.commandListHeading = builder.commandListHeading;
+        this.synopsisHeading = builder.synopsisHeading;
+        this.optionListHeading = builder.optionListHeading;
+        this.headerHeading = builder.headerHeading;
+        this.parameterListHeading = builder.parameterListHeading;
+        this.showDefaultValues = builder.showDefaultValues;
+        this.optionBindings = List.copyOf(builder.optionBindings);
+        this.parameterBindings = List.copyOf(builder.parameterBindings);
+        this.subcommandClasses = List.copyOf(builder.subcommandClasses);
+        this.mixinBindings = List.copyOf(builder.mixinBindings);
+        this.argGroupBindings = List.copyOf(builder.argGroupBindings);
+        this.parentCommandAccessor = builder.parentCommandAccessor;
+        this.unmatchedAccessor = builder.unmatchedAccessor;
+        this.specAccessor = builder.specAccessor;
+        this.mixeeSpecAccessors = List.copyOf(builder.mixeeSpecAccessors);
+    }
+
+    @Override
+    public Class<?> commandClass() {
+        return commandClass;
+    }
+
+    @Override
+    public Object createInstance() {
+        return instanceCreator.get();
+    }
+
+    @Override
+    public CommandSpec buildSpec() {
+        CommandSpec spec = new CommandSpec(name, description, version,
+                mixinStandardHelpOptions, header, footer, commandClass);
+        spec.setScope(scope);
+        spec.setAliases(aliases);
+        spec.setHasUnmatchedField(hasUnmatchedField);
+        spec.setHasSpecField(hasSpecField);
+        if (versionProviderClass != null
+                && versionProviderClass != VersionProvider.NoVersionProvider.class) {
+            spec.setVersionProviderClass(versionProviderClass);
+        }
+
+        // Configure usage message
+        var usage = spec.usageMessage();
+        usage.commandListHeading(commandListHeading);
+        usage.synopsisHeading(synopsisHeading);
+        usage.optionListHeading(optionListHeading);
+        usage.headerHeading(headerHeading);
+        usage.parameterListHeading(parameterListHeading);
+        usage.showDefaultValues(showDefaultValues);
+
+        for (OptionBinding ob : optionBindings) {
+            // For Optional<Boolean> fields, use the inner type for boolean detection
+            Class<?> effectiveType = ob.fieldKind == FieldKind.OPTIONAL && ob.optionalInnerType != null
+                    ? ob.optionalInnerType : ob.type;
+            spec.addOption(new OptionSpec(
+                    ob.names, ob.description, effectiveType, ob.required,
+                    ob.defaultValue, ob.arity, ob.hidden, ob.paramLabel,
+                    ob.fieldName, ob.versionHelp, ob.usageHelp, ob.negatable, ob.order));
+        }
+        for (ParameterBinding pb : parameterBindings) {
+            spec.addParameter(new ParameterSpec(
+                    pb.index, pb.description, pb.type, pb.defaultValue,
+                    pb.arity, pb.hidden, pb.paramLabel, pb.fieldName, pb.isMultiValue));
+        }
+        for (Class<?> subCls : subcommandClasses) {
+            CommandModel subModel = CommandModelRegistry.getModel(subCls);
+            if (subModel != null) {
+                CommandSpec subSpec = subModel.buildSpec();
+                spec.addSubcommand(subSpec.name(), subSpec);
+                for (String alias : subSpec.aliases()) {
+                    spec.addSubcommand(alias, subSpec);
+                }
+            }
+        }
+        for (List<String> group : exclusiveGroups) {
+            spec.addExclusiveGroup(group);
+        }
+        return spec;
+    }
+
+    @Override
+    public void applyValues(Object instance, ParseResult result) {
+        for (OptionBinding ob : optionBindings) {
+            applyOptionValue(instance, result, ob);
+        }
+        for (ParameterBinding pb : parameterBindings) {
+            applyParameterValue(instance, result, pb);
+        }
+    }
+
+    private void applyOptionValue(Object instance, ParseResult result, OptionBinding ob) {
+        switch (ob.fieldKind) {
+            case SINGLE -> applySingleOption(instance, result, ob);
+            case LIST -> applyListOption(instance, result, ob);
+            case SET -> applySetOption(instance, result, ob);
+            case ARRAY -> applyArrayOption(instance, result, ob);
+            case MAP -> applyMapOption(instance, result, ob);
+            case OPTIONAL -> applyOptionalOption(instance, result, ob);
+        }
+    }
+
+    private void applySingleOption(Object instance, ParseResult result, OptionBinding ob) {
+        String val = resolveOptionValue(result, ob.names);
+        if (val == null && ob.defaultValue != null && !ob.defaultValue.isEmpty()) {
+            val = ob.defaultValue;
+        }
+        if (val != null) {
+            ob.accessor.set(instance, TypeConverter.convert(val, ob.type));
+        }
+    }
+
+    private void applyListOption(Object instance, ParseResult result, OptionBinding ob) {
+        List<String> vals = collectOptionValues(result, ob);
+        if (!vals.isEmpty()) {
+            List<Object> converted = new ArrayList<>();
+            for (String v : vals) {
+                converted.add(TypeConverter.convert(v, ob.componentType));
+            }
+            ob.accessor.set(instance, converted);
+        }
+    }
+
+    private void applySetOption(Object instance, ParseResult result, OptionBinding ob) {
+        List<String> vals = collectOptionValues(result, ob);
+        if (!vals.isEmpty()) {
+            var converted = new HashSet<>();
+            for (String v : vals) {
+                converted.add(TypeConverter.convert(v, ob.componentType));
+            }
+            ob.accessor.set(instance, converted);
+        }
+    }
+
+    private void applyArrayOption(Object instance, ParseResult result, OptionBinding ob) {
+        List<String> vals = collectOptionValues(result, ob);
+        if (!vals.isEmpty()) {
+            Object arr = Array.newInstance(ob.componentType, vals.size());
+            for (int i = 0; i < vals.size(); i++) {
+                Array.set(arr, i, TypeConverter.convert(vals.get(i), ob.componentType));
+            }
+            ob.accessor.set(instance, arr);
+        }
+    }
+
+    private void applyMapOption(Object instance, ParseResult result, OptionBinding ob) {
+        List<String> vals = collectOptionValues(result, ob);
+        if (!vals.isEmpty()) {
+            Map<String, String> map = new LinkedHashMap<>();
+            for (String s : vals) {
+                int eq = s.indexOf('=');
+                if (eq >= 0) {
+                    map.put(s.substring(0, eq), s.substring(eq + 1));
+                } else {
+                    map.put(s, ob.mapFallbackValue != null ? ob.mapFallbackValue : "");
+                }
+            }
+            ob.accessor.set(instance, map);
+        }
+    }
+
+    private void applyOptionalOption(Object instance, ParseResult result, OptionBinding ob) {
+        ob.accessor.set(instance, Optional.empty());
+        String val = resolveOptionValue(result, ob.names);
+        if (val != null) {
+            ob.accessor.set(instance, Optional.of(
+                    TypeConverter.convert(val, ob.optionalInnerType)));
+        }
+    }
+
+    private void applyParameterValue(Object instance, ParseResult result, ParameterBinding pb) {
+        if (pb.isMultiValue) {
+            List<String> allPositional = result.positionalValues();
+            if (!allPositional.isEmpty()) {
+                int startIndex = pb.index;
+                if (startIndex < allPositional.size()) {
+                    List<String> rawValues = allPositional.subList(startIndex, allPositional.size());
+                    // Apply split if configured
+                    if (pb.split != null && !pb.split.isEmpty()) {
+                        List<String> splitValues = new ArrayList<>();
+                        for (String v : rawValues) {
+                            Collections.addAll(splitValues, v.split(pb.split));
+                        }
+                        rawValues = splitValues;
+                    }
+                    if (pb.fieldKind == FieldKind.SET) {
+                        var converted = new HashSet<>();
+                        for (String v : rawValues) {
+                            converted.add(TypeConverter.convert(v, pb.componentType));
+                        }
+                        pb.accessor.set(instance, converted);
+                    } else if (pb.fieldKind == FieldKind.ARRAY) {
+                        Object arr = Array.newInstance(pb.componentType, rawValues.size());
+                        for (int i = 0; i < rawValues.size(); i++) {
+                            Array.set(arr, i, TypeConverter.convert(rawValues.get(i), pb.componentType));
+                        }
+                        pb.accessor.set(instance, arr);
+                    } else {
+                        List<Object> converted = new ArrayList<>();
+                        for (String v : rawValues) {
+                            converted.add(TypeConverter.convert(v, pb.componentType));
+                        }
+                        pb.accessor.set(instance, converted);
+                    }
+                }
+            }
+        } else {
+            String val = result.getPositionalValue(pb.index);
+            if (val == null && pb.defaultValue != null && !pb.defaultValue.isEmpty()) {
+                val = pb.defaultValue;
+            }
+            if (val != null) {
+                pb.accessor.set(instance, TypeConverter.convert(val, pb.type));
+            }
+        }
+    }
+
+    private static String resolveOptionValue(ParseResult result, String[] names) {
+        for (String name : names) {
+            String val = result.getOptionValue(name);
+            if (val != null) {
+                return val;
+            }
+        }
+        return null;
+    }
+
+    private static List<String> collectOptionValues(ParseResult result, OptionBinding ob) {
+        List<String> collected = new ArrayList<>();
+        for (String name : ob.names) {
+            List<String> vals = result.getOptionValues(name);
+            if (vals != null) {
+                collected.addAll(vals);
+            }
+        }
+        if (ob.split != null && !ob.split.isEmpty()) {
+            List<String> split = new ArrayList<>();
+            for (String v : collected) {
+                Collections.addAll(split, v.split(ob.split));
+            }
+            return split;
+        }
+        return collected;
+    }
+
+    @Override
+    public void setParentCommand(Object instance, Object parent) {
+        if (parentCommandAccessor != null) {
+            parentCommandAccessor.set(instance, parent);
+        }
+    }
+
+    @Override
+    public void initMixins(Object instance, Factory factory) throws Exception {
+        for (MixinBinding mb : mixinBindings) {
+            Object mixin = factory.create(mb.mixinType);
+            mb.accessor.set(instance, mixin);
+        }
+    }
+
+    @Override
+    public void injectSpec(Object instance, CommandSpec spec) {
+        if (specAccessor != null) {
+            specAccessor.set(instance, spec);
+        }
+        for (FieldAccessor mixeeAccessor : mixeeSpecAccessors) {
+            mixeeAccessor.set(instance, spec);
+        }
+    }
+
+    @Override
+    public void setUnmatched(Object instance, List<String> unmatched) {
+        if (unmatchedAccessor != null) {
+            unmatchedAccessor.set(instance, unmatched);
+        }
+    }
+
+    @Override
+    public void initArgGroups(Object instance, Factory factory) throws Exception {
+        for (ArgGroupBinding ag : argGroupBindings) {
+            Object group = factory.create(ag.argGroupType);
+            ag.accessor.set(instance, group);
+        }
+    }
+
+    // --- Data records ---
+
+    public enum FieldKind {
+        SINGLE, LIST, SET, ARRAY, MAP, OPTIONAL
+    }
+
+    public record OptionBinding(
+            String[] names,
+            String description,
+            Class<?> type,
+            boolean required,
+            String defaultValue,
+            String arity,
+            boolean hidden,
+            String paramLabel,
+            String fieldName,
+            boolean versionHelp,
+            boolean usageHelp,
+            boolean negatable,
+            int order,
+            FieldKind fieldKind,
+            Class<?> componentType,
+            Class<?> optionalInnerType,
+            String split,
+            String mapFallbackValue,
+            FieldAccessor accessor) {
+    }
+
+    public record ParameterBinding(
+            int index,
+            String description,
+            Class<?> type,
+            String defaultValue,
+            String arity,
+            boolean hidden,
+            String paramLabel,
+            String fieldName,
+            boolean isMultiValue,
+            FieldKind fieldKind,
+            Class<?> componentType,
+            FieldAccessor accessor,
+            String split) {
+    }
+
+    public record MixinBinding(
+            String fieldName,
+            Class<?> mixinType,
+            FieldAccessor accessor) {
+    }
+
+    public record ArgGroupBinding(
+            String fieldName,
+            Class<?> argGroupType,
+            FieldAccessor accessor) {
+    }
+
+    // --- Builder ---
+
+    public static Builder builder(Class<?> commandClass, Supplier<Object> instanceCreator) {
+        return new Builder(commandClass, instanceCreator);
+    }
+
+    public static final class Builder {
+        private final Class<?> commandClass;
+        private final Supplier<Object> instanceCreator;
+        private String name = "";
+        private String[] description = new String[0];
+        private String[] version = new String[0];
+        private boolean mixinStandardHelpOptions;
+        private String[] header = new String[0];
+        private String[] footer = new String[0];
+        private ScopeType scope = ScopeType.LOCAL;
+        private String[] aliases = new String[0];
+        private boolean hasUnmatchedField;
+        private boolean hasSpecField;
+        private Class<? extends VersionProvider> versionProviderClass = VersionProvider.NoVersionProvider.class;
+        private final List<List<String>> exclusiveGroups = new ArrayList<>();
+        private String commandListHeading = "Commands:%n";
+        private String synopsisHeading = "Usage: ";
+        private String optionListHeading = "Options:%n";
+        private String headerHeading = "";
+        private String parameterListHeading = "%n";
+        private boolean showDefaultValues;
+        private final List<OptionBinding> optionBindings = new ArrayList<>();
+        private final List<ParameterBinding> parameterBindings = new ArrayList<>();
+        private final List<Class<?>> subcommandClasses = new ArrayList<>();
+        private final List<MixinBinding> mixinBindings = new ArrayList<>();
+        private final List<ArgGroupBinding> argGroupBindings = new ArrayList<>();
+        private FieldAccessor parentCommandAccessor;
+        private FieldAccessor unmatchedAccessor;
+        private FieldAccessor specAccessor;
+        private final List<FieldAccessor> mixeeSpecAccessors = new ArrayList<>();
+
+        Builder(Class<?> commandClass, Supplier<Object> instanceCreator) {
+            this.commandClass = commandClass;
+            this.instanceCreator = instanceCreator;
+        }
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder description(String... description) {
+            this.description = description;
+            return this;
+        }
+
+        public Builder version(String... version) {
+            this.version = version;
+            return this;
+        }
+
+        public Builder mixinStandardHelpOptions(boolean v) {
+            this.mixinStandardHelpOptions = v;
+            return this;
+        }
+
+        public Builder header(String... header) {
+            this.header = header;
+            return this;
+        }
+
+        public Builder footer(String... footer) {
+            this.footer = footer;
+            return this;
+        }
+
+        public Builder scope(ScopeType scope) {
+            this.scope = scope;
+            return this;
+        }
+
+        public Builder aliases(String... aliases) {
+            this.aliases = aliases;
+            return this;
+        }
+
+        public Builder hasUnmatchedField(boolean v) {
+            this.hasUnmatchedField = v;
+            return this;
+        }
+
+        public Builder hasSpecField(boolean v) {
+            this.hasSpecField = v;
+            return this;
+        }
+
+        public Builder versionProviderClass(Class<? extends VersionProvider> cls) {
+            this.versionProviderClass = cls;
+            return this;
+        }
+
+        public Builder commandListHeading(String v) {
+            this.commandListHeading = v;
+            return this;
+        }
+
+        public Builder synopsisHeading(String v) {
+            this.synopsisHeading = v;
+            return this;
+        }
+
+        public Builder optionListHeading(String v) {
+            this.optionListHeading = v;
+            return this;
+        }
+
+        public Builder headerHeading(String v) {
+            this.headerHeading = v;
+            return this;
+        }
+
+        public Builder parameterListHeading(String v) {
+            this.parameterListHeading = v;
+            return this;
+        }
+
+        public Builder showDefaultValues(boolean v) {
+            this.showDefaultValues = v;
+            return this;
+        }
+
+        public Builder addOption(OptionBinding binding) {
+            this.optionBindings.add(binding);
+            return this;
+        }
+
+        public Builder addParameter(ParameterBinding binding) {
+            this.parameterBindings.add(binding);
+            return this;
+        }
+
+        public Builder addSubcommand(Class<?> subcommandClass) {
+            this.subcommandClasses.add(subcommandClass);
+            return this;
+        }
+
+        public Builder addMixin(MixinBinding binding) {
+            this.mixinBindings.add(binding);
+            return this;
+        }
+
+        public Builder addArgGroup(ArgGroupBinding binding) {
+            this.argGroupBindings.add(binding);
+            return this;
+        }
+
+        public Builder addExclusiveGroup(List<String> group) {
+            this.exclusiveGroups.add(group);
+            return this;
+        }
+
+        public Builder parentCommandAccessor(FieldAccessor accessor) {
+            this.parentCommandAccessor = accessor;
+            return this;
+        }
+
+        public Builder unmatchedAccessor(FieldAccessor accessor) {
+            this.unmatchedAccessor = accessor;
+            return this;
+        }
+
+        public Builder specAccessor(FieldAccessor accessor) {
+            this.specAccessor = accessor;
+            return this;
+        }
+
+        public Builder addMixeeSpecAccessor(FieldAccessor accessor) {
+            this.mixeeSpecAccessors.add(accessor);
+            return this;
+        }
+
+        public BuiltCommandModel build() {
+            return new BuiltCommandModel(this);
+        }
+    }
+}

--- a/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/model/CommandModel.java
+++ b/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/model/CommandModel.java
@@ -1,0 +1,98 @@
+package io.quarkus.quickcli.model;
+
+import io.quarkus.quickcli.CommandSpec;
+import io.quarkus.quickcli.ParseResult;
+
+import java.util.List;
+
+/**
+ * Interface for generated command model classes. The annotation processor generates
+ * an implementation of this interface for each @Command-annotated class, containing
+ * all metadata that would otherwise require runtime reflection to discover.
+ *
+ * <p>Generated implementations self-register with {@link CommandModelRegistry}
+ * in a static initializer, eliminating any need for ServiceLoader or classpath scanning.</p>
+ */
+public interface CommandModel {
+
+    /**
+     * Returns the command class this model describes.
+     */
+    Class<?> commandClass();
+
+    /**
+     * Creates a new instance of the command class using a direct {@code new} call.
+     * No reflection is used.
+     */
+    Object createInstance();
+
+    /**
+     * Builds the command specification with all options, parameters, and subcommand
+     * metadata. This is called once during initialization — all metadata is hardcoded
+     * in the generated source, so no reflection is needed.
+     */
+    CommandSpec buildSpec();
+
+    /**
+     * Applies parsed values to the command instance. Uses direct field access for
+     * non-private fields, and setter methods for private fields. No reflection is used.
+     *
+     * @param instance the command instance to populate
+     * @param result the parse result containing option/parameter values
+     */
+    void applyValues(Object instance, ParseResult result);
+
+    /**
+     * Sets the parent command reference on the instance, if the command has a
+     * {@code @ParentCommand} annotated field.
+     *
+     * @param instance the command instance
+     * @param parent the parent command instance
+     */
+    default void setParentCommand(Object instance, Object parent) {
+        // Default no-op; overridden when @ParentCommand is present
+    }
+
+    /**
+     * Creates and populates mixin instances on the command, if the command has
+     * {@code @Mixin} annotated fields.
+     *
+     * @param instance the command instance
+     * @param factory factory for creating mixin instances
+     */
+    default void initMixins(Object instance, io.quarkus.quickcli.Factory factory) throws Exception {
+        // Default no-op; overridden when @Mixin fields are present
+    }
+
+    /**
+     * Injects the CommandSpec into the instance, if the command has a
+     * {@code @Spec} annotated field.
+     *
+     * @param instance the command instance
+     * @param spec the command specification
+     */
+    default void injectSpec(Object instance, CommandSpec spec) {
+        // Default no-op; overridden when @Spec is present
+    }
+
+    /**
+     * Sets unmatched arguments on the instance, if the command has an
+     * {@code @Unmatched} annotated field.
+     *
+     * @param instance the command instance
+     * @param unmatched the list of unmatched arguments
+     */
+    default void setUnmatched(Object instance, List<String> unmatched) {
+        // Default no-op; overridden when @Unmatched is present
+    }
+
+    /**
+     * Initializes ArgGroup fields on the command instance.
+     *
+     * @param instance the command instance
+     * @param factory factory for creating group instances
+     */
+    default void initArgGroups(Object instance, io.quarkus.quickcli.Factory factory) throws Exception {
+        // Default no-op; overridden when @ArgGroup fields are present
+    }
+}

--- a/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/model/CommandModelRegistry.java
+++ b/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/model/CommandModelRegistry.java
@@ -1,0 +1,83 @@
+package io.quarkus.quickcli.model;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+/**
+ * Registry of command models. Generated model classes self-register via a static
+ * initializer when their class is loaded. Loading is triggered by a {@link Class#forName}
+ * call using a deterministic naming convention ({@code ClassName_QuickCliModel}).
+ *
+ * <p>No ServiceLoader, no classpath scanning, no annotation reflection.</p>
+ */
+public final class CommandModelRegistry {
+
+    private static final Map<Class<?>, CommandModel> MODELS = new ConcurrentHashMap<>();
+    private static final Map<Class<?>, Supplier<Object>> INSTANCE_CREATORS = new ConcurrentHashMap<>();
+
+    private CommandModelRegistry() {
+    }
+
+    /**
+     * Get the command model for the given command class. If the model is not yet
+     * loaded, attempts to load the generated model class by naming convention
+     * using {@link Class#forName}.
+     *
+     * @param commandClass the @Command annotated class
+     * @return the pre-generated model
+     * @throws IllegalStateException if no generated model is found
+     */
+    public static CommandModel getModel(Class<?> commandClass) {
+        CommandModel model = MODELS.get(commandClass);
+        if (model != null) {
+            return model;
+        }
+
+        // Try to load the generated model class by naming convention.
+        // The class name is deterministic: <commandFQCN>_QuickCliModel.
+        // Class.forName triggers the static initializer which calls register().
+        String modelClassName = commandClass.getName() + "_QuickCliModel";
+        try {
+            Class.forName(modelClassName, true, commandClass.getClassLoader());
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException(
+                    "No build-time generated model found for " + commandClass.getName()
+                            + ". Ensure the class is annotated with @Command and processed"
+                            + " by the QuickCLI annotation processor or Quarkus build step.");
+        }
+
+        model = MODELS.get(commandClass);
+        if (model == null) {
+            throw new IllegalStateException(
+                    "Model class " + modelClassName + " was loaded but failed to register."
+                            + " Check for errors in its static initializer.");
+        }
+        return model;
+    }
+
+    /**
+     * Register a command model. Called from the static initializer of each
+     * generated model class.
+     */
+    public static void register(CommandModel model) {
+        MODELS.put(model.commandClass(), model);
+    }
+
+    /**
+     * Register an instance creator for a non-@Command class (e.g. mixin, arg group).
+     * Called from the static initializer of generated model classes.
+     */
+    public static void registerInstanceCreator(Class<?> cls, Supplier<Object> creator) {
+        INSTANCE_CREATORS.put(cls, creator);
+    }
+
+    /**
+     * Get a build-time generated instance creator for the given class.
+     *
+     * @return the supplier, or null if none was registered
+     */
+    public static Supplier<Object> getInstanceCreator(Class<?> cls) {
+        return INSTANCE_CREATORS.get(cls);
+    }
+}

--- a/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/model/FieldAccessor.java
+++ b/independent-projects/quickcli/quickcli-core/src/main/java/io/quarkus/quickcli/model/FieldAccessor.java
@@ -1,0 +1,12 @@
+package io.quarkus.quickcli.model;
+
+/**
+ * Sets a value on a command (or mixin/arggroup) instance field.
+ * Implementations are generated at build time with direct field access
+ * or setter calls — no reflection is used at runtime.
+ */
+@FunctionalInterface
+public interface FieldAccessor {
+
+    void set(Object instance, Object value);
+}

--- a/independent-projects/quickcli/quickcli-core/src/test/java/io/quarkus/quickcli/AnsiTest.java
+++ b/independent-projects/quickcli/quickcli-core/src/test/java/io/quarkus/quickcli/AnsiTest.java
@@ -1,0 +1,59 @@
+package io.quarkus.quickcli;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class AnsiTest {
+
+    @Test
+    void offDisabled() {
+        assertFalse(Ansi.OFF.enabled());
+    }
+
+    @Test
+    void onEnabled() {
+        assertTrue(Ansi.ON.enabled());
+    }
+
+    @Test
+    void textStripsMarkup() {
+        Ansi.Text text = new Ansi.Text("@|bold Hello|@ world", null);
+        assertEquals("Hello world", text.toString());
+    }
+
+    @Test
+    void textNoMarkup() {
+        Ansi.Text text = new Ansi.Text("plain text", null);
+        assertEquals("plain text", text.toString());
+    }
+
+    @Test
+    void textNull() {
+        Ansi.Text text = new Ansi.Text(null, null);
+        assertEquals("", text.toString());
+    }
+
+    @Test
+    void stripAnsiMarkupMultiple() {
+        assertEquals("a and b",
+                Ansi.Text.stripAnsiMarkup("@|red a|@ and @|green b|@"));
+    }
+
+    @Test
+    void stripAnsiMarkupNested() {
+        // No nested markup support — inner @ signs are literal
+        assertEquals("plain", Ansi.Text.stripAnsiMarkup("plain"));
+    }
+
+    @Test
+    void stripAnsiMarkupNull() {
+        assertEquals("", Ansi.Text.stripAnsiMarkup(null));
+    }
+
+    @Test
+    void ansiTextMethod() {
+        Ansi.Text text = Ansi.AUTO.text("@|bold test|@");
+        assertEquals("test", text.toString());
+    }
+}

--- a/independent-projects/quickcli/quickcli-core/src/test/java/io/quarkus/quickcli/AutoCompleteTest.java
+++ b/independent-projects/quickcli/quickcli-core/src/test/java/io/quarkus/quickcli/AutoCompleteTest.java
@@ -1,0 +1,182 @@
+package io.quarkus.quickcli;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.quickcli.model.BuiltCommandModel;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class AutoCompleteTest {
+
+    static class TopCmd implements Runnable {
+        boolean verbose;
+
+        public void run() {
+        }
+    }
+
+    static class SubCmd implements Runnable {
+        String file;
+
+        public void run() {
+        }
+    }
+
+    static class LeafCmd implements Runnable {
+        boolean force;
+        String output;
+
+        public void run() {
+        }
+    }
+
+    @BeforeAll
+    static void setup() {
+        // Register TopCmd with a --verbose flag and a "sub" subcommand
+        BuiltCommandModel topModel = TestModelHelper.builder(TopCmd.class, TopCmd::new)
+                .name("mycli")
+                .description("My CLI tool")
+                .addOption(TestModelHelper.booleanOption(
+                        new String[] { "-v", "--verbose" }, "Verbose output",
+                        (obj, val) -> ((TopCmd) obj).verbose = (boolean) val))
+                .addSubcommand(SubCmd.class)
+                .build();
+        TestModelHelper.register(topModel);
+
+        // Register SubCmd with a --file arg option and a "leaf" subcommand
+        BuiltCommandModel subModel = TestModelHelper.builder(SubCmd.class, SubCmd::new)
+                .name("sub")
+                .description("A sub command")
+                .addOption(TestModelHelper.option(
+                        new String[] { "-f", "--file" }, "Input file", String.class,
+                        (obj, val) -> ((SubCmd) obj).file = (String) val))
+                .addSubcommand(LeafCmd.class)
+                .build();
+        TestModelHelper.register(subModel);
+
+        // Register LeafCmd with --force flag and --output arg
+        BuiltCommandModel leafModel = TestModelHelper.builder(LeafCmd.class, LeafCmd::new)
+                .name("leaf")
+                .description("A leaf command")
+                .addOption(TestModelHelper.booleanOption(
+                        new String[] { "--force" }, "Force operation",
+                        (obj, val) -> ((LeafCmd) obj).force = (boolean) val))
+                .addOption(TestModelHelper.option(
+                        new String[] { "-o", "--output" }, "Output path", String.class,
+                        (obj, val) -> ((LeafCmd) obj).output = (String) val))
+                .build();
+        TestModelHelper.register(leafModel);
+    }
+
+    @Test
+    void generatesValidBashScript() {
+        CommandSpec rootSpec = new CommandLine(TopCmd.class).getCommandSpec();
+        String script = AutoComplete.bash("mycli", rootSpec);
+
+        // Header
+        assertTrue(script.startsWith("#!/usr/bin/env bash"), "Should start with shebang");
+        assertTrue(script.contains("mycli Bash Completion"));
+
+        // Entry point function
+        assertTrue(script.contains("function _complete_mycli()"));
+
+        // Footer: complete registration
+        assertTrue(script.contains("complete -F _complete_mycli -o default mycli"));
+    }
+
+    @Test
+    void containsSubcommandNames() {
+        CommandSpec rootSpec = new CommandLine(TopCmd.class).getCommandSpec();
+        String script = AutoComplete.bash("mycli", rootSpec);
+
+        // The top-level function should list "sub" as a command
+        assertTrue(script.contains("local commands=\"sub\""),
+                "Top-level function should list subcommand 'sub'");
+    }
+
+    @Test
+    void containsFlagOptions() {
+        CommandSpec rootSpec = new CommandLine(TopCmd.class).getCommandSpec();
+        String script = AutoComplete.bash("mycli", rootSpec);
+
+        // The top-level function should list --verbose as a flag
+        assertTrue(script.contains("'-v'") && script.contains("'--verbose'"),
+                "Should contain verbose flag options");
+    }
+
+    @Test
+    void containsArgOptions() {
+        CommandSpec rootSpec = new CommandLine(TopCmd.class).getCommandSpec();
+        String script = AutoComplete.bash("mycli", rootSpec);
+
+        // The sub function should have --file as an arg option
+        assertTrue(script.contains("'-f'") && script.contains("'--file'"),
+                "Should contain file arg options");
+    }
+
+    @Test
+    void generatesNestedSubcommandFunctions() {
+        CommandSpec rootSpec = new CommandLine(TopCmd.class).getCommandSpec();
+        String script = AutoComplete.bash("mycli", rootSpec);
+
+        // Should generate functions for sub and leaf
+        assertTrue(script.contains("function _picocli_mycli_sub()"),
+                "Should generate function for 'sub' subcommand");
+        assertTrue(script.contains("function _picocli_mycli_sub_leaf()"),
+                "Should generate function for 'leaf' subcommand");
+    }
+
+    @Test
+    void leafCommandHasFlagAndArgOptions() {
+        CommandSpec rootSpec = new CommandLine(TopCmd.class).getCommandSpec();
+        String script = AutoComplete.bash("mycli", rootSpec);
+
+        // leaf should have --force as flag, --output as arg
+        assertTrue(script.contains("'--force'"), "leaf should have --force flag");
+        assertTrue(script.contains("'--output'"), "leaf should have --output arg");
+    }
+
+    @Test
+    void edgeCaseLinesGenerated() {
+        CommandSpec rootSpec = new CommandLine(TopCmd.class).getCommandSpec();
+        String script = AutoComplete.bash("mycli", rootSpec);
+
+        // Edge case: no trailing space after subcommand
+        assertTrue(script.contains("\"${COMP_WORDS[0]} sub\""),
+                "Should have edge case for 'sub'");
+        assertTrue(script.contains("\"${COMP_WORDS[0]} sub leaf\""),
+                "Should have edge case for 'sub leaf'");
+    }
+
+    @Test
+    void compWordsContainsArrayCalls() {
+        CommandSpec rootSpec = new CommandLine(TopCmd.class).getCommandSpec();
+        String script = AutoComplete.bash("mycli", rootSpec);
+
+        assertTrue(script.contains("CompWordsContainsArray"),
+                "Should use CompWordsContainsArray for subcommand matching");
+    }
+
+    @Test
+    void bashAndZshSupport() {
+        CommandSpec rootSpec = new CommandLine(TopCmd.class).getCommandSpec();
+        String script = AutoComplete.bash("mycli", rootSpec);
+
+        assertTrue(script.contains("BASH_VERSION"), "Should support bash");
+        assertTrue(script.contains("ZSH_VERSION"), "Should support zsh");
+        assertTrue(script.contains("bashcompinit"), "Should enable bash compat in zsh");
+    }
+
+    @Test
+    void sanitizesScriptName() {
+        CommandSpec rootSpec = new CommandLine(TopCmd.class).getCommandSpec();
+        String script = AutoComplete.bash("./mycli.sh", rootSpec);
+
+        // Should strip .sh and ./
+        assertTrue(script.contains("function _complete_mycli()"),
+                "Should sanitize script name");
+        assertFalse(script.contains("_complete_./mycli"),
+                "Should not contain unsanitized name");
+    }
+}

--- a/independent-projects/quickcli/quickcli-core/src/test/java/io/quarkus/quickcli/BuiltCommandModelTest.java
+++ b/independent-projects/quickcli/quickcli-core/src/test/java/io/quarkus/quickcli/BuiltCommandModelTest.java
@@ -1,0 +1,274 @@
+package io.quarkus.quickcli;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.quickcli.model.BuiltCommandModel;
+import io.quarkus.quickcli.model.CommandModelRegistry;
+
+class BuiltCommandModelTest {
+
+    static class ModelCmd implements Runnable {
+        String name;
+        CommandSpec spec;
+        Object parent;
+        List<String> unmatched;
+
+        @Override
+        public void run() {
+        }
+    }
+
+    static class MixinClass {
+        String value;
+    }
+
+    static class ArgGroupClass {
+        boolean flag;
+    }
+
+    static class MixinCmd implements Runnable {
+        MixinClass mixin;
+        CommandSpec spec;
+
+        @Override
+        public void run() {
+        }
+    }
+
+    static class ArgGroupCmd implements Runnable {
+        ArgGroupClass group;
+
+        @Override
+        public void run() {
+        }
+    }
+
+    static class ParentCmd implements Runnable {
+        @Override
+        public void run() {
+        }
+    }
+
+    // --- createInstance ---
+
+    @Test
+    void createInstance() {
+        BuiltCommandModel model = TestModelHelper.builder(ModelCmd.class, ModelCmd::new)
+                .name("cmd").build();
+        Object instance = model.createInstance();
+        assertInstanceOf(ModelCmd.class, instance);
+    }
+
+    // --- commandClass ---
+
+    @Test
+    void commandClass() {
+        BuiltCommandModel model = TestModelHelper.builder(ModelCmd.class, ModelCmd::new)
+                .name("cmd").build();
+        assertEquals(ModelCmd.class, model.commandClass());
+    }
+
+    // --- initMixins ---
+
+    @Test
+    void initMixins() throws Exception {
+        BuiltCommandModel model = TestModelHelper.builder(MixinCmd.class, MixinCmd::new)
+                .name("cmd")
+                .addMixin(new BuiltCommandModel.MixinBinding(
+                        "mixin", MixinClass.class,
+                        (inst, val) -> ((MixinCmd) inst).mixin = (MixinClass) val))
+                .build();
+
+        MixinCmd instance = new MixinCmd();
+        assertNull(instance.mixin);
+        Factory factory = new Factory() {
+            @Override
+            public <T> T create(Class<T> cls) throws Exception {
+                return cls.getDeclaredConstructor().newInstance();
+            }
+        };
+        model.initMixins(instance, factory);
+        assertNotNull(instance.mixin);
+        assertInstanceOf(MixinClass.class, instance.mixin);
+    }
+
+    // --- initArgGroups ---
+
+    @Test
+    void initArgGroups() throws Exception {
+        BuiltCommandModel model = TestModelHelper.builder(ArgGroupCmd.class, ArgGroupCmd::new)
+                .name("cmd")
+                .addArgGroup(new BuiltCommandModel.ArgGroupBinding(
+                        "group", ArgGroupClass.class,
+                        (inst, val) -> ((ArgGroupCmd) inst).group = (ArgGroupClass) val))
+                .build();
+
+        ArgGroupCmd instance = new ArgGroupCmd();
+        assertNull(instance.group);
+        Factory factory = new Factory() {
+            @Override
+            public <T> T create(Class<T> cls) throws Exception {
+                return cls.getDeclaredConstructor().newInstance();
+            }
+        };
+        model.initArgGroups(instance, factory);
+        assertNotNull(instance.group);
+    }
+
+    // --- injectSpec ---
+
+    @Test
+    void injectSpec() {
+        BuiltCommandModel model = TestModelHelper.builder(ModelCmd.class, ModelCmd::new)
+                .name("cmd")
+                .specAccessor((inst, val) -> ((ModelCmd) inst).spec = (CommandSpec) val)
+                .build();
+
+        ModelCmd instance = new ModelCmd();
+        CommandSpec spec = model.buildSpec();
+        model.injectSpec(instance, spec);
+        assertSame(spec, instance.spec);
+    }
+
+    @Test
+    void injectSpecNoAccessor() {
+        BuiltCommandModel model = TestModelHelper.builder(ModelCmd.class, ModelCmd::new)
+                .name("cmd").build();
+
+        ModelCmd instance = new ModelCmd();
+        // Should not throw even without a spec accessor
+        model.injectSpec(instance, model.buildSpec());
+        assertNull(instance.spec);
+    }
+
+    // --- injectSpec with mixee spec accessors ---
+
+    @Test
+    void injectSpecWithMixeeAccessors() {
+        AtomicReference<CommandSpec> mixeeSpec = new AtomicReference<>();
+        BuiltCommandModel model = TestModelHelper.builder(MixinCmd.class, MixinCmd::new)
+                .name("cmd")
+                .specAccessor((inst, val) -> ((MixinCmd) inst).spec = (CommandSpec) val)
+                .addMixeeSpecAccessor((inst, val) -> mixeeSpec.set((CommandSpec) val))
+                .build();
+
+        MixinCmd instance = new MixinCmd();
+        CommandSpec spec = model.buildSpec();
+        model.injectSpec(instance, spec);
+        assertSame(spec, instance.spec);
+        assertSame(spec, mixeeSpec.get());
+    }
+
+    // --- setParentCommand ---
+
+    @Test
+    void setParentCommand() {
+        BuiltCommandModel model = TestModelHelper.builder(ModelCmd.class, ModelCmd::new)
+                .name("cmd")
+                .parentCommandAccessor((inst, val) -> ((ModelCmd) inst).parent = val)
+                .build();
+
+        ModelCmd instance = new ModelCmd();
+        ParentCmd parent = new ParentCmd();
+        model.setParentCommand(instance, parent);
+        assertSame(parent, instance.parent);
+    }
+
+    @Test
+    void setParentCommandNoAccessor() {
+        BuiltCommandModel model = TestModelHelper.builder(ModelCmd.class, ModelCmd::new)
+                .name("cmd").build();
+
+        ModelCmd instance = new ModelCmd();
+        // Should not throw even without a parent accessor
+        model.setParentCommand(instance, new ParentCmd());
+        assertNull(instance.parent);
+    }
+
+    // --- setUnmatched ---
+
+    @Test
+    void setUnmatched() {
+        BuiltCommandModel model = TestModelHelper.builder(ModelCmd.class, ModelCmd::new)
+                .name("cmd")
+                .unmatchedAccessor((inst, val) -> ((ModelCmd) inst).unmatched = castList(val))
+                .build();
+
+        ModelCmd instance = new ModelCmd();
+        model.setUnmatched(instance, List.of("--extra", "arg"));
+        assertEquals(List.of("--extra", "arg"), instance.unmatched);
+    }
+
+    @Test
+    void setUnmatchedNoAccessor() {
+        BuiltCommandModel model = TestModelHelper.builder(ModelCmd.class, ModelCmd::new)
+                .name("cmd").build();
+
+        ModelCmd instance = new ModelCmd();
+        // Should not throw even without an unmatched accessor
+        model.setUnmatched(instance, List.of("--extra"));
+        assertNull(instance.unmatched);
+    }
+
+    // --- buildSpec includes all metadata ---
+
+    @Test
+    void buildSpecIncludesMetadata() {
+        BuiltCommandModel model = TestModelHelper.builder(ModelCmd.class, ModelCmd::new)
+                .name("myapp")
+                .description("desc")
+                .version("1.0")
+                .mixinStandardHelpOptions(true)
+                .header("Header")
+                .footer("Footer")
+                .aliases("app", "ma")
+                .hasUnmatchedField(true)
+                .hasSpecField(true)
+                .build();
+
+        CommandSpec spec = model.buildSpec();
+        assertEquals("myapp", spec.name());
+        assertArrayEquals(new String[] { "desc" }, spec.description());
+        assertArrayEquals(new String[] { "1.0" }, spec.version());
+        assertTrue(spec.mixinStandardHelpOptions());
+        assertArrayEquals(new String[] { "Header" }, spec.header());
+        assertArrayEquals(new String[] { "Footer" }, spec.footer());
+        assertArrayEquals(new String[] { "app", "ma" }, spec.aliases());
+        assertTrue(spec.hasUnmatchedField());
+        assertTrue(spec.hasSpecField());
+    }
+
+    // --- buildSpec includes usage message config ---
+
+    @Test
+    void buildSpecUsageMessage() {
+        BuiltCommandModel model = TestModelHelper.builder(ModelCmd.class, ModelCmd::new)
+                .name("cmd")
+                .commandListHeading("Cmds:%n")
+                .synopsisHeading("Use: ")
+                .optionListHeading("Opts:%n")
+                .headerHeading("Head:%n")
+                .parameterListHeading("Params:%n")
+                .showDefaultValues(true)
+                .build();
+
+        CommandSpec spec = model.buildSpec();
+        UsageMessageSpec usage = spec.usageMessage();
+        assertEquals("Cmds:%n", usage.commandListHeading());
+        assertEquals("Use: ", usage.synopsisHeading());
+        assertEquals("Opts:%n", usage.optionListHeading());
+        assertEquals("Head:%n", usage.headerHeading());
+        assertEquals("Params:%n", usage.parameterListHeading());
+        assertTrue(usage.showDefaultValues());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> List<T> castList(Object val) {
+        return (List<T>) val;
+    }
+}

--- a/independent-projects/quickcli/quickcli-core/src/test/java/io/quarkus/quickcli/CommandLineTest.java
+++ b/independent-projects/quickcli/quickcli-core/src/test/java/io/quarkus/quickcli/CommandLineTest.java
@@ -1,0 +1,393 @@
+package io.quarkus.quickcli;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.quickcli.model.CommandModelRegistry;
+
+class CommandLineTest {
+
+    static class SimpleCmd implements Runnable {
+        String name;
+        boolean ran;
+
+        @Override
+        public void run() {
+            ran = true;
+        }
+    }
+
+    static class SubCmd implements Runnable {
+        @Override
+        public void run() {
+        }
+    }
+
+    static class FailCmd implements Runnable {
+        @Override
+        public void run() {
+            throw new RuntimeException("boom");
+        }
+    }
+
+    static class CallableCmd implements Callable<Integer> {
+        @Override
+        public Integer call() {
+            return 0;
+        }
+    }
+
+    static class VersionProviderCmd implements Runnable {
+        @Override
+        public void run() {
+        }
+    }
+
+    static class TestVersionProvider implements VersionProvider {
+        @Override
+        public String[] getVersion() {
+            return new String[] { "TestApp 3.0.0" };
+        }
+    }
+
+    // --- Output/Error streams ---
+
+    @Test
+    void setOutAndGetOut() {
+        CommandModelRegistry.register(TestModelHelper.builder(SimpleCmd.class, SimpleCmd::new)
+                .name("cmd").build());
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        CommandLine cmd = new CommandLine(SimpleCmd.class);
+        cmd.setOut(new PrintStream(baos));
+        PrintWriter out = cmd.getOut();
+        out.print("hello");
+        out.flush();
+        assertEquals("hello", baos.toString());
+    }
+
+    @Test
+    void setErrAndGetErr() {
+        CommandModelRegistry.register(TestModelHelper.builder(SimpleCmd.class, SimpleCmd::new)
+                .name("cmd").build());
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        CommandLine cmd = new CommandLine(SimpleCmd.class);
+        cmd.setErr(new PrintStream(baos));
+        PrintWriter err = cmd.getErr();
+        err.print("error");
+        err.flush();
+        assertEquals("error", baos.toString());
+    }
+
+    // --- Command name ---
+
+    @Test
+    void getCommandName() {
+        CommandModelRegistry.register(TestModelHelper.builder(SimpleCmd.class, SimpleCmd::new)
+                .name("myapp").build());
+
+        CommandLine cmd = new CommandLine(SimpleCmd.class);
+        assertEquals("myapp", cmd.getCommandName());
+    }
+
+    // --- parseArgs alias ---
+
+    @Test
+    void parseArgsAlias() {
+        CommandModelRegistry.register(TestModelHelper.builder(SimpleCmd.class, SimpleCmd::new)
+                .name("cmd")
+                .addOption(TestModelHelper.option(
+                        new String[] { "--name" }, "Name", String.class,
+                        (inst, val) -> ((SimpleCmd) inst).name = (String) val))
+                .build());
+
+        CommandLine cmd = new CommandLine(SimpleCmd.class);
+        ParseResult result = cmd.parseArgs("--name", "test");
+        assertEquals("test", result.getOptionValue("--name"));
+    }
+
+    // --- getParseResult ---
+
+    @Test
+    void getParseResultAfterParse() {
+        CommandModelRegistry.register(TestModelHelper.builder(SimpleCmd.class, SimpleCmd::new)
+                .name("cmd").build());
+
+        CommandLine cmd = new CommandLine(SimpleCmd.class);
+        ParseResult result = cmd.parse();
+        assertSame(result, cmd.getParseResult());
+    }
+
+    @Test
+    void getParseResultNull() {
+        CommandModelRegistry.register(TestModelHelper.builder(SimpleCmd.class, SimpleCmd::new)
+                .name("cmd").build());
+
+        CommandLine cmd = new CommandLine(SimpleCmd.class);
+        assertNull(cmd.getParseResult());
+    }
+
+    // --- getUnmatchedArguments ---
+
+    @Test
+    void getUnmatchedArgumentsEmpty() {
+        CommandModelRegistry.register(TestModelHelper.builder(SimpleCmd.class, SimpleCmd::new)
+                .name("cmd").build());
+
+        CommandLine cmd = new CommandLine(SimpleCmd.class);
+        assertTrue(cmd.getUnmatchedArguments().isEmpty());
+    }
+
+    @Test
+    void getUnmatchedArgumentsWithUnmatched() {
+        CommandModelRegistry.register(TestModelHelper.builder(SimpleCmd.class, SimpleCmd::new)
+                .name("cmd")
+                .hasUnmatchedField(true)
+                .unmatchedAccessor((inst, val) -> {
+                })
+                .build());
+
+        CommandLine cmd = new CommandLine(SimpleCmd.class);
+        cmd.parse("--extra", "arg");
+        assertEquals(List.of("--extra", "arg"), cmd.getUnmatchedArguments());
+    }
+
+    // --- usage ---
+
+    @Test
+    void usagePrintsHelp() {
+        CommandModelRegistry.register(TestModelHelper.builder(SimpleCmd.class, SimpleCmd::new)
+                .name("myapp")
+                .description("App desc")
+                .build());
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        CommandLine cmd = new CommandLine(SimpleCmd.class);
+        cmd.usage(new PrintStream(baos));
+        String output = baos.toString();
+        assertTrue(output.contains("myapp"));
+        assertTrue(output.contains("App desc"));
+    }
+
+    // --- getColorScheme ---
+
+    @Test
+    void getColorScheme() {
+        CommandModelRegistry.register(TestModelHelper.builder(SimpleCmd.class, SimpleCmd::new)
+                .name("cmd").build());
+
+        CommandLine cmd = new CommandLine(SimpleCmd.class);
+        assertNotNull(cmd.getColorScheme());
+    }
+
+    // --- getHelp ---
+
+    @Test
+    void getHelp() {
+        CommandModelRegistry.register(TestModelHelper.builder(SimpleCmd.class, SimpleCmd::new)
+                .name("cmd").build());
+
+        CommandLine cmd = new CommandLine(SimpleCmd.class);
+        Help help = cmd.getHelp();
+        assertNotNull(help);
+        assertSame(cmd.getCommandSpec(), help.commandSpec());
+    }
+
+    // --- Custom execution strategy ---
+
+    @Test
+    void customExecutionStrategy() {
+        CommandModelRegistry.register(TestModelHelper.builder(SimpleCmd.class, SimpleCmd::new)
+                .name("cmd").build());
+
+        CommandLine cmd = new CommandLine(SimpleCmd.class);
+        cmd.setExecutionStrategy((parseResult, commandLine) -> 77);
+        assertEquals(77, cmd.execute());
+    }
+
+    // --- Exit code exception mapper ---
+
+    @Test
+    void exitCodeExceptionMapper() {
+        CommandModelRegistry.register(TestModelHelper.builder(SimpleCmd.class, SimpleCmd::new)
+                .name("cmd").build());
+
+        CommandLine cmd = new CommandLine(SimpleCmd.class);
+        assertNull(cmd.getExitCodeExceptionMapper());
+        CommandLine.ExitCodeExceptionMapper mapper = ex -> 55;
+        cmd.setExitCodeExceptionMapper(mapper);
+        assertSame(mapper, cmd.getExitCodeExceptionMapper());
+    }
+
+    // --- Help section map ---
+
+    @Test
+    void helpSectionMap() {
+        CommandModelRegistry.register(TestModelHelper.builder(SimpleCmd.class, SimpleCmd::new)
+                .name("cmd").build());
+
+        CommandLine cmd = new CommandLine(SimpleCmd.class);
+        assertNotNull(cmd.getHelpSectionMap());
+    }
+
+    // --- Subcommand operations ---
+
+    @Test
+    void addSubcommandFromCommandLine() {
+        CommandModelRegistry.register(TestModelHelper.builder(SimpleCmd.class, SimpleCmd::new)
+                .name("myapp").build());
+        CommandModelRegistry.register(TestModelHelper.builder(SubCmd.class, SubCmd::new)
+                .name("sub").build());
+
+        CommandLine cmd = new CommandLine(SimpleCmd.class);
+        CommandLine subCmdLine = new CommandLine(SubCmd.class);
+        cmd.addSubcommand("dynamic", subCmdLine);
+        assertTrue(cmd.getSubcommands().containsKey("dynamic"));
+    }
+
+    @Test
+    void getSubcommandsUnmodifiable() {
+        CommandModelRegistry.register(TestModelHelper.builder(SimpleCmd.class, SimpleCmd::new)
+                .name("cmd").build());
+
+        CommandLine cmd = new CommandLine(SimpleCmd.class);
+        assertThrows(UnsupportedOperationException.class,
+                () -> cmd.getSubcommands().put("x", null));
+    }
+
+    // --- Error handling ---
+
+    @Test
+    void executeWithParameterErrorDefaultHandler() {
+        CommandModelRegistry.register(TestModelHelper.builder(SimpleCmd.class, SimpleCmd::new)
+                .name("cmd").build());
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        CommandLine cmd = new CommandLine(SimpleCmd.class);
+        cmd.setErr(new PrintStream(baos));
+        int code = cmd.execute("--invalid");
+        assertEquals(ExitCode.USAGE, code);
+        String errOutput = baos.toString();
+        assertTrue(errOutput.contains("Error"));
+        assertTrue(errOutput.contains("--help"));
+    }
+
+    @Test
+    void executeWithRuntimeException() {
+        CommandModelRegistry.register(TestModelHelper.builder(FailCmd.class, FailCmd::new)
+                .name("fail").build());
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        CommandLine cmd = new CommandLine(FailCmd.class);
+        cmd.setErr(new PrintStream(baos));
+        int code = cmd.execute();
+        assertEquals(ExitCode.SOFTWARE, code);
+    }
+
+    // --- Version via VersionProvider ---
+
+    @Test
+    void versionViaProvider() {
+        CommandModelRegistry.register(TestModelHelper.builder(VersionProviderCmd.class, VersionProviderCmd::new)
+                .name("vp")
+                .mixinStandardHelpOptions(true)
+                .versionProviderClass(TestVersionProvider.class)
+                .build());
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        Factory factory = new Factory() {
+            @Override
+            public <T> T create(Class<T> cls) throws Exception {
+                return cls.getDeclaredConstructor().newInstance();
+            }
+        };
+        CommandLine cmd = new CommandLine(VersionProviderCmd.class, factory);
+        cmd.setOut(new PrintStream(baos));
+        assertEquals(0, cmd.execute("--version"));
+        assertTrue(baos.toString().contains("TestApp 3.0.0"));
+    }
+
+    // --- Non-executable command with subcommands shows help ---
+
+    static class NonExecCmd {
+    }
+
+    @Test
+    void nonExecutableWithSubcommandsShowsHelp() {
+        CommandModelRegistry.register(TestModelHelper.builder(SubCmd.class, SubCmd::new)
+                .name("sub").build());
+        CommandModelRegistry.register(TestModelHelper.builder(NonExecCmd.class, NonExecCmd::new)
+                .name("app")
+                .addSubcommand(SubCmd.class)
+                .build());
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        CommandLine cmd = new CommandLine(NonExecCmd.class);
+        cmd.setOut(new PrintStream(baos));
+        int code = cmd.execute();
+        assertEquals(0, code);
+        assertTrue(baos.toString().contains("app"));
+    }
+
+    // --- usageHelp / versionHelp option flags ---
+
+    @Test
+    void usageHelpOption() {
+        CommandModelRegistry.register(TestModelHelper.builder(SimpleCmd.class, SimpleCmd::new)
+                .name("cmd")
+                .addOption(new io.quarkus.quickcli.model.BuiltCommandModel.OptionBinding(
+                        new String[] { "--help" }, "Show help", boolean.class,
+                        false, "", "", false, "", "help",
+                        false, true, false, -1,
+                        io.quarkus.quickcli.model.BuiltCommandModel.FieldKind.SINGLE,
+                        null, null, "", "", (inst, val) -> {
+                        }))
+                .build());
+
+        CommandLine cmd = new CommandLine(SimpleCmd.class);
+        ParseResult result = cmd.parse("--help");
+        assertTrue(result.isHelpRequested());
+    }
+
+    @Test
+    void versionHelpOption() {
+        CommandModelRegistry.register(TestModelHelper.builder(SimpleCmd.class, SimpleCmd::new)
+                .name("cmd")
+                .version("1.0")
+                .addOption(new io.quarkus.quickcli.model.BuiltCommandModel.OptionBinding(
+                        new String[] { "--version" }, "Show version", boolean.class,
+                        false, "", "", false, "", "version",
+                        true, false, false, -1,
+                        io.quarkus.quickcli.model.BuiltCommandModel.FieldKind.SINGLE,
+                        null, null, "", "", (inst, val) -> {
+                        }))
+                .build());
+
+        CommandLine cmd = new CommandLine(SimpleCmd.class);
+        ParseResult result = cmd.parse("--version");
+        assertTrue(result.isVersionRequested());
+    }
+
+    // --- CommandLine fluent API returns this ---
+
+    @Test
+    void fluentSettersReturnThis() {
+        CommandModelRegistry.register(TestModelHelper.builder(SimpleCmd.class, SimpleCmd::new)
+                .name("cmd").build());
+
+        CommandLine cmd = new CommandLine(SimpleCmd.class);
+        assertSame(cmd, cmd.setOut(System.out));
+        assertSame(cmd, cmd.setErr(System.err));
+        assertSame(cmd, cmd.setExecutionStrategy(new CommandLine.RunLastStrategy()));
+        assertSame(cmd, cmd.setParameterExceptionHandler((ex, args) -> 0));
+        assertSame(cmd, cmd.setExitCodeExceptionMapper(ex -> 0));
+    }
+}

--- a/independent-projects/quickcli/quickcli-core/src/test/java/io/quarkus/quickcli/CommandSpecTest.java
+++ b/independent-projects/quickcli/quickcli-core/src/test/java/io/quarkus/quickcli/CommandSpecTest.java
@@ -1,0 +1,228 @@
+package io.quarkus.quickcli;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.quickcli.model.CommandModelRegistry;
+
+class CommandSpecTest {
+
+    static class SpecCmd implements Runnable {
+        @Override
+        public void run() {
+        }
+    }
+
+    static class SubSpecCmd implements Runnable {
+        @Override
+        public void run() {
+        }
+    }
+
+    @Test
+    void specHasName() {
+        CommandModelRegistry.register(TestModelHelper.builder(SpecCmd.class, SpecCmd::new)
+                .name("myapp")
+                .build());
+
+        CommandLine cmd = new CommandLine(SpecCmd.class);
+        assertEquals("myapp", cmd.getCommandSpec().name());
+    }
+
+    @Test
+    void specHasDescription() {
+        CommandModelRegistry.register(TestModelHelper.builder(SpecCmd.class, SpecCmd::new)
+                .name("myapp")
+                .description("Line 1", "Line 2")
+                .build());
+
+        CommandLine cmd = new CommandLine(SpecCmd.class);
+        assertArrayEquals(new String[] { "Line 1", "Line 2" },
+                cmd.getCommandSpec().description());
+    }
+
+    @Test
+    void specHasVersion() {
+        CommandModelRegistry.register(TestModelHelper.builder(SpecCmd.class, SpecCmd::new)
+                .name("myapp")
+                .version("1.0.0", "Build 123")
+                .build());
+
+        CommandLine cmd = new CommandLine(SpecCmd.class);
+        assertArrayEquals(new String[] { "1.0.0", "Build 123" },
+                cmd.getCommandSpec().version());
+    }
+
+    @Test
+    void specOptions() {
+        CommandModelRegistry.register(TestModelHelper.builder(SpecCmd.class, SpecCmd::new)
+                .name("myapp")
+                .addOption(TestModelHelper.option(
+                        new String[] { "-n", "--name" }, "Name", String.class,
+                        (inst, val) -> {
+                        }))
+                .build());
+
+        CommandLine cmd = new CommandLine(SpecCmd.class);
+        assertEquals(1, cmd.getCommandSpec().options().size());
+        OptionSpec opt = cmd.getCommandSpec().options().get(0);
+        assertArrayEquals(new String[] { "-n", "--name" }, opt.names());
+        assertEquals("--name", opt.longestName());
+        assertEquals("Name", opt.description());
+    }
+
+    @Test
+    void specParameters() {
+        CommandModelRegistry.register(TestModelHelper.builder(SpecCmd.class, SpecCmd::new)
+                .name("myapp")
+                .addParameter(TestModelHelper.parameter(0, "Input file", String.class,
+                        (inst, val) -> {
+                        }))
+                .build());
+
+        CommandLine cmd = new CommandLine(SpecCmd.class);
+        assertEquals(1, cmd.getCommandSpec().parameters().size());
+        ParameterSpec param = cmd.getCommandSpec().parameters().get(0);
+        assertEquals(0, param.index());
+        assertEquals("Input file", param.description());
+    }
+
+    @Test
+    void specFindOption() {
+        CommandModelRegistry.register(TestModelHelper.builder(SpecCmd.class, SpecCmd::new)
+                .name("myapp")
+                .addOption(TestModelHelper.option(
+                        new String[] { "-n", "--name" }, "Name", String.class,
+                        (inst, val) -> {
+                        }))
+                .build());
+
+        CommandLine cmd = new CommandLine(SpecCmd.class);
+        CommandSpec spec = cmd.getCommandSpec();
+        assertNotNull(spec.findOption("-n"));
+        assertNotNull(spec.findOption("--name"));
+        assertNull(spec.findOption("--unknown"));
+    }
+
+    @Test
+    void specSubcommands() {
+        CommandModelRegistry.register(TestModelHelper.builder(SubSpecCmd.class, SubSpecCmd::new)
+                .name("sub")
+                .description("A subcommand")
+                .build());
+        CommandModelRegistry.register(TestModelHelper.builder(SpecCmd.class, SpecCmd::new)
+                .name("myapp")
+                .addSubcommand(SubSpecCmd.class)
+                .build());
+
+        CommandLine cmd = new CommandLine(SpecCmd.class);
+        assertTrue(cmd.getSubcommands().containsKey("sub"));
+        assertEquals("sub", cmd.getCommandSpec().subcommands().get("sub").name());
+    }
+
+    @Test
+    void specAliases() {
+        CommandModelRegistry.register(TestModelHelper.builder(SpecCmd.class, SpecCmd::new)
+                .name("myapp")
+                .aliases("app", "ma")
+                .build());
+
+        CommandLine cmd = new CommandLine(SpecCmd.class);
+        assertArrayEquals(new String[] { "app", "ma" }, cmd.getCommandSpec().aliases());
+    }
+
+    @Test
+    void specQualifiedName() {
+        CommandModelRegistry.register(TestModelHelper.builder(SubSpecCmd.class, SubSpecCmd::new)
+                .name("sub")
+                .build());
+        CommandModelRegistry.register(TestModelHelper.builder(SpecCmd.class, SpecCmd::new)
+                .name("myapp")
+                .addSubcommand(SubSpecCmd.class)
+                .build());
+
+        CommandLine cmd = new CommandLine(SpecCmd.class);
+        CommandSpec subSpec = cmd.getCommandSpec().subcommands().get("sub");
+        assertEquals("myapp sub", subSpec.qualifiedName());
+    }
+
+    @Test
+    void specAddSubcommandAtRuntime() {
+        CommandModelRegistry.register(TestModelHelper.builder(SpecCmd.class, SpecCmd::new)
+                .name("myapp")
+                .build());
+        CommandModelRegistry.register(TestModelHelper.builder(SubSpecCmd.class, SubSpecCmd::new)
+                .name("dynamic")
+                .build());
+
+        CommandLine cmd = new CommandLine(SpecCmd.class);
+        cmd.addSubcommand("dynamic", new CommandLine(SubSpecCmd.class));
+        assertTrue(cmd.getSubcommands().containsKey("dynamic"));
+    }
+
+    @Test
+    void specCreateForPlugins() {
+        CommandSpec spec = CommandSpec.create("plugin", Runnable.class);
+        assertEquals("plugin", spec.name());
+        assertEquals(Runnable.class, spec.commandClass());
+    }
+
+    @Test
+    void specHeaderAndFooter() {
+        CommandModelRegistry.register(TestModelHelper.builder(SpecCmd.class, SpecCmd::new)
+                .name("myapp")
+                .header("Header line")
+                .footer("Footer line")
+                .build());
+
+        CommandLine cmd = new CommandLine(SpecCmd.class);
+        assertArrayEquals(new String[] { "Header line" }, cmd.getCommandSpec().header());
+        assertArrayEquals(new String[] { "Footer line" }, cmd.getCommandSpec().footer());
+    }
+
+    @Test
+    void specExclusiveGroups() {
+        CommandModelRegistry.register(TestModelHelper.builder(SpecCmd.class, SpecCmd::new)
+                .name("myapp")
+                .addOption(TestModelHelper.booleanOption(
+                        new String[] { "--json" }, "JSON",
+                        (inst, val) -> {
+                        }))
+                .addOption(TestModelHelper.booleanOption(
+                        new String[] { "--xml" }, "XML",
+                        (inst, val) -> {
+                        }))
+                .addExclusiveGroup(List.of("--json", "--xml"))
+                .build());
+
+        CommandLine cmd = new CommandLine(SpecCmd.class);
+        assertEquals(1, cmd.getCommandSpec().exclusiveGroups().size());
+        assertEquals(List.of("--json", "--xml"), cmd.getCommandSpec().exclusiveGroups().get(0));
+    }
+
+    @Test
+    void optionSpecMatches() {
+        OptionSpec opt = new OptionSpec(
+                new String[] { "-n", "--name" }, "Name", String.class,
+                false, "", "", false, "", "name", false, false, false, -1);
+        assertTrue(opt.matches("-n"));
+        assertTrue(opt.matches("--name"));
+        assertFalse(opt.matches("--unknown"));
+    }
+
+    @Test
+    void optionSpecIsBoolean() {
+        OptionSpec boolOpt = new OptionSpec(
+                new String[] { "-v" }, "Verbose", boolean.class,
+                false, "", "", false, "", "verbose", false, false, false, -1);
+        assertTrue(boolOpt.isBoolean());
+
+        OptionSpec strOpt = new OptionSpec(
+                new String[] { "-n" }, "Name", String.class,
+                false, "", "", false, "", "name", false, false, false, -1);
+        assertFalse(strOpt.isBoolean());
+    }
+}

--- a/independent-projects/quickcli/quickcli-core/src/test/java/io/quarkus/quickcli/ExceptionTest.java
+++ b/independent-projects/quickcli/quickcli-core/src/test/java/io/quarkus/quickcli/ExceptionTest.java
@@ -1,0 +1,124 @@
+package io.quarkus.quickcli;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.quickcli.model.CommandModelRegistry;
+
+class ExceptionTest {
+
+    static class Cmd implements Runnable {
+        @Override
+        public void run() {
+        }
+    }
+
+    // --- ParameterException ---
+
+    @Test
+    void parameterExceptionMessageOnly() {
+        var ex = new CommandLine.ParameterException("bad param");
+        assertEquals("bad param", ex.getMessage());
+        assertNull(ex.getCommandLine());
+    }
+
+    @Test
+    void parameterExceptionWithCommandLine() {
+        CommandModelRegistry.register(TestModelHelper.builder(Cmd.class, Cmd::new)
+                .name("cmd").build());
+
+        CommandLine cmd = new CommandLine(Cmd.class);
+        var ex = new CommandLine.ParameterException("bad param", cmd);
+        assertEquals("bad param", ex.getMessage());
+        assertSame(cmd, ex.getCommandLine());
+    }
+
+    // --- UnmatchedArgumentException ---
+
+    @Test
+    void unmatchedArgumentException() {
+        var ex = new CommandLine.UnmatchedArgumentException("unmatched arg");
+        assertEquals("unmatched arg", ex.getMessage());
+        assertNull(ex.getCommandLine());
+    }
+
+    @Test
+    void unmatchedArgumentExceptionWithCommandLine() {
+        CommandModelRegistry.register(TestModelHelper.builder(Cmd.class, Cmd::new)
+                .name("cmd").build());
+
+        CommandLine cmd = new CommandLine(Cmd.class);
+        var ex = new CommandLine.UnmatchedArgumentException("unmatched", cmd);
+        assertSame(cmd, ex.getCommandLine());
+    }
+
+    @Test
+    void printSuggestions() {
+        CommandModelRegistry.register(TestModelHelper.builder(Cmd.class, Cmd::new)
+                .name("cmd").build());
+
+        // Register a subcommand so suggestions have something to print
+        CommandModelRegistry.register(TestModelHelper.builder(Cmd.class, Cmd::new)
+                .name("sub").build());
+
+        CommandLine cmd = new CommandLine(Cmd.class);
+        cmd.addSubcommand("sub", new CommandLine(Cmd.class));
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        var ex = new CommandLine.UnmatchedArgumentException("unknown", cmd);
+        CommandLine.UnmatchedArgumentException.printSuggestions(ex, new PrintStream(baos));
+        String output = baos.toString();
+        assertTrue(output.contains("Possible solutions"));
+        assertTrue(output.contains("sub"));
+    }
+
+    @Test
+    void printSuggestionsNoCommandLine() {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        var ex = new CommandLine.ParameterException("no cmd");
+        // Should not throw even without a CommandLine
+        CommandLine.UnmatchedArgumentException.printSuggestions(ex, new PrintStream(baos));
+        assertEquals("", baos.toString());
+    }
+
+    // --- MutuallyExclusiveArgsException ---
+
+    @Test
+    void mutuallyExclusiveArgsException() {
+        var ex = new CommandLine.MutuallyExclusiveArgsException("exclusive");
+        assertEquals("exclusive", ex.getMessage());
+        assertInstanceOf(CommandLine.ParameterException.class, ex);
+    }
+
+    @Test
+    void mutuallyExclusiveArgsExceptionWithCommandLine() {
+        CommandModelRegistry.register(TestModelHelper.builder(Cmd.class, Cmd::new)
+                .name("cmd").build());
+
+        CommandLine cmd = new CommandLine(Cmd.class);
+        var ex = new CommandLine.MutuallyExclusiveArgsException("exclusive", cmd);
+        assertSame(cmd, ex.getCommandLine());
+    }
+
+    // --- TypeConversionException ---
+
+    @Test
+    void typeConversionException() {
+        var ex = new CommandLine.TypeConversionException("bad type");
+        assertEquals("bad type", ex.getMessage());
+        assertInstanceOf(CommandLine.ParameterException.class, ex);
+    }
+
+    // --- ExecutionException ---
+
+    @Test
+    void executionException() {
+        var cause = new RuntimeException("inner");
+        var ex = new CommandLine.ExecutionException(cause);
+        assertSame(cause, ex.getCause());
+    }
+}

--- a/independent-projects/quickcli/quickcli-core/src/test/java/io/quarkus/quickcli/HelpFormatterTest.java
+++ b/independent-projects/quickcli/quickcli-core/src/test/java/io/quarkus/quickcli/HelpFormatterTest.java
@@ -1,0 +1,158 @@
+package io.quarkus.quickcli;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.quickcli.model.CommandModelRegistry;
+
+class HelpFormatterTest {
+
+    static class HelpCmd implements Runnable {
+        @Override
+        public void run() {
+        }
+    }
+
+    private String captureHelp(CommandSpec spec) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        HelpFormatter.printHelp(spec, new PrintStream(baos));
+        return baos.toString();
+    }
+
+    @Test
+    void helpShowsCommandName() {
+        CommandModelRegistry.register(TestModelHelper.builder(HelpCmd.class, HelpCmd::new)
+                .name("myapp")
+                .build());
+
+        CommandLine cmd = new CommandLine(HelpCmd.class);
+        String help = captureHelp(cmd.getCommandSpec());
+        assertTrue(help.contains("myapp"));
+    }
+
+    @Test
+    void helpShowsDescription() {
+        CommandModelRegistry.register(TestModelHelper.builder(HelpCmd.class, HelpCmd::new)
+                .name("myapp")
+                .description("A great application")
+                .build());
+
+        CommandLine cmd = new CommandLine(HelpCmd.class);
+        String help = captureHelp(cmd.getCommandSpec());
+        assertTrue(help.contains("A great application"));
+    }
+
+    @Test
+    void helpShowsOptions() {
+        CommandModelRegistry.register(TestModelHelper.builder(HelpCmd.class, HelpCmd::new)
+                .name("myapp")
+                .addOption(TestModelHelper.option(
+                        new String[] { "-n", "--name" }, "Your name", String.class,
+                        (inst, val) -> {
+                        }))
+                .build());
+
+        CommandLine cmd = new CommandLine(HelpCmd.class);
+        String help = captureHelp(cmd.getCommandSpec());
+        assertTrue(help.contains("-n"));
+        assertTrue(help.contains("--name"));
+        assertTrue(help.contains("Your name"));
+    }
+
+    @Test
+    void helpShowsHeader() {
+        CommandModelRegistry.register(TestModelHelper.builder(HelpCmd.class, HelpCmd::new)
+                .name("myapp")
+                .header("My App v1.0")
+                .build());
+
+        CommandLine cmd = new CommandLine(HelpCmd.class);
+        String help = captureHelp(cmd.getCommandSpec());
+        assertTrue(help.contains("My App v1.0"));
+    }
+
+    @Test
+    void helpShowsFooter() {
+        CommandModelRegistry.register(TestModelHelper.builder(HelpCmd.class, HelpCmd::new)
+                .name("myapp")
+                .footer("Copyright 2024")
+                .build());
+
+        CommandLine cmd = new CommandLine(HelpCmd.class);
+        String help = captureHelp(cmd.getCommandSpec());
+        assertTrue(help.contains("Copyright 2024"));
+    }
+
+    @Test
+    void helpHidesHiddenOptions() {
+        CommandModelRegistry.register(TestModelHelper.builder(HelpCmd.class, HelpCmd::new)
+                .name("myapp")
+                .addOption(TestModelHelper.option(
+                        new String[] { "--visible" }, "Visible option", String.class,
+                        (inst, val) -> {
+                        }))
+                .addOption(TestModelHelper.hiddenOption(
+                        new String[] { "--secret" }, "Secret option", String.class,
+                        (inst, val) -> {
+                        }))
+                .build());
+
+        CommandLine cmd = new CommandLine(HelpCmd.class);
+        String help = captureHelp(cmd.getCommandSpec());
+        assertTrue(help.contains("--visible"));
+        assertFalse(help.contains("--secret"));
+    }
+
+    @Test
+    void helpShowsStandardHelpOptions() {
+        CommandModelRegistry.register(TestModelHelper.builder(HelpCmd.class, HelpCmd::new)
+                .name("myapp")
+                .mixinStandardHelpOptions(true)
+                .build());
+
+        CommandLine cmd = new CommandLine(HelpCmd.class);
+        String help = captureHelp(cmd.getCommandSpec());
+        assertTrue(help.contains("--help"));
+        assertTrue(help.contains("--version"));
+    }
+
+    @Test
+    void helpShowsParameters() {
+        CommandModelRegistry.register(TestModelHelper.builder(HelpCmd.class, HelpCmd::new)
+                .name("myapp")
+                .addParameter(TestModelHelper.parameter(0, "Input file", String.class,
+                        (inst, val) -> {
+                        }))
+                .build());
+
+        CommandLine cmd = new CommandLine(HelpCmd.class);
+        String help = captureHelp(cmd.getCommandSpec());
+        assertTrue(help.contains("Input file"));
+    }
+
+    static class SubHelpCmd implements Runnable {
+        @Override
+        public void run() {
+        }
+    }
+
+    @Test
+    void helpShowsSubcommands() {
+        CommandModelRegistry.register(TestModelHelper.builder(SubHelpCmd.class, SubHelpCmd::new)
+                .name("sub")
+                .description("A subcommand")
+                .build());
+        CommandModelRegistry.register(TestModelHelper.builder(HelpCmd.class, HelpCmd::new)
+                .name("myapp")
+                .addSubcommand(SubHelpCmd.class)
+                .build());
+
+        CommandLine cmd = new CommandLine(HelpCmd.class);
+        String help = captureHelp(cmd.getCommandSpec());
+        assertTrue(help.contains("sub"));
+    }
+}

--- a/independent-projects/quickcli/quickcli-core/src/test/java/io/quarkus/quickcli/HelpTest.java
+++ b/independent-projects/quickcli/quickcli-core/src/test/java/io/quarkus/quickcli/HelpTest.java
@@ -1,0 +1,164 @@
+package io.quarkus.quickcli;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.quickcli.model.CommandModelRegistry;
+
+class HelpTest {
+
+    static class HelpCmd implements Runnable {
+        @Override
+        public void run() {
+        }
+    }
+
+    static class SubHelpCmd implements Runnable {
+        @Override
+        public void run() {
+        }
+    }
+
+    @Test
+    void fullSynopsisContainsName() {
+        CommandModelRegistry.register(TestModelHelper.builder(HelpCmd.class, HelpCmd::new)
+                .name("myapp").build());
+
+        CommandLine cmd = new CommandLine(HelpCmd.class);
+        Help help = cmd.getHelp();
+        String synopsis = help.fullSynopsis();
+        assertTrue(synopsis.contains("myapp"));
+    }
+
+    @Test
+    void fullSynopsisShowsOptions() {
+        CommandModelRegistry.register(TestModelHelper.builder(HelpCmd.class, HelpCmd::new)
+                .name("myapp")
+                .addOption(TestModelHelper.option(
+                        new String[] { "--name" }, "Name", String.class,
+                        (inst, val) -> {
+                        }))
+                .build());
+
+        CommandLine cmd = new CommandLine(HelpCmd.class);
+        assertTrue(cmd.getHelp().fullSynopsis().contains("[OPTIONS]"));
+    }
+
+    @Test
+    void fullSynopsisShowsCommand() {
+        CommandModelRegistry.register(TestModelHelper.builder(SubHelpCmd.class, SubHelpCmd::new)
+                .name("sub").build());
+        CommandModelRegistry.register(TestModelHelper.builder(HelpCmd.class, HelpCmd::new)
+                .name("myapp")
+                .addSubcommand(SubHelpCmd.class)
+                .build());
+
+        CommandLine cmd = new CommandLine(HelpCmd.class);
+        assertTrue(cmd.getHelp().fullSynopsis().contains("[COMMAND]"));
+    }
+
+    @Test
+    void fullSynopsisShowsParameters() {
+        CommandModelRegistry.register(TestModelHelper.builder(HelpCmd.class, HelpCmd::new)
+                .name("myapp")
+                .addParameter(TestModelHelper.parameter(0, "Input file", String.class,
+                        (inst, val) -> {
+                        }))
+                .build());
+
+        CommandLine cmd = new CommandLine(HelpCmd.class);
+        String synopsis = cmd.getHelp().fullSynopsis();
+        assertTrue(synopsis.contains("<param0>") || synopsis.contains("param0"));
+    }
+
+    @Test
+    void commandListEmpty() {
+        CommandModelRegistry.register(TestModelHelper.builder(HelpCmd.class, HelpCmd::new)
+                .name("myapp").build());
+
+        CommandLine cmd = new CommandLine(HelpCmd.class);
+        assertEquals("", cmd.getHelp().commandList());
+    }
+
+    @Test
+    void commandListWithSubcommands() {
+        CommandModelRegistry.register(TestModelHelper.builder(SubHelpCmd.class, SubHelpCmd::new)
+                .name("sub")
+                .description("A subcommand")
+                .build());
+        CommandModelRegistry.register(TestModelHelper.builder(HelpCmd.class, HelpCmd::new)
+                .name("myapp")
+                .addSubcommand(SubHelpCmd.class)
+                .build());
+
+        CommandLine cmd = new CommandLine(HelpCmd.class);
+        String list = cmd.getHelp().commandList();
+        assertTrue(list.contains("sub"));
+        assertTrue(list.contains("A subcommand"));
+    }
+
+    @Test
+    void formatHeadingReplacesNewlines() {
+        assertEquals("Title" + System.lineSeparator(), Help.formatHeading("Title%n"));
+    }
+
+    @Test
+    void formatHeadingEmpty() {
+        assertEquals("", Help.formatHeading(""));
+        assertEquals("", Help.formatHeading(null));
+    }
+
+    @Test
+    void colorSchemeErrorText() {
+        Help.ColorScheme cs = Help.ColorScheme.DEFAULT;
+        assertEquals("Error occurred", cs.errorText("@|red Error occurred|@"));
+    }
+
+    @Test
+    void colorSchemeStackTraceText() {
+        Help.ColorScheme cs = Help.ColorScheme.DEFAULT;
+        String trace = cs.stackTraceText(new RuntimeException("test"));
+        assertTrue(trace.contains("RuntimeException"));
+        assertTrue(trace.contains("test"));
+    }
+
+    @Test
+    void textTableRendering() {
+        Help.TextTable table = Help.TextTable.forColumns(
+                Help.ColorScheme.DEFAULT,
+                new Help.Column(20, 2, Help.Column.Overflow.SPAN),
+                new Help.Column(40, 2, Help.Column.Overflow.WRAP));
+        table.addRowValues("--name", "Your name");
+        table.addRowValues("--count", "Number of times");
+        String output = table.toString();
+        assertTrue(output.contains("--name"));
+        assertTrue(output.contains("Your name"));
+        assertTrue(output.contains("--count"));
+    }
+
+    @Test
+    void helpCommandSpec() {
+        CommandModelRegistry.register(TestModelHelper.builder(HelpCmd.class, HelpCmd::new)
+                .name("myapp").build());
+
+        CommandLine cmd = new CommandLine(HelpCmd.class);
+        Help help = new Help(cmd.getCommandSpec());
+        assertSame(cmd.getCommandSpec(), help.commandSpec());
+    }
+
+    @Test
+    void helpColorScheme() {
+        CommandModelRegistry.register(TestModelHelper.builder(HelpCmd.class, HelpCmd::new)
+                .name("myapp").build());
+
+        CommandLine cmd = new CommandLine(HelpCmd.class);
+        Help help = new Help(cmd.getCommandSpec(), Help.ColorScheme.DEFAULT);
+        assertSame(Help.ColorScheme.DEFAULT, help.colorScheme());
+    }
+
+    @Test
+    void colorSchemeAnsi() {
+        assertEquals(Ansi.AUTO, Help.ColorScheme.DEFAULT.ansi());
+    }
+}

--- a/independent-projects/quickcli/quickcli-core/src/test/java/io/quarkus/quickcli/ParseResultTest.java
+++ b/independent-projects/quickcli/quickcli-core/src/test/java/io/quarkus/quickcli/ParseResultTest.java
@@ -1,0 +1,163 @@
+package io.quarkus.quickcli;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.quickcli.model.CommandModelRegistry;
+
+class ParseResultTest {
+
+    static class Cmd implements Runnable {
+        String name;
+        boolean verbose;
+
+        @Override
+        public void run() {
+        }
+    }
+
+    static class SubCmd implements Runnable {
+        @Override
+        public void run() {
+        }
+    }
+
+    @Test
+    void originalArgs() {
+        CommandModelRegistry.register(TestModelHelper.builder(Cmd.class, Cmd::new)
+                .name("cmd")
+                .addOption(TestModelHelper.option(
+                        new String[] { "-n", "--name" }, "Name", String.class,
+                        (inst, val) -> ((Cmd) inst).name = (String) val))
+                .build());
+
+        CommandLine cmd = new CommandLine(Cmd.class);
+        ParseResult result = cmd.parse("-n", "Alice");
+        assertEquals(List.of("-n", "Alice"), result.originalArgs());
+    }
+
+    @Test
+    void matchedOptionByName() {
+        CommandModelRegistry.register(TestModelHelper.builder(Cmd.class, Cmd::new)
+                .name("cmd")
+                .addOption(TestModelHelper.option(
+                        new String[] { "-n", "--name" }, "Name", String.class,
+                        (inst, val) -> ((Cmd) inst).name = (String) val))
+                .build());
+
+        CommandLine cmd = new CommandLine(Cmd.class);
+        ParseResult result = cmd.parse("--name", "Bob");
+        assertNotNull(result.matchedOption("--name"));
+        assertNotNull(result.matchedOption("-n"));
+        assertNull(result.matchedOption("--unknown"));
+    }
+
+    @Test
+    void matchedOptionNotPresent() {
+        CommandModelRegistry.register(TestModelHelper.builder(Cmd.class, Cmd::new)
+                .name("cmd")
+                .addOption(TestModelHelper.option(
+                        new String[] { "--name" }, "Name", String.class,
+                        (inst, val) -> ((Cmd) inst).name = (String) val))
+                .build());
+
+        CommandLine cmd = new CommandLine(Cmd.class);
+        ParseResult result = cmd.parse();
+        assertNull(result.matchedOption("--name"));
+    }
+
+    @Test
+    void hasOptionBySpec() {
+        CommandModelRegistry.register(TestModelHelper.builder(Cmd.class, Cmd::new)
+                .name("cmd")
+                .addOption(TestModelHelper.option(
+                        new String[] { "-n", "--name" }, "Name", String.class,
+                        (inst, val) -> ((Cmd) inst).name = (String) val))
+                .build());
+
+        CommandLine cmd = new CommandLine(Cmd.class);
+        ParseResult result = cmd.parse("-n", "test");
+        OptionSpec opt = cmd.getCommandSpec().options().get(0);
+        assertTrue(result.hasOptionBySpec(opt));
+    }
+
+    @Test
+    void resolveOptionValue() {
+        CommandModelRegistry.register(TestModelHelper.builder(Cmd.class, Cmd::new)
+                .name("cmd")
+                .addOption(TestModelHelper.option(
+                        new String[] { "-n", "--name" }, "Name", String.class,
+                        (inst, val) -> ((Cmd) inst).name = (String) val))
+                .build());
+
+        CommandLine cmd = new CommandLine(Cmd.class);
+        ParseResult result = cmd.parse("-n", "resolved");
+        OptionSpec opt = cmd.getCommandSpec().options().get(0);
+        assertEquals("resolved", result.resolveOptionValue(opt));
+    }
+
+    @Test
+    void subcommandAlias() {
+        CommandModelRegistry.register(TestModelHelper.builder(SubCmd.class, SubCmd::new)
+                .name("sub").build());
+        CommandModelRegistry.register(TestModelHelper.builder(Cmd.class, Cmd::new)
+                .name("cmd")
+                .addSubcommand(SubCmd.class)
+                .build());
+
+        CommandLine cmd = new CommandLine(Cmd.class);
+        ParseResult result = cmd.parse("sub");
+        // subcommand() is an alias for subcommandResult()
+        assertSame(result.subcommandResult(), result.subcommand());
+    }
+
+    @Test
+    void getOptionValuesEmpty() {
+        CommandModelRegistry.register(TestModelHelper.builder(Cmd.class, Cmd::new)
+                .name("cmd").build());
+
+        CommandLine cmd = new CommandLine(Cmd.class);
+        ParseResult result = cmd.parse();
+        assertTrue(result.getOptionValues("--nonexistent").isEmpty());
+    }
+
+    @Test
+    void getOptionValueNull() {
+        CommandModelRegistry.register(TestModelHelper.builder(Cmd.class, Cmd::new)
+                .name("cmd").build());
+
+        CommandLine cmd = new CommandLine(Cmd.class);
+        ParseResult result = cmd.parse();
+        assertNull(result.getOptionValue("--nonexistent"));
+    }
+
+    @Test
+    void getPositionalValueOutOfBounds() {
+        CommandModelRegistry.register(TestModelHelper.builder(Cmd.class, Cmd::new)
+                .name("cmd").build());
+
+        CommandLine cmd = new CommandLine(Cmd.class);
+        ParseResult result = cmd.parse();
+        assertNull(result.getPositionalValue(0));
+    }
+
+    @Test
+    void multipleValuesForSameOption() {
+        CommandModelRegistry.register(TestModelHelper.builder(Cmd.class, Cmd::new)
+                .name("cmd")
+                .addOption(TestModelHelper.listOption(
+                        new String[] { "--item" }, "Items", String.class,
+                        (inst, val) -> {
+                        }))
+                .build());
+
+        CommandLine cmd = new CommandLine(Cmd.class);
+        ParseResult result = cmd.parse("--item", "a", "--item", "b");
+        assertEquals(List.of("a", "b"), result.getOptionValues("--item"));
+        // getOptionValue returns the first
+        assertEquals("a", result.getOptionValue("--item"));
+    }
+}

--- a/independent-projects/quickcli/quickcli-core/src/test/java/io/quarkus/quickcli/ParsingTest.java
+++ b/independent-projects/quickcli/quickcli-core/src/test/java/io/quarkus/quickcli/ParsingTest.java
@@ -1,0 +1,744 @@
+package io.quarkus.quickcli;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.quickcli.model.BuiltCommandModel;
+import io.quarkus.quickcli.model.BuiltCommandModel.FieldKind;
+import io.quarkus.quickcli.model.CommandModelRegistry;
+
+class ParsingTest {
+
+    // --- Simple command classes (plain POJOs) ---
+
+    static class GreetCmd implements Runnable {
+        String name;
+        int count;
+        boolean verbose;
+
+        @Override
+        public void run() {
+        }
+    }
+
+    static class RequiredCmd implements Runnable {
+        String name;
+
+        @Override
+        public void run() {
+        }
+    }
+
+    static class MultiCmd implements Runnable {
+        List<String> items;
+
+        @Override
+        public void run() {
+        }
+    }
+
+    static class MapCmd implements Runnable {
+        Map<String, String> props;
+
+        @Override
+        public void run() {
+        }
+    }
+
+    static class OptionalCmd implements Runnable {
+        Optional<String> name = Optional.empty();
+
+        @Override
+        public void run() {
+        }
+    }
+
+    static class SetCmd implements Runnable {
+        Set<String> tags;
+
+        @Override
+        public void run() {
+        }
+    }
+
+    static class ArrayCmd implements Runnable {
+        String[] files;
+
+        @Override
+        public void run() {
+        }
+    }
+
+    static class ParamCmd implements Runnable {
+        String file;
+        int line;
+
+        @Override
+        public void run() {
+        }
+    }
+
+    static class MultiParamCmd implements Runnable {
+        List<String> files;
+
+        @Override
+        public void run() {
+        }
+    }
+
+    static class UnmatchedCmd implements Runnable {
+        List<String> unmatched;
+
+        @Override
+        public void run() {
+        }
+    }
+
+    static class DefaultCmd implements Runnable {
+        String format;
+
+        @Override
+        public void run() {
+        }
+    }
+
+    static class NegatableCmd implements Runnable {
+        boolean verbose;
+
+        @Override
+        public void run() {
+        }
+    }
+
+    static class SplitCmd implements Runnable {
+        List<String> items;
+
+        @Override
+        public void run() {
+        }
+    }
+
+    static class ExitCmd implements Callable<Integer> {
+        int code;
+
+        @Override
+        public Integer call() {
+            return code;
+        }
+    }
+
+    static class ExclusiveCmd implements Runnable {
+        boolean json;
+        boolean xml;
+
+        @Override
+        public void run() {
+        }
+    }
+
+    static class TopCmd implements Runnable {
+        @Override
+        public void run() {
+        }
+    }
+
+    static class SubCmd implements Runnable {
+        String name;
+        boolean ran;
+
+        @Override
+        public void run() {
+            ran = true;
+        }
+    }
+
+    static class PrefixCmd implements Runnable {
+        String prop;
+
+        @Override
+        public void run() {
+        }
+    }
+
+    static class HiddenCmd implements Runnable {
+        String secret;
+
+        @Override
+        public void run() {
+        }
+    }
+
+    // --- Helper to register a model ---
+
+    private void registerModel(BuiltCommandModel model) {
+        CommandModelRegistry.register(model);
+    }
+
+    // --- Tests ---
+
+    @Test
+    void parseLongOption() {
+        var ref = new AtomicReference<String>();
+        registerModel(TestModelHelper.builder(GreetCmd.class, GreetCmd::new)
+                .name("greet")
+                .addOption(TestModelHelper.option(
+                        new String[] { "-n", "--name" }, "Name", String.class,
+                        (inst, val) -> ((GreetCmd) inst).name = (String) val))
+                .build());
+
+        CommandLine cmd = new CommandLine(GreetCmd.class);
+        ParseResult result = cmd.parse("--name", "Alice");
+        assertEquals("Alice", result.getOptionValue("--name"));
+    }
+
+    @Test
+    void parseShortOption() {
+        registerModel(TestModelHelper.builder(GreetCmd.class, GreetCmd::new)
+                .name("greet")
+                .addOption(TestModelHelper.option(
+                        new String[] { "-n", "--name" }, "Name", String.class,
+                        (inst, val) -> ((GreetCmd) inst).name = (String) val))
+                .build());
+
+        CommandLine cmd = new CommandLine(GreetCmd.class);
+        ParseResult result = cmd.parse("-n", "Bob");
+        assertEquals("Bob", result.getOptionValue("--name"));
+    }
+
+    @Test
+    void parseInlineValue() {
+        registerModel(TestModelHelper.builder(GreetCmd.class, GreetCmd::new)
+                .name("greet")
+                .addOption(TestModelHelper.option(
+                        new String[] { "-n", "--name" }, "Name", String.class,
+                        (inst, val) -> ((GreetCmd) inst).name = (String) val))
+                .build());
+
+        CommandLine cmd = new CommandLine(GreetCmd.class);
+        ParseResult result = cmd.parse("--name=Charlie");
+        assertEquals("Charlie", result.getOptionValue("--name"));
+    }
+
+    @Test
+    void parseBooleanFlag() {
+        registerModel(TestModelHelper.builder(GreetCmd.class, GreetCmd::new)
+                .name("greet")
+                .addOption(TestModelHelper.booleanOption(
+                        new String[] { "-v", "--verbose" }, "Verbose",
+                        (inst, val) -> ((GreetCmd) inst).verbose = (boolean) val))
+                .build());
+
+        CommandLine cmd = new CommandLine(GreetCmd.class);
+        ParseResult result = cmd.parse("-v");
+        assertEquals("true", result.getOptionValue("--verbose"));
+    }
+
+    @Test
+    void parseBooleanFlagNotPresent() {
+        registerModel(TestModelHelper.builder(GreetCmd.class, GreetCmd::new)
+                .name("greet")
+                .addOption(TestModelHelper.booleanOption(
+                        new String[] { "-v", "--verbose" }, "Verbose",
+                        (inst, val) -> ((GreetCmd) inst).verbose = (boolean) val))
+                .build());
+
+        CommandLine cmd = new CommandLine(GreetCmd.class);
+        ParseResult result = cmd.parse();
+        assertFalse(result.hasOption("--verbose"));
+    }
+
+    @Test
+    void parseIntOption() {
+        registerModel(TestModelHelper.builder(GreetCmd.class, GreetCmd::new)
+                .name("greet")
+                .addOption(TestModelHelper.option(
+                        new String[] { "-c", "--count" }, "Count", int.class,
+                        (inst, val) -> ((GreetCmd) inst).count = (int) val))
+                .build());
+
+        CommandLine cmd = new CommandLine(GreetCmd.class);
+        int exitCode = cmd.execute("-c", "5");
+        assertEquals(0, exitCode);
+    }
+
+    @Test
+    void parseRequiredOptionMissing() {
+        registerModel(TestModelHelper.builder(RequiredCmd.class, RequiredCmd::new)
+                .name("req")
+                .addOption(TestModelHelper.requiredOption(
+                        new String[] { "--name" }, "Name", String.class,
+                        (inst, val) -> ((RequiredCmd) inst).name = (String) val))
+                .build());
+
+        CommandLine cmd = new CommandLine(RequiredCmd.class);
+        assertThrows(CommandLine.ParameterException.class, () -> cmd.parse());
+    }
+
+    @Test
+    void parseRequiredOptionPresent() {
+        registerModel(TestModelHelper.builder(RequiredCmd.class, RequiredCmd::new)
+                .name("req")
+                .addOption(TestModelHelper.requiredOption(
+                        new String[] { "--name" }, "Name", String.class,
+                        (inst, val) -> ((RequiredCmd) inst).name = (String) val))
+                .build());
+
+        CommandLine cmd = new CommandLine(RequiredCmd.class);
+        ParseResult result = cmd.parse("--name", "test");
+        assertEquals("test", result.getOptionValue("--name"));
+    }
+
+    @Test
+    void unknownOptionThrows() {
+        registerModel(TestModelHelper.builder(GreetCmd.class, GreetCmd::new)
+                .name("greet")
+                .build());
+
+        CommandLine cmd = new CommandLine(GreetCmd.class);
+        assertThrows(CommandLine.ParameterException.class, () -> cmd.parse("--unknown"));
+    }
+
+    @Test
+    void optionMissingValueThrows() {
+        registerModel(TestModelHelper.builder(GreetCmd.class, GreetCmd::new)
+                .name("greet")
+                .addOption(TestModelHelper.option(
+                        new String[] { "--name" }, "Name", String.class,
+                        (inst, val) -> ((GreetCmd) inst).name = (String) val))
+                .build());
+
+        CommandLine cmd = new CommandLine(GreetCmd.class);
+        assertThrows(CommandLine.ParameterException.class, () -> cmd.parse("--name"));
+    }
+
+    @Test
+    void parsePositionalParameters() {
+        registerModel(TestModelHelper.builder(ParamCmd.class, ParamCmd::new)
+                .name("param")
+                .addParameter(TestModelHelper.parameter(0, "File", String.class,
+                        (inst, val) -> ((ParamCmd) inst).file = (String) val))
+                .addParameter(TestModelHelper.parameter(1, "Line", int.class,
+                        (inst, val) -> ((ParamCmd) inst).line = (int) val))
+                .build());
+
+        CommandLine cmd = new CommandLine(ParamCmd.class);
+        ParseResult result = cmd.parse("test.txt", "42");
+        assertEquals("test.txt", result.getPositionalValue(0));
+        assertEquals("42", result.getPositionalValue(1));
+    }
+
+    @Test
+    void parseMultiValueParameter() {
+        registerModel(TestModelHelper.builder(MultiParamCmd.class, MultiParamCmd::new)
+                .name("multi")
+                .addParameter(TestModelHelper.multiValueParameter(0, "Files", String.class,
+                        (inst, val) -> ((MultiParamCmd) inst).files = castList(val)))
+                .build());
+
+        CommandLine cmd = new CommandLine(MultiParamCmd.class);
+        ParseResult result = cmd.parse("a.txt", "b.txt", "c.txt");
+        assertEquals(List.of("a.txt", "b.txt", "c.txt"), result.positionalValues());
+    }
+
+    @Test
+    void parseDoubleDashEndsOptions() {
+        registerModel(TestModelHelper.builder(ParamCmd.class, ParamCmd::new)
+                .name("param")
+                .addParameter(TestModelHelper.parameter(0, "File", String.class,
+                        (inst, val) -> ((ParamCmd) inst).file = (String) val))
+                .build());
+
+        CommandLine cmd = new CommandLine(ParamCmd.class);
+        ParseResult result = cmd.parse("--", "--not-an-option");
+        assertEquals("--not-an-option", result.getPositionalValue(0));
+    }
+
+    @Test
+    void parseHelpFlag() {
+        registerModel(TestModelHelper.builder(GreetCmd.class, GreetCmd::new)
+                .name("greet")
+                .mixinStandardHelpOptions(true)
+                .build());
+
+        CommandLine cmd = new CommandLine(GreetCmd.class);
+        ParseResult result = cmd.parse("--help");
+        assertTrue(result.isHelpRequested());
+    }
+
+    @Test
+    void parseHelpShortFlag() {
+        registerModel(TestModelHelper.builder(GreetCmd.class, GreetCmd::new)
+                .name("greet")
+                .build());
+
+        CommandLine cmd = new CommandLine(GreetCmd.class);
+        ParseResult result = cmd.parse("-h");
+        assertTrue(result.isHelpRequested());
+    }
+
+    @Test
+    void parseVersionFlag() {
+        registerModel(TestModelHelper.builder(GreetCmd.class, GreetCmd::new)
+                .name("greet")
+                .version("1.0.0")
+                .mixinStandardHelpOptions(true)
+                .build());
+
+        CommandLine cmd = new CommandLine(GreetCmd.class);
+        ParseResult result = cmd.parse("--version");
+        assertTrue(result.isVersionRequested());
+    }
+
+    @Test
+    void parseListOption() {
+        registerModel(TestModelHelper.builder(MultiCmd.class, MultiCmd::new)
+                .name("multi")
+                .addOption(TestModelHelper.listOption(
+                        new String[] { "-i", "--item" }, "Items", String.class,
+                        (inst, val) -> ((MultiCmd) inst).items = castList(val)))
+                .build());
+
+        CommandLine cmd = new CommandLine(MultiCmd.class);
+        ParseResult result = cmd.parse("-i", "a", "-i", "b", "-i", "c");
+        assertEquals(List.of("a", "b", "c"), result.getOptionValues("--item"));
+    }
+
+    @Test
+    void parseSetOption() {
+        registerModel(TestModelHelper.builder(SetCmd.class, SetCmd::new)
+                .name("set")
+                .addOption(TestModelHelper.setOption(
+                        new String[] { "-t", "--tag" }, "Tags", String.class,
+                        (inst, val) -> ((SetCmd) inst).tags = castSet(val)))
+                .build());
+
+        CommandLine cmd = new CommandLine(SetCmd.class);
+        ParseResult result = cmd.parse("-t", "a", "-t", "b", "-t", "a");
+        assertEquals(List.of("a", "b", "a"), result.getOptionValues("--tag"));
+    }
+
+    @Test
+    void parseArrayOption() {
+        registerModel(TestModelHelper.builder(ArrayCmd.class, ArrayCmd::new)
+                .name("arr")
+                .addOption(TestModelHelper.arrayOption(
+                        new String[] { "-f", "--file" }, "Files", String.class,
+                        (inst, val) -> ((ArrayCmd) inst).files = (String[]) val))
+                .build());
+
+        CommandLine cmd = new CommandLine(ArrayCmd.class);
+        ParseResult result = cmd.parse("-f", "a.txt", "-f", "b.txt");
+        assertEquals(List.of("a.txt", "b.txt"), result.getOptionValues("--file"));
+    }
+
+    @Test
+    void parseMapOption() {
+        registerModel(TestModelHelper.builder(MapCmd.class, MapCmd::new)
+                .name("map")
+                .addOption(TestModelHelper.mapOption(
+                        new String[] { "-D" }, "Properties", "",
+                        (inst, val) -> ((MapCmd) inst).props = castMap(val)))
+                .build());
+
+        CommandLine cmd = new CommandLine(MapCmd.class);
+        ParseResult result = cmd.parse("-D", "key=value", "-D", "foo=bar");
+        assertEquals(List.of("key=value", "foo=bar"), result.getOptionValues("-D"));
+    }
+
+    @Test
+    void parseOptionalOption() {
+        registerModel(TestModelHelper.builder(OptionalCmd.class, OptionalCmd::new)
+                .name("opt")
+                .addOption(TestModelHelper.optionalOption(
+                        new String[] { "--name" }, "Name", String.class,
+                        (inst, val) -> ((OptionalCmd) inst).name = castOptional(val)))
+                .build());
+
+        CommandLine cmd = new CommandLine(OptionalCmd.class);
+        ParseResult result = cmd.parse("--name", "test");
+        assertEquals("test", result.getOptionValue("--name"));
+    }
+
+    @Test
+    void parseDefaultValue() {
+        registerModel(TestModelHelper.builder(DefaultCmd.class, DefaultCmd::new)
+                .name("def")
+                .addOption(TestModelHelper.defaultOption(
+                        new String[] { "--format" }, "Format", String.class, "json",
+                        (inst, val) -> ((DefaultCmd) inst).format = (String) val))
+                .build());
+
+        CommandLine cmd = new CommandLine(DefaultCmd.class);
+        int code = cmd.execute();
+        assertEquals(0, code);
+    }
+
+    @Test
+    void parseNegatableOption() {
+        registerModel(TestModelHelper.builder(NegatableCmd.class, NegatableCmd::new)
+                .name("neg")
+                .addOption(TestModelHelper.negatableOption(
+                        new String[] { "--verbose" }, "Verbose", "",
+                        (inst, val) -> ((NegatableCmd) inst).verbose = (boolean) val))
+                .build());
+
+        CommandLine cmd = new CommandLine(NegatableCmd.class);
+        ParseResult result = cmd.parse("--no-verbose");
+        assertEquals("false", result.getOptionValue("--verbose"));
+    }
+
+    @Test
+    void parseNegatableOptionPositive() {
+        registerModel(TestModelHelper.builder(NegatableCmd.class, NegatableCmd::new)
+                .name("neg")
+                .addOption(TestModelHelper.negatableOption(
+                        new String[] { "--verbose" }, "Verbose", "",
+                        (inst, val) -> ((NegatableCmd) inst).verbose = (boolean) val))
+                .build());
+
+        CommandLine cmd = new CommandLine(NegatableCmd.class);
+        ParseResult result = cmd.parse("--verbose");
+        assertEquals("true", result.getOptionValue("--verbose"));
+    }
+
+    @Test
+    void parseSplitOption() {
+        registerModel(TestModelHelper.builder(SplitCmd.class, SplitCmd::new)
+                .name("split")
+                .addOption(TestModelHelper.splitOption(
+                        new String[] { "--items" }, "Items", String.class, ",",
+                        (inst, val) -> ((SplitCmd) inst).items = castList(val)))
+                .build());
+
+        CommandLine cmd = new CommandLine(SplitCmd.class);
+        ParseResult result = cmd.parse("--items", "a,b,c");
+        assertEquals(List.of("a,b,c"), result.getOptionValues("--items"));
+    }
+
+    @Test
+    void parsePrefixOption() {
+        registerModel(TestModelHelper.builder(PrefixCmd.class, PrefixCmd::new)
+                .name("prefix")
+                .addOption(TestModelHelper.option(
+                        new String[] { "-D" }, "Property", String.class,
+                        (inst, val) -> ((PrefixCmd) inst).prop = (String) val))
+                .build());
+
+        CommandLine cmd = new CommandLine(PrefixCmd.class);
+        ParseResult result = cmd.parse("-Dkey=value");
+        assertEquals("key=value", result.getOptionValue("-D"));
+    }
+
+    @Test
+    void parseUnmatchedArgs() {
+        registerModel(TestModelHelper.builder(UnmatchedCmd.class, UnmatchedCmd::new)
+                .name("unmatched")
+                .hasUnmatchedField(true)
+                .unmatchedAccessor((inst, val) -> ((UnmatchedCmd) inst).unmatched = castList(val))
+                .build());
+
+        CommandLine cmd = new CommandLine(UnmatchedCmd.class);
+        ParseResult result = cmd.parse("--unknown", "extra");
+        assertEquals(List.of("--unknown", "extra"), result.unmatched());
+    }
+
+    @Test
+    void parseMutuallyExclusive() {
+        registerModel(TestModelHelper.builder(ExclusiveCmd.class, ExclusiveCmd::new)
+                .name("excl")
+                .addOption(TestModelHelper.booleanOption(
+                        new String[] { "--json" }, "JSON output",
+                        (inst, val) -> ((ExclusiveCmd) inst).json = (boolean) val))
+                .addOption(TestModelHelper.booleanOption(
+                        new String[] { "--xml" }, "XML output",
+                        (inst, val) -> ((ExclusiveCmd) inst).xml = (boolean) val))
+                .addExclusiveGroup(List.of("--json", "--xml"))
+                .build());
+
+        CommandLine cmd = new CommandLine(ExclusiveCmd.class);
+        assertThrows(CommandLine.ParameterException.class, () ->
+                cmd.parse("--json", "--xml"));
+    }
+
+    @Test
+    void parseMutuallyExclusiveSingle() {
+        registerModel(TestModelHelper.builder(ExclusiveCmd.class, ExclusiveCmd::new)
+                .name("excl")
+                .addOption(TestModelHelper.booleanOption(
+                        new String[] { "--json" }, "JSON output",
+                        (inst, val) -> ((ExclusiveCmd) inst).json = (boolean) val))
+                .addOption(TestModelHelper.booleanOption(
+                        new String[] { "--xml" }, "XML output",
+                        (inst, val) -> ((ExclusiveCmd) inst).xml = (boolean) val))
+                .addExclusiveGroup(List.of("--json", "--xml"))
+                .build());
+
+        CommandLine cmd = new CommandLine(ExclusiveCmd.class);
+        ParseResult result = cmd.parse("--json");
+        assertTrue(result.hasOption("--json"));
+        assertFalse(result.hasOption("--xml"));
+    }
+
+    @Test
+    void executeCallable() {
+        registerModel(TestModelHelper.builder(ExitCmd.class, ExitCmd::new)
+                .name("exit")
+                .addOption(TestModelHelper.option(
+                        new String[] { "--code" }, "Exit code", int.class,
+                        (inst, val) -> ((ExitCmd) inst).code = (int) val))
+                .build());
+
+        CommandLine cmd = new CommandLine(ExitCmd.class);
+        assertEquals(42, cmd.execute("--code", "42"));
+    }
+
+    @Test
+    void executeRunnable() {
+        registerModel(TestModelHelper.builder(GreetCmd.class, GreetCmd::new)
+                .name("greet")
+                .build());
+
+        CommandLine cmd = new CommandLine(GreetCmd.class);
+        assertEquals(0, cmd.execute());
+    }
+
+    @Test
+    void executeHelp() {
+        registerModel(TestModelHelper.builder(GreetCmd.class, GreetCmd::new)
+                .name("greet")
+                .description("A greeting command")
+                .mixinStandardHelpOptions(true)
+                .build());
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        CommandLine cmd = new CommandLine(GreetCmd.class);
+        cmd.setOut(new PrintStream(baos));
+        int code = cmd.execute("--help");
+        assertEquals(0, code);
+        assertTrue(baos.toString().contains("greet"));
+    }
+
+    @Test
+    void executeVersion() {
+        registerModel(TestModelHelper.builder(GreetCmd.class, GreetCmd::new)
+                .name("greet")
+                .version("2.0.0")
+                .mixinStandardHelpOptions(true)
+                .build());
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        CommandLine cmd = new CommandLine(GreetCmd.class);
+        cmd.setOut(new PrintStream(baos));
+        int code = cmd.execute("--version");
+        assertEquals(0, code);
+        assertTrue(baos.toString().contains("2.0.0"));
+    }
+
+    @Test
+    void executeWithError() {
+        registerModel(TestModelHelper.builder(GreetCmd.class, GreetCmd::new)
+                .name("greet")
+                .build());
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        CommandLine cmd = new CommandLine(GreetCmd.class);
+        cmd.setErr(new PrintStream(baos));
+        int code = cmd.execute("--unknown");
+        assertEquals(ExitCode.USAGE, code);
+        assertTrue(baos.toString().contains("Error"));
+    }
+
+    @Test
+    void customParameterExceptionHandler() {
+        registerModel(TestModelHelper.builder(GreetCmd.class, GreetCmd::new)
+                .name("greet")
+                .build());
+
+        CommandLine cmd = new CommandLine(GreetCmd.class);
+        cmd.setParameterExceptionHandler((ex, args) -> 99);
+        assertEquals(99, cmd.execute("--unknown"));
+    }
+
+    @Test
+    void parseSubcommand() {
+        registerModel(TestModelHelper.builder(SubCmd.class, SubCmd::new)
+                .name("sub")
+                .addOption(TestModelHelper.option(
+                        new String[] { "--name" }, "Name", String.class,
+                        (inst, val) -> ((SubCmd) inst).name = (String) val))
+                .build());
+        registerModel(TestModelHelper.builder(TopCmd.class, TopCmd::new)
+                .name("top")
+                .addSubcommand(SubCmd.class)
+                .build());
+
+        CommandLine cmd = new CommandLine(TopCmd.class);
+        ParseResult result = cmd.parse("sub", "--name", "test");
+        assertNotNull(result.subcommandResult());
+        assertEquals("test", result.subcommandResult().getOptionValue("--name"));
+    }
+
+    @Test
+    void multipleOptions() {
+        registerModel(TestModelHelper.builder(GreetCmd.class, GreetCmd::new)
+                .name("greet")
+                .addOption(TestModelHelper.option(
+                        new String[] { "-n", "--name" }, "Name", String.class,
+                        (inst, val) -> ((GreetCmd) inst).name = (String) val))
+                .addOption(TestModelHelper.option(
+                        new String[] { "-c", "--count" }, "Count", int.class,
+                        (inst, val) -> ((GreetCmd) inst).count = (int) val))
+                .addOption(TestModelHelper.booleanOption(
+                        new String[] { "-v", "--verbose" }, "Verbose",
+                        (inst, val) -> ((GreetCmd) inst).verbose = (boolean) val))
+                .build());
+
+        CommandLine cmd = new CommandLine(GreetCmd.class);
+        ParseResult result = cmd.parse("-n", "Alice", "-c", "3", "-v");
+        assertEquals("Alice", result.getOptionValue("--name"));
+        assertEquals("3", result.getOptionValue("--count"));
+        assertEquals("true", result.getOptionValue("--verbose"));
+    }
+
+    @Test
+    void emptyArgs() {
+        registerModel(TestModelHelper.builder(GreetCmd.class, GreetCmd::new)
+                .name("greet")
+                .build());
+
+        CommandLine cmd = new CommandLine(GreetCmd.class);
+        ParseResult result = cmd.parse();
+        assertNotNull(result);
+        assertTrue(result.positionalValues().isEmpty());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> List<T> castList(Object val) {
+        return (List<T>) val;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> Set<T> castSet(Object val) {
+        return (Set<T>) val;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <K, V> Map<K, V> castMap(Object val) {
+        return (Map<K, V>) val;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> Optional<T> castOptional(Object val) {
+        return (Optional<T>) val;
+    }
+}

--- a/independent-projects/quickcli/quickcli-core/src/test/java/io/quarkus/quickcli/TestModelHelper.java
+++ b/independent-projects/quickcli/quickcli-core/src/test/java/io/quarkus/quickcli/TestModelHelper.java
@@ -1,0 +1,129 @@
+package io.quarkus.quickcli;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import io.quarkus.quickcli.model.BuiltCommandModel;
+import io.quarkus.quickcli.model.BuiltCommandModel.FieldKind;
+import io.quarkus.quickcli.model.BuiltCommandModel.OptionBinding;
+import io.quarkus.quickcli.model.BuiltCommandModel.ParameterBinding;
+import io.quarkus.quickcli.model.CommandModelRegistry;
+import io.quarkus.quickcli.model.FieldAccessor;
+
+/**
+ * Test utility for building and registering command models without reflection
+ * or annotation processing. Uses BuiltCommandModel.Builder with lambda field
+ * accessors.
+ */
+public final class TestModelHelper {
+
+    private TestModelHelper() {
+    }
+
+    public static BuiltCommandModel.Builder builder(Class<?> cls, Supplier<Object> creator) {
+        return BuiltCommandModel.builder(cls, creator);
+    }
+
+    public static void register(BuiltCommandModel model) {
+        CommandModelRegistry.register(model);
+    }
+
+    public static OptionBinding option(String[] names, String description, Class<?> type,
+            FieldAccessor accessor) {
+        return new OptionBinding(names, description, type, false, "", "", false, "",
+                names[names.length - 1], false, false, false, -1,
+                FieldKind.SINGLE, null, null, "", "", accessor);
+    }
+
+    public static OptionBinding requiredOption(String[] names, String description, Class<?> type,
+            FieldAccessor accessor) {
+        return new OptionBinding(names, description, type, true, "", "", false, "",
+                names[names.length - 1], false, false, false, -1,
+                FieldKind.SINGLE, null, null, "", "", accessor);
+    }
+
+    public static OptionBinding booleanOption(String[] names, String description,
+            FieldAccessor accessor) {
+        return new OptionBinding(names, description, boolean.class, false, "", "", false, "",
+                names[names.length - 1], false, false, false, -1,
+                FieldKind.SINGLE, null, null, "", "", accessor);
+    }
+
+    public static OptionBinding negatableOption(String[] names, String description,
+            String defaultValue, FieldAccessor accessor) {
+        return new OptionBinding(names, description, boolean.class, false, defaultValue, "", false, "",
+                names[names.length - 1], false, false, true, -1,
+                FieldKind.SINGLE, null, null, "", "", accessor);
+    }
+
+    public static OptionBinding listOption(String[] names, String description,
+            Class<?> componentType, FieldAccessor accessor) {
+        return new OptionBinding(names, description, List.class, false, "", "", false, "",
+                names[names.length - 1], false, false, false, -1,
+                FieldKind.LIST, componentType, null, "", "", accessor);
+    }
+
+    public static OptionBinding setOption(String[] names, String description,
+            Class<?> componentType, FieldAccessor accessor) {
+        return new OptionBinding(names, description, Set.class, false, "", "", false, "",
+                names[names.length - 1], false, false, false, -1,
+                FieldKind.SET, componentType, null, "", "", accessor);
+    }
+
+    public static OptionBinding arrayOption(String[] names, String description,
+            Class<?> componentType, FieldAccessor accessor) {
+        return new OptionBinding(names, description, componentType.arrayType(), false, "", "", false, "",
+                names[names.length - 1], false, false, false, -1,
+                FieldKind.ARRAY, componentType, null, "", "", accessor);
+    }
+
+    public static OptionBinding mapOption(String[] names, String description,
+            String mapFallbackValue, FieldAccessor accessor) {
+        return new OptionBinding(names, description, Map.class, false, "", "", false, "",
+                names[names.length - 1], false, false, false, -1,
+                FieldKind.MAP, null, null, "", mapFallbackValue, accessor);
+    }
+
+    public static OptionBinding optionalOption(String[] names, String description,
+            Class<?> innerType, FieldAccessor accessor) {
+        return new OptionBinding(names, description, Optional.class, false, "", "", false, "",
+                names[names.length - 1], false, false, false, -1,
+                FieldKind.OPTIONAL, null, innerType, "", "", accessor);
+    }
+
+    public static OptionBinding splitOption(String[] names, String description,
+            Class<?> componentType, String split, FieldAccessor accessor) {
+        return new OptionBinding(names, description, List.class, false, "", "", false, "",
+                names[names.length - 1], false, false, false, -1,
+                FieldKind.LIST, componentType, null, split, "", accessor);
+    }
+
+    public static OptionBinding hiddenOption(String[] names, String description, Class<?> type,
+            FieldAccessor accessor) {
+        return new OptionBinding(names, description, type, false, "", "", true, "",
+                names[names.length - 1], false, false, false, -1,
+                FieldKind.SINGLE, null, null, "", "", accessor);
+    }
+
+    public static OptionBinding defaultOption(String[] names, String description, Class<?> type,
+            String defaultValue, FieldAccessor accessor) {
+        return new OptionBinding(names, description, type, false, defaultValue, "", false, "",
+                names[names.length - 1], false, false, false, -1,
+                FieldKind.SINGLE, null, null, "", "", accessor);
+    }
+
+    public static ParameterBinding parameter(int index, String description, Class<?> type,
+            FieldAccessor accessor) {
+        return new ParameterBinding(index, description, type, "", "", false, "",
+                "param" + index, false, FieldKind.SINGLE, null, accessor, "");
+    }
+
+    public static ParameterBinding multiValueParameter(int index, String description,
+            Class<?> componentType, FieldAccessor accessor) {
+        return new ParameterBinding(index, description, List.class, "", "", false, "",
+                "params", true, FieldKind.LIST, componentType, accessor, "");
+    }
+}

--- a/independent-projects/quickcli/quickcli-core/src/test/java/io/quarkus/quickcli/TypeConversionTest.java
+++ b/independent-projects/quickcli/quickcli-core/src/test/java/io/quarkus/quickcli/TypeConversionTest.java
@@ -1,0 +1,181 @@
+package io.quarkus.quickcli;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.File;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.URI;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+class TypeConversionTest {
+
+    // --- Primitives ---
+
+    @Test
+    void convertInt() {
+        assertEquals(42, TypeConverter.convert("42", int.class));
+        assertEquals(42, TypeConverter.convert("42", Integer.class));
+        assertEquals(-1, TypeConverter.convert("-1", int.class));
+    }
+
+    @Test
+    void convertLong() {
+        assertEquals(123456789L, TypeConverter.convert("123456789", long.class));
+        assertEquals(123456789L, TypeConverter.convert("123456789", Long.class));
+    }
+
+    @Test
+    void convertShort() {
+        assertEquals((short) 10, TypeConverter.convert("10", short.class));
+        assertEquals((short) 10, TypeConverter.convert("10", Short.class));
+    }
+
+    @Test
+    void convertByte() {
+        assertEquals((byte) 127, TypeConverter.convert("127", byte.class));
+        assertEquals((byte) 127, TypeConverter.convert("127", Byte.class));
+    }
+
+    @Test
+    void convertFloat() {
+        assertEquals(3.14f, TypeConverter.convert("3.14", float.class));
+        assertEquals(3.14f, TypeConverter.convert("3.14", Float.class));
+    }
+
+    @Test
+    void convertDouble() {
+        assertEquals(2.718, TypeConverter.convert("2.718", double.class));
+        assertEquals(2.718, TypeConverter.convert("2.718", Double.class));
+    }
+
+    @Test
+    void convertChar() {
+        assertEquals('x', TypeConverter.convert("x", char.class));
+        assertEquals('x', TypeConverter.convert("x", Character.class));
+    }
+
+    @Test
+    void convertString() {
+        assertEquals("hello", TypeConverter.convert("hello", String.class));
+    }
+
+    @Test
+    void convertNull() {
+        assertNull(TypeConverter.convert(null, String.class));
+    }
+
+    // --- Boolean ---
+
+    @Test
+    void convertBooleanTrue() {
+        assertTrue(TypeConverter.convert("true", boolean.class));
+        assertTrue(TypeConverter.convert("TRUE", Boolean.class));
+        assertTrue(TypeConverter.convert("yes", boolean.class));
+        assertTrue(TypeConverter.convert("YES", Boolean.class));
+        assertTrue(TypeConverter.convert("1", boolean.class));
+    }
+
+    @Test
+    void convertBooleanFalse() {
+        assertFalse(TypeConverter.convert("false", boolean.class));
+        assertFalse(TypeConverter.convert("FALSE", Boolean.class));
+        assertFalse(TypeConverter.convert("no", boolean.class));
+        assertFalse(TypeConverter.convert("NO", Boolean.class));
+        assertFalse(TypeConverter.convert("0", boolean.class));
+    }
+
+    @Test
+    void convertBooleanInvalid() {
+        assertThrows(IllegalArgumentException.class, () ->
+                TypeConverter.convert("maybe", boolean.class));
+    }
+
+    // --- Common types ---
+
+    @Test
+    void convertFile() {
+        File f = TypeConverter.convert("/tmp/test.txt", File.class);
+        assertEquals(new File("/tmp/test.txt").getPath(), f.getPath());
+    }
+
+    @Test
+    void convertPath() {
+        Path p = TypeConverter.convert("/tmp/test.txt", Path.class);
+        assertEquals(Path.of("/tmp/test.txt"), p);
+    }
+
+    @Test
+    void convertBigDecimal() {
+        assertEquals(new BigDecimal("123.456"), TypeConverter.convert("123.456", BigDecimal.class));
+    }
+
+    @Test
+    void convertBigInteger() {
+        assertEquals(new BigInteger("99999999999"), TypeConverter.convert("99999999999", BigInteger.class));
+    }
+
+    @Test
+    void convertURI() {
+        assertEquals(URI.create("https://example.com"), TypeConverter.convert("https://example.com", URI.class));
+    }
+
+    // --- Enums ---
+
+    enum Color { RED, GREEN, BLUE }
+
+    @Test
+    void convertEnum() {
+        assertEquals(Color.RED, TypeConverter.convert("RED", Color.class));
+        assertEquals(Color.BLUE, TypeConverter.convert("BLUE", Color.class));
+    }
+
+    @Test
+    void convertEnumInvalid() {
+        assertThrows(IllegalArgumentException.class, () ->
+                TypeConverter.convert("YELLOW", Color.class));
+    }
+
+    // --- Custom converters ---
+
+    @Test
+    void customConverter() {
+        TypeConverter.register(StringBuilder.class, StringBuilder::new);
+        StringBuilder sb = TypeConverter.convert("test", StringBuilder.class);
+        assertEquals("test", sb.toString());
+    }
+
+    // --- Type checks ---
+
+    @Test
+    void isBooleanType() {
+        assertTrue(TypeConverter.isBooleanType(boolean.class));
+        assertTrue(TypeConverter.isBooleanType(Boolean.class));
+        assertFalse(TypeConverter.isBooleanType(int.class));
+        assertFalse(TypeConverter.isBooleanType(String.class));
+    }
+
+    @Test
+    void hasConverter() {
+        assertTrue(TypeConverter.hasConverter(String.class));
+        assertTrue(TypeConverter.hasConverter(int.class));
+        assertTrue(TypeConverter.hasConverter(Color.class));
+        assertFalse(TypeConverter.hasConverter(Object.class));
+    }
+
+    // --- Error cases ---
+
+    @Test
+    void noConverterThrows() {
+        assertThrows(IllegalArgumentException.class, () ->
+                TypeConverter.convert("test", Object.class));
+    }
+
+    @Test
+    void invalidIntThrows() {
+        assertThrows(NumberFormatException.class, () ->
+                TypeConverter.convert("abc", int.class));
+    }
+}

--- a/independent-projects/quickcli/quickcli-core/src/test/java/io/quarkus/quickcli/ValueApplicationTest.java
+++ b/independent-projects/quickcli/quickcli-core/src/test/java/io/quarkus/quickcli/ValueApplicationTest.java
@@ -1,0 +1,259 @@
+package io.quarkus.quickcli;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.quickcli.model.CommandModelRegistry;
+
+/**
+ * Tests that parsed values are correctly applied to command instances
+ * via the BuiltCommandModel field accessors.
+ */
+class ValueApplicationTest {
+
+    static class AllTypesCmd implements Runnable {
+        String name;
+        int count;
+        boolean verbose;
+        List<String> items;
+        Set<Integer> ids;
+        String[] files;
+        Map<String, String> props;
+        Optional<String> format = Optional.empty();
+
+        @Override
+        public void run() {
+        }
+    }
+
+    @Test
+    void applySingleString() {
+        CommandModelRegistry.register(TestModelHelper.builder(AllTypesCmd.class, AllTypesCmd::new)
+                .name("all")
+                .addOption(TestModelHelper.option(
+                        new String[] { "--name" }, "Name", String.class,
+                        (inst, val) -> ((AllTypesCmd) inst).name = (String) val))
+                .build());
+
+        AllTypesCmd cmd = new AllTypesCmd();
+        CommandLine cl = new CommandLine(AllTypesCmd.class);
+        cl.execute("--name", "Alice");
+    }
+
+    @Test
+    void applySingleInt() {
+        CommandModelRegistry.register(TestModelHelper.builder(AllTypesCmd.class, AllTypesCmd::new)
+                .name("all")
+                .addOption(TestModelHelper.option(
+                        new String[] { "--count" }, "Count", int.class,
+                        (inst, val) -> ((AllTypesCmd) inst).count = (int) val))
+                .build());
+
+        CommandLine cl = new CommandLine(AllTypesCmd.class);
+        assertEquals(0, cl.execute("--count", "10"));
+    }
+
+    @Test
+    void applyBoolean() {
+        CommandModelRegistry.register(TestModelHelper.builder(AllTypesCmd.class, AllTypesCmd::new)
+                .name("all")
+                .addOption(TestModelHelper.booleanOption(
+                        new String[] { "-v", "--verbose" }, "Verbose",
+                        (inst, val) -> ((AllTypesCmd) inst).verbose = (boolean) val))
+                .build());
+
+        CommandLine cl = new CommandLine(AllTypesCmd.class);
+        assertEquals(0, cl.execute("-v"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void applyList() {
+        CommandModelRegistry.register(TestModelHelper.builder(AllTypesCmd.class, AllTypesCmd::new)
+                .name("all")
+                .addOption(TestModelHelper.listOption(
+                        new String[] { "--item" }, "Items", String.class,
+                        (inst, val) -> ((AllTypesCmd) inst).items = (List<String>) val))
+                .build());
+
+        CommandLine cl = new CommandLine(AllTypesCmd.class);
+        assertEquals(0, cl.execute("--item", "a", "--item", "b"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void applySet() {
+        CommandModelRegistry.register(TestModelHelper.builder(AllTypesCmd.class, AllTypesCmd::new)
+                .name("all")
+                .addOption(TestModelHelper.setOption(
+                        new String[] { "--id" }, "IDs", Integer.class,
+                        (inst, val) -> ((AllTypesCmd) inst).ids = (Set<Integer>) val))
+                .build());
+
+        CommandLine cl = new CommandLine(AllTypesCmd.class);
+        assertEquals(0, cl.execute("--id", "1", "--id", "2", "--id", "1"));
+    }
+
+    @Test
+    void applyArray() {
+        CommandModelRegistry.register(TestModelHelper.builder(AllTypesCmd.class, AllTypesCmd::new)
+                .name("all")
+                .addOption(TestModelHelper.arrayOption(
+                        new String[] { "--file" }, "Files", String.class,
+                        (inst, val) -> ((AllTypesCmd) inst).files = (String[]) val))
+                .build());
+
+        CommandLine cl = new CommandLine(AllTypesCmd.class);
+        assertEquals(0, cl.execute("--file", "a.txt", "--file", "b.txt"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void applyMap() {
+        CommandModelRegistry.register(TestModelHelper.builder(AllTypesCmd.class, AllTypesCmd::new)
+                .name("all")
+                .addOption(TestModelHelper.mapOption(
+                        new String[] { "-D" }, "Properties", "true",
+                        (inst, val) -> ((AllTypesCmd) inst).props = (Map<String, String>) val))
+                .build());
+
+        CommandLine cl = new CommandLine(AllTypesCmd.class);
+        assertEquals(0, cl.execute("-D", "key=value", "-D", "flag"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void applyOptional() {
+        CommandModelRegistry.register(TestModelHelper.builder(AllTypesCmd.class, AllTypesCmd::new)
+                .name("all")
+                .addOption(TestModelHelper.optionalOption(
+                        new String[] { "--format" }, "Format", String.class,
+                        (inst, val) -> ((AllTypesCmd) inst).format = (Optional<String>) val))
+                .build());
+
+        CommandLine cl = new CommandLine(AllTypesCmd.class);
+        assertEquals(0, cl.execute("--format", "json"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void applyOptionalNotProvided() {
+        CommandModelRegistry.register(TestModelHelper.builder(AllTypesCmd.class, AllTypesCmd::new)
+                .name("all")
+                .addOption(TestModelHelper.optionalOption(
+                        new String[] { "--format" }, "Format", String.class,
+                        (inst, val) -> ((AllTypesCmd) inst).format = (Optional<String>) val))
+                .build());
+
+        CommandLine cl = new CommandLine(AllTypesCmd.class);
+        assertEquals(0, cl.execute());
+    }
+
+    @Test
+    void applyDefaultValue() {
+        CommandModelRegistry.register(TestModelHelper.builder(AllTypesCmd.class, AllTypesCmd::new)
+                .name("all")
+                .addOption(TestModelHelper.defaultOption(
+                        new String[] { "--name" }, "Name", String.class, "World",
+                        (inst, val) -> ((AllTypesCmd) inst).name = (String) val))
+                .build());
+
+        CommandLine cl = new CommandLine(AllTypesCmd.class);
+        assertEquals(0, cl.execute());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void applySplitValues() {
+        CommandModelRegistry.register(TestModelHelper.builder(AllTypesCmd.class, AllTypesCmd::new)
+                .name("all")
+                .addOption(TestModelHelper.splitOption(
+                        new String[] { "--item" }, "Items", String.class, ",",
+                        (inst, val) -> ((AllTypesCmd) inst).items = (List<String>) val))
+                .build());
+
+        CommandLine cl = new CommandLine(AllTypesCmd.class);
+        assertEquals(0, cl.execute("--item", "a,b,c"));
+    }
+
+    static class PositionalCmd implements Runnable {
+        String file;
+        int line;
+        List<String> rest;
+
+        @Override
+        public void run() {
+        }
+    }
+
+    @Test
+    void applyPositionalParam() {
+        CommandModelRegistry.register(TestModelHelper.builder(PositionalCmd.class, PositionalCmd::new)
+                .name("pos")
+                .addParameter(TestModelHelper.parameter(0, "File", String.class,
+                        (inst, val) -> ((PositionalCmd) inst).file = (String) val))
+                .addParameter(TestModelHelper.parameter(1, "Line", int.class,
+                        (inst, val) -> ((PositionalCmd) inst).line = (int) val))
+                .build());
+
+        CommandLine cl = new CommandLine(PositionalCmd.class);
+        assertEquals(0, cl.execute("test.txt", "42"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void applyMultiValuePositional() {
+        CommandModelRegistry.register(TestModelHelper.builder(PositionalCmd.class, PositionalCmd::new)
+                .name("pos")
+                .addParameter(TestModelHelper.multiValueParameter(0, "Files", String.class,
+                        (inst, val) -> ((PositionalCmd) inst).rest = (List<String>) val))
+                .build());
+
+        CommandLine cl = new CommandLine(PositionalCmd.class);
+        assertEquals(0, cl.execute("a.txt", "b.txt", "c.txt"));
+    }
+
+    @Test
+    void mixedOptionsAndPositionals() {
+        CommandModelRegistry.register(TestModelHelper.builder(PositionalCmd.class, PositionalCmd::new)
+                .name("pos")
+                .addOption(TestModelHelper.option(
+                        new String[] { "--file" }, "File", String.class,
+                        (inst, val) -> ((PositionalCmd) inst).file = (String) val))
+                .addParameter(TestModelHelper.parameter(0, "Line", int.class,
+                        (inst, val) -> ((PositionalCmd) inst).line = (int) val))
+                .build());
+
+        CommandLine cl = new CommandLine(PositionalCmd.class);
+        assertEquals(0, cl.execute("--file", "test.txt", "42"));
+    }
+
+    enum OutputFormat { JSON, XML, TEXT }
+
+    static class EnumCmd implements Runnable {
+        OutputFormat format;
+
+        @Override
+        public void run() {
+        }
+    }
+
+    @Test
+    void applyEnumValue() {
+        CommandModelRegistry.register(TestModelHelper.builder(EnumCmd.class, EnumCmd::new)
+                .name("enum")
+                .addOption(TestModelHelper.option(
+                        new String[] { "--format" }, "Format", OutputFormat.class,
+                        (inst, val) -> ((EnumCmd) inst).format = (OutputFormat) val))
+                .build());
+
+        CommandLine cl = new CommandLine(EnumCmd.class);
+        assertEquals(0, cl.execute("--format", "JSON"));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
         <module>independent-projects/resteasy-reactive</module>
         <module>independent-projects/extension-maven-plugin</module>
         <module>independent-projects/junit-virtual-threads</module>
+        <module>independent-projects/quickcli</module>
 
         <!-- BOMs and parent POM -->
         <module>bom/application</module>


### PR DESCRIPTION
The main idea of this implementation is to
determine all the necessary annotation metadata
at build time

This new module is used in the Quarkus CLI in
place of PicoCLI. As can be seen, the changes to
Quarkus CLI are minimal

-------

Using this instead of picocli for the quarkus-cli yielded the following difference in startup for `time quarkus version`

From:

```
real	0m0.388s
user	0m1.086s
sys	0m0.070s
```

To:

```
real	0m0.312s
user	0m0.751s
sys	0m0.046s
```

-------

For a hello world CLI project using Picocli, the improvement is less impressive.

From:

```
real    0m0.225s
user    0m0.446s
sys     0m0.053s
```

To:

```
real    0m0.189s
user    0m0.408s
sys     0m0.039s
```