### PR TITLE
Testing: add checks to QuarkusMock

### DIFF
--- a/test-framework/junit-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/SetMockitoMockAsBeanMockCallback.java
+++ b/test-framework/junit-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/SetMockitoMockAsBeanMockCallback.java
@@ -24,7 +24,8 @@ public class SetMockitoMockAsBeanMockCallback implements QuarkusTestBeforeEachCa
             throw new RuntimeException(mocked.beanInstance
                     + " is not a normal scoped CDI bean, make sure the bean is a normal scope like @ApplicationScoped or @RequestScoped."
                     + " Alternatively you can use '@MockitoConfig(convertScopes = true)' in addition to '@InjectMock' if you would like"
-                    + " Quarkus to automatically make that conversion (you should only use this if you understand the implications).");
+                    + " Quarkus to automatically make that conversion (you should only use this if you understand the implications).",
+                    e);
         }
     }
 }

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusMock.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusMock.java
@@ -2,33 +2,37 @@ package io.quarkus.test.junit;
 
 import java.lang.annotation.Annotation;
 
+import jakarta.enterprise.event.Event;
 import jakarta.enterprise.inject.spi.CDI;
 import jakarta.enterprise.util.TypeLiteral;
 
 import org.junit.jupiter.api.TestInstance;
 
