### PR TITLE
Migrate the reactive routes extension to Vert.x 5

### DIFF
--- a/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/DotNames.java
+++ b/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/DotNames.java
@@ -30,7 +30,6 @@ final class DotNames {
     static final DotName UNI = DotName.createSimple(Uni.class.getName());
     static final DotName MULTI = DotName.createSimple(Multi.class.getName());
     static final DotName BUFFER = DotName.createSimple(Buffer.class.getName());
-    static final DotName MUTINY_BUFFER = DotName.createSimple(io.vertx.mutiny.core.buffer.Buffer.class.getName());
     static final DotName HTTP_SERVER_RESPONSE = DotName.createSimple(HttpServerResponse.class.getName());
     static final DotName HTTP_SERVER_REQUEST = DotName.createSimple(HttpServerRequest.class.getName());
     static final DotName MUTINY_HTTP_SERVER_RESPONSE = DotName.createSimple(

--- a/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/HandlerDescriptor.java
+++ b/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/HandlerDescriptor.java
@@ -106,11 +106,6 @@ class HandlerDescriptor {
         return type != null && type.name().equals(DotNames.BUFFER);
     }
 
-    boolean isPayloadMutinyBuffer() {
-        Type type = getPayloadType();
-        return type != null && type.name().equals(DotNames.MUTINY_BUFFER);
-    }
-
     boolean isFailureHandler() {
         return failureHandler;
     }

--- a/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/Methods.java
+++ b/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/Methods.java
@@ -54,6 +54,7 @@ import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RequestBody;
 import io.vertx.ext.web.RoutingContext;
 
 class Methods {
@@ -67,10 +68,11 @@ class Methods {
     static final MethodDesc REQUEST_GET_PARAM = MethodDesc.of(HttpServerRequest.class, "getParam", String.class, String.class);
     static final MethodDesc REQUEST_GET_HEADER = MethodDesc.of(HttpServerRequest.class, "getHeader",
             String.class, String.class);
-    static final MethodDesc GET_BODY = MethodDesc.of(RoutingContext.class, "getBody", Buffer.class);
-    static final MethodDesc GET_BODY_AS_STRING = MethodDesc.of(RoutingContext.class, "getBodyAsString", String.class);
-    static final MethodDesc GET_BODY_AS_JSON = MethodDesc.of(RoutingContext.class, "getBodyAsJson", JsonObject.class);
-    static final MethodDesc GET_BODY_AS_JSON_ARRAY = MethodDesc.of(RoutingContext.class, "getBodyAsJsonArray", JsonArray.class);
+    static final MethodDesc BODY = MethodDesc.of(RoutingContext.class, "body", RequestBody.class);
+    static final MethodDesc REQUEST_BODY_BUFFER = MethodDesc.of(RequestBody.class, "buffer", Buffer.class);
+    static final MethodDesc REQUEST_BODY_AS_STRING = MethodDesc.of(RequestBody.class, "asString", String.class);
+    static final MethodDesc REQUEST_BODY_AS_JSON_OBJECT = MethodDesc.of(RequestBody.class, "asJsonObject", JsonObject.class);
+    static final MethodDesc REQUEST_BODY_AS_JSON_ARRAY = MethodDesc.of(RequestBody.class, "asJsonArray", JsonArray.class);
     static final MethodDesc JSON_OBJECT_MAP_TO = MethodDesc.of(JsonObject.class, "mapTo", Object.class, Class.class);
     static final MethodDesc REQUEST_PARAMS = MethodDesc.of(HttpServerRequest.class, "params", MultiMap.class);
     static final MethodDesc REQUEST_HEADERS = MethodDesc.of(HttpServerRequest.class, "headers", MultiMap.class);
@@ -89,8 +91,6 @@ class Methods {
             void.class, Multi.class, RoutingContext.class);
     static final MethodDesc MULTI_SUBSCRIBE_BUFFER = MethodDesc.of(MultiSupport.class, "subscribeBuffer",
             void.class, Multi.class, RoutingContext.class);
-    static final MethodDesc MULTI_SUBSCRIBE_MUTINY_BUFFER = MethodDesc.of(MultiSupport.class, "subscribeMutinyBuffer",
-            void.class, Multi.class, RoutingContext.class);
     static final MethodDesc MULTI_SUBSCRIBE_OBJECT = MethodDesc.of(MultiSupport.class, "subscribeObject",
             void.class, Multi.class, RoutingContext.class);
 
@@ -98,8 +98,6 @@ class Methods {
     static final MethodDesc MULTI_SSE_SUBSCRIBE_STRING = MethodDesc.of(MultiSseSupport.class, "subscribeString",
             void.class, Multi.class, RoutingContext.class);
     static final MethodDesc MULTI_SSE_SUBSCRIBE_BUFFER = MethodDesc.of(MultiSseSupport.class, "subscribeBuffer",
-            void.class, Multi.class, RoutingContext.class);
-    static final MethodDesc MULTI_SSE_SUBSCRIBE_MUTINY_BUFFER = MethodDesc.of(MultiSseSupport.class, "subscribeMutinyBuffer",
             void.class, Multi.class, RoutingContext.class);
     static final MethodDesc MULTI_SSE_SUBSCRIBE_OBJECT = MethodDesc.of(MultiSseSupport.class, "subscribeObject",
             void.class, Multi.class, RoutingContext.class);
@@ -127,8 +125,6 @@ class Methods {
     static final MethodDesc END_WITH_BUFFER = MethodDesc.of(HttpServerResponse.class, "end", Future.class, Buffer.class);
     static final MethodDesc SET_STATUS = MethodDesc.of(HttpServerResponse.class, "setStatusCode",
             HttpServerResponse.class, Integer.TYPE);
-    static final MethodDesc MUTINY_GET_DELEGATE = MethodDesc.of(io.vertx.mutiny.core.buffer.Buffer.class, "getDelegate",
-            Buffer.class);
 
     static final MethodDesc JSON_ENCODE = MethodDesc.of(Json.class, "encode", String.class, Object.class);
 
@@ -200,7 +196,7 @@ class Methods {
     }
 
     static MethodDesc getEndMethodForContentType(HandlerDescriptor descriptor) {
-        if (descriptor.isPayloadBuffer() || descriptor.isPayloadMutinyBuffer()) {
+        if (descriptor.isPayloadBuffer()) {
             return END_WITH_BUFFER;
         }
         return END_WITH_STRING;

--- a/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/ReactiveRoutesProcessor.java
+++ b/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/ReactiveRoutesProcessor.java
@@ -793,9 +793,7 @@ class ReactiveRoutesProcessor {
                             }
                         });
                         tc.catch_(Methods.VALIDATION_CONSTRAINT_VIOLATION_EXCEPTION, "e", (b1, e) -> {
-                            boolean forceJsonEncoding = !descriptor.isPayloadString()
-                                    && !descriptor.isPayloadBuffer()
-                                    && !descriptor.isPayloadMutinyBuffer();
+                            boolean forceJsonEncoding = !descriptor.isPayloadString() && !descriptor.isPayloadBuffer();
                             b1.invokeStatic(Methods.VALIDATION_HANDLE_VIOLATION, e, routingContext,
                                     Const.of(forceJsonEncoding));
                             b1.return_();
@@ -935,8 +933,6 @@ class ReactiveRoutesProcessor {
             bc.invokeStatic(Methods.MULTI_SUBSCRIBE_VOID, res, routingContext);
         } else if (descriptor.isPayloadBuffer()) {
             bc.invokeStatic(Methods.MULTI_SUBSCRIBE_BUFFER, res, routingContext);
-        } else if (descriptor.isPayloadMutinyBuffer()) {
-            bc.invokeStatic(Methods.MULTI_SUBSCRIBE_MUTINY_BUFFER, res, routingContext);
         } else if (descriptor.isPayloadString()) {
             bc.invokeStatic(Methods.MULTI_SUBSCRIBE_STRING, res, routingContext);
         } else { // Multi<Object> - encode to json.
@@ -959,8 +955,6 @@ class ReactiveRoutesProcessor {
             bc.invokeStatic(Methods.MULTI_SUBSCRIBE_VOID, res, routingContext);
         } else if (descriptor.isPayloadBuffer()) {
             bc.invokeStatic(Methods.MULTI_SSE_SUBSCRIBE_BUFFER, res, routingContext);
-        } else if (descriptor.isPayloadMutinyBuffer()) {
-            bc.invokeStatic(Methods.MULTI_SSE_SUBSCRIBE_MUTINY_BUFFER, res, routingContext);
         } else if (descriptor.isPayloadString()) {
             bc.invokeStatic(Methods.MULTI_SSE_SUBSCRIBE_STRING, res, routingContext);
         } else { // Multi<Object> - encode to json.
@@ -983,7 +977,7 @@ class ReactiveRoutesProcessor {
             bc.invokeStatic(Methods.MULTI_SUBSCRIBE_VOID, res, routingContext);
         } else if (descriptor.isPayloadString()) {
             bc.invokeStatic(Methods.MULTI_NDJSON_SUBSCRIBE_STRING, res, routingContext);
-        } else if (descriptor.isPayloadBuffer() || descriptor.isPayloadMutinyBuffer()) {
+        } else if (descriptor.isPayloadBuffer()) {
             bc.invokeStatic(Methods.MULTI_JSON_FAIL, routingContext);
         } else { // Multi<Object> - encode to json.
             bc.invokeStatic(Methods.MULTI_NDJSON_SUBSCRIBE_OBJECT, res, routingContext);
@@ -1006,7 +1000,7 @@ class ReactiveRoutesProcessor {
             bc.invokeStatic(Methods.MULTI_JSON_SUBSCRIBE_VOID, res, routingContext);
         } else if (descriptor.isPayloadString()) {
             bc.invokeStatic(Methods.MULTI_JSON_SUBSCRIBE_STRING, res, routingContext);
-        } else if (descriptor.isPayloadBuffer() || descriptor.isPayloadMutinyBuffer()) {
+        } else if (descriptor.isPayloadBuffer()) {
             bc.invokeStatic(Methods.MULTI_JSON_FAIL, routingContext);
         } else { // Multi<Object> - encode to json.
             bc.invokeStatic(Methods.MULTI_JSON_SUBSCRIBE_OBJECT, res, routingContext);
@@ -1138,10 +1132,6 @@ class ReactiveRoutesProcessor {
             BlockCreator bc, Expr this_, FieldDesc validatorField) {
         if (descriptor.isPayloadString() || descriptor.isPayloadBuffer()) {
             return result;
-        }
-
-        if (descriptor.isPayloadMutinyBuffer()) {
-            return bc.invokeVirtual(Methods.MUTINY_GET_DELEGATE, result);
         }
 
         // Encode to Json
@@ -1376,14 +1366,15 @@ class ReactiveRoutesProcessor {
                     public Expr get(MethodParameterInfo methodParam, Set<AnnotationInstance> annotations, Var routingContext,
                             BlockCreator bc, BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchy) {
                         Type paramType = methodParam.type();
+                        Expr body = bc.invokeInterface(Methods.BODY, routingContext);
                         if (paramType.name().equals(DotName.STRING_NAME)) {
-                            return bc.invokeInterface(Methods.GET_BODY_AS_STRING, routingContext);
+                            return bc.invokeInterface(Methods.REQUEST_BODY_AS_STRING, body);
                         } else if (paramType.name().equals(DotNames.BUFFER)) {
-                            return bc.invokeInterface(Methods.GET_BODY, routingContext);
+                            return bc.invokeInterface(Methods.REQUEST_BODY_BUFFER, body);
                         } else if (paramType.name().equals(DotNames.JSON_OBJECT)) {
-                            return bc.invokeInterface(Methods.GET_BODY_AS_JSON, routingContext);
+                            return bc.invokeInterface(Methods.REQUEST_BODY_AS_JSON_OBJECT, body);
                         } else if (paramType.name().equals(DotNames.JSON_ARRAY)) {
-                            return bc.invokeInterface(Methods.GET_BODY_AS_JSON_ARRAY, routingContext);
+                            return bc.invokeInterface(Methods.REQUEST_BODY_AS_JSON_ARRAY, body);
                         }
                         // This should never happen
                         throw new IllegalArgumentException("Unsupported param type: " + paramType);
@@ -1402,8 +1393,9 @@ class ReactiveRoutesProcessor {
                             BlockCreator b0, BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchy) {
                         Type paramType = methodParam.type();
                         registerForReflection(paramType, reflectiveHierarchy);
+                        Expr body = b0.invokeInterface(Methods.BODY, routingContext);
                         LocalVar bodyAsJson = b0.localVar("bodyAsJson",
-                                b0.invokeInterface(Methods.GET_BODY_AS_JSON, routingContext));
+                                b0.invokeInterface(Methods.REQUEST_BODY_AS_JSON_OBJECT, body));
                         LocalVar result = b0.localVar("result", Const.ofDefault(Object.class));
                         b0.ifNotNull(bodyAsJson, b1 -> {
                             // TODO load `paramType` class from TCCL

--- a/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/SimpleRouteTest.java
+++ b/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/SimpleRouteTest.java
@@ -113,7 +113,7 @@ public class SimpleRouteTest {
 
         @Route(path = "/body", methods = POST, consumes = "text/plain")
         void post(RoutingContext context) {
-            context.response().setStatusCode(200).end("Hello " + context.getBodyAsString() + "!");
+            context.response().setStatusCode(200).end("Hello " + context.body().asString() + "!");
         }
 
         @Route
@@ -153,7 +153,7 @@ public class SimpleRouteTest {
 
         @Route(path = "/hello-event-bus", methods = GET)
         void helloEventBus(RoutingExchange exchange) {
-            eventBus.request("hello", exchange.getParam("name").orElse("missing"), ar -> {
+            eventBus.request("hello", exchange.getParam("name").orElse("missing")).onComplete(ar -> {
                 if (ar.succeeded()) {
                     exchange.ok(ar.result().body().toString());
                 } else {

--- a/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/cs/CompletionStageRouteTest.java
+++ b/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/cs/CompletionStageRouteTest.java
@@ -27,7 +27,6 @@ public class CompletionStageRouteTest {
     public void testCsRoute() {
         when().get("/hello").then().statusCode(200).body(is("Hello world!"));
         when().get("/hello-buffer").then().statusCode(200).body(is("Buffer"));
-        when().get("/hello-mutiny-buffer").then().statusCode(200).body(is("Mutiny Buffer"));
 
         when().get("/person").then().statusCode(200)
                 .body("name", is("neo"))
@@ -57,11 +56,6 @@ public class CompletionStageRouteTest {
         @Route(path = "hello-buffer")
         CompletionStage<Buffer> helloWithBuffer(RoutingContext context) {
             return CompletableFuture.completedFuture(Buffer.buffer("Buffer"));
-        }
-
-        @Route(path = "hello-mutiny-buffer")
-        CompletionStage<io.vertx.mutiny.core.buffer.Buffer> helloWithMutinyBuffer(RoutingContext context) {
-            return CompletableFuture.completedFuture(io.vertx.mutiny.core.buffer.Buffer.buffer("Mutiny Buffer"));
         }
 
         @Route(path = "failure")

--- a/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/mutiny/MultiRouteTest.java
+++ b/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/mutiny/MultiRouteTest.java
@@ -39,8 +39,6 @@ public class MultiRouteTest {
         when().get("/buffers").then().statusCode(200).body(is("Buffer Buffer Buffer."));
         when().get("/buffers-and-fail").then().statusCode(200).body(containsString("Buffer"));
 
-        when().get("/mutiny-buffer").then().statusCode(200).body(is("BufferBuffer"));
-
         when().get("/void").then().statusCode(204).body(hasLength(0));
 
         when().get("/people").then().statusCode(200)
@@ -97,12 +95,6 @@ public class MultiRouteTest {
                             Buffer.buffer(" Buffer.")),
                     Multi.createFrom().failure(new IOException("boom")));
 
-        }
-
-        @Route(path = "mutiny-buffer")
-        Multi<io.vertx.mutiny.core.buffer.Buffer> bufferMutiny(RoutingContext context) {
-            return Multi.createFrom().items(io.vertx.mutiny.core.buffer.Buffer.buffer("Buffer"),
-                    io.vertx.mutiny.core.buffer.Buffer.buffer("Buffer"));
         }
 
         @Route(path = "void")

--- a/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/mutiny/NdjsonMultiRouteWithAsJsonStreamTest.java
+++ b/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/mutiny/NdjsonMultiRouteWithAsJsonStreamTest.java
@@ -12,6 +12,7 @@ import io.quarkus.test.QuarkusExtensionTest;
 import io.quarkus.vertx.web.ReactiveRoutes;
 import io.quarkus.vertx.web.Route;
 import io.smallrye.mutiny.Multi;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.ext.web.RoutingContext;
 
@@ -77,6 +78,8 @@ public class NdjsonMultiRouteWithAsJsonStreamTest {
                 // @formatter:on
                 .header(HttpHeaders.CONTENT_TYPE.toString(), CONTENT_TYPE_STREAM_JSON);
 
+        when().get("/buffers").then().statusCode(500);
+
         when().get("/failure").then().statusCode(500).body(containsString("boom"));
         when().get("/null").then().statusCode(500).body(containsString(NullPointerException.class.getName()));
         when().get("/sync-failure").then().statusCode(500).body(containsString("boom"));
@@ -135,6 +138,11 @@ public class NdjsonMultiRouteWithAsJsonStreamTest {
                     new Person("superman", 1),
                     new Person("batman", 2),
                     new Person("spiderman", 3)));
+        }
+
+        @Route(path = "/buffers")
+        Multi<Buffer> buffers(RoutingContext context) {
+            return ReactiveRoutes.asJsonStream(Multi.createFrom().items(Buffer.buffer("Buffer"), Buffer.buffer("Buffer")));
         }
 
         @Route(path = "/failure")

--- a/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/mutiny/NdjsonMultiRouteWithContentTypeTest.java
+++ b/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/mutiny/NdjsonMultiRouteWithContentTypeTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusExtensionTest;
 import io.quarkus.vertx.web.Route;
 import io.smallrye.mutiny.Multi;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.ext.web.RoutingContext;
 
@@ -78,6 +79,8 @@ public class NdjsonMultiRouteWithContentTypeTest {
                 // @formatter:on
                 .header(HttpHeaders.CONTENT_TYPE.toString(), JSON_STREAM);
 
+        when().get("/buffers").then().statusCode(500);
+
         when().get("/failure").then().statusCode(500).body(containsString("boom"));
         when().get("/null").then().statusCode(500).body(containsString(NullPointerException.class.getName()));
         when().get("/sync-failure").then().statusCode(500).body(containsString("boom"));
@@ -136,6 +139,11 @@ public class NdjsonMultiRouteWithContentTypeTest {
                     new Person("superman", 1),
                     new Person("batman", 2),
                     new Person("spiderman", 3));
+        }
+
+        @Route(path = "/buffers", produces = ND_JSON)
+        Multi<Buffer> buffers() {
+            return Multi.createFrom().items(Buffer.buffer("Buffer"), Buffer.buffer("Buffer"));
         }
 
         @Route(path = "/failure", produces = ND_JSON)

--- a/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/mutiny/SSEMultiRouteWithAsEventStreamTest.java
+++ b/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/mutiny/SSEMultiRouteWithAsEventStreamTest.java
@@ -52,10 +52,6 @@ public class SSEMultiRouteWithAsEventStreamTest {
                 .body(is("data: Buffer\nid: 0\n\ndata: Buffer\nid: 1\n\ndata: Buffer.\nid: 2\n\n"))
                 .header("content-type", is("text/event-stream"));
 
-        when().get("/mutiny-buffer").then().statusCode(200)
-                .body(is("data: Buffer\nid: 0\n\ndata: Mutiny\nid: 1\n\n"))
-                .header("content-type", is("text/event-stream"));
-
         when().get("/void").then().statusCode(204).body(hasLength(0));
 
         when().get("/people").then().statusCode(200)
@@ -142,13 +138,6 @@ public class SSEMultiRouteWithAsEventStreamTest {
         Multi<Buffer> buffers(RoutingContext context) {
             return ReactiveRoutes.asEventStream(Multi.createFrom()
                     .items(Buffer.buffer("Buffer"), Buffer.buffer("Buffer"), Buffer.buffer("Buffer.")));
-        }
-
-        @Route(path = "mutiny-buffer")
-        Multi<io.vertx.mutiny.core.buffer.Buffer> bufferMutiny(RoutingContext context) {
-            return ReactiveRoutes
-                    .asEventStream(Multi.createFrom().items(io.vertx.mutiny.core.buffer.Buffer.buffer("Buffer"),
-                            io.vertx.mutiny.core.buffer.Buffer.buffer("Mutiny")));
         }
 
         @Route(path = "void")

--- a/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/mutiny/SSEMultiRouteWithContentTypeTest.java
+++ b/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/mutiny/SSEMultiRouteWithContentTypeTest.java
@@ -56,10 +56,6 @@ public class SSEMultiRouteWithContentTypeTest {
                 .body(is("data: Buffer\nid: 0\n\ndata: Buffer\nid: 1\n\ndata: Buffer.\nid: 2\n\n"))
                 .header("content-type", is("text/event-stream"));
 
-        when().get("/mutiny-buffer").then().statusCode(200)
-                .body(is("data: Buffer\nid: 0\n\ndata: Mutiny\nid: 1\n\n"))
-                .header("content-type", is("text/event-stream"));
-
         when().get("/void").then().statusCode(204).body(hasLength(0));
 
         when().get("/people").then().statusCode(200)
@@ -146,12 +142,6 @@ public class SSEMultiRouteWithContentTypeTest {
         Multi<Buffer> buffers() {
             return Multi.createFrom()
                     .items(Buffer.buffer("Buffer"), Buffer.buffer("Buffer"), Buffer.buffer("Buffer."));
-        }
-
-        @Route(path = "mutiny-buffer", produces = EVENT_STREAM)
-        Multi<io.vertx.mutiny.core.buffer.Buffer> bufferMutiny() {
-            return Multi.createFrom().items(io.vertx.mutiny.core.buffer.Buffer.buffer("Buffer"),
-                    io.vertx.mutiny.core.buffer.Buffer.buffer("Mutiny"));
         }
 
         @Route(path = "void", produces = EVENT_STREAM)

--- a/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/mutiny/SyncRouteTest.java
+++ b/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/mutiny/SyncRouteTest.java
@@ -42,9 +42,6 @@ public class SyncRouteTest {
         when().get("hello-buffer-sync").then().statusCode(200).body(is("Sync Buffer"))
                 .header("content-type", is(nullValue()));
 
-        when().get("hello-buffer-mutiny-sync").then().statusCode(200).body(is("Sync Mutiny Buffer"))
-                .header("content-type", is(nullValue()));
-
         when().get("/person-sync").then().statusCode(200)
                 .body("name", is("neo"))
                 .body("id", is(12345))
@@ -85,11 +82,6 @@ public class SyncRouteTest {
         @Route(path = "hello-buffer-sync")
         Buffer helloBufferSync(RoutingContext context) {
             return Buffer.buffer("Sync Buffer");
-        }
-
-        @Route(path = "hello-buffer-mutiny-sync")
-        io.vertx.mutiny.core.buffer.Buffer helloMutinyBufferSync(RoutingContext context) {
-            return io.vertx.mutiny.core.buffer.Buffer.buffer("Sync Mutiny Buffer");
         }
 
         @Route(path = "fail-sync")

--- a/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/mutiny/UniRouteTest.java
+++ b/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/mutiny/UniRouteTest.java
@@ -26,7 +26,6 @@ public class UniRouteTest {
         when().get("/hello").then().statusCode(200).body(is("Hello world!"));
         when().get("/hello-buffer").then().statusCode(200).body(is("Buffer"));
         when().get("/hello-on-pool").then().statusCode(200).body(is("Pool"));
-        when().get("/hello-mutiny-buffer").then().statusCode(200).body(is("Mutiny Buffer"));
 
         when().get("/person").then().statusCode(200)
                 .body("name", is("neo"))
@@ -56,11 +55,6 @@ public class UniRouteTest {
         @Route(path = "hello-buffer")
         Uni<Buffer> helloWithBuffer(RoutingContext context) {
             return Uni.createFrom().item(Buffer.buffer("Buffer"));
-        }
-
-        @Route(path = "hello-mutiny-buffer")
-        Uni<io.vertx.mutiny.core.buffer.Buffer> helloWithMutinyBuffer(RoutingContext context) {
-            return Uni.createFrom().item(io.vertx.mutiny.core.buffer.Buffer.buffer("Mutiny Buffer"));
         }
 
         @Route(path = "hello-on-pool")

--- a/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/params/RouteMethodParametersTest.java
+++ b/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/params/RouteMethodParametersTest.java
@@ -8,6 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
@@ -19,6 +21,7 @@ import io.quarkus.vertx.web.Header;
 import io.quarkus.vertx.web.Param;
 import io.quarkus.vertx.web.Route;
 import io.quarkus.vertx.web.RoutingExchange;
+import io.smallrye.mutiny.Uni;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
@@ -65,6 +68,14 @@ public class RouteMethodParametersTest {
         given().contentType("application/json").body("{\"name\":\"Eleven\"}")
                 .post("/hello-body-pojo?id=13").then().statusCode(200).body("name", is("Eleven"))
                 .body("id", is(13));
+        given().contentType("application/json").body("{\"name\":\"Eleven\"}")
+                .post("/hello-body-uni").then().statusCode(200).body("name", is("Eleven"))
+                .body("id", is(11));
+        given().contentType("application/json").body("{\"name\":\"Eleven\"}")
+                .post("/hello-body-cs").then().statusCode(200).body("name", is("Eleven"))
+                .body("id", is(11));
+        given().contentType("application/json")
+                .post("/hello-body-pojo-empty").then().statusCode(200).body(is("null"));
         when().get("/hello-params-conversion?id=22&size=100&valid=false&doubles=2").then().statusCode(200)
                 .body(is("id=22,size=100,valid=false,doubles=[2.0]"));
         when().get("/hello-param-conversion-optional").then().statusCode(200)
@@ -160,6 +171,25 @@ public class RouteMethodParametersTest {
         Person helloBodyPojo(@Body Person person, @Param("id") Optional<String> primaryKey) {
             person.setId(primaryKey.map(Integer::valueOf).orElse(11));
             return person;
+        }
+
+        @Route(produces = "application/json")
+        Uni<Person> helloBodyUni(@Body JsonObject body) {
+            Person p = body.mapTo(Person.class);
+            p.setId(11);
+            return Uni.createFrom().item(p);
+        }
+
+        @Route(produces = "application/json")
+        CompletionStage<Person> helloBodyCs(@Body JsonObject body) {
+            Person p = body.mapTo(Person.class);
+            p.setId(11);
+            return CompletableFuture.completedFuture(p);
+        }
+
+        @Route
+        String helloBodyPojoEmpty(@Body Person person) {
+            return String.valueOf(person);
         }
 
         @Route

--- a/extensions/reactive-routes/runtime/src/main/java/io/quarkus/vertx/web/Body.java
+++ b/extensions/reactive-routes/runtime/src/main/java/io/quarkus/vertx/web/Body.java
@@ -8,16 +8,16 @@ import java.lang.annotation.Target;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.RequestBody;
 
 /**
  * Identifies a route method parameter that should be injected with a value returned from:
  * <ul>
- * <li>{@link RoutingContext#getBody()} for type {@link Buffer}</li>
- * <li>{@link RoutingContext#getBodyAsString()} for type {@link String}</li>
- * <li>{@link RoutingContext#getBodyAsJson()} for type {@link JsonObject}</li>
- * <li>{@link RoutingContext#getBodyAsJsonArray()} for type {@link JsonArray}</li>
- * <li>{@link RoutingContext#getBodyAsJson()} and {@link JsonObject#mapTo(Class)} for any other type</li>
+ * <li>{@link RequestBody#buffer()} for type {@link Buffer}</li>
+ * <li>{@link RequestBody#asString()} for type {@link String}</li>
+ * <li>{@link RequestBody#asJsonObject()} for type {@link JsonObject}</li>
+ * <li>{@link RequestBody#asJsonArray()} for type {@link JsonArray}</li>
+ * <li>{{@link JsonObject#mapTo(Class)} for any other type</li>
  * </ul>
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/extensions/reactive-routes/runtime/src/main/java/io/quarkus/vertx/web/runtime/MultiJsonArraySupport.java
+++ b/extensions/reactive-routes/runtime/src/main/java/io/quarkus/vertx/web/runtime/MultiJsonArraySupport.java
@@ -13,7 +13,6 @@ import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.Json;
 import io.vertx.ext.web.RoutingContext;
 
-@SuppressWarnings("ReactiveStreamsSubscriberImplementation")
 public class MultiJsonArraySupport {
 
     private MultiJsonArraySupport() {
@@ -57,7 +56,7 @@ public class MultiJsonArraySupport {
                 } else {
                     toBeWritten = Buffer.buffer(",").appendBuffer(item);
                 }
-                response.write(toBeWritten, new Handler<AsyncResult<Void>>() {
+                response.write(toBeWritten).onComplete(new Handler<AsyncResult<Void>>() {
                     @Override
                     public void handle(AsyncResult<Void> ar) {
                         onWriteDone(upstream, ar, rc);

--- a/extensions/reactive-routes/runtime/src/main/java/io/quarkus/vertx/web/runtime/MultiNdjsonSupport.java
+++ b/extensions/reactive-routes/runtime/src/main/java/io/quarkus/vertx/web/runtime/MultiNdjsonSupport.java
@@ -12,7 +12,6 @@ import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.Json;
 import io.vertx.ext.web.RoutingContext;
 
-@SuppressWarnings("ReactiveStreamsSubscriberImplementation")
 public class MultiNdjsonSupport {
 
     private MultiNdjsonSupport() {
@@ -63,7 +62,7 @@ public class MultiNdjsonSupport {
             @Override
             public void onNext(Buffer item) {
                 initialize(response, rc);
-                response.write(item, ar -> onWriteDone(upstream, ar, rc));
+                response.write(item).onComplete(ar -> onWriteDone(upstream, ar, rc));
             }
 
             @Override

--- a/extensions/reactive-routes/runtime/src/main/java/io/quarkus/vertx/web/runtime/MultiSseSupport.java
+++ b/extensions/reactive-routes/runtime/src/main/java/io/quarkus/vertx/web/runtime/MultiSseSupport.java
@@ -15,7 +15,6 @@ import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.Json;
 import io.vertx.ext.web.RoutingContext;
 
-@SuppressWarnings("ReactiveStreamsSubscriberImplementation")
 public class MultiSseSupport {
 
     private MultiSseSupport() {
@@ -63,7 +62,7 @@ public class MultiSseSupport {
             @Override
             public void onNext(Buffer item) {
                 initialize(response);
-                response.write(item, new Handler<>() {
+                response.write(item).onComplete(new Handler<>() {
                     @Override
                     public void handle(AsyncResult<Void> ar) {
                         onWriteDone(upstream, ar, rc);
@@ -101,7 +100,7 @@ public class MultiSseSupport {
                 Buffer buffer = Buffer.buffer("data: ").appendBuffer(item).appendString("\n")
                         .appendString("id: " + count.getAndIncrement())
                         .appendString("\n\n");
-                response.write(buffer, new Handler<>() {
+                response.write(buffer).onComplete(new Handler<>() {
                     @Override
                     public void handle(AsyncResult<Void> ar) {
                         onWriteDone(upstream, ar, rc);
@@ -119,15 +118,6 @@ public class MultiSseSupport {
                 endOfStream(response);
             }
         });
-    }
-
-    public static void subscribeMutinyBuffer(Multi<io.vertx.mutiny.core.buffer.Buffer> multi, RoutingContext rc) {
-        subscribeBuffer(multi.map(new Function<>() {
-            @Override
-            public Buffer apply(io.vertx.mutiny.core.buffer.Buffer b) {
-                return b.getDelegate();
-            }
-        }), rc);
     }
 
     public static void subscribeObject(Multi<Object> multi, RoutingContext rc) {

--- a/extensions/reactive-routes/runtime/src/main/java/io/quarkus/vertx/web/runtime/MultiSupport.java
+++ b/extensions/reactive-routes/runtime/src/main/java/io/quarkus/vertx/web/runtime/MultiSupport.java
@@ -13,7 +13,6 @@ import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.Json;
 import io.vertx.ext.web.RoutingContext;
 
-@SuppressWarnings("ReactiveStreamsSubscriberImplementation")
 public class MultiSupport {
 
     private MultiSupport() {
@@ -44,7 +43,7 @@ public class MultiSupport {
     }
 
     public static void subscribeString(Multi<String> multi, RoutingContext rc) {
-        subscribeBuffer(multi.map(s -> Buffer.buffer(s)), rc);
+        subscribeBuffer(multi.map(Buffer::buffer), rc);
     }
 
     private static void onWriteDone(Subscription subscription, AsyncResult<Void> ar, RoutingContext rc) {
@@ -69,7 +68,7 @@ public class MultiSupport {
 
             @Override
             public void onNext(Buffer item) {
-                response.write(item, new Handler<AsyncResult<Void>>() {
+                response.write(item).onComplete(new Handler<AsyncResult<Void>>() {
                     @Override
                     public void handle(AsyncResult<Void> ar) {
                         onWriteDone(upstream, ar, rc);
@@ -90,15 +89,6 @@ public class MultiSupport {
                 response.end();
             }
         });
-    }
-
-    public static void subscribeMutinyBuffer(Multi<io.vertx.mutiny.core.buffer.Buffer> multi, RoutingContext rc) {
-        subscribeBuffer(multi.map(new Function<io.vertx.mutiny.core.buffer.Buffer, Buffer>() {
-            @Override
-            public Buffer apply(io.vertx.mutiny.core.buffer.Buffer b) {
-                return b.getDelegate();
-            }
-        }), rc);
     }
 
     public static void subscribeObject(Multi<Object> multi, RoutingContext rc) {


### PR DESCRIPTION
Mostly class relocations, removing the Mutiny Buffer, and a bit of bytecode generation as the API to access the body in Vert.x 5 has changed. 

I've also added a few tests, nothing major (I have to read NDJson "spec" again)