### PR TITLE
Webauthn IT: move test-webauthn to the test scope

### DIFF
--- a/integration-tests/security-webauthn/pom.xml
+++ b/integration-tests/security-webauthn/pom.xml
@@ -22,10 +22,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-test-security-webauthn</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-reactive-pg-client</artifactId>
         </dependency>
         <dependency>
@@ -35,6 +31,11 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-security-webauthn</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
This belongs in the test scope, it was not meant to end up in the native image.

Related to https://github.com/quarkusio/quarkus/issues/53266