### PR TITLE
Fix alignment of ByteBuddy and Hibernate Models with ORM 7.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,9 +75,9 @@
         <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version> <!-- version controlled by Hibernate ORM's needs -->
         <jakarta.data-api.version>1.0.1</jakarta.data-api.version> <!-- version controlled by Hibernate ORM's needs -->
         <antlr.version>4.13.2</antlr.version> <!-- version controlled by Hibernate ORM's needs -->
-        <bytebuddy.version>1.17.8</bytebuddy.version> <!-- version controlled by Hibernate ORM's needs -->
+        <bytebuddy.version>1.18.7</bytebuddy.version> <!-- version controlled by Hibernate ORM's needs -->
         <geolatte.version>1.10</geolatte.version> <!-- version controlled by Hibernate ORM's needs -->
-        <hibernate-models.version>1.0.1</hibernate-models.version> <!-- version controlled by Hibernate ORM's needs -->
+        <hibernate-models.version>1.1.0</hibernate-models.version> <!-- version controlled by Hibernate ORM's needs -->
         <hibernate-reactive.version>3.3.0.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
         <hibernate-validator.version>9.1.0.Final</hibernate-validator.version>
         <hibernate-search.version>8.3.0.Final</hibernate-search.version>


### PR DESCRIPTION
@lucamolteni if I'm not mistaken, I think these were forgotten.

I stumbled upon it as I plan to upgrade to ByteBuddy 1.18.8 as soon as it's out and I was worried we were using old versions.

Taken from: https://github.com/hibernate/hibernate-orm/blob/a61e69fcd23df00d53c0e6a94ce8e6f020951d8c/settings.gradle#L76-L87