### PR TITLE
Move Kubernetes Client Config to Runtime

### DIFF
--- a/extensions/kubernetes-client/deployment-internal/src/main/java/io/quarkus/kubernetes/client/deployment/internal/KubernetesClientBuildStep.java
+++ b/extensions/kubernetes-client/deployment-internal/src/main/java/io/quarkus/kubernetes/client/deployment/internal/KubernetesClientBuildStep.java
@@ -1,21 +1,17 @@
 package io.quarkus.kubernetes.client.deployment.internal;
 
-import static io.quarkus.kubernetes.client.runtime.internal.KubernetesClientUtils.createConfig;
-
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.QuarkusBuildCloseablesBuildItem;
-import io.quarkus.kubernetes.client.runtime.internal.KubernetesClientBuildConfig;
+import io.quarkus.kubernetes.client.runtime.internal.KubernetesClientUtils;
 import io.quarkus.kubernetes.client.runtime.internal.QuarkusHttpClientFactory;
 import io.quarkus.kubernetes.client.spi.KubernetesClientBuildItem;
 
 public class KubernetesClientBuildStep {
 
-    private KubernetesClientBuildConfig buildConfig;
-
     @BuildStep
     public KubernetesClientBuildItem process(QuarkusBuildCloseablesBuildItem closeablesBuildItem) {
         QuarkusHttpClientFactory httpClientFactory = new QuarkusHttpClientFactory();
         closeablesBuildItem.add(httpClientFactory);
-        return new KubernetesClientBuildItem(createConfig(buildConfig), httpClientFactory);
+        return new KubernetesClientBuildItem(KubernetesClientUtils.createConfig(), httpClientFactory);
     }
 }

--- a/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/DevServicesKubernetesProcessor.java
+++ b/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/DevServicesKubernetesProcessor.java
@@ -72,7 +72,7 @@ import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerAddress;
 import io.quarkus.devservices.common.ContainerLocator;
 import io.quarkus.devservices.common.ContainerShutdownCloseable;
-import io.quarkus.kubernetes.client.runtime.internal.KubernetesClientBuildConfig;
+import io.quarkus.kubernetes.client.runtime.internal.KubernetesClientBuildTimeConfig;
 import io.quarkus.kubernetes.client.runtime.internal.KubernetesDevServicesBuildTimeConfig;
 import io.quarkus.kubernetes.client.runtime.internal.KubernetesDevServicesBuildTimeConfig.Flavor;
 import io.quarkus.kubernetes.client.spi.KubernetesDevServiceInfoBuildItem;
