### PR TITLE
Add a Disable HTTPS note to Keycloak Dev Services doc

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -309,6 +309,36 @@ quarkus.keycloak.devservices.resource-mappings.policies=/opt/keycloak/providers/
 Policy jars can also be located in the file system.
 <2> The policies jar is mapped to the `/opt/keycloak/providers/policies.jar` container location.
 
+== Disable HTTPS
+
+In some cases, you might see Keycloak `HTTPS required` errors that cause either Keycloak startup or communication failures.
+
+You might be facing a Docker issue that mainly affects MacOS users attempting to use Keycloak locally where the ports do not automatically bind to `localhost`.
+
+The easiest option to resolve it is to disable HTTPS with a `quarkus.keycloak.devservices.disable-https=true` property.
+It runs the following Keycloak admin command inside your Keycloak container everytime it restarts:
+
+[source,bash]
+----
+kcadm.sh update realms/master -s sslRequired=NONE
+----
+
+Another approach is to provide a localhost with port bindings configuration.
+
+A common solution is to update your `docker-compose` file to use a private IPv4 address, such as `localhost`.
+For example:
+
+[source,yaml]
+----
+    ports:
+      - "127.0.0.1:8081:8080"
+----
+
+Alternatively, you can change the default behaviour within MacOS Docker Desktop to use `localhost` when binding ports.
+Inside the Docker Desktop, go to `Settings > Resources > Network > Port Binding Behaviour` and change it to `localhost by default`.
+Be aware that this change is applied to all docker containers, and may have unforeseen side affects.
+Update to the latest version of Docker if you do not see this Docker Desktop option.
+
 == Disable Dev Services for Keycloak
 
 Dev Services for Keycloak is not activated if either `quarkus.oidc.auth-server-url` is already initialized or the default OIDC tenant is disabled with `quarkus.oidc.tenant.enabled=false`, regardless of whether you work with Keycloak or not.


### PR DESCRIPTION
This PR is based on the work of @zer0origin who helped with #53184, I'm only replacing that PR to simplify the squash process, with a few updates given #53205