### PR TITLE
Add integrates extensions metadata to documentation

### DIFF
--- a/docs/src/main/asciidoc/extension-metadata.adoc
+++ b/docs/src/main/asciidoc/extension-metadata.adoc
@@ -45,6 +45,13 @@ metadata:
     artifact: "io.quarkus:quarkus-project-core-extension-codestarts"
   config: <10>
   - "quarkus.rest."
+  integrates: <11>
+    - name: "Jakarta REST"
+      artifact: "jakarta.ws.rs:jakarta.ws.rs-api"
+      version: "3.1.0"
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "4.14.0"
 ----
 
 <1> Extension name displayed to users
@@ -57,6 +64,7 @@ metadata:
 <8> Link to an externally hosted image. This is used in the Quarkus dev tools as the extension icon. It should be square, and any resolution greater than 220 pixels. Supported formats are png, jpeg, tiff, webp, and svg. Alternatively, if you https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/customizing-your-repositorys-social-media-preview[set the social media preview] on the extension's source code repository, the tools will pick up that image.
 <9> https://quarkus.io/guides/extension-codestart[Codestart] information
 <10> Configuration prefix
+<11> Libraries this extension integrates with. Each entry requires three fields: `name` (display name), `artifact` (groupId:artifactId), and `version` (full version string). For platform extensions where the artifact is managed in the BOM, it will be overridden with the BOM version in the generated descriptor if they differ during descriptor generation.
 
 And here is the final version of the file included in the runtime JAR augmented with other information collected by the Quarkus Maven plugin:
 


### PR DESCRIPTION
Ref https://github.com/quarkusio/quarkus/issues/35404

This is a proposal to add the new `integrates` section in the extension metadatas like:
```
metadata:
      integrates:
      - name: "Jakarta REST"
        artifact: "jakarta.ws.rs:jakarta.ws.rs-api"
        version: "3.1.0"
```

This PR updates the documentation.