### PR TITLE
Qute - Fix some build reproducibility issues

### DIFF
--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/GeneratedValueResolverBuildItem.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/GeneratedValueResolverBuildItem.java
@@ -5,7 +5,8 @@ import io.quarkus.builder.item.MultiBuildItem;
 /**
  * Holds a name of a generated {@link io.quarkus.qute.ValueResolver} class.
  */
-public final class GeneratedValueResolverBuildItem extends MultiBuildItem {
+public final class GeneratedValueResolverBuildItem extends MultiBuildItem
+        implements Comparable<GeneratedValueResolverBuildItem> {
 
     private final String className;
 
@@ -17,4 +18,8 @@ public final class GeneratedValueResolverBuildItem extends MultiBuildItem {
         return className;
     }
 
+    @Override
+    public int compareTo(GeneratedValueResolverBuildItem o) {
+        return className.compareTo(o.className);
+    }
 }

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
@@ -2116,6 +2116,7 @@ public class QuteProcessor {
                                         Set.copyOf(method.getMatchNames()),
                                         method.getMatchRegex(), method.getParams()));
                     }
+                    extensionMethods.sort(Comparator.comparing(e -> e.method().toString()));
                     String generatedType = extensionMethodGenerator.generateNamespaceResolver(
                             priorityEntry.getValue().get(0).getMethod().declaringClass(), nsEntry.getKey(),
                             priorityEntry.getKey(), extensionMethods);

--- a/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/ExtensionMethodGenerator.java
+++ b/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/ExtensionMethodGenerator.java
@@ -14,9 +14,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.BiConsumer;
@@ -262,8 +264,8 @@ public class ExtensionMethodGenerator extends AbstractGenerator {
                     // First group extension methods by number of _evaluated_ params, e.g.:
                     // 0 -> [ping(), pong()]
                     // 1 -> [ping(int a), ping(String name), pong(boolean val)]
-                    Map<Integer, List<NamespaceExtensionMethodInfo>> byNumberOfParams = new HashMap<>();
-                    Map<Integer, List<NamespaceExtensionMethodInfo>> varargsByMinParams = new HashMap<>();
+                    Map<Integer, List<NamespaceExtensionMethodInfo>> byNumberOfParams = new TreeMap<>();
+                    Map<Integer, List<NamespaceExtensionMethodInfo>> varargsByMinParams = new TreeMap<>();
                     for (NamespaceExtensionMethodInfo em : extensionMethods) {
                         int count = em.params().evaluated().size();
                         List<NamespaceExtensionMethodInfo> matching = byNumberOfParams.get(count);
@@ -294,8 +296,8 @@ public class ExtensionMethodGenerator extends AbstractGenerator {
                         // "ping" -> [ping(int a), ping(String name)]
                         // Keep in mind that extension methods may have a special name matching config,
                         // e.g. TemplateExtension#matchNames()
-                        Map<String, List<NamespaceExtensionMethodInfo>> matchingName = new HashMap<>();
-                        Map<Set<String>, List<NamespaceExtensionMethodInfo>> matchingNames = new HashMap<>();
+                        Map<String, List<NamespaceExtensionMethodInfo>> matchingName = new LinkedHashMap<>();
+                        Map<Set<String>, List<NamespaceExtensionMethodInfo>> matchingNames = new LinkedHashMap<>();
                         int numberOfParams = e.getKey();
                         List<NamespaceExtensionMethodInfo> extensionMethodForParams = e.getValue();
 
@@ -373,7 +375,7 @@ public class ExtensionMethodGenerator extends AbstractGenerator {
                             bc.block(nested -> {
                                 // Test that any of the names matches
                                 nested.block(nested2 -> {
-                                    for (String matchName : matchNames) {
+                                    for (String matchName : matchNames.stream().sorted().toList()) {
                                         nested2.if_(nested2.objEquals(name, Const.of(matchName)),
                                                 namesMatch -> namesMatch.break_(nested2));
                                     }
@@ -437,7 +439,7 @@ public class ExtensionMethodGenerator extends AbstractGenerator {
                                 } else if (em.matchesNames()) {
                                     // Test that any of the names matches
                                     nested.block(nested2 -> {
-                                        for (String matchName : em.matchNames()) {
+                                        for (String matchName : em.matchNames().stream().sorted().toList()) {
                                             nested2.if_(nested2.objEquals(name, Const.of(matchName)),
                                                     namesMatch -> namesMatch.break_(nested2));
                                         }


### PR DESCRIPTION
Making GeneratedValueResolverBuildItem comparable ensures the recorder will be called in a deterministic order.

Then we also make sure the bytecode generation is done in a reproducible order.

Note that I'm perfectly fine with another approach solving the same issues. It's always a bit hard to decide exactly where to solve the issue.

@mkouba So if you want to solve it another way, you're welcome, at least we have the issues we need to fix spotted.