### PR TITLE
Ensure `@Transactional` Unis can be re-executed

### DIFF
--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/transaction/HibernateReactiveTransactionalRetryTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/transaction/HibernateReactiveTransactionalRetryTest.java
@@ -1,0 +1,97 @@
+package io.quarkus.hibernate.reactive.transaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.vertx.RunOnVertxContext;
+import io.quarkus.test.vertx.UniAsserter;
+import io.smallrye.mutiny.Uni;
+
+public class HibernateReactiveTransactionalRetryTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar
+                    .addClasses(Hero.class)
+                    .addAsResource("initialTransactionRetryData.sql", "import.sql"))
+            .withConfigurationResource("application-reactive-transaction.properties");
+
+    @Inject
+    Mutiny.SessionFactory sessionFactory;
+
+    @Inject
+    Mutiny.Session session;
+
+    private final AtomicInteger callCounter = new AtomicInteger();
+
+    @Test
+    @RunOnVertxContext
+    public void testTransactionalRetry(UniAsserter asserter) {
+        Long hero1Id = 50L;
+        Long hero2Id = 51L;
+        callCounter.set(0);
+
+        // Test that:
+        // 1. First call fails -> DB changes to hero1 are rolled back
+        // 2. Method is retried (second call)
+        // 3. Second call succeeds -> DB changes to hero2 are committed
+        asserter.assertThat(
+                () -> updateHeroWithRetry(hero1Id, hero2Id)
+                        .onFailure().retry().atMost(1),
+                h -> {
+                    // Verify the successful update returned hero2
+                    assertThat(h.id).isEqualTo(hero2Id);
+                    assertThat(h.name).isEqualTo("updatedHero2");
+                    // Verify the method was called twice (first failed, second succeeded)
+                    assertThat(callCounter.get()).isEqualTo(2);
+                });
+
+        // Verify that hero1 still has its original name (first call was rolled back)
+        asserter.assertThat(
+                () -> findHero(hero1Id),
+                h -> assertThat(h.name).isEqualTo("hero1"));
+
+        // Verify that hero2 has the updated name (second call was committed)
+        asserter.assertThat(
+                () -> findHero(hero2Id),
+                h -> assertThat(h.name).isEqualTo("updatedHero2"));
+    }
+
+    @Transactional
+    public Uni<Hero> updateHeroWithRetry(Long hero1Id, Long hero2Id) {
+        int invocation = callCounter.incrementAndGet();
+
+        if (invocation == 1) {
+            // First call: update hero1, then fail
+            return session.find(Hero.class, hero1Id)
+                    .map(hero -> {
+                        hero.setName("shouldBeRolledBack");
+                        return hero;
+                    })
+                    .onItem().invoke(() -> {
+                        throw new RuntimeException("Simulated failure on first call");
+                    });
+        } else {
+            // Second call: update hero2, then succeed
+            return session.find(Hero.class, hero2Id)
+                    .map(hero -> {
+                        hero.setName("updatedHero2");
+                        return hero;
+                    });
+        }
+    }
+
+    @Transactional
+    public Uni<Hero> findHero(Long heroId) {
+        return session.find(Hero.class, heroId);
+    }
+}

--- a/extensions/hibernate-reactive/deployment/src/test/resources/initialTransactionRetryData.sql
+++ b/extensions/hibernate-reactive/deployment/src/test/resources/initialTransactionRetryData.sql
@@ -1,0 +1,2 @@
+insert into Hero (id, name) values (50, 'hero1');
+insert into Hero (id, name) values (51, 'hero2');

--- a/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/TransactionalInterceptorBase.java
+++ b/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/TransactionalInterceptorBase.java
@@ -65,9 +65,9 @@ public abstract class TransactionalInterceptorBase {
             validateLegacyPanacheAnnotations();
 
             Transactional annotation = getTransactionalAnnotation(context);
-            return defineReactiveTransactionalChain(annotation, method, () -> {
-                return proceedUni(context);
-            });
+            // Deferral allows the Uni to be reused (re-subscribed-to) in different Vert.x contexts.
+            return Uni.createFrom()
+                    .deferred(() -> defineReactiveTransactionalChain(annotation, method, () -> proceedUni(context)));
         }
         LOG.tracef("Transactional interceptor end from method %s", method);
         return context.proceed();
