### PR TITLE
KafkaCompanionResource respects explicitly set bootstrap servers

### DIFF
--- a/docs/src/main/asciidoc/kafka.adoc
+++ b/docs/src/main/asciidoc/kafka.adoc
@@ -2481,7 +2481,9 @@ otherwise you will get an `java.lang.AssertionError: No completion (or failure) 
 
 [TIP]
 ====
-If the Kafka Dev Service is available during tests, `KafkaCompanionResource` uses the created Kafka broker, otherwise it creates a Kafka broker using https://github.com/strimzi/test-container[Strimzi Test Container].
+If the Kafka Dev Service is available during tests, `KafkaCompanionResource` uses the created Kafka broker.
+If the `kafka.bootstrap.servers` system property or the `KAFKA_BOOTSTRAP_SERVERS` environment variable is set, `KafkaCompanionResource` connects to that broker instead.
+Otherwise, it creates a Kafka broker using https://github.com/strimzi/test-container[Strimzi Test Container].
 
 The configuration of the created Kafka broker can be customized using `@ResourceArg`, for example:
 [source,java]

--- a/test-framework/kafka-companion/src/main/java/io/quarkus/test/kafka/KafkaCompanionResource.java
+++ b/test-framework/kafka-companion/src/main/java/io/quarkus/test/kafka/KafkaCompanionResource.java
@@ -27,6 +27,12 @@ public class KafkaCompanionResource implements QuarkusTestResourceLifecycleManag
     public void setIntegrationTestContext(DevServicesContext context) {
         Map<String, String> devServicesProperties = context.devServicesProperties();
         String bootstrapServers = devServicesProperties.get("kafka.bootstrap.servers");
+        if (bootstrapServers == null) {
+            bootstrapServers = System.getProperty("kafka.bootstrap.servers");
+        }
+        if (bootstrapServers == null) {
+            bootstrapServers = System.getenv("KAFKA_BOOTSTRAP_SERVERS");
+        }
         if (bootstrapServers != null) {
             kafkaCompanion = new KafkaCompanion(bootstrapServers);
             String apicurioUrl = devServicesProperties.get("mp.messaging.connector.smallrye-kafka.apicurio.registry.url");

--- a/test-framework/kafka-companion/src/main/java/io/quarkus/test/kafka/KafkaCompanionResource.java
+++ b/test-framework/kafka-companion/src/main/java/io/quarkus/test/kafka/KafkaCompanionResource.java
@@ -6,6 +6,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.microprofile.config.ConfigProvider;
+
 import io.quarkus.test.common.DevServicesContext;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
@@ -28,10 +30,9 @@ public class KafkaCompanionResource implements QuarkusTestResourceLifecycleManag
         Map<String, String> devServicesProperties = context.devServicesProperties();
         String bootstrapServers = devServicesProperties.get("kafka.bootstrap.servers");
         if (bootstrapServers == null) {
-            bootstrapServers = System.getProperty("kafka.bootstrap.servers");
-        }
-        if (bootstrapServers == null) {
-            bootstrapServers = System.getenv("KAFKA_BOOTSTRAP_SERVERS");
+            bootstrapServers = ConfigProvider.getConfig()
+                    .getOptionalValue("kafka.bootstrap.servers", String.class)
+                    .orElse(null);
         }
         if (bootstrapServers != null) {
             kafkaCompanion = new KafkaCompanion(bootstrapServers);

--- a/test-framework/kafka-companion/src/test/java/io/quarkus/test/kafka/KafkaCompanionResourceTest.java
+++ b/test-framework/kafka-companion/src/test/java/io/quarkus/test/kafka/KafkaCompanionResourceTest.java
@@ -1,0 +1,67 @@
+package io.quarkus.test.kafka;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.DevServicesContext;
+
+public class KafkaCompanionResourceTest {
+
+    private static DevServicesContext contextWith(Map<String, String> properties) {
+        return new DevServicesContext() {
+            @Override
+            public Map<String, String> devServicesProperties() {
+                return properties;
+            }
+
+            @Override
+            public Optional<String> containerNetworkId() {
+                return Optional.empty();
+            }
+        };
+    }
+
+    @AfterEach
+    void cleanup() {
+        System.clearProperty("kafka.bootstrap.servers");
+    }
+
+    @Test
+    void testCompanionInitializedFromDevServices() {
+        KafkaCompanionResource resource = new KafkaCompanionResource();
+        resource.setIntegrationTestContext(contextWith(Map.of("kafka.bootstrap.servers", "localhost:9092")));
+
+        assertNotNull(resource.kafkaCompanion,
+                "kafkaCompanion should be set when Dev Services provide bootstrap servers");
+    }
+
+    @Test
+    void testCompanionInitializedFromSystemProperty() {
+        System.setProperty("kafka.bootstrap.servers", "localhost:9092");
+
+        KafkaCompanionResource resource = new KafkaCompanionResource();
+        resource.setIntegrationTestContext(contextWith(Collections.emptyMap()));
+
+        assertNotNull(resource.kafkaCompanion,
+                "kafkaCompanion should be set from system property when Dev Services are not running");
+    }
+
+    @Test
+    void testNoContainerStartedWhenBootstrapServersExplicitlySet() {
+        System.setProperty("kafka.bootstrap.servers", "localhost:9092");
+
+        KafkaCompanionResource resource = new KafkaCompanionResource();
+        resource.setIntegrationTestContext(contextWith(Collections.emptyMap()));
+        resource.init(Collections.emptyMap());
+
+        assertNull(resource.kafka,
+                "No Kafka container should be created when bootstrap servers are explicitly set");
+    }
+}


### PR DESCRIPTION


`KafkaCompanionResource.setIntegrationTestContext()` only looked for `kafka.bootstrap.servers` in the Dev Services properties. When Dev Services are disabled the map is empty, so `kafkaCompanion` stays null and `init()` starts an unwanted Strimzi container even though the user already configured bootstrap servers explicitly.

This PR adds fallbacks to `System.getProperty("kafka.bootstrap.servers")` and the `KAFKA_BOOTSTRAP_SERVERS` env var, so no container is started when an explicit address is already provided.

Also added three unit tests covering the existing behaviour and the two new fallback paths, and updated the relevant section in `kafka.adoc`.

- Fixes: #53269