### PR TITLE
Migration of the mailer extension to Vert.x 5

### DIFF
--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MutinyMailerImpl.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MutinyMailerImpl.java
@@ -325,7 +325,6 @@ public class MutinyMailerImpl implements ReactiveMailer {
                     new OpenOptions().setRead(true).setCreate(false));
             return open
                     .flatMap(af -> af.toMulti()
-                            .map(io.vertx.mutiny.core.buffer.Buffer::getDelegate)
                             .onTermination().call((r, f) -> af.close())
                             .collect().in(Buffer::buffer, Buffer::appendBuffer));
         } else if (attachment.getData() != null) {

--- a/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/AttachmentTest.java
+++ b/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/AttachmentTest.java
@@ -16,10 +16,10 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.mailer.runtime.MutinyMailerImpl;
 import io.smallrye.mutiny.Multi;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.file.FileSystemException;
 import io.vertx.core.file.OpenOptions;
 import io.vertx.mutiny.core.Vertx;
-import io.vertx.mutiny.core.buffer.Buffer;
 
 class AttachmentTest {
 

--- a/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/runtime/FakeSmtpServer.java
+++ b/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/runtime/FakeSmtpServer.java
@@ -50,7 +50,7 @@ public class FakeSmtpServer {
         int port = ssl ? 1465 : 1587;
         nsOptions.setPort(port);
         JksOptions jksOptions = new JksOptions().setPath(keystore).setPassword("password");
-        nsOptions.setKeyStoreOptions(jksOptions);
+        nsOptions.setKeyCertOptions(jksOptions);
         if (ssl) {
             nsOptions.setSsl(true);
         }
@@ -125,7 +125,7 @@ public class FakeSmtpServer {
                             vertx.setTimer(closeWaitTime * 1000L, v -> socket.closeAndForget());
                         }
                     }
-                }).handle(b.getDelegate()));
+                }).handle(b));
             }
         });
 


### PR DESCRIPTION
The migration was mostly `Buffer`-related (no more shim in the Vert.x Mutiny bindings).