### PR TITLE
Add custom enforcer rule to validate dependency version alignment

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -6715,6 +6715,58 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-dependency-alignment</id>
+                        <phase>${maven-enforcer-plugin.phase}</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <dependencyAlignmentRule implementation="io.quarkus.enforcer.DependencyAlignmentRule">
+                                    <referenceArtifact>org.hibernate.orm:hibernate-platform:${hibernate-orm.version}</referenceArtifact>
+                                    <dependencies>
+                                        <dependency>
+                                            <artifact>jakarta.persistence:jakarta.persistence-api</artifact>
+                                        </dependency>
+                                        <dependency>
+                                            <artifact>jakarta.data:jakarta.data-api</artifact>
+                                        </dependency>
+                                        <dependency>
+                                            <artifact>org.antlr:antlr4-runtime</artifact>
+                                        </dependency>
+                                        <dependency>
+                                            <artifact>net.bytebuddy:byte-buddy</artifact>
+                                        </dependency>
+                                        <dependency>
+                                            <artifact>org.hibernate.models:hibernate-models</artifact>
+                                        </dependency>
+                                    </dependencies>
+                                </dependencyAlignmentRule>
+                                <dependencyAlignmentRule implementation="io.quarkus.enforcer.DependencyAlignmentRule">
+                                    <referenceArtifact>org.hibernate.orm:hibernate-spatial:${hibernate-orm.version}</referenceArtifact>
+                                    <dependencies>
+                                        <dependency>
+                                            <artifact>org.geolatte:geolatte-geom</artifact>
+                                        </dependency>
+                                    </dependencies>
+                                </dependencyAlignmentRule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.quarkus</groupId>
+                        <artifactId>quarkus-enforcer-rules</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/independent-projects/enforcer-rules/pom.xml
+++ b/independent-projects/enforcer-rules/pom.xml
@@ -36,6 +36,7 @@
         <enforcer-api.version>3.0.0-M3</enforcer-api.version>
         <maven-invoker-plugin.version>3.9.1</maven-invoker-plugin.version>
         <maven-core.version>3.9.12</maven-core.version>
+        <aether.version>1.1.0</aether.version>
 
         <!--
            Supported Maven versions, interpreted as a version range (Also defined in build-parent)
