### PR TITLE
Change default OTel trace sampling to 10%

### DIFF
--- a/docs/src/main/asciidoc/opentelemetry-tracing.adoc
+++ b/docs/src/main/asciidoc/opentelemetry-tracing.adoc
@@ -336,6 +336,8 @@ A https://github.com/open-telemetry/opentelemetry-specification/blob/main/specif
 
 Quarkus comes equipped with a https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#built-in-samplers[built-in sampler], and you also have the option to create your custom sampler.
 
+By default, Quarkus uses the `parentbased_traceidratio` sampler with a ratio of `0.1` (10%). This means that only 10% of the traces are sampled when there is no parent span, while child spans follow the parent's sampling decision. This default is intended for production environments where 100% sampling would be too costly. To sample all traces during development, set `quarkus.otel.traces.sampler=parentbased_always_on` in your `application.properties`.
+
 To use the built-in sampler, you can configure it by setting the desired sampler parameters as detailed in the <<configuration-reference>>. As an example, you can configure the sampler to retain 50% of the traces:
 [source,application.properties]
 ----
@@ -352,7 +354,7 @@ An interesting use case for the sampler is to activate and deactivate tracing ex
 ----
 # build time property only:
 quarkus.otel.traces.sampler=traceidratio
-# On (default). All traces are exported:
+# On. All traces are exported:
 quarkus.otel.traces.sampler.arg=1.0
 # Off. No traces are exported:
 quarkus.otel.traces.sampler.arg=0.0

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/VertxOpenTelemetryTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/VertxOpenTelemetryTest.java
@@ -61,6 +61,7 @@ public class VertxOpenTelemetryTest {
                     .addClasses(TestSpanExporter.class, TestSpanExporterProvider.class, SemconvResolver.class)
                     .addAsResource(new StringAsset(TestSpanExporterProvider.class.getCanonicalName()),
                             "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider"))
