### PR TITLE
Add traffic control to quarkus-grpc

### DIFF
--- a/extensions/grpc/runtime/src/test/java/io/quarkus/grpc/runtime/ClientAndServerCallsTest.java
+++ b/extensions/grpc/runtime/src/test/java/io/quarkus/grpc/runtime/ClientAndServerCallsTest.java
@@ -2,13 +2,17 @@ package io.quarkus.grpc.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -17,6 +21,10 @@ import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.Status;
 import io.grpc.StatusException;
+import io.grpc.stub.ClientCallStreamObserver;
+import io.grpc.stub.ClientResponseObserver;
+import io.grpc.stub.ServerCallStreamObserver;
+import io.grpc.stub.StreamObserver;
 import io.quarkus.grpc.ExceptionHandler;
 import io.quarkus.grpc.ExceptionHandlerProvider;
 import io.quarkus.grpc.stubs.ClientCalls;
@@ -145,7 +153,103 @@ public class ClientAndServerCallsTest {
                 });
     }
 
+    @Test
+    public void testOneToManyFlowControl() {
+        var client2 = new FakeServiceClient(false, new FakeServiceVolume());
+        AtomicInteger received = new AtomicInteger();
+        client2.oneToMany("hello").subscribe().with(item -> received.getAndIncrement());
+
+        // Not ready — upstream prefetched PREFETCH items but nothing drained yet
+        assertEquals(0, received.get());
+        assertEquals(1, client2.service.requests.size());
+        assertThat(client2.service.requests.get(0)).isEqualTo(256L);
+
+        // Drain 256 items then pause — triggers 1 replenish at consumed=192
+        client2.fakeServerCallStreamObserver.flipReadyAfterIterations = 256;
+        client2.fakeServerCallStreamObserver.setReady(true);
+        assertEquals(256, received.get());
+        assertEquals(2, client2.service.requests.size());
+        assertThat(client2.service.requests.get(1)).isEqualTo(192L);
+
+        // Drain 128 more — consumed goes 64→192, triggers another replenish
+        client2.fakeServerCallStreamObserver.flipReadyAfterIterations = 128;
+        client2.fakeServerCallStreamObserver.setReady(true);
+        assertEquals(384, received.get());
+        assertEquals(3, client2.service.requests.size());
+        assertThat(client2.service.requests.get(2)).isEqualTo(192L);
+
+        // Drain just 1 item — consumed=1, well below replenish threshold
+        client2.fakeServerCallStreamObserver.flipReadyAfterIterations = 1;
+        client2.fakeServerCallStreamObserver.setReady(true);
+        assertEquals(385, received.get());
+        assertEquals(3, client2.service.requests.size());
+    }
+
+    @Test
+    public void testManyToOneFlowControl() {
+        var cf = new CompletableFuture<List<String>>();
+        var client2 = new FakeServiceClient(false, new FakeServiceVolume());
+        var requests = new ArrayList<Long>();
+        var res = client2.manyToOne(
+                Multi.createFrom()
+                        .range(0, 1000).map(Object::toString)
+                        .onRequest().invoke(requests::add))
+                .subscribe().with(cf::complete);
+
+        // Initial prefetch — drain loop requested PREFETCH from upstream, nothing forwarded yet
+        assertEquals(1, requests.size());
+        assertThat(requests.get(0)).isEqualTo(256L);
+
+        // Drain 256 items — triggers 1 replenish at consumed=192
+        client2.fakeClientCallStreamObserver.flipReadyAfterIterations = 256;
+        client2.fakeClientCallStreamObserver.setReady(true);
+        assertEquals(2, requests.size());
+        assertThat(requests.get(1)).isEqualTo(192L);
+
+        // Drain 128 more — consumed goes 64→192, triggers another replenish
+        client2.fakeClientCallStreamObserver.flipReadyAfterIterations = 128;
+        client2.fakeClientCallStreamObserver.setReady(true);
+        assertEquals(3, requests.size());
+        assertThat(requests.get(2)).isEqualTo(192L);
+
+        // Drain just 1 item — consumed=1, well below replenish threshold
+        client2.fakeClientCallStreamObserver.flipReadyAfterIterations = 1;
+        client2.fakeClientCallStreamObserver.setReady(true);
+        assertEquals(3, requests.size());
+    }
+
+    @Test
+    public void testManyToManyFlowControl() {
+        var client2 = new FakeServiceClient(false, new FakeService());
+        var inputRequests = new ArrayList<Long>();
+        AtomicInteger received = new AtomicInteger();
+
+        client2.manyToMany(
+                Multi.createFrom().range(0, 1000).map(Object::toString)
+                        .onRequest().invoke(inputRequests::add))
+                .subscribe().with(item -> received.getAndIncrement());
+
+        // Both sides not ready — client prefetched from input Multi, nothing forwarded
+        assertEquals(0, received.get());
+        assertEquals(1, inputRequests.size());
+        assertThat(inputRequests.get(0)).isEqualTo(256L);
+
+        // Make client ready for 256 — items flow to server queue but server not ready
+        client2.fakeClientCallStreamObserver.flipReadyAfterIterations = 256;
+        client2.fakeClientCallStreamObserver.setReady(true);
+        assertEquals(0, received.get());
+        assertEquals(2, inputRequests.size());
+        assertThat(inputRequests.get(1)).isEqualTo(192L);
+
+        // Make server ready for 256 — items drain to downstream subscriber
+        client2.fakeServerCallStreamObserver.flipReadyAfterIterations = 256;
+        client2.fakeServerCallStreamObserver.setReady(true);
+        assertEquals(256, received.get());
+    }
+
     static class FakeService {
+
+        List<Long> requests = new ArrayList<>();
 
         Uni<String> oneToOne(String s) {
             return Uni.createFrom().item(s).map(String::toUpperCase);
@@ -165,26 +269,222 @@ public class ClientAndServerCallsTest {
 
     }
 
+    static class FakeServiceVolume extends FakeService {
+
+        Multi<String> oneToMany(String s) {
+            return Multi.createFrom()
+                    .range(0, 1000)
+                    .map(i -> s.toUpperCase())
+                    .onRequest()
+                    .invoke(r -> requests.add(r));
+        }
+    }
+
     static class FakeServiceClient {
 
         FakeService service = new FakeService();
+        boolean startReady = true;
+
+        public FakeClientCallStreamObserver<String> fakeClientCallStreamObserver;
+        public FakeServerCallStreamObserver<String> fakeServerCallStreamObserver;
+
+        public FakeServiceClient() {
+        }
+
+        public FakeServiceClient(boolean startReady, FakeService service) {
+            this.service = service;
+            this.startReady = startReady;
+        }
 
         Uni<String> oneToOne(String s) {
             return ClientCalls.oneToOne(s, (i, o) -> ServerCalls.oneToOne(i, o, null, service::oneToOne));
         }
 
         Uni<List<String>> manyToOne(Multi<String> multi) {
-            return ClientCalls.manyToOne(multi, o -> ServerCalls.manyToOne(o, service::manyToOne));
+            return ClientCalls.manyToOne(multi,
+                    o -> {
+                        fakeClientCallStreamObserver = new FakeClientCallStreamObserver<>(
+                                ServerCalls.manyToOne(o, service::manyToOne),
+                                startReady);
+                        ((ClientResponseObserver<String, List<String>>) o).beforeStart(fakeClientCallStreamObserver);
+                        return fakeClientCallStreamObserver;
+                    });
         }
 
         Multi<String> oneToMany(String s) {
-            return ClientCalls.oneToMany(s, (i, o) -> ServerCalls.oneToMany(i, o, null, service::oneToMany));
+            return ClientCalls.oneToMany(s,
+                    (i, o) -> {
+                        fakeServerCallStreamObserver = new FakeServerCallStreamObserver<>(o, startReady);
+                        ServerCalls.oneToMany(i, fakeServerCallStreamObserver, null, service::oneToMany);
+                    });
         }
 
         Multi<String> manyToMany(Multi<String> multi) {
-            return ClientCalls.manyToMany(multi, o -> ServerCalls.manyToMany(o, service::manyToMany));
+            return ClientCalls.manyToMany(multi, o -> {
+                fakeServerCallStreamObserver = new FakeServerCallStreamObserver<String>(o, startReady);
+                fakeClientCallStreamObserver = new FakeClientCallStreamObserver<String>(
+                        ServerCalls.manyToMany(fakeServerCallStreamObserver, service::manyToMany),
+                        startReady);
+                ((ClientResponseObserver<String, String>) o).beforeStart(fakeClientCallStreamObserver);
+                return fakeClientCallStreamObserver;
+            });
+        }
+    }
+
+    static class FakeServerCallStreamObserver<T> extends ServerCallStreamObserver<T> {
+        private final StreamObserver<T> delegate;
+        private boolean isReady = true;
+        private Runnable onReadyHandler;
+        int flipReadyAfterIterations = 5;
+        int currentIteration = 0;
+
+        FakeServerCallStreamObserver(StreamObserver<T> delegate) {
+            this.delegate = delegate;
         }
 
+        FakeServerCallStreamObserver(StreamObserver<T> delegate, boolean isReady) {
+            this.delegate = delegate;
+            this.isReady = isReady;
+        }
+
+        @Override
+        public void onNext(T value) {
+            if (currentIteration == flipReadyAfterIterations - 1) {
+                setReady(false);
+            }
+            delegate.onNext(value);
+            currentIteration++;
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            delegate.onError(t);
+        }
+
+        @Override
+        public void onCompleted() {
+            delegate.onCompleted();
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return false;
+        }
+
+        @Override
+        public void setOnCancelHandler(Runnable onCancelHandler) {
+        }
+
+        @Override
+        public void setCompression(String compression) {
+        }
+
+        @Override
+        public boolean isReady() {
+            return isReady;
+        }
+
+        @Override
+        public void setOnReadyHandler(Runnable onReadyHandler) {
+            this.onReadyHandler = onReadyHandler;
+        }
+
+        @Override
+        public void request(int i) {
+        }
+
+        @Override
+        public void disableAutoInboundFlowControl() {
+        }
+
+        @Override
+        public void setMessageCompression(boolean enable) {
+        }
+
+        @Override
+        public void setOnCloseHandler(Runnable onCloseHandler) {
+        }
+
+        public void setReady(boolean isReady) {
+            this.isReady = isReady;
+            currentIteration = 0;
+            if (this.isReady) {
+                this.onReadyHandler.run();
+            }
+        }
+    }
+
+    static class FakeClientCallStreamObserver<T> extends ClientCallStreamObserver<T> {
+        private final StreamObserver<T> delegate;
+
+        private boolean isReady = true;
+        private Runnable onReadyHandler;
+        private List<Integer> requests = new ArrayList<Integer>();
+        int flipReadyAfterIterations = 5;
+        int currentIteration = 0;
+
+        FakeClientCallStreamObserver(StreamObserver<T> delegate) {
+            this.delegate = delegate;
+        }
+
+        FakeClientCallStreamObserver(StreamObserver<T> delegate, boolean isReady) {
+            this.delegate = delegate;
+            this.isReady = isReady;
+        }
+
+        @Override
+        public void onNext(T value) {
+            if (currentIteration == flipReadyAfterIterations - 1) {
+                setReady(false);
+            }
+            delegate.onNext(value);
+            currentIteration++;
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            delegate.onError(t);
+        }
+
+        @Override
+        public void onCompleted() {
+            delegate.onCompleted();
+        }
+
+        @Override
+        public boolean isReady() {
+            return isReady;
+        }
+
+        @Override
+        public void setOnReadyHandler(Runnable onReadyHandler) {
+            this.onReadyHandler = onReadyHandler;
+        }
+
+        @Override
+        public void disableAutoInboundFlowControl() {
+        }
+
+        public void setReady(boolean isReady) {
+            this.isReady = isReady;
+            if (this.isReady) {
+                currentIteration = 0;
+                onReadyHandler.run();
+            }
+        }
+
+        @Override
+        public void request(int count) {
+            this.requests.add(count);
+        }
+
+        @Override
+        public void setMessageCompression(boolean enable) {
+        }
+
+        @Override
+        public void cancel(String message, Throwable cause) {
+        }
     }
 
     static class FailingService {

--- a/extensions/grpc/stubs/src/main/java/io/quarkus/grpc/stubs/ClientCalls.java
+++ b/extensions/grpc/stubs/src/main/java/io/quarkus/grpc/stubs/ClientCalls.java
@@ -1,19 +1,36 @@
 package io.quarkus.grpc.stubs;
 
 import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import org.jctools.queues.SpscChunkedArrayQueue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.grpc.stub.ClientCallStreamObserver;
+import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
+import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.Subscriptions;
 import io.smallrye.mutiny.subscription.MultiEmitter;
+import io.smallrye.mutiny.subscription.Subscribers;
 import io.smallrye.mutiny.subscription.UniEmitter;
 
 public class ClientCalls {
+
+    final static long PREFETCH = 256;
+    final static long REPLENISH = PREFETCH * 3 / 4;
+
+    final static String ERROR_CAST_STREAM_OBSERVER = String.format("%s can't be casted as a %s", StreamObserver.class,
+            ServerCallStreamObserver.class);
+    private static final Logger log = LoggerFactory.getLogger(ClientCalls.class);
 
     private ClientCalls() {
     }
@@ -41,70 +58,124 @@ public class ClientCalls {
             @Override
             public void accept(UniEmitter<? super O> emitter) {
                 AtomicReference<Flow.Subscription> cancellable = new AtomicReference<>();
-                StreamObserver<O> observer = new UniStreamObserver<>(emitter, () -> {
+                AtomicReference<Runnable> drainRef = new AtomicReference<>();
+                Runnable onReady = () -> {
+                    Runnable drain = drainRef.get();
+                    if (drain != null) {
+                        drain.run();
+                    }
+                };
+                UniStreamObserver<I, O> responseObserver = new UniStreamObserver<>(emitter, () -> {
                     var subscription = cancellable.getAndSet(Subscriptions.CANCELLED);
                     if (subscription != null) {
                         subscription.cancel();
                     }
-                });
-                StreamObserver<I> request = delegate.apply(observer);
-                subscribeToUpstreamAndForwardToStreamObserver(items, cancellable, request);
+                }, onReady);
+
+                StreamObserver<I> request = delegate.apply(responseObserver);
+
+                if (request instanceof ClientCallStreamObserver<I>) {
+                    drainLoop((ClientCallStreamObserver<I>) request, items, cancellable, drainRef);
+                } else {
+                    responseObserver.onError(new Throwable(ERROR_CAST_STREAM_OBSERVER));
+                    log.error(ERROR_CAST_STREAM_OBSERVER);
+                }
             }
-
         }));
-    }
-
-    private static <I> void subscribeToUpstreamAndForwardToStreamObserver(Multi<I> items,
-            AtomicReference<Flow.Subscription> cancellable,
-            StreamObserver<I> request) {
-        items.subscribe().with(
-                new Consumer<Flow.Subscription>() {
-                    @Override
-                    public void accept(Flow.Subscription subscription) {
-                        if (!cancellable.compareAndSet(null, subscription)) {
-                            subscription.cancel();
-                        } else {
-                            subscription.request(Long.MAX_VALUE);
-                        }
-                    }
-                },
-
-                new Consumer<I>() {
-                    @Override
-                    public void accept(I v) {
-                        if (cancellable.get() != null && cancellable.get() != Subscriptions.CANCELLED) {
-                            request.onNext(v);
-                        }
-                    }
-                },
-                new Consumer<Throwable>() {
-                    @Override
-                    public void accept(Throwable throwable) {
-                        request.onError(throwable);
-                    }
-                },
-                new Runnable() {
-                    @Override
-                    public void run() {
-                        request.onCompleted();
-                    }
-                });
     }
 
     public static <I, O> Multi<O> manyToMany(Multi<I> items, Function<StreamObserver<O>, StreamObserver<I>> delegate) {
+
         return Multi.createFrom().emitter((new Consumer<MultiEmitter<? super O>>() {
+
             @Override
             public void accept(MultiEmitter<? super O> emitter) {
                 AtomicReference<Flow.Subscription> cancellable = new AtomicReference<>();
-                StreamObserver<I> request = delegate.apply(new MultiStreamObserver<>(emitter, () -> {
-                    var subscription = cancellable.getAndSet(Subscriptions.CANCELLED);
-                    if (subscription != null) {
-                        subscription.cancel();
-                    }
-                }));
-                subscribeToUpstreamAndForwardToStreamObserver(items, cancellable, request);
-            }
-        }));
+                AtomicReference<Runnable> drainRef = new AtomicReference<>();
 
+                Runnable onReady = () -> {
+                    Runnable drain = drainRef.get();
+                    if (drain != null) {
+                        drain.run();
+                    }
+                };
+                MultiStreamObserver<I, O> responseObserver = new MultiStreamObserver<>(
+                        emitter, () -> {
+                            var subscription = cancellable.getAndSet(Subscriptions.CANCELLED);
+                            if (subscription != null) {
+                                subscription.cancel();
+                            }
+                        }, onReady);
+
+                StreamObserver<I> request = delegate.apply(responseObserver);
+                if (request instanceof ClientCallStreamObserver<I>) {
+                    drainLoop((ClientCallStreamObserver<I>) request, items, cancellable, drainRef);
+                } else {
+                    responseObserver.onError(new Throwable(ERROR_CAST_STREAM_OBSERVER));
+                    log.error(ERROR_CAST_STREAM_OBSERVER);
+                }
+            }
+
+        }));
     }
