### PR TITLE
Document that @CacheInvalidateAll only invalidates after successful method execution

### DIFF
--- a/docs/src/main/asciidoc/cache.adoc
+++ b/docs/src/main/asciidoc/cache.adoc
@@ -321,6 +321,9 @@ If the key does not identify any cache entry, nothing will happen.
 
 When a method annotated with `@CacheInvalidateAll` is invoked, Quarkus will remove all entries from the cache.
 
+Cache invalidation is performed *after* the annotated method completes successfully.
+If the method throws an exception, the cache will *not* be invalidated.
+
 === @CacheKey
 
 When a method argument is annotated with `@CacheKey`, it is identified as a part of the cache key during an invocation of a

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/CacheInvalidateAll.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/CacheInvalidateAll.java
@@ -14,6 +14,9 @@ import io.quarkus.cache.CacheInvalidateAll.List;
 /**
  * When a method annotated with {@link CacheInvalidateAll} is invoked, Quarkus will remove all entries from the cache.
  * <p>
+ * Cache invalidation is performed <b>after</b> the annotated method completes successfully. If the method throws an
+ * exception, the cache will <b>not</b> be invalidated.
+ * <p>
  * This annotation can be combined with multiple other caching annotations on a single method. Caching operations will always
  * be executed in the same order: {@link CacheInvalidateAll} first, then {@link CacheInvalidate} and finally
  * {@link CacheResult}.


### PR DESCRIPTION
Clarify in both Javadoc and user guide that cache invalidation happens after the method completes successfully and is skipped if the method throws an exception. This behavior was introduced by #52200 to prevent race conditions.
* Fixes #53302
