### PR TITLE
ArC: use Set.of() in generated Bean.getInjectionPoints()

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
@@ -2,6 +2,7 @@ package io.quarkus.arc.processor;
 
 import static io.quarkus.arc.processor.IndexClassLookupUtils.getClassByName;
 import static io.quarkus.arc.processor.Reproducibility.orderedAnnotations;
+import static io.quarkus.arc.processor.Reproducibility.orderedInjectionPoints;
 import static io.quarkus.arc.processor.Reproducibility.orderedStereotypes;
 import static io.quarkus.arc.processor.Reproducibility.orderedTypes;
 import static org.jboss.jandex.gizmo2.Jandex2Gizmo.classDescOf;
@@ -1980,8 +1981,7 @@ public class BeanGenerator extends AbstractGenerator {
             mc.returning(Set.class);
             mc.body(bc -> {
                 LocalVar tccl = bc.localVar("tccl", bc.invokeVirtual(MethodDescs.THREAD_GET_TCCL, bc.currentThread()));
-                LocalVar result = bc.localVar("result", bc.new_(HashSet.class));
-                for (InjectionPointInfo injectionPoint : injectionPoints) {
+                bc.return_(bc.setOf(orderedInjectionPoints(injectionPoints), injectionPoint -> {
                     LocalVar type = RuntimeTypeCreator.of(bc).withTCCL(tccl).create(injectionPoint.getType());
                     Var qualifiers = collectInjectionPointQualifiers(bean.getDeployment(), bc, injectionPoint,
                             annotationLiterals);
@@ -1989,12 +1989,10 @@ public class BeanGenerator extends AbstractGenerator {
                             annotationLiterals, injectionPointAnnotationsPredicate);
                     Var member = getJavaMember(bc, injectionPoint, reflectionRegistration);
 
-                    Expr ip = bc.new_(MethodDescs.INJECTION_POINT_IMPL_CONSTRUCTOR, type, type, qualifiers, cc.this_(),
+                    return bc.new_(MethodDescs.INJECTION_POINT_IMPL_CONSTRUCTOR, type, type, qualifiers, cc.this_(),
                             annotations, member, Const.of(injectionPoint.getPosition()),
                             Const.of(injectionPoint.isTransient()));
-                    bc.withSet(result).add(ip);
-                }
-                bc.return_(result);
+                }));
             });
         });
     }
@@ -2190,8 +2188,8 @@ public class BeanGenerator extends AbstractGenerator {
             }
         }
 
