### PR TITLE
Add the lacking guide for new quickstart

### DIFF
--- a/docs/src/main/asciidoc/stork-manual-service-registration.adoc
+++ b/docs/src/main/asciidoc/stork-manual-service-registration.adoc
@@ -1,0 +1,287 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
+= Implementing a Custom Stork Service Registrar
+:extension-status: preview
+include::_attributes.adoc[]
+:categories: cloud
+:topics: service-discovery,service-registration,stork
+:extensions: io.quarkus:quarkus-smallrye-stork
+
+This guide explains how to implement a custom service registrar for https://smallrye.io/smallrye-stork[SmallRye Stork] and use it to programmatically register service instances at startup.
+
+If you are new to Stork, please read the xref:stork.adoc[Stork Getting Started Guide].
+
+include::{includes}/extension-status.adoc[]
+
+== Prerequisites
+
+include::{includes}/prerequisites.adoc[]
+
+== Architecture
+
+In this guide, we will build an application that:
+
+* Implements a custom service registrar by extending Stork's SPI
+* Programmatically registers a service instance at startup
+* Configures the registrar via `application.properties`
+
+Beyond service discovery and load balancing, it also supports xref:stork-registration.adoc[_service registration_].
+Service registration is the process of announcing a service instance to a registry so that other services can discover it.
+While Stork provides built-in registrars for Consul, Eureka, and others, you can implement your own by using the Stork SPI.
+
+== Solution
+
+We recommend that you follow the instructions in the next sections and create the application step by step.
+However, you can go right to the completed example.
+
+Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {quickstarts-archive-url}[archive].
+
+The solution is located in the `stork-programmatic-custom-registration-quickstart` link:{quickstarts-tree-url}/stork-programmatic-custom-registration-quickstart[directory].
+
+== Bootstrapping the project
+
+Create a Quarkus project importing the quarkus-rest, quarkus-smallrye-stork, and quarkus-rest-client-jackson extensions using your favorite approach:
+
+:create-app-artifact-id: stork-programmatic-custom-registration-quickstart
+:create-app-extensions: quarkus-rest,quarkus-smallrye-stork,quarkus-rest-client-jackson
+include::{includes}/devtools/create-app.adoc[]
+
+In the generated project, also add the following dependencies:
+
+[source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
+.pom.xml
+----
+<dependency>
+    <groupId>io.smallrye.stork</groupId>
+    <artifactId>stork-core</artifactId>
+</dependency>
+<dependency>
+    <groupId>io.smallrye.stork</groupId>
+    <artifactId>stork-configuration-generator</artifactId>
+</dependency>
+----
+
+[source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
+.build.gradle
+----
+implementation("io.smallrye.stork:stork-core")
+implementation("io.smallrye.stork:stork-configuration-generator")
+----
+
+`stork-core` provides the Stork API and SPI needed to implement a custom registrar.
+`stork-configuration-generator` generates configuration classes at build time based on annotations on your registrar provider.
+
+== The Custom Service Registrar Provider
+
+Stork uses a provider model.
+To create a custom registrar, you need two classes:
+
+1. A *provider* implementing `ServiceRegistrarProvider` — the factory that creates registrar instances.
+2. A *registrar* implementing `ServiceRegistrar` — the actual registration logic.
+
+Let's start with the provider.
+Create the `src/main/java/org/acme/services/CustomServiceRegistrarProvider.java` file with the following content:
+
+[source, java]
+----
+package org.acme.services;
+
+import io.smallrye.stork.api.Metadata;
+import io.smallrye.stork.api.ServiceRegistrar;
+import io.smallrye.stork.api.config.ServiceRegistrarAttribute;
+import io.smallrye.stork.api.config.ServiceRegistrarType;
+import io.smallrye.stork.spi.ServiceRegistrarProvider;
+import io.smallrye.stork.spi.StorkInfrastructure;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ServiceRegistrarType(value = "custom", metadataKey = Metadata.DefaultMetadataKey.class)
+@ServiceRegistrarAttribute(name = "host",
+        description = "Host name of the service registration server.", required = true)
+@ServiceRegistrarAttribute(name = "port",
+        description = "Port of the service registration server.", required = false)
+@ApplicationScoped
+public class CustomServiceRegistrarProvider
+        implements ServiceRegistrarProvider<CustomRegistrarConfiguration, Metadata.DefaultMetadataKey> {
+
+    @Override
+    public ServiceRegistrar createServiceRegistrar(
+            CustomRegistrarConfiguration config,
+            String serviceName,
+            StorkInfrastructure storkInfrastructure) {
+        return new CustomServiceRegistrar(config);
+    }
+
+}
+----
+
+There are a few important things to note:
+
+* The `@ServiceRegistrarType` annotation declares the registrar _type_.
+This is the value used in the `quarkus.stork.<service-name>.service-registrar.type` property.
+Here, it is `custom`.
+* The `@ServiceRegistrarAttribute` annotations declare the configuration attributes for this registrar.
+Stork's annotation processor (provided by `stork-configuration-generator`) uses these annotations to generate
+the `CustomRegistrarConfiguration` class at compile time. You do not need to write this class yourself.
+* The `@ApplicationScoped` annotation makes this provider a CDI bean, so Stork can discover it automatically.
+* The `createServiceRegistrar` method is the factory that creates a `CustomServiceRegistrar` from the generated configuration.
+
+== The Custom Service Registrar
+
+Now let's implement the registrar itself.
+Create the `src/main/java/org/acme/services/CustomServiceRegistrar.java` file with the following content:
+
+[source, java]
+----
+package org.acme.services;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.stork.api.Metadata;
+import io.smallrye.stork.api.ServiceRegistrar;
+
+import org.jboss.logging.Logger;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class CustomServiceRegistrar implements ServiceRegistrar {
+
+    private static final Logger LOGGER = Logger.getLogger(CustomServiceRegistrar.class.getName());
+
+    private final String backendHost;
+    private final int backendPort;
+    private final Map<String, String> registeredInstances = new ConcurrentHashMap<>();
+
+    public CustomServiceRegistrar(CustomRegistrarConfiguration configuration) {
+        this.backendHost = configuration.getHost();
+        this.backendPort = Integer.parseInt(configuration.getPort()!=null?configuration.getPort():"8080");
+    }
+
+
+    @Override
+    public Uni<Void> registerServiceInstance(String serviceName, Metadata metadata, String ipAddress, int defaultPort) {
+        String address = ipAddress + ":" + defaultPort;
+        LOGGER.info("Registering service: " + serviceName + " with ipAddress: " + ipAddress + " and port: " + defaultPort);
+        registeredInstances.put(serviceName, address);
+        return Uni.createFrom().voidItem();
+    }
+
+    @Override
+    public Uni<Void> deregisterServiceInstance(String serviceName) {
+        LOGGER.infof("Deregistering service '%s' from backend %s:%d", serviceName, backendHost, backendPort);
+        registeredInstances.remove(serviceName);
+        return Uni.createFrom().voidItem();
+    }
+}
+----
+
+This registrar:
+
+* Receives its configuration (host and port) from the generated `CustomRegistrarConfiguration` class.
+* Stores registered instances in a `ConcurrentHashMap`.
+* Implements `registerServiceInstance` to add a service instance to the map.
+* Implements `deregisterServiceInstance` to remove a service instance on shutdown.
+* Both methods return `Uni<Void>`, since Stork uses Mutiny for reactive support.
+
+== Programmatic Service Registration at Startup
+
+With the registrar in place, we can now register service instances programmatically.
+Create the `src/main/java/org/acme/services/Registration.java` file with the following content:
+
+[source, java]
+----
+package org.acme.services;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import io.quarkus.runtime.StartupEvent;
+import io.smallrye.stork.Stork;
+import io.vertx.mutiny.core.Vertx;
+
+@ApplicationScoped
+public class Registration {
+
+    /**
+     * Register our two services using custom registrar.
+     *
+     * Note: this method is called on a worker thread, and so it is allowed to block.
+     */
+    public void init(@Observes StartupEvent ev, Vertx vertx) {
+        Stork.getInstance().getService("my-service").registerInstance("my-service", "localhost",
+                9000);
+    }
+}
+----
+
+When the application starts, this CDI bean observes the `StartupEvent` and uses the Stork API to register a service instance.
+The `Stork.getInstance().getService("my-service")` call retrieves the Stork service named `my-service`, and `registerInstance`
+delegates to the custom registrar we created earlier.
+
+== Stork configuration
+
+Now we need to configure Stork to use our custom registrar.
+
+In the `src/main/resources/application.properties`, add:
+
+[source, properties]
+----
+quarkus.stork.my-service.service-registrar.type=custom
+quarkus.stork.my-service.service-registrar.host=localhost
+----
+
+The `quarkus.stork.my-service.service-registrar.type` property tells Stork to use the `custom` registrar type.
+This matches the value declared in the `@ServiceRegistrarType` annotation on `CustomServiceRegistrarProvider`.
+
+The `quarkus.stork.my-service.service-registrar.host` property maps to the `host` attribute declared with `@ServiceRegistrarAttribute` on the provider.
+This is a required attribute.
+
+You can optionally set `quarkus.stork.my-service.service-registrar.port` as well, since the provider declares an optional `port` attribute.
+If omitted, the registrar defaults to port `8080`.
+
+== Running the application
+
+Package the application:
+
+include::{includes}/devtools/build.adoc[]
+
+And run it:
+
+[source, shell script]
+----
+> java -jar target/quarkus-app/quarkus-run.jar
+----
+
+You should see the following log message in the output, confirming that the custom registrar is invoked:
+
+[source, text]
+----
+INFO  [org.acm.ser.CustomServiceRegistrar] Registering service: my-service with ipAddress: localhost and port: 9000
+----
+
+You can compile this application into a native executable:
+
+include::{includes}/devtools/build-native.adoc[]
+
+== Summary
+
+In this guide, we have:
+
+1. Implemented a custom `ServiceRegistrarProvider` using the `@ServiceRegistrarType` and `@ServiceRegistrarAttribute` annotations.
+2. Implemented a custom `ServiceRegistrar` with `registerServiceInstance` and `deregisterServiceInstance` methods.
+3. Used the Stork API to programmatically register a service instance at startup.
+4. Configured the custom registrar in `application.properties`.
+
+This pattern is useful when you need to integrate Stork with a service registry that is not supported out of the box.
+
+== Going further
+
+This guide has shown how to extend SmallRye Stork with a custom service registrar.
+You can find more about Stork in:
+
+- the xref:stork-reference.adoc[Stork reference guide],
+- the xref:stork.adoc[Stork with Consul getting started guide],
+- the xref:stork-kubernetes.adoc[Stork with Kubernetes guide],
+- the https://smallrye.io/smallrye-stork[SmallRye Stork website].


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

New guide (stork-custom-service-registrar.adoc) that explains how to implement a custom service registrar using the SmallRye Stork SPI and programmatically register service instances at startup.
Quickstart: stork-programmatic-custom-registration-quickstart in [this PR](https://github.com/quarkusio/quarkus-quickstarts/pull/1531)