### PR TITLE
Fix Oracle connection rollback interceptor

### DIFF
--- a/extensions/jdbc/jdbc-oracle/runtime/src/main/java/io/quarkus/jdbc/oracle/runtime/RollbackOnConnectionClosePoolInterceptor.java
+++ b/extensions/jdbc/jdbc-oracle/runtime/src/main/java/io/quarkus/jdbc/oracle/runtime/RollbackOnConnectionClosePoolInterceptor.java
@@ -48,7 +48,7 @@ public class RollbackOnConnectionClosePoolInterceptor implements AgroalPoolInter
 
         try {
             if (connection.unwrap(Connection.class) instanceof OracleConnection oracleConnection) {
-                if (connection.isClosed() || connection.getAutoCommit()) {
+                if (oracleConnection.isClosed() || oracleConnection.getAutoCommit()) {
                     return;
                 }
 


### PR DESCRIPTION
- Call `isClosed` and `getAutoCommit` from the unwrapped instance instead
- Fixes #53382 (tested against the reproducer provided by @Croway)
- Follow-ups https://github.com/quarkusio/quarkus/pull/45301
