### PR TITLE
[3.33] Manage plexus-utils version 3.6.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -84,6 +84,7 @@
         <jboss-metadata-web.version>17.0.0</jboss-metadata-web.version>
         <maven-toolchain.version>3.0-alpha-2</maven-toolchain.version>
         <plexus-component-annotations.version>2.1.0</plexus-component-annotations.version>
+        <plexus-utils.version>3.6.0</plexus-utils.version>
         <!-- GraalVM sdk 23.1.2 has a minimum JDK requirement of 17+ at runtime -->
         <graal-sdk.version>23.1.2</graal-sdk.version>
         <gizmo.version>1.10.1</gizmo.version>
@@ -4693,6 +4694,11 @@
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-component-annotations</artifactId>
                 <version>${plexus-component-annotations.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-utils</artifactId>
+                <version>${plexus-utils.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.microprofile.config</groupId>


### PR DESCRIPTION
Don't merge (yet). Testing whether we are compatible with this version