### PR TITLE
Fix Azure-functions: update default ExtensionBundle to [4.0.0, 5.0.0)

### DIFF
--- a/extensions/azure-functions/deployment/src/main/java/io/quarkus/azure/functions/deployment/AzureFunctionsProcessor.java
+++ b/extensions/azure-functions/deployment/src/main/java/io/quarkus/azure/functions/deployment/AzureFunctionsProcessor.java
@@ -138,7 +138,7 @@ public class AzureFunctionsProcessor {
     }
 
     private static final String DEFAULT_HOST_JSON = "{\"version\":\"2.0\",\"extensionBundle\":" +
-            "{\"id\":\"Microsoft.Azure.Functions.ExtensionBundle\",\"version\":\"[3.*, 4.0.0)\"}}\n";
+            "{\"id\":\"Microsoft.Azure.Functions.ExtensionBundle\",\"version\":\"[4.0.0, 5.0.0)\"}}\n";
 
     protected void copyHostJson(Path rootPath, Path functionStagingDir) throws IOException {
         final File sourceHostJsonFile = rootPath.resolve(HOST_JSON).toFile();


### PR DESCRIPTION
## Summary

Update the default Azure Functions `extensionBundle` range used in the generated `host.json` from:

```
[3.*, 4.0.0)
```

to:

```
[4.0.0, 5.0.0)
```

No behavioral changes beyond the default `host.json` content.

---

## File Changed

```
extensions/azure-functions/deployment/src/main/java/io/quarkus/azure/functions/deployment/AzureFunctionsProcessor.java
```

---

## Rationale

This change prevents Azure Portal warnings about deprecated bundles and aligns the default with current Microsoft guidance for Azure Functions v4.

---

## What Changed

In `AzureFunctionsProcessor`, the `extensionBundle.version` string emitted into `host.json` was updated:

* **Before:** `"[3.*, 4.0.0)"`
* **After:** `"[4.0.0, 5.0.0)"`

No other behavioral changes were introduced.

---

## Backport Request

This is a small, low-risk default update that improves the user experience for new applications.

Please backport to:

* 3.32.x
* 3.33 (LTS)

---

## Linked Issues

Fixes #50504
