### PR TITLE
Keep grpc codegen build-only

### DIFF
--- a/extensions/grpc/stubs/pom.xml
+++ b/extensions/grpc/stubs/pom.xml
@@ -23,10 +23,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-grpc-codegen</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-mutiny</artifactId>
         </dependency>
         <dependency>
@@ -107,6 +103,13 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.quarkus</groupId>
+                        <artifactId>quarkus-grpc-codegen</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
                         <id>post-process</id>
@@ -115,7 +118,12 @@
                             <goal>java</goal>
                         </goals>
                         <configuration>
-                            <includeProjectDependencies>true</includeProjectDependencies>
+                            <includeProjectDependencies>false</includeProjectDependencies>
+                            <includePluginDependencies>true</includePluginDependencies>
+                            <executableDependency>
+                                <groupId>io.quarkus</groupId>
+                                <artifactId>quarkus-grpc-codegen</artifactId>
+                            </executableDependency>
                             <arguments>
                                 <argument>${project.build.directory}/generated-sources/protobuf/grpc-java</argument>
                             </arguments>


### PR DESCRIPTION
Fixes #53239

## Summary

This PR keeps `quarkus-grpc-codegen` build-only in `quarkus-grpc-stubs`.

## What Changed

The `exec-maven-plugin` configuration was adjusted to:
- resolve `quarkus-grpc-codegen` as an executable plugin dependency, not package dependency
- flip `includeProjectDependencies` to `false` - not strictly needed, but is a good update to isolate build-time helper tool within a predictable classpath
- flip `includePluginDependencies` to `true` - obviously required

## Why

`quarkus-grpc-codegen` is only needed while building `quarkus-grpc-stubs`. Declaring it as a normal dependency caused it to be published transitively to downstream consumers. Since `quarkus-grpc-codegen` pulls in `quarkus-grpc-protoc-plugin:shaded`, this leaked build-time artifacts into consumer dependency trees.

By moving `quarkus-grpc-codegen` to the plugin dependency classpath, `GrpcPostProcessing` remains available for the `grpc-stubs` build, but the artifact is no longer exposed as a transitive dependency.

## Regression / Root Cause

This regressed when the post-processing step for generated gRPC sources was added to `quarkus-grpc-stubs` and `quarkus-grpc-codegen` was introduced as a regular module dependency so `exec-maven-plugin` could load `GrpcPostProcessing`.

That solved the build-time classpath problem for `grpc-stubs`, but it also made a build helper part of the published dependency graph. This change restores the intended boundary by keeping that dependency build-only.

Source: #31115

## Testing

I verified the effective POM for `quarkus-grpc-stubs` after this change to confirm that:
- `quarkus-grpc-codegen` is no longer part of the module's regular published dependencies
- `quarkus-grpc-codegen` is only present as an `exec-maven-plugin` dependency for the post-processing step

**This PR intentionally does not add regression tests or documentation updates.** My personal assessment does not justify adding a separate regression test or a documentation update to validate this specific fix. Please let me know if you think this is still needed.