### PR TITLE
[3.34] Update SmallRye Fault Tolerance to 6.10.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -50,7 +50,7 @@
         <smallrye-health.version>4.3.0</smallrye-health.version>
         <smallrye-open-api.version>4.2.4</smallrye-open-api.version>
         <smallrye-graphql.version>2.17.0</smallrye-graphql.version>
-        <smallrye-fault-tolerance.version>6.10.0</smallrye-fault-tolerance.version>
+        <smallrye-fault-tolerance.version>6.10.1</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>4.6.3</smallrye-jwt.version>
         <smallrye-context-propagation.version>2.3.0</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>


### PR DESCRIPTION
As discussed here: https://github.com/quarkusio/quarkus/pull/53353 .