+
+    private static <I> void drainLoop(ClientCallStreamObserver<I> requestFlow, Multi<I> items,
+            AtomicReference<Flow.Subscription> cancellable, AtomicReference<Runnable> drainRef) {
+        SpscChunkedArrayQueue<I> queue = new SpscChunkedArrayQueue<>((int) PREFETCH, (int) PREFETCH * 2);
+        AtomicBoolean done = new AtomicBoolean(false);
+        AtomicInteger wip = new AtomicInteger(0);
+        long[] consumed = { 0 };
+
+        AtomicReference<Flow.Subscription> subscription = new AtomicReference<>();
+
+        drainRef.set(() -> {
+            if (subscription.get() == null || wip.getAndIncrement() != 0) {
+                return;
+            }
+            try {
+                do {
+                    while (requestFlow.isReady()) {
+                        I item = queue.poll();
+                        if (item == null) {
+                            if (done.get()) {
+                                requestFlow.onCompleted();
+                                return;
+                            }
+                            break;
+                        }
+                        requestFlow.onNext(item);
+                        consumed[0]++;
+                        if (consumed[0] >= REPLENISH) {
+                            subscription.get().request(consumed[0]);
+                            consumed[0] = 0;
+                        }
+                    }
+                } while (wip.decrementAndGet() != 0);
+            } catch (Throwable t) {
+                requestFlow.onError(t);
+            }
+        });
+
+        items.subscribe().withSubscriber(Subscribers.from(
+                Context.empty(),
+                item -> {
+                    if (cancellable.get() != null && cancellable.get() != Subscriptions.CANCELLED) {
+                        queue.offer(item);
+                        drainRef.get().run();
+                    }
+                },
+                requestFlow::onError,
+                () -> {
+                    done.set(true);
+                    drainRef.get().run();
+                },
+                s -> {
+                    if (!cancellable.compareAndSet(null, s)) {
+                        s.cancel();
+                    }
+                    subscription.set(s);
+                    s.request(PREFETCH);
+                }));
+    }
+
 }

