### PR TITLE
Refactor jar building to a first-write-wins approach

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractJarBuilder.java
@@ -7,7 +7,6 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -168,12 +167,8 @@ public abstract class AbstractJarBuilder<T extends BuildItem> implements JarBuil
             Predicate<String> ignoredEntriesPredicate)
             throws IOException {
 
-        // Collect all transformed file names so we skip the originals during copyFiles.
-        // The transformed versions are added later in this method and should replace the originals.
-        Predicate<String> combinedIgnorePredicate = createCombinedIgnorePredicate(ignoredEntriesPredicate);
-
         // the order of operations is important here as we override elements in order
-        copyFiles(applicationArchives.getRootArchive(), archiveCreator, concatenatedEntries, combinedIgnorePredicate);
+        copyFiles(applicationArchives.getRootArchive(), archiveCreator, concatenatedEntries, ignoredEntriesPredicate);
 
         //TODO: this is probably broken in gradle
         //        if (Files.exists(augmentOutcome.getConfigDir())) {
@@ -207,18 +202,6 @@ public abstract class AbstractJarBuilder<T extends BuildItem> implements JarBuil
         for (Map.Entry<String, List<byte[]>> entry : concatenatedEntries.entrySet()) {
             archiveCreator.addFile(entry.getValue(), entry.getKey());
         }
-    }
-
-    private Predicate<String> createCombinedIgnorePredicate(Predicate<String> ignoredEntriesPredicate) {
-        Set<String> transformedFileNames = transformedClasses.getTransformedClassesByJar().values()
-                .stream()
-                .flatMap(Collection::stream)
-                .filter(tc -> tc.getData() != null)
-                .map(TransformedClassesBuildItem.TransformedClass::getFileName)
-                .collect(Collectors.toSet());
-        return transformedFileNames.isEmpty()
-                ? ignoredEntriesPredicate
-                : path -> ignoredEntriesPredicate.test(path) || transformedFileNames.contains(path);
     }
 
     protected static Manifest createManifest(PackageConfig config, ResolvedDependency appArtifact,

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractJarBuilder.java
@@ -150,7 +150,10 @@ public abstract class AbstractJarBuilder<T extends BuildItem> implements JarBuil
                 if (Files.isDirectory(pathEntry.getValue())) {
                     archiveCreator.addDirectory(pathEntry.getKey());
                 } else {
-                    archiveCreator.addFile(pathEntry.getValue(), pathEntry.getKey());
+                    // it's an expected behavior that there might be already an entry for
+                    // an application file as transformed classes have been added first
+                    // and should take precedence
+                    archiveCreator.addFileIfNotExists(pathEntry.getValue(), pathEntry.getKey());
                 }
             }
         } catch (RuntimeException re) {
@@ -162,18 +165,32 @@ public abstract class AbstractJarBuilder<T extends BuildItem> implements JarBuil
         }
     }
 
+    /**
+     * Copy application content to the archive.
+     * <p>
+     * The order of operations is important here: higher priority content is added first
+     * so that it takes precedence over lower priority content (first-write-wins in the archive creator).
+     * <p>
+     * Note: concatenated entries (services, etc.) are collected into a map but NOT written to the archive.
+     * Callers are responsible for writing them after all sources have been collected
+     * (see {@link #writeConcatenatedEntries(ArchiveCreator, Map)}).
+     */
     protected void copyApplicationContent(ArchiveCreator archiveCreator,
             Map<String, List<byte[]>> concatenatedEntries,
             Predicate<String> ignoredEntriesPredicate)
             throws IOException {
 
-        // the order of operations is important here as we override elements in order
-        copyFiles(applicationArchives.getRootArchive(), archiveCreator, concatenatedEntries, ignoredEntriesPredicate);
+        // transformed classes first (highest priority - these replace the original classes)
+        for (Set<TransformedClassesBuildItem.TransformedClass> transformed : transformedClasses
+                .getTransformedClassesByJar().values()) {
+            for (TransformedClassesBuildItem.TransformedClass i : transformed) {
+                if (i.getData() != null) {
+                    archiveCreator.addFile(i.getData(), i.getFileName());
+                }
+            }
+        }
 
-        //TODO: this is probably broken in gradle
-        //        if (Files.exists(augmentOutcome.getConfigDir())) {
-        //            copyFiles(augmentOutcome.getConfigDir(), runnerZipFs, services);
-        //        }
+        // then, generated classes and resources
         for (GeneratedClassBuildItem i : generatedClasses) {
             String fileName = fromClassNameToResourceName(i.internalName());
             archiveCreator.addFile(i.getClassData(), fileName, ArchiveCreator.CURRENT_APPLICATION);
@@ -190,15 +207,12 @@ public abstract class AbstractJarBuilder<T extends BuildItem> implements JarBuil
             archiveCreator.addFile(i.getData(), i.getName(), ArchiveCreator.CURRENT_APPLICATION);
         }
 
-        for (Set<TransformedClassesBuildItem.TransformedClass> transformed : transformedClasses
-                .getTransformedClassesByJar().values()) {
-            for (TransformedClassesBuildItem.TransformedClass i : transformed) {
-                if (i.getData() != null) {
-                    archiveCreator.addFile(i.getData(), i.getFileName());
-                }
-            }
-        }
+        // then the root archive files, note that in the case of Uberjars, dependencies will be added last
+        copyFiles(applicationArchives.getRootArchive(), archiveCreator, concatenatedEntries, ignoredEntriesPredicate);
+    }
 
