### PR TITLE
Bump smallrye-open-api.version from 4.2.4 to 4.3.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -48,7 +48,7 @@
         <smallrye-common.version>2.17.0</smallrye-common.version>
         <smallrye-config.version>3.16.0</smallrye-config.version>
         <smallrye-health.version>4.3.0</smallrye-health.version>
-        <smallrye-open-api.version>4.2.4</smallrye-open-api.version>
+        <smallrye-open-api.version>4.3.0</smallrye-open-api.version>
         <smallrye-graphql.version>2.18.0</smallrye-graphql.version>
         <smallrye-fault-tolerance.version>6.11.1</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>4.6.3</smallrye-jwt.version>


### PR DESCRIPTION
Bump smallrye-open-api.version from 4.2.4 to [4.3.0](https://github.com/smallrye/smallrye-open-api/releases/tag/4.3.0)

- Fixes: #52831