+import io.quarkus.runtime.MockedThroughWrapper;
+
 /**
  * Utility class that can be used to mock CDI normal scoped beans.
- *
+ * <p>
  * This includes beans that are {@link jakarta.enterprise.context.ApplicationScoped} and
  * {@link jakarta.enterprise.context.RequestScoped}.
- *
- * To use this inject the bean into a test, and then invoke the mock
- * method with your mock.
- *
+ * <p>
+ * To use this, inject the bean into a test and invoke {@link #installMockForInstance(Object, Object, Options)}.
+ * Alternatively, invoke {@link #installMockForType(Object, TypeLiteral, Options, Annotation...)}.
+ * <p>
  * Mocks installed in {@link org.junit.jupiter.api.BeforeAll} will be present for every test,
  * while mocks installed within a test are cleared after the test has run. Note that you will
  * likely need to use {@link TestInstance.Lifecycle#PER_CLASS} to have a non-static before all method
  * that can access injected beans.
- *
- * Note that as the bean is replaced globally you cannot use parallel test execution, as this will
+ * <p>
+ * Note that as the bean is replaced globally, you cannot use parallel test execution, as this will
  * result in race conditions where mocks from one test are active in another.
- *
  */
 public class QuarkusMock {
 
     /**
-     * Installs a mock for a CDI normal scoped bean
+     * Installs the given {@code mock} for a CDI normal scoped bean identified by given {@code instance}.
+     * Note that the given mock must be assignable to the bean class of the bean; it is <em>not enough</em>
+     * for it to implement only some of the bean types.
      *
      * @param mock The mock object
      * @param instance The CDI normal scoped bean that was injected into your test
@@ -36,56 +40,97 @@ public class QuarkusMock {
      */
     public static <T> void installMockForInstance(T mock, T instance) {
         //mock support does the actual work, but exposes other methods that are not part of the user API
+        checkMockAssignableToInstance(mock, instance);
         MockSupport.installMock(instance, mock, new Options());
     }
 
+    /**
+     * Installs the given {@code mock} for a CDI normal scoped bean identified by given {@code instance}.
+     * Note that the given mock must be assignable to the bean class of the bean; it is <em>not enough</em>
+     * for it to implement only some of the bean types.
+     *
+     * @param mock The mock object
+     * @param instance The CDI normal scoped bean that was injected into your test
+     * @param <T> The bean type
+     */
     public static <T> void installMockForInstance(T mock, T instance, Options options) {
         //mock support does the actual work, but exposes other methods that are not part of the user API
+        checkMockAssignableToInstance(mock, instance);
         MockSupport.installMock(instance, mock, options);
     }
 
     /**
-     * Installs a mock for a CDI normal scoped bean
+     * Installs the given {@code mock} for a CDI normal scoped bean of given {@code type} and with given {@code qualifiers}.
+     * Note that the given mock must be assignable to the bean class of the looked up bean; it is <em>not enough</em>
+     * for it to implement only some of the bean types.
      *
      * @param mock The mock object
-     * @param instance The type of the CDI normal scoped bean to replace
+     * @param type The type of the CDI normal scoped bean to replace
      * @param qualifiers The CDI qualifiers of the bean to mock
      * @param <T> The bean type
      */
-    public static <T> void installMockForType(T mock, Class<? super T> instance, Annotation... qualifiers) {
-        //mock support does the actual work, but exposes other methods that are not part of the user API
-        if (!instance.isAssignableFrom(mock.getClass())) {
-            if (!(instance.getClass().getSuperclass().isAssignableFrom(mock.getClass()))) {
-                throw new RuntimeException(mock
-                        + " is not assignable to type " + instance.getClass().getSuperclass());
-            }
-        }
-        MockSupport.installMock(CDI.current().select(instance, qualifiers).get(), mock, new Options());
+    public static <T> void installMockForType(T mock, Class<? super T> type, Annotation... qualifiers) {
+        Object instance = CDI.current().select(type, qualifiers).get();
+        checkMockAssignableToInstance(mock, instance);
+        MockSupport.installMock(instance, mock, new Options());
     }
 
     /**
-     * Installs a mock for a CDI normal scoped bean by typeLiteral and qualifiers
+     * Installs the given {@code mock} for a CDI normal scoped bean of given {@code type} and with given {@code qualifiers}.
+     * Note that the given mock must be assignable to the bean class of the looked up bean; it is <em>not enough</em>
+     * for it to implement only some of the bean types.
      *
      * @param mock The mock object
-     * @param typeLiteral TypeLiteral representing the required type
+     * @param type The type of the CDI normal scoped bean to replace
      * @param qualifiers The CDI qualifiers of the bean to mock
      * @param <T> The bean type
      */
-    public static <T> void installMockForType(T mock, TypeLiteral<? super T> typeLiteral, Annotation... qualifiers) {
-        MockSupport.installMock(CDI.current().select(typeLiteral, qualifiers).get(), mock, new Options());
+    public static <T> void installMockForType(T mock, TypeLiteral<? super T> type, Annotation... qualifiers) {
+        Object instance = CDI.current().select(type, qualifiers).get();
+        checkMockAssignableToInstance(mock, instance);
+        MockSupport.installMock(instance, mock, new Options());
     }
 
     /**
-     * Installs a mock for a CDI normal scoped bean by typeLiteral and qualifiers
+     * Installs the given {@code mock} for a CDI normal scoped bean of given {@code type} and with given {@code qualifiers}.
+     * Note that the given mock must be assignable to the bean class of the looked up bean; it is <em>not enough</em>
+     * for it to implement only some of the bean types.
      *
      * @param mock The mock object
-     * @param typeLiteral TypeLiteral representing the required type
+     * @param type TypeLiteral representing the required type
      * @param qualifiers The CDI qualifiers of the bean to mock
      * @param <T> The bean type
      */
-    public static <T> void installMockForType(T mock, TypeLiteral<? super T> typeLiteral, Options options,
+    public static <T> void installMockForType(T mock, TypeLiteral<? super T> type, Options options,
             Annotation... qualifiers) {
-        MockSupport.installMock(CDI.current().select(typeLiteral, qualifiers).get(), mock, options);
+        Object instance = CDI.current().select(type, qualifiers).get();
+        checkMockAssignableToInstance(mock, instance);
+        MockSupport.installMock(instance, mock, options);
+    }
+
+    private static <T> void checkMockAssignableToInstance(T mock, T instance) {
+        Class<?> instanceClass;
+        if (instance instanceof MockedThroughWrapper) {
+            instanceClass = instance.getClass();
+            if (instanceClass.getName().endsWith("_ClientProxy")) {
+                // the condition is hideous, but we don't depend on ArC in this module
+                instanceClass = instanceClass.getSuperclass();
+            }
+            // only generated by RestClient Reactive, which always implements exactly 1 interface
+            instanceClass = instanceClass.getInterfaces()[0];
+        } else if (instance instanceof Event<?>) {
+            instanceClass = Event.class;
+        } else if (instance.getClass().getName().endsWith("_ClientProxy")) {
+            // the condition is hideous, but we don't depend on ArC in this module
+            instanceClass = instance.getClass().getSuperclass();
+        } else {
+            throw new RuntimeException("Given instance (" + instance.getClass().getName()
+                    + ") is not a client proxy, only normal scoped beans may be mocked");
+        }
+        Class<?> mockClass = mock.getClass();
+        if (!instanceClass.isAssignableFrom(mockClass)) {
+            throw new RuntimeException("Given mock, which is " + mockClass + ", is not assignable to " + instanceClass);
+        }
     }
 
     /**


### PR DESCRIPTION
The `QuarkusMock.installMock*()` methods used to implicitly require that the given mock is assignable to the bean class of the selected bean. However, only one of the methods attempted to check that, and the attempt was subtly buggy so that it could actually never fail.

This commit adds a proper check to all methods. Further, this commit adds a check that the given instance may in fact be mocked (that is: it is a client proxy, `Event`, or `MockedThroughWrapper`). Nearly the same check exists in `MockSupport`, so we wouldn't have to check it in `QuarkusMock`, but if we didn't, we could get a wrong bean class or we could allow something we know is going to fail. Let's just live with this duplication.

- Fixes: #53051