+    protected static void writeConcatenatedEntries(ArchiveCreator archiveCreator,
+            Map<String, List<byte[]>> concatenatedEntries) throws IOException {
         for (Map.Entry<String, List<byte[]>> entry : concatenatedEntries.entrySet()) {
             archiveCreator.addFile(entry.getValue(), entry.getKey());
         }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractLegacyThinJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractLegacyThinJarBuilder.java
@@ -57,7 +57,6 @@ public abstract class AbstractLegacyThinJarBuilder<T extends BuildItem> extends 
         try (ArchiveCreator archiveCreator = new ParallelCommonsCompressArchiveCreator(runnerJar,
                 packageConfig.jar().compress(), packageConfig.outputTimestamp().orElse(null),
                 executorService)) {
-            final Map<String, String> seen = new HashMap<>();
             final StringBuilder classPath = new StringBuilder();
             final Map<String, List<byte[]>> services = new HashMap<>();
 
@@ -78,6 +77,8 @@ public abstract class AbstractLegacyThinJarBuilder<T extends BuildItem> extends 
             archiveCreator.addManifest(manifest);
 
             copyApplicationContent(archiveCreator, services, ignoredEntriesPredicate);
+
+            writeConcatenatedEntries(archiveCreator, services);
         }
         runnerJar.toFile().setReadable(true, false);
     }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/ParallelCommonsCompressArchiveCreator.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/ParallelCommonsCompressArchiveCreator.java
@@ -33,6 +33,7 @@ import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntryRequest;
 import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
 import org.apache.commons.compress.parallel.InputStreamSupplier;
