### PR TITLE
Also populate cache on GitHub Actions for main repo

### DIFF
--- a/.github/workflows/populate-cache.yml
+++ b/.github/workflows/populate-cache.yml
@@ -1,4 +1,4 @@
-name: Quarkus CI - Populate cache for forks
+name: Quarkus CI - Populate cache
 
 permissions:
   contents: read
@@ -23,19 +23,11 @@ jobs:
   configure:
     name: "Configure jobs"
     runs-on: ubuntu-latest
-    if: ${{ github.repository != 'quarkusio/quarkus' }}
     outputs:
       m2-monthly-branch-cache-key: ${{ steps.cache-key.outputs.m2-monthly-branch-cache-key }}
       m2-monthly-cache-key: ${{ steps.cache-key.outputs.m2-monthly-cache-key }}
       m2-cache-key: ${{ steps.cache-key.outputs.m2-cache-key }}
-      quarkus-metadata-cache-key: ${{ steps.cache-key.outputs.quarkus-metadata-cache-key }}
-      quarkus-metadata-cache-key-default: ${{ steps.cache-key.outputs.quarkus-metadata-cache-key-default }}
     steps:
-      - name: Set up JDK 21
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: 21
       - name: Generate cache key
         id: cache-key
         run: |
@@ -62,8 +54,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Cache Maven Repository
-        id: cache-maven
-        uses: quarkusio/cache-action@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           # A new cache will be stored weekly. After that first store of the day, cache save actions will fail because the cache is immutable but it's not a problem.
@@ -73,7 +64,6 @@ jobs:
           restore-keys: |
             ${{ needs.configure.outputs.m2-monthly-branch-cache-key }}-
             ${{ needs.configure.outputs.m2-monthly-cache-key }}-
-          runs-on: false
       - name: Populate the cache
         run: |
-          ./mvnw -T2C $COMMON_MAVEN_ARGS dependency:go-offline
+          ./mvnw -T2C $COMMON_MAVEN_ARGS -q dependency:go-offline -Dgo-offline


### PR DESCRIPTION
We moved back quite a few jobs from Runs On to GitHub Actions and the population of the cache that is made in the CI workflow is done on Runs On, thus leaving the GH Actions runners without any cache.

We have this populate-cache workflow for forks so let's also use it on the main repo to generate a weekly cache that GitHub Actions runners will be able to consume.

Important context: the Runs On cache is stored on S3 and not in the GitHub infrastructure.