@@ -77,7 +77,7 @@ public abstract class TransactionalInterceptorBase {
         Context context = vertxContext();
 
         if (context.getLocal(TRANSACTIONAL_METHOD_KEY) == null) {
-            // This is the parent method, responsible for commit, rollback or cancelation of the transaction
+            // This is the parent method, responsible for commit, rollback or cancellation of the transaction
 
             /*
              * Mark the current context to be @Transactional


### PR DESCRIPTION
I noticed this was missing while thinking about https://groups.google.com/g/quarkus-dev/c/dddcxKaS5rY/m/_JVSXtitAAAJ?utm_medium=email&utm_source=footer

If a Uni gets subscribed to twice, I think we want the Vert.x context to be checked each time, because it might be different.

Indeed, before the fix included in this PR, the test fails because it reuses context from the first subscription. Stack trace:

```
io.quarkus.hibernate.reactive.transaction.HibernateReactiveTransactionalRetryTest.testTransactionalRetry(UniAsserter) -- Time elapsed: 0.327 s <<< ERROR!
io.smallrye.mutiny.CompositeException:
Multiple exceptions caught:
        [Exception 0] io.smallrye.mutiny.CompositeException: Multiple exceptions caught:
        [Exception 0] java.lang.IllegalStateException: Session/EntityManager is closed
        [Exception 1] java.lang.NullPointerException: Cannot invoke "io.vertx.sqlclient.Transaction.rollback()" because "transaction" is null
        [Exception 1] io.vertx.core.impl.NoStackTraceThrowable: Connection released twice
        at io.smallrye.mutiny.operators.uni.UniOnTerminationCall$UniOnTerminationCallProcessor.lambda$onFailure$4(UniOnTerminationCall.java:83)
        at io.smallrye.context.impl.wrappers.SlowContextualConsumer.accept(SlowContextualConsumer.java:21)
        at io.smallrye.mutiny.helpers.UniCallbackSubscriber.onFailure(UniCallbackSubscriber.java:62)
        at io.smallrye.mutiny.operators.uni.builders.DefaultUniEmitter.fail(DefaultUniEmitter.java:53)
        at io.vertx.core.impl.future.FutureImpl$3.onFailure(FutureImpl.java:151)
        at io.vertx.core.impl.future.FutureBase.emitFailure(FutureBase.java:81)
        at io.vertx.core.impl.future.FutureImpl.addListener(FutureImpl.java:226)
        at io.vertx.core.impl.future.FutureImpl.onComplete(FutureImpl.java:132)
        at io.quarkus.reactive.transaction.TransactionalInterceptorBase.lambda$toUni$0(TransactionalInterceptorBase.java:163)
        at io.smallrye.context.impl.wrappers.SlowContextualConsumer.accept(SlowContextualConsumer.java:21)
        at io.smallrye.mutiny.operators.uni.builders.UniCreateWithEmitter.subscribe(UniCreateWithEmitter.java:22)
        at io.smallrye.mutiny.operators.AbstractUni.subscribe(AbstractUni.java:35)
        at io.smallrye.mutiny.groups.UniSubscribe.withSubscriber(UniSubscribe.java:51)
        at io.smallrye.mutiny.groups.UniSubscribe.with(UniSubscribe.java:110)
        at io.smallrye.mutiny.operators.uni.UniOnTerminationCall$UniOnTerminationCallProcessor.onFailure(UniOnTerminationCall.java:80)
        at io.smallrye.mutiny.operators.uni.UniOnTerminationCall$UniOnTerminationCallProcessor.lambda$onFailure$3(UniOnTerminationCall.java:82)
        at io.smallrye.context.impl.wrappers.SlowContextualConsumer.accept(SlowContextualConsumer.java:21)
        at io.smallrye.mutiny.helpers.UniCallbackSubscriber.onItem(UniCallbackSubscriber.java:73)
        at io.smallrye.mutiny.operators.uni.UniOnTermination$UniOnTerminationProcessor.onItem(UniOnTermination.java:39)
        at io.smallrye.mutiny.operators.uni.builders.UniCreateFromKnownItem$KnownItemSubscription.forward(UniCreateFromKnownItem.java:42)
        at io.smallrye.mutiny.operators.uni.builders.UniCreateFromKnownItem.subscribe(UniCreateFromKnownItem.java:23)
        at io.smallrye.mutiny.operators.AbstractUni.subscribe(AbstractUni.java:35)
        at io.smallrye.mutiny.operators.uni.UniOnTermination.subscribe(UniOnTermination.java:21)
        at io.smallrye.mutiny.operators.AbstractUni.subscribe(AbstractUni.java:35)
        at io.smallrye.mutiny.groups.UniSubscribe.withSubscriber(UniSubscribe.java:51)
        at io.smallrye.mutiny.groups.UniSubscribe.with(UniSubscribe.java:110)
        at io.smallrye.mutiny.operators.uni.UniOnTerminationCall$UniOnTerminationCallProcessor.onFailure(UniOnTerminationCall.java:80)
        at io.smallrye.mutiny.operators.uni.UniOperatorProcessor.onFailure(UniOperatorProcessor.java:55)
        at io.smallrye.mutiny.operators.uni.UniOnCancellationCall$UniOnCancellationCallProcessor.onFailure(UniOnCancellationCall.java:59)
        at io.smallrye.mutiny.operators.uni.UniOnFailureFlatMap$UniOnFailureFlatMapProcessor.performInnerSubscription(UniOnFailureFlatMap.java:97)
        at io.smallrye.mutiny.operators.uni.UniOnFailureFlatMap$UniOnFailureFlatMapProcessor.dispatch(UniOnFailureFlatMap.java:86)
        at io.smallrye.mutiny.operators.uni.UniOnFailureFlatMap$UniOnFailureFlatMapProcessor.onFailure(UniOnFailureFlatMap.java:63)
        at io.smallrye.mutiny.operators.uni.UniOnItemConsume$UniOnItemComsumeProcessor.onFailure(UniOnItemConsume.java:69)
        at io.smallrye.mutiny.operators.uni.UniOperatorProcessor.onFailure(UniOperatorProcessor.java:55)
        at io.smallrye.mutiny.operators.uni.UniOperatorProcessor.onFailure(UniOperatorProcessor.java:55)
        at io.smallrye.mutiny.helpers.EmptyUniSubscription.propagateFailureEvent(EmptyUniSubscription.java:40)
        at io.smallrye.mutiny.operators.uni.builders.UniCreateFromCompletionStage.subscribe(UniCreateFromCompletionStage.java:26)
        at io.smallrye.mutiny.operators.AbstractUni.subscribe(AbstractUni.java:35)
        at io.smallrye.mutiny.operators.uni.UniRunSubscribeOn.lambda$subscribe$0(UniRunSubscribeOn.java:27)
        at org.hibernate.reactive.context.impl.VertxContext.execute(VertxContext.java:90)
        at io.smallrye.mutiny.operators.uni.UniRunSubscribeOn.subscribe(UniRunSubscribeOn.java:25)
        at io.smallrye.mutiny.operators.AbstractUni.subscribe(AbstractUni.java:35)
        at io.smallrye.mutiny.operators.uni.UniOnItemTransform.subscribe(UniOnItemTransform.java:22)
        at io.smallrye.mutiny.operators.AbstractUni.subscribe(AbstractUni.java:35)
        at io.smallrye.mutiny.operators.uni.UniOnItemConsume.subscribe(UniOnItemConsume.java:34)
        at io.smallrye.mutiny.operators.AbstractUni.subscribe(AbstractUni.java:35)
        at io.smallrye.mutiny.operators.uni.UniOnFailureFlatMap.subscribe(UniOnFailureFlatMap.java:34)
        at io.smallrye.mutiny.operators.AbstractUni.subscribe(AbstractUni.java:35)
        at io.smallrye.mutiny.operators.uni.UniOnCancellationCall.subscribe(UniOnCancellationCall.java:27)
        at io.smallrye.mutiny.operators.AbstractUni.subscribe(AbstractUni.java:35)
        at io.smallrye.mutiny.operators.uni.UniOnItemTransformToUni.subscribe(UniOnItemTransformToUni.java:25)
        at io.smallrye.mutiny.operators.AbstractUni.subscribe(AbstractUni.java:35)
        at io.smallrye.mutiny.groups.UniSubscribe.withSubscriber(UniSubscribe.java:51)
        at io.smallrye.mutiny.operators.uni.UniOnTerminationCall.subscribe(UniOnTerminationCall.java:28)
        at io.smallrye.mutiny.operators.AbstractUni.subscribe(AbstractUni.java:35)
        at io.smallrye.mutiny.groups.UniSubscribe.withSubscriber(UniSubscribe.java:51)
        at io.smallrye.mutiny.operators.uni.UniOnTerminationCall.subscribe(UniOnTerminationCall.java:28)
        at io.smallrye.mutiny.operators.AbstractUni.subscribe(AbstractUni.java:35)
        at io.smallrye.mutiny.operators.uni.UniRetryAtMost$UniRetryAtMostProcessor.onFailure(UniRetryAtMost.java:74)
        at io.smallrye.mutiny.operators.uni.UniOnTerminationCall$UniOnTerminationCallProcessor.lambda$onFailure$3(UniOnTerminationCall.java:82)
        at io.smallrye.context.impl.wrappers.SlowContextualConsumer.accept(SlowContextualConsumer.java:21)
        at io.smallrye.mutiny.helpers.UniCallbackSubscriber.onItem(UniCallbackSubscriber.java:73)
        at io.smallrye.mutiny.operators.uni.builders.DefaultUniEmitter.complete(DefaultUniEmitter.java:37)
        at io.vertx.core.impl.future.FutureImpl$3.onSuccess(FutureImpl.java:137)
        at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:66)
        at io.vertx.core.impl.future.FutureImpl.addListener(FutureImpl.java:231)
        at io.vertx.core.impl.future.FutureImpl.onComplete(FutureImpl.java:132)
        at io.quarkus.reactive.transaction.TransactionalInterceptorBase.lambda$toUni$0(TransactionalInterceptorBase.java:163)
        at io.smallrye.context.impl.wrappers.SlowContextualConsumer.accept(SlowContextualConsumer.java:21)
        at io.smallrye.mutiny.operators.uni.builders.UniCreateWithEmitter.subscribe(UniCreateWithEmitter.java:22)
        at io.smallrye.mutiny.operators.AbstractUni.subscribe(AbstractUni.java:35)
        at io.smallrye.mutiny.groups.UniSubscribe.withSubscriber(UniSubscribe.java:51)
        at io.smallrye.mutiny.groups.UniSubscribe.with(UniSubscribe.java:110)
        at io.smallrye.mutiny.operators.uni.UniOnTerminationCall$UniOnTerminationCallProcessor.onFailure(UniOnTerminationCall.java:80)
        at io.smallrye.mutiny.operators.uni.UniOnTerminationCall$UniOnTerminationCallProcessor.lambda$onFailure$3(UniOnTerminationCall.java:82)
        at io.smallrye.context.impl.wrappers.SlowContextualConsumer.accept(SlowContextualConsumer.java:21)
        at io.smallrye.mutiny.helpers.UniCallbackSubscriber.onItem(UniCallbackSubscriber.java:73)
        at io.smallrye.mutiny.operators.uni.UniOnTermination$UniOnTerminationProcessor.onItem(UniOnTermination.java:39)
        at io.smallrye.mutiny.operators.uni.UniAndCombination$AndSupervisor.computeAndFireTheOutcome(UniAndCombination.java:159)
        at io.smallrye.mutiny.operators.uni.UniAndCombination$AndSupervisor.check(UniAndCombination.java:137)
        at io.smallrye.mutiny.operators.uni.UniAndCombination$UniHandler.onItem(UniAndCombination.java:232)
        at io.smallrye.mutiny.operators.uni.builders.UniCreateFromKnownItem$KnownItemSubscription.forward(UniCreateFromKnownItem.java:42)
        at io.smallrye.mutiny.operators.uni.builders.UniCreateFromKnownItem.subscribe(UniCreateFromKnownItem.java:23)
        at io.smallrye.mutiny.operators.AbstractUni.subscribe(AbstractUni.java:35)
        at io.smallrye.mutiny.operators.uni.UniAndCombination$UniHandler.subscribe(UniAndCombination.java:245)
        at io.smallrye.mutiny.operators.uni.UniAndCombination$AndSupervisor.run(UniAndCombination.java:88)
        at io.smallrye.mutiny.operators.uni.UniAndCombination.subscribe(UniAndCombination.java:53)
        at io.smallrye.mutiny.operators.AbstractUni.subscribe(AbstractUni.java:35)
        at io.smallrye.mutiny.operators.uni.UniOnTermination.subscribe(UniOnTermination.java:21)
        at io.smallrye.mutiny.operators.AbstractUni.subscribe(AbstractUni.java:35)
        at io.smallrye.mutiny.groups.UniSubscribe.withSubscriber(UniSubscribe.java:51)
        at io.smallrye.mutiny.groups.UniSubscribe.with(UniSubscribe.java:110)
        at io.smallrye.mutiny.operators.uni.UniOnTerminationCall$UniOnTerminationCallProcessor.onFailure(UniOnTerminationCall.java:80)
        at io.smallrye.mutiny.operators.uni.UniOperatorProcessor.onFailure(UniOperatorProcessor.java:55)
        at io.smallrye.mutiny.operators.uni.UniOnCancellationCall$UniOnCancellationCallProcessor.onFailure(UniOnCancellationCall.java:59)
        at io.smallrye.mutiny.operators.uni.UniOnFailureFlatMap$UniOnFailureFlatMapProcessor.onFailure(UniOnFailureFlatMap.java:65)
        at io.smallrye.mutiny.operators.uni.UniOnFailureTransform$UniOnFailureTransformProcessor.onFailure(UniOnFailureTransform.java:67)
        at io.smallrye.mutiny.operators.uni.UniOperatorProcessor.onFailure(UniOperatorProcessor.java:55)
        at io.smallrye.mutiny.operators.uni.builders.UniCreateFromKnownFailure$KnownFailureSubscription.forward(UniCreateFromKnownFailure.java:42)
        at io.smallrye.mutiny.operators.uni.builders.UniCreateFromKnownFailure.subscribe(UniCreateFromKnownFailure.java:23)
        at io.smallrye.mutiny.operators.AbstractUni.subscribe(AbstractUni.java:35)
        at io.smallrye.mutiny.operators.uni.UniOnItemTransformToUni$UniOnItemTransformToUniProcessor.performInnerSubscription(UniOnItemTransformToUni.java:81)
        at io.smallrye.mutiny.operators.uni.UniOnItemTransformToUni$UniOnItemTransformToUniProcessor.onItem(UniOnItemTransformToUni.java:57)
        at io.smallrye.mutiny.operators.uni.UniOnItemConsume$UniOnItemComsumeProcessor.onItem(UniOnItemConsume.java:47)
        at io.smallrye.mutiny.operators.uni.UniOnItemConsume$UniOnItemComsumeProcessor.onItem(UniOnItemConsume.java:47)
        at io.smallrye.mutiny.operators.uni.builders.DefaultUniEmitter.complete(DefaultUniEmitter.java:37)
        at io.vertx.core.impl.future.FutureImpl$3.onSuccess(FutureImpl.java:137)
        at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:66)
        at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:259)
        at io.vertx.core.impl.future.FixedMapping.onSuccess(FixedMapping.java:31)
        at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:66)
        at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:259)
        at io.vertx.core.Promise.complete(Promise.java:66)
        at io.vertx.sqlclient.impl.TransactionImpl.lambda$txCommand$2(TransactionImpl.java:154)
        at io.vertx.core.impl.future.FutureImpl$4.onSuccess(FutureImpl.java:176)
        at io.vertx.core.impl.future.FutureBase.lambda$emitSuccess$0(FutureBase.java:60)
        at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173)
        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166)
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472)
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569)
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:998)
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.base/java.lang.Thread.run(Thread.java:1474)
        Suppressed: io.vertx.core.impl.NoStackTraceThrowable: Connection released twice
Caused by: io.smallrye.mutiny.CompositeException: Multiple exceptions caught:
        [Exception 0] java.lang.IllegalStateException: Session/EntityManager is closed
        [Exception 1] java.lang.NullPointerException: Cannot invoke "io.vertx.sqlclient.Transaction.rollback()" because "transaction" is null
        ... 95 more
        Suppressed: java.lang.NullPointerException: Cannot invoke "io.vertx.sqlclient.Transaction.rollback()" because "transaction" is null
                at io.quarkus.reactive.transaction.TransactionalInterceptorBase.actualRollback(TransactionalInterceptorBase.java:214)
                at io.quarkus.reactive.transaction.TransactionalInterceptorBase.rollbackOrCommitBasedOnException(TransactionalInterceptorBase.java:210)
                at io.quarkus.reactive.transaction.TransactionalInterceptorBase.lambda$defineReactiveTransactionalChain$0(TransactionalInterceptorBase.java:92)
                at io.smallrye.context.impl.wrappers.SlowContextualFunction.apply(SlowContextualFunction.java:21)
                at io.smallrye.mutiny.groups.UniOnFailure.lambda$call$4(UniOnFailure.java:105)
                at io.smallrye.context.impl.wrappers.SlowContextualFunction.apply(SlowContextualFunction.java:21)
                at io.smallrye.mutiny.operators.uni.UniOnFailureFlatMap$UniOnFailureFlatMapProcessor.performInnerSubscription(UniOnFailureFlatMap.java:95)
                ... 94 more
Caused by: java.lang.IllegalStateException: Session/EntityManager is closed
        at org.hibernate.internal.AbstractSharedSessionContract.checkOpen(AbstractSharedSessionContract.java:576)
        at org.hibernate.internal.SessionImpl.checkOpen(SessionImpl.java:156)
        at org.hibernate.engine.spi.SharedSessionContractImplementor.checkOpen(SharedSessionContractImplementor.java:188)
        at org.hibernate.reactive.session.impl.ReactiveSessionImpl.checkOpen(ReactiveSessionImpl.java:1777)
        at org.hibernate.reactive.session.impl.ReactiveSessionImpl.reactiveFind(ReactiveSessionImpl.java:1242)
        at org.hibernate.reactive.session.ReactiveSession.reactiveFind(ReactiveSession.java:96)
        at org.hibernate.reactive.mutiny.impl.MutinySessionImpl.lambda$find$3(MutinySessionImpl.java:223)
        at io.smallrye.context.impl.wrappers.SlowContextualSupplier.get(SlowContextualSupplier.java:21)
        at io.smallrye.mutiny.operators.uni.builders.UniCreateFromCompletionStage.subscribe(UniCreateFromCompletionStage.java:24)
        ... 87 more
```
