### PR TITLE
Remove duplicated `plexus-utils` from bootstrap BOM

### DIFF
--- a/independent-projects/bootstrap/bom/pom.xml
+++ b/independent-projects/bootstrap/bom/pom.xml
@@ -435,11 +435,6 @@
                 <version>${plexus-sec-dispatcher.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-utils</artifactId>
-                <version>${plexus-utils.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.graalvm.sdk</groupId>
                 <artifactId>nativeimage</artifactId>
                 <version>${graal-sdk.version}</version>


### PR DESCRIPTION
Gets rid of the build warning:
```bash
[WARNING]
[WARNING] Some problems were encountered while building the effective model for io.quarkus:quarkus-bootstrap-bom:pom:999-SNAPSHOT
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.codehaus.plexus:plexus-utils:jar -> duplicate declaration of version ${plexus-utils.version} @ line 437, column 25
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```
- Follow up from https://github.com/quarkusio/quarkus/pull/53435