### PR TITLE
Remove NativeBuild/NativeOrNativeSourcesBuild conditions from build items that are consumed only by native build build steps

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -88,7 +88,7 @@ public class NativeImageBuildStep {
     public static final String APP_SOURCES = "app-sources";
     public static final String ARTIFACT_RESULT_TYPE = "native";
 
-    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    @BuildStep
     void nativeImageFeatures(BuildProducer<NativeImageFeatureBuildItem> features) {
         features.produce(new NativeImageFeatureBuildItem(NativeImageFeatureStep.GRAAL_FEATURE));
         features.produce(new NativeImageFeatureBuildItem(DisableLoggingFeature.class));

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/LocaleProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/LocaleProcessor.java
@@ -36,7 +36,7 @@ public class LocaleProcessor {
         //Adding sun.util.resources.TimeZoneNames is not necessary.
     }
 
-    @BuildStep(onlyIf = { NativeBuild.class, NonDefaultLocale.class })
+    @BuildStep(onlyIf = NonDefaultLocale.class)
     ReflectiveClassBuildItem setupReflectionClasses() {
         return ReflectiveClassBuildItem.builder("sun.util.resources.provider.SupplementaryLocaleDataProvider",
                 "sun.util.resources.provider.LocaleDataProvider").build();

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageConfigBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageConfigBuildStep.java
@@ -20,7 +20,6 @@ import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBundleBuil
 import io.quarkus.deployment.builditem.nativeimage.NativeImageSystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.pkg.NativeConfig;
-import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.runtime.ssl.SslContextConfigurationRecorder;
 
 //TODO: this should go away, once we decide on which one of the API's we want
@@ -78,7 +77,7 @@ class NativeImageConfigBuildStep {
         }
     }
 
-    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    @BuildStep
     void reinitHostNameUtil(BuildProducer<RuntimeInitializedClassBuildItem> runtimeReInitClass) {
         // certain libraries like JBoss logging internally use this class to determine the hostname
         // of the system. This HostName class computes and stores the hostname as a static field in a class,

--- a/extensions/amazon-lambda-xray/deployment/src/main/java/io/quarkus/amazon/lambda/xray/XrayBuildStep.java
+++ b/extensions/amazon-lambda-xray/deployment/src/main/java/io/quarkus/amazon/lambda/xray/XrayBuildStep.java
@@ -6,10 +6,9 @@ import io.quarkus.deployment.builditem.nativeimage.NativeImageProxyDefinitionBui
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
-import io.quarkus.deployment.pkg.steps.NativeBuild;
 
 public class XrayBuildStep {
-    @BuildStep(onlyIf = NativeBuild.class)
+    @BuildStep
     public void process(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<NativeImageProxyDefinitionBuildItem> proxyDefinition,
             BuildProducer<RuntimeInitializedClassBuildItem> runtimeInitialized,

--- a/extensions/amazon-lambda/common-deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaCommonProcessor.java
+++ b/extensions/amazon-lambda/common-deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaCommonProcessor.java
@@ -81,7 +81,7 @@ public final class AmazonLambdaCommonProcessor {
         }
     }
 
-    @BuildStep(onlyIf = NativeBuild.class)
+    @BuildStep
     public void registerForSerialization(BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
         reflectiveClass.produce(ReflectiveClassBuildItem.builder(
                 FunctionError.class.getName()).build());

--- a/extensions/awt/deployment/src/main/java/io/quarkus/awt/deployment/AwtProcessor.java
+++ b/extensions/awt/deployment/src/main/java/io/quarkus/awt/deployment/AwtProcessor.java
@@ -38,7 +38,7 @@ class AwtProcessor {
         return new FeatureBuildItem(Feature.AWT);
     }
 
-    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    @BuildStep
     void nativeImageFeatures(BuildProducer<NativeImageFeatureBuildItem> nativeImageFeatures) {
         nativeImageFeatures.produce(new NativeImageFeatureBuildItem(DarwinAwtFeature.class));
         nativeImageFeatures.produce(new NativeImageFeatureBuildItem(AwtFeature.class));
@@ -77,7 +77,7 @@ class AwtProcessor {
                         .build());
     }
 
-    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    @BuildStep
     ReflectiveClassBuildItem setupReflectionClasses() {
         return ReflectiveClassBuildItem.builder(
                 "com.sun.imageio.plugins.common.I18N",
@@ -86,7 +86,7 @@ class AwtProcessor {
                 "sun.awt.X11GraphicsEnvironment").build();
     }
 
-    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    @BuildStep
     ReflectiveClassBuildItem setupReflectionClassesWithMethods() {
         //@formatter:off
         return ReflectiveClassBuildItem.builder(

--- a/extensions/caffeine/deployment/src/main/java/io/quarkus/caffeine/deployment/CaffeineProcessor.java
+++ b/extensions/caffeine/deployment/src/main/java/io/quarkus/caffeine/deployment/CaffeineProcessor.java
@@ -16,7 +16,6 @@ import io.quarkus.deployment.builditem.NativeImageFeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageSystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.metrics.MetricsCapabilityBuildItem;
-import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.runtime.metrics.MetricsFactory;
 
 public class CaffeineProcessor {
@@ -52,12 +51,12 @@ public class CaffeineProcessor {
         }
     }
 
-    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    @BuildStep
     NativeImageFeatureBuildItem nativeImageFeature() {
         return new NativeImageFeatureBuildItem(CacheConstructorsFeature.class);
     }
 
-    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    @BuildStep
     NativeImageSystemPropertyBuildItem registerRecordStatsImplementationsIfMicrometerAround(
             Optional<MetricsCapabilityBuildItem> metricsCapability) {
         if (metricsCapability.isEmpty()) {

--- a/extensions/funqy/funqy-amazon-lambda/deployment/src/main/java/io/quarkus/funqy/deployment/bindings/FunqyAmazonLambdaProcessor.java
+++ b/extensions/funqy/funqy-amazon-lambda/deployment/src/main/java/io/quarkus/funqy/deployment/bindings/FunqyAmazonLambdaProcessor.java
@@ -11,7 +11,6 @@ import com.amazonaws.services.lambda.runtime.events.models.kinesis.Record;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
-import io.quarkus.deployment.pkg.steps.NativeBuild;
 import io.quarkus.funqy.lambda.model.cloudevents.CloudEventDataV1;
 import io.quarkus.funqy.lambda.model.cloudevents.CloudEventV1;
 import io.quarkus.funqy.lambda.model.kinesis.PipesKinesisEvent;
@@ -20,7 +19,7 @@ import io.quarkus.funqy.lambda.model.pipes.Response;
 
 public class FunqyAmazonLambdaProcessor {
 
-    @BuildStep(onlyIf = NativeBuild.class)
+    @BuildStep
     public void process(BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
         reflectiveClass.produce(ReflectiveClassBuildItem.builder(
                 // io CloudEvents

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -204,7 +204,7 @@ public final class HibernateOrmProcessor {
         return new NativeImageFeatureBuildItem(RegisterServicesForReflectionFeature.class);
     }
 
-    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    @BuildStep
     void registerStrategyForReflection(
             BuildProducer<ReflectiveClassBuildItem> reflective) {
 
@@ -554,7 +554,7 @@ public final class HibernateOrmProcessor {
         return new BytecodeRecorderConstantDefinitionBuildItem(PreGeneratedProxies.class, proxyDefinitions);
     }
 
-    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    @BuildStep
     public void preGenAnnotationProxies(List<PersistenceUnitDescriptorBuildItem> persistenceUnitDescriptorBuildItems,
             BuildProducer<ReflectiveClassBuildItem> reflective,
             BuildProducer<NativeImageProxyDefinitionBuildItem> proxyDefinitions) {
@@ -841,7 +841,7 @@ public final class HibernateOrmProcessor {
         }
     }
 
-    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    @BuildStep
     public void registerStaticMetamodelClassesForReflection(CombinedIndexBuildItem index,
             BuildProducer<ReflectiveClassBuildItem> reflective) {
         Collection<AnnotationInstance> annotationInstances = index.getIndex().getAnnotations(ClassNames.STATIC_METAMODEL);
@@ -861,7 +861,7 @@ public final class HibernateOrmProcessor {
      * Enable reflection for methods annotated with @InjectService,
      * such as org.hibernate.engine.jdbc.cursor.internal.StandardRefCursorSupport.injectJdbcServices.
      */
-    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    @BuildStep
     public void registerInjectServiceMethodsForReflection(CombinedIndexBuildItem index,
             BuildProducer<ReflectiveClassBuildItem> reflective) {
         Set<String> classes = new HashSet<>();

--- a/extensions/jaxb/deployment/src/main/java/io/quarkus/jaxb/deployment/JaxbProcessor.java
+++ b/extensions/jaxb/deployment/src/main/java/io/quarkus/jaxb/deployment/JaxbProcessor.java
@@ -80,7 +80,6 @@ import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyIgnoreWarningBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
-import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.jaxb.runtime.JaxbConfig;
 import io.quarkus.jaxb.runtime.JaxbContextConfigRecorder;
 import io.quarkus.jaxb.runtime.JaxbContextProducer;
@@ -554,7 +553,7 @@ public class JaxbProcessor {
         return XmlAccessType.valueOf(xmlAccessorTypeAi.value().asEnum());
     }
 
-    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    @BuildStep
     void jaxbIndex(final BuildProducer<NativeImageResourcePatternsBuildItem> resource) {
         LOG.debug("adding jaxb.index to native image resources");
         resource.produce(NativeImageResourcePatternsBuildItem.builder().includeGlob("**/jaxb.index").build());

--- a/extensions/jdbc/jdbc-mariadb/deployment/src/main/java/io/quarkus/jdbc/mariadb/deployment/JDBCMariaDBProcessor.java
+++ b/extensions/jdbc/jdbc-mariadb/deployment/src/main/java/io/quarkus/jdbc/mariadb/deployment/JDBCMariaDBProcessor.java
@@ -14,7 +14,6 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
-import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.jdbc.mariadb.runtime.MariaDBAgroalConnectionConfigurer;
 import io.quarkus.jdbc.mariadb.runtime.MariaDBServiceBindingConverter;
 
@@ -62,7 +61,7 @@ public class JDBCMariaDBProcessor {
                 .produce(ServiceProviderBuildItem.allProvidersFromClassPath("org.mariadb.jdbc.plugin.Codec"));
     }
 
-    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    @BuildStep
     void addNativeImageResources(BuildProducer<NativeImageResourceBuildItem> resources) {
         // mariadb.properties is used by org.mariadb.jdbc.util.VersionFactory and is small enough.
         // driver.properties is not added because it only provides optional descriptions for

--- a/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleMetadataOverrides.java
+++ b/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleMetadataOverrides.java
@@ -35,7 +35,7 @@ import io.quarkus.maven.dependency.ArtifactKey;
  * require it, so this would facilitate the option to revert to the older version in
  * case of problems.
  */
-@BuildSteps(onlyIf = NativeOrNativeSourcesBuild.class)
+@BuildSteps
 public final class OracleMetadataOverrides {
 
     static final String DRIVER_JAR_MATCH_REGEX = "com\\.oracle\\.database\\.jdbc";
@@ -136,7 +136,7 @@ public final class OracleMetadataOverrides {
         runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.diagnostics.OracleDiagnosticsMXBean"));
     }
 
-    @BuildStep
+    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
     void excludeOracleDirectives(BuildProducer<ExcludeConfigBuildItem> nativeImageExclusions) {
         // Excludes both native-image.properties and reflect-config.json, which are reimplemented above.
         // N.B. this could be expressed by using a single regex to match both resources,
@@ -151,7 +151,7 @@ public final class OracleMetadataOverrides {
         return new NativeImageAllowIncompleteClasspathBuildItem("quarkus-jdbc-oracle");
     }
 
-    @BuildStep
+    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
     RemovedResourceBuildItem enhancedCharsetSubstitutions() {
         return new RemovedResourceBuildItem(ArtifactKey.fromString("com.oracle.database.jdbc:ojdbc17"),
                 Collections.singleton("oracle/nativeimage/CharacterSetFeature.class"));

--- a/extensions/jdbc/jdbc-postgresql/deployment/src/main/java/io/quarkus/jdbc/postgresql/deployment/JDBCPostgreSQLProcessor.java
+++ b/extensions/jdbc/jdbc-postgresql/deployment/src/main/java/io/quarkus/jdbc/postgresql/deployment/JDBCPostgreSQLProcessor.java
@@ -17,7 +17,6 @@ import io.quarkus.deployment.builditem.SslNativeConfigBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
-import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.jdbc.postgresql.runtime.PostgreSQLAgroalConnectionConfigurer;
 import io.quarkus.jdbc.postgresql.runtime.PostgreSQLServiceBindingConverter;
 import io.quarkus.jdbc.postgresql.runtime.graal.SQLXMLFeature;
@@ -29,12 +28,12 @@ public class JDBCPostgreSQLProcessor {
         return new FeatureBuildItem(Feature.JDBC_POSTGRESQL);
     }
 
-    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    @BuildStep
     NativeImageFeatureBuildItem nativeImageFeature() {
         return new NativeImageFeatureBuildItem(SQLXMLFeature.class);
     }
 
-    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    @BuildStep
     RuntimeInitializedClassBuildItem runtimeReinitialize() {
         return new RuntimeInitializedClassBuildItem("org.postgresql.util.PasswordUtil$SecureRandomHolder");
     }

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
@@ -75,7 +75,6 @@ import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.logging.LogCleanupFilterBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.deployment.pkg.steps.NativeImageFutureDefault;
-import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.kafka.client.runtime.KafkaAdminClient;
 import io.quarkus.kafka.client.runtime.KafkaBindingConverter;
 import io.quarkus.kafka.client.runtime.KafkaRecorder;
@@ -324,14 +323,13 @@ public class KafkaProcessor {
                 "The tls-configuration to use for the Kafka client", null, null, ConfigPhase.RUN_TIME));
     }
 
-    @BuildStep(onlyIf = { HasSnappy.class, NativeOrNativeSourcesBuild.class })
-    public void handleSnappyInNative(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
+    @BuildStep(onlyIf = HasSnappy.class)
+    public void handleSnappyReflection(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<NativeImageFeatureBuildItem> feature) {
         reflectiveClass.produce(ReflectiveClassBuildItem.builder("org.xerial.snappy.SnappyInputStream",
                 "org.xerial.snappy.SnappyOutputStream")
                 .reason(getClass().getName() + " snappy support")
                 .methods().fields().build());
-
         feature.produce(new NativeImageFeatureBuildItem(SnappyFeature.class));
     }
 

--- a/extensions/kafka-streams/deployment/src/main/java/io/quarkus/kafka/streams/deployment/KafkaStreamsProcessor.java
+++ b/extensions/kafka-streams/deployment/src/main/java/io/quarkus/kafka/streams/deployment/KafkaStreamsProcessor.java
@@ -33,7 +33,6 @@ import io.quarkus.deployment.builditem.NativeImageFeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.JniRuntimeAccessBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
-import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.kafka.streams.runtime.KafkaStreamsProducer;
 import io.quarkus.kafka.streams.runtime.KafkaStreamsRecorder;
 import io.quarkus.kafka.streams.runtime.KafkaStreamsSupport;
@@ -49,7 +48,7 @@ class KafkaStreamsProcessor {
         return new FeatureBuildItem(Feature.KAFKA_STREAMS);
     }
 
-    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    @BuildStep
     void build(BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
             BuildProducer<JniRuntimeAccessBuildItem> jniRuntimeAccessibleClasses,
             BuildProducer<RuntimeInitializedClassBuildItem> reinitialized,

--- a/extensions/liquibase/liquibase-mongodb/deployment/src/main/java/io/quarkus/liquibase/mongodb/deployment/LiquibaseMongodbProcessor.java
+++ b/extensions/liquibase/liquibase-mongodb/deployment/src/main/java/io/quarkus/liquibase/mongodb/deployment/LiquibaseMongodbProcessor.java
@@ -98,7 +98,7 @@ class LiquibaseMongodbProcessor {
                         LIQUIBASE_MONGODB_ARTIFACT.getGroupId(), LIQUIBASE_MONGODB_ARTIFACT.getArtifactId()));
     }
 
-    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    @BuildStep
     void nativeImageConfiguration(
             LiquibaseMongodbBuildTimeConfig liquibaseBuildConfig,
             CombinedIndexBuildItem combinedIndex,

--- a/extensions/liquibase/liquibase/deployment/src/main/java/io/quarkus/liquibase/deployment/LiquibaseProcessor.java
+++ b/extensions/liquibase/liquibase/deployment/src/main/java/io/quarkus/liquibase/deployment/LiquibaseProcessor.java
@@ -108,7 +108,7 @@ class LiquibaseProcessor {
         return new IndexDependencyBuildItem(LIQUIBASE_ARTIFACT.getGroupId(), LIQUIBASE_ARTIFACT.getArtifactId());
     }
 
-    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    @BuildStep
     void nativeImageConfiguration(
             LiquibaseBuildTimeConfig liquibaseBuildConfig,
             List<JdbcDataSourceBuildItem> jdbcDataSourceBuildItems,

--- a/extensions/picocli/deployment/src/main/java/io/quarkus/picocli/deployment/PicocliNativeImageProcessor.java
+++ b/extensions/picocli/deployment/src/main/java/io/quarkus/picocli/deployment/PicocliNativeImageProcessor.java
@@ -28,14 +28,13 @@ import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBundleBuil
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveFieldBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
-import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import picocli.CommandLine;
 
 public class PicocliNativeImageProcessor {
 
     private static final Logger LOGGER = Logger.getLogger(PicocliNativeImageProcessor.class);
 
-    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    @BuildStep
     void reflectionConfiguration(CombinedIndexBuildItem combinedIndexBuildItem,
             BuildProducer<ReflectiveFieldBuildItem> reflectiveFields,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
@@ -111,7 +110,7 @@ public class PicocliNativeImageProcessor {
                 .build()));
     }
 
-    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    @BuildStep
     void resourceBundlesConfiguration(CombinedIndexBuildItem combinedIndexBuildItem,
             BuildProducer<NativeImageResourceBundleBuildItem> resourceBundles) {
         combinedIndexBuildItem.getIndex().getAnnotations(DotName.createSimple(CommandLine.Command.class.getName()))

--- a/extensions/smallrye-jwt-build/deployment/src/main/java/io/quarkus/smallrye/jwt/build/deployment/SmallRyeJwtBuildProcessor.java
+++ b/extensions/smallrye-jwt-build/deployment/src/main/java/io/quarkus/smallrye/jwt/build/deployment/SmallRyeJwtBuildProcessor.java
@@ -10,7 +10,6 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
-import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.smallrye.jwt.algorithm.KeyEncryptionAlgorithm;
 import io.smallrye.jwt.algorithm.SignatureAlgorithm;
 import io.smallrye.jwt.build.impl.JwtBuildUtils;
@@ -35,7 +34,7 @@ class SmallRyeJwtBuildProcessor {
      *
      * @return NativeImageResourceBuildItem
      */
-    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    @BuildStep
     void registerNativeImageResources(BuildProducer<NativeImageResourceBuildItem> nativeImageResource) {
         Config config = ConfigProvider.getConfig();
         registerKeyLocationResource(config, JwtBuildUtils.SIGN_KEY_LOCATION_PROPERTY, nativeImageResource);

--- a/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallRyeJwtProcessor.java
+++ b/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallRyeJwtProcessor.java
@@ -37,7 +37,6 @@ import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
-import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.security.deployment.JCAProviderBuildItem;
 import io.quarkus.smallrye.jwt.runtime.auth.BearerTokenAuthentication;
 import io.quarkus.smallrye.jwt.runtime.auth.JWTAuthMechanism;
@@ -137,7 +136,7 @@ class SmallRyeJwtProcessor {
      *
      * @return NativeImageResourceBuildItem
      */
-    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    @BuildStep
     void registerNativeImageResources(BuildProducer<NativeImageResourceBuildItem> nativeImageResource) {
         Config config = ConfigProvider.getConfig();
         registerKeyLocationResource(config, MP_JWT_VERIFY_KEY_LOCATION, nativeImageResource);

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/StaticResourcesProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/StaticResourcesProcessor.java
@@ -22,7 +22,6 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
-import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.paths.PathVisitor;
 import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
 import io.quarkus.vertx.http.deployment.spi.AdditionalStaticResourceBuildItem;
@@ -70,7 +69,7 @@ public class StaticResourcesProcessor {
         }
     }
 
-    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    @BuildStep
     public void nativeImageResource(Optional<StaticResourcesBuildItem> staticResources,
             BuildProducer<NativeImageResourceBuildItem> producer) {
         if (staticResources.isPresent()) {

--- a/extensions/websockets/client/deployment/src/main/java/io/quarkus/websockets/client/deployment/WebsocketClientProcessor.java
+++ b/extensions/websockets/client/deployment/src/main/java/io/quarkus/websockets/client/deployment/WebsocketClientProcessor.java
@@ -36,7 +36,6 @@ import io.quarkus.deployment.builditem.NativeImageFeatureBuildItem;
 import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
-import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.undertow.deployment.ServletContextAttributeBuildItem;
 import io.quarkus.websockets.client.runtime.DisableLoggingFeature;
@@ -52,7 +51,7 @@ public class WebsocketClientProcessor {
     private static final DotName SERVER_APPLICATION_CONFIG = DotName.createSimple(ServerApplicationConfig.class.getName());
     private static final DotName ENDPOINT = DotName.createSimple(Endpoint.class.getName());
 
-    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    @BuildStep
     NativeImageFeatureBuildItem nativeImageFeature() {
         return new NativeImageFeatureBuildItem(DisableLoggingFeature.class);
     }


### PR DESCRIPTION
Remove `onlyIf` conditions checking for native builds from build steps producing build items that are consumed only by build steps executed during native builds.
This allows tree shaker (https://github.com/quarkusio/quarkus/pull/53295) to consume reflective and a few other build items that were gated by native build conditions previously.