### PR TITLE
Migrate TLS Registry extension to Vert.x 5

### DIFF
--- a/docs/src/main/asciidoc/tls-registry-reference.adoc
+++ b/docs/src/main/asciidoc/tls-registry-reference.adoc
@@ -844,7 +844,7 @@ private final io.vertx.core.http.HttpServer server;
 
 public void onCertificateUpdate(@Observes CertificateUpdatedEvent reload) {
     if ("name".equals(event.getName())) {
-        server.updateSSLOptions(reload.tlsConfiguration().getSSLOptions());
+        server.updateSSLOptions(reload.tlsConfiguration().getServerSSLOptions());
         // Or update the SSLContext.
     }
 

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/CertificateRevocationListTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/CertificateRevocationListTest.java
@@ -31,8 +31,8 @@ public class CertificateRevocationListTest {
     void test() {
         TlsConfiguration def = certificates.getDefault().orElseThrow();
         TlsConfiguration foo = certificates.get("foo").orElseThrow();
-        assertThat(def.getSSLOptions().getCrlValues()).hasSize(1);
-        assertThat(foo.getSSLOptions().getCrlValues()).hasSize(1);
+        assertThat(def.getServerSSLOptions().getCrlValues()).hasSize(1);
+        assertThat(foo.getServerSSLOptions().getCrlValues()).hasSize(1);
     }
 
 }

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/DefaultSSLOptionsTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/DefaultSSLOptionsTest.java
@@ -53,15 +53,15 @@ public class DefaultSSLOptionsTest {
         assertThat(def.isTrustAll()).isFalse();
         assertThat(def.getHostnameVerificationAlgorithm()).isEmpty();
 
-        assertThat(def.getSSLOptions().getKeyCertOptions()).isNotNull();
-        assertThat(def.getSSLOptions().getTrustOptions()).isNotNull();
+        assertThat(def.getServerSSLOptions().getKeyCertOptions()).isNotNull();
+        assertThat(def.getServerSSLOptions().getTrustOptions()).isNotNull();
 
-        assertThat(def.getSSLOptions().isUseAlpn()).isTrue();
-        assertThat(def.getSSLOptions().getEnabledCipherSuites()).contains("TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256");
+        assertThat(def.getServerSSLOptions().isUseAlpn()).isTrue();
+        assertThat(def.getServerSSLOptions().getEnabledCipherSuites()).contains("TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256");
 
-        assertThat(def.getSSLOptions().getEnabledSecureTransportProtocols()).containsExactly("TLSv1.3");
-        assertThat(def.getSSLOptions().getSslHandshakeTimeoutUnit()).isEqualTo(TimeUnit.SECONDS);
-        assertThat(def.getSSLOptions().getSslHandshakeTimeout()).isEqualTo(20);
+        assertThat(def.getServerSSLOptions().getEnabledSecureTransportProtocols()).containsExactly("TLSv1.3");
+        assertThat(def.getServerSSLOptions().getSslHandshakeTimeoutUnit()).isEqualTo(TimeUnit.SECONDS);
+        assertThat(def.getServerSSLOptions().getSslHandshakeTimeout()).isEqualTo(20);
     }
 
 }

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/ExpiredJKSTrustStoreTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/ExpiredJKSTrustStoreTest.java
@@ -3,8 +3,6 @@ package io.quarkus.tls;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.concurrent.CountDownLatch;
-
 import javax.net.ssl.SSLHandshakeException;
 
 import jakarta.inject.Inject;
