### PR TITLE
Dev MCP: Expose last exception via Dev MCP tool

### DIFF
--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/exception/ExceptionProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/exception/ExceptionProcessor.java
@@ -1,0 +1,173 @@
+package io.quarkus.devui.deployment.exception;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.dev.ExceptionNotificationBuildItem;
+import io.quarkus.deployment.dev.RuntimeUpdatesProcessor;
+import io.quarkus.devui.spi.buildtime.BuildTimeActionBuildItem;
+
+/**
+ * Exposes the last exception (compilation, deployment, or runtime) as a Dev MCP tool.
+ */
+public class ExceptionProcessor {
+
+    private static final String NAMESPACE = "devui-exceptions";
+    static final int MAX_STACK_TRACE_LINES = 200;
+    static final int MAX_CAUSE_MESSAGE_LENGTH = 500;
+    static final int MAX_CAUSE_DEPTH = 5;
+
+    // Immutable snapshot of a runtime exception and its context
+    record ExceptionSnapshot(Throwable exception, StackTraceElement userCodeLocation) {
+    }
+
+    // Static so state survives hot reloads (build steps re-execute on reload).
+    // Single AtomicReference ensures atomic read/write of all fields together.
+    private static final AtomicReference<ExceptionSnapshot> lastRuntimeSnapshot = new AtomicReference<>();
+
+    @BuildStep(onlyIf = IsDevelopment.class)
+    void registerExceptionActions(
+            BuildProducer<BuildTimeActionBuildItem> buildTimeActionProducer,
+            BuildProducer<ExceptionNotificationBuildItem> exceptionNotificationProducer) {
+
+        exceptionNotificationProducer.produce(new ExceptionNotificationBuildItem((throwable, userCode) -> {
+            lastRuntimeSnapshot.set(new ExceptionSnapshot(throwable, userCode));
+        }));
+
+        BuildTimeActionBuildItem actions = new BuildTimeActionBuildItem(NAMESPACE);
+
+        actions.actionBuilder()
+                .methodName("getLastException")
+                .description(
+                        "Get the last exception that occurred in this Quarkus application. Returns compilation errors, deployment failures, hot-reload problems, or runtime exceptions with full stack traces and source locations. Deployment problems clear automatically on the next successful reload. For runtime exceptions, call clearLastException after handling to avoid seeing the same exception again.")
+                .enableMcpFunctionByDefault()
+                .parameter("maxCauseDepth",
+                        "Maximum depth for the cause chain (default " + MAX_CAUSE_DEPTH + ")")
+                .function(params -> {
+                    int causeDepth = MAX_CAUSE_DEPTH;
+                    String maxCauseDepthParam = params.get("maxCauseDepth");
+                    if (maxCauseDepthParam != null && !maxCauseDepthParam.isBlank()) {
+                        try {
+                            int parsed = Integer.parseInt(maxCauseDepthParam);
+                            if (parsed > 0 && parsed <= MAX_CAUSE_DEPTH) {
+                                causeDepth = parsed;
+                            }
+                        } catch (NumberFormatException e) {
+                            // LLM may pass non-numeric values like "three"; fall back to default
+                        }
+                    }
+
+                    // Check deployment problems (compilation, deployment, or hot-reload)
+                    Throwable deploymentProblem = null;
+                    if (RuntimeUpdatesProcessor.INSTANCE != null) {
+                        deploymentProblem = RuntimeUpdatesProcessor.INSTANCE.getDeploymentProblem();
+                    }
+
+                    // Check runtime exceptions (single atomic read)
+                    ExceptionSnapshot snapshot = lastRuntimeSnapshot.get();
+
+                    if (deploymentProblem == null && snapshot == null) {
+                        return Map.of("hasException", false, "message", "No exceptions recorded");
+                    }
+
+                    Map<String, Object> result = new HashMap<>();
+                    result.put("hasException", true);
+
+                    // Prefer deployment problems as they're more critical
+                    if (deploymentProblem != null) {
+                        result.put("source", "deployment");
+                        populateExceptionDetails(result, deploymentProblem, causeDepth);
+                        if (snapshot != null) {
+                            result.put("hasRuntimeException", true);
+                        }
+                    } else {
+                        result.put("source", "runtime");
+                        populateExceptionDetails(result, snapshot.exception(), causeDepth);
+                        if (snapshot.userCodeLocation() != null) {
+                            StackTraceElement userCode = snapshot.userCodeLocation();
+                            result.put("userCodeLocation",
+                                    userCode.getClassName() + "." + userCode.getMethodName()
+                                            + "(" + userCode.getFileName() + ":" + userCode.getLineNumber() + ")");
+                        }
+                    }
+
+                    return result;
+                })
+                .build();
+
+        actions.actionBuilder()
+                .methodName("clearLastException")
+                .description("Clear the last recorded runtime exception.")
+                .enableMcpFunctionByDefault()
+                .function(ignored -> {
+                    lastRuntimeSnapshot.set(null);
+                    return Map.of("cleared", true);
+                })
+                .build();
+
+        buildTimeActionProducer.produce(actions);
+    }
+
+    static void populateExceptionDetails(Map<String, Object> result, Throwable throwable, int maxCauseDepth) {
+        result.put("exceptionClass", throwable.getClass().getName());
+        result.put("message", throwable.getMessage());
+
+        String stackTrace;
+        try (StringWriter sw = new StringWriter();
+                PrintWriter pw = new PrintWriter(sw)) {
+            throwable.printStackTrace(pw);
+            pw.flush();
+            stackTrace = sw.toString();
+        } catch (IOException e) {
+            // StringWriter.close() is a no-op; this cannot happen
+            throw new RuntimeException(e);
+        }
+
+        // Truncate very long stack traces
+        String[] lines = stackTrace.split("\n");
+        if (lines.length > MAX_STACK_TRACE_LINES) {
+            StringBuilder truncated = new StringBuilder();
+            for (int i = 0; i < MAX_STACK_TRACE_LINES; i++) {
+                truncated.append(lines[i]).append('\n');
+            }
+            truncated.append("... ").append(lines.length - MAX_STACK_TRACE_LINES).append(" more lines truncated");
+            stackTrace = truncated.toString();
+        }
+        result.put("stackTrace", stackTrace);
+
+        // Include cause chain summary
+        Throwable cause = throwable.getCause();
+        if (cause != null) {
+            Set<Throwable> seen = new HashSet<>();
+            seen.add(throwable);
+            StringBuilder causeSummary = new StringBuilder();
+            int depth = 0;
+            // seen.add() returns false if already present, guarding against circular cause chains
+            while (cause != null && depth < maxCauseDepth && seen.add(cause)) {
+                if (depth > 0) {
+                    causeSummary.append(" <- ");
+                }
+                causeSummary.append(cause.getClass().getSimpleName());
+                if (cause.getMessage() != null) {
+                    String msg = cause.getMessage();
+                    if (msg.length() > MAX_CAUSE_MESSAGE_LENGTH) {
+                        msg = msg.substring(0, MAX_CAUSE_MESSAGE_LENGTH) + "...";
+                    }
+                    causeSummary.append(": ").append(msg);
+                }
+                cause = cause.getCause();
+                depth++;
+            }
+            result.put("causeChain", causeSummary.toString());
+        }
+    }
+}

