### PR TITLE
Document and test @ProjectedFieldName with aggregate functions

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -898,6 +898,21 @@ PanacheQuery<DogDto> query = Dog.findAll().project(DogDto.class);
 ----
 <1> The `ownerName` DTO constructor's parameter will be loaded from the `owner.name` HQL property.
 
+The `@ProjectedFieldName` annotation also supports HQL expressions, including aggregate functions.
+This is particularly useful for GROUP BY queries:
+
+[source,java]
+----
+public record DogWeightTotal(
+    @ProjectedFieldName("owner.name") String ownerName,
+    @ProjectedFieldName("SUM(weight)") Double totalWeight
+) {}
+
+PanacheQuery<DogWeightTotal> query = Dog.find(
+    "FROM Dog d JOIN d.owner o GROUP BY o.name"
+).project(DogWeightTotal.class);
+----
+
 In case you want to project an entity in a class with nested classes, you can use the `@NestedProjectedClass` annotation on those nested classes.
 
 [source,java]

--- a/docs/src/main/asciidoc/hibernate-reactive-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-reactive-panache.adoc
@@ -644,6 +644,21 @@ PanacheQuery<DogDto> query = Dog.findAll().project(DogDto.class);
 ----
 <1> The `ownerName` DTO constructor's parameter will be loaded from the `owner.name` HQL property.
 
+The `@ProjectedFieldName` annotation also supports HQL expressions, including aggregate functions.
+This is particularly useful for GROUP BY queries:
+
+[source,java]
+----
+public record DogWeightTotal(
+    @ProjectedFieldName("owner.name") String ownerName,
+    @ProjectedFieldName("SUM(weight)") Double totalWeight
+) {}
+
+PanacheQuery<DogWeightTotal> query = Dog.find(
+    "FROM Dog d JOIN d.owner o GROUP BY o.name"
+).project(DogWeightTotal.class);
+----
+
 In case you want to project an entity in a class with nested classes, you can use the `@NestedProjectedClass` annotation on those nested classes.
 
 [source,java]

--- a/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/ProjectedFieldName.java
+++ b/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/ProjectedFieldName.java
@@ -6,9 +6,15 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Define a field's path for the SELECT statement when using a projection DTO.
- * It supports the "dot" notation for fields in referenced entities:
- * the name is composed of the property name for the relationship, followed by a dot ("."), followed by the name of the field.
+ * Define a field's path or HQL expression for the SELECT statement when using a projection DTO.
+ * <p>
+ * It supports:
+ * <ul>
+ * <li>Simple field names</li>
+ * <li>Dot notation for fields in referenced entities (e.g., {@code "owner.name"})</li>
+ * <li>Any valid HQL expression, including aggregate functions (e.g., {@code "SUM(amount)"}, {@code "COUNT(id)"})</li>
+ * </ul>
+ * </p>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.PARAMETER, ElementType.FIELD })

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/ProjectedFieldName.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/ProjectedFieldName.java
@@ -6,9 +6,15 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Define a field's path for the SELECT statement when using a projection DTO.
- * It supports the "dot" notation for fields in referenced entities:
- * the name is composed of the property name for the relationship, followed by a dot ("."), followed by the name of the field.
+ * Define a field's path or HQL expression for the SELECT statement when using a projection DTO.
+ * <p>
+ * It supports:
+ * <ul>
+ * <li>Simple field names</li>
+ * <li>Dot notation for fields in referenced entities (e.g., {@code "owner.name"})</li>
+ * <li>Any valid HQL expression, including aggregate functions (e.g., {@code "SUM(amount)"}, {@code "COUNT(id)"})</li>
+ * </ul>
+ * </p>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.PARAMETER, ElementType.FIELD })

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/defaultpu/CatOwnerWeightDto.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/defaultpu/CatOwnerWeightDto.java
@@ -1,0 +1,10 @@
+package io.quarkus.it.panache.defaultpu;
+
+import io.quarkus.hibernate.orm.panache.common.ProjectedFieldName;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public record CatOwnerWeightDto(
+        @ProjectedFieldName("owner.name") String ownerName,
+        @ProjectedFieldName("SUM(weight)") Double totalWeight) {
+}

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/defaultpu/TestEndpoint.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/defaultpu/TestEndpoint.java
@@ -1699,6 +1699,45 @@ public class TestEndpoint {
     }
 
     @GET
