### PR TITLE
JFR extension event  fix

### DIFF
--- a/extensions/jfr/deployment/src/test/java/io/quarkus/jfr/deployment/runtime/JfrEmitOnExitTest.java
+++ b/extensions/jfr/deployment/src/test/java/io/quarkus/jfr/deployment/runtime/JfrEmitOnExitTest.java
@@ -1,0 +1,80 @@
+package io.quarkus.jfr.deployment.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.runtime.QuarkusApplication;
+import io.quarkus.runtime.annotations.QuarkusMain;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingFile;
+
+/**
+ * Verifies that Quarkus JFR events are present in a dumponexit recording.
+ * <p>
+ * JFR's dumponexit hook and Quarkus' shutdown hook are both JVM shutdown hooks
+ * that run concurrently with no ordering guarantee. If the Quarkus hook runs first, the events will be unregistered
+ * before JFR has a chance to emit them a final time. {@code JfrRuntimeBean.disable()}
+ * calls {@code emitEvents()} before unregistering to ensure events are committed
+ * to the JFR buffer regardless of which hook wins the race.
+ */
+public class JfrEmitOnExitTest {
+
+    private static final String DUMP_FILENAME = "emit-on-exit-test.jfr";
+
+    @RegisterExtension
+    static final QuarkusProdModeTest app = new QuarkusProdModeTest()
+            .withApplicationRoot(jar -> jar.addClass(ExitImmediately.class))
+            .setApplicationName("jfr-emit-on-exit-test")
+            .setExpectExit(true) // Wait for child process to exit
+            .setRun(true)
+            .setJVMArgs(List.of("-XX:StartFlightRecording:dumponexit=true,filename=" + DUMP_FILENAME));
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void dumpOnExitContainsQuarkusEvents() throws IOException {
+        Path dumpPath = prodModeTestResults.getBuiltArtifactPath().getParent().resolve(DUMP_FILENAME);
+        assertTrue(Files.exists(dumpPath), "JFR dump file should exist after shutdown");
+        dumpPath.toFile().deleteOnExit();
+
+        List<RecordedEvent> events = RecordingFile.readAllEvents(dumpPath);
+
+        List<RecordedEvent> runtimeEvents = events.stream()
+                .filter(e -> e.getEventType().getName().equals("quarkus.runtime"))
+                .toList();
+        assertFalse(runtimeEvents.isEmpty(),
+                "recording should contain quarkus.runtime events");
+
+        List<RecordedEvent> applicationEvents = events.stream()
+                .filter(e -> e.getEventType().getName().equals("quarkus.application"))
+                .toList();
+        assertFalse(applicationEvents.isEmpty(),
+                "recording should contain quarkus.application events");
+
+        List<RecordedEvent> extensionEvents = events.stream()
+                .filter(e -> e.getEventType().getName().equals("quarkus.extension"))
+                .toList();
+        assertFalse(extensionEvents.isEmpty(),
+                "recording should contain quarkus.extension events");
+    }
+
+    @QuarkusMain
+    public static class ExitImmediately implements QuarkusApplication {
+        @Override
+        public int run(String... args) {
+            return 0;
+        }
+    }
+}

--- a/extensions/jfr/runtime/src/main/java/io/quarkus/jfr/runtime/internal/runtime/JfrRuntimeBean.java
+++ b/extensions/jfr/runtime/src/main/java/io/quarkus/jfr/runtime/internal/runtime/JfrRuntimeBean.java
@@ -44,12 +44,33 @@ public class JfrRuntimeBean {
     }
 
     public void disable() {
-        FlightRecorder.removePeriodicEvent(runtimeEventTask);
-        FlightRecorder.removePeriodicEvent(applicationEventTask);
-        FlightRecorder.removePeriodicEvent(extensionEventTask);
-        FlightRecorder.unregister(QuarkusRuntimeEvent.class);
-        FlightRecorder.unregister(QuarkusApplicationEvent.class);
-        FlightRecorder.unregister(ExtensionEvent.class);
+        if (runtimeEventTask == null) {
+            // enable() didn't run/complete
+            return;
+        }
+        try {
+            /*
+             * Quarkus unregisters JFR Quarkus extension periodic events upon shutdown.
+             * Quarkus may shutdown earlier than JFR at the VM-level. If that happens,
+             * these events will miss being emitted as part of the final JFR chunk
+             * and the data will be lost. Directly emit the JFR extension events here
+             * to avoid that scenario.
+             */
+            emitEvents();
+        } finally {
+            FlightRecorder.removePeriodicEvent(runtimeEventTask);
+            FlightRecorder.removePeriodicEvent(applicationEventTask);
+            FlightRecorder.removePeriodicEvent(extensionEventTask);
+            FlightRecorder.unregister(QuarkusRuntimeEvent.class);
+            FlightRecorder.unregister(QuarkusApplicationEvent.class);
+            FlightRecorder.unregister(ExtensionEvent.class);
+        }
+    }
+
+    private void emitEvents() {
+        runtimeEventTask.run();
+        applicationEventTask.run();
+        extensionEventTask.run();
     }
 
     public void onStart(@Observes StartupEvent ev) {


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->
## Problem
The JFR extension uses periodic events to emit data. These events are registered upon Quarkus startup, and later unregistered upon Quarkus shutdown. JFR preiodic events only emit data when a JFR chunk is started or ended. When JFR begins recording, a chunk is started. And when recording ends, a chunk is ended. The problem is the ordering of Quarkus extension event registration and JFR start/shutdown:

1. JVM and JFR startup and chunk-begin periodic events are emitted
2. main() and Quarkus start up -- JfrRuntimeBean.enable() registers the events we care about
3. Quarkus shutdown hook -- JfrRuntimeBean.disable() unregisters the events we care about
4. JFR shutdown hook and chunk-end periodic events are emitted

So if the recording only lasts 1 chunk, the JFR Quarkus extension events miss both opportunities to be emitted (chunk start and end) -- and no data gets written. If the recording last longer than 1 chunk or a user forcibly dumps a .jfr file (inducing a chunk rotation), then some events will be emitted -- **However**, data recorded over the last chunk will still be lost since the events are unregistered before JFR shuts down the final chunk is closed. 

## Solution
Directly invoke JFR extension event emission when Quarkus shuts down. If Quarkus shuts down before JFR, the events get emitted. If JFR shuts down before Quarkus, the events do not get emitted twice, since by the time Quarkus tries to emit the events, JFR is already shut down. No matter the ordering, the events corresponding to the final JFR chunk get emitted exactly once - as expected.

Event counts before: 
<img width="429" height="100" alt="image" src="https://github.com/user-attachments/assets/3714d825-4f88-4f42-b474-286330389983" />

Event counts after fix: 
<img width="460" height="100" alt="image" src="https://github.com/user-attachments/assets/a1187aa3-84f2-4462-8204-c54ebd38aceb" />


* Fixes https://github.com/quarkusio/quarkus/issues/50392

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

