### PR TITLE
Update the SmallRye Certificate Generator to version 1.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <perfmark.version>0.27.0</perfmark.version><!-- dependency of io.grpc:grpc-core not managed in io.grpc:grpc-bom -->
 
         <!-- Used in the build parent and test BOM (for the JUnit plugin) and in the BOM (for the API) -->
-        <smallrye-certificate-generator.version>0.9.2</smallrye-certificate-generator.version>
+        <smallrye-certificate-generator.version>1.0.1</smallrye-certificate-generator.version>
 
         <!-- TestNG version: we don't enforce it in the BOM as it is mostly used in the MP TCKs and we need to use the version from the TCKs -->
         <testng.version>7.8.0</testng.version>


### PR DESCRIPTION
This version uses Vert.x 5. 

The previous version was working because the Vert.x API it uses did not change, but it was fragile (worked by accident).