### PR TITLE
Bump Otel to 1.60.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -29,7 +29,7 @@
         <resteasy-microprofile.version>3.0.1.Final</resteasy-microprofile.version>
         <resteasy-spring-web.version>3.2.0.Final</resteasy-spring-web.version>
         <resteasy.version>6.2.15.Final</resteasy.version>
-        <opentelemetry-instrumentation.version>2.25.0-alpha</opentelemetry-instrumentation.version> <!-- OTel SDk 1.59.0-->
+        <opentelemetry-instrumentation.version>2.26.1-alpha</opentelemetry-instrumentation.version> <!-- OTel SDk 1.60.1-->
         <opentelemetry-semconv.version>1.40.0-alpha</opentelemetry-semconv.version>
         <quarkus-http.version>5.4.0</quarkus-http.version>
         <micrometer.version>1.16.3</micrometer.version><!-- keep in sync with hdrhistogram: https://central.sonatype.com/artifact/io.micrometer/micrometer-core -->

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AgroalOpenTelemetryWrapper.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AgroalOpenTelemetryWrapper.java
@@ -2,12 +2,23 @@ package io.quarkus.agroal.runtime;
 
 import java.util.function.Function;
 
+import jakarta.inject.Inject;
+
 import io.agroal.api.AgroalDataSource;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.instrumentation.jdbc.datasource.JdbcTelemetry;
+import io.opentelemetry.instrumentation.jdbc.datasource.OpenTelemetryDataSource;
 
 public class AgroalOpenTelemetryWrapper implements Function<AgroalDataSource, AgroalDataSource> {
 
+    @Inject
+    OpenTelemetry openTelemetry;
+
     @Override
     public AgroalDataSource apply(AgroalDataSource originalDataSource) {
-        return new OpenTelemetryAgroalDataSource(originalDataSource);
+        OpenTelemetryDataSource otelDataSource = (OpenTelemetryDataSource) JdbcTelemetry
+                .create(openTelemetry)
+                .wrap(originalDataSource);
+        return new OpenTelemetryAgroalDataSource(originalDataSource, otelDataSource);
     }
 }

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/OpenTelemetryAgroalDataSource.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/OpenTelemetryAgroalDataSource.java
@@ -1,29 +1,79 @@
 package io.quarkus.agroal.runtime;
 
+import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.sql.ShardingKeyBuilder;
 import java.util.Collection;
 import java.util.List;
+import java.util.logging.Logger;
 
 import io.agroal.api.AgroalDataSource;
 import io.agroal.api.AgroalDataSourceMetrics;
 import io.agroal.api.AgroalPoolInterceptor;
 import io.agroal.api.configuration.AgroalDataSourceConfiguration;
-import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.jdbc.datasource.OpenTelemetryDataSource;
-import io.quarkus.arc.Arc;
 
 /**
  * The {@link AgroalDataSource} wrapper that activates OpenTelemetry JDBC instrumentation.
+ * <p>
+ * Uses composition to wrap an {@link OpenTelemetryDataSource} (for instrumented connections)
+ * while delegating {@link AgroalDataSource}-specific operations to the original data source.
  */
