### PR TITLE
Set up automatic Dependenbot updates for Hibernate * in 3.33

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -298,6 +298,36 @@ updates:
       - dependency-name: org.hibernate.*:*
         update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
     rebase-strategy: disabled
+  - package-ecosystem: maven
+    directory: "/"
+    target-branch: "3.33"
+    schedule:
+      interval: daily
+      time: "23:00"
+      timezone: Europe/Paris
+    open-pull-requests-limit: 10
+    labels:
+      - area/dependencies
+    allow:
+      # Hibernate
+      - dependency-name: org.hibernate.orm:*
+      - dependency-name: org.hibernate.reactive:*
+      - dependency-name: org.hibernate.validator:*
+      - dependency-name: org.hibernate.search:*
+    groups:
+      # Only group Hibernate ORM/Search/Reactive as Hibernate Validator is much more independent.
+      Hibernate:
+        patterns:
+          - "org.hibernate.orm*"
+          - "org.hibernate.reactive*"
+          - "org.hibernate.search*"
+          - "org.hibernate.validator*"
+    ignore:
+      # Major/minor upgrades require more work and synchronization, we do them manually.
+      # Only use dependabot for micros (patch versions).
+      - dependency-name: org.hibernate.*:*
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+    rebase-strategy: disabled
   - package-ecosystem: gradle
     directory: "/devtools/gradle"
     schedule:


### PR DESCRIPTION
Same as what we did for 3.20 and 3.27.