### PR TITLE
Dev MCP: Return METHOD_NOT_FOUND for unsupported MCP protocol methods

### DIFF
--- a/extensions/devui/deployment/src/test/java/io/quarkus/devui/devmcp/DevMcpTest.java
+++ b/extensions/devui/deployment/src/test/java/io/quarkus/devui/devmcp/DevMcpTest.java
@@ -261,6 +261,32 @@ public class DevMcpTest {
     }
 
     @Test
+    public void testUnsupportedMethodReturnsMethodNotFound() {
+        String jsonBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 8,
+                      "method": "prompts/list"
+                    }
+                """;
+
+        RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .body(jsonBody)
+                .when()
+                .post("/q/dev-mcp")
+                .then()
+                .statusCode(200)
+                .log().all()
+                .body("id", CoreMatchers.equalTo(8))
+                .body("jsonrpc", CoreMatchers.equalTo("2.0"))
+                .body("error.code", CoreMatchers.equalTo(-32601))
+                .body("error.message", CoreMatchers.containsString("prompts/list"));
+
+    }
+
+    @Test
     public void testResourcesReadWithInvalidUri() {
         String jsonBody = """
                     {

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpHttpHandler.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpHttpHandler.java
@@ -123,8 +123,7 @@ public class McpHttpHandler implements Handler<RoutingContext> {
                 if (jsonRpcRouter.isEnabled(jsonRpcRequest)) {
                     jsonRpcRouter.route(jsonRpcRequest, writer);
                 } else {
-                    codec.writeErrorResponse(writer, jsonRpcRequest.getId(), methodName,
-                            new McpMethodNotEnabledException("Method not enabled"));
+                    codec.writeMethodNotFoundResponse(writer, jsonRpcRequest.getId(), methodName);
                 }
             }
         });


### PR DESCRIPTION
When MCP clients like Cursor send unsupported protocol methods (e.g. `prompts/list`), the Dev MCP handler calls `writeErrorResponse`, which logs at ERROR level with a full stack trace and returns the wrong JSON-RPC error code (`-32603 INTERNAL_ERROR`).

Changed to use the existing `writeMethodNotFoundResponse`, which returns the correct `-32601 METHOD_NOT_FOUND` code without ERROR-level logging.

Related to zulip discussion: https://quarkusio.zulipchat.com/#narrow/channel/187030-users/topic/Cursor.3A.20Error.20in.20JsonRPC.20Call.20McpMethodNotEnabledException/with/582408865