### PR TITLE
Migrate vertx-http extension to Vert.x 5

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/DecompressionTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/DecompressionTest.java
@@ -63,7 +63,7 @@ public class DecompressionTest {
         public void register(@Observes Router router) {
             router.post("/echo").handler(BodyHandler.create());
             router.post("/echo").handler(rc -> {
-                rc.response().end(rc.getBodyAsString());
+                rc.response().end(rc.body().asString());
             });
         }
 

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/EmptyHostTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/EmptyHostTest.java
@@ -38,7 +38,7 @@ public class EmptyHostTest {
 
         public void register(@Observes Router router) {
 
-            router.route("/hello").handler(ctx -> ctx.response().end("Hello World! " + ctx.request().host()));
+            router.route("/hello").handler(ctx -> ctx.response().end("Hello World! " + ctx.request().authority()));
         }
 
     }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/NonApplicationEscapeTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/NonApplicationEscapeTest.java
@@ -28,7 +28,6 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
-import io.vertx.ext.web.client.predicate.ResponsePredicate;
 
 public class NonApplicationEscapeTest {
     private static final String APP_PROPS = "" +
@@ -86,8 +85,7 @@ public class NonApplicationEscapeTest {
 
         WebClient.create(vertx)
                 .get(uri.getPort(), uri.getHost(), "/non-app-absolute")
-                .expect(ResponsePredicate.SC_OK)
-                .send(ar -> {
+                .send().onComplete(ar -> {
                     if (ar.succeeded()) {
                         HttpResponse<Buffer> response = ar.result();
                         result.set(response.bodyAsString());
@@ -107,8 +105,7 @@ public class NonApplicationEscapeTest {
 
         WebClient.create(vertx)
                 .get(uri.getPort(), uri.getHost(), "/non-app-absolute?query=true")
-                .expect(ResponsePredicate.SC_OK)
-                .send(ar -> {
+                .send().onComplete(ar -> {
                     if (ar.succeeded()) {
                         HttpResponse<Buffer> response = ar.result();
                         result.set(response.bodyAsString());

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/UserRouteRegistrationTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/UserRouteRegistrationTest.java
@@ -66,7 +66,7 @@ public class UserRouteRegistrationTest {
             router.route("/inject").handler(rc -> rc.response().end("inject - ok"));
             router.route().failureHandler(rc -> rc.failure().printStackTrace());
             router.route("/body").consumes("text/plain").handler(BodyHandler.create())
-                    .handler(rc -> rc.response().end(rc.getBodyAsString()));
+                    .handler(rc -> rc.response().end(rc.body().asString()));
         }
 
     }
@@ -80,7 +80,7 @@ public class UserRouteRegistrationTest {
         public void register(@Observes StartupEvent ignored) {
             router.route("/inject-mutiny").handler(rc -> rc.response().endAndForget("inject mutiny - ok"));
             router.route("/body-mutiny").consumes("text/plain").handler(io.vertx.mutiny.ext.web.handler.BodyHandler.create())
-                    .handler(rc -> rc.response().endAndForget(rc.getBodyAsString()));
+                    .handler(rc -> rc.response().endAndForget(rc.body().asString()));
         }
 
     }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/certReload/CertReloadTestHelper.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/certReload/CertReloadTestHelper.java
@@ -1,0 +1,44 @@
+package io.quarkus.vertx.http.certReload;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import javax.net.ssl.SSLHandshakeException;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpMethod;
+
+final class CertReloadTestHelper {
+
+    private CertReloadTestHelper() {
+    }
+
+    static String httpsGet(Vertx vertx, HttpClientOptions options, String path) {
+        var client = vertx.createHttpClient(options);
+        try {
+            return client.request(HttpMethod.GET, path)
+                    .flatMap(HttpClientRequest::send)
+                    .flatMap(HttpClientResponse::body)
+                    .map(Buffer::toString)
+                    .await();
+        } finally {
+            client.close();
+        }
+    }
+
+    static void assertTlsFails(Vertx vertx, HttpClientOptions options, String path) {
+        var client = vertx.createHttpClient(options);
+        try {
+            assertThatThrownBy(() -> client.request(HttpMethod.GET, path)
+                    .flatMap(HttpClientRequest::send)
+                    .flatMap(HttpClientResponse::body)
+                    .map(Buffer::toString)
+                    .await()).hasCauseInstanceOf(SSLHandshakeException.class);
+        } finally {
+            client.close();
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/certReload/MainHttpServerMtlsPKCS12CertificateReloadTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/certReload/MainHttpServerMtlsPKCS12CertificateReloadTest.java
@@ -1,7 +1,8 @@
 package io.quarkus.vertx.http.certReload;
 
+import static io.quarkus.vertx.http.certReload.CertReloadTestHelper.assertTlsFails;
+import static io.quarkus.vertx.http.certReload.CertReloadTestHelper.httpsGet;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
@@ -12,8 +13,6 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
-import javax.net.ssl.SSLHandshakeException;
 
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
@@ -31,11 +30,7 @@ import io.smallrye.certs.Format;
 import io.smallrye.certs.junit5.Certificate;
 import io.smallrye.certs.junit5.Certificates;
 import io.vertx.core.Vertx;
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpClientResponse;
-import io.vertx.core.http.HttpMethod;
 import io.vertx.core.net.PfxOptions;
 import io.vertx.ext.web.Router;
 
@@ -53,7 +48,7 @@ public class MainHttpServerMtlsPKCS12CertificateReloadTest {
 
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
-            .withApplicationRoot((jar) -> jar.addClasses(MyBean.class))
+            .withApplicationRoot((jar) -> jar.addClasses(MyBean.class, CertReloadTestHelper.class))
             //            .overrideConfigKey("quarkus.http.insecure-requests", "redirect")
             .overrideConfigKey("quarkus.http.ssl.certificate.reload-period", "30s")
             .overrideConfigKey("quarkus.http.ssl.certificate.key-store-file", temp.getAbsolutePath() + "/server-keystore.p12")
@@ -105,12 +100,7 @@ public class MainHttpServerMtlsPKCS12CertificateReloadTest {
                         new PfxOptions().setPath("target/certificates/mtls-reload-A-client-truststore.p12")
                                 .setPassword("password"));
 
-        String response1 = vertx.createHttpClient(options)
-                .request(HttpMethod.GET, "/hello")
-                .flatMap(HttpClientRequest::send)
-                .flatMap(HttpClientResponse::body)
-                .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join();
+        String response1 = httpsGet(vertx, options, "/hello");
 
         // Update certs
         Files.copy(new File("target/certificates/mtls-reload-B-keystore.p12").toPath(),
@@ -122,12 +112,7 @@ public class MainHttpServerMtlsPKCS12CertificateReloadTest {
         TlsCertificateReloader.reload().toCompletableFuture().get(10, TimeUnit.SECONDS);
 
         // The client keystore and truststore are not updated, thus it should fail.
-        assertThatThrownBy(() -> vertx.createHttpClient(options)
-                .request(HttpMethod.GET, "/hello")
-                .flatMap(HttpClientRequest::send)
-                .flatMap(HttpClientResponse::body)
-                .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join()).hasCauseInstanceOf(SSLHandshakeException.class);
+        assertTlsFails(vertx, options, "/hello");
 
         var options2 = new HttpClientOptions(options)
                 .setKeyCertOptions(
@@ -137,24 +122,14 @@ public class MainHttpServerMtlsPKCS12CertificateReloadTest {
                         new PfxOptions().setPath("target/certificates/mtls-reload-B-client-truststore.p12")
                                 .setPassword("password"));
 
-        var response2 = vertx.createHttpClient(options2)
-                .request(HttpMethod.GET, "/hello")
-                .flatMap(HttpClientRequest::send)
-                .flatMap(HttpClientResponse::body)
-                .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join();
+        String response2 = httpsGet(vertx, options2, "/hello");
 
         assertThat(response1).isNotEqualTo(response2); // Because cert duration are different.
 
         // Trigger another reload
         TlsCertificateReloader.reload().toCompletableFuture().get(10, TimeUnit.SECONDS);
 
-        var response3 = vertx.createHttpClient(options2)
-                .request(HttpMethod.GET, "/hello")
-                .flatMap(HttpClientRequest::send)
-                .flatMap(HttpClientResponse::body)
-                .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join();
+        String response3 = httpsGet(vertx, options2, "/hello");
 
         assertThat(response2).isEqualTo(response3);
     }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/certReload/MainHttpServerTlsCertificateReloadTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/certReload/MainHttpServerTlsCertificateReloadTest.java
@@ -1,7 +1,8 @@
 package io.quarkus.vertx.http.certReload;
 
+import static io.quarkus.vertx.http.certReload.CertReloadTestHelper.assertTlsFails;
+import static io.quarkus.vertx.http.certReload.CertReloadTestHelper.httpsGet;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
@@ -12,8 +13,6 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
-import javax.net.ssl.SSLHandshakeException;
 
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
@@ -31,11 +30,7 @@ import io.smallrye.certs.Format;
 import io.smallrye.certs.junit5.Certificate;
 import io.smallrye.certs.junit5.Certificates;
 import io.vertx.core.Vertx;
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpClientResponse;
-import io.vertx.core.http.HttpMethod;
 import io.vertx.core.net.PemTrustOptions;
 import io.vertx.ext.web.Router;
 
@@ -53,7 +48,7 @@ public class MainHttpServerTlsCertificateReloadTest {
 
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
-            .withApplicationRoot((jar) -> jar.addClasses(MyBean.class))
+            .withApplicationRoot((jar) -> jar.addClasses(MyBean.class, CertReloadTestHelper.class))
             .overrideConfigKey("quarkus.http.ssl.insecure-requests", "redirect")
             .overrideConfigKey("quarkus.http.ssl.certificate.reload-period", "30s")
             .overrideConfigKey("quarkus.http.ssl.certificate.files", temp.getAbsolutePath() + "/tls.crt")
@@ -98,12 +93,7 @@ public class MainHttpServerTlsCertificateReloadTest {
                 .setDefaultHost(url.getHost())
                 .setTrustOptions(new PemTrustOptions().addCertPath("target/certificates/reload-A-ca.crt"));
 
-        String response1 = vertx.createHttpClient(options)
-                .request(HttpMethod.GET, "/hello")
-                .flatMap(HttpClientRequest::send)
-                .flatMap(HttpClientResponse::body)
-                .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join();
+        String response1 = httpsGet(vertx, options, "/hello");
 
         // Update certs
         Files.copy(new File("target/certificates/reload-B.crt").toPath(),
@@ -115,34 +105,19 @@ public class MainHttpServerTlsCertificateReloadTest {
         TlsCertificateReloader.reload().toCompletableFuture().get(10, TimeUnit.SECONDS);
 
         // The client truststore is not updated, thus it should fail.
-        assertThatThrownBy(() -> vertx.createHttpClient(options)
-                .request(HttpMethod.GET, "/hello")
-                .flatMap(HttpClientRequest::send)
-                .flatMap(HttpClientResponse::body)
-                .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join()).hasCauseInstanceOf(SSLHandshakeException.class);
+        assertTlsFails(vertx, options, "/hello");
 
         var options2 = new HttpClientOptions(options)
                 .setTrustOptions(new PemTrustOptions().addCertPath("target/certificates/reload-B-ca.crt"));
 
-        var response2 = vertx.createHttpClient(options2)
-                .request(HttpMethod.GET, "/hello")
-                .flatMap(HttpClientRequest::send)
-                .flatMap(HttpClientResponse::body)
-                .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join();
+        String response2 = httpsGet(vertx, options2, "/hello");
 
         assertThat(response1).isNotEqualTo(response2); // Because cert duration are different.
 
         // Trigger another reload
         TlsCertificateReloader.reload().toCompletableFuture().get(10, TimeUnit.SECONDS);
 
-        var response3 = vertx.createHttpClient(options2)
-                .request(HttpMethod.GET, "/hello")
-                .flatMap(HttpClientRequest::send)
-                .flatMap(HttpClientResponse::body)
-                .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join();
+        String response3 = httpsGet(vertx, options2, "/hello");
 
         assertThat(response2).isEqualTo(response3);
     }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/certReload/MainHttpServerTlsCertificateReloadWithTlsRegistryAndUpdateEventTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/certReload/MainHttpServerTlsCertificateReloadWithTlsRegistryAndUpdateEventTest.java
@@ -1,7 +1,8 @@
 package io.quarkus.vertx.http.certReload;
 
+import static io.quarkus.vertx.http.certReload.CertReloadTestHelper.assertTlsFails;
+import static io.quarkus.vertx.http.certReload.CertReloadTestHelper.httpsGet;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
@@ -11,8 +12,6 @@ import java.security.cert.X509Certificate;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
-
-import javax.net.ssl.SSLHandshakeException;
 
 import jakarta.enterprise.event.Event;
 import jakarta.enterprise.event.Observes;
@@ -32,11 +31,7 @@ import io.smallrye.certs.Format;
 import io.smallrye.certs.junit5.Certificate;
 import io.smallrye.certs.junit5.Certificates;
 import io.vertx.core.Vertx;
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpClientResponse;
-import io.vertx.core.http.HttpMethod;
 import io.vertx.core.net.PemTrustOptions;
 import io.vertx.ext.web.Router;
 
@@ -54,7 +49,7 @@ public class MainHttpServerTlsCertificateReloadWithTlsRegistryAndUpdateEventTest
 
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
-            .withApplicationRoot((jar) -> jar.addClasses(MyBean.class))
+            .withApplicationRoot((jar) -> jar.addClasses(MyBean.class, CertReloadTestHelper.class))
             .overrideConfigKey("quarkus.http.ssl.insecure-requests", "redirect")
             .overrideConfigKey("quarkus.tls.key-store.pem.0.cert", temp.getAbsolutePath() + "/tls.crt")
             .overrideConfigKey("quarkus.tls.key-store.pem.0.key", temp.getAbsolutePath() + "/tls.key")
@@ -104,12 +99,7 @@ public class MainHttpServerTlsCertificateReloadWithTlsRegistryAndUpdateEventTest
                 .setDefaultHost(url.getHost())
                 .setTrustOptions(new PemTrustOptions().addCertPath("target/certificates/reload-A-ca.crt"));
 
-        String response1 = vertx.createHttpClient(options)
-                .request(HttpMethod.GET, "/hello")
-                .flatMap(HttpClientRequest::send)
-                .flatMap(HttpClientResponse::body)
-                .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join();
+        String response1 = httpsGet(vertx, options, "/hello");
 
         // Update certs
         Files.copy(new File("target/certificates/reload-B.crt").toPath(),
@@ -122,22 +112,12 @@ public class MainHttpServerTlsCertificateReloadWithTlsRegistryAndUpdateEventTest
         event.fire(new CertificateUpdatedEvent("<default>", registry.getDefault().orElseThrow()));
 
         // The client truststore is not updated, thus it should fail.
-        assertThatThrownBy(() -> vertx.createHttpClient(options)
-                .request(HttpMethod.GET, "/hello")
-                .flatMap(HttpClientRequest::send)
-                .flatMap(HttpClientResponse::body)
-                .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join()).hasCauseInstanceOf(SSLHandshakeException.class);
+        assertTlsFails(vertx, options, "/hello");
 
         var options2 = new HttpClientOptions(options)
                 .setTrustOptions(new PemTrustOptions().addCertPath("target/certificates/reload-B-ca.crt"));
 
-        var response2 = vertx.createHttpClient(options2)
-                .request(HttpMethod.GET, "/hello")
-                .flatMap(HttpClientRequest::send)
-                .flatMap(HttpClientResponse::body)
-                .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join();
+        String response2 = httpsGet(vertx, options2, "/hello");
 
         assertThat(response1).isNotEqualTo(response2); // Because cert duration are different.
 
@@ -145,12 +125,7 @@ public class MainHttpServerTlsCertificateReloadWithTlsRegistryAndUpdateEventTest
         registry.getDefault().orElseThrow().reload();
         event.fire(new CertificateUpdatedEvent("<default>", registry.getDefault().orElseThrow()));
 
-        var response3 = vertx.createHttpClient(options2)
-                .request(HttpMethod.GET, "/hello")
-                .flatMap(HttpClientRequest::send)
-                .flatMap(HttpClientResponse::body)
-                .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join();
+        String response3 = httpsGet(vertx, options2, "/hello");
 
         assertThat(response2).isEqualTo(response3);
     }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/certReload/MainHttpServerTlsCertificateReloadWithTlsRegistryTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/certReload/MainHttpServerTlsCertificateReloadWithTlsRegistryTest.java
@@ -1,7 +1,8 @@
 package io.quarkus.vertx.http.certReload;
 
+import static io.quarkus.vertx.http.certReload.CertReloadTestHelper.assertTlsFails;
+import static io.quarkus.vertx.http.certReload.CertReloadTestHelper.httpsGet;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
@@ -12,8 +13,6 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
-import javax.net.ssl.SSLHandshakeException;
 
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
@@ -31,11 +30,7 @@ import io.smallrye.certs.Format;
 import io.smallrye.certs.junit5.Certificate;
 import io.smallrye.certs.junit5.Certificates;
 import io.vertx.core.Vertx;
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpClientResponse;
-import io.vertx.core.http.HttpMethod;
 import io.vertx.core.net.PemTrustOptions;
 import io.vertx.ext.web.Router;
 
@@ -53,7 +48,7 @@ public class MainHttpServerTlsCertificateReloadWithTlsRegistryTest {
 
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
-            .withApplicationRoot((jar) -> jar.addClasses(MyBean.class))
+            .withApplicationRoot((jar) -> jar.addClasses(MyBean.class, CertReloadTestHelper.class))
             .overrideConfigKey("quarkus.http.ssl.insecure-requests", "redirect")
             .overrideConfigKey("quarkus.http.ssl.certificate.reload-period", "30s")
             .overrideConfigKey("quarkus.tls.key-store.pem.0.cert", temp.getAbsolutePath() + "/tls.crt")
@@ -98,12 +93,7 @@ public class MainHttpServerTlsCertificateReloadWithTlsRegistryTest {
                 .setDefaultHost(url.getHost())
                 .setTrustOptions(new PemTrustOptions().addCertPath("target/certificates/reload-A-ca.crt"));
 
-        String response1 = vertx.createHttpClient(options)
-                .request(HttpMethod.GET, "/hello")
-                .flatMap(HttpClientRequest::send)
-                .flatMap(HttpClientResponse::body)
-                .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join();
+        String response1 = httpsGet(vertx, options, "/hello");
 
         // Update certs
         Files.copy(new File("target/certificates/reload-B.crt").toPath(),
@@ -115,34 +105,19 @@ public class MainHttpServerTlsCertificateReloadWithTlsRegistryTest {
         TlsCertificateReloader.reload().toCompletableFuture().get(10, TimeUnit.SECONDS);
 
         // The client truststore is not updated, thus it should fail.
-        assertThatThrownBy(() -> vertx.createHttpClient(options)
-                .request(HttpMethod.GET, "/hello")
-                .flatMap(HttpClientRequest::send)
-                .flatMap(HttpClientResponse::body)
-                .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join()).hasCauseInstanceOf(SSLHandshakeException.class);
+        assertTlsFails(vertx, options, "/hello");
 
         var options2 = new HttpClientOptions(options)
                 .setTrustOptions(new PemTrustOptions().addCertPath("target/certificates/reload-B-ca.crt"));
 
-        var response2 = vertx.createHttpClient(options2)
-                .request(HttpMethod.GET, "/hello")
-                .flatMap(HttpClientRequest::send)
-                .flatMap(HttpClientResponse::body)
-                .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join();
+        String response2 = httpsGet(vertx, options2, "/hello");
 
         assertThat(response1).isNotEqualTo(response2); // Because cert duration are different.
 
         // Trigger another reload
         TlsCertificateReloader.reload().toCompletableFuture().get(10, TimeUnit.SECONDS);
 
-        var response3 = vertx.createHttpClient(options2)
-                .request(HttpMethod.GET, "/hello")
-                .flatMap(HttpClientRequest::send)
-                .flatMap(HttpClientResponse::body)
-                .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join();
+        String response3 = httpsGet(vertx, options2, "/hello");
 
         assertThat(response2).isEqualTo(response3);
     }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/certReload/MainHttpServerTlsPKCS12CertificateReloadTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/certReload/MainHttpServerTlsPKCS12CertificateReloadTest.java
@@ -1,7 +1,8 @@
 package io.quarkus.vertx.http.certReload;
 
+import static io.quarkus.vertx.http.certReload.CertReloadTestHelper.assertTlsFails;
+import static io.quarkus.vertx.http.certReload.CertReloadTestHelper.httpsGet;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
@@ -12,8 +13,6 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
-import javax.net.ssl.SSLHandshakeException;
 
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
@@ -31,11 +30,7 @@ import io.smallrye.certs.Format;
 import io.smallrye.certs.junit5.Certificate;
 import io.smallrye.certs.junit5.Certificates;
 import io.vertx.core.Vertx;
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpClientResponse;
-import io.vertx.core.http.HttpMethod;
 import io.vertx.core.net.PfxOptions;
 import io.vertx.ext.web.Router;
 
@@ -53,7 +48,7 @@ public class MainHttpServerTlsPKCS12CertificateReloadTest {
 
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
-            .withApplicationRoot((jar) -> jar.addClasses(MyBean.class))
+            .withApplicationRoot((jar) -> jar.addClasses(MyBean.class, CertReloadTestHelper.class))
             .overrideConfigKey("quarkus.http.insecure-requests", "redirect")
             .overrideConfigKey("quarkus.http.ssl.certificate.reload-period", "30s")
             .overrideConfigKey("quarkus.http.ssl.certificate.key-store-file", temp.getAbsolutePath() + "/tls.p12")
@@ -94,12 +89,7 @@ public class MainHttpServerTlsPKCS12CertificateReloadTest {
                 .setTrustOptions(
                         new PfxOptions().setPath("target/certificates/reload-A-truststore.p12").setPassword("password"));
 
-        String response1 = vertx.createHttpClient(options)
-                .request(HttpMethod.GET, "/hello")
-                .flatMap(HttpClientRequest::send)
-                .flatMap(HttpClientResponse::body)
-                .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join();
+        String response1 = httpsGet(vertx, options, "/hello");
 
         // Update certs
         Files.copy(new File("target/certificates/reload-B-keystore.p12").toPath(),
@@ -109,35 +99,20 @@ public class MainHttpServerTlsPKCS12CertificateReloadTest {
         TlsCertificateReloader.reload().toCompletableFuture().get(10, TimeUnit.SECONDS);
 
         // The client truststore is not updated, thus it should fail.
-        assertThatThrownBy(() -> vertx.createHttpClient(options)
-                .request(HttpMethod.GET, "/hello")
-                .flatMap(HttpClientRequest::send)
-                .flatMap(HttpClientResponse::body)
-                .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join()).hasCauseInstanceOf(SSLHandshakeException.class);
+        assertTlsFails(vertx, options, "/hello");
 
         var options2 = new HttpClientOptions(options)
                 .setTrustOptions(
                         new PfxOptions().setPath("target/certificates/reload-B-truststore.p12").setPassword("password"));
 
-        var response2 = vertx.createHttpClient(options2)
-                .request(HttpMethod.GET, "/hello")
-                .flatMap(HttpClientRequest::send)
-                .flatMap(HttpClientResponse::body)
-                .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join();
+        String response2 = httpsGet(vertx, options2, "/hello");
 
         assertThat(response1).isNotEqualTo(response2); // Because cert duration are different.
 
         // Trigger another reload
         TlsCertificateReloader.reload().toCompletableFuture().get(10, TimeUnit.SECONDS);
 
-        var response3 = vertx.createHttpClient(options2)
-                .request(HttpMethod.GET, "/hello")
-                .flatMap(HttpClientRequest::send)
-                .flatMap(HttpClientResponse::body)
-                .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join();
+        String response3 = httpsGet(vertx, options2, "/hello");
 
         assertThat(response2).isEqualTo(response3);
     }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/certReload/MainHttpServerTlsPKCS12CertificateReloadWithTlsRegistryAndUpdateEventTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/certReload/MainHttpServerTlsPKCS12CertificateReloadWithTlsRegistryAndUpdateEventTest.java
@@ -1,7 +1,8 @@
 package io.quarkus.vertx.http.certReload;
 
+import static io.quarkus.vertx.http.certReload.CertReloadTestHelper.assertTlsFails;
+import static io.quarkus.vertx.http.certReload.CertReloadTestHelper.httpsGet;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
@@ -11,8 +12,6 @@ import java.security.cert.X509Certificate;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
-
-import javax.net.ssl.SSLHandshakeException;
 
 import jakarta.enterprise.event.Event;
 import jakarta.enterprise.event.Observes;
@@ -32,11 +31,7 @@ import io.smallrye.certs.Format;
 import io.smallrye.certs.junit5.Certificate;
 import io.smallrye.certs.junit5.Certificates;
 import io.vertx.core.Vertx;
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpClientResponse;
-import io.vertx.core.http.HttpMethod;
 import io.vertx.core.net.PfxOptions;
 import io.vertx.ext.web.Router;
 
@@ -54,7 +49,7 @@ public class MainHttpServerTlsPKCS12CertificateReloadWithTlsRegistryAndUpdateEve
 
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
-            .withApplicationRoot((jar) -> jar.addClasses(MyBean.class))
+            .withApplicationRoot((jar) -> jar.addClasses(MyBean.class, CertReloadTestHelper.class))
             .overrideConfigKey("quarkus.http.insecure-requests", "redirect")
             .overrideConfigKey("quarkus.http.tls-configuration-name", "http")
 
@@ -102,12 +97,7 @@ public class MainHttpServerTlsPKCS12CertificateReloadWithTlsRegistryAndUpdateEve
                 .setTrustOptions(
                         new PfxOptions().setPath("target/certificates/reload-A-truststore.p12").setPassword("password"));
 
-        String response1 = vertx.createHttpClient(options)
-                .request(HttpMethod.GET, "/hello")
-                .flatMap(HttpClientRequest::send)
-                .flatMap(HttpClientResponse::body)
-                .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join();
+        String response1 = httpsGet(vertx, options, "/hello");
 
         // Update certs
         Files.copy(new File("target/certificates/reload-B-keystore.p12").toPath(),
@@ -118,23 +108,13 @@ public class MainHttpServerTlsPKCS12CertificateReloadWithTlsRegistryAndUpdateEve
         event.fire(new CertificateUpdatedEvent("http", registry.get("http").orElseThrow()));
 
         // The client truststore is not updated, thus it should fail.
-        assertThatThrownBy(() -> vertx.createHttpClient(options)
-                .request(HttpMethod.GET, "/hello")
-                .flatMap(HttpClientRequest::send)
-                .flatMap(HttpClientResponse::body)
-                .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join()).hasCauseInstanceOf(SSLHandshakeException.class);
+        assertTlsFails(vertx, options, "/hello");
 
         var options2 = new HttpClientOptions(options)
                 .setTrustOptions(
                         new PfxOptions().setPath("target/certificates/reload-B-truststore.p12").setPassword("password"));
 
-        var response2 = vertx.createHttpClient(options2)
-                .request(HttpMethod.GET, "/hello")
-                .flatMap(HttpClientRequest::send)
-                .flatMap(HttpClientResponse::body)
-                .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join();
+        String response2 = httpsGet(vertx, options2, "/hello");
 
         assertThat(response1).isNotEqualTo(response2); // Because cert duration are different.
 
@@ -142,12 +122,7 @@ public class MainHttpServerTlsPKCS12CertificateReloadWithTlsRegistryAndUpdateEve
         registry.get("http").orElseThrow().reload();
         event.fire(new CertificateUpdatedEvent("http", registry.get("http").orElseThrow()));
 
-        var response3 = vertx.createHttpClient(options2)
-                .request(HttpMethod.GET, "/hello")
-                .flatMap(HttpClientRequest::send)
-                .flatMap(HttpClientResponse::body)
-                .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join();
+        String response3 = httpsGet(vertx, options2, "/hello");
 
         assertThat(response2).isEqualTo(response3);
     }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/certReload/MainHttpServerTlsPKCS12CertificateReloadWithTlsRegistryTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/certReload/MainHttpServerTlsPKCS12CertificateReloadWithTlsRegistryTest.java
@@ -1,7 +1,8 @@
 package io.quarkus.vertx.http.certReload;
 
+import static io.quarkus.vertx.http.certReload.CertReloadTestHelper.assertTlsFails;
+import static io.quarkus.vertx.http.certReload.CertReloadTestHelper.httpsGet;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
@@ -12,8 +13,6 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
-import javax.net.ssl.SSLHandshakeException;
 
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
@@ -31,11 +30,7 @@ import io.smallrye.certs.Format;
 import io.smallrye.certs.junit5.Certificate;
 import io.smallrye.certs.junit5.Certificates;
 import io.vertx.core.Vertx;
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpClientResponse;
-import io.vertx.core.http.HttpMethod;
 import io.vertx.core.net.PfxOptions;
 import io.vertx.ext.web.Router;
 
@@ -53,7 +48,7 @@ public class MainHttpServerTlsPKCS12CertificateReloadWithTlsRegistryTest {
 
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
-            .withApplicationRoot((jar) -> jar.addClasses(MyBean.class))
+            .withApplicationRoot((jar) -> jar.addClasses(MyBean.class, CertReloadTestHelper.class))
             .overrideConfigKey("quarkus.http.insecure-requests", "redirect")
             .overrideConfigKey("quarkus.http.tls-configuration-name", "http")
             .overrideConfigKey("quarkus.http.ssl.certificate.reload-period", "30s")
@@ -96,12 +91,7 @@ public class MainHttpServerTlsPKCS12CertificateReloadWithTlsRegistryTest {
                 .setTrustOptions(
                         new PfxOptions().setPath("target/certificates/reload-A-truststore.p12").setPassword("password"));
 
-        String response1 = vertx.createHttpClient(options)
-                .request(HttpMethod.GET, "/hello")
-                .flatMap(HttpClientRequest::send)
-                .flatMap(HttpClientResponse::body)
-                .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join();
+        String response1 = httpsGet(vertx, options, "/hello");
 
         // Update certs
         Files.copy(new File("target/certificates/reload-B-keystore.p12").toPath(),
@@ -111,35 +101,20 @@ public class MainHttpServerTlsPKCS12CertificateReloadWithTlsRegistryTest {
         TlsCertificateReloader.reload().toCompletableFuture().get(10, TimeUnit.SECONDS);
 
         // The client truststore is not updated, thus it should fail.
-        assertThatThrownBy(() -> vertx.createHttpClient(options)
-                .request(HttpMethod.GET, "/hello")
-                .flatMap(HttpClientRequest::send)
-                .flatMap(HttpClientResponse::body)
-                .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join()).hasCauseInstanceOf(SSLHandshakeException.class);
+        assertTlsFails(vertx, options, "/hello");
 
         var options2 = new HttpClientOptions(options)
                 .setTrustOptions(
                         new PfxOptions().setPath("target/certificates/reload-B-truststore.p12").setPassword("password"));
 
-        var response2 = vertx.createHttpClient(options2)
-                .request(HttpMethod.GET, "/hello")
-                .flatMap(HttpClientRequest::send)
-                .flatMap(HttpClientResponse::body)
-                .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join();
+        String response2 = httpsGet(vertx, options2, "/hello");
 
         assertThat(response1).isNotEqualTo(response2); // Because cert duration are different.
 
         // Trigger another reload
         TlsCertificateReloader.reload().toCompletableFuture().get(10, TimeUnit.SECONDS);
 
-        var response3 = vertx.createHttpClient(options2)
-                .request(HttpMethod.GET, "/hello")
-                .flatMap(HttpClientRequest::send)
-                .flatMap(HttpClientResponse::body)
-                .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join();
+        String response3 = httpsGet(vertx, options2, "/hello");
 
         assertThat(response2).isEqualTo(response3);
     }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/certReload/ManagementHttpServerTlsCertificateReloadTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/certReload/ManagementHttpServerTlsCertificateReloadTest.java
@@ -1,7 +1,8 @@
 package io.quarkus.vertx.http.certReload;
 
+import static io.quarkus.vertx.http.certReload.CertReloadTestHelper.assertTlsFails;
+import static io.quarkus.vertx.http.certReload.CertReloadTestHelper.httpsGet;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
@@ -12,8 +13,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
-
-import javax.net.ssl.SSLHandshakeException;
 
 import jakarta.inject.Inject;
 
@@ -36,11 +35,7 @@ import io.smallrye.certs.junit5.Certificate;
 import io.smallrye.certs.junit5.Certificates;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpClientResponse;
-import io.vertx.core.http.HttpMethod;
 import io.vertx.core.net.PemTrustOptions;
 import io.vertx.ext.web.RoutingContext;
 
@@ -65,6 +60,7 @@ public class ManagementHttpServerTlsCertificateReloadTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withApplicationRoot((jar) -> jar
+                    .addClasses(CertReloadTestHelper.class)
                     .addAsResource(new StringAsset(APP_PROPS), "application.properties"))
             .setBeforeAllCustomizer(() -> {
                 try {
@@ -127,12 +123,7 @@ public class ManagementHttpServerTlsCertificateReloadTest {
                 .setDefaultHost("localhost")
                 .setTrustOptions(new PemTrustOptions().addCertPath(new File(certs, "/ca.crt").getAbsolutePath()));
 
-        String response1 = vertx.createHttpClient(options)
-                .request(HttpMethod.GET, "/q/hello")
-                .flatMap(HttpClientRequest::send)
-                .flatMap(HttpClientResponse::body)
-                .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join();
+        String response1 = httpsGet(vertx, options, "/q/hello");
 
         // Update certs
         Files.copy(new File("target/certificates/reload-D.crt").toPath(),
@@ -144,22 +135,12 @@ public class ManagementHttpServerTlsCertificateReloadTest {
         TlsCertificateReloader.reload().toCompletableFuture().get(10, TimeUnit.SECONDS);
 
         // The client truststore is not updated, thus it should fail.
-        assertThatThrownBy(() -> vertx.createHttpClient(options)
-                .request(HttpMethod.GET, "/hello")
-                .flatMap(HttpClientRequest::send)
-                .flatMap(HttpClientResponse::body)
-                .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join()).hasCauseInstanceOf(SSLHandshakeException.class);
+        assertTlsFails(vertx, options, "/hello");
 
         var options2 = new HttpClientOptions(options)
                 .setTrustOptions(new PemTrustOptions().addCertPath("target/certificates/reload-D-ca.crt"));
 
-        var response2 = vertx.createHttpClient(options2)
-                .request(HttpMethod.GET, "/hello")
-                .flatMap(HttpClientRequest::send)
-                .flatMap(HttpClientResponse::body)
-                .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join();
+        String response2 = httpsGet(vertx, options2, "/hello");
 
         assertThat(response1).isNotEqualTo(response2); // Because cert duration are different.
     }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/certReload/ManagementHttpServerTlsCertificateReloadWithTlsRegistryTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/certReload/ManagementHttpServerTlsCertificateReloadWithTlsRegistryTest.java
@@ -1,7 +1,8 @@
 package io.quarkus.vertx.http.certReload;
 
+import static io.quarkus.vertx.http.certReload.CertReloadTestHelper.assertTlsFails;
+import static io.quarkus.vertx.http.certReload.CertReloadTestHelper.httpsGet;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
@@ -11,8 +12,6 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
-
-import javax.net.ssl.SSLHandshakeException;
 
 import jakarta.enterprise.event.Event;
 import jakarta.inject.Inject;
@@ -37,11 +36,7 @@ import io.smallrye.certs.junit5.Certificate;
 import io.smallrye.certs.junit5.Certificates;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpClientResponse;
-import io.vertx.core.http.HttpMethod;
 import io.vertx.core.net.PemTrustOptions;
 import io.vertx.ext.web.RoutingContext;
 
@@ -64,6 +59,7 @@ public class ManagementHttpServerTlsCertificateReloadWithTlsRegistryTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withApplicationRoot((jar) -> jar
+                    .addClasses(CertReloadTestHelper.class)
                     .addAsResource(new StringAsset(APP_PROPS), "application.properties"))
             .setBeforeAllCustomizer(() -> {
                 try {
@@ -132,12 +128,7 @@ public class ManagementHttpServerTlsCertificateReloadWithTlsRegistryTest {
                 .setDefaultHost("localhost")
                 .setTrustOptions(new PemTrustOptions().addCertPath(new File(certs, "/ca.crt").getAbsolutePath()));
 
-        String response1 = vertx.createHttpClient(options)
-                .request(HttpMethod.GET, "/q/hello")
-                .flatMap(HttpClientRequest::send)
-                .flatMap(HttpClientResponse::body)
-                .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join();
+        String response1 = httpsGet(vertx, options, "/q/hello");
 
         // Update certs
         Files.copy(new File("target/certificates/reload-D.crt").toPath(),
@@ -150,22 +141,12 @@ public class ManagementHttpServerTlsCertificateReloadWithTlsRegistryTest {
         event.fire(new CertificateUpdatedEvent("<default>", registry.getDefault().orElseThrow()));
 
         // The client truststore is not updated, thus it should fail.
-        assertThatThrownBy(() -> vertx.createHttpClient(options)
-                .request(HttpMethod.GET, "/hello")
-                .flatMap(HttpClientRequest::send)
-                .flatMap(HttpClientResponse::body)
-                .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join()).hasCauseInstanceOf(SSLHandshakeException.class);
+        assertTlsFails(vertx, options, "/hello");
 
         var options2 = new HttpClientOptions(options)
                 .setTrustOptions(new PemTrustOptions().addCertPath("target/certificates/reload-D-ca.crt"));
 
-        var response2 = vertx.createHttpClient(options2)
-                .request(HttpMethod.GET, "/hello")
-                .flatMap(HttpClientRequest::send)
-                .flatMap(HttpClientResponse::body)
-                .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join();
+        String response2 = httpsGet(vertx, options2, "/hello");
 
         assertThat(response1).isNotEqualTo(response2); // Because cert duration are different.
     }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/devmode/GeneratedStaticResourcesDevModeTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/devmode/GeneratedStaticResourcesDevModeTest.java
@@ -32,13 +32,14 @@ public class GeneratedStaticResourcesDevModeTest {
                 .statusCode(200)
                 .body(Matchers.containsString("This is the title of the webpage!"));
 
-        devMode.modifyResourceFile("META-INF/generated-resources-test/bytes/index.html", s -> s.replace("webpage", "Matheus"));
+        devMode.modifyResourceFile("META-INF/generated-resources-test/bytes/index.html",
+                s -> s.replace("webpage", "lorem ipsum"));
 
         RestAssured.given()
                 .get("/bytes/")
                 .then()
                 .statusCode(200)
-                .body(Matchers.containsString("This is the title of the Matheus!"));
+                .body(Matchers.containsString("This is the title of the lorem ipsum!"));
     }
 
     @Test

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/hotreload/VertxEventBusProducer.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/hotreload/VertxEventBusProducer.java
@@ -18,7 +18,7 @@ public class VertxEventBusProducer {
     Vertx vertx;
 
     public void register(@Observes StartupEvent ev) {
-        router.get("/").handler(rc -> vertx.eventBus().<String> request("my-address", "", m -> {
+        router.get("/").handler(rc -> vertx.eventBus().<String> request("my-address", "").onComplete(m -> {
             if (m.failed()) {
                 rc.response().end("failed");
             } else {

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/http2/Http2DisabledTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/http2/Http2DisabledTest.java
@@ -74,7 +74,7 @@ class Http2DisabledTest {
 
         client
                 .get(port, "localhost", "/ping")
-                .send(ar -> {
+                .send().onComplete(ar -> {
                     if (ar.succeeded()) {
                         result.complete(ar.result());
                     } else {

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/http2/Http2RSTFloodProtectionConfigTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/http2/Http2RSTFloodProtectionConfigTest.java
@@ -24,7 +24,7 @@ import io.quarkus.vertx.core.runtime.VertxCoreRecorder;
 import io.smallrye.certs.Format;
 import io.smallrye.certs.junit5.Certificate;
 import io.smallrye.certs.junit5.Certificates;
-import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientAgent;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpVersion;
@@ -62,6 +62,7 @@ public class Http2RSTFloodProtectionConfigTest {
 
     @Test
     void testRstFloodProtectionWithTlsEnabled() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
         HttpClientOptions options = new HttpClientOptions()
                 .setUseAlpn(true)
                 .setProtocolVersion(HttpVersion.HTTP_2)
@@ -69,26 +70,34 @@ public class Http2RSTFloodProtectionConfigTest {
                 .setTrustOptions(new JksOptions().setPath(new File("target/certs/ssl-test-truststore.jks").getAbsolutePath())
                         .setPassword("secret"));
 
-        var client = VertxCoreRecorder.getVertx().get().createHttpClient(options);
+        var client = VertxCoreRecorder.getVertx().get().httpClientBuilder()
+                .with(options)
+                .withConnectHandler(conn -> conn.goAwayHandler(ga -> {
+                    Assertions.assertEquals(11, ga.getErrorCode());
+                    latch.countDown();
+                }))
+                .build();
         int port = sslUrl.getPort();
-        run(client, port, false);
+        run(client, latch, port, false);
     }
 
     @Test
     public void testRstFloodProtection() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
         HttpClientOptions options = new HttpClientOptions()
                 .setProtocolVersion(HttpVersion.HTTP_2)
                 .setHttp2ClearTextUpgrade(true);
-        var client = VertxCoreRecorder.getVertx().get().createHttpClient(options);
-        run(client, url.getPort(), true);
+        var client = VertxCoreRecorder.getVertx().get().httpClientBuilder()
+                .with(options)
+                .withConnectHandler(conn -> conn.goAwayHandler(ga -> {
+                    Assertions.assertEquals(11, ga.getErrorCode());
+                    latch.countDown();
+                }))
+                .build();
+        run(client, latch, url.getPort(), true);
     }
 
-    void run(HttpClient client, int port, boolean plain) throws InterruptedException {
-        CountDownLatch latch = new CountDownLatch(1);
-        client.connectionHandler(conn -> conn.goAwayHandler(ga -> {
-            Assertions.assertEquals(11, ga.getErrorCode());
-            latch.countDown();
-        }));
+    void run(HttpClientAgent client, CountDownLatch latch, int port, boolean plain) throws InterruptedException {
 
         if (plain) {
             // Emit a first request to establish a connection.

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/http2/Http2RSTFloodProtectionTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/http2/Http2RSTFloodProtectionTest.java
@@ -24,7 +24,7 @@ import io.quarkus.vertx.core.runtime.VertxCoreRecorder;
 import io.smallrye.certs.Format;
 import io.smallrye.certs.junit5.Certificate;
 import io.smallrye.certs.junit5.Certificates;
-import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientAgent;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpVersion;
@@ -59,6 +59,7 @@ public class Http2RSTFloodProtectionTest {
 
     @Test
     void testRstFloodProtectionWithTlsEnabled() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
         HttpClientOptions options = new HttpClientOptions()
                 .setUseAlpn(true)
                 .setProtocolVersion(HttpVersion.HTTP_2)
@@ -66,26 +67,34 @@ public class Http2RSTFloodProtectionTest {
                 .setTrustOptions(new JksOptions().setPath(new File("target/certs/ssl-test-truststore.jks").getAbsolutePath())
                         .setPassword("secret"));
 
-        var client = VertxCoreRecorder.getVertx().get().createHttpClient(options);
+        var client = VertxCoreRecorder.getVertx().get().httpClientBuilder()
+                .with(options)
+                .withConnectHandler(conn -> conn.goAwayHandler(ga -> {
+                    Assertions.assertEquals(11, ga.getErrorCode());
+                    latch.countDown();
+                }))
+                .build();
         int port = sslUrl.getPort();
-        run(client, port, false);
+        run(client, latch, port, false);
     }
 
     @Test
     public void testRstFloodProtection() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
         HttpClientOptions options = new HttpClientOptions()
                 .setProtocolVersion(HttpVersion.HTTP_2)
                 .setHttp2ClearTextUpgrade(true);
-        var client = VertxCoreRecorder.getVertx().get().createHttpClient(options);
-        run(client, url.getPort(), true);
+        var client = VertxCoreRecorder.getVertx().get().httpClientBuilder()
+                .with(options)
+                .withConnectHandler(conn -> conn.goAwayHandler(ga -> {
+                    Assertions.assertEquals(11, ga.getErrorCode());
+                    latch.countDown();
+                }))
+                .build();
+        run(client, latch, url.getPort(), true);
     }
 
-    void run(HttpClient client, int port, boolean plain) throws InterruptedException {
-        CountDownLatch latch = new CountDownLatch(1);
-        client.connectionHandler(conn -> conn.goAwayHandler(ga -> {
-            Assertions.assertEquals(11, ga.getErrorCode());
-            latch.countDown();
-        }));
+    void run(HttpClientAgent client, CountDownLatch latch, int port, boolean plain) throws InterruptedException {
 
         if (plain) {
             // Emit a first request to establish a connection.

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/http2/Http2Test.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/http2/Http2Test.java
@@ -18,8 +18,6 @@ import io.quarkus.vertx.core.runtime.VertxCoreRecorder;
 import io.smallrye.certs.Format;
 import io.smallrye.certs.junit5.Certificate;
 import io.smallrye.certs.junit5.Certificates;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.net.JksOptions;
@@ -75,7 +73,7 @@ class Http2Test {
 
         client
                 .get(port, "localhost", "/ping")
-                .send(ar -> {
+                .send().onComplete(ar -> {
                     if (ar.succeeded()) {
                         // Obtain response
                         result.complete(ar.result());
@@ -95,11 +93,8 @@ class Http2Test {
         public void register(@Observes Router router) {
             //ping only works on HTTP/2
             router.get("/ping").handler(rc -> {
-                rc.request().connection().ping(Buffer.buffer(PING_DATA), new Handler<AsyncResult<Buffer>>() {
-                    @Override
-                    public void handle(AsyncResult<Buffer> event) {
-                        rc.response().end(event.result());
-                    }
+                rc.request().connection().ping(Buffer.buffer(PING_DATA)).onComplete(event -> {
+                    rc.response().end(event.result());
                 });
             });
         }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/http2/Http2WithNamedConfigTlsRegistryTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/http2/Http2WithNamedConfigTlsRegistryTest.java
@@ -18,8 +18,6 @@ import io.quarkus.vertx.core.runtime.VertxCoreRecorder;
 import io.smallrye.certs.Format;
 import io.smallrye.certs.junit5.Certificate;
 import io.smallrye.certs.junit5.Certificates;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.net.JksOptions;
@@ -74,7 +72,7 @@ public class Http2WithNamedConfigTlsRegistryTest {
         CompletableFuture<String> result = new CompletableFuture<>();
         client
                 .get(port, "localhost", "/ping")
-                .send(ar -> {
+                .send().onComplete(ar -> {
                     if (ar.succeeded()) {
                         // Obtain response
                         HttpResponse<Buffer> response = ar.result();
@@ -92,11 +90,8 @@ public class Http2WithNamedConfigTlsRegistryTest {
         public void register(@Observes Router router) {
             //ping only works on HTTP/2
             router.get("/ping").handler(rc -> {
-                rc.request().connection().ping(Buffer.buffer(PING_DATA), new Handler<AsyncResult<Buffer>>() {
-                    @Override
-                    public void handle(AsyncResult<Buffer> event) {
-                        rc.response().end(event.result());
-                    }
+                rc.request().connection().ping(Buffer.buffer(PING_DATA)).onComplete(event -> {
+                    rc.response().end(event.result());
                 });
             });
         }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/http2/Http2WithTlsRegistryTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/http2/Http2WithTlsRegistryTest.java
@@ -18,8 +18,6 @@ import io.quarkus.vertx.core.runtime.VertxCoreRecorder;
 import io.smallrye.certs.Format;
 import io.smallrye.certs.junit5.Certificate;
 import io.smallrye.certs.junit5.Certificates;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.net.JksOptions;
@@ -74,7 +72,7 @@ public class Http2WithTlsRegistryTest {
         CompletableFuture<String> result = new CompletableFuture<>();
         client
                 .get(port, "localhost", "/ping")
-                .send(ar -> {
+                .send().onComplete(ar -> {
                     if (ar.succeeded()) {
                         // Obtain response
                         HttpResponse<Buffer> response = ar.result();
@@ -92,11 +90,8 @@ public class Http2WithTlsRegistryTest {
         public void register(@Observes Router router) {
             //ping only works on HTTP/2
             router.get("/ping").handler(rc -> {
-                rc.request().connection().ping(Buffer.buffer(PING_DATA), new Handler<AsyncResult<Buffer>>() {
-                    @Override
-                    public void handle(AsyncResult<Buffer> event) {
-                        rc.response().end(event.result());
-                    }
+                rc.request().connection().ping(Buffer.buffer(PING_DATA)).onComplete(event -> {
+                    rc.response().end(event.result());
                 });
             });
         }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/AuthMechanismConfig.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/AuthMechanismConfig.java
@@ -9,7 +9,7 @@ import io.quarkus.tls.BaseTlsConfiguration;
 import io.quarkus.tls.TlsConfigurationRegistry;
 import io.vertx.core.net.KeyCertOptions;
 import io.vertx.core.net.KeyStoreOptions;
-import io.vertx.core.net.SSLOptions;
+import io.vertx.core.net.ServerSSLOptions;
 import io.vertx.core.net.TrustOptions;
 
 public class AuthMechanismConfig {
@@ -45,8 +45,8 @@ public class AuthMechanismConfig {
             }
 
             @Override
-            public SSLOptions getSSLOptions() {
-                SSLOptions options = new SSLOptions();
+            public ServerSSLOptions getServerSSLOptions() {
+                ServerSSLOptions options = new ServerSSLOptions();
                 options.setKeyCertOptions(getKeyStoreOptions());
                 options.setTrustOptions(getTrustStoreOptions());
                 options.setSslHandshakeTimeoutUnit(TimeUnit.SECONDS);

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/ConcurrentBlockingRequestTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/ConcurrentBlockingRequestTest.java
@@ -35,10 +35,10 @@ import io.quarkus.security.test.utils.TestIdentityProvider;
 import io.quarkus.test.QuarkusExtensionTest;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.smallrye.mutiny.Uni;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.mutiny.core.Vertx;
-import io.vertx.mutiny.core.buffer.Buffer;
 import io.vertx.mutiny.core.http.HttpClient;
 import io.vertx.mutiny.core.http.HttpClientRequest;
 

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FluentApiMTLSAuthenticationRequiredTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FluentApiMTLSAuthenticationRequiredTest.java
@@ -26,7 +26,7 @@ import io.smallrye.certs.junit5.Certificate;
 import io.smallrye.certs.junit5.Certificates;
 import io.vertx.core.net.KeyCertOptions;
 import io.vertx.core.net.KeyStoreOptions;
-import io.vertx.core.net.SSLOptions;
+import io.vertx.core.net.ServerSSLOptions;
 import io.vertx.core.net.TrustOptions;
 
 @Certificates(baseDir = "target/certs", certificates = @Certificate(name = "mtls-test", password = "secret", formats = Format.PKCS12, client = true))
@@ -127,8 +127,8 @@ public class FluentApiMTLSAuthenticationRequiredTest {
         }
 
         @Override
-        public SSLOptions getSSLOptions() {
-            SSLOptions options = new SSLOptions();
+        public ServerSSLOptions getServerSSLOptions() {
+            ServerSSLOptions options = new ServerSSLOptions();
             options.setKeyCertOptions(getKeyStoreOptions());
             options.setTrustOptions(getTrustStoreOptions());
             options.setSslHandshakeTimeoutUnit(TimeUnit.SECONDS);

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/letsencrypt/LetsEncryptFlowTestBase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/letsencrypt/LetsEncryptFlowTestBase.java
@@ -45,7 +45,7 @@ public abstract class LetsEncryptFlowTestBase {
     private String tlsConfigurationName;
 
     static <T> T await(Future<T> future) {
-        return future.toCompletionStage().toCompletableFuture().join();
+        return future.await();
     }
 
     public void initFlow(Vertx vertx, String tlsConfigurationName) {
@@ -181,14 +181,16 @@ public abstract class LetsEncryptFlowTestBase {
         // Verify the application is serving the new certificate
         // We should not use the WebClient as the connection are still established with the old certificate.
         URL url = new URL(getApplicationEndpoint());
-        assertThatThrownBy(() -> vertx.createHttpClient(
+        var httpClient = vertx.createHttpClient(
                 new HttpClientOptions().setSsl(true).setDefaultPort(url.getPort())
-                        .setTrustOptions(new PemTrustOptions().addCertPath(SELF_SIGNED_CA.getAbsolutePath())))
+                        .setTrustOptions(new PemTrustOptions().addCertPath(SELF_SIGNED_CA.getAbsolutePath())));
+        assertThatThrownBy(() -> httpClient
                 .request(HttpMethod.GET, "/tls")
                 .flatMap(HttpClientRequest::send)
                 .flatMap(HttpClientResponse::body)
                 .map(Buffer::toString)
-                .toCompletionStage().toCompletableFuture().join()).hasCauseInstanceOf(SSLHandshakeException.class);
+                .await()).hasCauseInstanceOf(SSLHandshakeException.class);
+        httpClient.close();
 
         WebClient newWebClient = WebClient.create(vertx,
                 options.setTrustOptions(new PemTrustOptions().addCertPath(ACME_CA.getAbsolutePath())));

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/letsencrypt/NoLetEncryptDisableRoutesTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/tls/letsencrypt/NoLetEncryptDisableRoutesTest.java
@@ -99,7 +99,7 @@ public class NoLetEncryptDisableRoutesTest {
     }
 
     private <T> T await(Future<T> future) {
-        return future.toCompletionStage().toCompletableFuture().join();
+        return future.await();
     }
 
     @ApplicationScoped

--- a/extensions/vertx-http/runtime/pom.xml
+++ b/extensions/vertx-http/runtime/pom.xml
@@ -34,10 +34,6 @@
             <artifactId>quarkus-mutiny</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.smallrye.common</groupId>
-            <artifactId>smallrye-common-vertx-context</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus.security</groupId>
             <artifactId>quarkus-security</artifactId>
             <exclusions>

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardedParser.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardedParser.java
@@ -29,7 +29,8 @@ import java.util.regex.Pattern;
 import org.jboss.logging.Logger;
 
 import io.netty.util.AsciiString;
-import io.vertx.core.http.impl.HttpServerRequestInternal;
+import io.smallrye.common.vertx.ContextLocals;
+import io.vertx.core.internal.http.HttpServerRequestInternal;
 import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.net.impl.SocketAddressImpl;
@@ -130,7 +131,7 @@ class ForwardedParser {
         calculated = true;
         remoteAddress = delegate.remoteAddress();
         scheme = delegate.scheme();
-        setHostAndPort(delegate.host(), port);
+        setHostAndPort(delegate.authority() != null ? delegate.authority().toString() : null, port);
         uri = delegate.uri();
 
         boolean isProxyAllowed = trustedProxyCheck.isProxyAllowed();
@@ -196,7 +197,7 @@ class ForwardedParser {
     }
 
     private void storeForwarded(Forwarded forwarded) {
-        delegate.context().putLocal(ForwardedInfo.CONTEXT_KEY, forwarded);
+        ContextLocals.put(ForwardedInfo.CONTEXT_KEY, forwarded);
     }
 
     private Forwarded processForwarded() {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardedServerRequestWrapper.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardedServerRequestWrapper.java
@@ -1,15 +1,10 @@
 package io.quarkus.vertx.http.runtime;
 
-import java.util.Map;
 import java.util.Set;
 
-import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
-import javax.security.cert.X509Certificate;
 
 import io.netty.handler.codec.DecoderResult;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
@@ -24,8 +19,8 @@ import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.http.StreamPriority;
-import io.vertx.core.http.impl.HttpServerRequestInternal;
-import io.vertx.core.http.impl.HttpServerRequestWrapper;
+import io.vertx.core.internal.http.HttpServerRequestInternal;
+import io.vertx.core.internal.http.HttpServerRequestWrapper;
 import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SocketAddress;
@@ -216,12 +211,6 @@ public class ForwardedServerRequestWrapper extends HttpServerRequestWrapper impl
     }
 
     @Override
-    @Deprecated
-    public X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException {
-        return delegate.peerCertificateChain();
-    }
-
-    @Override
     public SSLSession sslSession() {
         return delegate.sslSession();
     }
@@ -250,11 +239,6 @@ public class ForwardedServerRequestWrapper extends HttpServerRequestWrapper impl
     @Override
     public String scheme() {
         return forwardedParser.scheme();
-    }
-
-    @Override
-    public String host() {
-        return forwardedParser.host();
     }
 
     @Override
@@ -333,12 +317,6 @@ public class ForwardedServerRequestWrapper extends HttpServerRequestWrapper impl
     }
 
     @Override
-    @Deprecated
-    public Map<String, Cookie> cookieMap() {
-        return delegate.cookieMap();
-    }
-
-    @Override
     public Cookie getCookie(String name, String domain, String path) {
         return delegate.getCookie(name, domain, path);
     }
@@ -354,18 +332,8 @@ public class ForwardedServerRequestWrapper extends HttpServerRequestWrapper impl
     }
 
     @Override
-    public HttpServerRequest body(Handler<AsyncResult<Buffer>> handler) {
-        return delegate.body(handler);
-    }
-
-    @Override
     public Future<Buffer> body() {
         return delegate.body();
-    }
-
-    @Override
-    public void end(Handler<AsyncResult<Void>> handler) {
-        delegate.end(handler);
     }
 
     @Override
@@ -374,18 +342,8 @@ public class ForwardedServerRequestWrapper extends HttpServerRequestWrapper impl
     }
 
     @Override
-    public void toNetSocket(Handler<AsyncResult<NetSocket>> handler) {
-        delegate.toNetSocket(handler);
-    }
-
-    @Override
     public Future<NetSocket> toNetSocket() {
         return delegate.toNetSocket();
-    }
-
-    @Override
-    public void toWebSocket(Handler<AsyncResult<ServerWebSocket>> handler) {
-        delegate.toWebSocket(handler);
     }
 
     @Override
@@ -394,7 +352,7 @@ public class ForwardedServerRequestWrapper extends HttpServerRequestWrapper impl
     }
 
     @Override
-    public Context context() {
+    public io.vertx.core.internal.ContextInternal context() {
         return delegate.context();
     }
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpCertificateUpdateEventListener.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpCertificateUpdateEventListener.java
@@ -41,7 +41,7 @@ public class HttpCertificateUpdateEventListener {
         }
         CountDownLatch latch = new CountDownLatch(registrations.size());
         for (ServerRegistration server : registrations) {
-            server.server.updateSSLOptions(event.tlsConfiguration().getSSLOptions())
+            server.server.updateSSLOptions(event.tlsConfiguration().getServerSSLOptions())
                     .toCompletionStage().whenComplete(new BiConsumer<Boolean, Throwable>() {
                         @Override
                         public void accept(Boolean v, Throwable t) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/QuarkusHttpHeaders.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/QuarkusHttpHeaders.java
@@ -35,7 +35,33 @@ import io.vertx.core.http.impl.HttpUtils;
  */
 public final class QuarkusHttpHeaders extends HttpHeaders implements MultiMap {
 
+    /**
+     * JVM system property that disables HTTP headers validation, replaces the removed
+     * {@code HttpHeaders.DISABLE_HTTP_HEADERS_VALIDATION} constant from Vert.x 4.
+     */
+    private static final boolean DISABLE_HTTP_HEADERS_VALIDATION = Boolean.getBoolean("vertx.disableHttpHeadersValidation");
+
     private Map<Class<?>, Object> contextObjects;
+
+    @Override
+    public QuarkusHttpHeaders copy() {
+        return (QuarkusHttpHeaders) copy(true);
+    }
+
+    @Override
+    public MultiMap copy(boolean writeable) {
+        QuarkusHttpHeaders copy = new QuarkusHttpHeaders();
+        copy.setAll((MultiMap) this);
+        if (this.contextObjects != null) {
+            copy.contextObjects = new java.util.HashMap<>(this.contextObjects);
+        }
+        return copy;
+    }
+
+    @Override
+    public boolean isMutable() {
+        return true;
+    }
 
     @Override
     public MultiMap setAll(MultiMap headers) {
@@ -477,7 +503,7 @@ public final class QuarkusHttpHeaders extends HttpHeaders implements MultiMap {
         @Override
         public CharSequence setValue(CharSequence value) {
             Objects.requireNonNull(value, "value");
-            if (!io.vertx.core.http.HttpHeaders.DISABLE_HTTP_HEADERS_VALIDATION) {
+            if (!DISABLE_HTTP_HEADERS_VALIDATION) {
                 HttpUtils.validateHeaderValue(value);
             }
             CharSequence oldValue = this.value;
@@ -530,7 +556,7 @@ public final class QuarkusHttpHeaders extends HttpHeaders implements MultiMap {
     }
 
     private void add0(int h, int i, final CharSequence name, final CharSequence value) {
-        if (!io.vertx.core.http.HttpHeaders.DISABLE_HTTP_HEADERS_VALIDATION) {
+        if (!DISABLE_HTTP_HEADERS_VALIDATION) {
             HttpUtils.validateHeader(name, value);
         }
         // Update the hash table.

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ResumingRequestWrapper.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ResumingRequestWrapper.java
@@ -6,8 +6,8 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServerFileUpload;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
-import io.vertx.core.http.impl.HttpServerRequestInternal;
-import io.vertx.core.http.impl.HttpServerRequestWrapper;
+import io.vertx.core.internal.http.HttpServerRequestInternal;
+import io.vertx.core.internal.http.HttpServerRequestWrapper;
 
 public class ResumingRequestWrapper extends HttpServerRequestWrapper {
 
@@ -80,15 +80,6 @@ public class ResumingRequestWrapper extends HttpServerRequestWrapper {
     @Override
     public HttpServerRequest endHandler(Handler<Void> handler) {
         delegate.endHandler(handler);
-        if (!userSetState) {
-            delegate.resume();
-        }
-        return this;
-    }
-
-    @Override
-    public HttpServerRequest bodyHandler(Handler<Buffer> handler) {
-        delegate.bodyHandler(handler);
         if (!userSetState) {
             delegate.resume();
         }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/RoutingUtils.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/RoutingUtils.java
@@ -6,8 +6,8 @@ import java.util.Set;
 import org.jboss.logging.Logger;
 
 import io.vertx.core.http.HttpHeaders;
-import io.vertx.core.http.impl.MimeMapping;
-import io.vertx.core.net.impl.URIDecoder;
+import io.vertx.core.http.MimeMapping;
+import io.vertx.core.internal.net.RFC3986;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.StaticHandler;
 
@@ -49,7 +49,8 @@ public final class RoutingUtils {
     /**
      * Get the normalized and decoded path:
      * - normalize based on RFC3986
-     * - convert % encoded characters to their non encoded form (using {@link URIDecoder#decodeURIComponent})
+     * - convert % encoded characters to their non encoded form (using
+     * {@link RFC3986#decodeURIComponent(String, boolean)})
      * - invalid if the path contains '?' (query section of the path)
      *
      * @param ctx the RoutingContext
@@ -63,7 +64,7 @@ public final class RoutingUtils {
         if (normalizedPath.indexOf('%') == -1) {
             return normalizedPath;
         }
-        return URIDecoder.decodeURIComponent(normalizedPath);
+        return RFC3986.decodeURIComponent(normalizedPath, false);
     }
 
     /**
@@ -107,7 +108,7 @@ public final class RoutingUtils {
             return false;
         }
         final String resourcePath = path.endsWith("/") ? path + StaticHandler.DEFAULT_INDEX_PAGE : path;
-        final String contentType = MimeMapping.getMimeTypeForFilename(resourcePath);
+        final String contentType = MimeMapping.mimeTypeForFilename(resourcePath);
         return contentType != null && compressMediaTypes.contains(contentType);
     }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -126,9 +126,9 @@ import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.impl.Http1xServerConnection;
-import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.Utils;
-import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.net.impl.ConnectionBase;
 import io.vertx.core.net.impl.VertxHandler;
@@ -402,7 +402,8 @@ public class VertxHttpRecorder {
 
     public void mountFrameworkRouter(RuntimeValue<Router> mainRouter, RuntimeValue<Router> frameworkRouter,
             String frameworkPath) {
-        mainRouter.getValue().mountSubRouter(frameworkPath, frameworkRouter.getValue());
+        String p = frameworkPath.endsWith("/") ? frameworkPath + "*" : frameworkPath + "/*";
+        mainRouter.getValue().route(p).subRouter(frameworkRouter.getValue());
     }
 
     public void finalizeRouter(
@@ -488,7 +489,8 @@ public class VertxHttpRecorder {
         } else {
             Router mainRouter = mainRouterRuntimeValue.isPresent() ? mainRouterRuntimeValue.get().getValue()
                     : Router.router(vertx.get());
-            mainRouter.mountSubRouter(rootPath, httpRouteRouter);
+            String p = rootPath.endsWith("/") ? rootPath + "*" : rootPath + "/*";
+            mainRouter.route(p).subRouter(httpRouteRouter);
 
             addHotReplacementHandlerIfNeeded(mainRouter);
             root = mainRouter;
@@ -708,7 +710,7 @@ public class VertxHttpRecorder {
         if (domainSocketOptionsForManagement != null) {
             vertx.createHttpServer(domainSocketOptionsForManagement)
                     .requestHandler(managementRouter)
-                    .listen(ar -> {
+                    .listen().onComplete(ar -> {
                         if (ar.failed()) {
                             managementInterfaceDomainSocketFuture.completeExceptionally(
                                     new IllegalStateException(
@@ -752,7 +754,7 @@ public class VertxHttpRecorder {
         if (httpManagementServerOptions != null) {
             vertx.createHttpServer(httpManagementServerOptions)
                     .requestHandler(managementRouter)
-                    .listen(ar -> {
+                    .listen().onComplete(ar -> {
                         if (ar.failed()) {
                             managementInterfaceFuture.completeExceptionally(
                                     new IllegalStateException("Unable to start the management interface on "
@@ -869,7 +871,7 @@ public class VertxHttpRecorder {
         AtomicBoolean registerHttpServer = new AtomicBoolean();
         AtomicBoolean registerHttpsServer = new AtomicBoolean();
 
-        vertx.deployVerticle(new Supplier<>() {
+        vertx.deployVerticle(new Supplier<Verticle>() {
             @Override
             public Verticle get() {
                 return new WebDeploymentVerticle(
@@ -877,7 +879,7 @@ public class VertxHttpRecorder {
                         launchMode, insecureRequestStrategy, connectionCount, registry, startEventsFired,
                         httpBuildTimeConfig, httpConfig, registerHttpServer, registerHttpsServer);
             }
-        }, new DeploymentOptions().setInstances(ioThreads), new Handler<>() {
+        }, new DeploymentOptions().setInstances(ioThreads)).onComplete(new Handler<AsyncResult<String>>() {
             @Override
             public void handle(AsyncResult<String> event) {
                 if (event.failed()) {
@@ -959,7 +961,7 @@ public class VertxHttpRecorder {
                         // shutdown main HTTP server
                         if (deploymentIdIfAny != null) {
                             try {
-                                vertx.undeploy(deploymentIdIfAny, handler);
+                                vertx.undeploy(deploymentIdIfAny).onComplete(handler);
                             } catch (Exception e) {
                                 if (e instanceof RejectedExecutionException) {
                                     // Shutting down
@@ -977,10 +979,10 @@ public class VertxHttpRecorder {
                                 TlsCertificateReloader.unschedule(vertx, id);
                             }
                             if (managementServer != null && !isVertxClose) {
-                                managementServer.close(handler);
+                                managementServer.close().onComplete(handler);
                             }
                             if (managementServerDomainSocket != null && !isVertxClose) {
-                                managementServerDomainSocket.close(handler);
+                                managementServerDomainSocket.close().onComplete(handler);
                             }
                         } catch (Exception e) {
                             LOGGER.warn("Unable to shutdown the management interface quietly", e);
@@ -1317,7 +1319,7 @@ public class VertxHttpRecorder {
         private void setupUnixDomainSocketHttpServer(HttpServer httpServer, HttpServerOptions options,
                 Promise<Void> startFuture,
                 AtomicInteger remainingCount, ArcContainer container, boolean notifyStartObservers) {
-            httpServer.listen(SocketAddress.domainSocketAddress(options.getHost()), event -> {
+            httpServer.listen(SocketAddress.domainSocketAddress(options.getHost())).onComplete(event -> {
                 if (event.succeeded()) {
                     if (notifyStartObservers) {
                         container.beanManager().getEvent().select(DomainSocketServerStart.class)
@@ -1351,7 +1353,7 @@ public class VertxHttpRecorder {
 
             if (httpConfig.limits().maxConnections().isPresent() && httpConfig.limits().maxConnections().getAsInt() > 0) {
                 var tracker = vertx.isMetricsEnabled()
-                        ? ((ExtendedQuarkusVertxHttpMetrics) ((VertxInternal) vertx).metricsSPI()).getHttpConnectionTracker()
+                        ? ((ExtendedQuarkusVertxHttpMetrics) ((VertxInternal) vertx).metrics()).getHttpConnectionTracker()
                         : ExtendedQuarkusVertxHttpMetrics.NOOP_CONNECTION_TRACKER;
 
                 final int maxConnections = httpConfig.limits().maxConnections().getAsInt();
@@ -1381,7 +1383,7 @@ public class VertxHttpRecorder {
                     }
                 });
             }
-            httpServer.listen(options.getPort(), options.getHost(), new Handler<>() {
+            httpServer.listen(options.getPort(), options.getHost()).onComplete(new Handler<>() {
                 @Override
                 public void handle(AsyncResult<HttpServer> event) {
                     if (event.cause() != null) {
@@ -1520,13 +1522,13 @@ public class VertxHttpRecorder {
             };
 
             if (httpServer != null) {
-                httpServer.close(handleClose);
+                httpServer.close().onComplete(handleClose);
             }
             if (httpsServer != null) {
-                httpsServer.close(handleClose);
+                httpsServer.close().onComplete(handleClose);
             }
             if (domainSocketServer != null) {
-                domainSocketServer.close(handleClose);
+                domainSocketServer.close().onComplete(handleClose);
             }
         }
 
@@ -1560,7 +1562,7 @@ public class VertxHttpRecorder {
 
         VertxInternal vertx = (VertxInternal) vertxRuntime;
         virtualBootstrap = new ServerBootstrap();
-        virtualBootstrap.group(vertx.getEventLoopGroup())
+        virtualBootstrap.group(vertx.eventLoopGroup())
                 .channel(VirtualServerChannel.class)
                 .handler(new ChannelInitializer<VirtualServerChannel>() {
                     @Override
@@ -1575,6 +1577,7 @@ public class VertxHttpRecorder {
                         VertxHandler<Http1xServerConnection> handler = VertxHandler.create(chctx -> {
 
                             Http1xServerConnection conn = new Http1xServerConnection(
+                                    io.vertx.core.ThreadingModel.EVENT_LOOP,
                                     () -> {
                                         ContextInternal duplicated = (ContextInternal) VertxContext
                                                 .getOrCreateDuplicatedContext(rootContext);

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxInputStream.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxInputStream.java
@@ -18,6 +18,7 @@ import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.http.HttpVersion;
+import io.vertx.core.internal.buffer.BufferInternal;
 import io.vertx.core.net.impl.ConnectionBase;
 import io.vertx.ext.web.RoutingContext;
 
@@ -46,7 +47,7 @@ public class VertxInputStream extends InputStream {
         }
     }
 
-    public VertxInputStream(RoutingContext request, long timeout, ByteBuf existing) {
+    public VertxInputStream(RoutingContext request, long timeout, Buffer existing) {
         this.exchange = new VertxBlockingInput(request.request(), timeout);
         Long limitObj = request.get(VertxHttpRecorder.MAX_REQUEST_SIZE_KEY);
         if (limitObj == null) {
@@ -54,7 +55,7 @@ public class VertxInputStream extends InputStream {
         } else {
             limit = limitObj;
         }
-        this.pooled = existing;
+        this.pooled = ((BufferInternal) existing).getByteBuf();
     }
 
     @Override
@@ -201,13 +202,13 @@ public class VertxInputStream extends InputStream {
                             synchronized (connection) {
                                 readException = new IOException(event);
                                 if (input1 != null) {
-                                    input1.getByteBuf().release();
+                                    ((BufferInternal) input1).getByteBuf().release();
                                     input1 = null;
                                 }
                                 if (inputOverflow != null) {
                                     Buffer d = inputOverflow.poll();
                                     while (d != null) {
-                                        d.getByteBuf().release();
+                                        ((BufferInternal) d).getByteBuf().release();
                                         d = inputOverflow.poll();
                                     }
                                 }
@@ -264,7 +265,7 @@ public class VertxInputStream extends InputStream {
                 } else if (!eof) {
                     request.fetch(1);
                 }
-                return ret == null ? null : ret.getByteBuf();
+                return ret == null ? null : ((BufferInternal) ret).getByteBuf();
             }
         }
 
@@ -295,7 +296,7 @@ public class VertxInputStream extends InputStream {
 
         public int readBytesAvailable() {
             if (input1 != null) {
-                return input1.getByteBuf().readableBytes();
+                return ((BufferInternal) input1).getByteBuf().readableBytes();
             }
 
             String length = request.getHeader(HttpHeaders.CONTENT_LENGTH);

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/CookieAttribute.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/CookieAttribute.java
@@ -18,7 +18,7 @@ public class CookieAttribute implements ExchangeAttribute {
 
     @Override
     public String readAttribute(final RoutingContext exchange) {
-        Cookie cookie = exchange.getCookie(cookieName);
+        Cookie cookie = exchange.request().getCookie(cookieName);
         if (cookie == null) {
             return null;
         }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSFilter.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSFilter.java
@@ -247,7 +247,7 @@ public class CORSFilter implements Handler<RoutingContext> {
                         request.absoluteURI(), origin);
                 return false;
             }
-            if (substringMatch(origin, request.scheme().length() + 3, request.host(), true)) {
+            if (substringMatch(origin, request.scheme().length() + 3, request.authority().toString(), true)) {
                 //they are a simple match
                 return true;
             }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/ConfigDescriptionsManager.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/ConfigDescriptionsManager.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -17,7 +18,6 @@ import org.eclipse.microprofile.config.spi.ConfigSource;
 
 import io.smallrye.config.ConfigValue;
 import io.smallrye.config.SmallRyeConfig;
-import io.vertx.core.impl.ConcurrentHashSet;
 
 public class ConfigDescriptionsManager implements Supplier<ConfigDescriptionsManager> {
 
@@ -35,7 +35,7 @@ public class ConfigDescriptionsManager implements Supplier<ConfigDescriptionsMan
      *
      * This is static to persist across restarts
      */
-    private static Set<String> addedConfigKeys = new ConcurrentHashSet<>();
+    private static Set<String> addedConfigKeys = ConcurrentHashMap.newKeySet();
 
     public ConfigDescriptionsManager() {
         this(List.of());

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/FileSystemStaticHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/FileSystemStaticHandler.java
@@ -20,9 +20,8 @@ import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
-import io.vertx.core.http.impl.HttpUtils;
-import io.vertx.core.http.impl.MimeMapping;
-import io.vertx.core.net.impl.URIDecoder;
+import io.vertx.core.http.MimeMapping;
+import io.vertx.core.internal.net.RFC3986;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.impl.Utils;
 
@@ -70,14 +69,14 @@ public class FileSystemStaticHandler implements Handler<RoutingContext>, Closeab
         }
 
         // decode URL path
-        String uriDecodedPath = URIDecoder.decodeURIComponent(context.normalizedPath(), false);
+        String uriDecodedPath = RFC3986.decodeURIComponent(context.normalizedPath(), false);
         // if the normalized path is null it cannot be resolved
         if (uriDecodedPath == null) {
             context.next();
             return;
         }
         // will normalize and handle all paths as UNIX paths
-        String path = HttpUtils.removeDots(uriDecodedPath.replace('\\', '/'));
+        String path = uriDecodedPath.replace('\\', '/');
         path = Utils.pathOffset(path, context);
         if (path.startsWith("/")) {
             path = path.substring(1);
@@ -142,7 +141,7 @@ public class FileSystemStaticHandler implements Handler<RoutingContext>, Closeab
         }
 
         final HttpServerResponse response = context.response();
-        String contentType = MimeMapping.getMimeTypeForFilename(path);
+        String contentType = MimeMapping.mimeTypeForFilename(path);
         if (contentType != null) {
             if (contentType.startsWith("text")) {
                 response.putHeader(HttpHeaders.CONTENT_TYPE, contentType + ";charset=" + DEFAULT_CONTENT_ENCODING);

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/AbstractResponseWrapper.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/AbstractResponseWrapper.java
@@ -2,7 +2,6 @@ package io.quarkus.vertx.http.runtime.filters;
 
 import java.util.Set;
 
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
@@ -32,11 +31,6 @@ public class AbstractResponseWrapper implements HttpServerResponse {
     @Override
     public Future<Void> write(Buffer data) {
         return delegate.write(data);
-    }
-
-    @Override
-    public void write(Buffer data, Handler<AsyncResult<Void>> handler) {
-        delegate.write(data, handler);
     }
 
     @Override
@@ -181,11 +175,6 @@ public class AbstractResponseWrapper implements HttpServerResponse {
     }
 
     @Override
-    public void write(String chunk, String enc, Handler<AsyncResult<Void>> handler) {
-        delegate.write(chunk, enc, handler);
-    }
-
-    @Override
 
     public Future<Void> write(String chunk) {
         return delegate.write(chunk);
@@ -193,15 +182,8 @@ public class AbstractResponseWrapper implements HttpServerResponse {
 
     @Override
 
-    public void write(String chunk, Handler<AsyncResult<Void>> handler) {
-        delegate.write(chunk, handler);
-    }
-
-    @Override
-
-    public HttpServerResponse writeContinue() {
-        delegate.writeContinue();
-        return this;
+    public Future<Void> writeContinue() {
+        return delegate.writeContinue();
     }
 
     @Override
@@ -210,18 +192,8 @@ public class AbstractResponseWrapper implements HttpServerResponse {
     }
 
     @Override
-    public void writeEarlyHints(MultiMap headers, Handler<AsyncResult<Void>> handler) {
-        delegate.writeEarlyHints(headers, handler);
-    }
-
-    @Override
     public Future<Void> end(String chunk) {
         return delegate.end(chunk);
-    }
-
-    @Override
-    public void end(String chunk, Handler<AsyncResult<Void>> handler) {
-        delegate.end(chunk, handler);
     }
 
     @Override
@@ -230,18 +202,8 @@ public class AbstractResponseWrapper implements HttpServerResponse {
     }
 
     @Override
-    public void end(String chunk, String enc, Handler<AsyncResult<Void>> handler) {
-        delegate.end(chunk, enc, handler);
-    }
-
-    @Override
     public Future<Void> end(Buffer chunk) {
         return delegate.end(chunk);
-    }
-
-    @Override
-    public void end(Buffer chunk, Handler<AsyncResult<Void>> handler) {
-        delegate.end(chunk, handler);
     }
 
     @Override
@@ -250,18 +212,8 @@ public class AbstractResponseWrapper implements HttpServerResponse {
     }
 
     @Override
-    public void send(Handler<AsyncResult<Void>> handler) {
-        delegate.send(handler);
-    }
-
-    @Override
     public Future<Void> send() {
         return delegate.send();
-    }
-
-    @Override
-    public void send(String body, Handler<AsyncResult<Void>> handler) {
-        delegate.send(body, handler);
     }
 
     @Override
@@ -270,18 +222,8 @@ public class AbstractResponseWrapper implements HttpServerResponse {
     }
 
     @Override
-    public void send(Buffer body, Handler<AsyncResult<Void>> handler) {
-        delegate.send(body, handler);
-    }
-
-    @Override
     public Future<Void> send(Buffer body) {
         return delegate.send(body);
-    }
-
-    @Override
-    public void send(ReadStream<Buffer> body, Handler<AsyncResult<Void>> handler) {
-        delegate.send(body, handler);
     }
 
     @Override
@@ -307,31 +249,13 @@ public class AbstractResponseWrapper implements HttpServerResponse {
     }
 
     @Override
-
-    public HttpServerResponse sendFile(String filename, Handler<AsyncResult<Void>> resultHandler) {
-        delegate.sendFile(filename, resultHandler);
-        return this;
+    public Future<Void> sendFile(java.io.RandomAccessFile file, long offset, long length) {
+        return delegate.sendFile(file, offset, length);
     }
 
     @Override
-
-    public HttpServerResponse sendFile(String filename, long offset, Handler<AsyncResult<Void>> resultHandler) {
-        delegate.sendFile(filename, offset, resultHandler);
-        return this;
-    }
-
-    @Override
-
-    public HttpServerResponse sendFile(String filename, long offset, long length,
-            Handler<AsyncResult<Void>> resultHandler) {
-        delegate.sendFile(filename, offset, length, resultHandler);
-        return this;
-    }
-
-    @Override
-    @Deprecated
-    public void close() {
-        delegate.close();
+    public Future<Void> sendFile(java.nio.channels.FileChannel file, long offset, long length) {
+        return delegate.sendFile(file, offset, length);
     }
 
     @Override
@@ -374,84 +298,30 @@ public class AbstractResponseWrapper implements HttpServerResponse {
     }
 
     @Override
-
-    public HttpServerResponse push(HttpMethod method, String host, String path,
-            Handler<AsyncResult<HttpServerResponse>> handler) {
-        delegate.push(method, host, path, handler);
-        return this;
-    }
-
-    @Override
-    public Future<HttpServerResponse> push(HttpMethod method, String host, String path) {
-        return delegate.push(method, host, path);
-    }
-
-    @Override
-
-    public HttpServerResponse push(HttpMethod method, String path, MultiMap headers,
-            Handler<AsyncResult<HttpServerResponse>> handler) {
-        delegate.push(method, path, headers, handler);
-        return this;
-    }
-
-    @Override
-    public Future<HttpServerResponse> push(HttpMethod method, String path, MultiMap headers) {
-        return delegate.push(method, path, headers);
-    }
-
-    @Override
-
-    public HttpServerResponse push(HttpMethod method, String path, Handler<AsyncResult<HttpServerResponse>> handler) {
-        delegate.push(method, path, handler);
-        return this;
-    }
-
-    @Override
-    public Future<HttpServerResponse> push(HttpMethod method, String path) {
-        return delegate.push(method, path);
-    }
-
-    @Override
-
-    public HttpServerResponse push(HttpMethod method, String host, String path, MultiMap headers,
-            Handler<AsyncResult<HttpServerResponse>> handler) {
-        delegate.push(method, host, path, headers, handler);
-        return this;
-    }
-
-    @Override
-    @Deprecated
-    public Future<HttpServerResponse> push(HttpMethod method, String host, String path, MultiMap headers) {
-        return delegate.push(method, host, path, headers);
-    }
-
-    @Override
     public Future<HttpServerResponse> push(HttpMethod method, HostAndPort authority, String path, MultiMap headers) {
         return delegate.push(method, authority, path, headers);
     }
 
     @Override
-    public boolean reset() {
+    public Future<Void> reset() {
         return delegate.reset();
     }
 
     @Override
-    public boolean reset(long code) {
+    public Future<Void> reset(long code) {
         return delegate.reset(code);
     }
 
     @Override
 
-    public HttpServerResponse writeCustomFrame(int type, int flags, Buffer payload) {
-        delegate.writeCustomFrame(type, flags, payload);
-        return this;
+    public Future<Void> writeCustomFrame(int type, int flags, Buffer payload) {
+        return delegate.writeCustomFrame(type, flags, payload);
     }
 
     @Override
 
-    public HttpServerResponse writeCustomFrame(HttpFrame frame) {
-        delegate.writeCustomFrame(frame);
-        return this;
+    public Future<Void> writeCustomFrame(HttpFrame frame) {
+        return delegate.writeCustomFrame(frame);
     }
 
     @Override
@@ -497,11 +367,6 @@ public class AbstractResponseWrapper implements HttpServerResponse {
     @Override
     public Cookie removeCookie(String name, String domain, String path, boolean invalidate) {
         return delegate.removeCookie(name, domain, path, invalidate);
-    }
-
-    @Override
-    public void end(Handler<AsyncResult<Void>> handler) {
-        delegate.end(handler);
     }
 
     @Override

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/QuarkusRequestWrapper.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/QuarkusRequestWrapper.java
@@ -14,8 +14,8 @@ import io.vertx.core.http.Cookie;
 import io.vertx.core.http.CookieSameSite;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
-import io.vertx.core.http.impl.HttpServerRequestInternal;
-import io.vertx.core.http.impl.HttpServerRequestWrapper;
+import io.vertx.core.internal.http.HttpServerRequestInternal;
+import io.vertx.core.internal.http.HttpServerRequestWrapper;
 
 public class QuarkusRequestWrapper extends HttpServerRequestWrapper {
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/handlers/DevStaticHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/handlers/DevStaticHandler.java
@@ -18,7 +18,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.core.http.impl.MimeMapping;
+import io.vertx.core.http.MimeMapping;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.StaticHandler;
 
@@ -87,7 +87,7 @@ public class DevStaticHandler implements Handler<RoutingContext> {
         compressIfNeeded(httpBuildTimeConfig, compressMediaTypes, context, path);
 
         if (generatedFilesResources.containsKey(path)) {
-            context.vertx().fileSystem().readFile(generatedFilesResources.get(path), r -> {
+            context.vertx().fileSystem().readFile(generatedFilesResources.get(path)).onComplete(r -> {
                 if (r.succeeded()) {
                     handleAsyncResultSucceeded(context, r.result(), path);
                 } else {
@@ -97,16 +97,11 @@ public class DevStaticHandler implements Handler<RoutingContext> {
             return;
         }
 
-        context.vertx().executeBlocking(future -> {
-            try {
-                byte[] content = getClasspathResourceContent(path);
-                future.complete(content);
-            } catch (Exception e) {
-                future.fail(e);
-            }
-        }, asyncResult -> {
+        context.vertx().<byte[]> executeBlocking(() -> {
+            return getClasspathResourceContent(path);
+        }).onComplete(asyncResult -> {
             if (asyncResult.succeeded()) {
-                byte[] result = (byte[]) asyncResult.result();
+                byte[] result = asyncResult.result();
                 handleAsyncResultSucceeded(context, result == null ? null : Buffer.buffer(result), path);
             } else {
                 context.fail(asyncResult.cause());
@@ -121,7 +116,7 @@ public class DevStaticHandler implements Handler<RoutingContext> {
             beforeNextHandler(this.currentClassLoader, context);
             return;
         }
-        String contentType = MimeMapping.getMimeTypeForFilename(path);
+        String contentType = MimeMapping.mimeTypeForFilename(path);
         if (contentType != null) {
             if (contentType.startsWith("text")) {
                 context.response().putHeader(HttpHeaders.CONTENT_TYPE, contentType + ";charset=" + defaultEncoding);
@@ -148,10 +143,8 @@ public class DevStaticHandler implements Handler<RoutingContext> {
             LOG.warnf("The resource '%s' does not exist on classpath", resourceName);
             return null;
         }
-        try {
-            try (InputStream inputStream = resource.openStream()) {
-                return inputStream.readAllBytes();
-            }
+        try (InputStream inputStream = resource.openStream()) {
+            return inputStream.readAllBytes();
         } catch (IOException e) {
             LOG.error("Error while reading file from Classpath for path " + resourceName, e);
             return null;

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/handlers/GeneratedResource.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/handlers/GeneratedResource.java
@@ -4,8 +4,8 @@ import java.util.Objects;
 
 public class GeneratedResource {
 
-    private String publicPath;
-    private byte[] content;
+    private final String publicPath;
+    private final byte[] content;
 
     public GeneratedResource(String publicPath, byte[] content) {
         this.publicPath = publicPath;

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtils.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtils.java
@@ -42,7 +42,6 @@ import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.net.JdkSSLEngineOptions;
 import io.vertx.core.net.KeyCertOptions;
-import io.vertx.core.net.TCPSSLOptions;
 import io.vertx.core.net.TrafficShapingOptions;
 import io.vertx.core.net.TrustOptions;
 
@@ -183,7 +182,6 @@ public class HttpServerOptionsUtils {
         serverOptions.setEnabledSecureTransportProtocols(sslConfig.protocols());
         serverOptions.setSsl(true);
         serverOptions.setSni(sslConfig.sni());
-        setJdkHeapBufferPooling(serverOptions);
     }
 
     /**
@@ -229,7 +227,6 @@ public class HttpServerOptionsUtils {
 
     public static void applyTlsConfigurationToHttpServerOptions(TlsConfiguration bucket, HttpServerOptions serverOptions) {
         serverOptions.setSsl(true);
-        setJdkHeapBufferPooling(serverOptions);
 
         KeyCertOptions keyStoreOptions = bucket.getKeyStoreOptions();
         TrustOptions trustStoreOptions = bucket.getTrustStoreOptions();
@@ -241,7 +238,7 @@ public class HttpServerOptionsUtils {
         }
         serverOptions.setSni(bucket.usesSni());
 
-        var other = bucket.getSSLOptions();
+        var other = bucket.getServerSSLOptions();
         serverOptions.setSslHandshakeTimeout(other.getSslHandshakeTimeout());
         serverOptions.setSslHandshakeTimeoutUnit(other.getSslHandshakeTimeoutUnit());
         for (String suite : other.getEnabledCipherSuites()) {
@@ -254,20 +251,6 @@ public class HttpServerOptionsUtils {
             serverOptions.setUseAlpn(false);
         }
         serverOptions.setEnabledSecureTransportProtocols(other.getEnabledSecureTransportProtocols());
-    }
-
-    private static void setJdkHeapBufferPooling(TCPSSLOptions tcpSslOptions) {
-        if (!JDK_SSL_BUFFER_POOLING) {
-            return;
-        }
-        var engineOption = tcpSslOptions.getSslEngineOptions();
-        if (engineOption == null) {
-            var jdkEngineOptions = new JdkSSLEngineOptions();
-            jdkEngineOptions.setPooledHeapBuffers(true);
-            tcpSslOptions.setSslEngineOptions(jdkEngineOptions);
-        } else if (engineOption instanceof JdkSSLEngineOptions jdkEngineOptions) {
-            jdkEngineOptions.setPooledHeapBuffers(true);
-        }
     }
 
     public static Optional<String> getCredential(Optional<String> password, Map<String, String> credentials,

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/TlsCertificateReloader.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/TlsCertificateReloader.java
@@ -29,7 +29,7 @@ import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.net.KeyStoreOptions;
 import io.vertx.core.net.PemKeyCertOptions;
-import io.vertx.core.net.SSLOptions;
+import io.vertx.core.net.ServerSSLOptions;
 
 /**
  * Utility class to handle TLS certificate reloading.
@@ -61,10 +61,10 @@ public class TlsCertificateReloader {
             useRegistry = true;
         }
 
-        SSLOptions ssl = null;
+        ServerSSLOptions ssl = null;
         TlsConfiguration tlsConfiguration = null;
         if (!useRegistry) {
-            ssl = options.getSslOptions();
+            ssl = (ServerSSLOptions) options.getSslOptions();
             if (ssl == null) {
                 throw new IllegalArgumentException("Unable to configure TLS reloading - TLS/SSL is not enabled on the server");
             }
@@ -90,18 +90,18 @@ public class TlsCertificateReloader {
 
         boolean reloadFromRegistry = useRegistry;
         TlsConfiguration registryConfiguration = tlsConfiguration;
-        SSLOptions nonRegistryOptions = ssl;
+        ServerSSLOptions nonRegistryOptions = ssl;
         Supplier<CompletionStage<Boolean>> task = new Supplier<CompletionStage<Boolean>>() {
             @Override
             public CompletionStage<Boolean> get() {
 
                 // We are reading files - must be done on a worker thread.
-                Future<Boolean> future = vertx.executeBlocking(new Callable<SSLOptions>() {
+                Future<Boolean> future = vertx.executeBlocking(new Callable<ServerSSLOptions>() {
                     @Override
-                    public SSLOptions call() throws Exception {
+                    public ServerSSLOptions call() throws Exception {
                         if (reloadFromRegistry) {
                             if (registryConfiguration.reload()) {
-                                return registryConfiguration.getSSLOptions();
+                                return registryConfiguration.getServerSSLOptions();
                             } else {
                                 return null;
                             }
@@ -114,9 +114,9 @@ public class TlsCertificateReloader {
                         }
                     }
                 }, true)
-                        .flatMap(new Function<SSLOptions, Future<Boolean>>() {
+                        .flatMap(new Function<ServerSSLOptions, Future<Boolean>>() {
                             @Override
-                            public Future<Boolean> apply(SSLOptions res) {
+                            public Future<Boolean> apply(ServerSSLOptions res) {
                                 if (res != null) {
                                     return server.updateSSLOptions(res);
                                 } else {
@@ -179,8 +179,8 @@ public class TlsCertificateReloader {
         return CompletableFuture.allOf(futures);
     }
 
-    private static SSLOptions reloadFileContent(SSLOptions ssl, ServerSslConfig sslConfig) throws IOException {
-        var copy = new SSLOptions(ssl);
+    private static ServerSSLOptions reloadFileContent(ServerSSLOptions ssl, ServerSslConfig sslConfig) throws IOException {
+        var copy = new ServerSSLOptions(ssl);
 
         final List<Path> keys = new ArrayList<>();
         final List<Path> certificates = new ArrayList<>();

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
@@ -47,6 +47,7 @@ import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 import io.quarkus.vertx.http.runtime.cors.CORSConfig;
 import io.quarkus.vertx.http.security.MTLS;
+import io.smallrye.common.vertx.ContextLocals;
 import io.smallrye.common.vertx.VertxContext;
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Uni;
@@ -331,7 +332,7 @@ public class HttpSecurityRecorder {
             if (propagateRoutingContext) {
                 Context context = Vertx.currentContext();
                 if (context != null && VertxContext.isDuplicatedContext(context)) {
-                    context.putLocal(HttpSecurityUtils.ROUTING_CONTEXT_ATTRIBUTE, event);
+                    ContextLocals.put(HttpSecurityUtils.ROUTING_CONTEXT_ATTRIBUTE, event);
                 }
             }
             //we put the authenticator into the routing context so it can be used by other systems
@@ -437,7 +438,8 @@ public class HttpSecurityRecorder {
                             public void accept(SecurityIdentity identity, Throwable throwable, Boolean aBoolean) {
                                 if (identity != null) {
                                     //when the result is evaluated we set the user, even if it is evaluated lazily
-                                    event.setUser(new QuarkusHttpUser(identity));
+                                    ((io.vertx.ext.web.impl.UserContextInternal) event.userContext())
+                                            .setUser(new QuarkusHttpUser(identity));
                                 } else if (throwable != null) {
                                     //handle the auth failure
                                     //this can be customised

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/PersistentLoginManager.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/PersistentLoginManager.java
@@ -155,7 +155,7 @@ public class PersistentLoginManager {
             if (cookieDomain != null) {
                 cookie.setDomain(cookieDomain);
             }
-            context.addCookie(cookie);
+            context.response().addCookie(cookie);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/QuarkusHttpUser.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/QuarkusHttpUser.java
@@ -6,13 +6,8 @@ import io.quarkus.security.identity.IdentityProviderManager;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.identity.request.AnonymousAuthenticationRequest;
 import io.smallrye.mutiny.Uni;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.auth.AuthProvider;
 import io.vertx.ext.auth.User;
-import io.vertx.ext.auth.authorization.Authorization;
 import io.vertx.ext.web.RoutingContext;
 
 /**
@@ -44,34 +39,10 @@ public class QuarkusHttpUser implements User {
     }
 
     @Override
-    public User isAuthorized(Authorization authority, Handler<AsyncResult<Boolean>> resultHandler) {
-        return null;
-    }
-
-    @Override
-    @Deprecated
-    public User isAuthorized(String authority, Handler<AsyncResult<Boolean>> resultHandler) {
-        resultHandler.handle(Future.succeededFuture(securityIdentity.hasRole(authority)));
-        return this;
-    }
-
-    @Override
-    @Deprecated
-    public User clearCache() {
-        return this;
-    }
-
-    @Override
     public JsonObject principal() {
         JsonObject ret = new JsonObject();
         ret.put("username", securityIdentity.getPrincipal().getName());
         return ret;
-    }
-
-    @Override
-    @Deprecated
-    public void setAuthProvider(AuthProvider authProvider) {
-
     }
 
     public SecurityIdentity getSecurityIdentity() {
@@ -138,13 +109,13 @@ public class QuarkusHttpUser implements User {
     }
 
     static Uni<SecurityIdentity> setIdentity(Uni<SecurityIdentity> identityUni, RoutingContext routingContext) {
-        routingContext.setUser(null);
+        ((io.vertx.ext.web.impl.UserContextInternal) routingContext.userContext()).setUser(null);
         routingContext.put(QuarkusHttpUser.DEFERRED_IDENTITY_KEY, identityUni);
         return identityUni;
     }
 
     public static SecurityIdentity setIdentity(SecurityIdentity identity, RoutingContext routingContext) {
-        routingContext.setUser(new QuarkusHttpUser(identity));
+        ((io.vertx.ext.web.impl.UserContextInternal) routingContext.userContext()).setUser(new QuarkusHttpUser(identity));
         routingContext.put(QuarkusHttpUser.DEFERRED_IDENTITY_KEY, Uni.createFrom().item(identity));
         return identity;
     }

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/ForwardedServerRequestWrapperTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/ForwardedServerRequestWrapperTest.java
@@ -16,8 +16,8 @@ import org.mockito.quality.Strictness;
 
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.core.http.impl.HttpServerRequestInternal;
 import io.vertx.core.http.impl.headers.HeadersMultiMap;
+import io.vertx.core.internal.http.HttpServerRequestInternal;
 import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.SocketAddress;
 
@@ -32,10 +32,9 @@ class ForwardedServerRequestWrapperTest {
     void setUp() {
         mockRequest = Mockito.mock(HttpServerRequestInternal.class, Answers.RETURNS_DEEP_STUBS);
 
-        MultiMap headers = new HeadersMultiMap();
+        MultiMap headers = HeadersMultiMap.httpHeaders();
         when(mockRequest.headers()).thenReturn(headers);
         when(mockRequest.scheme()).thenReturn("http");
-        when(mockRequest.host()).thenReturn("localhost");
         when(mockRequest.uri()).thenReturn("/original");
         when(mockRequest.method()).thenReturn(HttpMethod.GET);
         when(mockRequest.path()).thenReturn("/original");
@@ -121,13 +120,13 @@ class ForwardedServerRequestWrapperTest {
 
         String absoluteURI = wrapper.absoluteURI();
 
-        assertEquals("http://localhost/new/path?q=1", absoluteURI);
+        assertEquals("http://localhost:8080/new/path?q=1", absoluteURI);
     }
 
     @Test
     void absoluteURIWhenNotModifiedDelegatesToForwardedParser() {
         String absoluteURI = wrapper.absoluteURI();
-        assertEquals("http://localhost/original", absoluteURI);
+        assertEquals("http://localhost:8080/original", absoluteURI);
     }
 
     @Test
@@ -159,7 +158,7 @@ class ForwardedServerRequestWrapperTest {
 
     @Test
     void hostReturnsForwardedParserHost() {
-        assertEquals("localhost", wrapper.host());
+        assertEquals("localhost", wrapper.authority().host());
     }
 
     @Test

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/VertxInputStreamIntegrationTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/VertxInputStreamIntegrationTest.java
@@ -1,0 +1,168 @@
+package io.quarkus.vertx.http.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServer;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+class VertxInputStreamIntegrationTest {
+
+    private Vertx vertx;
+    private HttpServer server;
+    private HttpClient client;
+    private int port;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        vertx = Vertx.vertx();
+        Router router = Router.router(vertx);
+
+        router.post("/read-body").handler(ctx -> {
+            ctx.request().pause();
+            vertx.executeBlocking(() -> {
+                try {
+                    return readFullBody(ctx);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }).onComplete(ar -> {
+                if (ar.succeeded()) {
+                    ctx.response().end(Buffer.buffer(ar.result()));
+                } else {
+                    ctx.response().setStatusCode(500).end(ar.cause().getMessage());
+                }
+            });
+        });
+
+        router.post("/read-body-sha256").handler(ctx -> {
+            ctx.request().pause();
+            vertx.executeBlocking(() -> {
+                try {
+                    return sha256(ctx);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }).onComplete(ar -> {
+                if (ar.succeeded()) {
+                    ctx.response().end(ar.result());
+                } else {
+                    ctx.response().setStatusCode(500).end(ar.cause().getMessage());
+                }
+            });
+        });
+
+        server = vertx.createHttpServer()
+                .requestHandler(router)
+                .listen(0)
+                .await(10, TimeUnit.SECONDS);
+        port = server.actualPort();
+        client = vertx.createHttpClient();
+    }
+
+    @AfterEach
+    void tearDown() throws TimeoutException {
+        if (client != null) {
+            client.close().await(5, TimeUnit.SECONDS);
+        }
+        if (server != null) {
+            server.close().await(5, TimeUnit.SECONDS);
+        }
+        if (vertx != null) {
+            vertx.close().await(5, TimeUnit.SECONDS);
+        }
+    }
+
+    private byte[] readFullBody(RoutingContext ctx) throws IOException {
+        try (VertxInputStream vis = new VertxInputStream(ctx, 30000)) {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            byte[] buf = new byte[4096];
+            int read;
+            while ((read = vis.read(buf)) != -1) {
+                baos.write(buf, 0, read);
+            }
+            return baos.toByteArray();
+        }
+    }
+
+    private String sha256(RoutingContext ctx) throws IOException, NoSuchAlgorithmException {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        try (VertxInputStream vis = new VertxInputStream(ctx, 30000)) {
+            byte[] buf = new byte[8192];
+            int read;
+            while ((read = vis.read(buf)) != -1) {
+                digest.update(buf, 0, read);
+            }
+        }
+        return hexEncode(digest.digest());
+    }
+
+    private static String hexEncode(byte[] bytes) {
+        StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+
+    private Buffer sendPost(Buffer body, String path) throws TimeoutException {
+        return client.request(HttpMethod.POST, port, "localhost", path)
+                .compose(req -> req.send(body))
+                .compose(resp -> resp.body())
+                .await(30, TimeUnit.SECONDS);
+    }
+
+    @Test
+    void simplePostBody() throws Exception {
+        byte[] data = "Hello, World!".getBytes();
+        Buffer response = sendPost(Buffer.buffer(data), "/read-body");
+        assertThat(response.getBytes()).isEqualTo(data);
+    }
+
+    @Test
+    void emptyPostBody() throws Exception {
+        Buffer response = sendPost(Buffer.buffer(), "/read-body");
+        assertThat(response.length()).isEqualTo(0);
+    }
+
+    @Test
+    void largePostBody() throws Exception {
+        byte[] data = new byte[128 * 1024];
+        for (int i = 0; i < data.length; i++) {
+            data[i] = (byte) (i % 251);
+        }
+        Buffer response = sendPost(Buffer.buffer(data), "/read-body");
+        assertThat(response.getBytes()).isEqualTo(data);
+    }
+
+    @Test
+    void veryLargePostBody() throws Exception {
+        // 5MB body — verifies sustained streaming and backpressure
+        int size = 5 * 1024 * 1024;
+        byte[] data = new byte[size];
+        for (int i = 0; i < data.length; i++) {
+            data[i] = (byte) (i % 251);
+        }
+
+        String expected = hexEncode(MessageDigest.getInstance("SHA-256").digest(data));
+
+        // Compare SHA-256 instead of transferring 5MB back in the response
+        Buffer response = sendPost(Buffer.buffer(data), "/read-body-sha256");
+        assertThat(response.toString()).isEqualTo(expected);
+    }
+}

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/VertxInputStreamTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/VertxInputStreamTest.java
@@ -1,0 +1,353 @@
+package io.quarkus.vertx.http.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import io.netty.channel.Channel;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpConnection;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.http.HttpVersion;
+import io.vertx.core.net.impl.ConnectionBase;
+import io.vertx.ext.web.RoutingContext;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class VertxInputStreamTest {
+
+    @Mock
+    RoutingContext routingContext;
+
+    @Mock
+    HttpServerRequest request;
+
+    @Mock
+    HttpServerResponse response;
+
+    @Mock(extraInterfaces = HttpConnection.class)
+    ConnectionBase connection;
+
+    @Mock
+    Channel channel;
+
+    @BeforeEach
+    void setUp() {
+        when(routingContext.request()).thenReturn(request);
+        when(request.connection()).thenReturn((HttpConnection) connection);
+        when(request.response()).thenReturn(response);
+        when(connection.channel()).thenReturn(channel);
+        when(channel.isOpen()).thenReturn(true);
+        when(request.isEnded()).thenReturn(true); // avoid handler setup complexity
+    }
+
+    @Test
+    void readSingleByteFromExistingBuffer() throws IOException {
+        Buffer buf = Buffer.buffer(new byte[] { 0x42 });
+        VertxInputStream stream = new VertxInputStream(routingContext, 10000, buf);
+
+        int result = stream.read();
+        assertThat(result).isEqualTo(0x42);
+
+        int eof = stream.read();
+        assertThat(eof).isEqualTo(-1);
+    }
+
+    @Test
+    void readFullArrayFromExistingBuffer() throws IOException {
+        Buffer buf = Buffer.buffer("hello");
+        VertxInputStream stream = new VertxInputStream(routingContext, 10000, buf);
+
+        byte[] out = new byte[5];
+        int read = stream.read(out);
+        assertThat(read).isEqualTo(5);
+        assertThat(out).isEqualTo("hello".getBytes());
+    }
+
+    @Test
+    void readPartialThenRemainder() throws IOException {
+        Buffer buf = Buffer.buffer("abcdef");
+        VertxInputStream stream = new VertxInputStream(routingContext, 10000, buf);
+
+        byte[] part1 = new byte[3];
+        int read1 = stream.read(part1, 0, 3);
+        assertThat(read1).isEqualTo(3);
+        assertThat(part1).isEqualTo("abc".getBytes());
+
+        byte[] part2 = new byte[3];
+        int read2 = stream.read(part2, 0, 3);
+        assertThat(read2).isEqualTo(3);
+        assertThat(part2).isEqualTo("def".getBytes());
+
+        int eof = stream.read();
+        assertThat(eof).isEqualTo(-1);
+    }
+
+    @Test
+    void readWithLenZeroReturnsZero() throws IOException {
+        Buffer buf = Buffer.buffer(new byte[] { 1, 2, 3 });
+        VertxInputStream stream = new VertxInputStream(routingContext, 10000, buf);
+
+        byte[] out = new byte[3];
+        int read = stream.read(out, 0, 0);
+        assertThat(read).isEqualTo(0);
+
+        // Data should still be available
+        read = stream.read(out);
+        assertThat(read).isEqualTo(3);
+        assertThat(out).isEqualTo(new byte[] { 1, 2, 3 });
+    }
+
+    @Test
+    void readHighByteValue() throws IOException {
+        Buffer buf = Buffer.buffer(new byte[] { (byte) 0xFF });
+        VertxInputStream stream = new VertxInputStream(routingContext, 10000, buf);
+
+        int result = stream.read();
+        assertThat(result).isEqualTo(0xFF);
+    }
+
+    @Test
+    void readOnClosedStreamThrows() throws IOException {
+        Buffer buf = Buffer.buffer("data");
+        VertxInputStream stream = new VertxInputStream(routingContext, 10000, buf);
+        stream.close();
+
+        assertThatThrownBy(stream::read)
+                .isInstanceOf(IOException.class)
+                .hasMessage("Stream is closed");
+    }
+
+    @Test
+    void availableOnClosedStreamThrows() throws IOException {
+        Buffer buf = Buffer.buffer("data");
+        VertxInputStream stream = new VertxInputStream(routingContext, 10000, buf);
+        stream.close();
+
+        assertThatThrownBy(stream::available)
+                .isInstanceOf(IOException.class)
+                .hasMessage("Stream is closed");
+    }
+
+    @Test
+    void closeIsIdempotent() throws IOException {
+        Buffer buf = Buffer.buffer("data");
+        VertxInputStream stream = new VertxInputStream(routingContext, 10000, buf);
+        stream.close();
+        stream.close(); // should not throw
+    }
+
+    @Test
+    void availableReturnsZeroWhenFinished() throws IOException {
+        Buffer buf = Buffer.buffer("hi");
+        VertxInputStream stream = new VertxInputStream(routingContext, 10000, buf);
+
+        // Read all data
+        byte[] out = new byte[2];
+        stream.read(out);
+        // Read once more to trigger finished (returns -1)
+        stream.read();
+
+        assertThat(stream.available()).isEqualTo(0);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void continueHeaderTriggersContinueResponse() throws IOException {
+        // Use 2-arg constructor which checks Expect header
+        when(request.getHeader(io.netty.handler.codec.http.HttpHeaderNames.EXPECT)).thenReturn("100-continue");
+        when(request.isEnded()).thenReturn(false);
+        when(request.pause()).thenReturn(request);
+        when(request.handler(any())).thenReturn(request);
+        when(request.endHandler(any())).thenReturn(request);
+        when(request.exceptionHandler(any())).thenReturn(request);
+        when(request.fetch(1)).thenReturn(request);
+
+        VertxInputStream stream = new VertxInputStream(routingContext, 10000);
+
+        // Capture the data handler to feed data
+        ArgumentCaptor<Handler<Buffer>> handlerCaptor = ArgumentCaptor.forClass(Handler.class);
+        verify(request).handler(handlerCaptor.capture());
+        Handler<Buffer> dataHandler = handlerCaptor.getValue();
+
+        // Feed data through handler (must be done in synchronized block on connection)
+        synchronized (connection) {
+            dataHandler.handle(Buffer.buffer("test"));
+        }
+
+        // Read triggers continueState -> writeContinue
+        byte[] out = new byte[4];
+        stream.read(out);
+
+        verify(response).writeContinue();
+        assertThat(out).isEqualTo("test".getBytes());
+    }
+
+    @Test
+    void noContinueWithoutExpectHeader() throws IOException {
+        // Use 3-arg constructor (with existing buffer) - no continueState set up
+        Buffer buf = Buffer.buffer("data");
+        VertxInputStream stream = new VertxInputStream(routingContext, 10000, buf);
+
+        byte[] out = new byte[4];
+        stream.read(out);
+
+        verify(response, never()).writeContinue();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void requestTooLargeHeadNotWritten() throws IOException {
+        when(routingContext.<Long> get(VertxHttpRecorder.MAX_REQUEST_SIZE_KEY)).thenReturn(10L);
+        when(request.bytesRead()).thenReturn(100L);
+        when(response.headWritten()).thenReturn(false);
+        MultiMap headers = HttpHeaders.headers();
+        when(response.headers()).thenReturn(headers);
+        when(response.setStatusCode(413)).thenReturn(response);
+        when(response.endHandler(any())).thenReturn(response);
+
+        Buffer buf = Buffer.buffer("data");
+        VertxInputStream stream = new VertxInputStream(routingContext, 10000, buf);
+
+        assertThatThrownBy(() -> stream.read(new byte[4]))
+                .isInstanceOf(IOException.class)
+                .hasMessage("Request too large");
+
+        verify(response).setStatusCode(413);
+    }
+
+    @Test
+    void requestTooLargeHeadAlreadyWritten() throws IOException {
+        when(routingContext.<Long> get(VertxHttpRecorder.MAX_REQUEST_SIZE_KEY)).thenReturn(10L);
+        when(request.bytesRead()).thenReturn(100L);
+        when(response.headWritten()).thenReturn(true);
+
+        Buffer buf = Buffer.buffer("data");
+        VertxInputStream stream = new VertxInputStream(routingContext, 10000, buf);
+
+        assertThatThrownBy(() -> stream.read(new byte[4]))
+                .isInstanceOf(IOException.class)
+                .hasMessage("Request too large");
+
+        verify(connection).close();
+    }
+
+    @Test
+    void closedChannelOnConstructionPropagatesException() throws IOException {
+        when(channel.isOpen()).thenReturn(false);
+        when(request.isEnded()).thenReturn(false);
+
+        Buffer buf = Buffer.buffer("initial");
+        VertxInputStream stream = new VertxInputStream(routingContext, 10000, buf);
+
+        // First read consumes existing buffer
+        byte[] out = new byte[7];
+        int read = stream.read(out);
+        assertThat(read).isEqualTo(7);
+        assertThat(out).isEqualTo("initial".getBytes());
+
+        // Second read triggers readBlocking which sees readException (ClosedChannelException)
+        assertThatThrownBy(() -> stream.read(new byte[1]))
+                .isInstanceOf(IOException.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void http2EmptyFrameTriggersEof() throws IOException {
+        when(request.isEnded()).thenReturn(false);
+        when(request.pause()).thenReturn(request);
+        when(request.handler(any())).thenReturn(request);
+        when(request.endHandler(any())).thenReturn(request);
+        when(request.exceptionHandler(any())).thenReturn(request);
+        when(request.fetch(1)).thenReturn(request);
+        when(request.version()).thenReturn(HttpVersion.HTTP_2);
+
+        VertxInputStream.VertxBlockingInput input = new VertxInputStream.VertxBlockingInput(request, 10000);
+
+        // Feed an empty buffer (HTTP/2 signals EOF)
+        synchronized (connection) {
+            input.handle(Buffer.buffer(new byte[0]));
+        }
+
+        io.netty.buffer.ByteBuf result = input.readBlocking();
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void readBytesAvailableWithContentLengthHeader() {
+        when(request.getHeader(HttpHeaders.CONTENT_LENGTH)).thenReturn("42");
+
+        VertxInputStream.VertxBlockingInput input = new VertxInputStream.VertxBlockingInput(request, 10000);
+
+        assertThat(input.readBytesAvailable()).isEqualTo(42);
+    }
+
+    @Test
+    void readBytesAvailableWithNoContentLength() {
+        when(request.getHeader(HttpHeaders.CONTENT_LENGTH)).thenReturn(null);
+
+        VertxInputStream.VertxBlockingInput input = new VertxInputStream.VertxBlockingInput(request, 10000);
+
+        assertThat(input.readBytesAvailable()).isEqualTo(0);
+    }
+
+    @Test
+    void readBytesAvailableWithLargeContentLength() {
+        when(request.getHeader(HttpHeaders.CONTENT_LENGTH)).thenReturn(String.valueOf(Long.MAX_VALUE));
+
+        VertxInputStream.VertxBlockingInput input = new VertxInputStream.VertxBlockingInput(request, 10000);
+
+        assertThat(input.readBytesAvailable()).isEqualTo(Integer.MAX_VALUE);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void multipleChunksViaHandle() throws IOException {
+        when(request.isEnded()).thenReturn(false);
+        when(request.pause()).thenReturn(request);
+        when(request.handler(any())).thenReturn(request);
+        when(request.endHandler(any())).thenReturn(request);
+        when(request.exceptionHandler(any())).thenReturn(request);
+        when(request.fetch(1)).thenReturn(request);
+
+        VertxInputStream.VertxBlockingInput input = new VertxInputStream.VertxBlockingInput(request, 10000);
+
+        // Feed two chunks
+        synchronized (connection) {
+            input.handle(Buffer.buffer("abc"));
+            input.handle(Buffer.buffer("def"));
+        }
+
+        io.netty.buffer.ByteBuf chunk1 = input.readBlocking();
+        assertThat(chunk1).isNotNull();
+        byte[] bytes1 = new byte[chunk1.readableBytes()];
+        chunk1.readBytes(bytes1);
+        assertThat(bytes1).isEqualTo("abc".getBytes());
+        chunk1.release();
+
+        io.netty.buffer.ByteBuf chunk2 = input.readBlocking();
+        assertThat(chunk2).isNotNull();
+        byte[] bytes2 = new byte[chunk2.readableBytes()];
+        chunk2.readBytes(bytes2);
+        assertThat(bytes2).isEqualTo("def".getBytes());
+        chunk2.release();
+    }
+}

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/cors/CORSFilterTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/cors/CORSFilterTest.java
@@ -21,6 +21,7 @@ import org.mockito.Mockito;
 
 import io.quarkus.vertx.http.security.CORS;
 import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.net.HostAndPort;
 
 public class CORSFilterTest {
 
@@ -51,26 +52,26 @@ public class CORSFilterTest {
     public void sameOriginTest() {
         var request = Mockito.mock(HttpServerRequest.class);
         Mockito.when(request.scheme()).thenReturn("http");
-        Mockito.when(request.host()).thenReturn("localhost");
+        Mockito.when(request.authority()).thenReturn(HostAndPort.create("localhost", -1));
         Mockito.when(request.absoluteURI()).thenReturn("http://localhost");
         Assertions.assertTrue(isSameOrigin(request, "http://localhost"));
         Assertions.assertTrue(isSameOrigin(request, "http://localhost:80"));
         Assertions.assertFalse(isSameOrigin(request, "http://localhost:8080"));
         Assertions.assertFalse(isSameOrigin(request, "https://localhost"));
-        Mockito.when(request.host()).thenReturn("localhost:8080");
+        Mockito.when(request.authority()).thenReturn(HostAndPort.create("localhost", 8080));
         Mockito.when(request.absoluteURI()).thenReturn("http://localhost:8080");
         Assertions.assertFalse(isSameOrigin(request, "http://localhost"));
         Assertions.assertFalse(isSameOrigin(request, "http://localhost:80"));
         Assertions.assertTrue(isSameOrigin(request, "http://localhost:8080"));
         Assertions.assertFalse(isSameOrigin(request, "https://localhost:8080"));
         Mockito.when(request.scheme()).thenReturn("https");
-        Mockito.when(request.host()).thenReturn("localhost");
+        Mockito.when(request.authority()).thenReturn(HostAndPort.create("localhost", -1));
         Mockito.when(request.absoluteURI()).thenReturn("http://localhost");
         Assertions.assertFalse(isSameOrigin(request, "http://localhost"));
         Assertions.assertFalse(isSameOrigin(request, "http://localhost:443"));
         Assertions.assertFalse(isSameOrigin(request, "https://localhost:8080"));
         Assertions.assertTrue(isSameOrigin(request, "https://localhost"));
-        Mockito.when(request.host()).thenReturn("localhost:8443");
+        Mockito.when(request.authority()).thenReturn(HostAndPort.create("localhost", 8443));
         Mockito.when(request.absoluteURI()).thenReturn("https://localhost:8443");
         Assertions.assertFalse(isSameOrigin(request, "http://localhost"));
         Assertions.assertFalse(isSameOrigin(request, "http://localhost:80"));
@@ -84,7 +85,7 @@ public class CORSFilterTest {
     public void sameOriginPublicWebAddressTest() {
         var request = Mockito.mock(HttpServerRequest.class);
         Mockito.when(request.scheme()).thenReturn("https");
-        Mockito.when(request.host()).thenReturn("stage.code.quarkus.io");
+        Mockito.when(request.authority()).thenReturn(HostAndPort.create("stage.code.quarkus.io", -1));
         Mockito.when(request.absoluteURI()).thenReturn("https://stage.code.quarkus.io/api/project");
         Assertions.assertFalse(isSameOrigin(request, "http://localhost"));
         Assertions.assertFalse(isSameOrigin(request, "https://code.quarkus.io"));

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/filters/AbstractResponseWrapperTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/filters/AbstractResponseWrapperTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
@@ -80,16 +79,6 @@ public class AbstractResponseWrapperTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    void writeBufferWithHandler_delegates() {
-        Buffer buf = mock(Buffer.class);
-        Handler<AsyncResult<Void>> handler = mock(Handler.class);
-
-        wrapper.write(buf, handler);
-        verify(delegate).write(buf, handler);
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
     void writeString_delegatesAndReturnsFuture() {
         Future<Void> future = mock(Future.class);
         when(delegate.write("hello")).thenReturn(future);
@@ -116,14 +105,6 @@ public class AbstractResponseWrapperTest {
 
         assertSame(future, wrapper.end());
         verify(delegate).end();
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    void endWithHandler_delegates() {
-        Handler<AsyncResult<Void>> handler = mock(Handler.class);
-        wrapper.end(handler);
-        verify(delegate).end(handler);
     }
 
     @Test
@@ -403,10 +384,13 @@ public class AbstractResponseWrapperTest {
     }
 
     @Test
-    void writeContinue_delegatesAndReturnsThis() {
-        HttpServerResponse result = wrapper.writeContinue();
+    @SuppressWarnings("unchecked")
+    void writeContinue_delegatesAndReturnsFuture() {
+        Future<Void> future = mock(Future.class);
+        when(delegate.writeContinue()).thenReturn(future);
+
+        assertSame(future, wrapper.writeContinue());
         verify(delegate).writeContinue();
-        assertSame(wrapper, result);
     }
 
     @Test
@@ -420,25 +404,10 @@ public class AbstractResponseWrapperTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
-    void sendFileWithHandler_delegatesAndReturnsThis() {
-        Handler<AsyncResult<Void>> handler = mock(Handler.class);
-        HttpServerResponse result = wrapper.sendFile("file.txt", handler);
-        verify(delegate).sendFile("file.txt", handler);
-        assertSame(wrapper, result);
-    }
-
-    @Test
-    @SuppressWarnings("deprecation")
-    void close_delegates() {
-        wrapper.close();
-        verify(delegate).close();
-    }
-
-    @Test
     void reset_delegates() {
-        when(delegate.reset()).thenReturn(true);
-        assertTrue(wrapper.reset());
+        when(delegate.reset()).thenReturn(Future.succeededFuture());
+        Future<Void> result = wrapper.reset();
         verify(delegate).reset();
+        assertSame(delegate.reset(), result);
     }
 }

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/options/TlsCertificateReloaderTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/options/TlsCertificateReloaderTest.java
@@ -56,6 +56,8 @@ class TlsCertificateReloaderTest {
     void initCertReloadingAction_periodBelow30Seconds_throws() {
         ServerSslConfig sslConfig = mockSslConfigWithReloadPeriod(Duration.ofSeconds(29));
         HttpServerOptions options = new HttpServerOptions();
+        options.setSsl(true);
+        options.setKeyCertOptions(new io.vertx.core.net.PemKeyCertOptions());
 
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
                 () -> TlsCertificateReloader.initCertReloadingAction(
@@ -84,6 +86,8 @@ class TlsCertificateReloaderTest {
     void initCertReloadingAction_periodOf1Second_throws() {
         ServerSslConfig sslConfig = mockSslConfigWithReloadPeriod(Duration.ofSeconds(1));
         HttpServerOptions options = new HttpServerOptions();
+        options.setSsl(true);
+        options.setKeyCertOptions(new io.vertx.core.net.PemKeyCertOptions());
 
         assertThrows(IllegalArgumentException.class,
                 () -> TlsCertificateReloader.initCertReloadingAction(
@@ -94,6 +98,8 @@ class TlsCertificateReloaderTest {
     void initCertReloadingAction_noReloadPeriod_returnsMinusOne() {
         ServerSslConfig sslConfig = mockSslConfigWithReloadPeriod(null);
         HttpServerOptions options = new HttpServerOptions();
+        options.setSsl(true);
+        options.setKeyCertOptions(new io.vertx.core.net.PemKeyCertOptions());
 
         long result = TlsCertificateReloader.initCertReloadingAction(
                 vertx, server, options, sslConfig, registry, Optional.empty());

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/security/QuarkusHttpUserTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/security/QuarkusHttpUserTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -24,11 +23,8 @@ import org.mockito.quality.Strictness;
 import io.quarkus.security.identity.IdentityProviderManager;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.smallrye.mutiny.Uni;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
-import io.vertx.ext.auth.authorization.Authorization;
 import io.vertx.ext.web.RoutingContext;
 
 @ExtendWith(MockitoExtension.class)
@@ -71,51 +67,6 @@ class QuarkusHttpUserTest {
     @Test
     void getSecurityIdentityReturnsWrappedIdentity() {
         assertSame(securityIdentity, user.getSecurityIdentity());
-    }
-
-    @SuppressWarnings({ "unchecked", "deprecation" })
-    @Test
-    void isAuthorizedStringCallsHandlerWithTrueWhenRolePresent() {
-        when(securityIdentity.hasRole("admin")).thenReturn(true);
-        Handler<AsyncResult<Boolean>> handler = mock(Handler.class);
-
-        User result = user.isAuthorized("admin", handler);
-
-        assertSame(user, result);
-        ArgumentCaptor<AsyncResult<Boolean>> captor = ArgumentCaptor.forClass(AsyncResult.class);
-        verify(handler).handle(captor.capture());
-        assertEquals(true, captor.getValue().result());
-    }
-
-    @SuppressWarnings({ "unchecked", "deprecation" })
-    @Test
-    void isAuthorizedStringCallsHandlerWithFalseWhenRoleAbsent() {
-        when(securityIdentity.hasRole("admin")).thenReturn(false);
-        Handler<AsyncResult<Boolean>> handler = mock(Handler.class);
-
-        User result = user.isAuthorized("admin", handler);
-
-        assertSame(user, result);
-        ArgumentCaptor<AsyncResult<Boolean>> captor = ArgumentCaptor.forClass(AsyncResult.class);
-        verify(handler).handle(captor.capture());
-        assertEquals(false, captor.getValue().result());
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    void isAuthorizedAuthorizationReturnsNull() {
-        Authorization authorization = mock(Authorization.class);
-        Handler<AsyncResult<Boolean>> handler = mock(Handler.class);
-
-        User result = user.isAuthorized(authorization, handler);
-
-        assertNull(result);
-    }
-
-    @SuppressWarnings("deprecation")
-    @Test
-    void clearCacheReturnsThis() {
-        assertSame(user, user.clearCache());
     }
 
     @Test
@@ -187,10 +138,13 @@ class QuarkusHttpUserTest {
 
     @Test
     void setIdentityWithSecurityIdentitySetsUserAndDeferredKey() {
+        io.vertx.ext.web.impl.UserContextInternal userContext = mock(io.vertx.ext.web.impl.UserContextInternal.class);
+        when(routingContext.userContext()).thenReturn(userContext);
+
         SecurityIdentity result = QuarkusHttpUser.setIdentity(securityIdentity, routingContext);
 
         assertSame(securityIdentity, result);
-        verify(routingContext).setUser(any(QuarkusHttpUser.class));
+        verify(userContext).setUser(any(QuarkusHttpUser.class));
         verify(routingContext).put(eq(QuarkusHttpUser.DEFERRED_IDENTITY_KEY), any(Uni.class));
     }
 }

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
@@ -261,7 +261,7 @@ public class VertxCoreRecorder {
             }
         };
         var bootstrap = VertxBootstrap.create()
-                .options(options)
+                .options(options.setDisableTCCL(true))
                 .executorServiceFactory(new QuarkusExecutorFactory(conf, launchMode))
                 .threadFactory(vertxThreadFactory);
 

--- a/vertx.justfile
+++ b/vertx.justfile
@@ -10,6 +10,7 @@ modules := """
     extensions/mutiny
     extensions/netty
     extensions/vertx
+    extensions/vertx-http
     extensions/tls-registry
     extensions/mailer
     """


### PR DESCRIPTION
- Migrate wrapper classes to Vert.x 5 API changes
- Migrate runtime classes (VertxHttpRecorder, VertxInputStream, CORSFilter, QuarkusHttpUser, HttpSecurityRecorder, DevStaticHandler, etc.)
- Update context locals to use Vert.x 5 ContextLocals API
- Fix sub-router mounting rework
- Replace URIDecoder.decodeURIComponent with RFC3986.decodeURIComponent
- Replace deprecated host() with authority() across request handling
- Replace getBodyAsString() with body().asString()
- Remove setJdkHeapBufferPooling (now managed internally by Vert.x 5)
- Use UserContextInternal.setUser() instead of removed RoutingContext.setUser()
- Add QuarkusHttpHeaders for HTTP header validation system property
- Disable Vert.x TCCL to avoid classloading issues
- Update TLS certificate reloader for Vert.x 5 ServerSSLOptions
