### PR TITLE
Honour the legacy resolver settings in go-offline goals

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/GoOfflineMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/GoOfflineMojo.java
@@ -79,7 +79,9 @@ public class GoOfflineMojo extends AbstractMojo {
                 project.getVersion());
 
         final MavenArtifactResolver resolver = getResolver();
-        final BootstrapAppModelResolver appModelResolver = new BootstrapAppModelResolver(resolver);
+        boolean useLegacy = BootstrapAppModelResolver.isLegacyModelResolver(project.getProperties());
+        final BootstrapAppModelResolver appModelResolver = new BootstrapAppModelResolver(resolver)
+                .setLegacyModelResolver(useLegacy);
 
         final Set<String> excludedScopes;
         if (mode.equals("all")) {


### PR DESCRIPTION
I don't think this affects much, and we'll drop the legacy resolver at some point soon-ish, but I noticed the go-offline goal doesn't honour it.