### PR TITLE
Fix ConfigPropertyBuildItem ordering

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigPropertyBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigPropertyBuildItem.java
@@ -1,5 +1,7 @@
 package io.quarkus.arc.deployment;
 
+import java.util.Comparator;
+
 import org.jboss.jandex.Type;
 
 import io.quarkus.builder.item.MultiBuildItem;
@@ -9,6 +11,9 @@ import io.quarkus.runtime.ExecutionMode;
  * Represents a mandatory config property that needs to be validated at runtime.
  */
 public final class ConfigPropertyBuildItem extends MultiBuildItem implements Comparable<ConfigPropertyBuildItem> {
+
+    private static final Comparator<String> DEFAULT_VALUE_COMPARATOR = Comparator.nullsFirst(Comparator.naturalOrder());
+
     private final String propertyName;
     private final Type propertyType;
     private final String defaultValue;
@@ -52,7 +57,15 @@ public final class ConfigPropertyBuildItem extends MultiBuildItem implements Com
 
     @Override
     public int compareTo(ConfigPropertyBuildItem other) {
-        return this.propertyName.compareTo(other.propertyName);
+        int result = this.propertyName.compareTo(other.propertyName);
+        if (result != 0) {
+            return result;
+        }
+        result = this.propertyType.name().compareTo(other.propertyType.name());
+        if (result != 0) {
+            return result;
+        }
+        return DEFAULT_VALUE_COMPARATOR.compare(this.defaultValue, other.defaultValue);
     }
 
     public static ConfigPropertyBuildItem staticInit(


### PR DESCRIPTION
A @ConfigProperty can be used with the same name in different locations and thus with different types and different default values.

We need to specify the order to be fully deterministic.

@radcortez this is related to our discussion of the other day. The build items are then fully ordered and it fixes the reproducibility issues I had with the Stork quickstart.