### PR TITLE
OpenAPI: Detect repeated @PermissionsAllowed annotations in Swagger UI

### DIFF
--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -873,7 +873,7 @@ public class SmallRyeOpenApiProcessor {
 
     private List<String> getPermissionsAllowedMethodReferences(OpenApiSecurityTransformer securityTransformer) {
         return securityTransformer
-                .getAnnotations(DotName.createSimple(PermissionsAllowed.class))
+                .getAnnotationsWithRepeatable(DotName.createSimple(PermissionsAllowed.class))
                 .stream()
                 .flatMap(t -> getMethods(t, securityTransformer.getIndex()))
                 .map(e -> createUniqueMethodReference(e.getKey().classInfo(), e.getKey().method()))
@@ -1559,6 +1559,18 @@ public class SmallRyeOpenApiProcessor {
             }
 
             @Override
+            public Collection<AnnotationInstance> getAnnotationsWithRepeatable(DotName securityAnnotationName) {
+                if (securityTransformer != null) {
+                    return securityTransformer.getAnnotationsWithRepeatable(securityAnnotationName);
+                }
+                // the annotation definition may not be in the index if the security extension is not on the classpath
+                if (index.getClassByName(securityAnnotationName) == null) {
+                    return Collections.emptyList();
+                }
+                return index.getAnnotationsWithRepeatable(securityAnnotationName, index);
+            }
+
+            @Override
             public IndexView getIndex() {
                 return index;
             }
@@ -1568,6 +1580,8 @@ public class SmallRyeOpenApiProcessor {
     private interface OpenApiSecurityTransformer {
 
         Collection<AnnotationInstance> getAnnotations(DotName securityAnnotationName);
+
+        Collection<AnnotationInstance> getAnnotationsWithRepeatable(DotName securityAnnotationName);
 
         IndexView getIndex();
 

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoSecurityRolesAllowedTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoSecurityRolesAllowedTestCase.java
@@ -75,6 +75,8 @@ class AutoSecurityRolesAllowedTestCase {
                 .body("paths.'/resource2/test-security/annotated/documented'.get.security", defaultSecurity)
                 .body("paths.'/resource2/test-security/methodLevel/3'.get.security", defaultSecurityScheme("admin"))
                 .body("paths.'/resource2/test-security/methodLevel/4'.get.security", defaultSecurity)
+                .body("paths.'/resource2/test-security/methodLevel/5'.get.security", defaultSecurity)
+                .body("paths.'/resource2/test-security/methodLevel/6'.get.security", defaultSecurity)
                 .and()
                 // OpenApiResourceSecuredAtClassLevel
                 .body("paths.'/resource2/test-security/classLevel/1'.get.security", defaultSecurityScheme("user1"))
@@ -172,6 +174,18 @@ class AutoSecurityRolesAllowedTestCase {
                         Matchers.equalTo("Not Authorized"))
                 .and()
                 .body("paths.'/resource2/test-security/methodLevel/4'.get.responses.403.description",
+                        Matchers.equalTo("Not Allowed"))
+                .and()
+                .body("paths.'/resource2/test-security/methodLevel/5'.get.responses.401.description",
+                        Matchers.equalTo("Not Authorized"))
+                .and()
+                .body("paths.'/resource2/test-security/methodLevel/5'.get.responses.403.description",
+                        Matchers.equalTo("Not Allowed"))
+                .and()
+                .body("paths.'/resource2/test-security/methodLevel/6'.get.responses.401.description",
+                        Matchers.equalTo("Not Authorized"))
+                .and()
+                .body("paths.'/resource2/test-security/methodLevel/6'.get.responses.403.description",
                         Matchers.equalTo("Not Allowed"))
                 .and()
                 .body("paths.'/resource3/test-security/classLevel-2/1'.get.responses.401.description",

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiResourceSecuredAtMethodLevel.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiResourceSecuredAtMethodLevel.java
@@ -85,4 +85,22 @@ public class OpenApiResourceSecuredAtMethodLevel {
         return "secret";
     }
 
+    @GET
+    @Path("/test-security/methodLevel/5")
+    @PermissionsAllowed("secure:read")
+    @PermissionsAllowed("secure:write")
+    public String secureEndpoint6MultiplePermissionsAllowed() {
+        return "secret";
+    }
+
+    @GET
+    @Path("/test-security/methodLevel/6")
+    @PermissionsAllowed.List({
+            @PermissionsAllowed("secure:read"),
+            @PermissionsAllowed("secure:write")
+    })
+    public String secureEndpoint7PermissionsAllowedList() {
+        return "secret";
+    }
+
 }


### PR DESCRIPTION
Endpoints annotated with multiple `@PermissionsAllowed` were not shown as
protected in Swagger UI.

The root cause is that `SmallRyeOpenApiProcessor` used `getAnnotations()` to
look up security annotations. This method does not unwrap the repeatable
container (`@PermissionsAllowed.List`), so any endpoint with more than one
`@PermissionsAllowed` was silently skipped.

Switched to `getAnnotationsWithRepeatable()`, which properly unwraps the
container. Also added a guard against `IllegalArgumentException` when the
annotation class is not in the Jandex index (i.e. quarkus-security not on
the classpath).

- Fixes: #53296