### PR TITLE
Bump SmallRye Reactive Messaging to 4.34.0 and Strimzi test container to 0.115.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -140,7 +140,7 @@
         <kafka.version>4.1.1</kafka.version>
         <lz4.version>1.10.1</lz4.version> <!-- dependency of the kafka-clients that could be overridden by other imported BOMs in the platform -->
         <snappy.version>1.1.10.8</snappy.version>
-        <strimzi-test-container.version>0.113.0</strimzi-test-container.version>
+        <strimzi-test-container.version>0.115.0</strimzi-test-container.version>
         <!-- Scala is used by Kafka so we need to choose a compatible version -->
         <scala.version>2.13.16</scala.version>
         <aws-lambda-java.version>1.4.0</aws-lambda-java.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -56,7 +56,7 @@
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.3</smallrye-reactive-types-converter.version>
         <smallrye-mutiny-vertx-binding.version>3.21.6</smallrye-mutiny-vertx-binding.version>
-        <smallrye-reactive-messaging.version>4.33.0</smallrye-reactive-messaging.version>
+        <smallrye-reactive-messaging.version>4.34.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>2.7.9</smallrye-stork.version>
         <jakarta.activation.version>2.1.4</jakarta.activation.version>
         <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>

--- a/bom/test/pom.xml
+++ b/bom/test/pom.xml
@@ -20,7 +20,7 @@
         <jaxb-api.version>2.3.1</jaxb-api.version>
 
         <rxjava1.version>1.3.8</rxjava1.version>
-        <strimzi-test-container.version>0.113.0</strimzi-test-container.version>
+        <strimzi-test-container.version>0.115.0</strimzi-test-container.version>
 
         <opentelemetry-proto.version>1.5.0-alpha</opentelemetry-proto.version>
     </properties>

--- a/docs/src/main/asciidoc/_includes/smallrye-kafka-incoming.adoc
+++ b/docs/src/main/asciidoc/_includes/smallrye-kafka-incoming.adoc
@@ -33,6 +33,14 @@ Type: _long_ | false |
 
 Type: _boolean_ | false | `false`
 
+| [.no-hyphens]#*health-topic-verification-readiness-disabled*# | Whether the topic verification is disabled for the readiness health check.
+
+Type: _boolean_ | false | `false`
+
+| [.no-hyphens]#*health-topic-verification-startup-disabled*# | Whether the topic verification is disabled for the startup health check.
+
+Type: _boolean_ | false | `false`
+
 | [.no-hyphens]#*health-topic-verification-timeout*# | During the startup and readiness health check, the connector connects to the broker and retrieves the list of topics. This attribute specifies the maximum duration (in ms) for the retrieval. If exceeded, the channel is considered not-ready.
 
 Type: _long_ | false | `2000`
@@ -41,7 +49,7 @@ Type: _long_ | false | `2000`
 
 Type: _boolean_ | false | `true`
 
-| [.no-hyphens]#*client-id-prefix*# | Prefix for Kafka client `client.id` attribute. If defined configured or generated `client.id` will be prefixed with the given value, otherwise `kafka-consumer-` is the prefix.
+| [.no-hyphens]#*client-id-prefix*# | Prefix for Kafka client `client.id` attribute. If defined configured or generated `client.id` will be prefixed with the given value.
 
 Type: _string_ | false |
 
@@ -53,7 +61,7 @@ Type: _string_ | false |
 
 Type: _string_ | false |
 
-| [.no-hyphens]#*checkpoint.unsynced-state-max-age.ms*# | While using the `checkpoint` commit-strategy, specify the max age in milliseconds that the processing state must be persisted before the connector is marked as unhealthy. Setting this attribute to `0` disables this monitoring.
+| [.no-hyphens]#*checkpoint.unsynced-state-max-age.ms*# | While using the `checkpoint` commit-strategy, specify the max age in milliseconds that the processing state must be persisted before the connector is marked as unhealthy. Setting this attribute to 0 disables this monitoring.
 
 Type: _int_ | false | `10000`
 
@@ -72,6 +80,10 @@ Type: _string_ | false |
 | [.no-hyphens]#*pattern*# | Indicate that the `topic` property is a regular expression. Must be used with the `topic` property. Cannot be used with the `topics` property
 
 Type: _boolean_ | false | `false`
+
+| [.no-hyphens]#*assign-seek*# | Assign partitions and optionally seek to offsets, instead of subscribing to topics. A comma-separating list of triplets in form of `<topic>:\|<partition>\|:<offset>` to assign statically to the consumer and seek to the given offsets. Offset `0` seeks to beginning and offset `-1` seeks to the end of the topic-partition. If the topic is omitted the configured topic will be used. If the offset is omitted partitions are assigned to the consumer but won't be seeked to offset.
+
+Type: _string_ | false |
 
 | [.no-hyphens]#*key.deserializer*# | The deserializer classname used to deserialize the record's key
 
@@ -104,7 +116,7 @@ Type: _string_ | false |
 
 Type: _boolean_ | false | `false`
 
-| [.no-hyphens]#*retry*# | Whether the connection to the broker is re-attempted in case of failure
+| [.no-hyphens]#*retry*# | Whether or not the connection to the broker is re-attempted in case of failure
 
 Type: _boolean_ | false | `true`
 
@@ -124,7 +136,7 @@ Type: _boolean_ | false | `false`
 
 Type: _string_ | false | `latest`
 
-| [.no-hyphens]#*failure-strategy*# | Specify the failure strategy to apply when a message produced from a record is acknowledged negatively (nack). Values can be `fail` (default), `ignore`, or `dead-letter-queue`
+| [.no-hyphens]#*failure-strategy*# | Specify the failure strategy to apply when a message produced from a record is acknowledged negatively (nack). Values can be `fail` (default), `ignore`, `dead-letter-queue`, or `delayed-retry-topic`
 
 Type: _string_ | false | `fail`
 
@@ -132,11 +144,23 @@ Type: _string_ | false | `fail`
 
 Type: _string_ | false |
 
+| [.no-hyphens]#*ordered*# | Configures ordering guarantees for concurrent processing. Possible values: `key` for per-key sequential processing, or `partition` for per-partition sequential processing. Requires `@Blocking(ordered = false)` for concurrency. Works with any commit strategy.
+
+Type: _string_ | false |
+
+| [.no-hyphens]#*ordered.max-concurrency*# | Maximum number of groups (keys or partitions) that can be processed concurrently. Defaults to `max.poll.records`.
+
+Type: _int_ | false |
+
 | [.no-hyphens]#*throttled.unprocessed-record-max-age.ms*# | While using the `throttled` commit-strategy, specify the max age in milliseconds that an unprocessed message can be before the connector is marked as unhealthy. Setting this attribute to 0 disables this monitoring.
 
 Type: _int_ | false | `60000`
 
 | [.no-hyphens]#*dead-letter-queue.topic*# | When the `failure-strategy` is set to `dead-letter-queue` indicates on which topic the record is sent. Defaults is `dead-letter-topic-$channel`
+
+Type: _string_ | false |
+
+| [.no-hyphens]#*dead-letter-queue.producer-client-id*# | When the `failure-strategy` is set to `dead-letter-queue` indicates what client id the generated producer should use. Defaults is `kafka-dead-letter-topic-producer-$client-id`
 
 Type: _string_ | false |
 
@@ -148,11 +172,23 @@ Type: _string_ | false |
 
 Type: _string_ | false |
 
-| [.no-hyphens]#*partitions*# | The number of partitions to be consumed concurrently. The connector creates the specified amount of Kafka consumers. It should match the number of partition of the targeted topic
+| [.no-hyphens]#*delayed-retry-topic.topics*# | When the `failure-strategy` is set to `delayed-retry-topic` indicates topics to use. If not set the source channel name is used, with 10, 20 and 50 seconds delayed topics.
+
+Type: _string_ | false |
+
+| [.no-hyphens]#*delayed-retry-topic.max-retries*# | When the `failure-strategy` is set to `delayed-retry-topic` indicates the maximum number of retries. If higher than the number of delayed retry topics, last topic is used.
+
+Type: _int_ | false |
+
+| [.no-hyphens]#*delayed-retry-topic.timeout*# | When the `failure-strategy` is set to `delayed-retry-topic` indicates the global timeout per record.
+
+Type: _int_ | false | `120000`
+
+| [.no-hyphens]#*partitions*# | _deprecated_ - The number of partitions to be consumed concurrently. The connector creates the specified amount of Kafka consumers. It should match the number of partition of the targeted topic. Deprecated: Use `concurrency` channel attribute instead.
 
 Type: _int_ | false | `1`
 
-| [.no-hyphens]#*requests*# | When `partitions` is greater than 1, this attribute allows configuring how many records are requested by each consumer every time.
+| [.no-hyphens]#*requests*# | _deprecated_ - When `partitions` is greater than 1, this attribute allows configuring how many records are requested by each consumers every time. Deprecated: Use `concurrency` channel attribute instead.
 
 Type: _int_ | false | `128`
 
@@ -172,7 +208,7 @@ Type: _string_ | false |
 
 Type: _boolean_ | false | `true`
 
-| [.no-hyphens]#*graceful-shutdown*# | Whether a graceful shutdown should be attempted when the application terminates.
+| [.no-hyphens]#*graceful-shutdown*# | Whether or not a graceful shutdown should be attempted when the application terminates.
 
 Type: _boolean_ | false | `true`
 
@@ -191,5 +227,21 @@ Type: _boolean_ | false | `false`
 | [.no-hyphens]#*max-queue-size-factor*# | Multiplier factor to determine maximum number of records queued for processing, using `max.poll.records` * `max-queue-size-factor`. Defaults to 2. In `batch` mode `max.poll.records` is considered `1`.
 
 Type: _int_ | false | `2`
+
+| [.no-hyphens]#*share-group*# | Whether to use Kafka Share Groups for consumption. When enabled, the consumer will use a ShareConsumer which provides cooperative record processing across multiple consumers without explicit partition assignment.
+
+Type: _boolean_ | false | `false`
+
+| [.no-hyphens]#*share-group.failure-acknowledgement-type*# | Default acknowledgement type to apply to the record, when the message is nacked.
+
+Type: _string_ | false | `release`
+
+| [.no-hyphens]#*share-group.failure-deserialization-acknowledgement-type*# | Default acknowledgement type to apply to the record, when the message is nacked because of failure on deserialization.
+
+Type: _string_ | false | `reject`
+
+| [.no-hyphens]#*share-group.unprocessed-record-max-age.ms*# | While using share groups, specify the max age in milliseconds that an unprocessed record can be before the connector reports a failure. Setting this attribute to 0 disables this monitoring.
+
+Type: _int_ | false | `60000`
 
 |===