--- a/extensions/devui/deployment/src/test/java/io/quarkus/devui/deployment/exception/ExceptionProcessorTest.java
+++ b/extensions/devui/deployment/src/test/java/io/quarkus/devui/deployment/exception/ExceptionProcessorTest.java
@@ -1,0 +1,170 @@
+package io.quarkus.devui.deployment.exception;
+
+import static io.quarkus.devui.deployment.exception.ExceptionProcessor.MAX_CAUSE_DEPTH;
+import static io.quarkus.devui.deployment.exception.ExceptionProcessor.MAX_CAUSE_MESSAGE_LENGTH;
+import static io.quarkus.devui.deployment.exception.ExceptionProcessor.MAX_STACK_TRACE_LINES;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class ExceptionProcessorTest {
+
+    @Test
+    void simpleException() {
+        Map<String, Object> result = populate(new RuntimeException("something broke"));
+
+        assertThat(result)
+                .containsEntry("exceptionClass", "java.lang.RuntimeException")
+                .containsEntry("message", "something broke");
+        assertThat((String) result.get("stackTrace")).contains("RuntimeException: something broke");
+        assertThat(result).doesNotContainKey("causeChain");
+    }
+
+    @Test
+    void causeChain() {
+        Exception root = new IllegalArgumentException("bad value");
+        Exception mid = new IllegalStateException("invalid state", root);
+        Exception top = new RuntimeException("operation failed", mid);
+
+        Map<String, Object> result = populate(top);
+
+        assertThat(result).containsEntry("exceptionClass", "java.lang.RuntimeException");
+        String causeChain = (String) result.get("causeChain");
+        assertThat(causeChain)
+                .startsWith("IllegalStateException: invalid state")
+                .contains("IllegalArgumentException: bad value");
+    }
+
+    @Test
+    void causeChainRespectsMaxDepth() {
+        // Build a chain deeper than MAX_CAUSE_DEPTH
+        Exception current = new Exception("root");
+        for (int i = 0; i < MAX_CAUSE_DEPTH + 3; i++) {
+            current = new Exception("level-" + i, current);
+        }
+
+        Map<String, Object> result = populate(current);
+
+        String causeChain = (String) result.get("causeChain");
+        // Count the separators to determine how many causes are listed
+        int causeCount = causeChain.split(" <- ").length;
+        assertThat(causeCount).isEqualTo(MAX_CAUSE_DEPTH);
+    }
+
+    @Test
+    void circularCauseChain() {
+        Exception a = new Exception("a");
+        Exception b = new Exception("b", a);
+        // Create a circular reference: a -> b -> a
+        try {
+            var causeField = Throwable.class.getDeclaredField("cause");
+            causeField.setAccessible(true);
+            causeField.set(a, b);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Could not set up circular cause chain", e);
+        }
+
+        Map<String, Object> result = populate(a);
+
+        // Should terminate without infinite loop
+        assertThat(result).containsKey("causeChain");
+        String causeChain = (String) result.get("causeChain");
+        assertThat(causeChain).contains("Exception: b");
+    }
+
+    @Test
+    void suppressedException() {
+        Exception primary = new RuntimeException("primary");
+        primary.addSuppressed(new IllegalStateException("suppressed-1"));
+        primary.addSuppressed(new IllegalArgumentException("suppressed-2"));
+
+        Map<String, Object> result = populate(primary);
+
+        // Suppressed exceptions appear in the full stack trace
+        String stackTrace = (String) result.get("stackTrace");
+        assertThat(stackTrace)
+                .contains("Suppressed: java.lang.IllegalStateException: suppressed-1")
+                .contains("Suppressed: java.lang.IllegalArgumentException: suppressed-2");
+    }
+
+    @Test
+    void stackTraceTruncation() {
+        // Create an exception with a very deep stack trace by generating one
+        RuntimeException exception = buildDeepException(MAX_STACK_TRACE_LINES + 100);
+
+        Map<String, Object> result = populate(exception);
+
+        String stackTrace = (String) result.get("stackTrace");
+        String[] lines = stackTrace.split("\n");
+        // Should be truncated to MAX_STACK_TRACE_LINES + 1 (the truncation message)
+        assertThat(lines.length).isLessThanOrEqualTo(MAX_STACK_TRACE_LINES + 1);
+        assertThat(stackTrace).contains("more lines truncated");
+    }
+
+    @Test
+    void longCauseMessageTruncated() {
+        String longMessage = "x".repeat(MAX_CAUSE_MESSAGE_LENGTH + 200);
+        Exception root = new Exception(longMessage);
+        Exception top = new RuntimeException("top", root);
+
+        Map<String, Object> result = populate(top);
+
+        String causeChain = (String) result.get("causeChain");
+        assertThat(causeChain).contains("...");
+        // The cause message portion should not exceed MAX_CAUSE_MESSAGE_LENGTH + "..."
+        String causeMessage = causeChain.substring(causeChain.indexOf(": ") + 2);
+        assertThat(causeMessage.length()).isLessThanOrEqualTo(MAX_CAUSE_MESSAGE_LENGTH + 3);
+    }
+
+    @Test
+    void nullMessage() {
+        Exception exception = new RuntimeException((String) null);
+
+        Map<String, Object> result = populate(exception);
+
+        assertThat(result)
+                .containsEntry("exceptionClass", "java.lang.RuntimeException")
+                .containsEntry("message", null);
+    }
+
+    @Test
+    void causeWithNullMessage() {
+        Exception root = new Exception((String) null);
+        Exception top = new RuntimeException("top", root);
+
+        Map<String, Object> result = populate(top);
+
+        String causeChain = (String) result.get("causeChain");
+        // Should contain the class name but no ": message" part
+        assertThat(causeChain).contains("Exception");
+        assertThat(causeChain).doesNotContain(": null");
+    }
+
+    private static Map<String, Object> populate(Throwable throwable) {
+        return populate(throwable, MAX_CAUSE_DEPTH);
+    }
+
+    private static Map<String, Object> populate(Throwable throwable, int maxCauseDepth) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        ExceptionProcessor.populateExceptionDetails(result, throwable, maxCauseDepth);
+        return result;
+    }
+
+    private static RuntimeException buildDeepException(int targetLines) {
+        try {
+            return buildDeepExceptionRecursive(targetLines, 0);
+        } catch (RuntimeException e) {
+            return e;
+        }
+    }
+
+    private static RuntimeException buildDeepExceptionRecursive(int targetDepth, int current) {
+        if (current >= targetDepth) {
+            throw new RuntimeException("deep exception");
+        }
+        return buildDeepExceptionRecursive(targetDepth, current + 1);
+    }
+}

