### PR TITLE
[4.0] Migrate the Undertow extension to Vert.x 5

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -31,7 +31,7 @@
         <resteasy.version>6.2.15.Final</resteasy.version>
         <opentelemetry-instrumentation.version>2.25.0-alpha</opentelemetry-instrumentation.version> <!-- OTel SDk 1.59.0-->
         <opentelemetry-semconv.version>1.40.0-alpha</opentelemetry-semconv.version>
-        <quarkus-http.version>5.4.0</quarkus-http.version>
+        <quarkus-http.version>6.0.0.Alpha3</quarkus-http.version>
         <micrometer.version>1.16.3</micrometer.version><!-- keep in sync with hdrhistogram: https://central.sonatype.com/artifact/io.micrometer/micrometer-core -->
         <hdrhistogram.version>2.2.2</hdrhistogram.version><!-- keep in sync with micrometer -->
         <google-auth.version>0.22.0</google-auth.version>

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
@@ -109,8 +109,8 @@ import io.undertow.servlet.spec.ServletContextImpl;
 import io.undertow.util.AttachmentKey;
 import io.undertow.util.ImmediateAuthenticationMechanismFactory;
 import io.undertow.vertx.VertxHttpExchange;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.web.RoutingContext;
 
 /**
@@ -436,20 +436,24 @@ public class UndertowDeploymentRecorder {
                 //we handle auth failure directly
                 event.remove(QuarkusHttpUser.AUTH_FAILURE_HANDLER);
 
+                Buffer buffer = null;
+                if (event.body() != null) {
+                    buffer = event.body().buffer();
+                }
                 VertxHttpExchange exchange = new VertxHttpExchange(event.request(), allocator, executorService, event,
-                        event.getBody());
+                        buffer);
                 exchange.setPushHandler(VertxHttpRecorder.getRootHandler());
 
-                // Note that we can't add an end handler in a separate HttpCompressionHandler because VertxHttpExchange does set
-                // its own end handler and so the end handlers added previously are just ignored...
+                // Note that we can't use HttpCompressionHandler because VertxHttpExchange sets its own
+                // response end handler. However, headersEndHandler is safe to use here since
+                // VertxHttpExchange does not set one. We must use addHeadersEndHandler (not addEndHandler)
+                // because headers need to be modified BEFORE they are flushed to the network.
                 if (!compressMediaTypes.isEmpty()) {
-                    event.addEndHandler(new Handler<AsyncResult<Void>>() {
+                    event.addHeadersEndHandler(new Handler<Void>() {
 
                         @Override
-                        public void handle(AsyncResult<Void> result) {
-                            if (result.succeeded()) {
-                                HttpCompressionHandler.compressIfNeeded(event, compressMediaTypes);
-                            }
+                        public void handle(Void result) {
+                            HttpCompressionHandler.compressIfNeeded(event, compressMediaTypes);
                         }
                     });
                 }

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/graal/VertxSubstitutions.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/graal/VertxSubstitutions.java
@@ -1,12 +1,15 @@
 package io.quarkus.undertow.runtime.graal;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 import java.util.function.BooleanSupplier;
 
 import com.oracle.svm.core.annotate.Delete;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 
-import io.vertx.core.ServiceHelper;
+import io.vertx.core.impl.ServiceHelper;
 import io.vertx.core.spi.JsonFactory;
 import io.vertx.core.spi.json.JsonCodec;
 
@@ -20,16 +23,18 @@ final class Target_io_vertx_core_json_Json {
 
     @Substitute
     public static io.vertx.core.spi.JsonFactory load() {
-        io.vertx.core.spi.JsonFactory factory = ServiceHelper.loadFactoryOrNull(io.vertx.core.spi.JsonFactory.class);
-        if (factory == null) {
-            factory = new JsonFactory() {
+        List<JsonFactory> factories = new ArrayList<>(ServiceHelper.loadFactories(io.vertx.core.spi.JsonFactory.class));
+        factories.sort(Comparator.comparingInt(JsonFactory::order));
+        if (!factories.isEmpty()) {
+            return factories.iterator().next();
+        } else {
+            return new JsonFactory() {
                 @Override
                 public JsonCodec codec() {
                     return null;
                 }
             };
         }
-        return factory;
     }
 }
 


### PR DESCRIPTION
Migrate the Undertow extension to Vert.x 5.

This commit bumps the Quarkus HTTP version to the version using Vert.x 5 (6.x)

Also, it reworks the compression mechanism, as the current approach has a race condition where the header change may occur after the response has been sent (with the header being sent first).

Relates to #51959 