### PR TITLE
Check for exempt dependencies in new maven resolver as well as old one

### DIFF
--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/ApplicationDependencyResolver.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/ApplicationDependencyResolver.java
@@ -1004,7 +1004,7 @@ public class ApplicationDependencyResolver {
                     runtimeNode.getDependency().isOptional());
 
             replaceRuntimeExtensionNodes(deploymentNode);
-            if (!presentInTargetGraph) {
+            if (!presentInTargetGraph && !isExemptGact(deploymentNode)) {
                 throw new RuntimeException(
                         "Quarkus extension deployment artifact " + deploymentNode.getArtifact()
                                 + " does not appear to depend on the corresponding runtime artifact "
@@ -1069,6 +1069,12 @@ public class ApplicationDependencyResolver {
             }
             return false;
         }
+    }
+
+    private boolean isExemptGact(DependencyNode gact) {
+        return DependencyUtils.isExemptFromDeploymentDependencyValidation(
+                gact.getArtifact().getGroupId(),
+                gact.getArtifact().getArtifactId());
     }
 
     private class ConditionalDependency {

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/util/DependencyUtils.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/util/DependencyUtils.java
@@ -179,4 +179,21 @@ public class DependencyUtils {
         final DependencyNode winner = (DependencyNode) node.getData().get(ConflictResolver.NODE_DATA_WINNER);
         return winner == null || !node.getChildren().isEmpty() ? null : winner;
     }
+
+    /**
+     * Checks if a given artifact is exempt from deployment dependency validation.
+     * <p>
+     * This is useful for core extensions which were introduced with only deployment
+     * modules, and then had runtime modules added later, when updating all the consumers would have been a major breaking
+     * change.
+     *
+     * @param groupId the artifact group ID
+     * @param artifactId the artifact ID
+     * @return true if the artifact is exempt from validation
+     */
+    public static boolean isExemptFromDeploymentDependencyValidation(String groupId, String artifactId) {
+        return "io.quarkus".equals(groupId)
+                && ("quarkus-devservices".equals(artifactId)
+                        || "quarkus-devservices-deployment".equals(artifactId));
+    }
 }

--- a/independent-projects/extension-maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
+++ b/independent-projects/extension-maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
@@ -1106,8 +1106,7 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
     }
 
     private static boolean isExemptGact(ArtifactKey gact) {
-        return (gact.getArtifactId().equals("quarkus-devservices")
-                || gact.getArtifactId().equals("quarkus-devservices-deployment")) && gact.getGroupId().equals("io.quarkus");
+        return DependencyUtils.isExemptFromDeploymentDependencyValidation(gact.getGroupId(), gact.getArtifactId());
     }
 
     private void visitRuntimeDeps(RootNode root, Node currentNode, int currentId, DependencyNode node)


### PR DESCRIPTION
Fixes #52695.

Also fixes this problem in JBang: 

```
       ... 23 more
Caused by: java.lang.RuntimeException: io.quarkus.bootstrap.BootstrapException: Failed to create the application model for dev.jbang.user:quarkus::jar:999-SNAPSHOT[paths: /Users/max/.jbang/cache/jars/db.java.7c601f94ae1c388ad3769c625afc5b924ae85ae78091e1ea207709ab09189261/classes;]
        at io.quarkus.bootstrap.jbang.JBangBuilderImpl.postBuild(JBangBuilderImpl.java:102)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
        ... 25 more
```

The problem was a maven resolving one, as suspected. What happened was that around the same time I put in the validation bypass in the maven resolver, @aloubyansky wrote a new maven resolver. Because the changes happened around the same time, my bypass was only in the legacy resolver. 

This didn’t matter too much, because Quarkus still defaulted to using the legacy resolver. But then in February, Alexey changed the default to use the new resolver. This meant my validation bypass was no longer effective. I’m not 100% sure why this didn’t break everything. At around the same time, I changed most dev services to use the new model, so the dependency was on the classpath of most test projects, but I think the validation checks individual poms, so that shouldn’t make a difference. 

In JBang, the legacy resolver stopped being used. It actually stopped being used so emphatically that even this won’t get it back to being used   

```
 //RUNTIME_OPTIONS -Dquarkus.bootstrap.legacy-model-resolver=true                                     
```

Claude spent quite a while debugging the flow and reckons `//RUNTIME_OPTIONS` doesn't pass system properties to the JBang Integration subprocess. @maxandersen, let me know if you want me to raise an issue for that. It’s not what I’d expect, but I don’t fully understand the JBang flow. 

