### PR TITLE
Remove unnecessary netty dependency in cli

### DIFF
--- a/devtools/cli/pom.xml
+++ b/devtools/cli/pom.xml
@@ -44,23 +44,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-netty</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-qute</artifactId>
-        </dependency>
-        <!--
-        Somehow, we need this as otherwise you end up with:
-        java.lang.ClassNotFoundException: io.netty.handler.codec.http2.DefaultHttp2FrameWriter
-        as we try to initialize them at runtime anyway
-        which is weird because the NettyProcessor correctly checks if the HTTP2 support is around.
-        Note that if you drop this dependency, the native image build will finish,
-        but the native image will be all broken.
-        -->
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-http2</artifactId>
         </dependency>
         <dependency>
             <groupId>io.smallrye.common</groupId>
@@ -86,7 +70,7 @@
             <artifactId>smallrye-config-crypto</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- This dependency is here to make sure the build order is correct-->
+        <!-- These test scoped dependencies are here to make sure the build order is correct-->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-picocli-deployment</artifactId>

--- a/devtools/cli/pom.xml
+++ b/devtools/cli/pom.xml
@@ -40,10 +40,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-apache-httpclient</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-qute</artifactId>
         </dependency>
         <dependency>
@@ -87,32 +83,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jackson-deployment</artifactId>
-            <type>pom</type>
-            <scope>test</scope>
-            <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-netty-deployment</artifactId>
-            <type>pom</type>
-            <scope>test</scope>
-            <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-apache-httpclient-deployment</artifactId>
             <type>pom</type>
             <scope>test</scope>
             <version>${project.version}</version>


### PR DESCRIPTION
@aloubyansky found by chance netty depedency in cli - chat here: [#dev > Netty in Quarkus CLI](https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/Netty.20in.20Quarkus.20CLI/with/583939504)

I removed the netty deps and things seem to build and native image does build - but fails for *other* reasons than netty http so since we dont support native image build of the cli atm and netty only seem added due to a commit [made 5 years ago](https://github.com/quarkusio/quarkus/commit/2167b1755539d63ede58d289d0d297261e4962ce) to try get native image to work lets remove it.