--- a/docs/src/main/asciidoc/_includes/smallrye-kafka-outgoing.adoc
+++ b/docs/src/main/asciidoc/_includes/smallrye-kafka-outgoing.adoc
@@ -13,13 +13,13 @@ Type: _string_ | false | `1`
 
 Type: _string_ | false | `localhost:9092`
 
-| [.no-hyphens]#*client-id-prefix*# | Prefix for Kafka client `client.id` attribute. If defined configured or generated `client.id` will be prefixed with the given value, otherwise `kafka-producer-` is the prefix.
-
-Type: _string_ | false |
-
 | [.no-hyphens]#*buffer.memory*# | The total bytes of memory the producer can use to buffer records waiting to be sent to the server.
 
 Type: _long_ | false | `33554432`
+
+| [.no-hyphens]#*client-id-prefix*# | Prefix for Kafka client `client.id` attribute. If defined configured or generated `client.id` will be prefixed with the given value.
+
+Type: _string_ | false |
 
 | [.no-hyphens]#*close-timeout*# | The amount of milliseconds waiting for a graceful shutdown of the Kafka producer
 
@@ -43,7 +43,7 @@ Type: _string_ | false |
 
 | [.no-hyphens]#*cloud-events-insert-timestamp*#
 
-[.no-hyphens]#_(cloud-events-default-timestamp)_# | Whether the connector should insert automatically the `time` attribute into the outgoing Cloud Event. Requires `cloud-events` to be set to `true`. This value is used if the message does not configure the `time` attribute itself
+[.no-hyphens]#_(cloud-events-default-timestamp)_# | Whether or not the connector should insert automatically the `time` attribute into the outgoing Cloud Event. Requires `cloud-events` to be set to `true`. This value is used if the message does not configure the `time` attribute itself
 
 Type: _boolean_ | false | `true`
 
@@ -89,9 +89,21 @@ Type: _boolean_ | false |
 
 Type: _boolean_ | false | `false`
 
+| [.no-hyphens]#*health-topic-verification-readiness-disabled*# | Whether the topic verification is disabled for the readiness health check.
+
+Type: _boolean_ | false | `false`
+
+| [.no-hyphens]#*health-topic-verification-startup-disabled*# | Whether the topic verification is disabled for the startup health check.
+
+Type: _boolean_ | false | `false`
+
 | [.no-hyphens]#*health-topic-verification-timeout*# | During the startup and readiness health check, the connector connects to the broker and retrieves the list of topics. This attribute specifies the maximum duration (in ms) for the retrieval. If exceeded, the channel is considered not-ready.
 
 Type: _long_ | false | `2000`
+
+| [.no-hyphens]#*interceptor-bean*# | The name set in `@Identifier` of a bean that implements `org.apache.kafka.clients.producer.ProducerInterceptor`. If set, the identified bean will be used as the producer interceptor.
+
+Type: _string_ | false |
 
 | [.no-hyphens]#*kafka-configuration*# | Identifier of a CDI bean that provides the default Kafka consumer/producer configuration for this channel. The channel configuration can still override any attribute. The bean must have a type of Map<String, Object> and must use the @io.smallrye.common.annotation.Identifier qualifier to set the identifier.
 
@@ -125,7 +137,19 @@ Type: _boolean_ | false | `false`
 
 Type: _int_ | false | `-1`
 
-| [.no-hyphens]#*propagate-headers*# | A comma-separated list of incoming record headers to be propagated to the outgoing record
+| [.no-hyphens]#*pooled-producer*# | Whether to use a pool of Kafka producers for concurrent transactions. Each transaction scope acquires a producer from the pool, enabling concurrent exactly-once processing. Requires transactional.id to be set.
+
+Type: _boolean_ | false | `false`
+
+| [.no-hyphens]#*pooled-producer.initial-pool-size*# | Number of Kafka producers to pre-create in the pool at startup. Respects the lazy-client setting. Defaults to 0 (lazy creation).
+
+Type: _int_ | false | `0`
+
+| [.no-hyphens]#*pooled-producer.max-pool-size*# | Maximum number of Kafka producers in the pool. When all producers are in use and the pool is exhausted, an exception is thrown. Defaults to 10.
+
+Type: _int_ | false | `10`
+
+| [.no-hyphens]#*propagate-headers*# | A comma-separating list of incoming record headers to be propagated to the outgoing record
 
 Type: _string_ | false |
 

--- a/docs/src/main/asciidoc/kafka-dev-services.adoc
+++ b/docs/src/main/asciidoc/kafka-dev-services.adoc
@@ -14,7 +14,7 @@ If any Kafka-related extension is present (e.g. `quarkus-messaging-kafka`), Dev 
 So, you don't have to start a broker manually.
 The application is configured automatically.
 
-IMPORTANT: Because starting a Kafka broker can be long, Dev Services for Kafka uses https://redpanda.com[Redpanda], a Kafka compatible broker which starts in ~1 second.
+IMPORTANT: By default, Dev Services for Kafka uses the https://hub.docker.com/r/apache/kafka-native[Apache Kafka native] image which starts in ~1 second.
 
 == Enabling / Disabling Dev Services for Kafka
 
@@ -52,26 +52,28 @@ Note that the Kafka advertised address is automatically configured with the chos
 [[configuring-the-image]]
 == Configuring the image
 
-Dev Services for Kafka supports https://redpanda.com[Redpanda], https://github.com/ozangunalp/kafka-native[kafka-native]
-and https://strimzi.io[Strimzi] (in https://github.com/apache/kafka/blob/trunk/config/kraft/README.md[Kraft] mode)  images.
+Dev Services for Kafka supports the following container providers:
 
-**Redpanda** is a Kafka compatible event streaming platform.
-Because it provides a fast startup times, Dev Services defaults to Redpanda images from `redpandadata/redpanda`.
-You can select any version from https://hub.docker.com/r/redpandadata/redpanda.
+**upstream-kafka-native** (default) uses the official https://hub.docker.com/r/apache/kafka-native[Apache Kafka native] image, compiled with GraalVM for fast startup.
 
-**kafka-native** provides images of standard Apache Kafka distribution compiled to native binary using Quarkus and GraalVM.
-While still being _experimental_, it provides very fast startup times with small footprint.
-
-Image type can be configured using
+**upstream-kafka** uses the official https://hub.docker.com/r/apache/kafka[Apache Kafka] JVM image.
 
 [source, properties]
 ----
-quarkus.kafka.devservices.provider=kafka-native
+quarkus.kafka.devservices.provider=upstream-kafka
+----
+
+**Redpanda** is a Kafka compatible event streaming platform.
+You can select any version from https://hub.docker.com/r/redpandadata/redpanda.
+
+[source, properties]
+----
+quarkus.kafka.devservices.provider=redpanda
 ----
 
 **Strimzi** provides container images and Operators for running Apache Kafka on Kubernetes.
 While Strimzi is optimized for Kubernetes, the images work perfectly in classic container environments.
-Strimzi container images run "genuine" Kafka broker on JVM, which is slower to start.
+Strimzi container images run a Kafka broker on JVM, which is slower to start.
 
 [source, properties]
 ----
@@ -82,7 +84,7 @@ For Strimzi, you can select any image with a Kafka version which has Kraft suppo
 
 [source, properties]
 ----
-quarkus.kafka.devservices.image-name=quay.io/strimzi-test-container/test-container:0.112.0-kafka-4.1.0
+quarkus.kafka.devservices.image-name=quay.io/strimzi-test-container/test-container:0.115.0-kafka-4.2.0
 ----
 
 == Configuring Kafka topics
@@ -133,7 +135,7 @@ It relies on a `compose-devservices.yml`, such as:
 name: <application name>
 services:
   kafka:
-    image: apache/kafka-native:3.9.0
+    image: apache/kafka-native:4.2.0
     restart: "no"
     ports:
       - '9092'

--- a/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
+++ b/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
@@ -556,11 +556,11 @@ import java.util.Map;
 import org.testcontainers.containers.GenericContainer;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