+            .overrideConfigKey("quarkus.otel.traces.sampler", "parentbased_always_on")
             .overrideConfigKey("quarkus.otel.traces.exporter", "test-span-exporter")
             .overrideConfigKey("quarkus.otel.metrics.exporter", "none")
             .overrideConfigKey("quarkus.otel.logs.exporter", "none")

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLoggingTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLoggingTest.java
@@ -55,6 +55,7 @@ public class OtelLoggingTest {
                             .add(new StringAsset(
                                     "quarkus.otel.logs.enabled=true\n" +
                                             "quarkus.otel.traces.enabled=true\n" +
+                                            "quarkus.otel.traces.sampler=parentbased_always_on\n" +
                                             "quarkus.log.category.\"io.quarkus.opentelemetry\".level=INFO\n"),
                                     "application.properties"));
 

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/MutinyTracingHelperTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/MutinyTracingHelperTest.java
@@ -45,7 +45,8 @@ class MutinyTracingHelperTest {
                             .addAsResource(new StringAsset(TestSpanExporterProvider.class.getCanonicalName()),
                                     "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider")
                             .addAsResource(new StringAsset(
-                                    "quarkus.otel.bsp.schedule.delay=50ms\n"),
+                                    "quarkus.otel.traces.sampler=parentbased_always_on\n" +
+                                            "quarkus.otel.bsp.schedule.delay=50ms\n"),
                                     "application.properties"));
 
     @Inject

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetrySpanSecurityEventsTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetrySpanSecurityEventsTest.java
@@ -38,6 +38,7 @@ public class OpenTelemetrySpanSecurityEventsTest {
                     .addClasses(TestSpanExporter.class, TestSpanExporterProvider.class, EventsResource.class,
                             CustomSecurityEvent.class)
                     .addAsResource(new StringAsset("""
+                            quarkus.otel.traces.sampler=parentbased_always_on
                             quarkus.otel.security-events.enabled=true
                             quarkus.otel.metrics.exporter=none
                             quarkus.otel.security-events.event-types=AUTHENTICATION_SUCCESS,AUTHORIZATION_SUCCESS,OTHER

--- a/extensions/opentelemetry/deployment/src/test/resources/application-default.properties
+++ b/extensions/opentelemetry/deployment/src/test/resources/application-default.properties
@@ -1,4 +1,5 @@
 # Traces
+quarkus.otel.traces.sampler=parentbased_always_on
 quarkus.otel.traces.exporter=test-span-exporter
 quarkus.otel.bsp.schedule.delay=50ms
 quarkus.otel.bsp.export.timeout=1s

--- a/extensions/opentelemetry/deployment/src/test/resources/resource-config/application-no-metrics.properties
+++ b/extensions/opentelemetry/deployment/src/test/resources/resource-config/application-no-metrics.properties
@@ -1,6 +1,7 @@
 quarkus.application.name=resource-test
 quarkus.otel.resource.attributes=service.name=authservice,service.instance.id=${quarkus.uuid}
 
+quarkus.otel.traces.sampler=parentbased_always_on
 quarkus.otel.traces.exporter=test-span-exporter
 quarkus.otel.bsp.schedule.delay=50ms
 quarkus.otel.metrics.exporter=none

--- a/extensions/opentelemetry/deployment/src/test/resources/resource-config/application.properties
+++ b/extensions/opentelemetry/deployment/src/test/resources/resource-config/application.properties
@@ -1,6 +1,7 @@
 quarkus.application.name=resource-test
 quarkus.otel.resource.attributes=service.name=authservice,service.instance.id=${quarkus.uuid}
 
+quarkus.otel.traces.sampler=parentbased_always_on
 quarkus.otel.traces.exporter=test-span-exporter
 quarkus.otel.bsp.schedule.delay=50ms
 quarkus.otel.metrics.enabled=true

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/build/TracesBuildConfig.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/build/TracesBuildConfig.java
@@ -48,9 +48,9 @@ public interface TracesBuildConfig {
      * {@link io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSamplerProvider}.
      * <p>
      * Fallbacks to the legacy property <code>quarkus.opentelemetry.tracer.sampler.sampler.name</code> or
-     * defaults to {@value SamplerType.Constants#PARENT_BASED_ALWAYS_ON}.
+     * defaults to {@value SamplerType.Constants#PARENT_BASED_TRACE_ID_RATIO}.
      */
-    @WithDefault(SamplerType.Constants.PARENT_BASED_ALWAYS_ON)
+    @WithDefault(SamplerType.Constants.PARENT_BASED_TRACE_ID_RATIO)
     String sampler();
 
     /**

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/TracesRuntimeConfig.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/TracesRuntimeConfig.java
@@ -58,9 +58,9 @@ public interface TracesRuntimeConfig {
      * value between `0.0d` and `1.0d`, like `0.01d` or `0.5d`. It is kept as a `String` to allow the flexible customisation of
      * alternative samplers.
      * <p>
-     * Defaults to `1.0d`.
+     * Defaults to `0.1d`.
      */
     @WithName("sampler.arg")
-    @WithDefault("1.0d")
+    @WithDefault("0.1d")
     Optional<String> samplerArg();
 }


### PR DESCRIPTION
Fix #53075

Changes the default OpenTelemetry trace sampling from 100% (`parentbased_always_on`) to 10% (`parentbased_traceidratio` with ratio `0.1`). Production environments should not use 100% sampling due to performance and cost constraints.

### Changes

**Config defaults:**
- `quarkus.otel.traces.sampler`: `parentbased_always_on` → `parentbased_traceidratio`
- `quarkus.otel.traces.sampler.arg`: `1.0d` → `0.1d`

**Tests:**
- Added explicit `quarkus.otel.traces.sampler=parentbased_always_on` to tests that rely on 100% sampling so they continue to pass with the new default.

**Docs:**
- Updated `opentelemetry-tracing.adoc` to document the new default and how to override it for development (`parentbased_always_on`).