### PR TITLE
Prevent weak partial matches from being auto-selected in CLI extension resolution

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/QuarkusCommandHandlers.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/QuarkusCommandHandlers.java
@@ -151,9 +151,7 @@ final class QuarkusCommandHandlers {
                             || extension.getArtifact().getArtifactId().toLowerCase().contains(q)
                             || getShortName(extension).toLowerCase().contains(q))
                     .forEach(e -> matches.putIfAbsent(e.getArtifact().getKey(), e));
-            // Even if we have a single partial match, if the name, artifactId and short names are ambiguous, so not
-            // consider it as a match.
-            if (matches.size() == 1 && returnOnExactMatch) {
+            if (matches.size() == 1 && returnOnExactMatch && isStrongPartialMatch(matches.values().iterator().next(), q)) {
                 return new SelectionResult(matches.values(), true);
             }
 
@@ -200,6 +198,12 @@ final class QuarkusCommandHandlers {
     private static boolean matchesArtifactId(String artifactId, String q) {
         return artifactId.equalsIgnoreCase(q) ||
                 artifactId.equalsIgnoreCase("quarkus-" + q);
+    }
+
+    private static boolean isStrongPartialMatch(Extension extension, String q) {
+        String artifactId = extension.getArtifact().getArtifactId().toLowerCase();
+        String stripped = artifactId.startsWith("quarkus-") ? artifactId.substring("quarkus-".length()) : artifactId;
+        return stripped.startsWith(q) || extension.getName().toLowerCase().startsWith(q);
     }
 
 }

--- a/integration-tests/devtools/src/test/java/io/quarkus/devtools/commands/handlers/QuarkusCommandHandlersTest.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/devtools/commands/handlers/QuarkusCommandHandlersTest.java
@@ -194,4 +194,38 @@ class QuarkusCommandHandlersTest {
         Assertions.assertEquals(1, matches.getExtensions().size());
 
     }
+
+    @Test
+    void testWeakPartialMatchIsNotAutoSelected() {
+        Extension e1 = Extension.builder()
+                .setArtifact(ArtifactCoords.jar("io.quarkiverse.groovy", "quarkus-groovy-junit5", "1.0"))
+                .setName("Quarkus - Groovy - JUnit 5");
+
+        Extension e2 = Extension.builder()
+                .setArtifact(ArtifactCoords.jar("org.acme", "quarkus-rest", "1.0"))
+                .setName("REST");
+
+        List<Extension> extensions = asList(e1, e2);
+        SelectionResult matches = selectExtensions("junit", extensions, false);
+        Assertions.assertFalse(matches.matches());
+        Assertions.assertEquals(1, matches.getExtensions().size());
+    }
+
+    @Test
+    void testStrongPartialMatchIsAutoSelected() {
+        Extension e1 = Extension.builder()
+                .setArtifact(ArtifactCoords.jar("org.acme", "quarkus-foo-bar", "1.0"))
+                .setName("Foo Bar Extension");
+
+        Extension e2 = Extension.builder()
+                .setArtifact(ArtifactCoords.jar("org.acme", "quarkus-baz", "1.0"))
+                .setName("Baz Extension");
+
+        List<Extension> extensions = asList(e1, e2);
+        SelectionResult matches = selectExtensions("foo", extensions, false);
+        Assertions.assertTrue(matches.matches());
+        Assertions.assertEquals(1, matches.getExtensions().size());
+        Assertions.assertEquals("quarkus-foo-bar",
+                matches.getExtensions().iterator().next().getArtifact().getArtifactId());
+    }
 }


### PR DESCRIPTION
Fixes #53373

When running `quarkus create app -x junit`, the CLI incorrectly auto-selects `io.quarkiverse.groovy:quarkus-groovy-junit5` because it is the only extension whose artifactId contains the substring "junit". The selection algorithm treats any single partial match as a definitive selection, regardless of match quality.

This PR adds a `isStrongPartialMatch` check: a single partial match is only auto-selected if the query is a **prefix** of the artifactId (after stripping the `quarkus-` prefix) or the extension name starts with the query. Otherwise, the match is reported as ambiguous, prompting the user to be more specific.

Examples:
- `junit` → `quarkus-groovy-junit5`: stripped = `groovy-junit5`, does not start with `junit` → **rejected** (ambiguity error shown)
- `foo` → `quarkus-foo-bar`: stripped = `foo-bar`, starts with `foo` → **accepted** (auto-selected as before)

All 9 tests pass (7 existing + 2 new).