### PR TITLE
Add --enable-native-access=ALL-UNNAMED to dev mode JVM args

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/DevModeCommandLineBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/DevModeCommandLineBuilder.java
@@ -402,6 +402,10 @@ public class DevModeCommandLineBuilder {
         //Useful for AgentBasedModulesReconfigurer; should we use -agent and load it explicitly?
         jvmOptionsBuilder.addXxOption("EnableDynamicAgentLoading", "true");
 
+        // Jansi is on the dev mode classpath for terminal/console support and calls System.load
+        // to load native libraries, which requires native access on JDK 22+
+        jvmOptionsBuilder.add("enable-native-access", "ALL-UNNAMED");
+
         setJvmOptions();
         args.add("-Djava.util.logging.manager=org.jboss.logmanager.LogManager");
         args.add("--add-opens=java.base/java.lang.invoke=ALL-UNNAMED");

--- a/core/deployment/src/test/java/io/quarkus/deployment/dev/DevModeCommandLineBuilderTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/dev/DevModeCommandLineBuilderTest.java
@@ -33,6 +33,14 @@ public class DevModeCommandLineBuilderTest {
     }
 
     @Test
+    public void enableNativeAccessAlwaysPresent() throws Exception {
+        // --enable-native-access=ALL-UNNAMED must be set even without extensions,
+        // because Jansi (used for dev mode terminal support) calls System.load
+        var args = getCliArguments();
+        assertThat(args).contains("--enable-native-access=ALL-UNNAMED");
+    }
+
+    @Test
     public void extensionSetsJvmOptionWithValue() throws Exception {
 
         final ExtensionDevModeConfig acmeMagic = new ExtensionDevModeConfig(


### PR DESCRIPTION
## Summary

- Add `--enable-native-access=ALL-UNNAMED` unconditionally to dev mode JVM arguments
- Jansi (used for terminal/console support in dev mode) calls `System.load` to load native libraries, which triggers warnings on JDK 22+ about restricted method usage
- The flag is already supported by the `JvmOptionsBuilder` infrastructure and deduplicates with extension-provided values (e.g., from picocli)

- Fixes: #53342

## Test plan

- [x] Added `enableNativeAccessAlwaysPresent` test to `DevModeCommandLineBuilderTest` verifying the flag is always present even without extensions
- [x] All 11 existing tests in `DevModeCommandLineBuilderTest` continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Claude Code on behalf of Guillaume Nodet_