### PR TITLE
Docs: Add caution note to Using RestResponse section in rest-client.adoc

### DIFF
--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -404,6 +404,10 @@ public interface ExtensionsService {
 }
 ----
 
+CAUTION: When configuring the REST client to use `RestResponse` as the return type,
+you need to disable the xref:rest-client.adoc#disabling-the-default-mapper[Quarkus REST client default exception mapper],
+so that no `WebApplicationException` will be thrown when the response status code is not in the successful range (2xx).
+
 NOTE: You can also use the Jakarta REST type link:{jaxrsapi}/jakarta/ws/rs/core/Response.html[`Response`] but it is
 not strongly typed to your entity.
 


### PR DESCRIPTION
Recently I wanted to make use of `RestResponse` as return type in my REST client interface:
https://quarkus.io/guides/rest-client#using-restresponse

But only making use of RestResponse did not do the trick, and I had to add this property:

```properties
quarkus.rest-client.bar.disable-default-mapper=true
```

I hope this PR makes the docs reader aware that when using the `RestResponse` as return type `disable-default-mapper=true` has to be set as well to avoid throwing a WebApplicationException in case the response status is not 2xx.

I´ve also ran `build-docs`  resulting in:

<img width="867" height="111" alt="image" src="https://github.com/user-attachments/assets/ee0231cf-5aac-461b-823e-bd19246cc1a9" />