### PR TITLE
Dev MCP: Add config search and per-extension config lookup tools

### DIFF
--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/DevUIProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/DevUIProcessor.java
@@ -546,10 +546,9 @@ public class DevUIProcessor {
                         EnumSet<Usage> usage = EnumSet.noneOf(Usage.class);
                         AnnotationInstance jsonRpcUsageAnnotation = method.annotation(DotName.createSimple(JsonRpcUsage.class));
                         if (jsonRpcUsageAnnotation != null) {
-                            AnnotationInstance[] usageArray = jsonRpcUsageAnnotation.value().asNestedArray();
+                            String[] usageArray = jsonRpcUsageAnnotation.value().asEnumArray();
 
-                            for (AnnotationInstance usageInstance : usageArray) {
-                                String usageStr = usageInstance.value().asEnum();
+                            for (String usageStr : usageArray) {
                                 usage.add(Usage.valueOf(usageStr));
                             }
                         }

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/ConfigurationProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/ConfigurationProcessor.java
@@ -11,6 +11,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -35,7 +36,9 @@ import io.quarkus.deployment.builditem.CuratedApplicationShutdownBuildItem;
 import io.quarkus.deployment.builditem.DevServicesLauncherConfigResultBuildItem;
 import io.quarkus.dev.config.CurrentConfig;
 import io.quarkus.dev.console.DevConsoleManager;
+import io.quarkus.devui.deployment.ExtensionsBuildItem;
 import io.quarkus.devui.deployment.InternalPageBuildItem;
+import io.quarkus.devui.deployment.extension.Extension;
 import io.quarkus.devui.runtime.config.ConfigDescriptionBean;
 import io.quarkus.devui.runtime.config.ConfigDevUIRecorder;
 import io.quarkus.devui.runtime.config.ConfigJsonRPCService;
@@ -79,6 +82,7 @@ public class ConfigurationProcessor {
     @Record(ExecutionTime.STATIC_INIT)
     void registerConfigs(List<ConfigDescriptionBuildItem> configDescriptionBuildItems,
             Optional<DevServicesLauncherConfigResultBuildItem> devServicesLauncherConfig,
+            ExtensionsBuildItem extensionsBuildItem,
             ConfigDevUIRecorder recorder) {
 
         List<ConfigDescription> configDescriptions = new ArrayList<>();
@@ -99,6 +103,26 @@ public class ConfigurationProcessor {
         }
 
         recorder.registerConfigs(configDescriptions, devServicesConfig);
+        recorder.registerExtensionConfigFilters(buildExtensionConfigFilterMap(extensionsBuildItem));
+    }
+
+    private Map<String, List<String>> buildExtensionConfigFilterMap(ExtensionsBuildItem extensionsBuildItem) {
+        Map<String, List<String>> configFilterMap = new HashMap<>();
+        for (Extension extension : extensionsBuildItem.getActiveExtensions()) {
+            List<String> configFilter = extension.getConfigFilter();
+            if (configFilter != null && !configFilter.isEmpty()) {
+                String name = extension.getName();
+                if (name != null && !name.isBlank()) {
+                    configFilterMap.put(name.toLowerCase(Locale.ROOT), configFilter);
+                }
+                String shortName = extension.getShortName();
+                if (shortName != null && !shortName.isBlank()
+                        && !shortName.equalsIgnoreCase(name)) {
+                    configFilterMap.put(shortName.toLowerCase(Locale.ROOT), configFilter);
+                }
+            }
+        }
+        return configFilterMap;
     }
 
     @BuildStep(onlyIf = IsLocalDevelopment.class)

--- a/extensions/devui/deployment/src/test/java/io/quarkus/devui/ConfigurationTest.java
+++ b/extensions/devui/deployment/src/test/java/io/quarkus/devui/ConfigurationTest.java
@@ -37,4 +37,82 @@ public class ConfigurationTest extends DevUIJsonRPCTest {
         String applicationName = allPropertiesResponse.get("quarkus.application.name").asText();
         Assertions.assertEquals("changedByTest", applicationName);
     }
+
+    @Test
+    public void testSearchConfigByQuery() throws Exception {
+        JsonNode response = super.executeJsonRPCMethod("searchConfig",
+                Map.of("query", "application.name"));
+        Assertions.assertNotNull(response);
+        Assertions.assertTrue(response.isArray());
+        Assertions.assertTrue(response.size() > 0, "Should find at least one config matching 'application.name'");
+
+        // Verify the result structure
+        JsonNode first = response.get(0);
+        Assertions.assertNotNull(first.get("name"));
+        Assertions.assertTrue(first.get("name").asText().contains("application.name"));
+    }
+
+    @Test
+    public void testSearchConfigWithLimit() throws Exception {
+        JsonNode response = super.executeJsonRPCMethod("searchConfig",
+                Map.of("query", "quarkus", "limit", 2));
+        Assertions.assertNotNull(response);
+        Assertions.assertTrue(response.isArray());
+        Assertions.assertTrue(response.size() <= 2, "Should respect the limit parameter");
+    }
+
+    @Test
+    public void testSearchConfigByExtension() throws Exception {
+        JsonNode response = super.executeJsonRPCMethod("searchConfig",
+                Map.of("query", "", "extension", "log"));
+        Assertions.assertNotNull(response);
+        Assertions.assertTrue(response.isArray());
+        for (int i = 0; i < response.size(); i++) {
+            String name = response.get(i).get("name").asText();
+            Assertions.assertTrue(name.startsWith("quarkus.log."),
+                    "Config key '" + name + "' should start with 'quarkus.log.'");
+        }
+    }
+
+    @Test
+    public void testGetExtensionConfig() throws Exception {
+        JsonNode response = super.executeJsonRPCMethod("getExtensionConfig",
+                Map.of("extension", "log"));
+        Assertions.assertNotNull(response);
+        Assertions.assertTrue(response.isArray());
+        Assertions.assertTrue(response.size() > 0, "Should find config keys for the 'log' extension");
+
+        for (int i = 0; i < response.size(); i++) {
+            String name = response.get(i).get("name").asText();
+            Assertions.assertTrue(name.startsWith("quarkus.log."),
+                    "Config key '" + name + "' should start with 'quarkus.log.'");
+        }
+    }
+
+    @Test
+    public void testGetExtensionConfigEmpty() throws Exception {
+        JsonNode response = super.executeJsonRPCMethod("getExtensionConfig",
+                Map.of("extension", ""));
+        Assertions.assertNotNull(response);
+        Assertions.assertTrue(response.isArray());
+        Assertions.assertEquals(0, response.size(), "Empty extension should return no results");
+    }
+
+    @Test
+    public void testSearchConfigResultStructure() throws Exception {
+        JsonNode response = super.executeJsonRPCMethod("searchConfig",
+                Map.of("query", "log.level", "limit", 1));
+        Assertions.assertNotNull(response);
+        Assertions.assertTrue(response.isArray());
+        Assertions.assertTrue(response.size() > 0);
+
+        JsonNode entry = response.get(0);
+        Assertions.assertNotNull(entry.get("name"), "Result should have 'name'");
+        Assertions.assertNotNull(entry.get("type"), "Result should have 'type'");
+        // currentValue should only be present when non-null
+        if (entry.has("currentValue")) {
+            Assertions.assertFalse(entry.get("currentValue").isNull(),
+                    "currentValue should not be null when present");
+        }
+    }
 }

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/config/ConfigDescriptionBean.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/config/ConfigDescriptionBean.java
@@ -1,17 +1,25 @@
 package io.quarkus.devui.runtime.config;
 
 import java.util.List;
+import java.util.Map;
 
 import io.quarkus.vertx.http.runtime.devmode.ConfigDescription;
 
 public class ConfigDescriptionBean {
     private List<ConfigDescription> allConfig;
+    private Map<String, List<String>> extensionConfigFilters;
 
-    public ConfigDescriptionBean(final List<ConfigDescription> allConfig) {
+    public ConfigDescriptionBean(final List<ConfigDescription> allConfig,
+            final Map<String, List<String>> extensionConfigFilters) {
         this.allConfig = allConfig;
+        this.extensionConfigFilters = extensionConfigFilters;
     }
 
     public List<ConfigDescription> getAllConfig() {
         return allConfig;
+    }
+
+    public Map<String, List<String>> getExtensionConfigFilters() {
+        return extensionConfigFilters;
     }
 }

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/config/ConfigDevUIRecorder.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/config/ConfigDevUIRecorder.java
@@ -25,17 +25,23 @@ public class ConfigDevUIRecorder {
 
     private static List<ConfigDescription> configDescriptions;
     private static Set<String> devServicesConfig;
+    private static Map<String, List<String>> extensionConfigFilters;
 
     public void registerConfigs(final List<ConfigDescription> configDescriptions, final Set<String> devServicesConfig) {
         ConfigDevUIRecorder.configDescriptions = configDescriptions;
         ConfigDevUIRecorder.devServicesConfig = devServicesConfig;
     }
 
+    public void registerExtensionConfigFilters(final Map<String, List<String>> extensionConfigFilters) {
+        ConfigDevUIRecorder.extensionConfigFilters = extensionConfigFilters;
+    }
+
     public Supplier<ConfigDescriptionBean> configDescriptionBean() {
         return new Supplier<>() {
             @Override
             public ConfigDescriptionBean get() {
-                return new ConfigDescriptionBean(calculate(configDescriptions, devServicesConfig));
+                return new ConfigDescriptionBean(calculate(configDescriptions, devServicesConfig),
+                        extensionConfigFilters != null ? extensionConfigFilters : Map.of());
             }
         };
     }

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/config/ConfigJsonRPCService.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/config/ConfigJsonRPCService.java
@@ -2,7 +2,10 @@ package io.quarkus.devui.runtime.config;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -10,12 +13,17 @@ import jakarta.inject.Inject;
 import io.quarkus.dev.console.DevConsoleManager;
 import io.quarkus.runtime.annotations.DevMCPEnableByDefault;
 import io.quarkus.runtime.annotations.JsonRpcDescription;
+import io.quarkus.runtime.annotations.JsonRpcUsage;
+import io.quarkus.runtime.annotations.Usage;
 import io.quarkus.vertx.http.runtime.devmode.ConfigDescription;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 @ApplicationScoped
 public class ConfigJsonRPCService {
+
+    private static final int DEFAULT_LIMIT = 50;
+    private static final int MAX_LIMIT = 500;
 
     @Inject
     ConfigDescriptionBean configDescriptionBean;
@@ -25,13 +33,70 @@ public class ConfigJsonRPCService {
     }
 
     @JsonRpcDescription("Get all configurations and their values for the Quarkus application")
-    @DevMCPEnableByDefault
+    @JsonRpcUsage({ Usage.DEV_UI })
     public JsonObject getAllValues() {
         JsonObject values = new JsonObject();
         for (ConfigDescription configDescription : configDescriptionBean.getAllConfig()) {
             values.put(configDescription.getName(), configDescription.getConfigValue().getValue());
         }
         return values;
+    }
+
+    @JsonRpcDescription("Search for configuration keys in the Quarkus application by matching against key names and descriptions. Returns matching configuration properties with their full metadata including description, type, default value, current value, phase and allowed values.")
+    @DevMCPEnableByDefault
+    public JsonArray searchConfig(
+            @JsonRpcDescription("Text to search for in configuration key names and descriptions") String query,
+            @JsonRpcDescription("Optional extension prefix to filter by, e.g. 'datasource', 'oidc', 'hibernate-orm'") String extension,
+            @JsonRpcDescription("Maximum number of results to return (default 50)") Integer limit) {
+
+        int maxResults = limit != null && limit > 0 ? Math.min(limit, MAX_LIMIT) : DEFAULT_LIMIT;
+        String queryLower = query != null ? query.toLowerCase(Locale.ROOT) : null;
+        List<String> extensionPrefixes = resolveExtensionPrefixes(extension);
+
+        List<ConfigDescription> matches = new ArrayList<>();
+        for (ConfigDescription config : configDescriptionBean.getAllConfig()) {
+            if (extensionPrefixes != null && !matchesAnyPrefix(config.getName(), extensionPrefixes)) {
+                continue;
+            }
+            if (queryLower != null) {
+                String nameLower = config.getName().toLowerCase(Locale.ROOT);
+                String descLower = config.getDescription() != null ? config.getDescription().toLowerCase(Locale.ROOT) : "";
+                if (!nameLower.contains(queryLower) && !descLower.contains(queryLower)) {
+                    continue;
+                }
+            }
+            matches.add(config);
+            if (matches.size() >= maxResults) {
+                break;
+            }
+        }
+
+        return toJsonArray(matches);
+    }
+
+    @JsonRpcDescription("Get all configuration keys for a specific Quarkus extension. Returns configuration properties with their full metadata including description, type, default value, current value, phase and allowed values.")
+    @DevMCPEnableByDefault
+    public JsonArray getExtensionConfig(
+            @JsonRpcDescription("The extension prefix, e.g. 'datasource', 'oidc', 'rest-client', 'hibernate-orm'") String extension,
+            @JsonRpcDescription("Maximum number of results to return (default 50)") Integer limit) {
+
+        int maxResults = limit != null && limit > 0 ? Math.min(limit, MAX_LIMIT) : DEFAULT_LIMIT;
+        List<String> extensionPrefixes = resolveExtensionPrefixes(extension);
+        if (extensionPrefixes == null) {
+            return new JsonArray();
+        }
+
+        List<ConfigDescription> matches = new ArrayList<>();
+        for (ConfigDescription config : configDescriptionBean.getAllConfig()) {
+            if (matchesAnyPrefix(config.getName(), extensionPrefixes)) {
+                matches.add(config);
+                if (matches.size() >= maxResults) {
+                    break;
+                }
+            }
+        }
+
+        return toJsonArray(matches);
     }
 
     @JsonRpcDescription("Get the project properties for the Quarkus application")
@@ -61,5 +126,63 @@ public class ConfigJsonRPCService {
             throw new RuntimeException(t);
         }
         return response;
+    }
+
+    /**
+     * Resolves extension prefixes by first looking up the extension's configFilter metadata,
+     * then falling back to a normalized prefix based on the extension name.
+     */
+    private List<String> resolveExtensionPrefixes(String extension) {
+        if (extension == null || extension.isBlank()) {
+            return null;
+        }
+        String trimmed = extension.trim();
+
+        // Try metadata lookup first
+        Map<String, List<String>> configFilters = configDescriptionBean.getExtensionConfigFilters();
+        if (configFilters != null && !configFilters.isEmpty()) {
+            List<String> prefixes = configFilters.get(trimmed.toLowerCase(Locale.ROOT));
+            if (prefixes != null) {
+                return prefixes;
+            }
+        }
+
+        // Fall back to normalized prefix
+        String prefix;
+        if (trimmed.startsWith("quarkus.")) {
+            prefix = trimmed.endsWith(".") ? trimmed : trimmed + ".";
+        } else {
+            prefix = "quarkus." + trimmed + ".";
+        }
+        return List.of(prefix);
+    }
+
+    private static boolean matchesAnyPrefix(String name, List<String> prefixes) {
+        for (String prefix : prefixes) {
+            if (name.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static JsonArray toJsonArray(List<ConfigDescription> configs) {
+        JsonArray result = new JsonArray();
+        for (ConfigDescription config : configs) {
+            JsonObject obj = new JsonObject();
+            obj.put("name", config.getName());
+            obj.put("description", config.getDescription());
+            obj.put("defaultValue", config.getDefaultValue());
+            if (config.getConfigValue() != null && config.getConfigValue().getValue() != null) {
+                obj.put("currentValue", config.getConfigValue().getValue());
+            }
+            obj.put("type", config.getTypeName());
+            obj.put("phase", config.getConfigPhase());
+            if (config.getAllowedValues() != null && !config.getAllowedValues().isEmpty()) {
+                obj.put("allowedValues", new JsonArray(config.getAllowedValues()));
+            }
+            result.add(obj);
+        }
+        return result;
     }
 }


### PR DESCRIPTION
The Dev MCP server lacks a way for agents to search or browse extension
configuration programmatically.

Adds two new tools:
- `searchConfig(query, extension, limit)` — search config keys by name/description,
  optionally filtered by extension prefix
- `getExtensionConfig(extension, limit)` — get all config for a specific extension
  with rich metadata

Also restricts `getAllValues` to Dev UI only, as it returns too much unstructured
data for agent consumption.

- Closes: #53299