### PR TITLE
Build-time config property to disable Kafka Clients JMX MBean registration

### DIFF
--- a/docs/src/main/asciidoc/kafka.adoc
+++ b/docs/src/main/asciidoc/kafka.adoc
@@ -2106,6 +2106,18 @@ add `quarkus.kafka.snappy.enabled=true` to your `application.properties`.
 
 In native mode, Snappy is disabled by default as the use of Snappy requires embedding a native library and unpacking it when the application starts.
 
+== Disabling JMX MBean registration
+
+To disable JMX MBean registration, set the following property in your `application.properties`:
+
+[source, properties]
+----
+quarkus.kafka.jmx.enabled=false
+----
+
+When disabled, the `AppInfoParser` skipş the JMX MBean registration and the default value for `kafka.metric.reporters` is set to empty, preventing the `JmxReporter` from being loaded.
+Kafka client metrics are available through Micrometer when the xref:telemetry-micrometer.adoc[Micrometer extension] is present.
+
 == Authentication with OAuth
 
 If your Kafka broker uses OAuth as authentication mechanism, you need to configure the Kafka consumer to enable this authentication process.

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/AppInfoClassVisitor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/AppInfoClassVisitor.java
@@ -1,0 +1,158 @@
+package io.quarkus.kafka.client.deployment;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+
+import io.quarkus.gizmo.Gizmo;
+
+/**
+ * ASM {@link ClassVisitor} that rewrites {@code registerAppInfo} and {@code unregisterAppInfo}
+ * in {@code org.apache.kafka.common.utils.AppInfoParser} to skip JMX MBean registration/unregistration
+ * while preserving the calls to {@code registerMetrics} and {@code unregisterMetrics}.
+ * <p>
+ * The original methods register/unregister JMX MBeans which causes "Error registering AppInfo mbean"
+ * warnings in dev/test mode. This transformation replaces the method bodies to only delegate to
+ * the internal metrics methods, removing the JMX side-effects.
+ * <p>
+ * The visitor detects the Kafka version by inspecting the {@code registerMetrics} method signature:
+ * <ul>
+ * <li>Kafka &ge; 4.2: {@code registerMetrics(Metrics, AppInfo, String)}</li>
+ * <li>Kafka &lt; 4.2: {@code registerMetrics(Metrics, AppInfo)}</li>
+ * </ul>
+ */
+class AppInfoClassVisitor extends ClassVisitor {
+
+    private static final String APP_INFO_PARSER = "org/apache/kafka/common/utils/AppInfoParser";
+    private static final String APP_INFO_INNER = "org/apache/kafka/common/utils/AppInfoParser$AppInfo";
+    private static final String METRICS = "org/apache/kafka/common/metrics/Metrics";
+
+    private boolean hasClientIdParam;
+    private final List<DeferredMethod> deferredMethods = new ArrayList<>();
+
+    AppInfoClassVisitor(ClassVisitor classVisitor) {
+        super(Gizmo.ASM_API_VERSION, classVisitor);
+    }
+
+    @Override
+    public MethodVisitor visitMethod(int access, String name, String descriptor,
+            String signature, String[] exceptions) {
+        // Detect registerMetrics signature to determine Kafka version
+        if ("registerMetrics".equals(name)) {
+            Type[] argTypes = Type.getArgumentTypes(descriptor);
+            // Kafka >= 4.2: registerMetrics(Metrics, AppInfo, String)
+            // Kafka < 4.2:  registerMetrics(Metrics, AppInfo)
+            hasClientIdParam = argTypes.length >= 3;
+        }
+
+        if ("registerAppInfo".equals(name) || "unregisterAppInfo".equals(name)) {
+            // Defer these methods until visitEnd(), when we know the registerMetrics signature
+            deferredMethods.add(new DeferredMethod(access, name, descriptor, signature, exceptions));
+            // Return null to discard the original method body
+            return null;
+        }
+
+        return super.visitMethod(access, name, descriptor, signature, exceptions);
+    }
+
+    @Override
+    public void visitEnd() {
+        for (DeferredMethod m : deferredMethods) {
+            MethodVisitor mv = super.visitMethod(m.access, m.name, m.descriptor, m.signature, m.exceptions);
+            if (mv != null) {
+                mv.visitCode();
+                if ("registerAppInfo".equals(m.name)) {
+                    generateRegisterAppInfo(mv);
+                } else {
+                    generateUnregisterAppInfo(mv);
+                }
+                mv.visitEnd();
+            }
+        }
+        super.visitEnd();
+    }
+
+    /**
+     * Generates the body for registerAppInfo(String prefix, String id, Metrics metrics, long nowMs):
+     *
+     * <pre>
+     * // Kafka >= 4.2:
+     * registerMetrics(metrics, new AppInfoParser.AppInfo(nowMs), id);
+     *
+     * // Kafka < 4.2:
+     * registerMetrics(metrics, new AppInfoParser.AppInfo(nowMs));
+     * </pre>
+     */
+    private void generateRegisterAppInfo(MethodVisitor mv) {
+        // Local variables for registerAppInfo(String prefix, String id, Metrics metrics, long nowMs):
+        // 0: prefix (String)
+        // 1: id (String)
+        // 2: metrics (Metrics)
+        // 3-4: nowMs (long, takes 2 slots)
+
+        // Push metrics (arg 2) onto stack
+        mv.visitVarInsn(Opcodes.ALOAD, 2);
+
+        // Create new AppInfoParser.AppInfo(nowMs)
+        mv.visitTypeInsn(Opcodes.NEW, APP_INFO_INNER);
+        mv.visitInsn(Opcodes.DUP);
+        mv.visitVarInsn(Opcodes.LLOAD, 3); // nowMs
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, APP_INFO_INNER, "<init>", "(J)V", false);
+
+        if (hasClientIdParam) {
+            // Kafka >= 4.2: registerMetrics(metrics, appInfo, id)
+            mv.visitVarInsn(Opcodes.ALOAD, 1); // id
+            mv.visitMethodInsn(Opcodes.INVOKESTATIC, APP_INFO_PARSER, "registerMetrics",
+                    "(L" + METRICS + ";L" + APP_INFO_INNER + ";Ljava/lang/String;)V", false);
+        } else {
+            // Kafka < 4.2: registerMetrics(metrics, appInfo)
+            mv.visitMethodInsn(Opcodes.INVOKESTATIC, APP_INFO_PARSER, "registerMetrics",
+                    "(L" + METRICS + ";L" + APP_INFO_INNER + ";)V", false);
+        }
+
+        mv.visitInsn(Opcodes.RETURN);
+        mv.visitMaxs(hasClientIdParam ? 5 : 4, 5);
+    }
+
+    /**
+     * Generates the body for unregisterAppInfo(String prefix, String id, Metrics metrics):
+     *
+     * <pre>
+     * // Kafka >= 4.2:
+     * unregisterMetrics(metrics, id);
+     *
+     * // Kafka < 4.2:
+     * unregisterMetrics(metrics);
+     * </pre>
+     */
+    private void generateUnregisterAppInfo(MethodVisitor mv) {
+        // Local variables for unregisterAppInfo(String prefix, String id, Metrics metrics):
+        // 0: prefix (String)
+        // 1: id (String)
+        // 2: metrics (Metrics)
+
+        // Push metrics (arg 2)
+        mv.visitVarInsn(Opcodes.ALOAD, 2);
+
+        if (hasClientIdParam) {
+            // Kafka >= 4.2: unregisterMetrics(metrics, id)
+            mv.visitVarInsn(Opcodes.ALOAD, 1); // id
+            mv.visitMethodInsn(Opcodes.INVOKESTATIC, APP_INFO_PARSER, "unregisterMetrics",
+                    "(L" + METRICS + ";Ljava/lang/String;)V", false);
+        } else {
+            // Kafka < 4.2: unregisterMetrics(metrics)
+            mv.visitMethodInsn(Opcodes.INVOKESTATIC, APP_INFO_PARSER, "unregisterMetrics",
+                    "(L" + METRICS + ";)V", false);
+        }
+
+        mv.visitInsn(Opcodes.RETURN);
+        mv.visitMaxs(hasClientIdParam ? 2 : 1, 3);
+    }
+
+    private record DeferredMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+    }
+}

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaBuildTimeConfig.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaBuildTimeConfig.java
@@ -39,6 +39,18 @@ public interface KafkaBuildTimeConfig {
     boolean snappyLoadFromSharedClassLoader();
 
     /**
+     * Whether Kafka JMX MBean registration is enabled.
+     * <p>
+     * When disabled, the {@code AppInfoParser.registerAppInfo} and {@code unregisterAppInfo} methods
+     * no longer register JMX MBean while preserving internal metrics registration.
+     * <p>
+     * When disabled, also sets the default value of the `kafka.metric.reporters` property to empty value.
+     */
+    @WithName("jmx.enabled")
+    @WithDefault("true")
+    boolean jmxEnabled();
+
+    /**
      * Dev Services.
      * <p>
      * Dev Services allows Quarkus to automatically start Kafka in dev and test mode.

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
@@ -51,6 +51,7 @@ import io.quarkus.deployment.annotations.Consume;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.AdditionalIndexedClassesBuildItem;
+import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.ConfigDescriptionBuildItem;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
@@ -159,6 +160,21 @@ public class KafkaProcessor {
         log.produce(new LogCategoryBuildItem("org.apache.kafka.common.metrics", Level.WARNING));
         log.produce(new LogCategoryBuildItem("org.apache.kafka.common.config", Level.WARNING));
         log.produce(new LogCategoryBuildItem("org.apache.kafka.common.telemetry", Level.WARNING));
+    }
+
+    @BuildStep
+    void removeAppInfoJmxRegistration(KafkaBuildTimeConfig config,
+            BuildProducer<BytecodeTransformerBuildItem> transformers,
+            BuildProducer<RunTimeConfigurationDefaultBuildItem> runtimeConfig) {
+        if (config.jmxEnabled()) {
+            return;
+        }
+        transformers.produce(new BytecodeTransformerBuildItem.Builder()
+                .setClassToTransform("org.apache.kafka.common.utils.AppInfoParser")
+                .setCacheable(true)
+                .setVisitorFunction((className, classVisitor) -> new AppInfoClassVisitor(classVisitor))
+                .build());
+        runtimeConfig.produce(new RunTimeConfigurationDefaultBuildItem("kafka.metric.reporters", ""));
     }
 
     @BuildStep


### PR DESCRIPTION
Introduces `quarkus.kafka.jmx.enabled` property, defaults to `true`. 

When enabled=false, it also sets the default value of kafka.metric.reporters to empty value; otherwise, the default Kafka value is JmxReporter.