### PR TITLE
Update Gradle template to select `quarkus-junit` or `quarkus-junit5` based on Quarkus platform version

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle/base/build-layout.include.qute
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle/base/build-layout.include.qute
@@ -38,7 +38,11 @@ dependencies {
 {#if input.selected-extensions-ga.contains('io.quarkus:quarkus-hibernate-panache-next')}
     annotationProcessor 'org.hibernate.orm:hibernate-processor'
 {/if}
+{#if quarkus.version == null || quarkus.version.compareVersionTo("3.30.999") > 0}
     testImplementation 'io.quarkus:quarkus-junit'
+{#else}
+    testImplementation 'io.quarkus:quarkus-junit5'
+{/if}
 {#for dep in test-dependencies}
     testImplementation '{dep}'
 {/for}


### PR DESCRIPTION
- Follow-up to https://github.com/quarkusio/quarkus/pull/51563