@@ -69,6 +70,12 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.aether</groupId>
+            <artifactId>aether-api</artifactId>
+            <version>${aether.version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/independent-projects/enforcer-rules/src/it/dependency-alignment-bom-test/invoker.properties
+++ b/independent-projects/enforcer-rules/src/it/dependency-alignment-bom-test/invoker.properties
@@ -1,0 +1,2 @@
+# Test should fail because of misaligned versions
+invoker.buildResult=failure

--- a/independent-projects/enforcer-rules/src/it/dependency-alignment-bom-test/pom.xml
+++ b/independent-projects/enforcer-rules/src/it/dependency-alignment-bom-test/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.quarkus.enforcer.test</groupId>
+    <artifactId>dependency-alignment-bom-test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <!-- Use a real Hibernate ORM version that exists in Maven Central -->
+        <hibernate-orm.version>6.4.0.Final</hibernate-orm.version>
+
+        <!-- These versions should match what's in hibernate-platform:6.4.0.Final -->
+        <bytebuddy.version>1.14.0</bytebuddy.version> <!-- Wrong: should be 1.14.7 -->
+        <antlr.version>4.10.1</antlr.version> <!-- Wrong: should be 4.13.0 -->
+        <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version> <!-- Correct: matches hibernate-platform -->
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>${bytebuddy.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.antlr</groupId>
+                <artifactId>antlr4</artifactId>
+                <version>${antlr.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.persistence</groupId>
+                <artifactId>jakarta.persistence-api</artifactId>
+                <version>${jakarta.persistence-api.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>@enforcer-api.version@</version>
+                <executions>
+                    <execution>
+                        <id>test-bom-alignment</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <dependencyAlignmentRule implementation="io.quarkus.enforcer.DependencyAlignmentRule">
+                                    <referenceArtifact>org.hibernate.orm:hibernate-platform:${hibernate-orm.version}</referenceArtifact>
+                                    <dependencies>
+                                        <dependency>
+                                            <artifact>net.bytebuddy:byte-buddy</artifact>
+                                        </dependency>
+                                        <dependency>
+                                            <artifact>org.antlr:antlr4</artifact>
+                                        </dependency>
+                                        <dependency>
+                                            <artifact>jakarta.persistence:jakarta.persistence-api</artifact>
+                                        </dependency>
+                                    </dependencies>
+                                </dependencyAlignmentRule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>@project.groupId@</groupId>
+                        <artifactId>@project.artifactId@</artifactId>
+                        <version>@project.version@</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/independent-projects/enforcer-rules/src/it/dependency-alignment-bom-test/verify.groovy
+++ b/independent-projects/enforcer-rules/src/it/dependency-alignment-bom-test/verify.groovy
@@ -1,0 +1,10 @@
+File buildLog = new File( basedir, 'build.log' )
+
+// Test DependencyAlignmentRule failure - should report ALL misalignments
+assert buildLog.text.contains( 'Dependency version alignment check failed' )
+assert buildLog.text.contains( 'Version mismatch' )
+// Both misaligned dependencies should be reported
+assert buildLog.text.contains( 'net.bytebuddy:byte-buddy' )
+assert buildLog.text.contains( 'org.antlr:antlr4' )
+// The aligned dependency should NOT be reported
+assert !buildLog.text.contains( 'jakarta.persistence:jakarta.persistence-api' )

--- a/independent-projects/enforcer-rules/src/it/dependency-alignment-dependencies-test/invoker.properties
+++ b/independent-projects/enforcer-rules/src/it/dependency-alignment-dependencies-test/invoker.properties
@@ -1,0 +1,2 @@
+# Test should fail because one dependency is misaligned (but found in <dependencies> section)
+invoker.buildResult=failure

--- a/independent-projects/enforcer-rules/src/it/dependency-alignment-dependencies-test/pom.xml
+++ b/independent-projects/enforcer-rules/src/it/dependency-alignment-dependencies-test/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.quarkus.enforcer.test</groupId>
+    <artifactId>dependency-alignment-dependencies-test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <!-- Use a real Hibernate ORM version that exists in Maven Central -->
+        <hibernate-orm.version>6.4.0.Final</hibernate-orm.version>
+
+        <!-- These dependencies are found in hibernate-spatial's <dependencies> section, not <dependencyManagement> -->
+        <geolatte.version>1.8.0</geolatte.version> <!-- Wrong: should be 1.8.2 -->
+        <jboss-logging.version>3.5.0.Final</jboss-logging.version> <!-- Correct: matches hibernate-spatial -->
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.geolatte</groupId>
+            <artifactId>geolatte-geom</artifactId>
+            <version>${geolatte.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <version>${jboss-logging.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>@enforcer-api.version@</version>
+                <executions>
+                    <execution>
+                        <id>test-dependency-fallback</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <dependencyAlignmentRule implementation="io.quarkus.enforcer.DependencyAlignmentRule">
+                                    <referenceArtifact>org.hibernate.orm:hibernate-spatial:${hibernate-orm.version}</referenceArtifact>
+                                    <dependencies>
+                                        <dependency>
+                                            <artifact>org.geolatte:geolatte-geom</artifact>
+                                        </dependency>
+                                        <dependency>
+                                            <artifact>org.jboss.logging:jboss-logging</artifact>
+                                        </dependency>
+                                    </dependencies>
+                                </dependencyAlignmentRule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>@project.groupId@</groupId>
+                        <artifactId>@project.artifactId@</artifactId>
+                        <version>@project.version@</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/independent-projects/enforcer-rules/src/it/dependency-alignment-dependencies-test/verify.groovy
+++ b/independent-projects/enforcer-rules/src/it/dependency-alignment-dependencies-test/verify.groovy
@@ -1,0 +1,13 @@
+File buildLog = new File( basedir, 'build.log' )
+
+// Test should FAIL - dependencies found in <dependencies> section (not <dependencyManagement>)
+// This tests the fallback to <dependencies> when not in <dependencyManagement>
+assert buildLog.text.contains( 'BUILD FAILURE' )
+assert buildLog.text.contains( 'Dependency version alignment check failed' )
+// The misaligned dependency should be reported
+assert buildLog.text.contains( 'org.geolatte:geolatte-geom' )
+assert buildLog.text.contains( 'Version mismatch' )
+// The aligned dependency should NOT be reported
+assert !buildLog.text.contains( 'org.jboss.logging:jboss-logging' )
+// Both dependencies should have been found in the reference artifact
+assert !buildLog.text.contains( 'not found in reference artifact' )

--- a/independent-projects/enforcer-rules/src/main/java/io/quarkus/enforcer/DependencyAlignmentData.java
+++ b/independent-projects/enforcer-rules/src/main/java/io/quarkus/enforcer/DependencyAlignmentData.java
@@ -1,0 +1,42 @@
+package io.quarkus.enforcer;
+
+/**
+ * Configuration data for a single dependency that needs to be aligned with a reference artifact.
+ */
+public class DependencyAlignmentData {
+
+    /**
+     * The artifact coordinates in the form "groupId:artifactId" (e.g., "jakarta.persistence:jakarta.persistence-api").
+     */
+    private String artifact;
+
+    /**
+     * Whether to fail if the artifact is not found in the project's dependencyManagement or dependencies (default: true).
+     * Note: If the artifact is not found in the reference artifact, the rule will always fail regardless of this setting.
+     */
+    private boolean failOnNotFound = true;
+
+    public String getArtifact() {
+        return artifact;
+    }
+
+    public void setArtifact(String artifact) {
+        this.artifact = artifact;
+    }
+
+    public boolean isFailOnNotFound() {
+        return failOnNotFound;
+    }
+
+    public void setFailOnNotFound(boolean failOnNotFound) {
+        this.failOnNotFound = failOnNotFound;
+    }
+
+    @Override
+    public String toString() {
+        return "{" +
+                "artifact='" + artifact + '\'' +
+                ", failOnNotFound=" + failOnNotFound +
+                '}';
+    }
+}

--- a/independent-projects/enforcer-rules/src/main/java/io/quarkus/enforcer/DependencyAlignmentRule.java
+++ b/independent-projects/enforcer-rules/src/main/java/io/quarkus/enforcer/DependencyAlignmentRule.java
@@ -1,0 +1,297 @@
+package io.quarkus.enforcer;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.enforcer.rule.api.EnforcerLevel;
+import org.apache.maven.enforcer.rule.api.EnforcerRule;
+import org.apache.maven.enforcer.rule.api.EnforcerRule2;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactDescriptorException;
+import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
+
+/**
+ * Custom enforcer rule to ensure dependency versions are aligned with a reference artifact.
+ * <p>
+ * This rule resolves a reference artifact (e.g., Hibernate Platform) and checks that the versions
+ * declared in the project's dependencyManagement/dependencies sections match those in the reference artifact.
+ */
+public class DependencyAlignmentRule implements EnforcerRule2 {
+
+    /**
+     * The reference artifact to check against in the format "groupId:artifactId:version".
+     * Example: "org.hibernate.orm:hibernate-platform:7.3.0.Final"
+     * The version can contain property references like "${hibernate-orm.version}".
+     * Required.
+     */
+    private String referenceArtifact;
+
+    /**
+     * List of dependencies to check for alignment with the reference artifact.
+     * Each entry specifies the artifact coordinates (groupId:artifactId) to check.
+     */
+    private List<DependencyAlignmentData> dependencies;
+
+    private Log logger;
+
+    private EnforcerLevel level = EnforcerLevel.ERROR;
+
+    public void setReferenceArtifact(String referenceArtifact) {
+        this.referenceArtifact = referenceArtifact;
+    }
+
+    public void setDependencies(List<DependencyAlignmentData> dependencies) {
+        this.dependencies = dependencies;
+    }
+
+    @Override
+    public EnforcerLevel getLevel() {
+        return level;
+    }
+
+    public void setLevel(EnforcerLevel level) {
+        this.level = level;
+    }
+
+    @Override
+    public void execute(EnforcerRuleHelper helper) throws EnforcerRuleException {
+        logger = helper.getLog();
+
+        // Validate configuration
+        if (referenceArtifact == null || referenceArtifact.trim().isEmpty()) {
+            throw new EnforcerRuleException(
+                    "referenceArtifact must be configured (e.g., 'org.hibernate.orm:hibernate-platform:7.3.0.Final')");
+        }
+        if (dependencies == null || dependencies.isEmpty()) {
+            logger.warn("No dependencies configured for alignment check");
+            return;
+        }
+
+        // Parse the reference artifact GAV
+        String[] parts = referenceArtifact.split(":");
+        if (parts.length != 3) {
+            throw new EnforcerRuleException(
+                    "referenceArtifact must be in format 'groupId:artifactId:version', got: " + referenceArtifact);
+        }
+        String referenceGroupId = parts[0];
+        String referenceArtifactId = parts[1];
+        String referenceVersion = parts[2];
+
+        logger.debug("Checking alignment with " + referenceArtifact);
+
+        MavenProject project;
+        RepositorySystem repositorySystem;
+        RepositorySystemSession repositorySession;
+
+        try {
+            // With the old enforcer API (3.0.0-M3), we need to use evaluate() to get the project and session
+            // The newer API (3.2.1+) would allow cleaner dependency injection with @Inject
+            project = (MavenProject) helper.evaluate("${project}");
+            repositorySystem = helper.getComponent(RepositorySystem.class);
+            // RepositorySystemSession is not available via helper methods, must use property evaluation
+            repositorySession = (RepositorySystemSession) helper.evaluate("${repositorySystemSession}");
+        } catch (ExpressionEvaluationException | ComponentLookupException e) {
+            throw new EnforcerRuleException("Failed to get Maven components from context", e);
+        }
+
+        // Get remote repositories directly from the project (no need for property evaluation)
+        var remoteRepositories = project.getRemoteArtifactRepositories();
+
+        // Get project's dependency versions
+        Map<String, String> projectDependencyVersions = getProjectDependencyVersions(project);
+
+        // Resolve the reference artifact
+        Map<String, String> referenceDependencyVersions = resolveReferenceArtifact(
+                referenceGroupId, referenceArtifactId, referenceVersion,
+                repositorySystem, repositorySession, remoteRepositories);
+
+        // Check each configured dependency
+        var errors = new StringBuilder();
+        for (var dependency : dependencies) {
+            var artifact = dependency.getArtifact();
+            var expectedVersion = referenceDependencyVersions.get(artifact);
+
+            // If we can't determine the expected version, always fail
+            if (expectedVersion == null) {
+                errors.append("  - Artifact '%s' not found in reference artifact\n".formatted(artifact));
+                continue;
+            }
+
+            var actualVersion = projectDependencyVersions.get(artifact);
+            // If the dependency is not in the project, only fail if failOnNotFound is true
+            if (actualVersion == null) {
+                if (dependency.isFailOnNotFound()) {
+                    errors.append("  - Artifact '%s' not found in project's dependencyManagement or dependencies\n"
+                            .formatted(artifact));
+                } else {
+                    logger.debug("Artifact '%s' not found in project (skipping)".formatted(artifact));
+                }
+                continue;
+            }
+
+            if (!expectedVersion.equals(actualVersion)) {
+                errors.append("""
+                          - Version mismatch for '%s':
+                            Project declares version '%s'
+                            but reference artifact expects '%s'
+                        """.formatted(artifact, actualVersion, expectedVersion));
+            } else {
+                logger.debug("✓ %s version %s is aligned".formatted(artifact, actualVersion));
+            }
+        }
+
+        if (!errors.isEmpty()) {
+            throw new EnforcerRuleException("Dependency version alignment check failed:\n" + errors);
+        }
+    }
+
+    /**
+     * Extracts dependency versions from the project's dependencyManagement and dependencies sections.
+     *
+     * @param project the Maven project
+     * @return a map of "groupId:artifactId" to version
+     */
+    private Map<String, String> getProjectDependencyVersions(MavenProject project) {
+        Map<String, String> versions = new HashMap<>();
+
+        // First, check dependencyManagement section
+        if (project.getDependencyManagement() != null
+                && project.getDependencyManagement().getDependencies() != null) {
+            project.getDependencyManagement().getDependencies().forEach(dep -> {
+                String key = dep.getGroupId() + ":" + dep.getArtifactId();
+                if (dep.getVersion() != null) {
+                    versions.put(key, dep.getVersion());
+                }
+            });
+            logger.debug("Extracted " + versions.size() + " dependencies from project's dependencyManagement");
+        }
+
+        // Also check dependencies section for artifacts not in dependencyManagement
+        if (project.getDependencies() != null) {
+            int dependenciesAdded = 0;
+            for (org.apache.maven.model.Dependency dep : project.getDependencies()) {
+                String key = dep.getGroupId() + ":" + dep.getArtifactId();
+                // Only add if not already present from dependencyManagement
+                if (!versions.containsKey(key) && dep.getVersion() != null) {
+                    versions.put(key, dep.getVersion());
+                    dependenciesAdded++;
+                }
+            }
+            if (dependenciesAdded > 0) {
+                logger.debug("Extracted " + dependenciesAdded + " additional dependencies from project's dependencies section");
+            }
+        }
+
+        logger.debug("Total: " + versions.size() + " dependencies extracted from project");
+        return versions;
+    }
+
+    /**
+     * Resolves the reference artifact descriptor and extracts its managed dependencies and regular dependencies.
+     * Uses Maven's Aether API to read the artifact descriptor without manually parsing the POM.
+     *
+     * @param groupId the reference artifact groupId
+     * @param artifactId the reference artifact artifactId
+     * @param version the reference artifact version
+     * @param repositorySystem the repository system
+     * @param repositorySession the repository session
+     * @param remoteRepositories the remote repositories
+     * @return a map of "groupId:artifactId" to version
+     * @throws EnforcerRuleException if resolution fails
+     */
+    private Map<String, String> resolveReferenceArtifact(
+            String groupId,
+            String artifactId,
+            String version,
+            RepositorySystem repositorySystem,
+            RepositorySystemSession repositorySession,
+            List<ArtifactRepository> remoteRepositories) throws EnforcerRuleException {
+        try {
+
+            // Create artifact coordinates
+            var artifact = new DefaultArtifact(groupId, artifactId, "pom", version);
+
+            // Convert Maven repositories to Aether repositories
+            var aetherRepositories = remoteRepositories.stream()
+                    .map(repo -> new RemoteRepository.Builder(repo.getId(), "default", repo.getUrl()).build())
+                    .toList();
+
+            // Read the artifact descriptor to get managed dependencies
+            var descriptorRequest = new ArtifactDescriptorRequest();
+            descriptorRequest.setArtifact(artifact);
+            descriptorRequest.setRepositories(aetherRepositories);
+
+            var descriptorResult = repositorySystem.readArtifactDescriptor(repositorySession, descriptorRequest);
+
+            logger.debug("Resolved reference artifact: " + artifact);
+
+            var versions = new HashMap<String, String>();
+
+            // Extract managed dependencies (from dependencyManagement section)
+            var managedDeps = descriptorResult.getManagedDependencies();
+            if (managedDeps != null) {
+                managedDeps.stream()
+                        .map(org.eclipse.aether.graph.Dependency::getArtifact)
+                        .filter(a -> a.getVersion() != null && !a.getVersion().isEmpty())
+                        .forEach(a -> versions.put(a.getGroupId() + ":" + a.getArtifactId(), a.getVersion()));
+                logger.debug("Extracted %d managed dependencies".formatted(managedDeps.size()));
+            }
+
+            // Extract regular dependencies (from dependencies section) for those not in managedDependencies
+            var deps = descriptorResult.getDependencies();
+            if (deps != null) {
+                var dependenciesAdded = (int) deps.stream()
+                        .map(org.eclipse.aether.graph.Dependency::getArtifact)
+                        .filter(a -> a.getVersion() != null && !a.getVersion().isEmpty())
+                        .filter(a -> !versions.containsKey(a.getGroupId() + ":" + a.getArtifactId()))
+                        .peek(a -> versions.put(a.getGroupId() + ":" + a.getArtifactId(), a.getVersion()))
+                        .count();
+                if (dependenciesAdded > 0) {
+                    logger.debug("Extracted %d additional dependencies from dependencies section"
+                            .formatted(dependenciesAdded));
+                }
+            }
+
+            logger.debug("Total: %d dependencies extracted from reference artifact".formatted(versions.size()));
+            return versions;
+
+        } catch (ArtifactDescriptorException e) {
+            throw new EnforcerRuleException(
+                    "Failed to resolve reference artifact " + groupId + ":" + artifactId + ":" + version, e);
+        }
+    }
+
+    @Override
+    public boolean isCacheable() {
+        return false;
+    }
+
+    @Override
+    public boolean isResultValid(EnforcerRule cachedRule) {
+        return false;
+    }
+
+    @Override
+    public String getCacheId() {
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return "DependencyAlignmentRule{" +
+                "referenceArtifact='" + referenceArtifact + '\'' +
+                ", dependencies=" + dependencies +
+                '}';
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -71,13 +71,13 @@
         <jacoco.version>0.8.14</jacoco.version>
         <kubernetes-client.version>7.6.1</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
         <rest-assured.version>6.0.0</rest-assured.version>
-        <hibernate-orm.version>7.3.0.Final</hibernate-orm.version> <!-- WARNING when updating, also align the versions below -->
-        <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version> <!-- version controlled by Hibernate ORM's needs -->
-        <jakarta.data-api.version>1.0.1</jakarta.data-api.version> <!-- version controlled by Hibernate ORM's needs -->
-        <antlr.version>4.13.2</antlr.version> <!-- version controlled by Hibernate ORM's needs -->
-        <bytebuddy.version>1.18.7</bytebuddy.version> <!-- version controlled by Hibernate ORM's needs -->
-        <geolatte.version>1.10</geolatte.version> <!-- version controlled by Hibernate ORM's needs -->
-        <hibernate-models.version>1.1.0</hibernate-models.version> <!-- version controlled by Hibernate ORM's needs -->
+        <hibernate-orm.version>7.3.0.Final</hibernate-orm.version> <!-- WARNING when updating, also align the versions below; checked by maven-enforcer-plugin in bom -->
+        <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version> <!-- version controlled by Hibernate ORM's needs; checked by maven-enforcer-plugin in bom -->
+        <jakarta.data-api.version>1.0.1</jakarta.data-api.version> <!-- version controlled by Hibernate ORM's needs; checked by maven-enforcer-plugin in bom -->
+        <antlr.version>4.13.2</antlr.version> <!-- version controlled by Hibernate ORM's needs; checked by maven-enforcer-plugin in bom -->
+        <bytebuddy.version>1.18.7</bytebuddy.version> <!-- version controlled by Hibernate ORM's needs; checked by maven-enforcer-plugin in bom -->
+        <geolatte.version>1.10</geolatte.version> <!-- version controlled by Hibernate ORM's needs; checked by maven-enforcer-plugin in bom -->
+        <hibernate-models.version>1.1.0</hibernate-models.version> <!-- version controlled by Hibernate ORM's needs; checked by maven-enforcer-plugin in bom -->
         <hibernate-reactive.version>3.3.0.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
         <hibernate-validator.version>9.1.0.Final</hibernate-validator.version>
         <hibernate-search.version>8.3.0.Final</hibernate-search.version>


### PR DESCRIPTION
Automates checking that dependencies versions declared in the BOM match those from reference artifacts (e.g., Hibernate ORM platform), preventing manual alignment errors when updating dependencies.

This should prevent https://github.com/quarkusio/quarkus/pull/53341 from happening again -- CI will detect such problems in the very PR that does the upgrade.

Note we're using old Maven Enforcer APIs and this leads to warnings. I could ask Claude to fix that, but I thought a different PR would be better...