@@ -57,7 +55,7 @@ public class ExpiredJKSTrustStoreTest {
     Vertx vertx;
 
     @Test
-    void testWarn() throws InterruptedException {
+    void testWarn() {
         TlsConfiguration cf = certificates.get("warn").orElseThrow();
         assertThat(cf.getTrustStoreOptions()).isNotNull();
 
@@ -68,16 +66,11 @@ public class ExpiredJKSTrustStoreTest {
         vertx.createHttpServer(new HttpServerOptions()
                 .setSsl(true)
                 .setKeyCertOptions(certificates.getDefault().orElseThrow().getKeyStoreOptions()))
-                .requestHandler(rc -> rc.response().end("Hello")).listen(8081).toCompletionStage().toCompletableFuture().join();
+                .requestHandler(rc -> rc.response().end("Hello")).listen(8081).await();
 
-        CountDownLatch latch = new CountDownLatch(1);
-        client.get(8081, "localhost", "/").send(ar -> {
-            assertThat(ar.succeeded()).isTrue();
-            assertThat(ar.result().bodyAsString()).isEqualTo("Hello");
-            latch.countDown();
-        });
-
-        assertThat(latch.await(10, java.util.concurrent.TimeUnit.SECONDS)).isTrue();
+        var response = client.get(8081, "localhost", "/").send()
+                .await();
+        assertThat(response.bodyAsString()).isEqualTo("Hello");
     }
 
     @Test
@@ -92,9 +85,9 @@ public class ExpiredJKSTrustStoreTest {
         vertx.createHttpServer(new HttpServerOptions()
                 .setSsl(true)
                 .setKeyCertOptions(certificates.getDefault().orElseThrow().getKeyStoreOptions()))
-                .requestHandler(rc -> rc.response().end("Hello")).listen(8081).toCompletionStage().toCompletableFuture().join();
+                .requestHandler(rc -> rc.response().end("Hello")).listen(8081).await();
 
         assertThatThrownBy(() -> client.get(8081, "localhost", "/")
-                .send().toCompletionStage().toCompletableFuture().join()).hasCauseInstanceOf(SSLHandshakeException.class);
+                .send().await()).isInstanceOf(SSLHandshakeException.class);
     }
 }

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/ExpiredP12TrustStoreTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/ExpiredP12TrustStoreTest.java
@@ -3,8 +3,6 @@ package io.quarkus.tls;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.concurrent.CountDownLatch;
-
 import javax.net.ssl.SSLHandshakeException;
 
 import jakarta.inject.Inject;
@@ -57,7 +55,7 @@ public class ExpiredP12TrustStoreTest {
     Vertx vertx;
 
     @Test
-    void testWarn() throws InterruptedException {
+    void testWarn() {
         TlsConfiguration cf = certificates.get("warn").orElseThrow();
         assertThat(cf.getTrustStoreOptions()).isNotNull();
 
@@ -68,16 +66,11 @@ public class ExpiredP12TrustStoreTest {
         vertx.createHttpServer(new HttpServerOptions()
                 .setSsl(true)
                 .setKeyCertOptions(certificates.getDefault().orElseThrow().getKeyStoreOptions()))
-                .requestHandler(rc -> rc.response().end("Hello")).listen(8081).toCompletionStage().toCompletableFuture().join();
+                .requestHandler(rc -> rc.response().end("Hello")).listen(8081).await();
 
-        CountDownLatch latch = new CountDownLatch(1);
-        client.get(8081, "localhost", "/").send(ar -> {
-            assertThat(ar.succeeded()).isTrue();
-            assertThat(ar.result().bodyAsString()).isEqualTo("Hello");
-            latch.countDown();
-        });
-
-        assertThat(latch.await(10, java.util.concurrent.TimeUnit.SECONDS)).isTrue();
+        var response = client.get(8081, "localhost", "/").send()
+                .await();
+        assertThat(response.bodyAsString()).isEqualTo("Hello");
     }
 
     @Test
@@ -92,9 +85,9 @@ public class ExpiredP12TrustStoreTest {
         vertx.createHttpServer(new HttpServerOptions()
                 .setSsl(true)
                 .setKeyCertOptions(certificates.getDefault().orElseThrow().getKeyStoreOptions()))
-                .requestHandler(rc -> rc.response().end("Hello")).listen(8081).toCompletionStage().toCompletableFuture().join();
+                .requestHandler(rc -> rc.response().end("Hello")).listen(8081).await();
 
         assertThatThrownBy(() -> client.get(8081, "localhost", "/")
-                .send().toCompletionStage().toCompletableFuture().join()).hasCauseInstanceOf(SSLHandshakeException.class);
+                .send().await()).isInstanceOf(SSLHandshakeException.class);
     }
 }

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/ExpiredPemTrustStoreTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/ExpiredPemTrustStoreTest.java
@@ -3,8 +3,6 @@ package io.quarkus.tls;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.concurrent.CountDownLatch;
-
 import javax.net.ssl.SSLHandshakeException;
 
 import jakarta.inject.Inject;
@@ -55,7 +53,7 @@ public class ExpiredPemTrustStoreTest {
     Vertx vertx;
 
     @Test
-    void testWarn() throws InterruptedException {
+    void testWarn() {
         TlsConfiguration cf = certificates.get("warn").orElseThrow();
         assertThat(cf.getTrustStoreOptions()).isNotNull();
 
@@ -66,16 +64,11 @@ public class ExpiredPemTrustStoreTest {
         vertx.createHttpServer(new HttpServerOptions()
                 .setSsl(true)
                 .setKeyCertOptions(certificates.getDefault().orElseThrow().getKeyStoreOptions()))
-                .requestHandler(rc -> rc.response().end("Hello")).listen(8081).toCompletionStage().toCompletableFuture().join();
+                .requestHandler(rc -> rc.response().end("Hello")).listen(8081).await();
 
-        CountDownLatch latch = new CountDownLatch(1);
-        client.get(8081, "localhost", "/").send(ar -> {
-            assertThat(ar.succeeded()).isTrue();
-            assertThat(ar.result().bodyAsString()).isEqualTo("Hello");
-            latch.countDown();
-        });
-
-        assertThat(latch.await(10, java.util.concurrent.TimeUnit.SECONDS)).isTrue();
+        var response = client.get(8081, "localhost", "/").send()
+                .await();
+        assertThat(response.bodyAsString()).isEqualTo("Hello");
     }
 
     @Test
@@ -90,9 +83,9 @@ public class ExpiredPemTrustStoreTest {
         vertx.createHttpServer(new HttpServerOptions()
                 .setSsl(true)
                 .setKeyCertOptions(certificates.getDefault().orElseThrow().getKeyStoreOptions()))
-                .requestHandler(rc -> rc.response().end("Hello")).listen(8081).toCompletionStage().toCompletableFuture().join();
+                .requestHandler(rc -> rc.response().end("Hello")).listen(8081).await();
 
         assertThatThrownBy(() -> client.get(8081, "localhost", "/")
-                .send().toCompletionStage().toCompletableFuture().join()).hasCauseInstanceOf(SSLHandshakeException.class);
+                .send().await()).isInstanceOf(SSLHandshakeException.class);
     }
 }

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/ExpiredTrustStoreWithMTLSAndIgnorePolicyTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/ExpiredTrustStoreWithMTLSAndIgnorePolicyTest.java
@@ -84,7 +84,7 @@ public class ExpiredTrustStoreWithMTLSAndIgnorePolicyTest {
                 .listen(8081).toCompletionStage().toCompletableFuture().join();
 
         CountDownLatch latch = new CountDownLatch(1);
-        client.get(8081, "localhost", "/").send(ar -> {
+        client.get(8081, "localhost", "/").send().onComplete(ar -> {
             assertThat(ar.succeeded()).isTrue();
             assertThat(ar.result().bodyAsString()).isEqualTo("Hello");
             latch.countDown();

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/ExpiredTrustStoreWithMTLSAndServerRejectionTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/ExpiredTrustStoreWithMTLSAndServerRejectionTest.java
@@ -3,6 +3,8 @@ package io.quarkus.tls;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import javax.net.ssl.SSLHandshakeException;
+
 import jakarta.inject.Inject;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -60,12 +62,12 @@ public class ExpiredTrustStoreWithMTLSAndServerRejectionTest {
     @AfterEach
     void cleanup() {
         if (server != null) {
-            server.close().toCompletionStage().toCompletableFuture().join();
+            server.close().await();
         }
     }
 
     @Test
-    void testServerRejection() throws InterruptedException {
+    void testServerRejection() {
         TlsConfiguration cf = certificates.get("warn").orElseThrow();
         assertThat(cf.getTrustStoreOptions()).isNotNull();
 
@@ -79,9 +81,9 @@ public class ExpiredTrustStoreWithMTLSAndServerRejectionTest {
                 .setClientAuth(ClientAuth.REQUIRED)
                 .setTrustOptions(certificates.getDefault().orElseThrow().getTrustStoreOptions())
                 .setKeyCertOptions(certificates.getDefault().orElseThrow().getKeyStoreOptions()))
-                .requestHandler(rc -> rc.response().end("Hello")).listen(8081).toCompletionStage().toCompletableFuture().join();
+                .requestHandler(rc -> rc.response().end("Hello")).listen(8081).await();
 
-        assertThatThrownBy(() -> client.get(8081, "localhost", "/").send().toCompletionStage().toCompletableFuture().join())
-                .hasMessageContaining("SSLHandshakeException");
+        assertThatThrownBy(() -> client.get(8081, "localhost", "/").send().await())
+                .hasCauseInstanceOf(SSLHandshakeException.class);
     }
 }

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/ExpiredTrustStoreWithMTLSTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/ExpiredTrustStoreWithMTLSTest.java
@@ -3,8 +3,6 @@ package io.quarkus.tls;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.concurrent.CountDownLatch;
-
 import javax.net.ssl.SSLHandshakeException;
 
 import jakarta.inject.Inject;
@@ -70,12 +68,12 @@ public class ExpiredTrustStoreWithMTLSTest {
     @AfterEach
     void cleanup() {
         if (server != null) {
-            server.close().toCompletionStage().toCompletableFuture().join();
+            server.close().await();
         }
     }
 
     @Test
-    void testWarn() throws InterruptedException {
+    void testWarn() {
         TlsConfiguration cf = certificates.get("warn").orElseThrow();
         assertThat(cf.getTrustStoreOptions()).isNotNull();
 
@@ -89,16 +87,11 @@ public class ExpiredTrustStoreWithMTLSTest {
                 .setClientAuth(ClientAuth.REQUIRED)
                 .setTrustOptions(certificates.getDefault().orElseThrow().getTrustStoreOptions())
                 .setKeyCertOptions(certificates.getDefault().orElseThrow().getKeyStoreOptions()))
-                .requestHandler(rc -> rc.response().end("Hello")).listen(8081).toCompletionStage().toCompletableFuture().join();
+                .requestHandler(rc -> rc.response().end("Hello")).listen(8081).await();
 
-        CountDownLatch latch = new CountDownLatch(1);
-        client.get(8081, "localhost", "/").send(ar -> {
-            assertThat(ar.succeeded()).isTrue();
-            assertThat(ar.result().bodyAsString()).isEqualTo("Hello");
-            latch.countDown();
-        });
-
-        assertThat(latch.await(10, java.util.concurrent.TimeUnit.SECONDS)).isTrue();
+        var response = client.get(8081, "localhost", "/").send()
+                .await();
+        assertThat(response.bodyAsString()).isEqualTo("Hello");
     }
 
     @Test
@@ -116,9 +109,9 @@ public class ExpiredTrustStoreWithMTLSTest {
                 .setClientAuth(ClientAuth.REQUIRED)
                 .setTrustOptions(certificates.getDefault().orElseThrow().getTrustStoreOptions())
                 .setKeyCertOptions(certificates.getDefault().orElseThrow().getKeyStoreOptions()))
-                .requestHandler(rc -> rc.response().end("Hello")).listen(8081).toCompletionStage().toCompletableFuture().join();
+                .requestHandler(rc -> rc.response().end("Hello")).listen(8081).await();
 
         assertThatThrownBy(() -> client.get(8081, "localhost", "/")
-                .send().toCompletionStage().toCompletableFuture().join()).hasCauseInstanceOf(SSLHandshakeException.class);
+                .send().await()).isInstanceOf(SSLHandshakeException.class);
     }
 }

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/IgnoreExpirationPolicyTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/IgnoreExpirationPolicyTest.java
@@ -75,7 +75,7 @@ public class IgnoreExpirationPolicyTest {
                 .listen(8081).toCompletionStage().toCompletableFuture().join();
 
         CountDownLatch latch = new CountDownLatch(1);
-        client.get(8081, "localhost", "/").send(ar -> {
+        client.get(8081, "localhost", "/").send().onComplete(ar -> {
             assertThat(ar.succeeded()).isTrue();
             assertThat(ar.result().bodyAsString()).isEqualTo("Hello");
             latch.countDown();

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/JavaxNetSslTrustStoreProviderTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/JavaxNetSslTrustStoreProviderTest.java
@@ -153,7 +153,7 @@ public class JavaxNetSslTrustStoreProviderTest {
 
     TrustManager[] trustManagers(String key) throws Exception {
         final TlsConfiguration javaNetSsl = certificates.get(key).orElseThrow();
-        final TrustManagerFactory javaNetSslTrustManagerFactory = javaNetSsl.getSSLOptions().getTrustOptions()
+        final TrustManagerFactory javaNetSslTrustManagerFactory = javaNetSsl.getServerSSLOptions().getTrustOptions()
                 .getTrustManagerFactory(vertx);
         return javaNetSslTrustManagerFactory.getTrustManagers();
     }

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/MTLSEndToEndTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/MTLSEndToEndTest.java
@@ -84,7 +84,7 @@ public class MTLSEndToEndTest {
         WebClient client = WebClient.create(vertx, clientOptions);
 
         CountDownLatch latch = new CountDownLatch(1);
-        client.get(8081, "localhost", "/").send(ar -> {
+        client.get(8081, "localhost", "/").send().onComplete(ar -> {
             assertThat(ar.succeeded()).isTrue();
             assertThat(ar.result().bodyAsString()).isEqualTo("mTLS OK");
             latch.countDown();

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/MixedDefaultAndNamedConfigTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/MixedDefaultAndNamedConfigTest.java
@@ -61,15 +61,15 @@ public class MixedDefaultAndNamedConfigTest {
         assertThat(defConfig.getKeyStoreOptions()).isNotNull();
         assertThat(defConfig.getTrustStoreOptions()).isNotNull();
         assertThat(defConfig.isTrustAll()).isFalse();
-        assertThat(defConfig.getSSLOptions().getEnabledSecureTransportProtocols()).containsExactly("TLSv1.3");
-        assertThat(defConfig.getSSLOptions().isUseAlpn()).isTrue();
+        assertThat(defConfig.getServerSSLOptions().getEnabledSecureTransportProtocols()).containsExactly("TLSv1.3");
+        assertThat(defConfig.getServerSSLOptions().isUseAlpn()).isTrue();
 
         assertThat(httpConfig.getKeyStoreOptions()).isNotNull();
         assertThat(httpConfig.getTrustStoreOptions()).isNotNull();
         assertThat(httpConfig.isTrustAll()).isFalse();
-        assertThat(httpConfig.getSSLOptions().getEnabledSecureTransportProtocols())
+        assertThat(httpConfig.getServerSSLOptions().getEnabledSecureTransportProtocols())
                 .containsExactlyInAnyOrder("TLSv1.3", "TLSv1.2");
-        assertThat(httpConfig.getSSLOptions().isUseAlpn()).isFalse();
+        assertThat(httpConfig.getServerSSLOptions().isUseAlpn()).isFalse();
 
         assertThat(grpcConfig.isTrustAll()).isTrue();
         assertThat(grpcConfig.getHostnameVerificationAlgorithm()).hasValue("NONE");

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/MultipleCRLFilesTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/MultipleCRLFilesTest.java
@@ -29,6 +29,6 @@ public class MultipleCRLFilesTest {
     @Test
     void testMultipleCRLFiles() {
         TlsConfiguration def = certificates.getDefault().orElseThrow();
-        assertThat(def.getSSLOptions().getCrlValues()).hasSize(2);
+        assertThat(def.getServerSSLOptions().getCrlValues()).hasSize(2);
     }
 }

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/NamedSSLOptionsTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/NamedSSLOptionsTest.java
@@ -16,7 +16,7 @@ import io.quarkus.test.QuarkusExtensionTest;
 import io.smallrye.certs.Format;
 import io.smallrye.certs.junit5.Certificate;
 import io.smallrye.certs.junit5.Certificates;
-import io.vertx.core.net.SSLOptions;
+import io.vertx.core.net.ServerSSLOptions;
 
 @Certificates(baseDir = "target/certs", certificates = {
         @Certificate(name = "test-ssl-options", password = "password", formats = { Format.PKCS12 })
@@ -54,7 +54,7 @@ public class NamedSSLOptionsTest {
         assertThat(named.isTrustAll()).isFalse();
         assertThat(named.getHostnameVerificationAlgorithm()).isEmpty();
 
-        SSLOptions options = named.getSSLOptions();
+        ServerSSLOptions options = named.getServerSSLOptions();
 
         assertThat(options.getKeyCertOptions()).isNotNull();
         assertThat(options.getTrustOptions()).isNotNull();

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/ProtocolEnforcementTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/ProtocolEnforcementTest.java
@@ -76,17 +76,17 @@ public class ProtocolEnforcementTest {
         server = vertx.createHttpServer(new HttpServerOptions()
                 .setSsl(true)
                 .setKeyCertOptions(serverConfig.getKeyStoreOptions())
-                .setEnabledSecureTransportProtocols(serverConfig.getSSLOptions().getEnabledSecureTransportProtocols()))
+                .setEnabledSecureTransportProtocols(serverConfig.getServerSSLOptions().getEnabledSecureTransportProtocols()))
                 .requestHandler(rc -> rc.response().end("TLSv1.3 OK"))
                 .listen(8081).toCompletionStage().toCompletableFuture().join();
 
         WebClient client = WebClient.create(vertx, new WebClientOptions()
                 .setSsl(true)
                 .setTrustOptions(clientConfig.getTrustStoreOptions())
-                .setEnabledSecureTransportProtocols(clientConfig.getSSLOptions().getEnabledSecureTransportProtocols()));
+                .setEnabledSecureTransportProtocols(clientConfig.getClientSSLOptions().getEnabledSecureTransportProtocols()));
 
         CountDownLatch latch = new CountDownLatch(1);
-        client.get(8081, "localhost", "/").send(ar -> {
+        client.get(8081, "localhost", "/").send().onComplete(ar -> {
             assertThat(ar.succeeded()).isTrue();
             assertThat(ar.result().bodyAsString()).isEqualTo("TLSv1.3 OK");
             latch.countDown();
@@ -103,14 +103,14 @@ public class ProtocolEnforcementTest {
         server = vertx.createHttpServer(new HttpServerOptions()
                 .setSsl(true)
                 .setKeyCertOptions(serverConfig.getKeyStoreOptions())
-                .setEnabledSecureTransportProtocols(serverConfig.getSSLOptions().getEnabledSecureTransportProtocols()))
+                .setEnabledSecureTransportProtocols(serverConfig.getServerSSLOptions().getEnabledSecureTransportProtocols()))
                 .requestHandler(rc -> rc.response().end("Should not reach"))
                 .listen(8081).toCompletionStage().toCompletableFuture().join();
 
         WebClient client = WebClient.create(vertx, new WebClientOptions()
                 .setSsl(true)
                 .setTrustOptions(clientConfig.getTrustStoreOptions())
-                .setEnabledSecureTransportProtocols(clientConfig.getSSLOptions().getEnabledSecureTransportProtocols()));
+                .setEnabledSecureTransportProtocols(clientConfig.getClientSSLOptions().getEnabledSecureTransportProtocols()));
 
         assertThatThrownBy(() -> client.get(8081, "localhost", "/")
                 .send().toCompletionStage().toCompletableFuture().join())

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/ReloadWithCRLUpdateTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/ReloadWithCRLUpdateTest.java
@@ -67,12 +67,12 @@ public class ReloadWithCRLUpdateTest {
     void testCRLIsReloadedWithCertificate() throws IOException {
         TlsConfiguration def = registry.getDefault().orElseThrow();
 
-        assertThat(def.getSSLOptions().getCrlValues()).hasSize(1);
+        assertThat(def.getServerSSLOptions().getCrlValues()).hasSize(1);
 
         Files.copy(new File("target/certs/test-reload-crl-B-keystore.p12").toPath(),
                 new File(certs, "/tls.p12").toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
 
         assertThat(def.reload()).isTrue();
-        assertThat(def.getSSLOptions().getCrlValues()).hasSize(1);
+        assertThat(def.getServerSSLOptions().getCrlValues()).hasSize(1);
     }
 }

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/SNIEndToEndTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/SNIEndToEndTest.java
@@ -80,7 +80,7 @@ public class SNIEndToEndTest {
                 .setForceSni(true));
 
         CountDownLatch latch = new CountDownLatch(1);
-        client.get(8081, "localhost", "/").send(ar -> {
+        client.get(8081, "localhost", "/").send().onComplete(ar -> {
             assertThat(ar.succeeded()).isTrue();
             assertThat(ar.result().bodyAsString()).isEqualTo("SNI OK");
             latch.countDown();

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/SSLOptionsCompositionTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/SSLOptionsCompositionTest.java
@@ -50,7 +50,7 @@ public class SSLOptionsCompositionTest {
     @Test
     void testFullSSLOptionsComposition() {
         TlsConfiguration tlsConfig = certificates.get("full").orElseThrow();
-        SSLOptions options = tlsConfig.getSSLOptions();
+        SSLOptions options = tlsConfig.getServerSSLOptions();
 
         assertThat(options).isNotNull();
         assertThat(options.getKeyCertOptions()).isNotNull();
@@ -68,7 +68,7 @@ public class SSLOptionsCompositionTest {
     @Test
     void testMinimalSSLOptionsHaveDefaults() {
         TlsConfiguration tlsConfig = certificates.get("minimal").orElseThrow();
-        SSLOptions options = tlsConfig.getSSLOptions();
+        SSLOptions options = tlsConfig.getServerSSLOptions();
 
         assertThat(options).isNotNull();
         assertThat(options.getKeyCertOptions()).isNull();

--- a/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/TrustAllWithHttpClientHandshakeTest.java
+++ b/extensions/tls-registry/deployment/src/test/java/io/quarkus/tls/TrustAllWithHttpClientHandshakeTest.java
@@ -78,7 +78,7 @@ public class TrustAllWithHttpClientHandshakeTest {
         WebClient client = WebClient.create(vertx, clientOptions);
 
         CountDownLatch latch = new CountDownLatch(1);
-        client.get(8081, "localhost", "/").send(ar -> {
+        client.get(8081, "localhost", "/").send().onComplete(ar -> {
             assertThat(ar.succeeded()).isTrue();
             assertThat(ar.result().bodyAsString()).isEqualTo("Trust All OK");
             latch.countDown();

--- a/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/VertxCertificateHolder.java
+++ b/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/VertxCertificateHolder.java
@@ -23,8 +23,10 @@ import io.quarkus.tls.runtime.config.TlsBucketConfig;
 import io.quarkus.tls.runtime.config.TlsConfigUtils;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.net.ClientSSLOptions;
 import io.vertx.core.net.KeyCertOptions;
 import io.vertx.core.net.SSLOptions;
+import io.vertx.core.net.ServerSSLOptions;
 import io.vertx.core.net.TrustOptions;
 
 public class VertxCertificateHolder implements TlsConfiguration {
@@ -109,9 +111,7 @@ public class VertxCertificateHolder implements TlsConfiguration {
         return sslContext;
     }
 
-    @Override
-    public synchronized SSLOptions getSSLOptions() {
-        SSLOptions options = new SSLOptions();
+    private synchronized void populateCommonSSLOptions(SSLOptions options) {
         options.setKeyCertOptions(getKeyStoreOptions());
         options.setTrustOptions(getTrustStoreOptions());
         options.setUseAlpn(config().alpn());
@@ -128,7 +128,24 @@ public class VertxCertificateHolder implements TlsConfiguration {
         for (String cipher : config().cipherSuites().orElse(Collections.emptyList())) {
             options.addEnabledCipherSuite(cipher);
         }
+    }
 
+    @Override
+    public synchronized ServerSSLOptions getServerSSLOptions() {
+        ServerSSLOptions options = new ServerSSLOptions();
+        populateCommonSSLOptions(options);
+        if (config.keyStore().isPresent()) {
+            options.setSni(config.keyStore().get().sni());
+        }
+        return options;
+    }
+
+    @Override
+    public synchronized ClientSSLOptions getClientSSLOptions() {
+        ClientSSLOptions options = new ClientSSLOptions();
+        populateCommonSSLOptions(options);
+        options.setTrustAll(isTrustAll());
+        config.hostnameVerificationAlgorithm().ifPresent(options::setHostnameVerificationAlgorithm);
         return options;
     }
 

--- a/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/config/TlsConfigUtils.java
+++ b/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/config/TlsConfigUtils.java
@@ -14,6 +14,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.WebSocketClientOptions;
 import io.vertx.core.net.ClientOptionsBase;
+import io.vertx.core.net.ClientSSLOptions;
 import io.vertx.core.net.NetClientOptions;
 import io.vertx.core.net.SSLOptions;
 import io.vertx.core.net.TCPSSLOptions;
@@ -55,23 +56,9 @@ public class TlsConfigUtils {
     }
 
     /**
-     * Configure the {@link TCPSSLOptions} with the given {@link TlsConfiguration}.
-     *
-     * @param options the options to configure
-     * @param configuration the configuration to use
+     * Apply common SSL properties from a {@link SSLOptions} to a {@link TCPSSLOptions}.
      */
-    public static void configure(TCPSSLOptions options, TlsConfiguration configuration) {
-        options.setSsl(true);
-        if (configuration.getTrustStoreOptions() != null) {
-            options.setTrustOptions(configuration.getTrustStoreOptions());
-        }
-
-        // For mTLS:
-        if (configuration.getKeyStoreOptions() != null) {
-            options.setKeyCertOptions(configuration.getKeyStoreOptions());
-        }
-
-        SSLOptions sslOptions = configuration.getSSLOptions();
+    private static void applySSLOptions(TCPSSLOptions options, SSLOptions sslOptions) {
         if (sslOptions != null) {
             options.setSslHandshakeTimeout(sslOptions.getSslHandshakeTimeout());
             options.setSslHandshakeTimeoutUnit(sslOptions.getSslHandshakeTimeoutUnit());
@@ -95,16 +82,43 @@ public class TlsConfigUtils {
     }
 
     /**
-     * Configure the {@link ClientOptionsBase} with the given {@link TlsConfiguration}.
+     * Configure the {@link TCPSSLOptions} with the given {@link TlsConfiguration}.
+     * Uses server-side SSL options.
      *
      * @param options the options to configure
      * @param configuration the configuration to use
      */
-    public static void configure(ClientOptionsBase options, TlsConfiguration configuration) {
-        configure((TCPSSLOptions) options, configuration);
-        if (configuration.isTrustAll()) {
-            options.setTrustAll(true);
+    public static void configure(TCPSSLOptions options, TlsConfiguration configuration) {
+        options.setSsl(true);
+        if (configuration.getTrustStoreOptions() != null) {
+            options.setTrustOptions(configuration.getTrustStoreOptions());
         }
+
+        // For mTLS:
+        if (configuration.getKeyStoreOptions() != null) {
+            options.setKeyCertOptions(configuration.getKeyStoreOptions());
+        }
+
+        applySSLOptions(options, configuration.getServerSSLOptions());
+    }
+
+    /**
+     * Apply client-side SSL options (trust, keycert, trustAll) from {@link ClientSSLOptions} to a {@link ClientOptionsBase}.
+     */
+    private static ClientSSLOptions applyClientSSLOptions(ClientOptionsBase options, TlsConfiguration configuration) {
+        options.setSsl(true);
+        ClientSSLOptions sslOptions = configuration.getClientSSLOptions();
+        if (sslOptions != null) {
+            if (sslOptions.getTrustOptions() != null) {
+                options.setTrustOptions(sslOptions.getTrustOptions());
+            }
+            if (sslOptions.getKeyCertOptions() != null) {
+                options.setKeyCertOptions(sslOptions.getKeyCertOptions());
+            }
+            options.setTrustAll(sslOptions.isTrustAll());
+        }
+        applySSLOptions(options, sslOptions);
+        return sslOptions;
     }
 
     /**
@@ -114,9 +128,9 @@ public class TlsConfigUtils {
      * @param configuration the configuration to use
      */
     public static void configure(NetClientOptions options, TlsConfiguration configuration) {
-        configure((ClientOptionsBase) options, configuration);
-        if (configuration.getHostnameVerificationAlgorithm().isPresent()) {
-            options.setHostnameVerificationAlgorithm(configuration.getHostnameVerificationAlgorithm().get());
+        ClientSSLOptions sslOptions = applyClientSSLOptions(options, configuration);
+        if (sslOptions != null && sslOptions.getHostnameVerificationAlgorithm() != null) {
+            options.setHostnameVerificationAlgorithm(sslOptions.getHostnameVerificationAlgorithm());
         }
     }
 
@@ -127,13 +141,12 @@ public class TlsConfigUtils {
      * @param configuration the configuration to use
      */
     public static void configure(HttpClientOptions options, TlsConfiguration configuration) {
-        configure((ClientOptionsBase) options, configuration);
-        options.setForceSni(configuration.usesSni());
-        if (configuration.getHostnameVerificationAlgorithm().isPresent()
-                && configuration.getHostnameVerificationAlgorithm().get().equals("NONE")) {
-            // Only disable hostname verification if the algorithm is explicitly set to NONE
+        ClientSSLOptions sslOptions = applyClientSSLOptions(options, configuration);
+        if (sslOptions != null && sslOptions.getHostnameVerificationAlgorithm() != null
+                && sslOptions.getHostnameVerificationAlgorithm().equals("NONE")) {
             options.setVerifyHost(false);
         }
+        options.setForceSni(configuration.usesSni());
     }
 
     /**
@@ -143,10 +156,9 @@ public class TlsConfigUtils {
      * @param configuration the configuration to use
      */
     public static void configure(WebSocketClientOptions options, TlsConfiguration configuration) {
-        configure((ClientOptionsBase) options, configuration);
-        if (configuration.getHostnameVerificationAlgorithm().isPresent()
-                && configuration.getHostnameVerificationAlgorithm().get().equals("NONE")) {
-            // Only disable hostname verification if the algorithm is explicitly set to NONE
+        ClientSSLOptions sslOptions = applyClientSSLOptions(options, configuration);
+        if (sslOptions != null && sslOptions.getHostnameVerificationAlgorithm() != null
+                && sslOptions.getHostnameVerificationAlgorithm().equals("NONE")) {
             options.setVerifyHost(false);
         }
     }

--- a/extensions/tls-registry/spi/src/main/java/io/quarkus/tls/BaseTlsConfiguration.java
+++ b/extensions/tls-registry/spi/src/main/java/io/quarkus/tls/BaseTlsConfiguration.java
@@ -5,8 +5,9 @@ import java.util.Optional;
 
 import javax.net.ssl.SSLContext;
 
+import io.vertx.core.net.ClientSSLOptions;
 import io.vertx.core.net.KeyCertOptions;
-import io.vertx.core.net.SSLOptions;
+import io.vertx.core.net.ServerSSLOptions;
 import io.vertx.core.net.TrustOptions;
 
 /**
@@ -51,11 +52,20 @@ public abstract class BaseTlsConfiguration implements TlsConfiguration {
     }
 
     /**
-     * Returns the (Vert.x) SSL options.
+     * Returns the server-side SSL options.
      *
-     * @return the {@link SSLOptions}, {@code null} if not configured.
+     * @return the {@link ServerSSLOptions}, {@code null} if not configured.
      */
-    public SSLOptions getSSLOptions() {
+    public ServerSSLOptions getServerSSLOptions() {
+        return null;
+    }
+
+    /**
+     * Returns the client-side SSL options.
+     *
+     * @return the {@link ClientSSLOptions}, {@code null} if not configured.
+     */
+    public ClientSSLOptions getClientSSLOptions() {
         return null;
     }
 

--- a/extensions/tls-registry/spi/src/main/java/io/quarkus/tls/TlsConfiguration.java
+++ b/extensions/tls-registry/spi/src/main/java/io/quarkus/tls/TlsConfiguration.java
@@ -5,8 +5,9 @@ import java.util.Optional;
 
 import javax.net.ssl.SSLContext;
 
+import io.vertx.core.net.ClientSSLOptions;
 import io.vertx.core.net.KeyCertOptions;
-import io.vertx.core.net.SSLOptions;
+import io.vertx.core.net.ServerSSLOptions;
 import io.vertx.core.net.TrustOptions;
 
 /**
@@ -54,11 +55,18 @@ public interface TlsConfiguration {
     TrustOptions getTrustStoreOptions();
 
     /**
-     * Returns the (Vert.x) SSL options.
+     * Returns the server-side SSL options.
      *
-     * @return the {@link SSLOptions}, {@code null} if not configured.
+     * @return the {@link ServerSSLOptions}, {@code null} if not configured.
      */
-    SSLOptions getSSLOptions();
+    ServerSSLOptions getServerSSLOptions();
+
+    /**
+     * Returns the client-side SSL options.
+     *
+     * @return the {@link ClientSSLOptions}, {@code null} if not configured.
+     */
+    ClientSSLOptions getClientSSLOptions();
 
     /**
      * Creates and returns the SSL Context.


### PR DESCRIPTION
Migration of the TLS registry extension to Vert.x 5.


Related to #51959. 