-public class OpenTelemetryAgroalDataSource extends OpenTelemetryDataSource implements AgroalDataSource {
+public class OpenTelemetryAgroalDataSource implements AgroalDataSource {
 
     private final AgroalDataSource delegate;
+    private final OpenTelemetryDataSource otelDataSource;
 
-    public OpenTelemetryAgroalDataSource(AgroalDataSource delegate) {
-        super(delegate, Arc.container().instance(OpenTelemetry.class).get());
+    public OpenTelemetryAgroalDataSource(AgroalDataSource delegate, OpenTelemetryDataSource otelDataSource) {
         this.delegate = delegate;
+        this.otelDataSource = otelDataSource;
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        return otelDataSource.getConnection();
+    }
+
+    @Override
+    public Connection getConnection(String username, String password) throws SQLException {
+        return otelDataSource.getConnection(username, password);
+    }
+
+    @Override
+    public PrintWriter getLogWriter() throws SQLException {
+        return delegate.getLogWriter();
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter out) throws SQLException {
+        delegate.setLogWriter(out);
+    }
+
+    @Override
+    public int getLoginTimeout() throws SQLException {
+        return delegate.getLoginTimeout();
+    }
+
+    @Override
+    public void setLoginTimeout(int seconds) throws SQLException {
+        delegate.setLoginTimeout(seconds);
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        return delegate.getParentLogger();
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        return delegate.unwrap(iface);
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        return delegate.isWrapperFor(iface);
     }
 
     @Override

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/JvmMetricsTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/JvmMetricsTest.java
@@ -85,13 +85,16 @@ public class JvmMetricsTest extends BaseJvmMetricsTest {
             allMetrics.add(new MetricToAssert("jvm.network.io", "Network read/write bytes.", "By", HISTOGRAM));
             allMetrics.add(new MetricToAssert("jvm.network.time", "Network read/write duration.", "s", HISTOGRAM));
         }
-        // Recommended sdk metrics
+        // SDK self-diagnostics metrics
         allMetrics.add(new MetricToAssert("otel.sdk.span.live",
                 "The number of created spans with recording=true for which the end operation has not been called yet.",
                 "{span}", LONG_SUM));
         allMetrics.add(new MetricToAssert("otel.sdk.span.started",
                 "The number of created spans.",
                 "{span}", LONG_SUM));
+        allMetrics.add(new MetricToAssert("otel.sdk.metric_reader.collection.duration",
+                "The duration of the collect operation of the metric reader.",
+                "s", HISTOGRAM));
 
         // Force GC to run
         System.gc();

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/AutoConfiguredOpenTelemetrySdkBuilderCustomizer.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/AutoConfiguredOpenTelemetrySdkBuilderCustomizer.java
@@ -291,7 +291,8 @@ public interface AutoConfiguredOpenTelemetrySdkBuilderCustomizer {
                                 // In the future we can inject scopes here.
                                 Set<String> dropInstrumentationScopes = Set.of(
                                         "io.opentelemetry.sdk.trace",
-                                        "io.opentelemetry.sdk.logs");
+                                        "io.opentelemetry.sdk.logs",
+                                        "io.opentelemetry.sdk.metrics");
                                 for (String target : dropInstrumentationScopes) {
                                     SdkMeterProviderUtil.addMeterConfiguratorCondition(
                                             meterProviderBuilder,

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/OTelRuntimeConfig.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/OTelRuntimeConfig.java
@@ -99,6 +99,20 @@ public interface OTelRuntimeConfig {
     InstrumentRuntimeConfig instrument();
 
     /**
+     * Controls the OpenTelemetry SDK internal telemetry version.
+     * <p>
+     * When set to <code>latest</code>, the SDK emits self-diagnostics metrics for spans
+     * (<code>otel.sdk.span.live</code>, <code>otel.sdk.span.started</code>) in addition to
+     * metric reader diagnostics (<code>otel.sdk.metric_reader.collection.duration</code>).
+     * When set to <code>legacy</code>, only metric reader diagnostics are emitted.
+     * <p>
+     * Defaults to <code>latest</code>.
+     */
+    @WithName("experimental.sdk.telemetry.version")
+    @WithDefault("latest")
+    String experimentalSdkTelemetryVersion();
+
+    /**
      * Prioritize OpenTelemetry configuration <code>otel.</code> on top of Quarkus OpenTelemetry configuration
      * <code>quarkus.otel</code>.
      * <p>

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/RedisClientInstrumenterVertxTracer.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/RedisClientInstrumenterVertxTracer.java
@@ -1,6 +1,6 @@
 package io.quarkus.opentelemetry.runtime.tracing.instrumentation.vertx;
 
-import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAMESPACE;
+import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.REDIS;
 import static io.quarkus.opentelemetry.runtime.config.build.OTelBuildConfig.INSTRUMENTATION_NAME;
 
@@ -16,7 +16,6 @@ import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
-import io.opentelemetry.instrumentation.api.internal.AttributesExtractorUtil;
 import io.opentelemetry.instrumentation.api.semconv.network.NetworkAttributesExtractor;
 import io.opentelemetry.instrumentation.api.semconv.network.NetworkAttributesGetter;
 import io.quarkus.opentelemetry.runtime.config.runtime.OTelRuntimeConfig;
@@ -231,7 +230,9 @@ public class RedisClientInstrumenterVertxTracer implements
         @Override
         public void onStart(AttributesBuilder attributes, io.opentelemetry.context.Context parentContext,
                 CommandTrace request) {
-            AttributesExtractorUtil.internalSet(attributes, DB_NAMESPACE, request.dbIndex());
+            if (request.dbIndex() != null) {
+                attributes.put(DB_NAMESPACE, request.dbIndex());
+            }
         }
 
         @Override

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/SqlClientInstrumenterVertxTracer.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/SqlClientInstrumenterVertxTracer.java
@@ -1,16 +1,20 @@
 package io.quarkus.opentelemetry.runtime.tracing.instrumentation.vertx;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlDialect.DOUBLE_QUOTES_ARE_IDENTIFIERS;
+import static io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlDialect.DOUBLE_QUOTES_ARE_STRING_LITERALS;
 import static io.quarkus.opentelemetry.runtime.config.build.OTelBuildConfig.INSTRUMENTATION_NAME;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiConsumer;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlClientAttributesExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlDialect;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.semconv.network.NetworkAttributesExtractor;
@@ -143,6 +147,54 @@ public class SqlClientInstrumenterVertxTracer implements
     static class SqlClientAttributesGetter implements
             io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlClientAttributesGetter<QueryTrace, Object>,
             NetworkAttributesGetter<QueryTrace, Object> {
+
+        // Databases where double quotes are exclusively identifiers and cannot be string literals.
+        private static final Set<String> DOUBLE_QUOTES_FOR_IDENTIFIERS_SYSTEMS = Set.of(
+                // "A string constant in SQL is an arbitrary sequence of characters
+                // bounded by single quotes (')"
+                // https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-STRINGS
+                "postgresql",
+                // "Text, character, and string literals are always surrounded
+                // by single quotation marks."
+                // https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/Literals.html
+                "oracle",
+                // "A sequence of characters that starts and ends with a string delimiter,
+                // which is an apostrophe (')"
+                // https://www.ibm.com/docs/en/db2/12.1?topic=elements-constants
+                "db2",
+                // "Single quotation marks delimit character strings."
+                // "Double quotation marks delimit special identifiers"
+                // https://db.apache.org/derby/docs/10.17/ref/rrefsqlj28468.html
+                "derby",
+                // "names of objects are enclosed in double-quotes"
+                // (double quotes are exclusively for identifiers; follows SQL standard strictly)
+                // https://hsqldb.org/doc/2.0/guide/sqlgeneral-chapt.html
+                "hsqldb",
+                // <string_literal> ::= <single_quote>[<any_character>...]<single_quote>
+                // <special_identifier> ::= <double_quotes><any_character>...<double_quotes>
+                // https://help.sap.com/docs/hana-cloud-database/sap-hana-cloud-sap-hana-database-sql-reference-guide/sql-notation-conventions
+                "hanadb",
+                // "String literals must be enclosed in single quotes.
+                // Double quotes are not supported."
+                // https://clickhouse.com/docs/en/sql-reference/syntax#string
+                "clickhouse",
+                // PostgreSQL-compatible fork, inherits PG string literal rules
+                "polardb");
+
+        /**
+         * Same as in
+         * io.opentelemetry.instrumentation.jdbc.internal.JdbcAttributesGetter#getSqlDialect(io.opentelemetry.instrumentation.jdbc.internal.DbRequest)
+         */
+        @Override
+        public SqlDialect getSqlDialect(QueryTrace queryTrace) {
+            String system = queryTrace.system();
+            if (system != null && DOUBLE_QUOTES_FOR_IDENTIFIERS_SYSTEMS.contains(system)) {
+                return DOUBLE_QUOTES_ARE_IDENTIFIERS;
+            }
+            // default to treating double-quoted tokens as string literals for safety, ensuring that
+            // potentially sensitive values are not captured
+            return DOUBLE_QUOTES_ARE_STRING_LITERALS;
+        }
 
         @Override
         public Collection<String> getRawQueryTexts(final QueryTrace queryTrace) {


### PR DESCRIPTION
Agroal tracing bootstrap has changed due to the removal of deprecated methods.

**SqlDialect** is now mandatory for the SQL instrumentation we use. This is not the same as the old hibernate.dialect. It is used internally by OTel to escape double quotes. It's a bit puzzling and I'm consulting with upstream ppl to see if there is a better way to express and implement the feature. 

**New:** 
* SDK self diagnostics metric: `otel.sdk.metric_reader.collection.duration`
* New config for the SDK sef diagnostic: `quarkus.otel.experimental.sdk.telemetry.version`