### PR TITLE
Add an option to disable HTTPS in Keycloak DevService

### DIFF
--- a/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesConfig.java
+++ b/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesConfig.java
@@ -220,4 +220,13 @@ public interface KeycloakDevServicesConfig {
     @WithDefault("4S")
     Duration webClientTimeout();
 
+    /**
+     * Specifies whether to disable HTTPS on the master realm by setting {@code sslRequired=NONE}.
+     *
+     * This is useful when the Keycloak container is started without HTTPS support and the master realm's
+     * default SSL requirement prevents HTTP access.
+     */
+    @WithDefault("false")
+    boolean disableHttps();
+
 }

--- a/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesProcessor.java
+++ b/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesProcessor.java
@@ -215,7 +215,8 @@ public class KeycloakDevServicesProcessor {
                 config.port(),
                 safeMapHash(config.containerEnv()),
                 config.containerMemoryLimit(),
-                config.webClientTimeout());
+                config.webClientTimeout(),
+                config.disableHttps());
         serviceConfigIdentifier.append(configHashCode);
 
         for (int fileTimeHashCode : getRealmFileLastModifiedDateHashCode(config.realmPath())) {
@@ -511,7 +512,29 @@ public class KeycloakDevServicesProcessor {
         @Override
         public void start() {
             super.start();
+            if (config.disableHttps()) {
+                disableMasterRealmHttpsRequirement();
+            }
             configPropertiesContext = createConfigPropertiesContext();
+        }
+
+        private void disableMasterRealmHttpsRequirement() {
+            try {
+                var configResult = execInContainer("/opt/keycloak/bin/kcadm.sh",
+                        "config", "credentials", "--server", "http://localhost:8080",
+                        "--realm", "master", "--user", KEYCLOAK_ADMIN_USER, "--password", KEYCLOAK_ADMIN_PASSWORD);
+                if (configResult.getExitCode() != 0) {
+                    LOG.errorf("Failed to configure kcadm.sh credentials: %s", configResult.getStderr());
+                    return;
+                }
+                var updateResult = execInContainer("/opt/keycloak/bin/kcadm.sh",
+                        "update", "realms/master", "-s", "sslRequired=NONE");
+                if (updateResult.getExitCode() != 0) {
+                    LOG.errorf("Failed to disable HTTPS on the master realm: %s", updateResult.getStderr());
+                }
+            } catch (IOException | InterruptedException e) {
+                LOG.error("Failed to disable HTTPS on the master realm", e);
+            }
         }
 
         @Override

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -2,6 +2,7 @@ quarkus.oidc.health.enabled=true
 
 quarkus.keycloak.devservices.create-realm=false
 quarkus.keycloak.devservices.show-logs=true
+quarkus.keycloak.devservices.disable-https=true
 # Default tenant configuration
 quarkus.oidc.client-id=quarkus-app
 quarkus.oidc.client-name=Quarkus Keycloak


### PR DESCRIPTION
Fixes #53192.

Mac users are suffering for too long, we need to have an easy way for them to disable HTTPS at the master realm level.
This PR (done by Claude, I only did a minor test configuration update - to check enabling the property has no side-effects) disables HTTPS on the master realm if requested by the user, as proposed by @holly-cummins, @maxlam79, and @agahkarakuzu

See also the discussion #48905.
Also CC @zer0origin.

Note we can't just disable HTTPS by default as it will conflict with tests that do TLS and mTLS related actions
