### PR TITLE
[4.0] Migrate the Redis extension to Vert.x 5

### DIFF
--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/RedisConfigureClientNameTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/RedisConfigureClientNameTest.java
@@ -12,8 +12,8 @@ import io.quarkus.redis.client.RedisClientName;
 import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.test.QuarkusExtensionTest;
 import io.quarkus.test.common.QuarkusTestResource;
-import io.vertx.mutiny.redis.client.Response;
 import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Response;
 
 @QuarkusTestResource(RedisTestResource.class)
 public class RedisConfigureClientNameTest {

--- a/extensions/redis-client/runtime/src/etc/RedisCommandGenerator.java
+++ b/extensions/redis-client/runtime/src/etc/RedisCommandGenerator.java
@@ -14,7 +14,7 @@ import org.slf4j.LoggerFactory;
 import io.vertx.mutiny.core.Vertx;
 import io.vertx.mutiny.redis.client.Redis;
 import io.vertx.mutiny.redis.client.RedisAPI;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 import io.vertx.redis.client.RedisOptions;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/client/reactive/ReactiveRedisClient.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/client/reactive/ReactiveRedisClient.java
@@ -7,7 +7,7 @@ import java.util.List;
 import io.quarkus.redis.client.RedisClient;
 import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 
 /**
  * A Redis client offering reactive Redis commands.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/ReactiveRedisDataSource.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/ReactiveRedisDataSource.java
@@ -33,9 +33,9 @@ import io.quarkus.redis.datasource.transactions.TransactionResult;
 import io.quarkus.redis.datasource.value.ReactiveValueCommands;
 import io.smallrye.common.annotation.Experimental;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Command;
 import io.vertx.mutiny.redis.client.Redis;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Response;
 
 /**
  * Non-Blocking and Reactive Redis Data Source.
@@ -990,16 +990,6 @@ public interface ReactiveRedisDataSource {
      * @return the response
      */
     Uni<Response> execute(Command command, String... args);
-
-    /**
-     * Executes a command.
-     * This method is used to execute commands not offered by the API.
-     *
-     * @param command the command
-     * @param args the parameters, encoded as String.
-     * @return the response
-     */
-    Uni<Response> execute(io.vertx.redis.client.Command command, String... args);
 
     /**
      * @return the underlying Redis client.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/RedisDataSource.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/RedisDataSource.java
@@ -33,8 +33,8 @@ import io.quarkus.redis.datasource.transactions.TransactionResult;
 import io.quarkus.redis.datasource.transactions.TransactionalRedisDataSource;
 import io.quarkus.redis.datasource.value.ValueCommands;
 import io.smallrye.common.annotation.Experimental;
-import io.vertx.mutiny.redis.client.Command;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Response;
 
 /**
  * Synchronous / Blocking Redis Data Source.
@@ -990,16 +990,6 @@ public interface RedisDataSource {
      * @return the response
      */
     Response execute(Command command, String... args);
-
-    /**
-     * Executes a command.
-     * This method is used to execute commands not offered by the API.
-     *
-     * @param command the command
-     * @param args the parameters, encoded as String.
-     * @return the response
-     */
-    Response execute(io.vertx.redis.client.Command command, String... args);
 
     /**
      * @return the reactive data source.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/search/Document.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/search/Document.java
@@ -4,7 +4,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import io.vertx.core.json.JsonObject;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 
 /**
  * Represents a document containing in the response of a {@code ft.search} command.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/transactions/ReactiveTransactionalRedisDataSource.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/transactions/ReactiveTransactionalRedisDataSource.java
@@ -22,7 +22,7 @@ import io.quarkus.redis.datasource.topk.ReactiveTransactionalTopKCommands;
 import io.quarkus.redis.datasource.value.ReactiveTransactionalValueCommands;
 import io.smallrye.common.annotation.Experimental;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Command;
+import io.vertx.redis.client.Command;
 
 /**
  * Redis Data Source object used to execute commands in a Redis transaction ({@code MULTI}).
@@ -524,13 +524,4 @@ public interface ReactiveTransactionalRedisDataSource {
      */
     Uni<Void> execute(Command command, String... args);
 
-    /**
-     * Executes a command.
-     * This method is used to execute commands not offered by the API.
-     *
-     * @param command the command
-     * @param args the parameters, encoded as String.
-     * @return the response
-     */
-    Uni<Void> execute(io.vertx.redis.client.Command command, String... args);
 }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/transactions/TransactionalRedisDataSource.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/transactions/TransactionalRedisDataSource.java
@@ -21,7 +21,7 @@ import io.quarkus.redis.datasource.timeseries.TransactionalTimeSeriesCommands;
 import io.quarkus.redis.datasource.topk.TransactionalTopKCommands;
 import io.quarkus.redis.datasource.value.TransactionalValueCommands;
 import io.smallrye.common.annotation.Experimental;
-import io.vertx.mutiny.redis.client.Command;
+import io.vertx.redis.client.Command;
 
 /**
  * Redis Data Source object used to execute commands in a Redis transaction ({@code MULTI}).
@@ -519,14 +519,5 @@ public interface TransactionalRedisDataSource {
      * @param args the parameters, encoded as String.
      */
     void execute(Command command, String... args);
-
-    /**
-     * Executes a command.
-     * This method is used to execute commands not offered by the API.
-     *
-     * @param command the command
-     * @param args the parameters, encoded as String.
-     */
-    void execute(io.vertx.redis.client.Command command, String... args);
 
 }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/ObservableRedis.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/ObservableRedis.java
@@ -3,7 +3,6 @@ package io.quarkus.redis.runtime.client;
 import java.util.List;
 
 import io.vertx.codegen.annotations.Nullable;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.redis.client.Redis;
@@ -35,46 +34,14 @@ public class ObservableRedis implements Redis {
     }
 
     @Override
-    public Redis connect(Handler<AsyncResult<RedisConnection>> handler) {
-        this.redis.connect(ar -> {
-            if (ar.failed()) {
-                handler.handle(Future.failedFuture(ar.cause()));
-            } else {
-                handler.handle(Future.succeededFuture(new ObservableRedisConnection(ar.result())));
-            }
-        });
-        return this;
-    }
-
-    @Override
-    public Redis send(Request command, Handler<AsyncResult<@Nullable Response>> onSend) {
-        long begin = System.nanoTime();
-        redis.send(command, ar -> {
-            report(System.nanoTime() - begin, ar.succeeded());
-            onSend.handle(ar);
-        });
-        return this;
-    }
-
-    @Override
-    public Redis batch(List<Request> commands, Handler<AsyncResult<List<@Nullable Response>>> onSend) {
-        long begin = System.nanoTime();
-        redis.batch(commands, ar -> {
-            report(System.nanoTime() - begin, ar.succeeded());
-            onSend.handle(ar);
-        });
-        return this;
-    }
-
-    @Override
     public Future<RedisConnection> connect() {
         return redis.connect()
                 .map(ObservableRedisConnection::new);
     }
 
     @Override
