### PR TITLE
[3.20] Update to plexus-utils 3.6.1

### DIFF
--- a/independent-projects/bootstrap/bom/pom.xml
+++ b/independent-projects/bootstrap/bom/pom.xml
@@ -154,6 +154,11 @@
                 </exclusions>
             </dependency>
             <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-utils</artifactId>
+                <version>${plexus-utils.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-settings</artifactId>
                 <version>${maven-core.version}</version>

--- a/independent-projects/bootstrap/bom/pom.xml
+++ b/independent-projects/bootstrap/bom/pom.xml
@@ -420,11 +420,6 @@
                 <version>${plexus-sec-dispatcher.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-utils</artifactId>
-                <version>${plexus-utils.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.graalvm.sdk</groupId>
                 <artifactId>nativeimage</artifactId>
                 <version>${graal-sdk.version}</version>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -69,7 +69,7 @@
         <plexus-cipher.version>2.0</plexus-cipher.version>
         <plexus-interpolation.version>1.26</plexus-interpolation.version>
         <plexus-sec-dispatcher.version>2.0</plexus-sec-dispatcher.version>
-        <plexus-utils.version>3.5.1</plexus-utils.version>
+        <plexus-utils.version>3.6.1</plexus-utils.version>
         <smallrye-common.version>2.12.2</smallrye-common.version>
         <smallrye-beanbag.version>1.5.2</smallrye-beanbag.version>
         <gradle-tooling.version>8.13</gradle-tooling.version>


### PR DESCRIPTION
backport of https://github.com/quarkusio/quarkus/pull/53435 and https://github.com/quarkusio/quarkus/pull/53458