### PR TITLE
Added a test to make sure we never regress on not setting `@Context` for record bean params

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/beanparam/BeanParamRecordTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/beanparam/BeanParamRecordTest.java
@@ -43,7 +43,7 @@ public class BeanParamRecordTest {
                 .get("/record")
                 .then()
                 .statusCode(200)
-                .body(equalTo("got it/2/3/4/5/6.0/7.0/true/a/query/query/query/query"));
+                .body(equalTo("got it/2/3/4/5/6.0/7.0/true/a/query/query/query/query//record"));
 
     }
 
@@ -102,7 +102,8 @@ public class BeanParamRecordTest {
                     + p.obp().q + "/"
                     + p.obp().obpr.q() + "/"
                     + p.obp().obpc.q + "/"
-                    + p.obpr().q;
+                    + p.obpr().q + "/"
+                    + p.uriInfo().getPath();
         }
     }
 }

--- a/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/scanning/ClassInjectorTransformer.java
+++ b/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/scanning/ClassInjectorTransformer.java
@@ -239,7 +239,7 @@ public class ClassInjectorTransformer implements BiFunction<String, ClassVisitor
 
         // For records, create instance and return it
         if (isRecord) {
-            List<RecordComponentInfo> components = classInfo.unsortedRecordComponents();
+            List<RecordComponentInfo> components = classInfo.recordComponentsInDeclarationOrder();
             ResultHandle[] args = new ResultHandle[components.size()];
             String[] paramTypes = new String[components.size()];
 


### PR DESCRIPTION
The previous code, prior to the ASM->Gizmo rewrite, simply forgot to store the injected param, so it was never used: https://github.com/FroMage/quarkus/blob/9206f882e145075429254d9e0668076cd53b1dd1/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/scanning/ClassInjectorTransformer.java#L492

This should also have failed for non-`record` cases, but I suspect that `@Context` behaved like an auto-`@Inject` and so the value was was set elsewhere and we never caught this. And I forgot to test this when adding support for records.

See https://github.com/quarkusio/quarkus/issues/53477 for the QE failure that led to this discovery.