--- a/extensions/devui/deployment/src/test/java/io/quarkus/devui/devmcp/DevMcpTest.java
+++ b/extensions/devui/deployment/src/test/java/io/quarkus/devui/devmcp/DevMcpTest.java
@@ -206,6 +206,80 @@ public class DevMcpTest {
     }
 
     @Test
+    public void testGetLastExceptionToolAvailable() {
+        String jsonBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 3,
+                      "method": "tools/list"
+                    }
+                """;
+
+        RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .body(jsonBody)
+                .when()
+                .post("/q/dev-mcp")
+                .then()
+                .statusCode(200)
+                .body("result.tools.name", CoreMatchers.hasItem("devui-exceptions_getLastException"))
+                .body("result.tools.name", CoreMatchers.hasItem("devui-exceptions_clearLastException"));
+    }
+
+    @Test
+    public void testGetLastExceptionNoException() {
+        String jsonBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 10,
+                      "method": "tools/call",
+                      "params": {
+                        "name": "devui-exceptions_getLastException",
+                        "arguments": {}
+                      }
+                    }
+                """;
+
+        RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .body(jsonBody)
+                .when()
+                .post("/q/dev-mcp")
+                .then()
+                .statusCode(200)
+                .body("id", CoreMatchers.equalTo(10))
+                .body("result.content.text", CoreMatchers.hasItem(CoreMatchers.containsString("\"hasException\" : false")));
+    }
+
+    @Test
+    public void testClearLastException() {
+        String jsonBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 11,
+                      "method": "tools/call",
+                      "params": {
+                        "name": "devui-exceptions_clearLastException",
+                        "arguments": {}
+                      }
+                    }
+                """;
+
+        RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .body(jsonBody)
+                .when()
+                .post("/q/dev-mcp")
+                .then()
+                .statusCode(200)
+                .body("id", CoreMatchers.equalTo(11))
+                .body("result.content.text", CoreMatchers.hasItem(CoreMatchers.containsString("\"cleared\" : true")));
+    }
+
+    @Test
     public void testResourcesList() {
         String jsonBody = """
                     {


### PR DESCRIPTION
When a compilation, deployment, or runtime error occurs, agents have no
programmatic way to retrieve the exception details — they must parse logs.

Adds a `getLastException` Dev MCP tool that captures exceptions via
`ExceptionNotificationBuildItem` (runtime) and `RuntimeUpdatesProcessor`
(deployment), returning structured data: exception class, message, full
stack trace, user code location, and cause chain.

- Closes: #53297