+import org.jboss.logging.Logger;
 
 /**
  * This ArchiveCreator may not be used to build Uberjars.
@@ -43,6 +44,8 @@ import org.apache.commons.compress.parallel.InputStreamSupplier;
  * and allow getting it/setting it again, and adding it first in close().
  */
 public class ParallelCommonsCompressArchiveCreator implements ArchiveCreator {
+
+    private static final Logger LOG = Logger.getLogger(ParallelCommonsCompressArchiveCreator.class);
 
     private static final Set<String> MANIFESTS = Set.of("META-INF/MANIFEST.MF", "META-INF\\MANIFEST.MF");
     private static final Set<String> VERSIONS = Set.of("META-INF/versions/", "META-INF\\versions\\");
@@ -110,21 +113,39 @@ public class ParallelCommonsCompressArchiveCreator implements ArchiveCreator {
         addDirectoryEntry(new ZipArchiveEntry(directory));
     }
 
+    /**
+     * First-write wins, subsequent additions of the same file will generate a warning.
+     * <p>
+     * Use {@link #addFileIfNotExists(Path, String, String)} if you expect a second write to be an expected behavior.
+     * It has the same first-write wins behavior but won't generate a warning.
+     */
     @Override
     public void addFile(Path origin, String target, String source) throws IOException {
         doAddFile(toInputStreamSupplier(origin), target, source);
     }
 
+    /**
+     * First-write wins, subsequent additions of the same file will generate a warning.
+     * <p>
+     * Use {@link #addFileIfNotExists(byte[], String, String)} if you expect a second write to be an expected behavior.
+     * It has the same first-write wins behavior but won't generate a warning.
+     */
     @Override
     public void addFile(byte[] bytes, String target, String source) throws IOException {
         doAddFile(toInputStreamSupplier(bytes), target, source);
     }
 
+    /**
+     * First-write wins, subsequent additions of the same file will generate a warning.
+     */
     @Override
     public void addFile(List<byte[]> bytes, String target, String source) throws IOException {
         addFile(joinWithNewlines(bytes), target, source);
     }
 
+    /**
+     * First-write wins but don't generate a warning if an entry with this name already exists.
+     */
     @Override
     public void addFileIfNotExists(Path origin, String target, String source) throws IOException {
         if (addedFiles.containsKey(target)) {
@@ -134,6 +155,9 @@ public class ParallelCommonsCompressArchiveCreator implements ArchiveCreator {
         addFile(origin, target, source);
     }
 
+    /**
+     * First-write wins but don't generate a warning if an entry with this name already exists.
+     */
     @Override
     public void addFileIfNotExists(byte[] bytes, String target, String source) throws IOException {
         if (addedFiles.containsKey(target)) {
@@ -146,6 +170,13 @@ public class ParallelCommonsCompressArchiveCreator implements ArchiveCreator {
     private void doAddFile(InputStreamSupplier inputStreamSupplier, String target, String source) throws IOException {
         // the MANIFEST.MF file is handled separately as it need to be the first entry of the jar
         if (MANIFESTS.contains(target)) {
+            return;
+        }
+
+        String existingSource = addedFiles.get(target);
+        if (existingSource != null) {
+            LOG.warn("Duplicate entry '" + target + "': already added from '" + existingSource
+                    + "', ignoring entry from '" + source + "'");
             return;
         }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/UberJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/UberJarBuilder.java
@@ -149,7 +149,6 @@ public class UberJarBuilder extends AbstractJarBuilder<JarBuildItem> {
                 executorService)) {
             LOG.info("Building uber jar: " + runnerJar);
 
-            final Map<String, Set<Dependency>> duplicateCatcher = new HashMap<>();
             final Map<String, List<byte[]>> concatenatedEntries = new HashMap<>();
             final Set<String> mergeResourcePaths = mergedResources.stream()
                     .map(UberJarMergedResourceBuildItem::getPath)
@@ -166,10 +165,11 @@ public class UberJarBuilder extends AbstractJarBuilder<JarBuildItem> {
             attachRunnerMetadata(manifest, mainClass.getClassName(), "", jvmRequirements);
             archiveCreator.addManifest(manifest);
 
-            final Set<String> existingEntries = new HashSet<>();
-            generatedResources.stream()
-                    .map(GeneratedResourceBuildItem::getName)
-                    .forEach(existingEntries::add);
+            // application content is added first so that it takes precedence over dependency content
+            // the archive creator uses first-write-wins semantics
+            copyApplicationContent(archiveCreator, concatenatedEntries, allIgnoredEntriesPredicate);
+
+            final Map<String, Set<Dependency>> duplicateCatcher = new HashMap<>();
 
             for (ResolvedDependency appDep : curateOutcome.getApplicationModel().getRuntimeDependencies()) {
 
@@ -179,15 +179,8 @@ public class UberJarBuilder extends AbstractJarBuilder<JarBuildItem> {
                     continue;
                 }
 
-                for (Path resolvedDep : appDep.getResolvedPaths()) {
-                    Set<String> transformedFilesByJar = transformedClasses.getTransformedFilesByJar().get(resolvedDep);
-                    if (transformedFilesByJar != null) {
-                        existingEntries.addAll(transformedFilesByJar);
-                    }
-                }
-
                 walkFileDependencyForDependency(archiveCreator, duplicateCatcher,
-                        concatenatedEntries, allIgnoredEntriesPredicate, appDep, existingEntries,
+                        concatenatedEntries, allIgnoredEntriesPredicate, appDep,
                         mergeResourcePaths);
             }
 
@@ -211,7 +204,9 @@ public class UberJarBuilder extends AbstractJarBuilder<JarBuildItem> {
                 }
             }
 
-            copyApplicationContent(archiveCreator, concatenatedEntries, allIgnoredEntriesPredicate);
+            // write concatenated entries (services, etc.) after all sources have been collected
+            writeConcatenatedEntries(archiveCreator, concatenatedEntries);
+
             // now that all entries have been added, check if there's a META-INF/versions/ entry. If present,
             // mark this jar as multi-release jar. Strictly speaking, the jar spec expects META-INF/versions/N
             // directory where N is an integer greater than 8, but we don't do that level of checks here but that
@@ -241,7 +236,7 @@ public class UberJarBuilder extends AbstractJarBuilder<JarBuildItem> {
 
     private void walkFileDependencyForDependency(ArchiveCreator archiveCreator,
             Map<String, Set<Dependency>> duplicateCatcher, Map<String, List<byte[]>> concatenatedEntries,
-            Predicate<String> ignoredEntriesPredicate, ResolvedDependency appDep, Set<String> existingEntries,
+            Predicate<String> ignoredEntriesPredicate, ResolvedDependency appDep,
             Set<String> mergeResourcePaths) throws IOException {
 
         // The reason opening and closing a path tree right away works, unlike creating and closing a ZipFileSystem,
@@ -260,7 +255,6 @@ public class UberJarBuilder extends AbstractJarBuilder<JarBuildItem> {
                     }
 
                     final Path file = visit.getPath();
-                    //if this has been transformed we do not copy it
                     // if it's a signature file (under the <jar>/META-INF directory),
                     // then we don't add it to the uber jar
                     if (isBlockOrSF(relativePath) &&
@@ -272,18 +266,16 @@ public class UberJarBuilder extends AbstractJarBuilder<JarBuildItem> {
                         return;
                     }
 
-                    if (!existingEntries.contains(relativePath)) {
-                        if (UBER_JAR_CONCATENATED_ENTRIES_PREDICATE.test(relativePath)
-                                || mergeResourcePaths.contains(relativePath)) {
-                            concatenatedEntries.computeIfAbsent(relativePath, (u) -> new ArrayList<>())
-                                    .add(Files.readAllBytes(file));
-                        } else if (!ignoredEntriesPredicate.test(relativePath)) {
-                            if (!UBER_JAR_IGNORED_DUPLICATE_ENTRIES_PREDICATE.test(relativePath)) {
-                                duplicateCatcher.computeIfAbsent(relativePath, (a) -> new HashSet<>())
-                                        .add(appDep);
-                            }
-                            archiveCreator.addFileIfNotExists(file, relativePath, appDep.toString());
+                    if (UBER_JAR_CONCATENATED_ENTRIES_PREDICATE.test(relativePath)
+                            || mergeResourcePaths.contains(relativePath)) {
+                        concatenatedEntries.computeIfAbsent(relativePath, (u) -> new ArrayList<>())
+                                .add(Files.readAllBytes(file));
+                    } else if (!ignoredEntriesPredicate.test(relativePath)) {
+                        if (!UBER_JAR_IGNORED_DUPLICATE_ENTRIES_PREDICATE.test(relativePath)) {
+                            duplicateCatcher.computeIfAbsent(relativePath, (a) -> new HashSet<>())
+                                    .add(appDep);
                         }
+                        archiveCreator.addFileIfNotExists(file, relativePath, appDep.toString());
                     }
                 } catch (IOException e) {
                     throw new UncheckedIOException(e);

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/ZipFileSystemArchiveCreator.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/ZipFileSystemArchiveCreator.java
@@ -18,9 +18,13 @@ import java.util.Set;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
+import org.jboss.logging.Logger;
+
 import io.quarkus.fs.util.ZipUtils;
 
 class ZipFileSystemArchiveCreator implements ArchiveCreator {
+
+    private static final Logger LOG = Logger.getLogger(ZipFileSystemArchiveCreator.class);
 
     // we probably don't need the Windows entry but let's be safe
     private static final Set<String> MANIFESTS = Set.of("META-INF/MANIFEST.MF", "META-INF\\MANIFEST.MF");
@@ -67,35 +71,42 @@ class ZipFileSystemArchiveCreator implements ArchiveCreator {
         }
     }
 
+    /**
+     * First-write wins, subsequent additions of the same file will generate a warning.
+     * <p>
+     * Use {@link #addFileIfNotExists(Path, String, String)} if you expect a second write to be an expected behavior.
+     * It has the same first-write wins behavior but won't generate a warning.
+     */
     @Override
     public void addFile(Path origin, String target, String source) throws IOException {
-        if (MANIFESTS.contains(target)) {
-            return;
-        }
-        if (addedFiles.putIfAbsent(target, source) != null) {
-            return;
-        }
-        Path targetInFsPath = zipFileSystem.getPath(target);
-        handleParentDirectories(targetInFsPath, source);
-        Files.copy(origin, targetInFsPath, StandardCopyOption.REPLACE_EXISTING);
+        doAddFile(target, source,
+                targetInFsPath -> Files.copy(origin, targetInFsPath, StandardCopyOption.REPLACE_EXISTING));
     }
 
+    /**
+     * First-write wins, subsequent additions of the same file will generate a warning.
+     * <p>
+     * Use {@link #addFileIfNotExists(byte[], String, String)} if you expect a second write to be an expected behavior.
+     * It has the same first-write wins behavior but won't generate a warning.
+     */
     @Override
     public void addFile(byte[] bytes, String target, String source) throws IOException {
-        if (MANIFESTS.contains(target)) {
-            return;
-        }
-        Path targetInFsPath = zipFileSystem.getPath(target);
-        handleParentDirectories(targetInFsPath, source);
-        Files.write(targetInFsPath, bytes);
-        addedFiles.put(target, source);
+        doAddFile(target, source, targetInFsPath -> Files.write(targetInFsPath, bytes));
     }
 
+    /**
+     * First-write wins, subsequent additions of the same file will generate a warning.
+     */
+    @Override
+    public void addFile(List<byte[]> bytes, String target, String source) throws IOException {
+        addFile(joinWithNewlines(bytes), target, source);
+    }
+
+    /**
+     * First-write wins but don't generate a warning if an entry with this name already exists.
+     */
     @Override
     public void addFileIfNotExists(Path origin, String target, String source) throws IOException {
-        if (MANIFESTS.contains(target)) {
-            return;
-        }
         if (addedFiles.containsKey(target)) {
             return;
         }
@@ -103,11 +114,11 @@ class ZipFileSystemArchiveCreator implements ArchiveCreator {
         addFile(origin, target, source);
     }
 
+    /**
+     * First-write wins but don't generate a warning if an entry with this name already exists.
+     */
     @Override
     public void addFileIfNotExists(byte[] bytes, String target, String source) throws IOException {
-        if (MANIFESTS.contains(target)) {
-            return;
-        }
         if (addedFiles.containsKey(target)) {
             return;
         }
@@ -115,12 +126,24 @@ class ZipFileSystemArchiveCreator implements ArchiveCreator {
         addFile(bytes, target, source);
     }
 
-    @Override
-    public void addFile(List<byte[]> bytes, String target, String source) throws IOException {
+    private void doAddFile(String target, String source, FileWriter writer) throws IOException {
         if (MANIFESTS.contains(target)) {
             return;
         }
-        addFile(joinWithNewlines(bytes), target, source);
+        String existingSource = addedFiles.putIfAbsent(target, source);
+        if (existingSource != null) {
+            LOG.warn("Duplicate entry '" + target + "' — already added from '" + existingSource
+                    + "', ignoring entry from '" + source + "'");
+            return;
+        }
+        Path targetInFsPath = zipFileSystem.getPath(target);
+        handleParentDirectories(targetInFsPath, source);
+        writer.write(targetInFsPath);
+    }
+
+    @FunctionalInterface
+    private interface FileWriter {
+        void write(Path targetInFsPath) throws IOException;
     }
 
     @Override


### PR DESCRIPTION
We went back and forth on this and it has caused all sorts of issues,
the latest having been fixed by:
https://github.com/quarkusio/quarkus/pull/53187
that I just reverted.

I think we need to refactor this and have a very clear and consistent
semantic, which should now be the case.

The reason why an unclear semantic was detrimental is that ZipFileSystem
and Commons Compress have different behavior:
- ZipFileSystem only allows one entry per name and will fail if another
  is added
- Commons Compress will happily add several entries with the same name
  to the Zip file (which is a behavior that is allowed by the format)

When I switched from ZipFileSystem to Commons Compress, I didn't see
this difference in behavior.
Having a clear semantic should avoid all issues.

In passing, make ZipFileSystemArchiveCreator consistent with
ParallelCommonsCompressArchiveCreator, as it derived a bit.
It's not used anymore but who knows...