-import io.strimzi.StrimziKafkaContainer;
+import io.strimzi.test.container.StrimziKafkaCluster;
 
 public class KafkaAndSchemaRegistryTestResource implements QuarkusTestResourceLifecycleManager {
 
-    private final StrimziKafkaContainer kafka = new StrimziKafkaContainer();
+    private final StrimziKafkaCluster kafka = new StrimziKafkaCluster.StrimziKafkaClusterBuilder().build();
 
     private GenericContainer<?> registry;
 

--- a/docs/src/main/asciidoc/kafka-schema-registry-json-schema.adoc
+++ b/docs/src/main/asciidoc/kafka-schema-registry-json-schema.adoc
@@ -584,11 +584,11 @@ import java.util.Map;
 import org.testcontainers.containers.GenericContainer;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
-import io.strimzi.StrimziKafkaContainer;
+import io.strimzi.test.container.StrimziKafkaCluster;
 
 public class KafkaAndSchemaRegistryTestResource implements QuarkusTestResourceLifecycleManager {
 
-    private final StrimziKafkaContainer kafka = new StrimziKafkaContainer();
+    private final StrimziKafkaCluster kafka = new StrimziKafkaCluster.StrimziKafkaClusterBuilder().build();
 
     private GenericContainer<?> registry;
 

--- a/docs/src/main/asciidoc/kafka.adoc
+++ b/docs/src/main/asciidoc/kafka.adoc
@@ -62,7 +62,7 @@ implementation("io.quarkus:quarkus-messaging-kafka")
 
 [NOTE]
 ====
-The extension includes `kafka-clients` version 3.2.1 as a transitive dependency and is compatible with Kafka brokers version 2.x.
+The extension includes `kafka-clients` version 4.1.1 as a transitive dependency and is compatible with Kafka brokers version 2.x and above.
 ====
 
 == Configuring SmallRye Kafka Connector
@@ -387,11 +387,12 @@ See https://smallrye.io/smallrye-reactive-messaging/latest/kafka/receiving-kafka
 [[error-handling]]
 === Error Handling Strategies
 
-If a message produced from a Kafka record is nacked, a failure strategy is applied. The Kafka connector supports three strategies:
+If a message produced from a Kafka record is nacked, a failure strategy is applied. The Kafka connector supports the following strategies:
 
 - `fail`: fail the application, no more records will be processed (default strategy). The offset of the record that has not been processed correctly is not committed.
 - `ignore`: the failure is logged, but the processing continue. The offset of the record that has not been processed correctly is committed.
 - `dead-letter-queue`: the offset of the record that has not been processed correctly is committed, but the record is written to a Kafka dead letter topic.
+- `delayed-retry-topic`: the failed record is sent to delayed retry topics for later reprocessing, with configurable delays and maximum retries.
 
 The strategy is selected using the `failure-strategy` attribute.
 
@@ -538,6 +539,16 @@ The default partitioner uses record key hash to compute the partition for a reco
 
 During normal operation, a Kafka consumer preserves the order of records inside each partition assigned to it.
 SmallRye Reactive Messaging keeps this order for processing, unless `@Blocking(ordered = false)` is used (see <<blocking-processing>>).
+
+When using `@Blocking(ordered = false)`, you can still enforce ordering guarantees with the `ordered` channel attribute:
+
+- `ordered=partition`: records from the same partition are processed sequentially, but different partitions can be processed concurrently.
+- `ordered=key`: records with the same key are processed sequentially, regardless of partition.
+
+[source, properties]
+----
+mp.messaging.incoming.your-channel.ordered=key
+----
 
 Note that due to consumer rebalances, Kafka consumers only guarantee at-least-once processing of single records, meaning that uncommitted records _can_ be processed again by consumers.
 ====
@@ -752,6 +763,124 @@ Conversely, if the processing throws an exception, all messages are _nacked_, ap
 Quarkus autodetects batch types for incoming channels and sets batch configuration automatically.
 You can configure batch mode explicitly with `mp.messaging.incoming.$channel.batch` property.
 ====
+
+[[share-groups]]
+=== Share Groups (Kafka Queues)
+
+[IMPORTANT]
+====
+Kafka Share Groups require Apache Kafka 4.2+ brokers and are an early access feature in Kafka.
+====
+
+Share Groups (https://cwiki.apache.org/confluence/display/KAFKA/KIP-932[KIP-932]) provide a queue-like consumption model for Kafka topics.
+Unlike consumer groups, records are distributed across share consumers without explicit partition assignment -- the broker handles distribution of records and acquisition locks automatically.
+This provides queue-style workloads where records are processed by any available consumer with at-least-once delivery semantics.
+
+==== Enabling Share Groups
+
+To enable share group consumption, set the `share-group` attribute on the incoming channel:
+
+[source, properties]
+----
+mp.messaging.incoming.queue.connector=smallrye-kafka
+mp.messaging.incoming.queue.topic=prices
+mp.messaging.incoming.queue.value.deserializer=org.apache.kafka.common.serialization.DoubleDeserializer
+mp.messaging.incoming.queue.share-group=true
+----
+
+Consuming messages works like any other incoming channel:
+
+[source, java]
+----
+@ApplicationScoped
+public class KafkaShareGroupConsumer {
+
+    @Incoming("queue")
+    public void consume(double price) {
+        // process price
+    }
+}
+----
+
+==== Per-record Acknowledgement
+
+Share groups support three acknowledgement types:
+
+- **ACCEPT**: Record processed successfully (default on ack).
+- **RELEASE**: Record failed processing and is eligible for re-delivery to another consumer.
+- **REJECT**: Permanent rejection with no re-delivery.
+
+You can control the acknowledgement per record using `ShareGroupAcknowledgement` metadata:
+
+[source, java]
+----
+@Incoming("queue")
+@Outgoing("processed")
+public String consume(double msg, ShareGroupAcknowledgement ack) {
+    try {
+        // successful processing is ACCEPT
+        return process(msg);
+    } catch (TransientException e) {
+        ack.release();
+    } catch (Exception e) {
+        ack.reject();
+    }
+    // Skip publishing message
+    return null;
+}
+----
+
+==== Acquisition Lock Renewal
+
+Each acquired record has a time-limited acquisition lock managed by the broker.
+The connector tracks in-processing records and periodically renews their locks to prevent re-delivery.
+The `share-group.unprocessed-record-max-age.ms` attribute controls this behavior:
+
+[source, properties]
+----
+mp.messaging.incoming.queue.share-group=true
+mp.messaging.incoming.queue.share-group.unprocessed-record-max-age.ms=30000
+----
+
+When enabled (default: `60000`), records still in processing are periodically renewed with the broker.
+If a record exceeds this timeout, the health check reports a failure.
+Set to `0` to disable monitoring and automatic renewal.
+
+==== Batch Mode
+
+Share groups support batch consumption.
+Enable it by setting `batch=true` alongside `share-group=true`:
+
+[source, properties]
+----
+mp.messaging.incoming.queue.share-group=true
+mp.messaging.incoming.queue.batch=true
+----
+
+With per-record acknowledgement control, each record inside a batch can be individually acknowledged using `IncomingKafkaRecordBatchMetadata`:
+
+[source, java]
+----
+@Incoming("queue")
+public void consume(ConsumerRecords<String, String> batch, IncomingKafkaRecordBatchMetadata metadata) {
+    for (var record : batch) {
+        ShareGroupAcknowledgement ack = metadata.getMetadataForRecord(record, ShareGroupAcknowledgement.class);
+        String event = record.value();
+        if (event.startsWith("INVALID")) {
+            Log.warnf("[Batch] Rejecting invalid event: %s", event);
+            ack.reject();
+        } else {
+            Log.infof("[Batch] Accepted event: %s", event);
+            ack.accept();
+        }
+    }
+}
+----
+
+==== Incompatible Configuration
+
+When `share-group=true`, the following attributes are ignored:
+`pattern`, `assign-seek`, `partitions`, `commit-strategy`, `failure-strategy`, and `consumer-rebalance-listener.name`.
 
 [[stateful-processing-checkpointing]]
 === Stateful processing with Checkpointing
@@ -1402,10 +1531,9 @@ Note that for production use the `transactional.id` must be unique across all ap
 
 [IMPORTANT]
 ====
-While a normal message emitter would support concurrent calls to `send` methods and consequently queues outgoing messages to be written to Kafka,
-a `KafkaTransactions` emitter only supports one transaction at a time.
+By default, a `KafkaTransactions` emitter supports one transaction at a time per producer.
 A transaction is considered in progress from the call to the `withTransaction` until the returned `Uni` results in success or failure.
-While a transaction is in progress, subsequent calls to the `withTransaction`, including nested ones inside the given function, will throw `IllegalStateException`.
+While a transaction is in progress on the same producer, subsequent calls to the `withTransaction`, including nested ones inside the given function, will throw `IllegalStateException`.
 
 Note that in Reactive Messaging, the execution of processing methods, is already serialized, unless `@Blocking(ordered = false)` is used.
 If `withTransaction` can be called concurrently, for example from a REST endpoint, it is recommended to limit the concurrency of the execution.
@@ -1413,6 +1541,72 @@ This can be done using the `@Bulkhead` annotation from xref:smallrye-fault-toler
 
 An example usage can be found in <<chaining-kafka-transactions-with-hibernate-reactive-transactions>>.
 ====
+
+==== Concurrent Exactly-Once Processing with Pooled Producers
+
+By default, `KafkaTransactions` uses a single producer, so only one transaction can run at a time.
+The *pooled producer* mode uses a pool of Kafka producers, each with its own `transactional.id`, derived from the configured `transactional.id` (e.g., `my-tx-id-1`, `my-tx-id-2`, etc.).
+Each transaction reserves a producer from the pool for the duration of the transaction, enabling concurrent exactly-once processing.
+
+Combined with `@Blocking(ordered = false)` and `ordered=partition` on the incoming channel, records from different partitions can be processed concurrently while maintaining per-partition ordering:
+
+[source, properties]
+----
+mp.messaging.incoming.prices-in.ordered=partition
+mp.messaging.incoming.prices-in.commit-strategy=ignore
+mp.messaging.incoming.prices-in.failure-strategy=ignore
+
+mp.messaging.outgoing.prices-out.pooled-producer=true
+
+// when running on dev mode with Kafka Dev Services, pre-create 3 producers for the 3 partitions
+quarkus.kafka.devservices.topic-partitions.prices-in=3
+quarkus.kafka.devservices.topic-partitions.prices-out=3
+----
+
+The `KafkaTransactions` API is the same as for regular exactly-once processing.
+The outgoing record's partition defaults to the incoming record's partition:
+
+[source, java]
+----
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.OnOverflow;
+
+import io.quarkus.logging.Log;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.reactive.messaging.annotations.Blocking;
+import io.smallrye.reactive.messaging.kafka.KafkaRecord;
+import io.smallrye.reactive.messaging.kafka.api.IncomingKafkaRecordMetadata;
+import io.smallrye.reactive.messaging.kafka.transactions.KafkaTransactions;
+
+@ApplicationScoped
+public class ConcurrentExactlyOnceProcessor {
+
+    @Channel("prices-out")
+    @OnOverflow(value = OnOverflow.Strategy.BUFFER, bufferSize = 500)
+    KafkaTransactions<Integer> txProducer;
+
+    @Incoming("prices-in")
+    @Blocking(ordered = false)
+    public void process(ConsumerRecord<String, Integer> record, // <1>
+            IncomingKafkaRecordMetadata<String, Integer> metadata) {
+        txProducer.withTransactionAndAwait(metadata, emitter -> { // <2>
+            emitter.send(KafkaRecord.of(record.key(), record.value() + 1));
+            return Uni.createFrom().voidItem();
+        });
+    }
+}
+----
+<1> `@Blocking(ordered = false)` enables concurrent processing across worker threads. With `ordered=partition`, records from the same partition are still processed sequentially. The record payload and metadata are injected directly as method parameters.
+<2> `withTransactionAndAwait` is the synchronous variant that blocks the worker thread until the transaction completes. It accepts `IncomingKafkaRecordMetadata` for managing consumer offset commits within the transaction. Each call acquires a separate producer from the pool.
+
+Producers are returned to the pool after commit or abort.
+On abort, only the partitions involved in that transaction are reset so other concurrent transactions are not affected.
+By default, the pool grows lazily to match actual concurrency, up to `pooled-producer.max-pool-size` (default 10).
+Number of producers that are pre-created at startup can be configured with `pooled-producer.initial-pool-size` (default 0).
 
 ==== Transaction-aware consumers
 
@@ -2487,9 +2681,8 @@ The configuration of the created Kafka broker can be customized using `@Resource
 [source,java]
 ----
 @QuarkusTestResource(value = KafkaCompanionResource.class, initArgs = {
-        @ResourceArg(name = "strimzi.kafka.image", value = "quay.io/strimzi-test-container/test-container:0.112.0-kafka-4.1.0"), // Image name
+        @ResourceArg(name = "strimzi.kafka.image", value = "quay.io/strimzi-test-container/test-container:0.115.0-kafka-4.2.0"), // Image name
         @ResourceArg(name = "kafka.port", value = "9092"), // Fixed port for kafka, by default it will be exposed on a random port
-        @ResourceArg(name = "kraft", value = "true"), // Enable Kraft mode
         @ResourceArg(name = "num.partitions", value = "3"), // Other custom broker configurations
 })
 public class OrderProcessorTest {
@@ -2629,7 +2822,7 @@ For example, to configure the `max.block.ms` property, use:
 
 [source,properties]
 ----
-mp.messaging.incoming.[channel].max.block.ms=10000
+mp.messaging.outgoing.[channel].max.block.ms=10000
 ----
 
 Some producer client properties are configured to sensible default values:

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/DevServicesKafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/DevServicesKafkaProcessor.java
@@ -39,6 +39,7 @@ import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerLocator;
 import io.quarkus.devservices.common.StartableContainer;
 import io.quarkus.runtime.configuration.ConfigUtils;
+import io.strimzi.test.container.StrimziKafkaCluster;
 import io.strimzi.test.container.StrimziKafkaContainer;
 
 /**
@@ -108,21 +109,24 @@ public class DevServicesKafkaProcessor {
                     .withEnv(config.containerEnv())
                     .withSharedServiceLabel(launchMode.getLaunchMode(), config.serviceName());
             case STRIMZI -> {
-                StrimziKafkaContainer strimzi = new StrimziKafkaContainer(config.effectiveImageName())
-                        .withNodeId(1)
-                        .withBrokerId(1)
-                        .waitForRunning();
-                String hostName = ConfigureUtil.configureNetwork(strimzi,
-                        composeProjectBuildItem.getDefaultNetworkId(), useSharedNetwork, "kafka");
-                if (useSharedNetwork) {
-                    strimzi.withBootstrapServers(c -> String.format("PLAINTEXT://%s:%s", hostName, KAFKA_PORT));
-                }
-                if (config.port().isPresent() && config.port().get() != 0) {
-                    strimzi.withPort(config.port().get());
-                }
-                strimzi.withEnv(config.containerEnv());
-                strimzi.withKafkaConfigurationMap(config.strimzi().serverConfigs());
-                configureSharedServiceLabel(strimzi, launchMode.getLaunchMode(), DEV_SERVICE_LABEL, config.serviceName());
+                StrimziKafkaCluster cluster = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
+                        .withImage(config.effectiveImageName())
+                        .withContainerCustomizer(strimzi -> {
+                            String hostName = ConfigureUtil.configureNetwork(strimzi,
+                                    composeProjectBuildItem.getDefaultNetworkId(), useSharedNetwork, "kafka");
+                            if (useSharedNetwork) {
+                                strimzi.withBootstrapServers(c -> String.format("PLAINTEXT://%s:%s", hostName, KAFKA_PORT));
+                            }
+                            if (config.port().isPresent() && config.port().get() != 0) {
+                                strimzi.withPort(config.port().get());
+                            }
+                            strimzi.withEnv(config.containerEnv());
+                            strimzi.withKafkaConfigurationMap(config.strimzi().serverConfigs());
+                            configureSharedServiceLabel(strimzi, launchMode.getLaunchMode(), DEV_SERVICE_LABEL,
+                                    config.serviceName());
+                        })
+                        .build();
+                StrimziKafkaContainer strimzi = cluster.getBrokers().stream().findFirst().get();
                 yield new StartableContainer<>(strimzi, StrimziKafkaContainer::getBootstrapServers);
             }
             case KAFKA_NATIVE -> new KafkaNativeContainer(DockerImageName.parse(config.effectiveImageName()),

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/DevServicesKafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/DevServicesKafkaProcessor.java
@@ -99,7 +99,7 @@ public class DevServicesKafkaProcessor {
     private Startable createContainer(DevServicesComposeProjectBuildItem composeProjectBuildItem,
             KafkaDevServicesBuildTimeConfig config, boolean useSharedNetwork,
             LaunchModeBuildItem launchMode) {
-        Startable startable = switch (config.provider()) {
+        return switch (config.provider()) {
             case REDPANDA -> new RedpandaKafkaContainer(DockerImageName.parse(config.effectiveImageName())
                     .asCompatibleSubstituteFor("redpandadata/redpanda"),
                     config.port().orElse(0),
@@ -129,14 +129,24 @@ public class DevServicesKafkaProcessor {
                 StrimziKafkaContainer strimzi = cluster.getBrokers().stream().findFirst().get();
                 yield new StartableContainer<>(strimzi, StrimziKafkaContainer::getBootstrapServers);
             }
-            case KAFKA_NATIVE -> new KafkaNativeContainer(DockerImageName.parse(config.effectiveImageName()),
-                    config.port().orElse(0),
-                    composeProjectBuildItem.getDefaultNetworkId(),
-                    useSharedNetwork)
-                    .withEnv(config.containerEnv())
-                    .withSharedServiceLabel(launchMode.getLaunchMode(), config.serviceName());
+            case KAFKA_NATIVE -> {
+                log.warnf("`kafka-native` provider is deprecated and will be removed in future versions. " +
+                        "Please switch to upstream-kafka-native provider.");
+                yield new KafkaNativeContainer(DockerImageName.parse(config.effectiveImageName()),
+                        config.port().orElse(0),
+                        composeProjectBuildItem.getDefaultNetworkId(),
+                        useSharedNetwork)
+                        .withEnv(config.containerEnv())
+                        .withSharedServiceLabel(launchMode.getLaunchMode(), config.serviceName());
+            }
+            case UPSTREAM_KAFKA, UPSTREAM_KAFKA_NATIVE ->
+                new KafkaContainer(DockerImageName.parse(config.effectiveImageName()),
+                        composeProjectBuildItem.getDefaultNetworkId(),
+                        useSharedNetwork)
+                        .withPort(config.port().orElse(0))
+                        .withEnv(config.containerEnv())
+                        .withSharedServiceLabel(launchMode.getLaunchMode(), config.serviceName());
         };
-        return startable;
     }
 
     public void logStartedAndCreateTopicPartitions(String bootstrapServers, KafkaDevServicesBuildTimeConfig configuration) {

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaContainer.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaContainer.java
@@ -33,7 +33,7 @@ public class KafkaContainer extends GenericContainer<KafkaContainer> implements 
     static final String[] COMMAND = {
             "sh",
             "-c",
-            "while [ ! -f " + STARTER_SCRIPT + " ]; do sleep 0.1; done; " + STARTER_SCRIPT,
+            "while [ ! -x " + STARTER_SCRIPT + " ]; do sleep 0.1; done; " + STARTER_SCRIPT,
     };
 
     static final WaitStrategy WAIT_STRATEGY = Wait.forLogMessage(".*Transitioning from RECOVERY to RUNNING.*", 1);
@@ -103,11 +103,53 @@ public class KafkaContainer extends GenericContainer<KafkaContainer> implements 
         String kafkaAdvertisedListeners = String.join(",", advertisedListeners);
 
         String command = "#!/bin/bash\n";
-        // exporting KAFKA_ADVERTISED_LISTENERS with the container hostname
         command += String.format("export KAFKA_ADVERTISED_LISTENERS=%s\n", kafkaAdvertisedListeners);
-
-        command += "/etc/kafka/docker/run \n";
+        command += nativeLaunchScript();
         copyFileToContainer(Transferable.of(command, 0777), STARTER_SCRIPT);
+    }
+
+    /**
+     * Generates a shell snippet that detects whether the container runs a native image
+     * and, if so, launches Kafka directly with {@code -Duser.name} / {@code -Duser.home} flags
+     * to work around a gcompat {@code getpwuid} segfault on Alpine (KAFKA-20314).
+     * For JVM images the original {@code /etc/kafka/docker/run} entrypoint is used as-is.
+     */
+    static String nativeLaunchScript() {
+        String userOpts = "-Duser.name=appuser -Duser.home=/home/appuser";
+        return "if [ -f /opt/kafka/kafka.Kafka ]; then\n" +
+        // source config scripts (normally done by /etc/kafka/docker/run)
+                "  . /etc/kafka/docker/bash-config\n" +
+                "  . /etc/kafka/docker/configureDefaults\n" +
+                "  . /etc/kafka/docker/configure\n" +
+                // JMX setup (mirrors /etc/kafka/docker/launch)
+                "  if [ -z \"${KAFKA_JMX_OPTS-}\" ]; then\n" +
+                "    export KAFKA_JMX_OPTS=\"-Dcom.sun.management.jmxremote=true" +
+                " -Dcom.sun.management.jmxremote.authenticate=false" +
+                " -Dcom.sun.management.jmxremote.ssl=false\"\n" +
+                "  fi\n" +
+                "  export KAFKA_JMX_HOSTNAME=${KAFKA_JMX_HOSTNAME:-$(hostname -i | cut -d' ' -f1)}\n" +
+                "  if [ \"${KAFKA_JMX_PORT-}\" ]; then\n" +
+                "    export JMX_PORT=$KAFKA_JMX_PORT\n" +
+                "    export KAFKA_JMX_OPTS=\"$KAFKA_JMX_OPTS" +
+                " -Djava.rmi.server.hostname=$KAFKA_JMX_HOSTNAME" +
+                " -Dcom.sun.management.jmxremote.local.only=false" +
+                " -Dcom.sun.management.jmxremote.rmi.port=$JMX_PORT" +
+                " -Dcom.sun.management.jmxremote.port=$JMX_PORT\"\n" +
+                "  fi\n" +
+                // setup
+                "  /opt/kafka/kafka.Kafka " + userOpts + " setup" +
+                " --default-configs-dir /etc/kafka/docker" +
+                " --mounted-configs-dir /mnt/shared/config" +
+                " --final-configs-dir /opt/kafka/config 2>&1 || true\n" +
+                // start
+                "  KAFKA_LOG4J_CMD_OPTS=\"-Dkafka.logs.dir=/opt/kafka/logs/" +
+                " -Dlog4j2.configurationFile=file:/opt/kafka/config/log4j2.yaml\"\n" +
+                "  exec /opt/kafka/kafka.Kafka " + userOpts + " start" +
+                " --config /opt/kafka/config/server.properties" +
+                " $KAFKA_LOG4J_CMD_OPTS $KAFKA_JMX_OPTS ${KAFKA_OPTS-}\n" +
+                "else\n" +
+                "  exec /etc/kafka/docker/run\n" +
+                "fi\n";
     }
 
     public KafkaContainer withPort(int fixedPort) {

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaContainer.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaContainer.java
@@ -1,0 +1,147 @@
+package io.quarkus.kafka.client.deployment;
+
+import static io.quarkus.devservices.common.ConfigureUtil.configureSharedServiceLabel;
+import static io.quarkus.kafka.client.deployment.DevServicesKafkaProcessor.DEV_SERVICE_LABEL;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.containers.wait.strategy.WaitStrategy;
+import org.testcontainers.images.builder.Transferable;
+import org.testcontainers.utility.DockerImageName;
+
+import com.github.dockerjava.api.command.InspectContainerResponse;
+
+import io.quarkus.deployment.builditem.Startable;
+import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.runtime.LaunchMode;
+
+public class KafkaContainer extends GenericContainer<KafkaContainer> implements Startable {
+
+    private static final String DEFAULT_INTERNAL_TOPIC_RF = "1";
+
+    private static final String DEFAULT_CLUSTER_ID = "4L6g3nShT-eMCtK--X86sw";
+
+    static final int KAFKA_PORT = 9092;
+
+    static final String STARTER_SCRIPT = "/tmp/testcontainers_start.sh";
+
+    static final String[] COMMAND = {
+            "sh",
+            "-c",
+            "while [ ! -f " + STARTER_SCRIPT + " ]; do sleep 0.1; done; " + STARTER_SCRIPT,
+    };
+
+    static final WaitStrategy WAIT_STRATEGY = Wait.forLogMessage(".*Transitioning from RECOVERY to RUNNING.*", 1);
+
+    private final String hostName;
+    private final boolean useSharedNetwork;
+
+    static Map<String, String> envVars() {
+        Map<String, String> envVars = new HashMap<>();
+        envVars.put("CLUSTER_ID", DEFAULT_CLUSTER_ID);
+
+        envVars.put("KAFKA_LISTENERS",
+                "PLAINTEXT://0.0.0.0:" + KAFKA_PORT + ",BROKER://0.0.0.0:9093,CONTROLLER://0.0.0.0:9094");
+        envVars.put(
+                "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP",
+                "BROKER:PLAINTEXT,PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT");
+        envVars.put("KAFKA_INTER_BROKER_LISTENER_NAME", "BROKER");
+        envVars.put("KAFKA_PROCESS_ROLES", "broker,controller");
+        envVars.put("KAFKA_CONTROLLER_LISTENER_NAMES", "CONTROLLER");
+
+        envVars.put("KAFKA_NODE_ID", "1");
+
+        String controllerQuorumVoters = String.format("%s@localhost:9094", envVars.get("KAFKA_NODE_ID"));
+        envVars.put("KAFKA_CONTROLLER_QUORUM_VOTERS", controllerQuorumVoters);
+
+        envVars.put("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", DEFAULT_INTERNAL_TOPIC_RF);
+        envVars.put("KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS", DEFAULT_INTERNAL_TOPIC_RF);
+        envVars.put("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", DEFAULT_INTERNAL_TOPIC_RF);
+        envVars.put("KAFKA_TRANSACTION_STATE_LOG_MIN_ISR", DEFAULT_INTERNAL_TOPIC_RF);
+        envVars.put("KAFKA_LOG_FLUSH_INTERVAL_MESSAGES", Long.MAX_VALUE + "");
+        envVars.put("KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS", "0");
+
+        // Kafka Queues default config
+        envVars.put("KAFKA_GROUP_COORDINATOR_REBALANCE_PROTOCOLS", "classic,consumer,share");
+        envVars.put("KAFKA_UNSTABLE_API_VERSIONS_ENABLE", "true");
+        envVars.put("KAFKA_SHARE_COORDINATOR_STATE_TOPIC_REPLICATION_FACTOR", DEFAULT_INTERNAL_TOPIC_RF);
+        return envVars;
+    }
+
+    public KafkaContainer(DockerImageName dockerImageName, String defaultNetworkId, boolean useSharedNetwork) {
+        super(dockerImageName);
+        this.useSharedNetwork = useSharedNetwork;
+
+        withExposedPorts(KAFKA_PORT);
+        withEnv(envVars());
+
+        withCommand(COMMAND);
+        waitingFor(WAIT_STRATEGY);
+
+        this.hostName = ConfigureUtil.configureNetwork(this, defaultNetworkId, useSharedNetwork, "kafka");
+    }
+
+    @Override
+    public void close() {
+        super.close();
+    }
+
+    @Override
+    protected void containerIsStarting(InspectContainerResponse containerInfo) {
+        String brokerAdvertisedListener = String.format(
+                "BROKER://%s:%s", containerInfo.getConfig().getHostName(),
+                "9093");
+        List<String> advertisedListeners = new ArrayList<>();
+        advertisedListeners.add("PLAINTEXT://" + getBootstrapServers());
+        advertisedListeners.add(brokerAdvertisedListener);
+
+        String kafkaAdvertisedListeners = String.join(",", advertisedListeners);
+
+        String command = "#!/bin/bash\n";
+        // exporting KAFKA_ADVERTISED_LISTENERS with the container hostname
+        command += String.format("export KAFKA_ADVERTISED_LISTENERS=%s\n", kafkaAdvertisedListeners);
+
+        command += "/etc/kafka/docker/run \n";
+        copyFileToContainer(Transferable.of(command, 0777), STARTER_SCRIPT);
+    }
+
+    public KafkaContainer withPort(int fixedPort) {
+        if (fixedPort < 0) {
+            throw new IllegalArgumentException("The fixed Kafka port must be greater than 0");
+        } else if (fixedPort > 0) {
+            addFixedExposedPort(fixedPort, 9092);
+        }
+        return this;
+    }
+
+    public KafkaContainer withEnv(Map<String, String> envVars) {
+        super.withEnv(envVars);
+        return this;
+    }
+
+    public String getEffectiveHostName() {
+        return useSharedNetwork ? hostName : getHost();
+    }
+
+    public int getEffectivePort() {
+        return useSharedNetwork ? 9092 : getMappedPort(KAFKA_PORT);
+    }
+
+    public String getBootstrapServers() {
+        return String.format("%s:%s", getEffectiveHostName(), getEffectivePort());
+    }
+
+    @Override
+    public String getConnectionInfo() {
+        return getBootstrapServers();
+    }
+
+    public KafkaContainer withSharedServiceLabel(LaunchMode launchMode, String serviceName) {
+        return configureSharedServiceLabel(this, launchMode, DEV_SERVICE_LABEL, serviceName);
+    }
+}

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaDevServicesBuildTimeConfig.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaDevServicesBuildTimeConfig.java
@@ -27,7 +27,7 @@ public interface KafkaDevServicesBuildTimeConfig {
     /**
      * Kafka dev service container type.
      * <p>
-     * Redpanda, Strimzi and kafka-native container providers are supported. Default is redpanda.
+     * Redpanda, Strimzi, kafka-native and upstream kafka container providers are supported. Default is upstream-kafka-native.
      * <p>
      * For Redpanda:
      * See https://docs.redpanda.com/current/get-started/quick-start/ and https://hub.docker.com/r/redpandadata/redpanda
@@ -38,15 +38,20 @@ public interface KafkaDevServicesBuildTimeConfig {
      * For Kafka Native:
      * See https://github.com/ozangunalp/kafka-native and https://quay.io/repository/ogunalp/kafka-native
      * <p>
-     * Note that Strimzi and Kafka Native images are launched in Kraft mode.
+     * For Upstream Kafka:
+     * See https://hub.docker.com/r/apache/kafka and https://hub.docker.com/r/apache/kafka-native
+     * <p>
      */
-    @WithDefault("redpanda")
+    @WithDefault("upstream-kafka-native")
     Provider provider();
 
     enum Provider {
         REDPANDA("docker.io/redpandadata/redpanda:v24.1.2"),
-        STRIMZI("quay.io/strimzi-test-container/test-container:0.114.0-kafka-4.1.1"),
-        KAFKA_NATIVE("quay.io/ogunalp/kafka-native:latest");
+        STRIMZI("quay.io/strimzi-test-container/test-container:0.115.0-kafka-4.2.0"),
+        @Deprecated(forRemoval = true)
+        KAFKA_NATIVE("quay.io/ogunalp/kafka-native:latest"),
+        UPSTREAM_KAFKA("docker.io/apache/kafka:4.2.0"),
+        UPSTREAM_KAFKA_NATIVE("docker.io/apache/kafka-native:4.2.0");
 
         private final String defaultImageName;
 

--- a/extensions/smallrye-reactive-messaging-kafka/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging-kafka/runtime/pom.xml
@@ -46,6 +46,11 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>nativeimage</artifactId>
+            <scope>provided</scope>
+        </dependency>
         <!-- TODO: remove this after upgrading to kafka-clients that already depends on the new lz4 groupId -->
         <dependency>
             <groupId>at.yawk.lz4</groupId>

--- a/extensions/smallrye-reactive-messaging-kafka/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/graal/ShareGroupSubstitutions.java
+++ b/extensions/smallrye-reactive-messaging-kafka/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/graal/ShareGroupSubstitutions.java
@@ -1,0 +1,48 @@
+package io.quarkus.smallrye.reactivemessaging.kafka.graal;
+
+import java.util.function.BooleanSupplier;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+/**
+ * Substitution for {@code KafkaShareGroupCommit} when the Kafka client version
+ * does not include {@code ShareConsumer.acquisitionLockTimeoutMs()} (added in kafka-clients 4.2.0).
+ * <p>
+ * Without this substitution, GraalVM's {@code --link-at-build-time} fails with an
+ * {@code UnresolvedElementException} because the method reference cannot be resolved.
+ */
+final class ShareGroupSubstitutions {
+
+    static final class IsAcquisitionLockTimeoutMsMissing implements BooleanSupplier {
+        @Override
+        public boolean getAsBoolean() {
+            try {
+                Class.forName("org.apache.kafka.clients.consumer.ShareConsumer")
+                        .getMethod("acquisitionLockTimeoutMs");
+                return false;
+            } catch (ClassNotFoundException | NoSuchMethodException e) {
+                return true;
+            }
+        }
+    }
+}
+
+@TargetClass(className = "io.smallrye.reactive.messaging.kafka.commit.KafkaShareGroupCommit", onlyWith = ShareGroupSubstitutions.IsAcquisitionLockTimeoutMsMissing.class)
+final class Target_io_smallrye_reactive_messaging_kafka_commit_KafkaShareGroupCommit {
+
+    @Alias
+    private void startRenewTimer() {
+    }
+
+    /**
+     * Substituted to avoid the unresolvable call to
+     * {@code ShareConsumer.acquisitionLockTimeoutMs()} in kafka-clients &lt; 4.2.0.
+     * The timer is restarted but no lock renewal or timeout checking is performed.
+     */
+    @Substitute
+    private void renewAndCheckTimeout(long ignored) {
+        startRenewTimer();
+    }
+}

--- a/integration-tests/kafka-devservices/src/main/resources/application.properties
+++ b/integration-tests/kafka-devservices/src/main/resources/application.properties
@@ -5,7 +5,7 @@ quarkus.log.category.\"org.apache.zookeeper\".level=WARN
 # enable health check
 quarkus.kafka.health.enabled=true
 
-quarkus.kafka.devservices.provider=kafka-native
+quarkus.kafka.devservices.provider=upstream-kafka-native
 quarkus.kafka.devservices.topic-partitions.test=2
 quarkus.kafka.devservices.topic-partitions.test-consumer=3
 quarkus.kafka.devservices.topic-partitions-timeout=4S

--- a/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/continuoustesting/DevServicesContainerSharingTest.java
+++ b/integration-tests/kafka-devservices/src/test/java/io/quarkus/it/kafka/continuoustesting/DevServicesContainerSharingTest.java
@@ -17,7 +17,7 @@ import io.quarkus.it.kafka.KafkaAdminTest;
 import io.quarkus.it.kafka.KafkaEndpoint;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.test.QuarkusDevModeTest;
-import io.strimzi.test.container.StrimziKafkaContainer;
+import io.strimzi.test.container.StrimziKafkaCluster;
 
 public class DevServicesContainerSharingTest extends BaseDevServiceTest {
 
@@ -29,11 +29,13 @@ public class DevServicesContainerSharingTest extends BaseDevServiceTest {
                     .addClass(KafkaAdminManager.class))
             .setTestArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(KafkaAdminTest.class));
 
-    static StrimziKafkaContainer kafka;
+    static StrimziKafkaCluster kafka;
 
     @BeforeAll
     static void beforeAll() {
-        kafka = new StrimziKafkaContainer().withLabel("quarkus-dev-service-kafka", "kafka");
+        kafka = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
+                .withContainerCustomizer(c -> c.withLabel("quarkus-dev-service-kafka", "kafka"))
+                .build();
         kafka.start();
     }
 

--- a/integration-tests/kafka-oauth-keycloak/src/test/java/io/quarkus/it/kafka/KafkaKeycloakTestResource.java
+++ b/integration-tests/kafka-oauth-keycloak/src/test/java/io/quarkus/it/kafka/KafkaKeycloakTestResource.java
@@ -9,11 +9,11 @@ import java.util.Map;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import io.quarkus.test.keycloak.client.KeycloakTestClient;
 import io.quarkus.test.keycloak.server.KeycloakContainer;
-import io.strimzi.test.container.StrimziKafkaContainer;
+import io.strimzi.test.container.StrimziKafkaCluster;
 
 public class KafkaKeycloakTestResource implements QuarkusTestResourceLifecycleManager {
 
-    private StrimziKafkaContainer kafka;
+    private StrimziKafkaCluster kafka;
     private KeycloakContainer keycloak;
     private static final String KEYCLOAK_REALM_JSON = System.getProperty("keycloak.realm.json");
 
@@ -28,28 +28,32 @@ public class KafkaKeycloakTestResource implements QuarkusTestResourceLifecycleMa
         client.createRealmFromPath(KEYCLOAK_REALM_JSON);
 
         //Start kafka container
-        this.kafka = new StrimziKafkaContainer("quay.io/strimzi/kafka:latest-kafka-4.1.0")
-                .withBrokerId(1)
-                .withKafkaConfigurationMap(Map.ofEntries(
-                        entry("listener.security.protocol.map", "JWT:SASL_PLAINTEXT,BROKER1:PLAINTEXT,CONTROLLER:PLAINTEXT"),
-                        entry("listener.name.jwt.oauthbearer.sasl.jaas.config",
-                                getOauthSaslJaasConfig(keycloak.getInternalUrl(), keycloak.getServerUrl())),
-                        entry("listener.name.jwt.plain.sasl.jaas.config",
-                                getPlainSaslJaasConfig(keycloak.getInternalUrl(), keycloak.getServerUrl())),
-                        entry("sasl.enabled.mechanisms", "OAUTHBEARER"),
-                        entry("sasl.mechanism.inter.broker.protocol", "OAUTHBEARER"),
-                        entry("oauth.username.claim", "preferred_username"),
-                        entry("principal.builder.class", "io.strimzi.kafka.oauth.server.OAuthKafkaPrincipalBuilder"),
-                        entry("listener.name.jwt.sasl.enabled.mechanisms", "OAUTHBEARER,PLAIN"),
-                        entry("listener.name.jwt.oauthbearer.sasl.server.callback.handler.class",
-                                "io.strimzi.kafka.oauth.server.JaasServerOauthValidatorCallbackHandler"),
-                        entry("listener.name.jwt.oauthbearer.sasl.login.callback.handler.class",
-                                "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler"),
-                        entry("listener.name.jwt.plain.sasl.server.callback.handler.class",
-                                "io.strimzi.kafka.oauth.server.plain.JaasServerOauthOverPlainValidatorCallbackHandler")))
-                .withNetworkAliases("kafka")
+        this.kafka = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
+                .withImage("quay.io/strimzi/kafka:latest-kafka-4.1.0")
+                .withSharedNetwork()
+                .withContainerCustomizer(c -> c
+                        .withKafkaConfigurationMap(Map.ofEntries(
+                                entry("listener.security.protocol.map",
+                                        "JWT:SASL_PLAINTEXT,BROKER1:PLAINTEXT,CONTROLLER:PLAINTEXT"),
+                                entry("listener.name.jwt.oauthbearer.sasl.jaas.config",
+                                        getOauthSaslJaasConfig(keycloak.getInternalUrl(), keycloak.getServerUrl())),
+                                entry("listener.name.jwt.plain.sasl.jaas.config",
+                                        getPlainSaslJaasConfig(keycloak.getInternalUrl(), keycloak.getServerUrl())),
+                                entry("sasl.enabled.mechanisms", "OAUTHBEARER"),
+                                entry("sasl.mechanism.inter.broker.protocol", "OAUTHBEARER"),
+                                entry("oauth.username.claim", "preferred_username"),
+                                entry("principal.builder.class", "io.strimzi.kafka.oauth.server.OAuthKafkaPrincipalBuilder"),
+                                entry("listener.name.jwt.sasl.enabled.mechanisms", "OAUTHBEARER,PLAIN"),
+                                entry("listener.name.jwt.oauthbearer.sasl.server.callback.handler.class",
+                                        "io.strimzi.kafka.oauth.server.JaasServerOauthValidatorCallbackHandler"),
+                                entry("listener.name.jwt.oauthbearer.sasl.login.callback.handler.class",
+                                        "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler"),
+                                entry("listener.name.jwt.plain.sasl.server.callback.handler.class",
+                                        "io.strimzi.kafka.oauth.server.plain.JaasServerOauthOverPlainValidatorCallbackHandler")))
+                        .withNetworkAliases("kafka"))
                 .withBootstrapServers(
-                        c -> String.format("JWT://%s:%s", c.getHost(), c.getMappedPort(KAFKA_PORT)));
+                        c -> String.format("JWT://%s:%s", c.getHost(), c.getMappedPort(KAFKA_PORT)))
+                .build();
         this.kafka.start();
         properties.put("kafka.bootstrap.servers", this.kafka.getBootstrapServers());
         properties.put("mp.messaging.connector.smallrye-kafka.sasl.jaas.config",

--- a/integration-tests/kafka-sasl-elytron/src/test/java/io/quarkus/it/kafka/KafkaSaslTestResource.java
+++ b/integration-tests/kafka-sasl-elytron/src/test/java/io/quarkus/it/kafka/KafkaSaslTestResource.java
@@ -11,13 +11,13 @@ import org.testcontainers.utility.MountableFile;
 
 import io.quarkus.it.kafka.containers.KerberosContainer;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
-import io.strimzi.test.container.StrimziKafkaContainer;
+import io.strimzi.test.container.StrimziKafkaCluster;
 
 public class KafkaSaslTestResource implements QuarkusTestResourceLifecycleManager {
 
     private final Logger log = Logger.getLogger(KafkaSaslTestResource.class);
 
-    private StrimziKafkaContainer kafka;
+    private StrimziKafkaCluster kafka;
     private KerberosContainer kerberos;
 
     @Override
@@ -34,31 +34,32 @@ public class KafkaSaslTestResource implements QuarkusTestResourceLifecycleManage
         properties.put("java.security.krb5.conf", "src/test/resources/krb5.conf");
 
         //Start kafka container
-        kafka = new StrimziKafkaContainer()
-                .withBrokerId(0)
+        kafka = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
+                .withSharedNetwork()
                 .withBootstrapServers(
                         c -> String.format("SASL_PLAINTEXT://%s:%s", c.getHost(), c.getMappedPort(KAFKA_PORT)))
-                .withKafkaConfigurationMap(Map.ofEntries(
-                        entry("listener.security.protocol.map",
-                                "SASL_PLAINTEXT:SASL_PLAINTEXT,BROKER1:PLAINTEXT,CONTROLLER:PLAINTEXT"),
-                        entry("inter.broker.listener.name", "SASL_PLAINTEXT"),
-                        entry("sasl.enabled.mechanisms", "GSSAPI"),
-                        entry("sasl.mechanism.inter.broker.protocol", "GSSAPI"),
-                        entry("listener.name.sasl_plaintext.gssapi.sasl.jaas.config",
-                                "com.sun.security.auth.module.Krb5LoginModule required " +
-                                        "useKeyTab=true storeKey=true debug=true serviceName=\"kafka\" " +
-                                        "keyTab=\"/opt/kafka/config/kafkabroker.keytab\" " +
-                                        "principal=\"kafka/localhost@EXAMPLE.COM\";"),
-                        entry("sasl.kerberos.service.name", "kafka"),
-                        entry("ssl.endpoint.identification.algorithm", "https"),
-                        entry("ssl.client.auth", "none")))
-                .withPort(KAFKA_PORT)
-                .withCopyFileToContainer(MountableFile.forClasspathResource("krb5KafkaBroker.conf"),
-                        "/etc/krb5.conf")
-                .withCopyFileToContainer(MountableFile.forHostPath("target/kafkabroker.keytab"),
-                        "/opt/kafka/config/kafkabroker.keytab");
+                .withContainerCustomizer(c -> c
+                        .withKafkaConfigurationMap(Map.ofEntries(
+                                entry("listener.security.protocol.map",
+                                        "SASL_PLAINTEXT:SASL_PLAINTEXT,BROKER1:PLAINTEXT,CONTROLLER:PLAINTEXT"),
+                                entry("inter.broker.listener.name", "SASL_PLAINTEXT"),
+                                entry("sasl.enabled.mechanisms", "GSSAPI"),
+                                entry("sasl.mechanism.inter.broker.protocol", "GSSAPI"),
+                                entry("listener.name.sasl_plaintext.gssapi.sasl.jaas.config",
+                                        "com.sun.security.auth.module.Krb5LoginModule required " +
+                                                "useKeyTab=true storeKey=true debug=true serviceName=\"kafka\" " +
+                                                "keyTab=\"/opt/kafka/config/kafkabroker.keytab\" " +
+                                                "principal=\"kafka/localhost@EXAMPLE.COM\";"),
+                                entry("sasl.kerberos.service.name", "kafka"),
+                                entry("ssl.endpoint.identification.algorithm", "https"),
+                                entry("ssl.client.auth", "none")))
+                        .withPort(KAFKA_PORT)
+                        .withCopyFileToContainer(MountableFile.forClasspathResource("krb5KafkaBroker.conf"),
+                                "/etc/krb5.conf")
+                        .withCopyFileToContainer(MountableFile.forHostPath("target/kafkabroker.keytab"),
+                                "/opt/kafka/config/kafkabroker.keytab"))
+                .build();
         kafka.start();
-        log.info(kafka.getLogs());
         properties.put("kafka.bootstrap.servers", kafka.getBootstrapServers());
 
         return properties;

--- a/integration-tests/kafka-sasl/src/test/java/io/quarkus/it/kafka/KafkaSASLTestResource.java
+++ b/integration-tests/kafka-sasl/src/test/java/io/quarkus/it/kafka/KafkaSASLTestResource.java
@@ -7,25 +7,26 @@ import java.util.HashMap;
 import java.util.Map;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
-import io.strimzi.test.container.StrimziKafkaContainer;
+import io.strimzi.test.container.StrimziKafkaCluster;
 
 public class KafkaSASLTestResource implements QuarkusTestResourceLifecycleManager {
 
-    private final StrimziKafkaContainer kafka = new StrimziKafkaContainer()
-            .withBrokerId(0)
+    private final StrimziKafkaCluster kafka = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
+            .withContainerCustomizer(c -> c
+                    .withKafkaConfigurationMap(Map.ofEntries(
+                            entry("listener.security.protocol.map",
+                                    "SASL_PLAINTEXT:SASL_PLAINTEXT,BROKER1:PLAINTEXT,PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT"),
+                            entry("sasl.enabled.mechanisms", "PLAIN"),
+                            entry("sasl.mechanism.inter.broker.protocol", "PLAIN"),
+                            entry("listener.name.sasl_plaintext.plain.sasl.jaas.config",
+                                    "org.apache.kafka.common.security.plain.PlainLoginModule required " +
+                                            "username=\"broker\" " +
+                                            "password=\"broker-secret\" " +
+                                            "user_broker=\"broker-secret\" " +
+                                            "user_client=\"client-secret\";"))))
             .withBootstrapServers(c -> String.format("SASL_PLAINTEXT://%s:%s", c.getHost(),
                     c.getMappedPort(KAFKA_PORT)))
-            .withKafkaConfigurationMap(Map.ofEntries(
-                    entry("listener.security.protocol.map",
-                            "SASL_PLAINTEXT:SASL_PLAINTEXT,BROKER1:PLAINTEXT,PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT"),
-                    entry("sasl.enabled.mechanisms", "PLAIN"),
-                    entry("sasl.mechanism.inter.broker.protocol", "PLAIN"),
-                    entry("listener.name.sasl_plaintext.plain.sasl.jaas.config",
-                            "org.apache.kafka.common.security.plain.PlainLoginModule required " +
-                                    "username=\"broker\" " +
-                                    "password=\"broker-secret\" " +
-                                    "user_broker=\"broker-secret\" " +
-                                    "user_client=\"client-secret\";")));
+            .build();
 
     @Override
     public Map<String, String> start() {

--- a/integration-tests/kafka-snappy/src/test/java/io/quarkus/it/kafka/KafkaTestResource.java
+++ b/integration-tests/kafka-snappy/src/test/java/io/quarkus/it/kafka/KafkaTestResource.java
@@ -4,11 +4,12 @@ import java.util.Collections;
 import java.util.Map;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
-import io.strimzi.test.container.StrimziKafkaContainer;
+import io.strimzi.test.container.StrimziKafkaCluster;
 
 public class KafkaTestResource implements QuarkusTestResourceLifecycleManager {
 
-    private static final StrimziKafkaContainer kafka = new StrimziKafkaContainer().withBrokerId(1);
+    private static final StrimziKafkaCluster kafka = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
+            .build();
 
     public static String getBootstrapServers() {
         return kafka.getBootstrapServers();

--- a/integration-tests/kafka-ssl/src/test/java/io/quarkus/it/kafka/KafkaSSLTestResource.java
+++ b/integration-tests/kafka-ssl/src/test/java/io/quarkus/it/kafka/KafkaSSLTestResource.java
@@ -10,30 +10,31 @@ import java.util.Map;
 import org.testcontainers.utility.MountableFile;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
-import io.strimzi.test.container.StrimziKafkaContainer;
+import io.strimzi.test.container.StrimziKafkaCluster;
 
 public class KafkaSSLTestResource implements QuarkusTestResourceLifecycleManager {
 
     Map<String, String> conf = new HashMap<>();
 
-    private final StrimziKafkaContainer kafka = new StrimziKafkaContainer()
+    private final StrimziKafkaCluster kafka = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
             .withBootstrapServers(c -> String.format("SSL://%s:%s", c.getHost(), c.getMappedPort(KAFKA_PORT)))
-            .withBrokerId(0)
-            .withKafkaConfigurationMap(Map.ofEntries(
-                    entry("ssl.keystore.location", "/opt/kafka/config/kafka-keystore.p12"),
-                    entry("ssl.keystore.password", "Z_pkTh9xgZovK4t34cGB2o6afT4zZg0L"),
-                    entry("ssl.keystore.type", "PKCS12"),
-                    entry("ssl.key.password", "Z_pkTh9xgZovK4t34cGB2o6afT4zZg0L"),
-                    entry("ssl.truststore.location", "/opt/kafka/config/kafka-truststore.p12"),
-                    entry("ssl.truststore.password", "Z_pkTh9xgZovK4t34cGB2o6afT4zZg0L"),
-                    entry("ssl.truststore.type", "PKCS12"),
-                    entry("ssl.endpoint.identification.algorithm", ""),
-                    entry("listener.security.protocol.map",
-                            "BROKER1:PLAINTEXT,PLAINTEXT:PLAINTEXT,SSL:SSL,CONTROLLER:PLAINTEXT")))
-            .withCopyFileToContainer(MountableFile.forHostPath("target/certs/kafka-keystore.p12"),
-                    "/opt/kafka/config/kafka-keystore.p12")
-            .withCopyFileToContainer(MountableFile.forHostPath("target/certs/kafka-truststore.p12"),
-                    "/opt/kafka/config/kafka-truststore.p12");
+            .withContainerCustomizer(c -> c
+                    .withKafkaConfigurationMap(Map.ofEntries(
+                            entry("ssl.keystore.location", "/opt/kafka/config/kafka-keystore.p12"),
+                            entry("ssl.keystore.password", "Z_pkTh9xgZovK4t34cGB2o6afT4zZg0L"),
+                            entry("ssl.keystore.type", "PKCS12"),
+                            entry("ssl.key.password", "Z_pkTh9xgZovK4t34cGB2o6afT4zZg0L"),
+                            entry("ssl.truststore.location", "/opt/kafka/config/kafka-truststore.p12"),
+                            entry("ssl.truststore.password", "Z_pkTh9xgZovK4t34cGB2o6afT4zZg0L"),
+                            entry("ssl.truststore.type", "PKCS12"),
+                            entry("ssl.endpoint.identification.algorithm", ""),
+                            entry("listener.security.protocol.map",
+                                    "BROKER1:PLAINTEXT,PLAINTEXT:PLAINTEXT,SSL:SSL,CONTROLLER:PLAINTEXT")))
+                    .withCopyFileToContainer(MountableFile.forHostPath("target/certs/kafka-keystore.p12"),
+                            "/opt/kafka/config/kafka-keystore.p12")
+                    .withCopyFileToContainer(MountableFile.forHostPath("target/certs/kafka-truststore.p12"),
+                            "/opt/kafka/config/kafka-truststore.p12"))
+            .build();
 
     private Map<String, String> initProps;
 

--- a/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaSSLTestResource.java
+++ b/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaSSLTestResource.java
@@ -10,27 +10,29 @@ import java.util.Map;
 import org.testcontainers.utility.MountableFile;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
-import io.strimzi.test.container.StrimziKafkaContainer;
+import io.strimzi.test.container.StrimziKafkaCluster;
 
 public class KafkaSSLTestResource implements QuarkusTestResourceLifecycleManager {
 
-    private static final StrimziKafkaContainer kafka = new StrimziKafkaContainer()
-            .withKafkaConfigurationMap(Map.ofEntries(
-                    entry("ssl.keystore.location", "/opt/kafka/config/kafka-keystore.p12"),
-                    entry("ssl.keystore.password", "Z_pkTh9xgZovK4t34cGB2o6afT4zZg0L"),
-                    entry("ssl.keystore.type", "PKCS12"),
-                    entry("ssl.key.password", "Z_pkTh9xgZovK4t34cGB2o6afT4zZg0L"),
-                    entry("ssl.truststore.location", "/opt/kafka/config/kafka-truststore.p12"),
-                    entry("ssl.truststore.password", "Z_pkTh9xgZovK4t34cGB2o6afT4zZg0L"),
-                    entry("ssl.truststore.type", "PKCS12"),
-                    entry("ssl.endpoint.identification.algorithm=", ""),
-                    entry("listener.security.protocol.map",
-                            "BROKER1:PLAINTEXT,PLAINTEXT:PLAINTEXT,SSL:SSL,CONTROLLER:PLAINTEXT")))
+    private static final StrimziKafkaCluster kafka = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
             .withBootstrapServers(c -> String.format("SSL://%s:%s", c.getHost(), c.getMappedPort(KAFKA_PORT)))
-            .withCopyFileToContainer(MountableFile.forClasspathResource("ks-keystore.p12"),
-                    "/opt/kafka/config/kafka-keystore.p12")
-            .withCopyFileToContainer(MountableFile.forClasspathResource("ks-truststore.p12"),
-                    "/opt/kafka/config/kafka-truststore.p12");
+            .withContainerCustomizer(c -> c
+                    .withKafkaConfigurationMap(Map.ofEntries(
+                            entry("ssl.keystore.location", "/opt/kafka/config/kafka-keystore.p12"),
+                            entry("ssl.keystore.password", "Z_pkTh9xgZovK4t34cGB2o6afT4zZg0L"),
+                            entry("ssl.keystore.type", "PKCS12"),
+                            entry("ssl.key.password", "Z_pkTh9xgZovK4t34cGB2o6afT4zZg0L"),
+                            entry("ssl.truststore.location", "/opt/kafka/config/kafka-truststore.p12"),
+                            entry("ssl.truststore.password", "Z_pkTh9xgZovK4t34cGB2o6afT4zZg0L"),
+                            entry("ssl.truststore.type", "PKCS12"),
+                            entry("ssl.endpoint.identification.algorithm=", ""),
+                            entry("listener.security.protocol.map",
+                                    "BROKER1:PLAINTEXT,PLAINTEXT:PLAINTEXT,SSL:SSL,CONTROLLER:PLAINTEXT")))
+                    .withCopyFileToContainer(MountableFile.forClasspathResource("ks-keystore.p12"),
+                            "/opt/kafka/config/kafka-keystore.p12")
+                    .withCopyFileToContainer(MountableFile.forClasspathResource("ks-truststore.p12"),
+                            "/opt/kafka/config/kafka-truststore.p12"))
+            .build();
 
     public static String getBootstrapServers() {
         return kafka.getBootstrapServers();

--- a/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/KafkaCodecTest.java
+++ b/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/KafkaCodecTest.java
@@ -2,25 +2,43 @@ package io.quarkus.it.kafka;
 
 import static org.hamcrest.Matchers.is;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.InjectKafkaProxy;
+import io.quarkus.test.kafka.ProxiedKafkaCompanionResource;
 import io.restassured.RestAssured;
 import io.restassured.config.ObjectMapperConfig;
 import io.restassured.mapper.ObjectMapperType;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import io.smallrye.reactive.messaging.kafka.companion.test.KafkaProxy;
 
-@QuarkusTestResource(KafkaCompanionResource.class)
+@QuarkusTestResource(ProxiedKafkaCompanionResource.class)
 @QuarkusTest
 public class KafkaCodecTest {
+
+    @InjectKafkaCompanion
+    KafkaCompanion companion;
+
+    @InjectKafkaProxy
+    KafkaProxy proxy;
 
     @BeforeAll
     public static void configureMapper() {
         // We have JSON-B and Jackson around, we want to ensure REST Assured uses Jackson and not JSON-B
         RestAssured.config = RestAssured.config.objectMapperConfig(ObjectMapperConfig.objectMapperConfig()
                 .defaultObjectMapperType(ObjectMapperType.JACKSON_2));
+    }
+
+    @BeforeEach
+    void setUp() {
+        Assertions.assertTrue(proxy.toxi.isEnabled());
+        Assertions.assertNotNull(companion.cluster().clusterId());
     }
 
     @Test

--- a/integration-tests/resteasy-reactive-kotlin/standard/src/test/kotlin/io/quarkus/it/resteasy/reactive/kotlin/KafkaTestResource.kt
+++ b/integration-tests/resteasy-reactive-kotlin/standard/src/test/kotlin/io/quarkus/it/resteasy/reactive/kotlin/KafkaTestResource.kt
@@ -1,11 +1,12 @@
 package io.quarkus.it.resteasy.reactive.kotlin
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
-import io.strimzi.test.container.StrimziKafkaContainer
+import io.strimzi.test.container.StrimziKafkaCluster
 
 class KafkaTestResource : QuarkusTestResourceLifecycleManager {
 
-    private val kafka: StrimziKafkaContainer = StrimziKafkaContainer()
+    private val kafka: StrimziKafkaCluster =
+        StrimziKafkaCluster.StrimziKafkaClusterBuilder().build()
 
     fun getBootstrapServers(): String? {
         return kafka.getBootstrapServers()

--- a/test-framework/kafka-companion/src/main/java/io/quarkus/test/kafka/KafkaCompanionResource.java
+++ b/test-framework/kafka-companion/src/main/java/io/quarkus/test/kafka/KafkaCompanionResource.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import io.quarkus.test.common.DevServicesContext;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import io.strimzi.test.container.StrimziKafkaCluster;
 import io.strimzi.test.container.StrimziKafkaContainer;
 
 public class KafkaCompanionResource implements QuarkusTestResourceLifecycleManager, DevServicesContext.ContextAware {
@@ -18,7 +19,6 @@ public class KafkaCompanionResource implements QuarkusTestResourceLifecycleManag
 
     protected String strimziKafkaContainerImage;
     protected Integer kafkaPort;
-    protected boolean kraft;
 
     protected StrimziKafkaContainer kafka;
     protected KafkaCompanion kafkaCompanion;
@@ -42,11 +42,11 @@ public class KafkaCompanionResource implements QuarkusTestResourceLifecycleManag
     }
 
     protected StrimziKafkaContainer createContainer(String imageName) {
+        var builder = new StrimziKafkaCluster.StrimziKafkaClusterBuilder();
         if (imageName == null) {
-            return new StrimziKafkaContainer();
-        } else {
-            return new StrimziKafkaContainer(imageName);
+            return builder.build().getBrokers().stream().findFirst().get();
         }
+        return builder.withImage(imageName).build().getBrokers().stream().findFirst().get();
     }
 
     @Override
@@ -55,9 +55,7 @@ public class KafkaCompanionResource implements QuarkusTestResourceLifecycleManag
             strimziKafkaContainerImage = initArgs.get(STRIMZI_KAFKA_IMAGE_KEY);
             String portString = initArgs.get(KAFKA_PORT_KEY);
             kafkaPort = portString == null ? null : Integer.parseInt(portString);
-            kafka = createContainer(strimziKafkaContainerImage)
-                    .withNodeId(1)
-                    .withBrokerId(1);
+            kafka = createContainer(strimziKafkaContainerImage);
             if (kafkaPort != null) {
                 kafka.withPort(kafkaPort);
             }

--- a/test-framework/kafka-companion/src/main/java/io/quarkus/test/kafka/ProxiedKafkaCompanionResource.java
+++ b/test-framework/kafka-companion/src/main/java/io/quarkus/test/kafka/ProxiedKafkaCompanionResource.java
@@ -1,31 +1,52 @@
 package io.quarkus.test.kafka;
 
+import static org.awaitility.Awaitility.await;
+
+import java.util.Collections;
 import java.util.Map;
 
+import org.testcontainers.toxiproxy.ToxiproxyContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import eu.rekawek.toxiproxy.Proxy;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
 import io.smallrye.reactive.messaging.kafka.companion.test.KafkaProxy;
-import io.smallrye.reactive.messaging.kafka.companion.test.ProxiedStrimziKafkaContainer;
+import io.strimzi.test.container.StrimziKafkaCluster;
 import io.strimzi.test.container.StrimziKafkaContainer;
 
 public class ProxiedKafkaCompanionResource extends KafkaCompanionResource {
 
-    private ProxiedStrimziKafkaContainer proxiedKafka;
+    private StrimziKafkaCluster cluster;
+    private StrimziKafkaContainer proxiedKafka;
     private KafkaProxy toxiProxy;
 
     @Override
     protected StrimziKafkaContainer createContainer(String imageName) {
-        if (imageName == null) {
-            proxiedKafka = new ProxiedStrimziKafkaContainer();
-        } else {
-            proxiedKafka = new ProxiedStrimziKafkaContainer(imageName);
-        }
+        ToxiproxyContainer toxiproxy = new ToxiproxyContainer(
+                DockerImageName.parse(System.getProperty("toxiproxy.image.name", "ghcr.io/shopify/toxiproxy:2.4.0"))
+                        .asCompatibleSubstituteFor("shopify/toxiproxy"))
+                .withNetworkAliases("toxiproxy");
+        cluster = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
+                .withProxyContainer(toxiproxy)
+                .build();
+        proxiedKafka = cluster.getBrokers().stream().findFirst().get();
         return proxiedKafka;
     }
 
     @Override
     public Map<String, String> start() {
-        Map<String, String> config = super.start();
+        Map<String, String> config;
+        if (kafkaCompanion == null && kafka != null) {
+            cluster.start();
+            await().until(kafka::isRunning);
+            kafkaCompanion = new KafkaCompanion(cluster.getBootstrapServers());
+            config = Collections.singletonMap("kafka.bootstrap.servers", kafka.getBootstrapServers());
+        } else {
+            config = Collections.emptyMap();
+        }
         if (proxiedKafka != null) {
-            toxiProxy = proxiedKafka.getKafkaProxy();
+            Proxy proxyForNode = cluster.getProxyForNode(proxiedKafka.getNodeId());
+            toxiProxy = new KafkaProxy(proxyForNode, proxiedKafka.getHost(), kafka.getMappedPort(9092), 0);
         }
         return config;
     }


### PR DESCRIPTION
I didn't squash commits as they are quite distinct.

- Bump strimzi-test-container to 0.115.0. Migrated usages of StrimziKafkaContainer to StrimziKafkaCluster.
- Bump to SMRM 4.34.0, update Kafka documentation with Share Groups usage guide, concurrent transactions with pooled producers.
- Added native image substitution for the usage of Kafka share group API, which is not available in kafka-clients < 4.2. Effectively disables the auto-renewal for the Kafka queue's long-running processing.
- Kafka Dev Services providers for upstream Apache Kafka containers, regular and kafka-native. 
- Made the upstream-kafka-native provider the default. Deprecate the ogunalp/kafka-native provider. 
- Ran into the issue [KAFKA-20314](https://issues.apache.org/jira/browse/KAFKA-20314) when testing this. I added a workaround by adding `-Duser.name/-Duser.home` flags into the native binary invocation. I think it is somewhat caused by a gcompat getpwuid issue on Alpine when GraalVM tries to populate user.name and user.home.

Will bump to kafka-clients 4.2.0 on a separate PR.