### PR TITLE
Fix import.sql not executed when using only StatelessSession (no entities)

### DIFF
--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_script/ImportSqlLoadScriptNoEntitiesTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_script/ImportSqlLoadScriptNoEntitiesTestCase.java
@@ -1,0 +1,38 @@
+package io.quarkus.hibernate.orm.sql_load_script;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
+import org.hibernate.StatelessSession;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * Test that import.sql is executed even when no @Entity classes are present.
+ *
+ * @see <a href="https://github.com/quarkusio/quarkus/issues/53413">quarkusio/quarkus#53413</a>
+ */
+public class ImportSqlLoadScriptNoEntitiesTestCase {
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("import-no-entities.sql", "import.sql"));
+
+    @Inject
+    StatelessSession statelessSession;
+
+    @Test
+    @Transactional
+    public void testImportSqlExecutedWithoutEntities() {
+        // import-no-entities.sql
+        String name = statelessSession
+                .createNativeQuery("SELECT name FROM test_data WHERE id = 1", String.class)
+                .getSingleResult();
+        assertThat(name).isEqualTo("imported without entities");
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/resources/import-no-entities.sql
+++ b/extensions/hibernate-orm/deployment/src/test/resources/import-no-entities.sql
@@ -1,0 +1,2 @@
+CREATE TABLE test_data (id INT PRIMARY KEY, name VARCHAR(255));
+INSERT INTO test_data(id, name) VALUES(1, 'imported without entities');

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/PrevalidatedQuarkusMetadata.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/PrevalidatedQuarkusMetadata.java
@@ -228,7 +228,14 @@ public final class PrevalidatedQuarkusMetadata implements MetadataImplementor {
 
     @Override
     public Set<String> getContributors() {
-        return metadata.getContributors();
+        Set<String> contributors = metadata.getContributors();
+        if (contributors.isEmpty()) {
+            // Even with no entities, we need at least one contributor so that
+            // SchemaManagementToolCoordinator processes the configured schema actions
+            // (e.g. executing import.sql). See https://github.com/quarkusio/quarkus/issues/53413
+            return Set.of("no-entities");
+        }
+        return contributors;
     }
 
     //All methods from org.hibernate.engine.spi.Mapping, the parent of Metadata:


### PR DESCRIPTION
## Summary

- When there are no `@Entity` classes but `StatelessSession` is used with `import.sql`, the SQL script was not executed
- Root cause: `metadata.getContributors()` returns an empty set with no entities, causing `SchemaManagementToolCoordinator` to skip all schema actions including `import.sql` execution
- Fix: ensure `PrevalidatedQuarkusMetadata.getContributors()` always returns at least one contributor so configured schema actions are processed

- Fixes: https://github.com/quarkusio/quarkus/issues/53413

## Test plan

- [x] Added `ImportSqlLoadScriptNoEntitiesTestCase` that verifies `import.sql` runs without any `@Entity`
- [x] All existing `sql_load_script` tests pass
- [x] All existing `NoEntities` tests pass
- [x] Full Quarkus build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)