-    public void close() {
-        redis.close();
+    public Future<Void> close() {
+        return redis.close();
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/ReactiveRedisClientImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/ReactiveRedisClientImpl.java
@@ -4,11 +4,11 @@ import java.util.List;
 
 import io.quarkus.redis.client.reactive.ReactiveRedisClient;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Command;
 import io.vertx.mutiny.redis.client.Redis;
 import io.vertx.mutiny.redis.client.RedisAPI;
-import io.vertx.mutiny.redis.client.Request;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Request;
+import io.vertx.redis.client.Response;
 
 class ReactiveRedisClientImpl implements ReactiveRedisClient {
     private final RedisAPI redisAPI;

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/RedisClientImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/RedisClientImpl.java
@@ -5,10 +5,10 @@ import java.util.List;
 
 import io.quarkus.redis.client.RedisClient;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Command;
 import io.vertx.mutiny.redis.client.Redis;
 import io.vertx.mutiny.redis.client.RedisAPI;
-import io.vertx.mutiny.redis.client.Request;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Request;
 import io.vertx.redis.client.Response;
 
 class RedisClientImpl implements RedisClient {
@@ -1053,11 +1053,7 @@ class RedisClientImpl implements RedisClient {
         return await(redisAPI.zunionstore(args));
     }
 
-    private Response await(Uni<io.vertx.mutiny.redis.client.Response> mutinyResponse) {
-        io.vertx.mutiny.redis.client.Response response = mutinyResponse.await().atMost(timeout);
-        if (response == null) {
-            return null;
-        }
-        return response.getDelegate();
+    private Response await(Uni<Response> response) {
+        return response.await().atMost(timeout);
     }
 }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/RedisClientRecorder.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/RedisClientRecorder.java
@@ -31,10 +31,10 @@ import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.tls.TlsConfigurationRegistry;
 import io.vertx.mutiny.core.Vertx;
-import io.vertx.mutiny.redis.client.Command;
 import io.vertx.mutiny.redis.client.Redis;
 import io.vertx.mutiny.redis.client.RedisAPI;
-import io.vertx.mutiny.redis.client.Request;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Request;
 
 @Recorder
 public class RedisClientRecorder {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/RedisDataLoader.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/RedisDataLoader.java
@@ -8,11 +8,11 @@ import java.util.stream.Collectors;
 import org.jboss.logging.Logger;
 
 import io.quarkus.runtime.configuration.ConfigurationException;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.mutiny.core.Vertx;
-import io.vertx.mutiny.core.buffer.Buffer;
-import io.vertx.mutiny.redis.client.Command;
 import io.vertx.mutiny.redis.client.Redis;
-import io.vertx.mutiny.redis.client.Request;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Request;
 
 public class RedisDataLoader {
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/health/RedisHealthCheck.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/health/RedisHealthCheck.java
@@ -22,10 +22,10 @@ import io.quarkus.arc.InstanceHandle;
 import io.quarkus.redis.client.RedisClientName;
 import io.quarkus.redis.runtime.client.config.RedisConfig;
 import io.smallrye.mutiny.TimeoutException;
-import io.vertx.mutiny.redis.client.Command;
 import io.vertx.mutiny.redis.client.Redis;
-import io.vertx.mutiny.redis.client.Request;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Request;
+import io.vertx.redis.client.Response;
 
 @Readiness
 @ApplicationScoped

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractAutoSuggestCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractAutoSuggestCommands.java
@@ -7,8 +7,8 @@ import java.lang.reflect.Type;
 
 import io.quarkus.redis.datasource.autosuggest.GetArgs;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Command;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Response;
 
 public class AbstractAutoSuggestCommands<K> extends AbstractRedisCommands {
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractBitMapCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractBitMapCommands.java
@@ -9,8 +9,8 @@ import java.util.List;
 
 import io.quarkus.redis.datasource.bitmap.BitFieldArgs;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Command;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Response;
 
 class AbstractBitMapCommands<K> extends AbstractRedisCommands {
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractBloomCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractBloomCommands.java
@@ -8,8 +8,8 @@ import java.lang.reflect.Type;
 import io.quarkus.redis.datasource.bloom.BfInsertArgs;
 import io.quarkus.redis.datasource.bloom.BfReserveArgs;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Command;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Response;
 
 class AbstractBloomCommands<K, V> extends AbstractRedisCommands {
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractCountMinCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractCountMinCommands.java
@@ -9,8 +9,8 @@ import java.util.List;
 import java.util.Map;
 
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Command;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Response;
 
 public class AbstractCountMinCommands<K, V> extends AbstractRedisCommands {
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractCuckooCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractCuckooCommands.java
@@ -8,8 +8,8 @@ import java.lang.reflect.Type;
 import io.quarkus.redis.datasource.cuckoo.CfInsertArgs;
 import io.quarkus.redis.datasource.cuckoo.CfReserveArgs;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Command;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Response;
 
 public class AbstractCuckooCommands<K, V> extends AbstractRedisCommands {
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractGeoCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractGeoCommands.java
@@ -27,8 +27,8 @@ import io.quarkus.redis.datasource.geo.GeoSearchStoreArgs;
 import io.quarkus.redis.datasource.geo.GeoUnit;
 import io.quarkus.redis.datasource.geo.GeoValue;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Command;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Response;
 
 class AbstractGeoCommands<K, V> extends AbstractRedisCommands {
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractGraphCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractGraphCommands.java
@@ -6,8 +6,8 @@ import java.lang.reflect.Type;
 import java.time.Duration;
 
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Command;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Response;
 
 public class AbstractGraphCommands<K> extends AbstractRedisCommands {
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractHashCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractHashCommands.java
@@ -12,8 +12,8 @@ import java.util.List;
 import java.util.Map;
 
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Command;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Response;
 
 class AbstractHashCommands<K, F, V> extends AbstractRedisCommands {
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractHyperLogLogCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractHyperLogLogCommands.java
@@ -7,8 +7,8 @@ import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 import java.lang.reflect.Type;
 
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Command;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Response;
 
 class AbstractHyperLogLogCommands<K, V> extends AbstractRedisCommands {
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractJsonCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractJsonCommands.java
@@ -13,8 +13,8 @@ import io.smallrye.mutiny.Uni;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.mutiny.redis.client.Command;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Response;
 
 public class AbstractJsonCommands<K> extends AbstractRedisCommands {
     private static final JsonSetArgs JSON_SET_DEFAULT = new JsonSetArgs();

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractKeyCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractKeyCommands.java
@@ -5,8 +5,8 @@ import static io.smallrye.mutiny.helpers.ParameterValidation.doesNotContainNull;
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 import static io.smallrye.mutiny.helpers.ParameterValidation.positive;
 import static io.smallrye.mutiny.helpers.ParameterValidation.positiveOrZero;
-import static io.vertx.mutiny.redis.client.Command.EXPIRETIME;
-import static io.vertx.mutiny.redis.client.Command.PEXPIRETIME;
+import static io.vertx.redis.client.Command.EXPIRETIME;
+import static io.vertx.redis.client.Command.PEXPIRETIME;
 
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
@@ -20,8 +20,8 @@ import io.quarkus.redis.datasource.keys.ExpireArgs;
 import io.quarkus.redis.datasource.keys.RedisKeyNotFoundException;
 import io.quarkus.redis.datasource.keys.RedisValueType;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Command;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Response;
 
 class AbstractKeyCommands<K> extends AbstractRedisCommands {
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractListCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractListCommands.java
@@ -17,8 +17,8 @@ import io.quarkus.redis.datasource.list.KeyValue;
 import io.quarkus.redis.datasource.list.LPosArgs;
 import io.quarkus.redis.datasource.list.Position;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Command;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Response;
 
 class AbstractListCommands<K, V> extends ReactiveSortable<K, V> {
 
@@ -67,7 +67,7 @@ class AbstractListCommands<K, V> extends ReactiveSortable<K, V> {
     }
 
     KeyValue<K, V> decodeKeyValue(Response r) {
-        if (r != null && r.getDelegate() != null) {
+        if (r != null) {
             Response r1 = r.get(0);
             Response r2 = r.get(1);
             K key = marshaller.decode(typeOfKey, r1);
@@ -78,7 +78,7 @@ class AbstractListCommands<K, V> extends ReactiveSortable<K, V> {
     }
 
     KeyValue<K, V> decodeKeyValueWithList(Response r) {
-        if (r != null && r.getDelegate() != null) {
+        if (r != null) {
             Response r1 = r.get(0);
             Response r2 = r.get(1).get(0);
             K key = marshaller.decode(typeOfKey, r1);
@@ -107,7 +107,7 @@ class AbstractListCommands<K, V> extends ReactiveSortable<K, V> {
     }
 
     List<KeyValue<K, V>> decodeListOfKeyValue(Response r) {
-        if (r == null || r.getDelegate() == null) {
+        if (r == null) {
             return Collections.emptyList();
         }
         List<KeyValue<K, V>> res = new ArrayList<>();

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractRedisCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractRedisCommands.java
@@ -3,7 +3,7 @@ package io.quarkus.redis.runtime.datasource;
 import java.util.Set;
 
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 import io.vertx.redis.client.ResponseType;
 
 public class AbstractRedisCommands {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractSearchCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractSearchCommands.java
@@ -15,8 +15,8 @@ import io.quarkus.redis.datasource.search.IndexedField;
 import io.quarkus.redis.datasource.search.QueryArgs;
 import io.quarkus.redis.datasource.search.SpellCheckArgs;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Command;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Response;
 
 public class AbstractSearchCommands<K> extends AbstractRedisCommands {
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractSetCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractSetCommands.java
@@ -10,8 +10,8 @@ import java.util.List;
 import java.util.Set;
 
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Command;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Response;
 
 class AbstractSetCommands<K, V> extends ReactiveSortable<K, V> {
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractSortedSetCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractSortedSetCommands.java
@@ -27,8 +27,8 @@ import io.quarkus.redis.datasource.sortedset.ZAggregateArgs;
 import io.quarkus.redis.datasource.sortedset.ZRangeArgs;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.ParameterValidation;
-import io.vertx.mutiny.redis.client.Command;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Response;
 import io.vertx.redis.client.ResponseType;
 
 class AbstractSortedSetCommands<K, V> extends ReactiveSortable<K, V> {
@@ -756,7 +756,7 @@ class AbstractSortedSetCommands<K, V> extends ReactiveSortable<K, V> {
     }
 
     ScoredValue<V> decodeAsScoredValue(Response r) {
-        if (r == null || r.getDelegate() == null) {
+        if (r == null) {
             return null;
         }
 
@@ -809,14 +809,14 @@ class AbstractSortedSetCommands<K, V> extends ReactiveSortable<K, V> {
     }
 
     List<ScoredValue<V>> decodePopResponseWithCount(Response r) {
-        if (r != null && r.getDelegate() != null && r.size() > 1) {
+        if (r != null && r.size() > 1) {
             return decodeAsListOfScoredValues(r.get(1));
         }
         return Collections.emptyList();
     }
 
     ScoredValue<V> decodePopResponse(Response r) {
-        if (r == null || r.getDelegate() == null) {
+        if (r == null) {
             return null;
         }
         List<ScoredValue<V>> values = decodeAsListOfScoredValues(r.get(1));

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractStreamCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractStreamCommands.java
@@ -23,8 +23,8 @@ import io.quarkus.redis.datasource.stream.XReadArgs;
 import io.quarkus.redis.datasource.stream.XReadGroupArgs;
 import io.quarkus.redis.datasource.stream.XTrimArgs;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Command;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Response;
 
 public class AbstractStreamCommands<K, F, V> extends AbstractRedisCommands {
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractStringCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractStringCommands.java
@@ -10,8 +10,8 @@ import java.lang.reflect.Type;
 import java.util.Map;
 
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Command;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Response;
 
 class AbstractStringCommands<K, V> extends AbstractRedisCommands {
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractTimeSeriesCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractTimeSeriesCommands.java
@@ -19,8 +19,8 @@ import io.quarkus.redis.datasource.timeseries.RangeArgs;
 import io.quarkus.redis.datasource.timeseries.SeriesSample;
 import io.quarkus.redis.datasource.timeseries.TimeSeriesRange;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Command;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Response;
 
 public class AbstractTimeSeriesCommands<K> extends AbstractRedisCommands {
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractTopKCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractTopKCommands.java
@@ -9,8 +9,8 @@ import java.lang.reflect.Type;
 import java.util.Map;
 
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Command;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Response;
 
 public class AbstractTopKCommands<K, V> extends AbstractRedisCommands {
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractTransactionalCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractTransactionalCommands.java
@@ -2,7 +2,7 @@ package io.quarkus.redis.runtime.datasource;
 
 import io.quarkus.redis.datasource.ReactiveTransactionalRedisCommands;
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 
 public class AbstractTransactionalCommands implements ReactiveTransactionalRedisCommands {
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingRedisDataSourceImpl.java
@@ -39,12 +39,12 @@ import io.quarkus.redis.datasource.transactions.TransactionResult;
 import io.quarkus.redis.datasource.transactions.TransactionalRedisDataSource;
 import io.quarkus.redis.datasource.value.ValueCommands;
 import io.vertx.mutiny.core.Vertx;
-import io.vertx.mutiny.redis.client.Command;
 import io.vertx.mutiny.redis.client.Redis;
 import io.vertx.mutiny.redis.client.RedisAPI;
 import io.vertx.mutiny.redis.client.RedisConnection;
-import io.vertx.mutiny.redis.client.Request;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Request;
+import io.vertx.redis.client.Response;
 
 public class BlockingRedisDataSourceImpl implements RedisDataSource {
 
@@ -434,12 +434,6 @@ public class BlockingRedisDataSourceImpl implements RedisDataSource {
 
     @Override
     public Response execute(Command command, String... args) {
-        return reactive.execute(command, args)
-                .await().atMost(timeout);
-    }
-
-    @Override
-    public Response execute(io.vertx.redis.client.Command command, String... args) {
         return reactive.execute(command, args)
                 .await().atMost(timeout);
     }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalRedisDataSourceImpl.java
@@ -24,7 +24,7 @@ import io.quarkus.redis.datasource.topk.TransactionalTopKCommands;
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.quarkus.redis.datasource.transactions.TransactionalRedisDataSource;
 import io.quarkus.redis.datasource.value.TransactionalValueCommands;
-import io.vertx.mutiny.redis.client.Command;
+import io.vertx.redis.client.Command;
 
 public class BlockingTransactionalRedisDataSourceImpl implements TransactionalRedisDataSource {
 
@@ -158,11 +158,6 @@ public class BlockingTransactionalRedisDataSourceImpl implements TransactionalRe
 
     @Override
     public void execute(Command command, String... args) {
-        reactive.execute(command, args).await().atMost(timeout);
-    }
-
-    @Override
-    public void execute(io.vertx.redis.client.Command command, String... args) {
         reactive.execute(command, args).await().atMost(timeout);
     }
 }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/HScanReactiveCursorImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/HScanReactiveCursorImpl.java
@@ -9,8 +9,8 @@ import java.util.Map;
 import io.quarkus.redis.datasource.hash.ReactiveHashScanCursor;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Command;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Response;
 
 public class HScanReactiveCursorImpl<F, V> extends AbstractRedisCommands implements ReactiveHashScanCursor<F, V> {
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/Marshaller.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/Marshaller.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 
 import io.quarkus.redis.datasource.codecs.Codec;
 import io.quarkus.redis.datasource.codecs.Codecs;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 import io.vertx.redis.client.ResponseType;
 
 public class Marshaller {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveAutoSuggestCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveAutoSuggestCommandsImpl.java
@@ -10,7 +10,7 @@ import io.quarkus.redis.datasource.autosuggest.GetArgs;
 import io.quarkus.redis.datasource.autosuggest.ReactiveAutoSuggestCommands;
 import io.quarkus.redis.datasource.autosuggest.Suggestion;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 
 public class ReactiveAutoSuggestCommandsImpl<K> extends AbstractAutoSuggestCommands<K>
         implements ReactiveAutoSuggestCommands<K>, ReactiveRedisCommands {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveBitMapCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveBitMapCommandsImpl.java
@@ -8,7 +8,7 @@ import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.bitmap.BitFieldArgs;
 import io.quarkus.redis.datasource.bitmap.ReactiveBitMapCommands;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 
 public class ReactiveBitMapCommandsImpl<K> extends AbstractBitMapCommands<K>
         implements ReactiveBitMapCommands<K>, ReactiveRedisCommands {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveBloomCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveBloomCommandsImpl.java
@@ -9,7 +9,7 @@ import io.quarkus.redis.datasource.bloom.BfInsertArgs;
 import io.quarkus.redis.datasource.bloom.BfReserveArgs;
 import io.quarkus.redis.datasource.bloom.ReactiveBloomCommands;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 
 public class ReactiveBloomCommandsImpl<K, V> extends AbstractBloomCommands<K, V>
         implements ReactiveBloomCommands<K, V> {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveCountMinCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveCountMinCommandsImpl.java
@@ -10,7 +10,7 @@ import io.quarkus.redis.datasource.ReactiveRedisCommands;
 import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.countmin.ReactiveCountMinCommands;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 
 public class ReactiveCountMinCommandsImpl<K, V> extends AbstractCountMinCommands<K, V>
         implements ReactiveCountMinCommands<K, V>, ReactiveRedisCommands {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveCuckooCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveCuckooCommandsImpl.java
@@ -9,7 +9,7 @@ import io.quarkus.redis.datasource.cuckoo.CfInsertArgs;
 import io.quarkus.redis.datasource.cuckoo.CfReserveArgs;
 import io.quarkus.redis.datasource.cuckoo.ReactiveCuckooCommands;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 
 public class ReactiveCuckooCommandsImpl<K, V> extends AbstractCuckooCommands<K, V>
         implements ReactiveCuckooCommands<K, V>, ReactiveRedisCommands {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveGeoCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveGeoCommandsImpl.java
@@ -18,7 +18,7 @@ import io.quarkus.redis.datasource.geo.GeoUnit;
 import io.quarkus.redis.datasource.geo.GeoValue;
 import io.quarkus.redis.datasource.geo.ReactiveGeoCommands;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 
 public class ReactiveGeoCommandsImpl<K, V> extends AbstractGeoCommands<K, V> implements ReactiveGeoCommands<K, V> {
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveGraphCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveGraphCommandsImpl.java
@@ -13,7 +13,7 @@ import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.graph.GraphQueryResponseItem;
 import io.quarkus.redis.datasource.graph.ReactiveGraphCommands;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 import io.vertx.redis.client.ResponseType;
 
 public class ReactiveGraphCommandsImpl<K> extends AbstractGraphCommands<K>

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveHashCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveHashCommandsImpl.java
@@ -12,7 +12,7 @@ import io.quarkus.redis.datasource.ScanArgs;
 import io.quarkus.redis.datasource.hash.ReactiveHashCommands;
 import io.quarkus.redis.datasource.hash.ReactiveHashScanCursor;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 
 public class ReactiveHashCommandsImpl<K, F, V> extends AbstractHashCommands<K, F, V> implements ReactiveHashCommands<K, F, V> {
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveHyperLogLogCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveHyperLogLogCommandsImpl.java
@@ -5,7 +5,7 @@ import java.lang.reflect.Type;
 import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.hyperloglog.ReactiveHyperLogLogCommands;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 
 public class ReactiveHyperLogLogCommandsImpl<K, V> extends AbstractHyperLogLogCommands<K, V>
         implements ReactiveHyperLogLogCommands<K, V> {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveJsonCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveJsonCommandsImpl.java
@@ -10,11 +10,11 @@ import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.json.JsonSetArgs;
 import io.quarkus.redis.datasource.json.ReactiveJsonCommands;
 import io.smallrye.mutiny.Uni;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.mutiny.core.buffer.Buffer;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 import io.vertx.redis.client.ResponseType;
 
 public class ReactiveJsonCommandsImpl<K> extends AbstractJsonCommands<K> implements ReactiveJsonCommands<K> {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveKeyCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveKeyCommandsImpl.java
@@ -16,7 +16,7 @@ import io.quarkus.redis.datasource.keys.ReactiveKeyCommands;
 import io.quarkus.redis.datasource.keys.ReactiveKeyScanCursor;
 import io.quarkus.redis.datasource.keys.RedisValueType;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 
 public class ReactiveKeyCommandsImpl<K> extends AbstractKeyCommands<K> implements ReactiveKeyCommands<K> {
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveListCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveListCommandsImpl.java
@@ -10,7 +10,7 @@ import io.quarkus.redis.datasource.list.LPosArgs;
 import io.quarkus.redis.datasource.list.Position;
 import io.quarkus.redis.datasource.list.ReactiveListCommands;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 
 public class ReactiveListCommandsImpl<K, V> extends AbstractListCommands<K, V> implements ReactiveListCommands<K, V> {
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactivePubSubCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactivePubSubCommandsImpl.java
@@ -23,11 +23,11 @@ import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.subscription.UniEmitter;
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
-import io.vertx.mutiny.redis.client.Command;
 import io.vertx.mutiny.redis.client.Redis;
 import io.vertx.mutiny.redis.client.RedisAPI;
 import io.vertx.mutiny.redis.client.RedisConnection;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Response;
 
 public class ReactivePubSubCommandsImpl<V> extends AbstractRedisCommands implements ReactivePubSubCommands<V> {
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveRedisDataSourceImpl.java
@@ -38,12 +38,12 @@ import io.quarkus.redis.datasource.transactions.TransactionResult;
 import io.quarkus.redis.datasource.value.ReactiveValueCommands;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.core.Vertx;
-import io.vertx.mutiny.redis.client.Command;
 import io.vertx.mutiny.redis.client.Redis;
 import io.vertx.mutiny.redis.client.RedisAPI;
 import io.vertx.mutiny.redis.client.RedisConnection;
-import io.vertx.mutiny.redis.client.Request;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Request;
+import io.vertx.redis.client.Response;
 
 public class ReactiveRedisDataSourceImpl implements ReactiveRedisDataSource, RedisCommandExecutor {
 
@@ -232,16 +232,6 @@ public class ReactiveRedisDataSourceImpl implements ReactiveRedisDataSource, Red
     public Uni<Response> execute(Command command, String... args) {
         nonNull(command, "command");
         Request request = Request.cmd(command);
-        for (String arg : args) {
-            request.arg(arg);
-        }
-        return execute(request);
-    }
-
-    @Override
-    public Uni<Response> execute(io.vertx.redis.client.Command command, String... args) {
-        nonNull(command, "command");
-        Request request = Request.newInstance(io.vertx.redis.client.Request.cmd(command));
         for (String arg : args) {
             request.arg(arg);
         }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveSearchCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveSearchCommandsImpl.java
@@ -24,7 +24,7 @@ import io.quarkus.redis.datasource.search.SpellCheckArgs;
 import io.quarkus.redis.datasource.search.SpellCheckResponse;
 import io.quarkus.redis.datasource.search.SynDumpResponse;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 import io.vertx.redis.client.ResponseType;
 
 public class ReactiveSearchCommandsImpl<K> extends AbstractSearchCommands<K>

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveSetCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveSetCommandsImpl.java
@@ -12,7 +12,7 @@ import io.quarkus.redis.datasource.ScanArgs;
 import io.quarkus.redis.datasource.set.ReactiveSScanCursor;
 import io.quarkus.redis.datasource.set.ReactiveSetCommands;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 
 public class ReactiveSetCommandsImpl<K, V> extends AbstractSetCommands<K, V> implements ReactiveSetCommands<K, V> {
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveSortable.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveSortable.java
@@ -7,8 +7,8 @@ import java.util.List;
 
 import io.quarkus.redis.datasource.SortArgs;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Command;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Response;
 
 public class ReactiveSortable<K, V> extends AbstractRedisCommands {
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveSortedSetCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveSortedSetCommandsImpl.java
@@ -21,7 +21,7 @@ import io.quarkus.redis.datasource.sortedset.ZAddArgs;
 import io.quarkus.redis.datasource.sortedset.ZAggregateArgs;
 import io.quarkus.redis.datasource.sortedset.ZRangeArgs;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 
 public class ReactiveSortedSetCommandsImpl<K, V> extends AbstractSortedSetCommands<K, V>
         implements ReactiveSortedSetCommands<K, V> {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveStreamCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveStreamCommandsImpl.java
@@ -24,7 +24,7 @@ import io.quarkus.redis.datasource.stream.XReadArgs;
 import io.quarkus.redis.datasource.stream.XReadGroupArgs;
 import io.quarkus.redis.datasource.stream.XTrimArgs;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 import io.vertx.redis.client.ResponseType;
 
 public class ReactiveStreamCommandsImpl<K, F, V> extends AbstractStreamCommands<K, F, V>

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveStringCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveStringCommandsImpl.java
@@ -8,7 +8,7 @@ import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.string.ReactiveStringCommands;
 import io.quarkus.redis.datasource.value.ReactiveValueCommands;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 
 public class ReactiveStringCommandsImpl<K, V> extends AbstractStringCommands<K, V>
         implements ReactiveStringCommands<K, V>, ReactiveValueCommands<K, V> {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTimeSeriesCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTimeSeriesCommandsImpl.java
@@ -25,7 +25,7 @@ import io.quarkus.redis.datasource.timeseries.SampleGroup;
 import io.quarkus.redis.datasource.timeseries.SeriesSample;
 import io.quarkus.redis.datasource.timeseries.TimeSeriesRange;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 import io.vertx.redis.client.ResponseType;
 
 public class ReactiveTimeSeriesCommandsImpl<K> extends AbstractTimeSeriesCommands<K>

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTopKCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTopKCommandsImpl.java
@@ -10,7 +10,7 @@ import io.quarkus.redis.datasource.ReactiveRedisCommands;
 import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.topk.ReactiveTopKCommands;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 
 public class ReactiveTopKCommandsImpl<K, V> extends AbstractTopKCommands<K, V>
         implements ReactiveTopKCommands<K, V>, ReactiveRedisCommands {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalAutoSuggestCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalAutoSuggestCommandsImpl.java
@@ -4,7 +4,7 @@ import io.quarkus.redis.datasource.autosuggest.GetArgs;
 import io.quarkus.redis.datasource.autosuggest.ReactiveTransactionalAutoSuggestCommands;
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 
 public class ReactiveTransactionalAutoSuggestCommandsImpl<K> extends AbstractTransactionalCommands
         implements ReactiveTransactionalAutoSuggestCommands<K> {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalBitMapCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalBitMapCommandsImpl.java
@@ -4,7 +4,7 @@ import io.quarkus.redis.datasource.bitmap.BitFieldArgs;
 import io.quarkus.redis.datasource.bitmap.ReactiveTransactionalBitMapCommands;
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 
 public class ReactiveTransactionalBitMapCommandsImpl<K> extends AbstractTransactionalCommands
         implements ReactiveTransactionalBitMapCommands<K> {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalBloomCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalBloomCommandsImpl.java
@@ -5,7 +5,7 @@ import io.quarkus.redis.datasource.bloom.BfReserveArgs;
 import io.quarkus.redis.datasource.bloom.ReactiveTransactionalBloomCommands;
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 
 public class ReactiveTransactionalBloomCommandsImpl<K, V> extends AbstractTransactionalCommands
         implements ReactiveTransactionalBloomCommands<K, V> {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalCuckooCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalCuckooCommandsImpl.java
@@ -5,7 +5,7 @@ import io.quarkus.redis.datasource.cuckoo.CfReserveArgs;
 import io.quarkus.redis.datasource.cuckoo.ReactiveTransactionalCuckooCommands;
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 
 public class ReactiveTransactionalCuckooCommandsImpl<K, V> extends AbstractTransactionalCommands
         implements ReactiveTransactionalCuckooCommands<K, V> {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalGeoCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalGeoCommandsImpl.java
@@ -14,7 +14,7 @@ import io.quarkus.redis.datasource.geo.GeoUnit;
 import io.quarkus.redis.datasource.geo.ReactiveTransactionalGeoCommands;
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 
 public class ReactiveTransactionalGeoCommandsImpl<K, V> extends AbstractTransactionalCommands
         implements ReactiveTransactionalGeoCommands<K, V> {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalGraphCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalGraphCommandsImpl.java
@@ -5,7 +5,7 @@ import java.time.Duration;
 import io.quarkus.redis.datasource.graph.ReactiveTransactionalGraphCommands;
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 
 public class ReactiveTransactionalGraphCommandsImpl<K> extends AbstractTransactionalCommands
         implements ReactiveTransactionalGraphCommands<K> {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalHashCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalHashCommandsImpl.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import io.quarkus.redis.datasource.hash.ReactiveTransactionalHashCommands;
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 
 public class ReactiveTransactionalHashCommandsImpl<K, F, V> extends AbstractTransactionalCommands
         implements ReactiveTransactionalHashCommands<K, F, V> {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalHyperLogLogCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalHyperLogLogCommandsImpl.java
@@ -3,7 +3,7 @@ package io.quarkus.redis.runtime.datasource;
 import io.quarkus.redis.datasource.hyperloglog.ReactiveTransactionalHyperLogLogCommands;
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 
 public class ReactiveTransactionalHyperLogLogCommandsImpl<K, V> extends AbstractTransactionalCommands
         implements ReactiveTransactionalHyperLogLogCommands<K, V> {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalJsonCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalJsonCommandsImpl.java
@@ -9,7 +9,7 @@ import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSo
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 
 public class ReactiveTransactionalJsonCommandsImpl<K> extends AbstractTransactionalCommands
         implements ReactiveTransactionalJsonCommands<K> {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalKeyCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalKeyCommandsImpl.java
@@ -9,7 +9,7 @@ import io.quarkus.redis.datasource.keys.ReactiveTransactionalKeyCommands;
 import io.quarkus.redis.datasource.keys.RedisKeyNotFoundException;
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 
 public class ReactiveTransactionalKeyCommandsImpl<K> extends AbstractTransactionalCommands
         implements ReactiveTransactionalKeyCommands<K> {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalListCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalListCommandsImpl.java
@@ -7,7 +7,7 @@ import io.quarkus.redis.datasource.list.Position;
 import io.quarkus.redis.datasource.list.ReactiveTransactionalListCommands;
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 
 public class ReactiveTransactionalListCommandsImpl<K, V> extends AbstractTransactionalCommands
         implements ReactiveTransactionalListCommands<K, V> {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalRedisDataSourceImpl.java
@@ -27,7 +27,7 @@ import io.quarkus.redis.datasource.topk.ReactiveTransactionalTopKCommands;
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.quarkus.redis.datasource.value.ReactiveTransactionalValueCommands;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Command;
+import io.vertx.redis.client.Command;
 
 public class ReactiveTransactionalRedisDataSourceImpl implements ReactiveTransactionalRedisDataSource {
 
@@ -197,11 +197,5 @@ public class ReactiveTransactionalRedisDataSourceImpl implements ReactiveTransac
                     return r;
                 })
                 .replaceWithVoid();
-    }
-
-    @Override
-    public Uni<Void> execute(io.vertx.redis.client.Command command, String... args) {
-        nonNull(command, "command");
-        return execute(new Command(command), args);
     }
 }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalSetCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalSetCommandsImpl.java
@@ -3,7 +3,7 @@ package io.quarkus.redis.runtime.datasource;
 import io.quarkus.redis.datasource.set.ReactiveTransactionalSetCommands;
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 
 public class ReactiveTransactionalSetCommandsImpl<K, V> extends AbstractTransactionalCommands
         implements ReactiveTransactionalSetCommands<K, V> {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalSortedSetCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalSortedSetCommandsImpl.java
@@ -12,7 +12,7 @@ import io.quarkus.redis.datasource.sortedset.ZAggregateArgs;
 import io.quarkus.redis.datasource.sortedset.ZRangeArgs;
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 
 public class ReactiveTransactionalSortedSetCommandsImpl<K, V> extends AbstractTransactionalCommands
         implements ReactiveTransactionalSortedSetCommands<K, V> {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalStreamCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalStreamCommandsImpl.java
@@ -15,7 +15,7 @@ import io.quarkus.redis.datasource.stream.XReadGroupArgs;
 import io.quarkus.redis.datasource.stream.XTrimArgs;
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 
 public class ReactiveTransactionalStreamCommandsImpl<K, F, V> extends AbstractTransactionalCommands
         implements ReactiveTransactionalStreamCommands<K, F, V> {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalStringCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalStringCommandsImpl.java
@@ -7,7 +7,7 @@ import io.quarkus.redis.datasource.string.ReactiveTransactionalStringCommands;
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.quarkus.redis.datasource.value.ReactiveTransactionalValueCommands;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 
 public class ReactiveTransactionalStringCommandsImpl<K, V> extends AbstractTransactionalCommands
         implements ReactiveTransactionalStringCommands<K, V>, ReactiveTransactionalValueCommands<K, V> {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalTopKCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalTopKCommandsImpl.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import io.quarkus.redis.datasource.topk.ReactiveTransactionalTopKCommands;
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 
 public class ReactiveTransactionalTopKCommandsImpl<K, V> extends AbstractTransactionalCommands
         implements ReactiveTransactionalTopKCommands<K, V> {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/RedisCommand.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/RedisCommand.java
@@ -4,9 +4,9 @@ import java.util.List;
 
 import io.quarkus.redis.datasource.RedisCommandExtraArguments;
 import io.quarkus.redis.datasource.codecs.Codec;
-import io.vertx.mutiny.core.buffer.Buffer;
-import io.vertx.mutiny.redis.client.Command;
-import io.vertx.mutiny.redis.client.Request;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Request;
 
 public class RedisCommand {
 
@@ -83,10 +83,10 @@ public class RedisCommand {
     }
 
     public void putNullable(byte[] encoded) {
-        if (encoded == null) {
-            this.request.nullArg();
-        } else {
+        if (encoded != null) {
             this.request.arg(encoded);
+        } else {
+            this.request.arg("null");
         }
     }
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/RedisCommandExecutor.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/RedisCommandExecutor.java
@@ -1,8 +1,8 @@
 package io.quarkus.redis.runtime.datasource;
 
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Request;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Request;
+import io.vertx.redis.client.Response;
 
 public interface RedisCommandExecutor {
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/SScanReactiveCursorImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/SScanReactiveCursorImpl.java
@@ -7,8 +7,8 @@ import java.util.List;
 import io.quarkus.redis.datasource.set.ReactiveSScanCursor;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Command;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Response;
 
 public class SScanReactiveCursorImpl<V> extends AbstractRedisCommands implements ReactiveSScanCursor<V> {
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ScanReactiveCursorImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ScanReactiveCursorImpl.java
@@ -8,7 +8,7 @@ import java.util.Set;
 import io.quarkus.redis.datasource.keys.ReactiveKeyScanCursor;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Command;
+import io.vertx.redis.client.Command;
 
 public class ScanReactiveCursorImpl<K> extends AbstractRedisCommands implements ReactiveKeyScanCursor<K> {
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/TransactionHolder.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/TransactionHolder.java
@@ -6,7 +6,7 @@ import java.util.function.Function;
 
 import io.quarkus.redis.datasource.transactions.OptimisticLockingTransactionResult;
 import io.quarkus.redis.datasource.transactions.TransactionResult;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 import io.vertx.redis.client.ResponseType;
 
 public class TransactionHolder {
@@ -28,7 +28,7 @@ public class TransactionHolder {
                 results.add(mappers.get(i).apply(responsePart));
             } else {
                 hasErrors = true;
-                results.add(responsePart.getDelegate()); // it's also an exception
+                results.add(responsePart); // it's also an exception
             }
         }
         return new TransactionResultImpl(discarded, hasErrors, results);
@@ -44,7 +44,7 @@ public class TransactionHolder {
                 results.add(mappers.get(i).apply(responsePart));
             } else {
                 hasErrors = true;
-                results.add(responsePart.getDelegate()); // it's also an exception
+                results.add(responsePart); // it's also an exception
             }
         }
         return new OptimisticLockingTransactionResultImpl<>(discarded, hasErrors, input, results);

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ZScanReactiveCursorImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ZScanReactiveCursorImpl.java
@@ -8,8 +8,8 @@ import io.quarkus.redis.datasource.sortedset.ReactiveZScanCursor;
 import io.quarkus.redis.datasource.sortedset.ScoredValue;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Command;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Response;
 
 public class ZScanReactiveCursorImpl<V> extends AbstractRedisCommands implements ReactiveZScanCursor<V> {
 

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/CommandNormalizationTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/CommandNormalizationTest.java
@@ -15,8 +15,8 @@ import io.vertx.redis.client.impl.RequestImpl;
 public class CommandNormalizationTest {
     @Test
     void test() {
-        RequestImpl req = (RequestImpl) RedisCommand.of(io.vertx.mutiny.redis.client.Command.create("hset"))
-                .put("key").put("field").put("value").toRequest().getDelegate();
+        RequestImpl req = (RequestImpl) RedisCommand.of(io.vertx.redis.client.Command.create("hset"))
+                .put("key").put("field").put("value").toRequest();
         CommandImpl cmd = (CommandImpl) req.command();
         assertEquals("hset", cmd.toString());
         assertNotEquals(-1, cmd.getArity());

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/CustomCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/CustomCommandsTest.java
@@ -10,9 +10,9 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.redis.datasource.list.ListCommands;
 import io.quarkus.redis.datasource.transactions.TransactionResult;
 import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
-import io.vertx.mutiny.redis.client.Command;
-import io.vertx.mutiny.redis.client.Request;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Request;
+import io.vertx.redis.client.Response;
 
 public class CustomCommandsTest extends DatasourceTestBase {
 

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/PubSubCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/PubSubCommandsTest.java
@@ -27,7 +27,7 @@ import io.quarkus.redis.runtime.datasource.ReactiveRedisDataSourceImpl;
 import io.smallrye.common.vertx.VertxContext;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.subscription.Cancellable;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Response;
 
 public class PubSubCommandsTest extends DatasourceTestBase {
 

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/PubSubTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/PubSubTest.java
@@ -44,17 +44,12 @@ public class PubSubTest extends DatasourceTestBase {
         CountDownLatch latch = new CountDownLatch(3);
         ReactivePubSubCommands.ReactiveRedisSubscriber subscriber = ps.subscribe("people",
                 p -> latch.countDown()).await().indefinitely();
-
         ps.publish("people", person1).await().indefinitely();
         ps.publish("people", person2).await().indefinitely();
-
         ds.value(String.class, String.class)
                 .set("hello", "foo").await().indefinitely();
-
         ps.publish("people", person2).await().indefinitely();
-
         assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
-
         subscriber.unsubscribe().await().indefinitely();
     }
 

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/RedisServerExtension.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/RedisServerExtension.java
@@ -9,12 +9,13 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import io.smallrye.common.vertx.VertxContext;
 import io.vertx.mutiny.core.Vertx;
-import io.vertx.mutiny.redis.client.Command;
 import io.vertx.mutiny.redis.client.Redis;
 import io.vertx.mutiny.redis.client.RedisAPI;
-import io.vertx.mutiny.redis.client.Request;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Request;
+import io.vertx.redis.client.Response;
 
 @SuppressWarnings("resource")
 public class RedisServerExtension implements BeforeAllCallback, AfterAllCallback {
@@ -41,6 +42,8 @@ public class RedisServerExtension implements BeforeAllCallback, AfterAllCallback
     }
 
     private static boolean init() {
+        // Force registration of context locals
+        VertxContext.isOnDuplicatedContext();
         if (!server.isRunning()) {
             server.start();
             vertx = Vertx.vertx();

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionErrorHandlingTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionErrorHandlingTest.java
@@ -18,8 +18,8 @@ import io.quarkus.redis.datasource.transactions.TransactionResult;
 import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
 import io.quarkus.redis.runtime.datasource.ReactiveRedisDataSourceImpl;
 import io.smallrye.mutiny.Uni;
-import io.vertx.core.impl.NoStackTraceThrowable;
-import io.vertx.mutiny.redis.client.Command;
+import io.vertx.core.VertxException;
+import io.vertx.redis.client.Command;
 import io.vertx.redis.client.impl.types.ErrorType;
 
 @RequiresRedis6OrHigher
@@ -69,8 +69,7 @@ public class TransactionErrorHandlingTest extends DatasourceTestBase {
                 tx.value(String.class).set(key, "foobar");
                 tx.execute(Command.SET, key); // missing argument
             });
-        }).isExactlyInstanceOf(CompletionException.class)
-                .hasCauseExactlyInstanceOf(NoStackTraceThrowable.class)
+        }).isInstanceOf(VertxException.class)
                 .hasMessageContaining("Redis command is not valid");
 
         assertThat(blocking.value(String.class).get(key)).isEqualTo("hello");
@@ -135,8 +134,7 @@ public class TransactionErrorHandlingTest extends DatasourceTestBase {
                 tx.value(String.class).set(key, "foobar");
                 tx.execute(Command.SET, key); // missing argument
             }, key);
-        }).isExactlyInstanceOf(CompletionException.class)
-                .hasCauseExactlyInstanceOf(NoStackTraceThrowable.class)
+        }).isInstanceOf(VertxException.class)
                 .hasMessageContaining("Redis command is not valid");
 
         assertThat(blocking.value(String.class).get(key)).isEqualTo("hello");
@@ -230,8 +228,7 @@ public class TransactionErrorHandlingTest extends DatasourceTestBase {
             }, (input, tx) -> {
                 tx.value(String.class).set(key, input + "|foobar");
             }, key);
-        }).isExactlyInstanceOf(CompletionException.class)
-                .hasCauseExactlyInstanceOf(NoStackTraceThrowable.class)
+        }).isInstanceOf(VertxException.class)
                 .hasMessageContaining("Redis command is not valid");
 
         assertThat(blocking.value(String.class).get(key)).isEqualTo("hello");
@@ -293,8 +290,7 @@ public class TransactionErrorHandlingTest extends DatasourceTestBase {
                 tx.value(String.class).set(key, input + "|foobar");
                 tx.execute(Command.SET, key); // missing argument
             }, key);
-        }).isExactlyInstanceOf(CompletionException.class)
-                .hasCauseExactlyInstanceOf(NoStackTraceThrowable.class)
+        }).isInstanceOf(VertxException.class)
                 .hasMessageContaining("Redis command is not valid");
 
         assertThat(blocking.value(String.class).get(key)).isEqualTo("hello");
@@ -311,7 +307,7 @@ public class TransactionErrorHandlingTest extends DatasourceTestBase {
                 tx.value(String.class).set(key, input + "|foobar");
                 tx.execute("nonexisting_command");
             }, key);
-        }).isExactlyInstanceOf(CompletionException.class)
+        }).isInstanceOf(CompletionException.class)
                 .hasCauseExactlyInstanceOf(ErrorType.class)
                 .hasMessageContaining("ERR unknown command");
 
@@ -393,8 +389,7 @@ public class TransactionErrorHandlingTest extends DatasourceTestBase {
                 return tx.value(String.class).set(key, "foobar")
                         .flatMap(ignored -> tx.execute(Command.SET, key)); // missing argument
             }).await().indefinitely();
-        }).isExactlyInstanceOf(CompletionException.class)
-                .hasCauseExactlyInstanceOf(NoStackTraceThrowable.class)
+        }).isInstanceOf(VertxException.class)
                 .hasMessageContaining("Redis command is not valid");
 
         assertThat(reactive.value(String.class).get(key).await().indefinitely()).isEqualTo("hello");
@@ -459,8 +454,7 @@ public class TransactionErrorHandlingTest extends DatasourceTestBase {
                 return tx.value(String.class).set(key, "foobar")
                         .flatMap(ignored -> tx.execute(Command.SET, key)); // missing argument
             }, key).await().indefinitely();
-        }).isExactlyInstanceOf(CompletionException.class)
-                .hasCauseExactlyInstanceOf(NoStackTraceThrowable.class)
+        }).isInstanceOf(VertxException.class)
                 .hasMessageContaining("Redis command is not valid");
 
         assertThat(reactive.value(String.class).get(key).await().indefinitely()).isEqualTo("hello");
@@ -555,8 +549,7 @@ public class TransactionErrorHandlingTest extends DatasourceTestBase {
             }, (input, tx) -> {
                 return tx.value(String.class).set(key, input + "|foobar");
             }, key).await().indefinitely();
-        }).isExactlyInstanceOf(CompletionException.class)
-                .hasCauseExactlyInstanceOf(NoStackTraceThrowable.class)
+        }).isInstanceOf(VertxException.class)
                 .hasMessageContaining("Redis command is not valid");
 
         assertThat(reactive.value(String.class).get(key).await().indefinitely()).isEqualTo("hello");
@@ -619,8 +612,7 @@ public class TransactionErrorHandlingTest extends DatasourceTestBase {
                 return tx.value(String.class).set(key, input + "|foobar")
                         .flatMap(ignored -> tx.execute(Command.SET, key)); // missing argument
             }, key).await().indefinitely();
-        }).isExactlyInstanceOf(CompletionException.class)
-                .hasCauseExactlyInstanceOf(NoStackTraceThrowable.class)
+        }).isInstanceOf(VertxException.class)
                 .hasMessageContaining("Redis command is not valid");
 
         assertThat(reactive.value(String.class).get(key).await().indefinitely()).isEqualTo("hello");

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/generator/RedisApiGenerator.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/generator/RedisApiGenerator.java
@@ -49,8 +49,8 @@ import io.quarkus.redis.runtime.datasource.AbstractTransactionalRedisCommandGrou
 import io.quarkus.redis.runtime.datasource.ReactiveRedisDataSourceImpl;
 import io.quarkus.redis.runtime.datasource.RedisCommandExecutor;
 import io.quarkus.redis.runtime.datasource.TransactionHolder;
-import io.vertx.mutiny.redis.client.Command;
-import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Response;
 
 /**
  * A tools generating the various interface and implementation from the existing reactive API.

--- a/vertx.justfile
+++ b/vertx.justfile
@@ -19,6 +19,7 @@ modules := """
     extensions/reactive-mysql-client
     extensions/reactive-oracle-client
     extensions/reactive-pg-client
+    extensions/redis-client
     """
 
 # Build the comma-separated list of directories containing a pom.xml


### PR DESCRIPTION
Migrate the Redis extension to Vert.x 5

Unfortunately, this is currently blocked as we need resteasy reactive. 

Related to #51959 