### PR TITLE
native-image, FFM UpCall/DownCall build items, JDK 25+

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/FfmCallBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/FfmCallBuildItem.java
@@ -1,0 +1,48 @@
+package io.quarkus.deployment.builditem.nativeimage;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * Used to register an upcall/downcall signature for FFI/FFM runtime access.
+ */
+public abstract class FfmCallBuildItem extends MultiBuildItem {
+
+    private final String returnType;
+    private final List<String> parameterTypes;
+
+    public FfmCallBuildItem(FfmType returnType, FfmType... parameterTypes) {
+        this.returnType = requireNonNull(returnType, "returnType cannot be null").getCanonicalName();
+        this.parameterTypes = Arrays.stream(parameterTypes).map(FfmType::getCanonicalName).toList();
+    }
+
+    public String getReturnType() {
+        return returnType;
+    }
+
+    public List<String> getParameterTypes() {
+        return parameterTypes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final FfmCallBuildItem that = (FfmCallBuildItem) o;
+        return returnType.equals(that.returnType) && parameterTypes.equals(that.parameterTypes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(returnType, parameterTypes);
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/FfmDowncallBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/FfmDowncallBuildItem.java
@@ -1,0 +1,10 @@
+package io.quarkus.deployment.builditem.nativeimage;
+
+/**
+ * Used to register a downcall signature for FFI/FFM runtime access.
+ */
+public final class FfmDowncallBuildItem extends FfmCallBuildItem {
+    public FfmDowncallBuildItem(FfmType returnType, FfmType... parameterTypes) {
+        super(returnType, parameterTypes);
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/FfmType.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/FfmType.java
@@ -1,0 +1,41 @@
+package io.quarkus.deployment.builditem.nativeimage;
+
+/**
+ * Required by GraalVM's FFM API reachability metadata.
+ * Maps Panama ValueLayouts to the strings expected by native-image.
+ *
+ * https://github.com/openjdk/jdk25u/blob/master/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
+ */
+public enum FfmType {
+
+    // Used for function return types.
+    VOID("void"),
+    // ValueLayout.ADDRESS, or any C pointer (void*)
+    ADDRESS("void*"),
+    // ValueLayout.JAVA_INT (32-bit integer)
+    INT("jint"),
+    // ValueLayout.JAVA_LONG (64-bit integer)
+    LONG("jlong"),
+    // ValueLayout.JAVA_FLOAT (32-bit floating point)
+    FLOAT("jfloat"),
+    // ValueLayout.JAVA_DOUBLE (64-bit floating point)
+    DOUBLE("jdouble"),
+    // ValueLayout.JAVA_BOOLEAN
+    BOOLEAN("jboolean"),
+    // ValueLayout.JAVA_BYTE
+    BYTE("jbyte"),
+    // ValueLayout.JAVA_CHAR
+    CHAR("jchar"),
+    // ValueLayout.JAVA_SHORT
+    SHORT("jshort");
+
+    private final String canonicalName;
+
+    FfmType(String canonicalName) {
+        this.canonicalName = canonicalName;
+    }
+
+    public String getCanonicalName() {
+        return canonicalName;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/FfmUpcallBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/FfmUpcallBuildItem.java
@@ -1,0 +1,10 @@
+package io.quarkus.deployment.builditem.nativeimage;
+
+/**
+ * Used to register an upcall signature for FFI/FFM runtime access.
+ */
+public final class FfmUpcallBuildItem extends FfmCallBuildItem {
+    public FfmUpcallBuildItem(FfmType returnType, FfmType... parameterTypes) {
+        super(returnType, parameterTypes);
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageFFMConfigStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageFFMConfigStep.java
@@ -1,0 +1,77 @@
+package io.quarkus.deployment.steps;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import io.quarkus.bootstrap.json.Json;
+import io.quarkus.bootstrap.json.Json.JsonArrayBuilder;
+import io.quarkus.bootstrap.json.Json.JsonObjectBuilder;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.FfmDowncallBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.FfmUpcallBuildItem;
+
+/**
+ * Creates reachability-metadata.json with:
+ * https://www.graalvm.org/latest/reference-manual/native-image/native-code-interoperability/ffm-api/#registering-foreign-calls
+ * https://www.graalvm.org/latest/reference-manual/native-image/metadata/#foreign-function-and-memory-api
+ *
+ * It does not handle anything else, i.e. it does not implement
+ * https://github.com/quarkusio/quarkus/issues/41016
+ */
+public class NativeImageFFMConfigStep {
+
+    @BuildStep
+    void generateFfmConfig(BuildProducer<GeneratedResourceBuildItem> reachabilityMetadata,
+            List<FfmDowncallBuildItem> downcalls,
+            List<FfmUpcallBuildItem> upcalls) {
+        if (downcalls.isEmpty() && upcalls.isEmpty()) {
+            return;
+        }
+        final JsonObjectBuilder foreignJson = Json.object();
+        if (!downcalls.isEmpty()) {
+            final JsonArrayBuilder downcallsArray = Json.array();
+            downcalls.stream().distinct().forEach(downcall -> {
+                final JsonObjectBuilder dcb = Json.object();
+                dcb.put("returnType", downcall.getReturnType());
+                final JsonArrayBuilder paramsArray = Json.array();
+                paramsArray.addAll(downcall.getParameterTypes());
+                dcb.put("parameterTypes", paramsArray);
+                downcallsArray.add(dcb);
+            });
+            foreignJson.put("downcalls", downcallsArray);
+        }
+        if (!upcalls.isEmpty()) {
+            final JsonArrayBuilder upcallsArray = Json.array();
+            upcalls.stream().distinct().forEach(upcall -> {
+                final JsonObjectBuilder ucb = Json.object();
+                ucb.put("returnType", upcall.getReturnType());
+                final JsonArrayBuilder paramsArray = Json.array();
+                paramsArray.addAll(upcall.getParameterTypes());
+                ucb.put("parameterTypes", paramsArray);
+                upcallsArray.add(ucb);
+            });
+            foreignJson.put("upcalls", upcallsArray);
+        }
+        final JsonObjectBuilder root = Json.object();
+        root.put("foreign", foreignJson);
+        try (StringWriter writer = new StringWriter()) {
+            root.appendTo(writer);
+            // The nested location seems important to the native-image metadata lookup.
+            reachabilityMetadata.produce(new GeneratedResourceBuildItem(
+                    /*
+                     * Despite the doc [1] stating:
+                     * "located in any of the classpath entries at META-INF/native-image/<group.Id>\/<artifactId>\/."
+                     * it is fine both leaving it in `META-INF/native-image` and nesting it in an arbitrary dir.
+                     * [1] https://www.graalvm.org/latest/reference-manual/native-image/metadata/#specifying-metadata-with-json
+                     */
+                    "META-INF/native-image/foreign/reachability-metadata.json",
+                    writer.toString().getBytes(StandardCharsets.UTF_8)));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/extensions/awt/deployment/src/main/java/io/quarkus/awt/deployment/AwtProcessor.java
+++ b/extensions/awt/deployment/src/main/java/io/quarkus/awt/deployment/AwtProcessor.java
@@ -1,5 +1,10 @@
 package io.quarkus.awt.deployment;
 
+import static io.quarkus.deployment.builditem.nativeimage.FfmType.ADDRESS;
+import static io.quarkus.deployment.builditem.nativeimage.FfmType.FLOAT;
+import static io.quarkus.deployment.builditem.nativeimage.FfmType.INT;
+import static io.quarkus.deployment.builditem.nativeimage.FfmType.LONG;
+import static io.quarkus.deployment.builditem.nativeimage.FfmType.VOID;
 import static io.quarkus.runtime.graal.GraalVM.Version.CURRENT;
 
 import java.util.ArrayList;
@@ -15,6 +20,8 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.NativeImageFeatureBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.FfmDowncallBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.FfmUpcallBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.JniRuntimeAccessBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.JniRuntimeAccessFieldBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.JniRuntimeAccessMethodBuildItem;
@@ -106,7 +113,8 @@ class AwtProcessor {
                 "sun.java2d.loops.SetDrawRectANY",
                 "sun.java2d.loops.SetFillPathANY",
                 "sun.java2d.loops.SetFillRectANY",
-                "sun.java2d.loops.SetFillSpansANY"
+                "sun.java2d.loops.SetFillSpansANY",
+                "sun.font.HBShaper"
         ).methods().build();
         //@formatter:on
     }
@@ -372,5 +380,49 @@ class AwtProcessor {
                 .map(RuntimeInitializedPackageBuildItem::new)
                 .forEach(runtimeInitilizedPackages::produce);
         //@formatter:on
+    }
+
+    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    void setupFfmReachability(
+            BuildProducer<FfmDowncallBuildItem> downcalls,
+            BuildProducer<FfmUpcallBuildItem> upcalls,
+            NativeImageRunnerBuildItem nativeImageRunnerBuildItem) {
+        final GraalVM.Version v;
+        if (nativeImageRunnerBuildItem.getBuildRunner() instanceof NoopNativeImageBuildRunner) {
+            v = CURRENT;
+            log.warnf("native-image is not installed. " +
+                    "Using the default %s version as a reference to build native-sources step.", v.getVersionAsString());
+        } else {
+            v = nativeImageRunnerBuildItem.getBuildRunner().getGraalVMVersion();
+        }
+        // Not needed with older GraalVM
+        if (v.compareTo(GraalVM.Version.VERSION_25_0_0) >= 0) {
+            // Downcalls
+            // malloc
+            downcalls.produce(new FfmDowncallBuildItem(ADDRESS, LONG));
+            // HBCreateFace
+            downcalls.produce(new FfmDowncallBuildItem(ADDRESS, ADDRESS));
+            // HBDisposeFace
+            downcalls.produce(new FfmDowncallBuildItem(VOID, ADDRESS));
+            // jdk_hb_shape
+            downcalls.produce(new FfmDowncallBuildItem(VOID, FLOAT, ADDRESS, ADDRESS, ADDRESS, INT, INT, INT, INT, INT, FLOAT,
+                    FLOAT, INT, INT, ADDRESS, ADDRESS));
+            // HBCreateFontFuncs
+            downcalls.produce(new FfmDowncallBuildItem(ADDRESS, ADDRESS, ADDRESS, ADDRESS, ADDRESS, ADDRESS));
+
+            // Upcalls
+            // getFontTableData
+            upcalls.produce(new FfmUpcallBuildItem(INT, INT, ADDRESS));
+            // get_variation_glyph
+            upcalls.produce(new FfmUpcallBuildItem(INT, ADDRESS, ADDRESS, INT, INT, ADDRESS, ADDRESS));
+            // get_nominal_glyph
+            upcalls.produce(new FfmUpcallBuildItem(INT, ADDRESS, ADDRESS, INT, ADDRESS, ADDRESS));
+            // get_glyph_h_advance & get_glyph_v_advance
+            upcalls.produce(new FfmUpcallBuildItem(INT, ADDRESS, ADDRESS, INT, ADDRESS));
+            // get_contour_pt_stub
+            upcalls.produce(new FfmUpcallBuildItem(INT, ADDRESS, ADDRESS, INT, INT, ADDRESS, ADDRESS, ADDRESS));
+            // store_layout_results_stub
+            upcalls.produce(new FfmUpcallBuildItem(VOID, INT, INT, INT, FLOAT, FLOAT, FLOAT, INT, INT, ADDRESS, ADDRESS));
+        }
     }
 }

--- a/integration-tests/awt/src/main/java/io/quarkus/awt/it/ImageResource.java
+++ b/integration-tests/awt/src/main/java/io/quarkus/awt/it/ImageResource.java
@@ -1,16 +1,21 @@
 package io.quarkus.awt.it;
 
 import static io.quarkus.awt.it.enums.ColorSpaceEnum.CS_DEFAULT;
+import static java.awt.Font.PLAIN;
 import static java.awt.image.BufferedImage.TYPE_3BYTE_BGR;
 import static java.awt.image.BufferedImage.TYPE_BYTE_BINARY;
 import static javax.imageio.ImageWriteParam.MODE_DEFAULT;
 
 import java.awt.AlphaComposite;
 import java.awt.Color;
+import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.GraphicsEnvironment;
 import java.awt.Transparency;
 import java.awt.color.ColorSpace;
+import java.awt.font.FontRenderContext;
+import java.awt.font.LineBreakMeasurer;
+import java.awt.font.TextAttribute;
 import java.awt.image.BufferedImage;
 import java.awt.image.ColorModel;
 import java.awt.image.ComponentColorModel;
@@ -18,6 +23,8 @@ import java.awt.image.WritableRaster;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.text.AttributedCharacterIterator;
+import java.text.AttributedString;
 import java.util.Arrays;
 import java.util.function.Supplier;
 
@@ -233,6 +240,27 @@ public class ImageResource {
     public Response fonts() {
         return Response.ok().entity(Arrays.toString(
                 GraphicsEnvironment.getLocalGraphicsEnvironment().getAvailableFontFamilyNames())).build();
+    }
+
+    /**
+     * Uses a layout that forces the initialization of sun.font.HBShaper.
+     */
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    @Path("/fonts-shaper")
+    public Response fontsShaper() {
+        // Devanagari, "नमस्ते" "Namastē, Hello..."
+        final String complexText = "Quarkus Mandrel \u0928\u092E\u0938\u094D\u0924\u0947";
+        final AttributedString attrStr = new AttributedString(complexText);
+        attrStr.addAttribute(TextAttribute.FONT, new Font("DejaVu Sans Mono X", PLAIN, 16));
+        final AttributedCharacterIterator paragraph = attrStr.getIterator();
+        final LineBreakMeasurer measurer = new LineBreakMeasurer(paragraph, new FontRenderContext(null, true, true));
+        // use it
+        measurer.setPosition(paragraph.getBeginIndex());
+        final int nextOffset = measurer.nextOffset(50.0f);
+        return Response
+                .ok("HBShaper invoked successfully. Computed next offset: " + nextOffset)
+                .build();
     }
 
     /**

--- a/integration-tests/awt/src/test/java/io/quarkus/awt/it/ImageGeometryFontsTest.java
+++ b/integration-tests/awt/src/test/java/io/quarkus/awt/it/ImageGeometryFontsTest.java
@@ -120,4 +120,16 @@ public class ImageGeometryFontsTest {
                 "Not all expected fonts were found: " + expected + ". " +
                         "These fonts were found though: " + Arrays.toString(actual));
     }
+
+    @Test
+    void testHBShaper() {
+        final String response = given()
+                .when()
+                .get("/fonts-shaper")
+                .then()
+                .statusCode(200)
+                .extract().asString();
+        Assertions.assertTrue(response.contains("HBShaper invoked successfully"),
+                "Expected HBShaper to process text successfully, but got: " + response);
+    }
 }


### PR DESCRIPTION
This PR enables FFM/FFI for native-image reachability metadata config. 
The functionality is used and tested in AWT, specifically as a response to HarfBuzz transition from JNI to FFM/FFI; e.g.
 * [#dev > AWT FFM issue in JDK25](https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/AWT.20FFM.20issue.20in.20JDK25/with/579944678)
 * https://github.com/quarkiverse/quarkus-jasperreports/issues/246#issuecomment-4030758229

These added Build Items are general though and can be used for other FFM/FFI metadata registration.

This PR creates `reachability-metadata.json` **if needed**, solely for the purpose of FFI/FFM metadata registration, it **does not** implement https://github.com/quarkusio/quarkus/issues/41016.  I'll take a jab at that later.

FYI @melloware @redddcyclone @ls-bit