### PR TITLE
Cache Static mappings to the Runtime config

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
@@ -861,6 +861,7 @@ public class ConfigGenerationBuildStep {
                         method.readStaticField(configClassField));
             }
 
+            mappings.removeAll(mappingsShared);
             mappings.removeAll(mappingsInstances);
             for (ConfigClass mapping : mappings) {
                 method.invokeStaticMethod(WITH_MAPPING, configBuilder, method.readStaticField(sharedFields.get(mapping)));


### PR DESCRIPTION
This will avoid having to reinitialize Static Init mappings in the Runtime config, introduced in https://github.com/quarkusio/quarkus/pull/46249, but later removed in https://github.com/quarkusio/quarkus/pull/51248, due to https://github.com/quarkusio/quarkus/pull/53425#issue-4197307412.

Requires https://github.com/quarkusio/quarkus/pull/53425.