-        LocalVar qualifiersVar = bc.localVar("qualifiers",
-                bc.setOf(Reproducibility.orderedAnnotations(filteredQualifiers), qualifier -> {
+        return bc.localVar("qualifiers",
+                bc.setOf(orderedAnnotations(filteredQualifiers), qualifier -> {
                     BuiltinQualifier builtinQualifier = BuiltinQualifier.of(qualifier);
                     Expr qualifierExpr;
                     if (builtinQualifier != null) {
@@ -2203,8 +2201,6 @@ public class BeanGenerator extends AbstractGenerator {
                     }
                     return qualifierExpr;
                 }));
-
-        return qualifiersVar;
     }
 
     static void destroyTransientReferences(BlockCreator bc, Iterable<TransientReference> transientReferences) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Reproducibility.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Reproducibility.java
@@ -1,9 +1,12 @@
 package io.quarkus.arc.processor;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
+import java.util.function.IntFunction;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationInstanceEquivalenceProxy;
@@ -28,6 +31,28 @@ public class Reproducibility {
             .<AnnotationInstanceEquivalenceProxy, DotName> comparing(it -> it.get().name())
             .thenComparing(it -> it.get().toString());
     static final Comparator<StereotypeInfo> STEREOTYPE_COMPARATOR = Comparator.comparing(StereotypeInfo::getName);
+    static final Comparator<InjectionPointInfo> INJECTION_POINT_COMPARATOR = Comparator
+            .comparing(InjectionPointInfo::getType, TYPE_COMPARATOR)
+            .thenComparing(InjectionPointInfo::getRequiredQualifiers,
+                    setComparator(ANNOTATION_COMPARATOR, AnnotationInstance[]::new));
+
+    // this is relatively sane only for tiny sets, which is the case here
+    private static <T> Comparator<Set<T>> setComparator(Comparator<T> comparator, IntFunction<T[]> toArray) {
+        return (a, b) -> {
+            T[] aArray = a.toArray(toArray);
+            T[] bArray = b.toArray(toArray);
+            Arrays.sort(aArray, comparator);
+            Arrays.sort(bArray, comparator);
+            int len = Math.min(aArray.length, bArray.length);
+            for (int i = 0; i < len; i++) {
+                int cmp = comparator.compare(aArray[i], bArray[i]);
+                if (cmp != 0) {
+                    return cmp;
+                }
+            }
+            return Integer.compare(aArray.length, bArray.length);
+        };
+    }
 
     static List<BeanInfo> orderedBeans(Collection<BeanInfo> beans) {
         return ordered(beans, BEAN_COMPARATOR);
@@ -60,6 +85,10 @@ public class Reproducibility {
 
     static List<StereotypeInfo> orderedStereotypes(Collection<StereotypeInfo> stereotypes) {
         return ordered(stereotypes, STEREOTYPE_COMPARATOR);
+    }
+
+    static List<InjectionPointInfo> orderedInjectionPoints(Collection<InjectionPointInfo> injectionPoints) {
+        return ordered(injectionPoints, INJECTION_POINT_COMPARATOR);
     }
 
     private static <T> List<T> ordered(Collection<T> collection, Comparator<? super T> comparator) {

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ListProvider.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ListProvider.java
@@ -28,6 +28,8 @@ public class ListProvider implements InjectableReferenceProvider<List<?>> {
             Member javaMember, int position, boolean isTransient, boolean needsInstanceHandle) {
         this.requiredType = requiredType;
         this.injectionPointType = injectionPointType;
+        // we previously used to remove the `@All` qualifier here, but we no longer have to,
+        // it is removed in `BeanGenerator` at build time and doesn't reach runtime anymore
         this.qualifiers = qualifiers;
         this.targetBean = targetBean;
         this.annotations = annotations;

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/duplicates/DuplicateBeanInjectionPointQualifiersTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/duplicates/DuplicateBeanInjectionPointQualifiersTest.java
@@ -1,0 +1,92 @@
+package io.quarkus.arc.test.duplicates;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.Set;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Qualifier;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.ClassType;
+import org.jboss.jandex.Index;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.BeanCreator;
+import io.quarkus.arc.SyntheticCreationalContext;
+import io.quarkus.arc.processor.BeanRegistrar;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class DuplicateBeanInjectionPointQualifiersTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(MyQualifier.class, MyDependency.class)
+            .beanRegistrars(new MyBeanRegistrar())
+            .strictCompatibility(true) // we only generate `Bean.getInjectionPoints()` in strict mode
+            .build();
+
+    @Test
+    public void test() {
+        Set<InjectionPoint> ips = Arc.container().select(MyBean.class).getHandle().getBean().getInjectionPoints();
+        assertNotNull(ips);
+        assertEquals(1, ips.size());
+        InjectionPoint ip = ips.iterator().next();
+        assertEquals(MyDependency.class, ip.getType());
+        assertEquals(Set.of(new MyQualifier.Literal()), ip.getQualifiers());
+    }
+
+    @Qualifier
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface MyQualifier {
+        final class Literal extends AnnotationLiteral<MyQualifier> implements MyQualifier {
+        }
+    }
+
+    @Dependent
+    @MyQualifier
+    static class MyDependency {
+    }
+
+    static class MyBean {
+    }
+
+    static class MyBeanCreator implements BeanCreator<MyBean> {
+        @Override
+        public MyBean create(SyntheticCreationalContext<MyBean> context) {
+            return new MyBean();
+        }
+    }
+
+    static class MyBeanRegistrar implements BeanRegistrar {
+        @Override
+        public void register(RegistrationContext context) {
+            Index index = null;
+            try {
+                index = Index.of(MyDependency.class, Object.class);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+
+            ClassInfo objectClass = index.getClassByName(Object.class);
+            ClassInfo myDependencyClass = index.getClassByName(MyDependency.class);
+
+            context.configure(MyBean.class)
+                    .addType(MyBean.class)
+                    .addInjectionPoint(ClassType.create(MyDependency.class),
+                            AnnotationInstance.builder(MyQualifier.class).buildWithTarget(objectClass),
+                            AnnotationInstance.builder(MyQualifier.class).buildWithTarget(myDependencyClass))
+                    .creator(MyBeanCreator.class)
+                    .done();
+        }
+    }
+}


### PR DESCRIPTION
We already make sure that qualifiers in `InjectionPointInfo` are unique by calling `Unique.annotations()`. However, we didn't make use of that yet. In this commit, we use `Set.of()` instead of `new HashSet()` when generating the `Bean.getInjectionPoints()` method implementation (which we only do in the strict mode), and we add a test that verifies this.

Follows up on #52944; I intended to submit the PR a lot earlier, but forgot :-) 