### PR TITLE
Ensure that shared Config build time runtime fixed uses the expected profile when set from @TestProfile

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
@@ -19,6 +19,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -99,6 +100,7 @@ import io.quarkus.runtime.configuration.DisableableConfigSource;
 import io.quarkus.runtime.configuration.QuarkusConfigValue;
 import io.quarkus.runtime.configuration.RuntimeConfigBuilder;
 import io.quarkus.runtime.configuration.StaticInitConfigBuilder;
+import io.smallrye.config.Config;
 import io.smallrye.config.ConfigMappingInterface;
 import io.smallrye.config.ConfigMappingLoader;
 import io.smallrye.config.ConfigMappingMetadata;
@@ -578,6 +580,12 @@ public class ConfigGenerationBuildStep {
     private static final MethodDescriptor BUILDER_CUSTOMIZER = MethodDescriptor.ofMethod(SmallRyeConfigBuilderCustomizer.class,
             "configBuilder",
             void.class, SmallRyeConfigBuilder.class);
+    private static final MethodDescriptor WITH_SHARED_BUILDER = MethodDescriptor.ofMethod(AbstractConfigBuilder.class,
+            "withSharedBuilder",
+            void.class, SmallRyeConfigBuilder.class);
+    private static final MethodDescriptor WITH_PROFILES = MethodDescriptor.ofMethod(AbstractConfigBuilder.class,
+            "withProfiles",
+            void.class, SmallRyeConfigBuilder.class, List.class);
     private static final MethodDescriptor WITH_DEFAULTS = MethodDescriptor.ofMethod(AbstractConfigBuilder.class,
             "withDefaultValues",
             void.class, SmallRyeConfigBuilder.class, Map.class);
@@ -633,6 +641,10 @@ public class ConfigGenerationBuildStep {
     private static final MethodDescriptor ENSURE_LOADED = MethodDescriptor.ofMethod(AbstractConfigBuilder.class,
             "ensureLoaded",
             void.class, String.class);
+    private static final MethodDescriptor LIST_NEW = MethodDescriptor.ofConstructor(ArrayList.class);
+    private static final MethodDescriptor LIST_ADD = MethodDescriptor.ofMethod(ArrayList.class,
+            "add",
+            boolean.class, Object.class);
     private static final MethodDescriptor MAP_NEW = MethodDescriptor.ofConstructor(HashMap.class, int.class);
     private static final MethodDescriptor MAP_PUT = MethodDescriptor.ofMethod(HashMap.class,
             "put",
@@ -688,8 +700,7 @@ public class ConfigGenerationBuildStep {
 
             // init build and runtime fixed mappings
             ResultHandle configBuilder = clinit.newInstance(NEW_BUILDER);
-            clinit.invokeStaticMethod(MethodDescriptor.ofMethod(AbstractConfigBuilder.class, "withSharedBuilder", void.class,
-                    SmallRyeConfigBuilder.class), configBuilder);
+            clinit.invokeStaticMethod(WITH_SHARED_BUILDER, configBuilder);
             for (String converter : converters) {
                 ClassInfo converterClass = combinedIndex.getComputingIndex().getClassByName(converter);
                 Type type = getConverterType(converterClass, combinedIndex);
@@ -706,7 +717,17 @@ public class ConfigGenerationBuildStep {
             }
             clinit.invokeStaticMethod(WITH_BUILDER, configBuilder, clinit.newInstance(
                     MethodDescriptor.ofConstructor("io.quarkus.runtime.generated.BuildTimeRunTimeFixedConfigSourceBuilder")));
+
+            List<String> profiles = new ArrayList<>(Config.get().getProfiles());
+            Collections.reverse(profiles);
+            ResultHandle list = clinit.newInstance(LIST_NEW);
+            for (String profile : profiles) {
+                clinit.invokeVirtualMethod(LIST_ADD, list, clinit.load(profile));
+            }
+            clinit.invokeStaticMethod(WITH_PROFILES, configBuilder, list);
+
             ResultHandle config = clinit.invokeVirtualMethod(BUILD, configBuilder);
+
             int mappingIndex = 0;
             for (ConfigClass mapping : staticMappings) {
                 FieldDescriptor mappingField = classCreator.getFieldCreator("mapping$" + mappingIndex++, mapping.getType())

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/AbstractConfigBuilder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/AbstractConfigBuilder.java
@@ -1,5 +1,6 @@
 package io.quarkus.runtime.configuration;
 
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -32,6 +33,10 @@ public abstract class AbstractConfigBuilder implements SmallRyeConfigBuilderCust
 
     protected static void withSharedBuilder(SmallRyeConfigBuilder builder) {
         builder.addDefaultInterceptors().withCustomizers(new QuarkusConfigBuilderCustomizer());
+    }
+
+    protected static void withProfiles(SmallRyeConfigBuilder builder, List<String> profiles) {
+        builder.withProfiles(profiles);
     }
 
     protected static void withDefaultValues(SmallRyeConfigBuilder builder, Map<String, String> values) {

--- a/integration-tests/smallrye-config/src/test/java/io/quarkus/it/smallrye/config/QuarkusTestProfileTest.java
+++ b/integration-tests/smallrye-config/src/test/java/io/quarkus/it/smallrye/config/QuarkusTestProfileTest.java
@@ -3,15 +3,19 @@ package io.quarkus.it.smallrye.config;
 import static io.restassured.RestAssured.given;
 import static jakarta.ws.rs.core.Response.Status.OK;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import jakarta.inject.Inject;
 
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 
 @QuarkusTest
 @TestProfile(QuarkusTestProfileTest.TestProfile.class)
@@ -31,12 +35,21 @@ public class QuarkusTestProfileTest {
                 .body("value", equalTo("custom"));
     }
 
+    @Inject
+    VertxHttpBuildTimeConfig vertxHttpBuildTimeConfig;
+
+    @Test
+    void profiledBuildTimeRuntimeFixed() {
+        assertTrue(vertxHttpBuildTimeConfig.enableCompression());
+    }
+
     public static class TestProfile implements QuarkusTestProfile {
         @Override
         public Map<String, String> getConfigOverrides() {
             Map<String, String> configs = new HashMap<>();
             configs.put("quarkus.config.locations", "test-profile.properties");
             configs.put("smallrye.config.locations", "relocate.properties");
+            configs.put("%custom.quarkus.http.enable-compression", "true");
             return configs;
         }
 


### PR DESCRIPTION
- Fixes #53383 

Relates to:
- https://github.com/quarkusio/quarkus/pull/53098
- https://github.com/quarkusio/quarkus/pull/51248

With https://github.com/quarkusio/quarkus/pull/51248, we use a new `Config` instance to ensure nothing can replace build time and runtime fixed values. The issus is that `Config` instance was running without a specific profile. It works, when we stick with the  default launch modes, but causing issues when there is a different profile in build time. I've now fixed the profile in this specific `Config` to the build time profile.