+    @Path("projection-aggregate-function")
+    @Transactional
+    public String testProjectionWithAggregateFunction() {
+        // Clean up and setup test data
+        Cat.deleteAll();
+        CatOwner.deleteAll();
+
+        CatOwner owner1 = new CatOwner("Owner1");
+        owner1.persist();
+        CatOwner owner2 = new CatOwner("Owner2");
+        owner2.persist();
+
+        Cat cat1 = new Cat("Cat1", owner1);
+        cat1.weight = 5.0;
+        cat1.persist();
+
+        Cat cat2 = new Cat("Cat2", owner1);
+        cat2.weight = 7.0;
+        cat2.persist();
+
+        Cat cat3 = new Cat("Cat3", owner2);
+        cat3.weight = 3.0;
+        cat3.persist();
+
+        // Test projection with aggregate function
+        List<CatOwnerWeightDto> results = Cat.find("FROM Cat c GROUP BY c.owner ORDER BY c.owner.name")
+                .project(CatOwnerWeightDto.class)
+                .list();
+
+        Assertions.assertEquals(2, results.size());
+        Assertions.assertEquals("Owner1", results.get(0).ownerName());
+        Assertions.assertEquals(12.0, results.get(0).totalWeight());
+        Assertions.assertEquals("Owner2", results.get(1).ownerName());
+        Assertions.assertEquals(3.0, results.get(1).totalWeight());
+
+        return "OK";
+    }
+
+    @GET
     @Path("model3")
     @Transactional
     public String testModel3() {

--- a/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/defaultpu/PanacheFunctionalityTest.java
+++ b/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/defaultpu/PanacheFunctionalityTest.java
@@ -51,6 +51,7 @@ public class PanacheFunctionalityTest {
         RestAssured.when().get("/test/projection-constructor-annotation").then().body(is("OK"));
         RestAssured.when().get("/test/projection-projected-field-name").then().body(is("OK"));
         RestAssured.when().get("/test/projection-no-arguments-constructor").then().body(is("OK"));
+        RestAssured.when().get("/test/projection-aggregate-function").then().body(is("OK"));
         RestAssured.when().get("/test/model3").then().body(is("OK"));
     }
 

--- a/integration-tests/hibernate-reactive-panache/src/main/java/io/quarkus/it/panache/reactive/CatOwnerWeightDto.java
+++ b/integration-tests/hibernate-reactive-panache/src/main/java/io/quarkus/it/panache/reactive/CatOwnerWeightDto.java
@@ -1,0 +1,10 @@
+package io.quarkus.it.panache.reactive;
+
+import io.quarkus.hibernate.reactive.panache.common.ProjectedFieldName;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public record CatOwnerWeightDto(
+        @ProjectedFieldName("owner.name") String ownerName,
+        @ProjectedFieldName("SUM(weight)") Double totalWeight) {
+}

--- a/integration-tests/hibernate-reactive-panache/src/main/java/io/quarkus/it/panache/reactive/TestEndpoint.java
+++ b/integration-tests/hibernate-reactive-panache/src/main/java/io/quarkus/it/panache/reactive/TestEndpoint.java
@@ -2062,6 +2062,46 @@ public class TestEndpoint {
 
     @WithTransaction
     @GET
+    @Path("projection-aggregate-function")
+    public Uni<String> testProjectionWithAggregateFunction() {
+        // Clean up and setup test data
+        return Cat.deleteAll()
+                .chain(() -> CatOwner.deleteAll())
+                .chain(() -> {
+                    CatOwner owner1 = new CatOwner("Owner1");
+                    return owner1.persist()
+                            .chain(() -> {
+                                CatOwner owner2 = new CatOwner("Owner2");
+                                return owner2.persist()
+                                        .chain(() -> {
+                                            Cat cat1 = new Cat("Cat1", owner1, 5.0);
+                                            return cat1.persist();
+                                        })
+                                        .chain(() -> {
+                                            Cat cat2 = new Cat("Cat2", owner1, 7.0);
+                                            return cat2.persist();
+                                        })
+                                        .chain(() -> {
+                                            Cat cat3 = new Cat("Cat3", owner2, 3.0);
+                                            return cat3.persist();
+                                        });
+                            });
+                })
+                .chain(() -> Cat.find("FROM Cat c GROUP BY c.owner ORDER BY c.owner.name")
+                        .project(CatOwnerWeightDto.class)
+                        .list())
+                .invoke(results -> {
+                    Assertions.assertEquals(2, results.size());
+                    Assertions.assertEquals("Owner1", results.get(0).ownerName());
+                    Assertions.assertEquals(12.0, results.get(0).totalWeight());
+                    Assertions.assertEquals("Owner2", results.get(1).ownerName());
+                    Assertions.assertEquals(3.0, results.get(1).totalWeight());
+                })
+                .replaceWith("OK");
+    }
+
+    @WithTransaction
+    @GET
     @Path("model3")
     public Uni<String> testModel3() {
         return Person.count()

--- a/integration-tests/hibernate-reactive-panache/src/test/java/io/quarkus/it/panache/reactive/PanacheFunctionalityTest.java
+++ b/integration-tests/hibernate-reactive-panache/src/test/java/io/quarkus/it/panache/reactive/PanacheFunctionalityTest.java
@@ -58,6 +58,7 @@ public class PanacheFunctionalityTest {
         RestAssured.when().get("/test/projection-constructor-annotation").then().body(is("OK"));
         RestAssured.when().get("/test/projection-projected-field-name").then().body(is("OK"));
         RestAssured.when().get("/test/projection-no-arguments-constructor").then().body(is("OK"));
+        RestAssured.when().get("/test/projection-aggregate-function").then().body(is("OK"));
         RestAssured.when().get("/test/model3").then().body(is("OK"));
     }
 


### PR DESCRIPTION
Fixes #52905

This PR documents and tests the existing support for aggregate functions in `@ProjectedFieldName`.

After investigating the implementation, it's clear that the annotation accepts any valid HQL expression. This behavior is useful, already working, and safe (Hibernate validates the HQL anyway).

Changes:
- Updated `@ProjectedFieldName` javadoc (both ORM and Reactive) to document support for HQL expressions and aggregate functions
- Added documentation examples in hibernate-orm-panache.adoc and hibernate-reactive-panache.adoc
- Added integration tests for both ORM and Reactive Panache to verify aggregate function support