### PR TITLE
Avoid skipping config tracking when the Quarkus build is skipped

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/TrackConfigChangesMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/TrackConfigChangesMojo.java
@@ -42,7 +42,7 @@ public class TrackConfigChangesMojo extends QuarkusBootstrapMojo {
      * Skip the execution of this mojo
      */
     @Parameter(defaultValue = "false", property = "quarkus.track-config-changes.skip")
-    boolean skip = false;
+    boolean skipConfigChangesTracking = false;
 
     @Parameter(property = "launchMode")
     String mode;
@@ -79,7 +79,7 @@ public class TrackConfigChangesMojo extends QuarkusBootstrapMojo {
 
     @Override
     protected boolean beforeExecute() throws MojoExecutionException, MojoFailureException {
-        if (skip) {
+        if (skipConfigChangesTracking) {
             getLog().info("Skipping config dump");
             return false;
         }


### PR DESCRIPTION
Config tracking is also used to dump the dependencies for the Develocity cache to work and we need this to be enabled even if we decide to skip the Quarkus build, as we might not skip the code generation.

This was causing issues with cache being stalled, in particular for pull request https://github.com/quarkusio/quarkus/pull/52948 .

Renaming the variable avoids that configuring <skip>${skipTests}<skip> as done in integration-tests/pom.xml also skips config tracking.

See https://github.com/quarkusio/quarkus/blob/111d27eac7392ff7425ecffec6bdfa27eb70da0a/integration-tests/pom.xml#L73-L92 .