### PR TITLE
Document aarch64 fallback image for MS SQL Server Dev Services

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -90,6 +90,7 @@
         <mariadb.image>docker.io/library/mariadb:12.1</mariadb.image>
         <db2.image>icr.io/db2_community/db2:12.1.0.0</db2.image>
         <mssql.image>mcr.microsoft.com/mssql/server:2022-latest</mssql.image>
+        <mssql.image.aarch64>mcr.microsoft.com/azure-sql-edge:latest</mssql.image.aarch64>
         <mysql.image>docker.io/library/mysql:9.5</mysql.image>
         <oracle.image>docker.io/gvenzl/oracle-free:23-slim-faststart</oracle.image>
         <mongo.image>docker.io/library/mongo:7.0</mongo.image>
@@ -1171,7 +1172,7 @@
                 <!-- See
                 https://github.com/microsoft/mssql-docker/issues/668 and https://stackoverflow.com/questions/65398641/docker-connect-sql-server-container-non-zero-code-1/66919852#66919852.
                 The MS SQL image segfaults on ARM. Azure Edge is not fully compatible, but it is better than not running the tests at all. -->
-                <mssql.image>mcr.microsoft.com/azure-sql-edge:latest</mssql.image>
+                <mssql.image>${mssql.image.aarch64}</mssql.image>
             </properties>
         </profile>
     </profiles>

--- a/docs/src/main/asciidoc/_attributes.adoc
+++ b/docs/src/main/asciidoc/_attributes.adoc
@@ -14,6 +14,7 @@
 :db2-image: ${db2.image}
 :mariadb-image: ${mariadb.image}
 :mssql-image: ${mssql.image}
+:mssql-image-aarch64: ${mssql.image.aarch64}
 :mysql-image: ${mysql.image}
 :oracle-image: ${oracle.image}
 :postgres-image: ${postgres.image}

--- a/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DevServicesBuildTimeConfig.java
+++ b/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DevServicesBuildTimeConfig.java
@@ -33,7 +33,8 @@ public interface DevServicesBuildTimeConfig {
      *
      * * DB2: `{db2-image}`
      * * MariaDB: `{mariadb-image}`
-     * * Microsoft SQL Server: `{mssql-image}`
+     * * Microsoft SQL Server: `{mssql-image}` +
+     * On ARM (aarch64),`{mssql-image-aarch64}` is used instead, because the standard MS SQL Server image does not run on ARM.
      * * MySQL: `{mysql-image}`
      * * Oracle Express Edition: `{oracle-image}`
      * * PostgreSQL: `{postgres-image}`


### PR DESCRIPTION
The `build-parent/pom.xml` defines two values for `mssql.image`:

- **Default (x86_64):** `mcr.microsoft.com/mssql/server:2022-latest`
- **aarch64 profile:** `mcr.microsoft.com/azure-sql-edge:latest` (the standard MS SQL image segfaults on ARM — see #25830)

The generated datasource configuration reference only shows the default image. Developers on ARM (Apple Silicon, Graviton) who look up the default image in the docs won't discover that they need `azure-sql-edge` instead, and will hit the segfault without understanding why.

### Changes

1. **`build-parent/pom.xml`** — Add a `<mssql.image.aarch64>` property to the default `<properties>` section and update the `aarch64` profile to reference it via `${mssql.image.aarch64}`. This centralizes the fallback image value in one place so it cannot drift between the pom.xml and the docs. The resolved value on aarch64 is unchanged.

2. **`docs/src/main/asciidoc/_attributes.adoc`** — Add `:mssql-image-aarch64: ${mssql.image.aarch64}`. This follows the same Maven property pattern used by all other image attributes (`:mssql-image:`, `:postgres-image:`, etc.), so the value is always sourced from the pom.xml rather than hardcoded in the docs.

3. **`DevServicesBuildTimeConfig.java`** — Add an ARM note to the `imageName()` Javadoc. Because this method uses `@asciidoclet`, the AsciiDoc markup (`+` line continuation and `{mssql-image-aarch64}` attribute reference) renders correctly in the generated config reference that developers read.

### Context

The aarch64 fallback was originally added in #25830. Updated per review feedback from @wjglerum on #53367 to avoid hardcoding the image value in the docs.

CC @holly-cummins @wjglerum @famod

* Fixes #53357