@@ -101,7 +101,7 @@ public class DevServicesKubernetesProcessor {
             DockerStatusBuildItem dockerStatusBuildItem,
             DevServicesComposeProjectBuildItem composeProjectBuildItem,
             LaunchModeBuildItem launchMode,
-            KubernetesClientBuildConfig kubernetesClientBuildTimeConfig,
+            KubernetesClientBuildTimeConfig kubernetesClientBuildTimeConfig,
             List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,
             Optional<ConsoleInstalledBuildItem> consoleInstalledBuildItem,
             CuratedApplicationShutdownBuildItem closeBuildItem,
@@ -110,7 +110,7 @@ public class DevServicesKubernetesProcessor {
             BuildProducer<KubernetesDevServiceInfoBuildItem> devServicesKube,
             Optional<KubernetesDevServiceRequestBuildItem> devServiceKubeRequest) {
 
-        KubernetesDevServiceCfg configuration = getConfiguration(kubernetesClientBuildTimeConfig);
+        KubernetesDevServiceCfg configuration = new KubernetesDevServiceCfg(kubernetesClientBuildTimeConfig.devservices());
 
         if (devService != null) {
             boolean shouldShutdownTheCluster = !configuration.equals(cfg);
@@ -181,7 +181,7 @@ public class DevServicesKubernetesProcessor {
     @Produce(ServiceStartBuildItem.class)
     public void applyManifests(
             KubernetesDevServiceInfoBuildItem kubernetesDevServiceInfoBuildItem,
-            KubernetesClientBuildConfig kubernetesClientBuildTimeConfig) {
+            KubernetesClientBuildTimeConfig kubernetesClientBuildTimeConfig) {
         if (kubernetesDevServiceInfoBuildItem == null) {
             // Gracefully return in case the Kubernetes dev service could not be found
             log.error("Cannot apply manifests because the Kubernetes dev service is not running");
@@ -399,7 +399,6 @@ public class DevServicesKubernetesProcessor {
     }
 
     private Map<String, String> getKubernetesClientConfigFromKubeConfig(KubeConfig kubeConfig) {
-
         ClusterSpec cluster = kubeConfig.getClusters().get(0).getCluster();
         UserSpec user = kubeConfig.getUsers().get(0).getUser();
         return Map.of(
@@ -425,11 +424,6 @@ public class DevServicesKubernetesProcessor {
         var container = new RunningContainer(dockerClient, containerAddress);
 
         return container.getKubeconfigFromContainer();
-    }
-
-    private KubernetesDevServiceCfg getConfiguration(KubernetesClientBuildConfig cfg) {
-        KubernetesDevServicesBuildTimeConfig devServicesConfig = cfg.devservices();
-        return new KubernetesDevServiceCfg(devServicesConfig);
     }
 
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")

--- a/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/KubernetesClientProcessor.java
+++ b/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/KubernetesClientProcessor.java
@@ -50,7 +50,7 @@ import io.quarkus.kubernetes.client.runtime.KubernetesClientObjectMapperProducer
 import io.quarkus.kubernetes.client.runtime.KubernetesClientProducer;
 import io.quarkus.kubernetes.client.runtime.KubernetesConfigProducer;
 import io.quarkus.kubernetes.client.runtime.KubernetesSerializationProducer;
-import io.quarkus.kubernetes.client.runtime.internal.KubernetesClientBuildConfig;
+import io.quarkus.kubernetes.client.runtime.internal.KubernetesClientBuildTimeConfig;
 import io.quarkus.kubernetes.client.spi.KubernetesClientCapabilityBuildItem;
 import io.quarkus.maven.dependency.ArtifactKey;
 
@@ -98,7 +98,7 @@ public class KubernetesClientProcessor {
 
     @BuildStep
     public void process(ApplicationIndexBuildItem applicationIndex, CombinedIndexBuildItem combinedIndexBuildItem,
-            KubernetesClientBuildConfig kubernetesClientConfig,
+            KubernetesClientBuildTimeConfig kubernetesClientBuildTimeConfig,
             BuildProducer<ExtensionSslNativeSupportBuildItem> sslNativeSupport,
             BuildProducer<FeatureBuildItem> featureProducer,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
@@ -110,7 +110,7 @@ public class KubernetesClientProcessor {
         featureProducer.produce(new FeatureBuildItem(Feature.KUBERNETES_CLIENT));
 
         kubernetesClientCapabilityProducer
-                .produce(new KubernetesClientCapabilityBuildItem(kubernetesClientConfig.generateRbac()));
+                .produce(new KubernetesClientCapabilityBuildItem(kubernetesClientBuildTimeConfig.generateRbac()));
 
         // register fully (and not weakly) for reflection watchers, informers and custom resources
         final Set<DotName> watchedClasses = new HashSet<>();

--- a/extensions/kubernetes-client/runtime-internal/src/main/java/io/quarkus/kubernetes/client/runtime/internal/KubernetesClientBuildTimeConfig.java
+++ b/extensions/kubernetes-client/runtime-internal/src/main/java/io/quarkus/kubernetes/client/runtime/internal/KubernetesClientBuildTimeConfig.java
@@ -1,0 +1,26 @@
+package io.quarkus.kubernetes.client.runtime.internal;
+
+import io.quarkus.runtime.annotations.ConfigDocSection;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+@ConfigMapping(prefix = "quarkus.kubernetes-client")
+@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
+public interface KubernetesClientBuildTimeConfig {
+
+    /**
+     * Enable the generation of the RBAC manifests. If enabled and no other role binding are provided using the properties
+     * `quarkus.kubernetes.rbac.`, it will generate a default role binding using the role "view" and the application
+     * service account.
+     */
+    @WithDefault("true")
+    boolean generateRbac();
+
+    /**
+     * Dev Services
+     */
+    @ConfigDocSection(generated = true)
+    KubernetesDevServicesBuildTimeConfig devservices();
+}

--- a/extensions/kubernetes-client/runtime-internal/src/main/java/io/quarkus/kubernetes/client/runtime/internal/KubernetesClientConfig.java
+++ b/extensions/kubernetes-client/runtime-internal/src/main/java/io/quarkus/kubernetes/client/runtime/internal/KubernetesClientConfig.java
@@ -5,15 +5,13 @@ import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 
-import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
-import io.smallrye.config.WithDefault;
 
 @ConfigMapping(prefix = "quarkus.kubernetes-client")
-@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
-public interface KubernetesClientBuildConfig {
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public interface KubernetesClientConfig {
 
     /**
      * Whether the client should trust a self-signed certificate if so presented by the API server
@@ -24,12 +22,6 @@ public interface KubernetesClientBuildConfig {
      * URL of the Kubernetes API server
      */
     Optional<String> apiServerUrl();
-
-    /**
-     * Use api-server-url instead.
-     */
-    @Deprecated(forRemoval = true)
-    Optional<String> masterUrl();
 
     /**
      * Default namespace to use
@@ -153,17 +145,4 @@ public interface KubernetesClientBuildConfig {
      */
     Optional<List<String>> noProxy();
 
-    /**
-     * Enable the generation of the RBAC manifests. If enabled and no other role binding are provided using the properties
-     * `quarkus.kubernetes.rbac.`, it will generate a default role binding using the role "view" and the application
-     * service account.
-     */
-    @WithDefault("true")
-    boolean generateRbac();
-
-    /**
-     * Dev Services
-     */
-    @ConfigDocSection(generated = true)
-    KubernetesDevServicesBuildTimeConfig devservices();
 }

--- a/extensions/kubernetes-client/runtime-internal/src/main/java/io/quarkus/kubernetes/client/runtime/internal/KubernetesClientUtils.java
+++ b/extensions/kubernetes-client/runtime-internal/src/main/java/io/quarkus/kubernetes/client/runtime/internal/KubernetesClientUtils.java
@@ -6,8 +6,6 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Optional;
 
-import org.eclipse.microprofile.config.ConfigProvider;
-
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -20,12 +18,12 @@ public class KubernetesClientUtils {
     private KubernetesClientUtils() {
     }
 
-    public static Config createConfig(KubernetesClientBuildConfig buildConfig) {
-        boolean globalTrustAll = ConfigProvider.getConfig().getOptionalValue("quarkus.tls.trust-all", Boolean.class)
-                .orElse(false);
+    public static Config createConfig(KubernetesClientConfig clientConfig) {
+        io.smallrye.config.Config config = io.smallrye.config.Config.get();
+        boolean globalTrustAll = config.getOptionalValue("quarkus.tls.trust-all", Boolean.class).orElse(false);
         Config base;
-        if (buildConfig.kubeconfigFile().isPresent()) {
-            String kubeconfigPath = buildConfig.kubeconfigFile().get();
+        if (clientConfig.kubeconfigFile().isPresent()) {
+            String kubeconfigPath = clientConfig.kubeconfigFile().get();
             try {
                 String kubeconfig = Files.readString(Path.of(kubeconfigPath));
                 base = Config.fromKubeconfig(kubeconfig);
@@ -35,81 +33,100 @@ public class KubernetesClientUtils {
         } else {
             base = Config.autoConfigure(null);
         }
-        boolean trustAll = buildConfig.trustCerts().isPresent() ? buildConfig.trustCerts().get() : globalTrustAll;
+        boolean trustAll = clientConfig.trustCerts().isPresent() ? clientConfig.trustCerts().get() : globalTrustAll;
         final var configBuilder = new ConfigBuilder(base).withTrustCerts(trustAll);
-        buildConfig.watchReconnectInterval().ifPresent(d -> configBuilder.withWatchReconnectInterval(millisAsInt(d)));
-        buildConfig.watchReconnectLimit().ifPresent(configBuilder::withWatchReconnectLimit);
-        buildConfig.connectionTimeout().ifPresent(d -> configBuilder.withConnectionTimeout(millisAsInt(d)));
-        buildConfig.requestTimeout().ifPresent(d -> configBuilder.withRequestTimeout(millisAsInt(d)));
-        buildConfig.apiServerUrl().or(buildConfig::masterUrl).ifPresent(configBuilder::withMasterUrl);
-        buildConfig.namespace().ifPresent(configBuilder::withNamespace);
-        buildConfig.username().ifPresent(configBuilder::withUsername);
-        buildConfig.password().ifPresent(configBuilder::withPassword);
-        buildConfig.token().ifPresent(configBuilder::withOauthToken);
-        buildConfig.caCertFile().ifPresent(configBuilder::withCaCertFile);
-        buildConfig.caCertData().ifPresent(configBuilder::withCaCertData);
-        buildConfig.clientCertFile().ifPresent(configBuilder::withClientCertFile);
-        buildConfig.clientCertData().ifPresent(configBuilder::withClientCertData);
-        buildConfig.clientKeyFile().ifPresent(configBuilder::withClientKeyFile);
-        buildConfig.clientKeyData().ifPresent(configBuilder::withClientKeyData);
-        buildConfig.clientKeyAlgo().ifPresent(configBuilder::withClientKeyAlgo);
-        buildConfig.clientKeyPassphrase().ifPresent(configBuilder::withClientKeyPassphrase);
-        buildConfig.httpProxy().ifPresent(configBuilder::withHttpProxy);
-        buildConfig.httpsProxy().ifPresent(configBuilder::withHttpsProxy);
-        buildConfig.proxyUsername().ifPresent(configBuilder::withProxyUsername);
-        buildConfig.proxyPassword().ifPresent(configBuilder::withProxyPassword);
-        buildConfig.noProxy().ifPresent(list -> list.toArray(new String[0]));
-        buildConfig.requestRetryBackoffInterval().ifPresent(d -> configBuilder.withRequestRetryBackoffInterval(millisAsInt(d)));
-        buildConfig.requestRetryBackoffLimit().ifPresent(configBuilder::withRequestRetryBackoffLimit);
+        clientConfig.watchReconnectInterval().ifPresent(d -> configBuilder.withWatchReconnectInterval(millisAsInt(d)));
+        clientConfig.watchReconnectLimit().ifPresent(configBuilder::withWatchReconnectLimit);
+        clientConfig.connectionTimeout().ifPresent(d -> configBuilder.withConnectionTimeout(millisAsInt(d)));
+        clientConfig.requestTimeout().ifPresent(d -> configBuilder.withRequestTimeout(millisAsInt(d)));
+        clientConfig.apiServerUrl().ifPresent(configBuilder::withMasterUrl);
+        clientConfig.namespace().ifPresent(configBuilder::withNamespace);
+        clientConfig.username().ifPresent(configBuilder::withUsername);
+        clientConfig.password().ifPresent(configBuilder::withPassword);
+        clientConfig.token().ifPresent(configBuilder::withOauthToken);
+        clientConfig.caCertFile().ifPresent(configBuilder::withCaCertFile);
+        clientConfig.caCertData().ifPresent(configBuilder::withCaCertData);
+        clientConfig.clientCertFile().ifPresent(configBuilder::withClientCertFile);
+        clientConfig.clientCertData().ifPresent(configBuilder::withClientCertData);
+        clientConfig.clientKeyFile().ifPresent(configBuilder::withClientKeyFile);
+        clientConfig.clientKeyData().ifPresent(configBuilder::withClientKeyData);
+        clientConfig.clientKeyAlgo().ifPresent(configBuilder::withClientKeyAlgo);
+        clientConfig.clientKeyPassphrase().ifPresent(configBuilder::withClientKeyPassphrase);
+        clientConfig.httpProxy().ifPresent(configBuilder::withHttpProxy);
+        clientConfig.httpsProxy().ifPresent(configBuilder::withHttpsProxy);
+        clientConfig.proxyUsername().ifPresent(configBuilder::withProxyUsername);
+        clientConfig.proxyPassword().ifPresent(configBuilder::withProxyPassword);
+        clientConfig.noProxy().ifPresent(list -> configBuilder.withNoProxy(list.toArray(new String[0])));
+        clientConfig.requestRetryBackoffInterval()
+                .ifPresent(d -> configBuilder.withRequestRetryBackoffInterval(millisAsInt(d)));
+        clientConfig.requestRetryBackoffLimit().ifPresent(configBuilder::withRequestRetryBackoffLimit);
         return configBuilder.build();
     }
 
-    private static int millisAsInt(Duration duration) {
-        return (int) duration.toMillis();
-    }
-
-    public static KubernetesClient createClient(KubernetesClientBuildConfig buildConfig) {
-        return new KubernetesClientBuilder().withConfig(createConfig(buildConfig)).build();
-    }
-
-    public static KubernetesClient createClient() {
-        org.eclipse.microprofile.config.Config config = ConfigProvider.getConfig();
-        Config base = Config.autoConfigure(null);
-        final var configBuilder = new ConfigBuilder(base);
-        optional(config, "trust-certs", Boolean.class).ifPresent(configBuilder::withTrustCerts);
-        optional(config, "watch-reconnect-limit", Integer.class).ifPresent(configBuilder::withWatchReconnectLimit);
+    public static Config createConfig() {
+        io.smallrye.config.Config config = io.smallrye.config.Config.get();
+        boolean globalTrustAll = config.getOptionalValue("quarkus.tls.trust-all", Boolean.class).orElse(false);
+        Config base;
+        Optional<String> kubeconfigFile = optional(config, "kubeconfig-file", String.class);
+        if (kubeconfigFile.isPresent()) {
+            String kubeconfigPath = kubeconfigFile.get();
+            try {
+                String kubeconfig = Files.readString(Path.of(kubeconfigPath));
+                base = Config.fromKubeconfig(kubeconfig);
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to read kubeconfig file: " + kubeconfigPath, e);
+            }
+        } else {
+            base = Config.autoConfigure(null);
+        }
+        boolean trustAll = optional(config, "trust-certs", Boolean.class).orElse(globalTrustAll);
+        final var configBuilder = new ConfigBuilder(base).withTrustCerts(trustAll);
         optional(config, "watch-reconnect-interval", Duration.class)
-                .map(KubernetesClientUtils::millisAsInt)
-                .ifPresent(configBuilder::withWatchReconnectInterval);
+                .ifPresent(d -> configBuilder.withWatchReconnectInterval(millisAsInt(d)));
+        optional(config, "watch-reconnect-limit", Integer.class).ifPresent(configBuilder::withWatchReconnectLimit);
         optional(config, "connection-timeout", Duration.class)
-                .map(KubernetesClientUtils::millisAsInt)
-                .ifPresent(configBuilder::withConnectionTimeout);
+                .ifPresent(d -> configBuilder.withConnectionTimeout(millisAsInt(d)));
         optional(config, "request-timeout", Duration.class)
-                .map(KubernetesClientUtils::millisAsInt)
-                .ifPresent(configBuilder::withRequestTimeout);
+                .ifPresent(d -> configBuilder.withRequestTimeout(millisAsInt(d)));
         optional(config, "api-server-url", String.class)
                 .or(() -> optional(config, "master-url", String.class))
                 .ifPresent(configBuilder::withMasterUrl);
         optional(config, "namespace", String.class).ifPresent(configBuilder::withNamespace);
         optional(config, "username", String.class).ifPresent(configBuilder::withUsername);
         optional(config, "password", String.class).ifPresent(configBuilder::withPassword);
+        optional(config, "token", String.class).ifPresent(configBuilder::withOauthToken);
         optional(config, "ca-cert-file", String.class).ifPresent(configBuilder::withCaCertFile);
         optional(config, "ca-cert-data", String.class).ifPresent(configBuilder::withCaCertData);
         optional(config, "client-cert-file", String.class).ifPresent(configBuilder::withClientCertFile);
         optional(config, "client-cert-data", String.class).ifPresent(configBuilder::withClientCertData);
         optional(config, "client-key-file", String.class).ifPresent(configBuilder::withClientKeyFile);
         optional(config, "client-key-data", String.class).ifPresent(configBuilder::withClientKeyData);
-        optional(config, "client-key-passphrase", String.class).ifPresent(configBuilder::withClientKeyPassphrase);
         optional(config, "client-key-algo", String.class).ifPresent(configBuilder::withClientKeyAlgo);
+        optional(config, "client-key-passphrase", String.class).ifPresent(configBuilder::withClientKeyPassphrase);
         optional(config, "http-proxy", String.class).ifPresent(configBuilder::withHttpProxy);
         optional(config, "https-proxy", String.class).ifPresent(configBuilder::withHttpsProxy);
         optional(config, "proxy-username", String.class).ifPresent(configBuilder::withProxyUsername);
         optional(config, "proxy-password", String.class).ifPresent(configBuilder::withProxyPassword);
         optional(config, "no-proxy", String[].class).ifPresent(configBuilder::withNoProxy);
-        return new KubernetesClientBuilder().withConfig(configBuilder.build()).build();
+        optional(config, "request-retry-backoff-interval", Duration.class)
+                .ifPresent(d -> configBuilder.withRequestRetryBackoffInterval(millisAsInt(d)));
+        optional(config, "request-retry-backoff-limit", Integer.class).ifPresent(configBuilder::withRequestRetryBackoffLimit);
+        return configBuilder.build();
+    }
+
+    public static KubernetesClient createClient(KubernetesClientConfig buildConfig) {
+        return new KubernetesClientBuilder().withConfig(createConfig(buildConfig)).build();
+    }
+
+    public static KubernetesClient createClient() {
+        return new KubernetesClientBuilder().withConfig(createConfig()).build();
     }
 
     private static <T> Optional<T> optional(org.eclipse.microprofile.config.Config config, String key, Class<T> valueType) {
         return config.getOptionalValue(PREFIX + key, valueType);
+    }
+
+    private static int millisAsInt(Duration duration) {
+        return (int) duration.toMillis();
     }
 }

--- a/extensions/kubernetes-client/runtime/src/main/java/io/quarkus/kubernetes/client/KubernetesConfigCustomizer.java
+++ b/extensions/kubernetes-client/runtime/src/main/java/io/quarkus/kubernetes/client/KubernetesConfigCustomizer.java
@@ -7,7 +7,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.utils.KubernetesSerialization;
 import io.quarkus.kubernetes.client.runtime.KubernetesClientProducer;
 import io.quarkus.kubernetes.client.runtime.KubernetesConfigProducer;
-import io.quarkus.kubernetes.client.runtime.internal.KubernetesClientBuildConfig;
+import io.quarkus.kubernetes.client.runtime.internal.KubernetesClientConfig;
 
 /**
  * Meant to be implemented by a CDI bean that provided arbitrary customization for the default {@link Config} created by
@@ -16,7 +16,7 @@ import io.quarkus.kubernetes.client.runtime.internal.KubernetesClientBuildConfig
  * The {@link Config} is in turn used to produce the default {@link KubernetesClient}
  * <p>
  *
- * @see KubernetesConfigProducer#config(KubernetesClientBuildConfig, List)
+ * @see KubernetesConfigProducer#config(KubernetesClientConfig, List)
  * @see KubernetesClientProducer#kubernetesClient(KubernetesSerialization, Config)
  */
 public interface KubernetesConfigCustomizer {

--- a/extensions/kubernetes-client/runtime/src/main/java/io/quarkus/kubernetes/client/runtime/KubernetesConfigProducer.java
+++ b/extensions/kubernetes-client/runtime/src/main/java/io/quarkus/kubernetes/client/runtime/KubernetesConfigProducer.java
@@ -9,7 +9,7 @@ import io.fabric8.kubernetes.client.Config;
 import io.quarkus.arc.All;
 import io.quarkus.arc.DefaultBean;
 import io.quarkus.kubernetes.client.KubernetesConfigCustomizer;
-import io.quarkus.kubernetes.client.runtime.internal.KubernetesClientBuildConfig;
+import io.quarkus.kubernetes.client.runtime.internal.KubernetesClientConfig;
 import io.quarkus.kubernetes.client.runtime.internal.KubernetesClientUtils;
 
 @Singleton
@@ -18,9 +18,9 @@ public class KubernetesConfigProducer {
     @DefaultBean
     @Singleton
     @Produces
-    public Config config(KubernetesClientBuildConfig buildConfig,
+    public Config config(KubernetesClientConfig clientConfig,
             @All List<KubernetesConfigCustomizer> customizers) {
-        var result = KubernetesClientUtils.createConfig(buildConfig);
+        var result = KubernetesClientUtils.createConfig(clientConfig);
         for (KubernetesConfigCustomizer customizer : customizers) {
             customizer.customize(result);
         }

--- a/extensions/kubernetes-client/runtime/src/test/java/io/quarkus/kubernetes/client/runtime/KubernetesClientUtilsTest.java
+++ b/extensions/kubernetes-client/runtime/src/test/java/io/quarkus/kubernetes/client/runtime/KubernetesClientUtilsTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,10 +32,12 @@ class KubernetesClientUtilsTest {
 
     @Test
     void shouldGetClientWithTrustCerts() throws Exception {
+        io.smallrye.config.Config config = io.smallrye.config.Config.getOrCreate();
         System.setProperty(Config.KUBERNETES_KUBECONFIG_FILE,
                 new File(getClass().getResource("/test-kubeconfig").toURI()).getAbsolutePath());
         try (KubernetesClient client = KubernetesClientUtils.createClient()) {
             assertTrue(client.getConfiguration().isTrustCerts());
         }
+        ConfigProviderResolver.instance().releaseConfig(config);
     }
 }

--- a/extensions/kubernetes-config/runtime/src/main/java/io/quarkus/kubernetes/config/runtime/KubernetesConfigSourceFactoryBuilder.java
+++ b/extensions/kubernetes-config/runtime/src/main/java/io/quarkus/kubernetes/config/runtime/KubernetesConfigSourceFactoryBuilder.java
@@ -5,7 +5,7 @@ import java.util.Collections;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.quarkus.kubernetes.client.runtime.internal.KubernetesClientBuildConfig;
+import io.quarkus.kubernetes.client.runtime.internal.KubernetesClientConfig;
 import io.quarkus.kubernetes.client.runtime.internal.KubernetesClientUtils;
 import io.quarkus.runtime.ApplicationLifecycleManager;
 import io.quarkus.runtime.configuration.ConfigBuilder;
@@ -19,10 +19,10 @@ public class KubernetesConfigSourceFactoryBuilder implements ConfigBuilder {
         return builder.withSources(new KubernetesConfigFactory());
     }
 
-    static class KubernetesConfigFactory implements ConfigurableConfigSourceFactory<KubernetesClientBuildConfig> {
+    static class KubernetesConfigFactory implements ConfigurableConfigSourceFactory<KubernetesClientConfig> {
         @Override
         public Iterable<ConfigSource> getConfigSources(final ConfigSourceContext context,
-                final KubernetesClientBuildConfig config) {
+                final KubernetesClientConfig config) {
             boolean inAppCDsGeneration = Boolean
                     .parseBoolean(System.getProperty(ApplicationLifecycleManager.QUARKUS_APPCDS_GENERATE_PROP, "false"));
             if (inAppCDsGeneration) {


### PR DESCRIPTION
This moves the Kubernetes Client Config to Runtime. Why?

This is a unique case in our core repo, at least. The Kubernetes Client can be used both at build time and runtime. It does look weird that something that requires a connection url is fixed at build time. Until now, this worked only by chance.

As an example, when running with DevServices, the `api-server-url` must be set by the DevService, but at the same time, this property is marked as runtime fixed, so you shouldn't be allowed to change that property. With #51248, one of the conditions for this to work was removed (Optionals, which would not record a value). The other condition was caching the static mappings to runtime, which I've tried to enable in #53399, and ultimately surfaced this issue https://github.com/quarkusio/quarkus/pull/53399#issuecomment-4176127021.

While I've always advocated that runtime configuration shouldn't be used at build time, with our current design, I don't see any other solution than to move the configuration to be runtime, so the DevService can contribute configuration to the client, but with the downside of requiring lookups to the now new runtime configuration during build time when the client is needed there.