--- a/extensions/grpc/stubs/src/main/java/io/quarkus/grpc/stubs/MultiStreamObserver.java
+++ b/extensions/grpc/stubs/src/main/java/io/quarkus/grpc/stubs/MultiStreamObserver.java
@@ -13,9 +13,13 @@ public class MultiStreamObserver<I, O> implements ClientResponseObserver<I, O> {
     // If this is set, the Multi was terminated by completion or failure, not by cancellation.
     private final AtomicBoolean terminated = new AtomicBoolean();
 
-    private AtomicReference<ClientCallStreamObserver<I>> requestStreamObserver = new AtomicReference<>();
+    private final AtomicReference<ClientCallStreamObserver<I>> requestStreamObserver = new AtomicReference<>();
+    private final Runnable onReady;
+    private ClientCallStreamObserver<I> requestStream;
+    private long pending = 0;
 
-    public MultiStreamObserver(MultiEmitter<? super O> emitter, Runnable onTermination) {
+    public MultiStreamObserver(MultiEmitter<? super O> emitter, Runnable onTermination, Runnable onReady) {
+        this.onReady = onReady;
         this.emitter = emitter.onTermination(() -> {
             // This is called when the reply Multi (the return value of the RPC method) is cancelled or the gRPC server completes the request.
             if (terminated.compareAndSet(false, true)) {
@@ -32,13 +36,50 @@ public class MultiStreamObserver<I, O> implements ClientResponseObserver<I, O> {
         });
     }
 
+    public MultiStreamObserver(MultiEmitter<? super O> emitter, Runnable onTermination) {
+        this(emitter, onTermination, null);
+    }
+
     @Override
     public void beforeStart(ClientCallStreamObserver<I> requestStreamObserver) {
         this.requestStreamObserver.set(requestStreamObserver);
+        this.requestStream = requestStreamObserver;
+
+        long requested = emitter.requested();
+        // if requested == Long.MAX_VALUE we leave autoRequest on
+        if (requested < Long.MAX_VALUE && requested > Integer.MAX_VALUE) { // if it is < Long.MAX_VALUE we disable it and request a lot
+            this.requestStream.disableAutoRequestWithInitial(Integer.MAX_VALUE);
+            pending = requested - Integer.MAX_VALUE;
+        } else if (requested < Integer.MAX_VALUE) {
+            this.requestStream.disableAutoRequestWithInitial((int) requested);
+        }
+
+        this.emitter.onRequest(demand -> {
+            if (demand > Integer.MAX_VALUE) {
+                this.requestStream.request(Integer.MAX_VALUE);
+                pending += Integer.MAX_VALUE;
+            } else if (demand > 0) {
+                this.requestStream.request((int) demand);
+            }
+        });
+
+        if (onReady != null) {
+            requestStreamObserver.setOnReadyHandler(onReady);
+        }
     }
 
     @Override
     public void onNext(O item) {
+        if (requestStream != null) {
+            if (pending > Integer.MAX_VALUE) {
+                requestStream.request(Integer.MAX_VALUE);
+                pending -= Integer.MAX_VALUE;
+            } else if (pending > 0) {
+                requestStream.request((int) pending);
+                pending = 0;
+            }
+        }
+
         emitter.emit(item);
     }
 

--- a/extensions/grpc/stubs/src/main/java/io/quarkus/grpc/stubs/ServerCalls.java
+++ b/extensions/grpc/stubs/src/main/java/io/quarkus/grpc/stubs/ServerCalls.java
@@ -1,20 +1,34 @@
 package io.quarkus.grpc.stubs;
 
+import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 import org.jboss.logging.Logger;
+import org.jctools.queues.SpscChunkedArrayQueue;
 
 import io.grpc.Status;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import io.quarkus.arc.Arc;
 import io.quarkus.grpc.ExceptionHandlerProvider;
+import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.operators.multi.processors.UnicastProcessor;
 import io.smallrye.mutiny.subscription.Cancellable;
+import io.smallrye.mutiny.subscription.Subscribers;
 
 public class ServerCalls {
+
+    final static long PREFETCH = 256;
+    final static long REPLENISH = PREFETCH * 3 / 4;
+
+    final static String ERROR_CAST_STREAM_OBSERVER = String.format("%s can't be casted as a %s", StreamObserver.class,
+            ServerCallStreamObserver.class);
+
     private static final Logger log = Logger.getLogger(ServerCalls.class);
 
     private static StreamCollector streamCollector = StreamCollector.NO_OP;
@@ -48,22 +62,20 @@ public class ServerCalls {
 
     public static <I, O> void oneToMany(I request, StreamObserver<O> response, String compression,
             Function<I, Multi<O>> implementation) {
-        try {
-            trySetCompression(response, compression);
-            streamCollector.add(response);
-            Multi<O> returnValue = implementation.apply(request);
-            if (returnValue == null) {
-                log.error("gRPC service method returned null instead of Multi. " +
-                        "Please change the implementation to return a Multi object or throw StatusRuntimeException");
-                onError(response, Status.fromCode(Status.Code.INTERNAL).asException());
-                return;
+        if (response instanceof ServerCallStreamObserver<O>) {
+            ServerCallStreamObserver<O> responseFlowControl = (ServerCallStreamObserver<O>) response;
+            try {
+                trySetCompression(responseFlowControl, compression);
+                streamCollector.add(responseFlowControl);
+                var multi = implementation.apply(request);
+
+                handleSubscription(multi, responseFlowControl);
+            } catch (Throwable throwable) {
+                onError(responseFlowControl, throwable);
             }
-            handleSubscription(returnValue.subscribe().with(
-                    response::onNext,
-                    throwable -> onError(response, throwable),
-                    () -> onCompleted(response)), response);
-        } catch (Throwable throwable) {
-            onError(response, throwable);
+        } else {
+            onError(response, new Throwable(ERROR_CAST_STREAM_OBSERVER));
+            log.error(ERROR_CAST_STREAM_OBSERVER);
         }
     }
 
@@ -95,6 +107,35 @@ public class ServerCalls {
         }
     }
 
+    public static <I, O> StreamObserver<I> manyToMany(StreamObserver<O> response,
+            Function<Multi<I>, Multi<O>> implementation) {
+        if (response instanceof ServerCallStreamObserver<O>) {
+            ServerCallStreamObserver<O> responseFlowControl = (ServerCallStreamObserver<O>) response;
+            try {
+                streamCollector.add(responseFlowControl);
+                UnicastProcessor<I> input = UnicastProcessor.create();
+                StreamObserver<I> pump = getStreamObserverFeedingProcessor(input);
+                Multi<O> multi = implementation.apply(input);
+                if (multi == null) {
+                    log.error("gRPC service method returned null instead of Multi. " +
+                            "Please change the implementation to return a Multi object or throw StatusRuntimeException");
+                    onError(responseFlowControl, Status.fromCode(Status.Code.INTERNAL).asException());
+                    return null;
+                }
+
+                handleSubscription(multi, responseFlowControl);
+                return pump;
+            } catch (Throwable throwable) {
+                onError(responseFlowControl, throwable);
+                return null;
+            }
+        } else {
+            log.error(ERROR_CAST_STREAM_OBSERVER);
+            onError(response, new Throwable(ERROR_CAST_STREAM_OBSERVER));
+            return null;
+        }
+    }
+
     private static <O> void handleSubscription(Cancellable cancellable, StreamObserver<O> response) {
         if (response instanceof ServerCallStreamObserver) {
             ServerCallStreamObserver<O> serverCallResponse = (ServerCallStreamObserver<O>) response;
@@ -106,29 +147,65 @@ public class ServerCalls {
         }
     }
 
-    public static <I, O> StreamObserver<I> manyToMany(StreamObserver<O> response,
-            Function<Multi<I>, Multi<O>> implementation) {
-        try {
-            streamCollector.add(response);
-            UnicastProcessor<I> input = UnicastProcessor.create();
-            StreamObserver<I> pump = getStreamObserverFeedingProcessor(input);
-            Multi<O> multi = implementation.apply(input);
-            if (multi == null) {
-                log.error("gRPC service method returned null instead of Multi. " +
-                        "Please change the implementation to return a Multi object or throw StatusRuntimeException");
-                onError(response, Status.fromCode(Status.Code.INTERNAL).asException());
-                return null;
-            }
-            handleSubscription(multi.subscribe().with(
-                    response::onNext,
-                    failure -> onError(response, failure),
-                    () -> onCompleted(response)), response);
+    public static <O> void handleSubscription(Multi<O> items, ServerCallStreamObserver<O> response) {
+        SpscChunkedArrayQueue<O> queue = new SpscChunkedArrayQueue<>((int) PREFETCH, (int) PREFETCH * 2);
+        AtomicBoolean done = new AtomicBoolean(false);
+        AtomicInteger wip = new AtomicInteger(0);
+        long[] consumed = { 0 };
 
-            return pump;
-        } catch (Throwable throwable) {
-            onError(response, throwable);
-            return null;
-        }
+        AtomicReference<Flow.Subscription> subscription = new AtomicReference<>();
+
+        Runnable drain = new Runnable() {
+            @Override
+            public void run() {
+                if (wip.getAndIncrement() != 0) {
+                    return;
+                }
+                try {
+                    do {
+                        while (response.isReady()) {
+                            O item = queue.poll();
+                            if (item == null) {
+                                if (done.get()) {
+                                    response.onCompleted();
+                                    return;
+                                }
+                                break;
+                            }
+                            response.onNext(item);
+                            consumed[0]++;
+                            if (consumed[0] >= REPLENISH) {
+                                subscription.get().request(consumed[0]);
+                                consumed[0] = 0;
+                            }
+                        }
+                    } while (wip.decrementAndGet() != 0);
+                } catch (Throwable t) {
+                    onError(response, t);
+                }
+            }
+        };
+
+        var cancellable = items.subscribe().withSubscriber(Subscribers.from(
+                Context.empty(),
+                item -> {
+                    queue.offer(item);
+                    drain.run();
+                },
+                failure -> onError(response, failure),
+                () -> {
+                    done.set(true);
+                    drain.run();
+                },
+                s -> {
+                    subscription.set(s);
+                    s.request(PREFETCH);
+                }));
+
+        response.setOnReadyHandler(drain);
+        response.setOnCloseHandler(cancellable::cancel);
+        response.setOnCancelHandler(cancellable::cancel);
+        drain.run();
     }
 
     private static <O> void onCompleted(StreamObserver<O> response) {

--- a/extensions/grpc/stubs/src/main/java/io/quarkus/grpc/stubs/UniStreamObserver.java
+++ b/extensions/grpc/stubs/src/main/java/io/quarkus/grpc/stubs/UniStreamObserver.java
@@ -13,9 +13,11 @@ public class UniStreamObserver<I, O> implements ClientResponseObserver<I, O> {
     // If this is set, the Uni was terminated by item or failure, not by cancellation.
     private final AtomicBoolean terminated = new AtomicBoolean();
 
-    private AtomicReference<ClientCallStreamObserver<I>> requestStreamObserver = new AtomicReference<>();
+    private final AtomicReference<ClientCallStreamObserver<I>> requestStreamObserver = new AtomicReference<>();
+    private final Runnable onReady;
 
-    public UniStreamObserver(UniEmitter<? super O> emitter, Runnable onTermination) {
+    public UniStreamObserver(UniEmitter<? super O> emitter, Runnable onTermination, Runnable onReady) {
+        this.onReady = onReady;
         this.emitter = emitter.onTermination(() -> {
             // This is called when the reply Uni (the return value of the RPC method) is cancelled or the gRPC server completes the request.
             if (terminated.compareAndSet(false, true)) {
@@ -32,9 +34,16 @@ public class UniStreamObserver<I, O> implements ClientResponseObserver<I, O> {
         });
     }
 
+    public UniStreamObserver(UniEmitter<? super O> emitter, Runnable onTermination) {
+        this(emitter, onTermination, null);
+    }
+
     @Override
     public void beforeStart(ClientCallStreamObserver<I> requestStreamObserver) {
         this.requestStreamObserver.set(requestStreamObserver);
+        if (onReady != null) {
+            requestStreamObserver.setOnReadyHandler(onReady);
+        }
     }
 
     @Override


### PR DESCRIPTION
**INITIAL PROBLEM**
Due to the absence of traffic control, a fast emitter involved in streaming (unilateral or bilateral) could lead to `OutOfMemoryException` on the server side (if the server could not send data fast enough), or in the client side (if the client could not consume it fast enough)

**SOLUTION**
By leveraging grpc experimental apis `ServerCallStreamObserver` and `ClientCallStreamObserver`, it is now possible to regulate the rate at which grpc server sends data to grpc client.
On the server side, the sending will be triggered by a `onReady(cb)` callback leveraging HTTP2 readiness based on window size. On the client, it is now possible to set a `request()` strategy.

It is important to note that the client `request()` api does not request data directly from the server. It requests data from the `DirectMemoryBuffer` on the client side. The rate at which the client frees DirectMemoryBuffer (by paring buffers and instantiating grpc types in heap) changes how frequently the HTTP2 window size will be large enough to receive data, and thus how frequently the server `onReady()` callback will be called.

We also implemented a way to consume MultiEmitters lazily on the server side to avoid OOME: if a Multi creates instance eagerly, it might create too many instances in heap that are sent slowly to a slow client. They accumulate in heap on the server side and crash it.

Example of a 1-N call from a client:

*server side*
service method definition -> Mutli ----|heap|----> ServerCallStreamObserver

----> network ---->

*client side*
direct memory buffer ----> ClientCallStreamObserver --|heap|--> Multi consumed by service method definition.

HTTP2 window size is responsible for avoiding direct memory buffer running out of memory and ending the session thanks to the ServerCallStreamObserver.

**IMPROVEMENTS**:
The strategy we use is the most conservative: the ServerCallStreamObserver requests item from the multi defined by the user in the service definition 1 by 1, it would be possible to consume it faster depending on the client's demand. We would use more memory to reduce latency.

The same is true on the client side, we request data from the `DirectMemoryBuffer` slowly, 1 element per 1 element, and we could go faster if enough memory is available.

- Fixes: #46475 
- Replaces: #47149 
