### PR TITLE
[3.33] Bump Hibernate ORM to 7.2.9.Final, Reactive to 3.2.9.Final

### DIFF
--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/mapping/id/optimizer/optimizer/AbstractIdOptimizerDefaultTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/mapping/id/optimizer/optimizer/AbstractIdOptimizerDefaultTest.java
@@ -12,8 +12,9 @@ import org.hibernate.id.OptimizableGenerator;
 import org.hibernate.id.enhanced.Optimizer;
 import org.hibernate.id.enhanced.PooledLoOptimizer;
 import org.hibernate.id.enhanced.PooledOptimizer;
-import org.hibernate.reactive.id.impl.ReactiveGeneratorWrapper;
+import org.hibernate.reactive.id.ReactiveIdentifierGenerator;
 import org.hibernate.reactive.mutiny.Mutiny;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.hibernate.reactive.SchemaUtil;
@@ -28,6 +29,7 @@ public abstract class AbstractIdOptimizerDefaultTest {
     abstract Class<?> defaultOptimizerType();
 
     @Test
+    @Disabled("Hibernate Reactive doesn't implement reactive optimizers, so we need to implement the feature or update the test")
     public void defaults() {
         assertThat(List.of(
                 EntityWithDefaultGenerator.class,
@@ -38,6 +40,7 @@ public abstract class AbstractIdOptimizerDefaultTest {
     }
 
     @Test
+    @Disabled("Hibernate Reactive doesn't implement reactive optimizers, so we need to implement the feature or update the test")
     public void explicitOverrides() {
         assertOptimizer(EntityWithGenericGeneratorAndPooledOptimizer.class)
                 .isInstanceOf(PooledOptimizer.class);
@@ -47,6 +50,7 @@ public abstract class AbstractIdOptimizerDefaultTest {
 
     @Test
     @RunOnVertxContext
+    @Disabled("Hibernate Reactive doesn't implement reactive optimizers, so we need to implement the feature or update the test")
     public void ids(UniAsserter asserter) {
         for (long i = 1; i <= 51; i++) {
             long expectedId = i;
@@ -62,7 +66,7 @@ public abstract class AbstractIdOptimizerDefaultTest {
     AbstractObjectAssert<?, Optimizer> assertOptimizer(Class<?> entityType) {
         return assertThat(SchemaUtil.getGenerator(entityType, SchemaUtil.mappingMetamodel(sessionFactory)))
                 .as("Reactive ID generator wrapper for entity type " + entityType.getSimpleName())
-                .asInstanceOf(InstanceOfAssertFactories.type(ReactiveGeneratorWrapper.class))
+                .asInstanceOf(InstanceOfAssertFactories.type(ReactiveIdentifierGenerator.class))
                 .extracting("generator") // Needs reflection, unfortunately the blocking generator is not exposed...
                 .as("Blocking ID generator for entity type " + entityType.getSimpleName())
                 .asInstanceOf(InstanceOfAssertFactories.type(OptimizableGenerator.class))

--- a/pom.xml
+++ b/pom.xml
@@ -71,17 +71,17 @@
         <jacoco.version>0.8.14</jacoco.version>
         <kubernetes-client.version>7.5.2</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
         <rest-assured.version>5.5.6</rest-assured.version>
-        <hibernate-orm.version>7.2.6.Final</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
+        <hibernate-orm.version>7.2.9.Final</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
         <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version> <!-- version controlled by Hibernate ORM's needs -->
         <jakarta.data-api.version>1.0.1</jakarta.data-api.version> <!-- version controlled by Hibernate ORM's needs -->
         <antlr.version>4.13.2</antlr.version> <!-- version controlled by Hibernate ORM's needs -->
         <bytebuddy.version>1.17.8</bytebuddy.version> <!-- version controlled by Hibernate ORM's needs -->
         <geolatte.version>1.10</geolatte.version> <!-- version controlled by Hibernate ORM's needs -->
         <hibernate-models.version>1.0.1</hibernate-models.version> <!-- version controlled by Hibernate ORM's needs -->
-        <hibernate-reactive.version>3.2.5.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
+        <hibernate-reactive.version>3.2.9.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
         <hibernate-validator.version>9.1.0.Final</hibernate-validator.version>
         <hibernate-search.version>8.2.2.Final</hibernate-search.version>
-        <hibernate-tools.version>7.2.6.Final</hibernate-tools.version>
+        <hibernate-tools.version>7.2.9.Final</hibernate-tools.version>
 
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->
         <grpc.version>1.79.0</grpc.version> <!-- when updating, verify if following versions should not be updated too: -->


### PR DESCRIPTION
## Summary
Backport of https://github.com/quarkusio/quarkus/pull/53235 for the 3.33 branch.

Bumps the hibernate group with 10 updates:

| Package | From | To |
| --- | --- | --- |
| org.hibernate.orm:hibernate-core | 7.2.6.Final | 7.2.9.Final |
| org.hibernate.orm:hibernate-graalvm | 7.2.6.Final | 7.2.9.Final |
| org.hibernate.orm:hibernate-envers | 7.2.6.Final | 7.2.9.Final |
| org.hibernate.orm:hibernate-spatial | 7.2.6.Final | 7.2.9.Final |
| org.hibernate.orm:hibernate-processor | 7.2.6.Final | 7.2.9.Final |
| org.hibernate.orm:hibernate-jpamodelgen | 7.2.6.Final | 7.2.9.Final |
| org.hibernate.orm:hibernate-community-dialects | 7.2.6.Final | 7.2.9.Final |
| org.hibernate.orm:hibernate-vector | 7.2.6.Final | 7.2.9.Final |
| org.hibernate.reactive:hibernate-reactive-core | 3.2.5.Final | 3.2.9.Final |
| org.hibernate.tool:hibernate-tools-language | 7.2.6.Final | 7.2.9.Final |

- Backport test fix from https://github.com/quarkusio/quarkus/pull/52168: disable reactive optimizer tests and update `ReactiveGeneratorWrapper` → `ReactiveIdentifierGenerator`

## Test plan
- [x] Hibernate ORM/Reactive extensions and integration tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)