### PR TITLE
Switch to relocated ContextInternal in virtual threads extension

### DIFF
--- a/extensions/virtual-threads/runtime/src/main/java/io/quarkus/virtual/threads/ContextPreservingExecutorService.java
+++ b/extensions/virtual-threads/runtime/src/main/java/io/quarkus/virtual/threads/ContextPreservingExecutorService.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
-import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.internal.ContextInternal;
 
 /**
  * Delegating executor service implementation preserving the Vert.x context on {@link #execute(Runnable)}

--- a/extensions/virtual-threads/runtime/src/main/java/io/quarkus/virtual/threads/FallbackVirtualThreadsExecutorService.java
+++ b/extensions/virtual-threads/runtime/src/main/java/io/quarkus/virtual/threads/FallbackVirtualThreadsExecutorService.java
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.vertx.core.Vertx;
-import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.internal.ContextInternal;
 
 /**
  * Fallback executor service implementation in case the virtual threads are disabled or not available on the current platform.


### PR DESCRIPTION
The class was moved in Vert.x 5 to an `internal` package.