### PR TITLE
Style and grammar review for the "OpenID Connect (OIDC) and OAuth2 client and filters" guide

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
@@ -15,9 +15,9 @@ You can use Quarkus extensions for OpenID Connect and OAuth 2.0 access token man
 
 This includes the following:
 
- - Using `quarkus-oidc-client`, `quarkus-rest-client-oidc-filter` and `quarkus-resteasy-client-oidc-filter` extensions to acquire and refresh access tokens from OpenID Connect and OAuth 2.0 compliant Authorization Servers such as link:https://www.keycloak.org[Keycloak].
+* Using `quarkus-oidc-client`, `quarkus-rest-client-oidc-filter` and `quarkus-resteasy-client-oidc-filter` extensions to acquire and refresh access tokens from OpenID Connect and OAuth 2.0 compliant Authorization Servers such as link:https://www.keycloak.org[Keycloak].
 
- - Using `quarkus-rest-client-oidc-token-propagation` and `quarkus-resteasy-client-oidc-token-propagation` extensions to propagate the current `Bearer` or `Authorization Code Flow` access tokens.
+* Using `quarkus-rest-client-oidc-token-propagation` and `quarkus-resteasy-client-oidc-token-propagation` extensions to propagate the current `Bearer` or `Authorization Code Flow` access tokens.
 
 The access tokens managed by these extensions can be used as HTTP Authorization Bearer tokens to access the remote services.
 
@@ -35,9 +35,10 @@ Add the following dependency:
 </dependency>
 ----
 
-The `quarkus-oidc-client` extension provides a reactive `io.quarkus.oidc.client.OidcClient`, which can be used to acquire and refresh tokens using SmallRye Mutiny `Uni` and `Vert.x WebClient`.
+The `quarkus-oidc-client` extension provides a reactive `io.quarkus.oidc.client.OidcClient`, which can be used to acquire and refresh tokens by using SmallRye Mutiny `Uni` and `Vert.x WebClient`.
 
-`OidcClient` is initialized at build time with the IDP token endpoint URL, which can be auto-discovered or manually configured. `OidcClient` uses this endpoint to acquire access tokens by using token grants such as `client_credentials` or `password` and refresh the tokens by using a `refresh_token` grant.
+`OidcClient` is initialized at build time with the IDP token endpoint URL, which can be auto-discovered or manually configured.
+`OidcClient` uses this endpoint to acquire access tokens with token grants such as `client_credentials` or `password`, and to refresh tokens with a `refresh_token` grant.
 
 === Token endpoint configuration
 
@@ -45,16 +46,18 @@ By default, the token endpoint address is discovered by adding a `/.well-known/o
 
 For example, given this Keycloak URL:
 
-[source, properties]
+[source,properties]
 ----
 quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus
 ----
 
 `OidcClient` will discover that the token endpoint URL is `http://localhost:8180/auth/realms/quarkus/protocol/openid-connect/tokens`.
 
-Alternatively, if the discovery endpoint is unavailable or you want to save on the discovery endpoint round-trip, you can disable the discovery and configure the token endpoint address with a relative path value. For example:
+Alternatively, if the discovery endpoint is unavailable or you want to avoid an extra round-trip to it, you can disable discovery and configure the token endpoint address with a relative path.
 
-[source, properties]
+For example:
+
+[source,properties]
 ----
 quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus
 quarkus.oidc-client.discovery-enabled=false
@@ -64,7 +67,7 @@ quarkus.oidc-client.token-path=/protocol/openid-connect/tokens
 
 A more compact way to configure the token endpoint URL without the discovery is to set `quarkus.oidc-client.token-path` to an absolute URL:
 
-[source, properties]
+[source,properties]
 ----
 quarkus.oidc-client.token-path=http://localhost:8180/auth/realms/quarkus/protocol/openid-connect/tokens
 ----
@@ -86,7 +89,9 @@ quarkus.oidc-client.client-id=quarkus-app
 quarkus.oidc-client.credentials.secret=secret
 ----
 
-The `client_credentials` grant allows setting extra parameters for the token request by using `quarkus.oidc-client.grant-options.client.<param-name>=<value>`. Here is how to set the intended token recipient by using the `audience` parameter:
+The `client_credentials` grant allows setting extra parameters for the token request by using `quarkus.oidc-client.grant-options.client.<param-name>=<value>`.
+
+Here is how to set the intended token recipient by using the `audience` parameter:
 
 [source,properties]
 ----
@@ -112,13 +117,20 @@ quarkus.oidc-client.grant-options.password.username=alice
 quarkus.oidc-client.grant-options.password.password=alice
 ----
 
-It can be further customized by using a `quarkus.oidc-client.grant-options.password` configuration prefix, similar to how the client credentials grant can be customized.
+It can be further customized with the `quarkus.oidc-client.grant-options.password` configuration prefix, similar to the client credentials grant.
 
 ==== Other grants
 
-`OidcClient` can also help acquire the tokens by using grants that require some extra input parameters that cannot be captured in the configuration. These grants are `refresh_token` (with the external refresh token), `authorization_code`, and two grants which can be used to exchange the current access token, namely, `urn:ietf:params:oauth:grant-type:token-exchange` and `urn:ietf:params:oauth:grant-type:jwt-bearer`.
+`OidcClient` can also help acquire tokens with grants that require additional input parameters that cannot be captured in the configuration.
 
-If you need to acquire an access token and have posted an existing refresh token to the current Quarkus endpoint, you must use the `refresh_token` grant. This grant employs an out-of-band refresh token to obtain a new token set.
+These grants are `refresh_token` (with the external refresh token), `authorization_code`, and two grants which can be used to exchange the current access token, namely:
+
+* `urn:ietf:params:oauth:grant-type:token-exchange`
+* `urn:ietf:params:oauth:grant-type:jwt-bearer`.
+
+If you need to acquire an access token and have posted an existing refresh token to the current Quarkus endpoint, you must use the `refresh_token` grant.
+This grant uses an out-of-band refresh token to obtain a new token set.
+
 In this case, configure `OidcClient` as follows:
 
 [source,properties]
@@ -131,9 +143,13 @@ quarkus.oidc-client.grant.type=refresh
 
 Then you can use the `OidcClient.refreshTokens` method with a provided refresh token to get the access token.
 
-Using the `urn:ietf:params:oauth:grant-type:token-exchange` or `urn:ietf:params:oauth:grant-type:jwt-bearer` grants might be required if you are building a complex microservices application and want to avoid the same `Bearer` token be propagated to and used by more than one service. See <<token-propagation-rest,Token Propagation for Quarkus REST>> and <<token-propagation-resteasy,Token Propagation for RESTEasy Classic>> for more details.
+Using the `urn:ietf:params:oauth:grant-type:token-exchange` or `urn:ietf:params:oauth:grant-type:jwt-bearer` grants might be required if you are building a complex microservices application and want to avoid the same `Bearer` token being propagated to and used by more than one service.
 
-Using `OidcClient` to support the `authorization code` grant might be required if, for some reason, you cannot use the xref:security-oidc-code-flow-authentication.adoc[Quarkus OIDC extension] to support Authorization Code Flow. If there is a very good reason for you to implement Authorization Code Flow, then you can configure `OidcClient` as follows:
+For more information, see <<token-propagation-rest,Token Propagation for Quarkus REST>> and <<token-propagation-resteasy,Token Propagation for RESTEasy Classic>>.
+
+Using `OidcClient` to support the `authorization code` grant might be required if you cannot use the xref:security-oidc-code-flow-authentication.adoc[Quarkus OIDC extension] to support Authorization Code Flow.
+
+If there is a very good reason for you to implement Authorization Code Flow, then you can configure `OidcClient` as follows:
 
 [source,properties]
 ----
@@ -167,9 +183,10 @@ Use a dedicated `quarkus.oidc-client.scopes` list property, for example: `quarku
 
 You can use `OidcClient` directly to acquire access tokens and set them in an HTTP `Authorization` header as a `Bearer` scheme value.
 
-For example, let's assume the Quarkus endpoint has to access a microservice that returns a user name.
-First, create a REST client:
+For example, assume that the Quarkus endpoint must access a microservice that returns a user name.
 
+. Create a REST client:
++
 [source,java]
 ----
 package org.acme.security.openid.connect.client;
@@ -193,8 +210,8 @@ public interface RestClientWithTokenHeaderParam {
 }
 ----
 
-Now, use `OidcClient` to acquire the tokens and propagate them:
-
+. Use `OidcClient` to acquire the tokens and propagate them:
++
 [source,java]
 ----
 package org.acme.security.openid.connect.client;
@@ -234,7 +251,8 @@ public class OidcClientResource {
 
 === Inject tokens
 
-You can inject `Tokens` that use `OidcClient` internally. `Tokens` can be used to acquire the access tokens and refresh them if necessary:
+You can inject `Tokens` that use `OidcClient` internally.
+`Tokens` can be used to acquire the access tokens and refresh them if necessary:
 
 [source,java]
 ----
@@ -261,7 +279,9 @@ public class OidcClientResource {
 [[use-oidc-clients]]
 === Use OidcClients
 
-`io.quarkus.oidc.client.OidcClients` is a container of ``OidcClient``s - it includes a default `OidcClient` and named clients which can be configured like this:
+`io.quarkus.oidc.client.OidcClients` is a container of `OidcClient` instances.
+
+It includes a default `OidcClient` and named clients that can be configured like this:
 
 [source,properties]
 ----
@@ -272,7 +292,8 @@ quarkus.oidc-client.jwt-secret.client-id=quarkus-app
 quarkus.oidc-client.jwt-secret.credentials.jwt.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
 ----
 
-In this case, the default client is disabled with a `client-enabled=false` property. The `jwt-secret` client can be accessed like this:
+In this case, the default client is disabled with a `client-enabled=false` property.
+The `jwt-secret` client can be accessed like this:
 
 [source,java]
 ----
@@ -312,7 +333,9 @@ public class OidcClientResource {
 
 [NOTE]
 ====
-If you also use xref:security-openid-connect-multitenancy.adoc[OIDC multitenancy], and each OIDC tenant has its own associated `OidcClient`, you can use a Vert.x `RoutingContext` `tenant-id` attribute. For example:
+If you also use xref:security-openid-connect-multitenancy.adoc[OIDC multitenancy], and each OIDC tenant has its own associated `OidcClient`, you can use a Vert.x `RoutingContext` `tenant-id` attribute.
+
+For example:
 
 [source,java]
 ----
@@ -344,7 +367,7 @@ public class OidcClientResource {
 ====
 
 You can also create a new `OidcClient` programmatically.
-For example, let's assume you must create it at startup time:
+For example, assume that you must create it at startup time:
 
 [source,java]
 ----
@@ -431,10 +454,11 @@ public class OidcClientResource {
 ----
 <1> See the `RestClientWithTokenHeaderParam` declaration in the <<use-oidc-client-directly>> section.
 
+
 [[named-oidc-clients]]
 === Inject named OidcClient and tokens
 
-In case of multiple configured `OidcClient` objects, you can specify the `OidcClient` injection target by the extra qualifier `@NamedOidcClient` instead of working with `OidcClients`:
+If multiple `OidcClient` objects are configured, you can specify the `OidcClient` injection target with the `@NamedOidcClient` qualifier instead of working with `OidcClients`:
 
 [source,java]
 ----
@@ -511,7 +535,7 @@ public class OidcClientRequestCustomFilter implements ClientRequestFilter {
 [[rest-client-oidc-filter]]
 === Use OidcClient in RestClient Reactive ClientFilter
 
-Add the following Maven Dependency:
+Add the following Maven dependency:
 
 [source,xml]
 ----
@@ -525,7 +549,11 @@ NOTE: It will also bring `io.quarkus:quarkus-oidc-client`.
 
 `quarkus-rest-client-oidc-filter` extension provides `io.quarkus.oidc.client.filter.OidcClientRequestReactiveFilter`.
 
-It works similarly to the way `OidcClientRequestFilter` does (see <<resteasy-client-oidc-filter,Use OidcClient in MicroProfile RestClient client filter>>) - it uses `OidcClient` to acquire the access token, refresh it if needed, and set it as an HTTP `Authorization Bearer` scheme value. The difference is that it works with xref:rest-client.adoc[Reactive RestClient] and implements a non-blocking client filter that does not block the current IO thread when acquiring or refreshing the tokens.
+It works similarly to `OidcClientRequestFilter`.
+See <<resteasy-client-oidc-filter,Use OidcClient in MicroProfile RestClient client filter>>.
+It uses `OidcClient` to acquire the access token, refresh it if needed, and set it as an HTTP `Authorization Bearer` scheme value.
+
+The difference is that it works with xref:rest-client.adoc[Reactive RestClient] and implements a non-blocking client filter that does not block the current IO thread when acquiring or refreshing the tokens.
 
 `OidcClientRequestReactiveFilter` delays an initial token acquisition until it is executed to avoid blocking an IO thread.
 
@@ -594,8 +622,12 @@ public interface ProtectedResourceService {
 }
 ----
 
-`OidcClientRequestReactiveFilter` uses a default `OidcClient` by default. A named `OidcClient` can be selected with a `quarkus.rest-client-oidc-filter.client-name` configuration property.
-You can also select `OidcClient` by setting the `value` attribute of the `@OidcClientFilter` annotation. The client name set through annotation has higher priority than the `quarkus.rest-client-oidc-filter.client-name` configuration property.
+`OidcClientRequestReactiveFilter` uses a default `OidcClient` by default.
+A named `OidcClient` can be selected with the `quarkus.rest-client-oidc-filter.client-name` configuration property.
+You can also select `OidcClient` by setting the `value` attribute of the `@OidcClientFilter` annotation.
+
+The client name set through annotation has higher priority than the `quarkus.rest-client-oidc-filter.client-name` configuration property.
+
 For example, given <<use-oidc-clients,this>> `jwt-secret` named OIDC client declaration, you can refer to this client like this:
 
 [source,java]
@@ -616,14 +648,14 @@ public interface ProtectedResourceService {
 }
 ----
 
-If you also want to refresh the token every time the `ProtectedResourceService#getUserName` call results in a 401 Unauthorized error, use the `quarkus.rest-client-oidc-filter.refresh-on-unauthorized` configuration property like in the example below:
+If you also want to refresh the token every time the `ProtectedResourceService#getUserName` call results in a 401 Unauthorized error, use the `quarkus.rest-client-oidc-filter.refresh-on-unauthorized` configuration property, as in the following example:
 
 [source,properties]
 ----
 quarkus.rest-client-oidc-filter.refresh-on-unauthorized=true
 ----
 
-Alternatively, if you only need to enable this feature for individual endpoints, create a custom filter like in the example below:
+Alternatively, if you only need to enable this feature for individual endpoints, create a custom filter, as in the following example:
 
 [source,java]
 ----
@@ -646,7 +678,7 @@ public class OidcClientRequestCustomFilter extends AbstractOidcClientRequestReac
 [[resteasy-client-oidc-filter]]
 === Use OidcClient in RestClient ClientFilter
 
-Add the following Maven Dependency:
+Add the following Maven dependency:
 
 [source,xml]
 ----
@@ -658,9 +690,10 @@ Add the following Maven Dependency:
 
 NOTE: It will also bring `io.quarkus:quarkus-oidc-client`.
 
-`quarkus-resteasy-client-oidc-filter` extension provides `io.quarkus.oidc.client.resteasy.filter.OidcClientRequestFilter` Jakarta REST ClientRequestFilter which uses `OidcClient` to acquire the access token, refresh it if needed, and set it as an HTTP `Authorization Bearer` scheme value.
+`quarkus-resteasy-client-oidc-filter` extension provides `io.quarkus.oidc.client.resteasy.filter.OidcClientRequestFilter`, a Jakarta REST `ClientRequestFilter` that uses `OidcClient` to acquire the access token, refresh it if needed, and set it as an HTTP `Authorization Bearer` scheme value.
 
-By default, this filter will get `OidcClient` to acquire the first pair of access and refresh tokens at its initialization time. If the access tokens are short-lived and refresh tokens are unavailable, then the token acquisition should be delayed with `quarkus.oidc-client.early-tokens-acquisition=false`.
+By default, this filter uses `OidcClient` to acquire the first pair of access and refresh tokens at initialization time.
+If the access tokens are short-lived and refresh tokens are unavailable, then the token acquisition should be delayed with `quarkus.oidc-client.early-tokens-acquisition=false`.
 
 You can selectively register `OidcClientRequestFilter` by using either `io.quarkus.oidc.client.filter.OidcClientFilter` or `org.eclipse.microprofile.rest.client.annotation.RegisterProvider` annotations:
 
@@ -725,8 +758,12 @@ public interface ProtectedResourceService {
 
 Alternatively, `OidcClientRequestFilter` can be registered automatically with all MP Rest or Jakarta REST clients if the `quarkus.resteasy-client-oidc-filter.register-filter=true` property is set.
 
-`OidcClientRequestFilter` uses a default `OidcClient` by default. A named `OidcClient` can be selected with a `quarkus.resteasy-client-oidc-filter.client-name` configuration property.
-You can also select `OidcClient` by setting the `value` attribute of the `@OidcClientFilter` annotation. The client name set through annotation has higher priority than the `quarkus.resteasy-client-oidc-filter.client-name` configuration property.
+`OidcClientRequestFilter` uses a default `OidcClient` by default.
+A named `OidcClient` can be selected with the `quarkus.resteasy-client-oidc-filter.client-name` configuration property.
+You can also select `OidcClient` by setting the `value` attribute of the `@OidcClientFilter` annotation.
+
+The client name set through annotation has higher priority than the `quarkus.resteasy-client-oidc-filter.client-name` configuration property.
+
 For example, given <<use-oidc-clients,this>> `jwt-secret` named OIDC client declaration, you can refer to this client like this:
 
 [source,java]
@@ -746,14 +783,14 @@ public interface ProtectedResourceService {
 }
 ----
 
-If you also want to refresh the token every time the `ProtectedResourceService#getUserName` call results in a 401 Unauthorized error, use the `quarkus.resteasy-client-oidc-filter.refresh-on-unauthorized` configuration property like in the example below:
+If you also want to refresh the token every time the `ProtectedResourceService#getUserName` call results in a 401 Unauthorized error, use the `quarkus.resteasy-client-oidc-filter.refresh-on-unauthorized` configuration property, as in the following example:
 
 [source,properties]
 ----
 quarkus.resteasy-client-oidc-filter.refresh-on-unauthorized=true
 ----
 
-Alternatively, if you only need to enable this feature for individual endpoints, create a custom filter like in the example below:
+Alternatively, if you only need to enable this feature for individual endpoints, create a custom filter, as in the following example:
 
 [source,java]
 ----
@@ -810,37 +847,47 @@ You can also inject named `Tokens`, see <<named-oidc-clients,Inject named OidcCl
 [[refresh-access-tokens]]
 === Refreshing access tokens
 
-`OidcClientRequestReactiveFilter`, `OidcClientRequestFilter` and `Tokens` producers will refresh the current expired access token if the refresh token is available.
-Additionally, the `quarkus.oidc-client.refresh-token-time-skew` property can be used for a preemptive access token refreshment to avoid sending nearly expired access tokens that might cause HTTP 401 errors. For example, if this property is set to `3S` and the access token will expire in less than 3 seconds, then this token will be auto-refreshed.
+`OidcClientRequestReactiveFilter`, `OidcClientRequestFilter`, and `Tokens` producers refresh the current expired access token if a refresh token is available.
 
+Additionally, you can use the `quarkus.oidc-client.refresh-token-time-skew` property for preemptive access token refresh to avoid sending nearly expired access tokens that might cause HTTP 401 errors.
 
-By default, OIDC client refreshes the token during the current request, when it detects that it has expired, or nearly expired if the xref:#quarkus-oidc-client_quarkus-oidc-client-refresh-token-time-skew[refresh token time skew] is configured.
-Performance critical applications may want to avoid having to wait for a possible token refresh during the incoming requests and configure an asynchronous token refresh instead, for example:
+For example, if this property is set to `3S` and the access token will expire in less than 3 seconds, the token is refreshed automatically.
+
+By default, the OIDC client refreshes the token during the current request when it detects that the token has expired, or is nearly expired if the xref:#quarkus-oidc-client_quarkus-oidc-client-refresh-token-time-skew[refresh token time skew] is configured.
+Performance-critical applications might want to avoid waiting for a possible token refresh during incoming requests and configure an asynchronous token refresh instead.
+
+For example:
 
 [source,properties]
 ----
 quarkus.oidc-client.refresh-interval=1m <1>
 ----
-<1> Check every minute if the current access token is expired and must be refreshed.
+<1> Check every minute whether the current access token is expired and must be refreshed.
 
-If the access token needs to be refreshed, but no refresh token is available, then an attempt is made to acquire a new token by using a configured grant, such as `client_credentials`.
+If the access token needs to be refreshed but no refresh token is available, an attempt is made to acquire a new token with a configured grant, such as `client_credentials`.
 
-Some OpenID Connect Providers will not return a refresh token in a `client_credentials` grant response. For example, starting from Keycloak 12, a refresh token will not be returned by default for `client_credentials`. The providers might also restrict the number of times a refresh token can be used.
+Some OpenID Connect providers do not return a refresh token in a `client_credentials` grant response.
+For example, starting with Keycloak 12, a refresh token is not returned by default for `client_credentials`.
+Providers might also restrict how many times a refresh token can be used.
 
 [[revoke-access-tokens]]
 === Revoking access tokens
 
-If your OpenId Connect provider, such as Keycloak, supports a token revocation endpoint, then `OidcClient#revokeAccessToken` can be used to revoke the current access token. The revocation endpoint URL will be discovered alongside the token request URI or can be configured with `quarkus.oidc-client.revoke-path`.
+If your OpenID Connect provider, such as Keycloak, supports a token revocation endpoint, you can use `OidcClient#revokeAccessToken` to revoke the current access token.
+The revocation endpoint URL is discovered alongside the token request URI or can be configured with `quarkus.oidc-client.revoke-path`.
 
-You might want to have the access token revoked if using this token with a REST client fails with an HTTP `401` status code or if the access token has already been used for a long time and you would like to refresh it.
+You might want to revoke the access token if a REST client call that uses this token fails with an HTTP `401` status code, or if the token has been used for a long time and you want to refresh it.
 
-This can be achieved by requesting a token refresh by using a refresh token. However, if the refresh token is unavailable, you can refresh it by revoking it first and then requesting a new access token.
+You can do this by requesting a token refresh with a refresh token.
+However, if the refresh token is unavailable, you can revoke the current access token first and then request a new access token.
 
 [[oidc-client-authentication]]
 === OidcClient authentication
 
-`OidcClient` has to authenticate to the OpenID Connect Provider for the `client_credentials` and other grant requests to succeed.
-All the https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication[OIDC Client Authentication] options are supported, for example:
+`OidcClient` must authenticate to the OpenID Connect provider for the `client_credentials` and other grant requests to succeed.
+All the https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication[OIDC Client Authentication] options are supported.
+
+For example:
 
 `client_secret_basic`:
 
@@ -909,7 +956,7 @@ quarkus.oidc.credentials.client-secret.provider.keyring-name=oidc
 quarkus.oidc-client.credentials.jwt.secret-provider.name=oidc-credentials-provider
 ----
 
-`private_key_jwt` with the PEM key inlined in application.properties, and where the signature algorithm is `RS256`:
+`private_key_jwt` with the PEM key inlined in application.properties, where the signature algorithm is `RS256`:
 
 [source,properties]
 ----
@@ -945,7 +992,9 @@ Using `client_secret_jwt` or `private_key_jwt` authentication methods ensures th
 
 ==== Additional JWT authentication options
 
-If either `client_secret_jwt` or `private_key_jwt` authentication methods are used, then the JWT signature algorithm, key identifier, audience, subject, and issuer can be customized, for example:
+If either `client_secret_jwt` or `private_key_jwt` authentication method is used, you can customize the JWT signature algorithm, key identifier, audience, subject, and issuer.
+
+For example:
 
 [source,properties]
 ----
@@ -975,9 +1024,10 @@ quarkus.oidc-client.credentials.jwt.issuer=custom-issuer
 
 ==== JWT Bearer
 
-link:https://www.rfc-editor.org/rfc/rfc7523[RFC7523] explains how JWT Bearer tokens can be used to authenticate clients, see the link:https://www.rfc-editor.org/rfc/rfc7523#section-2.2[Using JWTs for Client Authentication] section for more information.
+link:https://www.rfc-editor.org/rfc/rfc7523[RFC7523] explains how JWT Bearer tokens can be used to authenticate clients.
+For more information, see the link:https://www.rfc-editor.org/rfc/rfc7523#section-2.2[Using JWTs for Client Authentication] section.
 
-It can be enabled as follows:
+Enable it as follows:
 
 [source,properties]
 ----
@@ -986,21 +1036,22 @@ quarkus.oidc-client.client-id=quarkus-app
 quarkus.oidc-client.credentials.jwt.source=bearer
 ----
 
-Next, the JWT bearer token must be provided as a `client_assertion` parameter to the OIDC client.
+Next, provide the JWT bearer token as a `client_assertion` parameter to the OIDC client.
 
-Quarkus can load the JWT bearer token from a file system.
+Quarkus can load the JWT bearer token from the file system.
 For example, in Kubernetes, a service account token projection can be mounted to a `/var/run/secrets/tokens` path.
-Then all you need to do is configure a JWT bearer token path as follows:
+Then configure the JWT bearer token path as follows:
 
 [source,properties]
 ----
 quarkus.oidc-client.credentials.jwt.token-path=/var/run/secrets/tokens <1>
 ----
-<1> Path to a JWT bearer token. Quarkus loads a new token from a filesystem and reload it when the token has expired.
+<1> Path to a JWT bearer token.
+Quarkus loads a new token from the file system and reloads it when the token expires.
 
-Your other option is to use `OidcClient` methods for acquiring or refreshing tokens which accept additional grant parameters, for example, `oidcClient.getTokens(Map.of("client_assertion", "ey..."))`.
+Your other option is to use `OidcClient` methods for acquiring or refreshing tokens that accept additional grant parameters, for example, `oidcClient.getTokens(Map.of("client_assertion", "ey..."))`.
 
-If you work work with the OIDC client filters then you must register a custom filter which will provide this assertion.
+If you use the OIDC client filters, you must register a custom filter that provides this assertion.
 
 Here is an example of the Quarkus REST (formerly RESTEasy Reactive) custom filter:
 
@@ -1050,7 +1101,7 @@ public class OidcClientRequestCustomFilter extends AbstractOidcClientRequestFilt
 
 ==== Apple POST JWT
 
-Apple OpenID Connect Provider uses a `client_secret_post` method where a secret is a JWT produced with a `private_key_jwt` authentication method but with Apple account-specific issuer and subject properties.
+Apple OpenID Connect provider uses the `client_secret_post` method, where the secret is a JWT produced with the `private_key_jwt` authentication method, but with Apple account-specific issuer and subject properties.
 
 `quarkus-oidc-client` supports a non-standard `client_secret_post_jwt` authentication method, which can be configured as follows:
 
@@ -1068,7 +1119,7 @@ quarkus.oidc-client.credentials.jwt.issuer=${apple.issuer}
 
 ==== Mutual TLS
 
-Some OpenID Connect Providers require that a client is authenticated as part of the mutual TLS (`mTLS`) authentication process.
+Some OpenID Connect providers require that a client be authenticated as part of the mutual TLS (`mTLS`) authentication process.
 
 `quarkus-oidc-client` can be configured as follows to support `mTLS`:
 
@@ -1096,10 +1147,10 @@ quarkus.tls.oidc-client.trust-store.p12.password=${trust-store-password}
 
 === OIDC Client SPI
 
-When your custom extension must acquire OIDC tokens using one of the OIDC token grants supported by OIDC client, this extension can depend on the OIDC Client SPI only and let OIDC client itself acquire and refresh access tokens as necessary.
+When your custom extension must acquire OIDC tokens by using one of the token grants supported by the OIDC client, the extension can depend only on the OIDC Client SPI and let the OIDC client itself acquire and refresh access tokens as needed.
 
-Add the following dependency:
-
+. Add the following dependency:
++
 [source,xml]
 ----
 <dependency>
@@ -1108,7 +1159,8 @@ Add the following dependency:
 </dependency>
 ----
 
-Next update your extension to use `io.quarkus.oidc.client.spi.TokenProvider` CDI bean as required, for example:
+. Update your extension to use the `io.quarkus.oidc.client.spi.TokenProvider` CDI bean as required.
+For example:
 
 [source,java]
 ----
@@ -1127,8 +1179,8 @@ public class ExtensionOAuth2Support {
    }
 }
 ----
-
-Currently, `io.quarkus.oidc.client.spi.TokenProvider` is only available for default OIDC clients, since custom extensions are unlikely to be aware of multiple named OIDC clients.
++
+Currently, `io.quarkus.oidc.client.spi.TokenProvider` is available only for default OIDC clients because custom extensions are unlikely to be aware of multiple named OIDC clients.
 
 [[integration-testing-oidc-client]]
 === Testing
@@ -1152,8 +1204,8 @@ Start by adding the following dependencies to your test project:
 [[oidc-client-ref-integration-testing-wiremock]]
 ==== Wiremock
 
-Add the following dependencies to your test project:
-
+. Add the following dependencies to your test project:
++
 [source,xml]
 ----
 <dependency>
@@ -1163,10 +1215,12 @@ Add the following dependencies to your test project:
     <version>${wiremock.version}</version> // <1>
 </dependency>
 ----
-<1> Use a proper Wiremock version. View all link:https://central.sonatype.com/artifact/org.wiremock/wiremock?smo=true[available WireMock versions] on Maven Central.
+<1> Use a proper Wiremock version.
+View all link:https://central.sonatype.com/artifact/org.wiremock/wiremock?smo=true[available WireMock versions] on Maven Central.
 
-Write a Wiremock-based `QuarkusTestResourceLifecycleManager`, for example:
-[source, java]
+. Write a Wiremock-based `QuarkusTestResourceLifecycleManager`, for example:
++
+[source,properties]
 ----
 package io.quarkus.it.keycloak;
 
@@ -1222,11 +1276,15 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
 }
 ----
 
-Prepare the REST test endpoints. You can have the test front-end endpoint, which uses the injected MP REST client with a registered OidcClient filter, call the downstream endpoint. This endpoint echoes the token back. For example, see the `integration-tests/oidc-client-wiremock` in the `main` Quarkus repository.
+. Prepare the REST test endpoints.
++
+You can have the test front-end endpoint, which uses the injected MP REST client with a registered OidcClient filter, call the downstream endpoint.
+This endpoint echoes the token back.
+For example, see the `integration-tests/oidc-client-wiremock` in the `main` Quarkus repository.
 
-Set `application.properties`, for example:
-
-[source, properties]
+. Set `application.properties`, for example:
++
+[source,properties]
 ----
 # Use the 'keycloak.url' property set by the test KeycloakRealmResourceManager
 quarkus.oidc-client.auth-server-url=${keycloak.url:replaced-by-test-resource}
@@ -1239,7 +1297,11 @@ quarkus.oidc-client.grant-options.password.username=alice
 quarkus.oidc-client.grant-options.password.password=alice
 ----
 
-And finally, write the test code. Given the Wiremock-based resource above, the first test invocation should return the `access_token_1` access token, which will expire in 4 seconds. Use `awaitility` to wait for about 5 seconds, and now the next test invocation should return the `access_token_2` access token, which confirms the expired `access_token_1` access token has been refreshed.
+. Write the test code.
++
+Given the Wiremock-based resource above, the first test invocation should return the `access_token_1` access token, which will expire in 4 seconds.
+Use `awaitility` to wait for about 5 seconds.
+The next test invocation should return the `access_token_2` access token, which confirms the expired `access_token_1` access token has been refreshed.
 
 ==== Keycloak
 
@@ -1247,17 +1309,17 @@ If you work with Keycloak, you can use the same approach described in the xref:s
 
 === How to check the errors in the logs
 
-Enable `io.quarkus.oidc.client.runtime.OidcClientImpl` `TRACE` level logging to see more details about the token acquisition and refresh errors:
-
-[source, properties]
+. Enable `io.quarkus.oidc.client.runtime.OidcClientImpl` `TRACE` level logging to see more details about the token acquisition and refresh errors:
++
+[source,properties]
 ----
 quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientImpl".level=TRACE
 quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientImpl".min-level=TRACE
 ----
 
-Enable `io.quarkus.oidc.client.runtime.OidcClientRecorder` `TRACE` level logging to see more details about the OidcClient initialization errors:
-
-[source, properties]
+. Enable `io.quarkus.oidc.client.runtime.OidcClientRecorder` `TRACE` level logging to see more details about the OidcClient initialization errors:
++
+[source,properties]
 ----
 quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientRecorder".level=TRACE
 quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientRecorder".min-level=TRACE
@@ -1266,9 +1328,11 @@ quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientRecorder".min-lev
 [[oidc-client-ref-oidc-request-filters]]
 == OIDC request filters
 
-You can filter OIDC requests made by OIDC client to the OIDC provider by registering one or more `OidcRequestFilter` implementations, which can update or add new request headers, customize or analyze the request body.
+You can filter OIDC requests made by the OIDC client to the OIDC provider by registering one or more `OidcRequestFilter` implementations, which can update or add new request headers, customize or analyze the request body.
 
-You can have a single filter intercepting requests to all OIDC provider endpoints, or use an `@OidcEndpoint` annotation to apply this filter to requests to specific endpoints only. For example:
+You can have a single filter intercept requests to all OIDC provider endpoints, or use an `@OidcEndpoint` annotation to apply this filter to requests to specific endpoints only.
+
+For example:
 
 [source,java]
 ----
@@ -1278,6 +1342,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 
 import io.quarkus.arc.Unremovable;
 import io.quarkus.oidc.common.OidcEndpoint;
+import io.quarkus.oidc.common.OidcEndpoint.Type;
 import io.quarkus.oidc.common.OidcRequestFilter;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.http.HttpMethod;
@@ -1298,16 +1363,16 @@ public class OidcRequestCustomizer implements OidcRequestFilter {
     }
 
     private String calculateDigest(String bodyString) {
-        // Apply the required digest algorithm to the body string
+        // Apply the required digest algorithm to the body string.
+        // Implementation details are omitted for brevity.
     }
 }
 ----
 
 `OidcRequestContextProperties` can be used to access request properties.
-Currently, you can use a `client_id` key to access the client tenant id and a `grant_type` key to access the grant type which the OIDC client uses to acquire tokens.
+Currently, you can use a `client_id` key to access the client tenant ID and a `grant_type` key to access the grant type that the OIDC client uses to acquire tokens.
 
-`OidcRequestFilter` can customize a request body by preparing an instance of `io.vertx.mutiny.core.buffer.Buffer`
-and setting it on a request context, for example:
+`OidcRequestFilter` can customize the request body by updating it with a `String` or by preparing an instance of `io.vertx.mutiny.core.buffer.Buffer` and setting it on a request context, for example:
 
 [source,java]
 ----
@@ -1320,7 +1385,6 @@ import io.quarkus.oidc.common.OidcEndpoint;
 import io.quarkus.oidc.common.OidcEndpoint.Type;
 import io.quarkus.oidc.common.OidcRequestFilter;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.core.buffer.Buffer;
 
 @ApplicationScoped
 @Unremovable
@@ -1339,9 +1403,11 @@ public class TokenRequestFilter implements OidcRequestFilter {
 [[oidc-client-ref-oidc-response-filters]]
 == OIDC response filters
 
-You can filter responses to the OIDC client requests by registering one or more `OidcResponseFilter` implementations, which can check the response status, headers and body, in order to log them or perform other actions.
+You can filter responses to OIDC client requests by registering one or more `OidcResponseFilter` implementations that can check the response status, headers, and body to log them or perform other actions.
 
-You can have a single filter intercepting responses to all OIDC client requests, or use an `@OidcEndpoint` annotation to apply this filter to the responses to the specific OIDC client requests only. For example:
+You can have a single filter intercept responses to all OIDC client requests, or use an `@OidcEndpoint` annotation to apply this filter to responses to specific OIDC client requests only.
+
+For example:
 
 [source,java]
 ----
@@ -1382,8 +1448,7 @@ public class TokenEndpointResponseFilter implements OidcResponseFilter {
 <3> Use `OidcRequestContextProperties` request properties to confirm it is a `refresh_grant` token grant response.
 <4> Confirm the response JSON contains a `refresh_token` property.
 
-`OidcResponseFilter` can customize a response body by preparing an instance of `io.vertx.mutiny.core.buffer.Buffer`
-and setting it as a property on a response context, for example:
+`OidcResponseFilter` can customize the response body by preparing an instance of `io.vertx.mutiny.core.buffer.Buffer` and setting it as a property on a response context, for example:
 
 [source,java]
 ----
@@ -1421,9 +1486,11 @@ public class TokenResponseFilter implements OidcResponseFilter {
 [[token-propagation-rest]]
 == Token Propagation for Quarkus REST
 
-The `quarkus-rest-client-oidc-token-propagation` extension provides a REST Client filter, `io.quarkus.oidc.token.propagation.reactive.AccessTokenRequestReactiveFilter`, that simplifies the propagation of authentication information. This client propagates the xref:security-oidc-bearer-token-authentication.adoc[bearer token] present in the currently active request or the token acquired from the xref:security-oidc-code-flow-authentication.adoc[authorization code flow mechanism] as the HTTP `Authorization` header's `Bearer` scheme value.
+The `quarkus-rest-client-oidc-token-propagation` extension provides a REST Client filter, `io.quarkus.oidc.token.propagation.reactive.AccessTokenRequestReactiveFilter`, that simplifies the propagation of authentication information.
 
-You can selectively register `AccessTokenRequestReactiveFilter` by using either `io.quarkus.oidc.token.propagation.common.AccessToken` or `org.eclipse.microprofile.rest.client.annotation.RegisterProvider` annotation, for example:
+This filter propagates the xref:security-oidc-bearer-token-authentication.adoc[bearer token] present in the currently active request or the token acquired from the xref:security-oidc-code-flow-authentication.adoc[authorization code flow mechanism] as the HTTP `Authorization` header's `Bearer` scheme value.
+
+You can selectively register `AccessTokenRequestReactiveFilter` by using either the `io.quarkus.oidc.token.propagation.common.AccessToken` annotation or the `org.eclipse.microprofile.rest.client.annotation.RegisterProvider` annotation, for example:
 
 [source,java]
 ----
@@ -1485,8 +1552,7 @@ public interface ProtectedResourceService {
 }
 ----
 
-
-Additionally, `AccessTokenRequestReactiveFilter` can support a complex application that needs to exchange the tokens before propagating them.
+Additionally, `AccessTokenRequestReactiveFilter` can support a complex application that needs to exchange tokens before propagating them.
 
 If you work with link:https://www.keycloak.org/securing-apps/token-exchange[Keycloak] or another OIDC provider that supports a link:https://tools.ietf.org/html/rfc8693[Token Exchange] token grant, then you can configure `AccessTokenRequestReactiveFilter` to exchange the token like this:
 
@@ -1502,7 +1568,7 @@ quarkus.rest-client-oidc-token-propagation.exchange-token=true <1>
 ----
 <1> Please note that the `exchange-token` configuration property is ignored when the OidcClient name is set with the `io.quarkus.oidc.token.propagation.common.AccessToken#exchangeTokenClient` annotation attribute.
 
-NOTE: `AccessTokenRequestReactiveFilter` will use `OidcClient` to exchange the current token, and you can use `quarkus.oidc-client.grant-options.exchange` to set the additional exchange properties expected by your OpenID Connect Provider.
+NOTE: `AccessTokenRequestReactiveFilter` will use `OidcClient` to exchange the current token, and you can use `quarkus.oidc-client.grant-options.exchange` to set the additional exchange properties expected by your OpenID Connect provider.
 
 If you work with providers such as `Azure` that link:https://learn.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow#example[require using] link:https://www.rfc-editor.org/rfc/rfc7523#section-2.1[JWT bearer token grant] to exchange the current token, then you can configure `AccessTokenRequestReactiveFilter` to exchange the token like this:
 
@@ -1519,26 +1585,34 @@ quarkus.oidc-client.scopes=https://graph.microsoft.com/user.read,offline_access
 quarkus.resteasy-client-oidc-token-propagation.exchange-token=true
 ----
 
-`AccessTokenRequestReactiveFilter` uses a default `OidcClient` by default. A named `OidcClient` can be selected with a `quarkus.rest-client-oidc-token-propagation.client-name` configuration property or with the `io.quarkus.oidc.token.propagation.common.AccessToken#exchangeTokenClient` annotation attribute.
+`AccessTokenRequestReactiveFilter` uses a default `OidcClient` by default.
+A named `OidcClient` can be selected with a `quarkus.rest-client-oidc-token-propagation.client-name` configuration property or with the `io.quarkus.oidc.token.propagation.common.AccessToken#exchangeTokenClient` annotation attribute.
+
 
 [[token-propagation-resteasy]]
 == Token Propagation for RESTEasy Classic
 
 The `quarkus-resteasy-client-oidc-token-propagation` extension provides two Jakarta REST `jakarta.ws.rs.client.ClientRequestFilter` class implementations that simplify the propagation of authentication information.
 `io.quarkus.oidc.token.propagation.AccessTokenRequestFilter` propagates the xref:security-oidc-bearer-token-authentication.adoc[Bearer token] present in the current active request or the token acquired from the xref:security-oidc-code-flow-authentication.adoc[Authorization code flow mechanism], as the HTTP `Authorization` header's `Bearer` scheme value.
-The `io.quarkus.oidc.token.propagation.JsonWebTokenRequestFilter` provides the same functionality but, in addition, provides support for JWT tokens.
 
-When you need to propagate the current Authorization Code Flow access token, then the immediate token propagation will work well - as the code flow access tokens (as opposed to ID tokens) are meant to be propagated for the current Quarkus endpoint to access the remote services on behalf of the currently authenticated user.
+The `io.quarkus.oidc.token.propagation.JsonWebTokenRequestFilter` provides the same functionality and, in addition, supports JWT tokens.
 
-However, the direct end-to-end Bearer token propagation should be avoided. For example, `Client -> Service A -> Service B` where `Service B` receives a token sent by `Client` to `Service A`. In such cases, `Service B` cannot distinguish if the token came from `Service A` or from `Client` directly. For `Service B` to verify the token came from `Service A`, it should be able to assert a new issuer and audience claims.
+When you need to propagate the current Authorization Code Flow access token, immediate token propagation works well because the code flow access tokens, as opposed to ID tokens, are meant to be propagated for the current Quarkus endpoint to access the remote services on behalf of the currently authenticated user.
 
-Additionally, a complex application might need to exchange or update the tokens before propagating them. For example, the access context might be different when `Service A` is accessing `Service B`. In this case, `Service A` might be granted a narrow or completely different set of scopes to access `Service B`.
+However, direct end-to-end Bearer token propagation should be avoided.
+For example, `Client -> Service A -> Service B`, where `Service B` receives a token sent by `Client` to `Service A`.
+In such cases, `Service B` cannot distinguish whether the token came from `Service A` or directly from `Client`.
+For `Service B` to verify that the token originated from `Service A`, it should be able to assert new issuer and audience claims.
+
+Additionally, a complex application might need to exchange or update the tokens before propagating them.
+For example, the access context might differ when `Service A` accesses `Service B`.
+In this case, `Service A` might be granted a narrow or completely different set of scopes to access `Service B`.
 
 The following sections show how `AccessTokenRequestFilter` and `JsonWebTokenRequestFilter` can help.
 
 === RestClient AccessTokenRequestFilter
 
-`AccessTokenRequestFilter` treats all tokens as Strings, and as such, it can work with both JWT and opaque tokens.
+`AccessTokenRequestFilter` treats all tokens as strings and, as such, can work with both JWT and opaque tokens.
 
 You can selectively register `AccessTokenRequestFilter` by using either `io.quarkus.oidc.token.propagation.common.AccessToken` or `org.eclipse.microprofile.rest.client.annotation.RegisterProvider`, for example:
 
@@ -1602,11 +1676,11 @@ public interface ProtectedResourceService {
 }
 ----
 
-Alternatively, `AccessTokenRequestFilter` can be registered automatically with all MP Rest or Jakarta REST clients if the `quarkus.resteasy-client-oidc-token-propagation.register-filter` property is set to `true` and `quarkus.resteasy-client-oidc-token-propagation.json-web-token` property is set to `false` (which is a default value).
+Alternatively, `AccessTokenRequestFilter` can be registered automatically with all MP Rest or Jakarta REST clients if the `quarkus.resteasy-client-oidc-token-propagation.register-filter` property is set to `true` and the `quarkus.resteasy-client-oidc-token-propagation.json-web-token` property is set to `false`, which is the default value.
 
 ==== Exchange token before propagation
 
-If the current access token needs to be exchanged before propagation and you work with link:https://www.keycloak.org/securing-apps/token-exchange[Keycloak] or other OpenID Connect Provider which supports a link:https://tools.ietf.org/html/rfc8693[Token Exchange] token grant, then you can configure `AccessTokenRequestFilter` like this:
+If the current access token needs to be exchanged before propagation and you work with link:https://www.keycloak.org/securing-apps/token-exchange[Keycloak] or another OpenID Connect provider that supports a link:https://tools.ietf.org/html/rfc8693[Token Exchange] token grant, you can configure `AccessTokenRequestFilter` like this:
 
 [source,properties]
 ----
@@ -1619,7 +1693,7 @@ quarkus.oidc-client.grant-options.exchange.audience=quarkus-app-exchange
 quarkus.resteasy-client-oidc-token-propagation.exchange-token=true
 ----
 
-If you work with providers such as `Azure` that link:https://learn.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow#example[require using] link:https://www.rfc-editor.org/rfc/rfc7523#section-2.1[JWT bearer token grant] to exchange the current token, then you can configure `AccessTokenRequestFilter` to exchange the token like this:
+If you work with providers such as `Azure` that link:https://learn.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow#example[require using] link:https://www.rfc-editor.org/rfc/rfc7523#section-2.1[JWT bearer token grant] to exchange the current token, you can configure `AccessTokenRequestFilter` to exchange the token like this:
 
 [source,properties]
 ----
@@ -1634,15 +1708,20 @@ quarkus.oidc-client.scopes=https://graph.microsoft.com/user.read,offline_access
 quarkus.resteasy-client-oidc-token-propagation.exchange-token=true
 ----
 
-NOTE: `AccessTokenRequestFilter` will use `OidcClient` to exchange the current token, and you can use `quarkus.oidc-client.grant-options.exchange` to set the additional exchange properties expected by your OpenID Connect Provider.
+NOTE: `AccessTokenRequestFilter` will use `OidcClient` to exchange the current token, and you can use `quarkus.oidc-client.grant-options.exchange` to set the additional exchange properties expected by your OpenID Connect provider.
 
-`AccessTokenRequestFilter` uses a default `OidcClient` by default. A named `OidcClient` can be selected with a `quarkus.resteasy-client-oidc-token-propagation.client-name` configuration property.
+`AccessTokenRequestFilter` uses a default `OidcClient` by default.
+A named `OidcClient` can be selected with the `quarkus.resteasy-client-oidc-token-propagation.client-name` configuration property.
 
 === RestClient JsonWebTokenRequestFilter
 
-Using `JsonWebTokenRequestFilter` is recommended if you work with Bearer JWT tokens where these tokens can have their claims, such as `issuer` and `audience` modified and the updated tokens secured (for example, re-signed) again. It expects an injected `org.eclipse.microprofile.jwt.JsonWebToken` and, therefore, will not work with the opaque tokens. Also, if your OpenID Connect Provider supports a Token Exchange protocol, then it is recommended to use `AccessTokenRequestFilter` instead - as both JWT and opaque bearer tokens can be securely exchanged with `AccessTokenRequestFilter`.
+Using `JsonWebTokenRequestFilter` is recommended if you work with Bearer JWT tokens whose claims, such as `issuer` and `audience`, can be modified and the updated tokens re-secured, for example, re-signed.
 
-`JsonWebTokenRequestFilter` makes it easy for `Service A` implementations to update the injected `org.eclipse.microprofile.jwt.JsonWebToken` with the new `issuer` and `audience` claim values and secure the updated token again with a new signature. The only difficult step is ensuring that `Service A` has a signing key which should be provisioned from a secure file system or remote secure storage such as Vault.
+It expects an injected `org.eclipse.microprofile.jwt.JsonWebToken` and therefore will not work with opaque tokens.
+Also, if your OpenID Connect provider supports a Token Exchange protocol, it is recommended to use `AccessTokenRequestFilter` instead, because both JWT and opaque bearer tokens can be securely exchanged with `AccessTokenRequestFilter`.
+
+`JsonWebTokenRequestFilter` makes it easy for `Service A` implementations to update the injected `org.eclipse.microprofile.jwt.JsonWebToken` with the new `issuer` and `audience` claim values and secure the updated token again with a new signature.
+The only difficult step is ensuring that `Service A` has a signing key, which should be provisioned from a secure file system or remote secure storage such as Vault.
 
 You can selectively register `JsonWebTokenRequestFilter` by using either `io.quarkus.oidc.token.propagation.JsonWebToken` or `org.eclipse.microprofile.rest.client.annotation.RegisterProvider`, for example:
 
@@ -1682,7 +1761,7 @@ public interface ProtectedResourceService {
 }
 ----
 
-Alternatively, `JsonWebTokenRequestFilter` can be registered automatically with all MicroProfile REST or Jakarta REST clients if both `quarkus.resteasy-client-oidc-token-propagation.register-filter` and `quarkus.resteasy-client-oidc-token-propagation.json-web-token` properties are set to `true`.
+Alternatively, `JsonWebTokenRequestFilter` can be registered automatically with all MicroProfile REST or Jakarta REST clients if both the `quarkus.resteasy-client-oidc-token-propagation.register-filter` and `quarkus.resteasy-client-oidc-token-propagation.json-web-token` properties are set to `true`.
 
 ==== Update token before propagation
 
@@ -1700,7 +1779,7 @@ smallrye.jwt.new-token.audience=http://downstream-resource
 smallrye.jwt.new-token.override-matching-claims=true
 ----
 
-As mentioned, use `AccessTokenRequestFilter` if you work with Keycloak or an OpenID Connect Provider that supports a Token Exchange protocol.
+As mentioned, use `AccessTokenRequestFilter` if you work with Keycloak or an OpenID Connect provider that supports a Token Exchange protocol.
 
 [[integration-testing-token-propagation]]
 === Testing
@@ -1708,17 +1787,18 @@ As mentioned, use `AccessTokenRequestFilter` if you work with Keycloak or an Ope
 Typically, you must prepare two REST test endpoints.
 The first endpoint uses the injected MP REST client with a registered token propagation filter to call the second endpoint.
 
-To learn how it can be done, please follow the xref:security-openid-connect-client.adoc[OpenID Connect client and token propagation] quickstart, and its xref:security-openid-connect-client.adoc#testing[Testing] section in particular.
+To learn how it can be done, follow the xref:security-openid-connect-client.adoc[OpenID Connect client and token propagation] quickstart, and its xref:security-openid-connect-client.adoc#testing[Testing] section in particular.
 
 ifndef::no-quarkus-oidc-client-graphql[]
 [[quarkus-oidc-client-graphql]]
 == GraphQL client integration
 
-The `quarkus-oidc-client-graphql` extension provides a way to integrate an OIDC client into xref:smallrye-graphql-client.adoc[GraphQL clients] paralleling the approach used with REST clients.
-When this extension is active, any GraphQL client configured through properties (rather than programmatically by the builder) will use the OIDC client to acquire an access token, which it will then set as the `Authorization` header value.
-The OIDC client will also refresh expired access tokens.
+The `quarkus-oidc-client-graphql` extension provides a way to integrate an OIDC client into xref:smallrye-graphql-client.adoc[GraphQL clients], paralleling the approach used with REST clients.
 
-To configure which OIDC client should be used by the GraphQL client, select one of the configured OIDC clients with the `quarkus.oidc-client-graphql.client-name` property, for example:
+When this extension is active, any GraphQL client configured through properties, rather than programmatically by the builder, uses the OIDC client to acquire an access token, which it then sets as the `Authorization` header value.
+The OIDC client also refreshes expired access tokens.
+
+To configure which OIDC client the GraphQL client should use, select one of the configured OIDC clients with the `quarkus.oidc-client-graphql.client-name` property, for example:
 
 [source,properties]
 ----
@@ -1734,12 +1814,14 @@ quarkus.oidc-client.oidc-client-for-graphql.credentials.client-secret.value=${ke
 quarkus.oidc-client.oidc-client-for-graphql.credentials.client-secret.method=POST
 ----
 
-NOTE: If you don't specify the `quarkus.oidc-client-graphql.client-name` property,
-GraphQL clients will use the default OIDC client (without an explicit name).
+[NOTE]
+====
+If you do not specify the `quarkus.oidc-client-graphql.client-name` property, GraphQL clients will use the default OIDC client without an explicit name.
+====
 
-Specifically for type-safe GraphQL clients, you can override this on a
-per-client basis by annotating the `GraphQLClientApi` interface with
-`@io.quarkus.oidc.client.filter.OidcClientFilter`. For example:
+Specifically for type-safe GraphQL clients, you can override this on a per-client basis by annotating the `GraphQLClientApi` interface with `@io.quarkus.oidc.client.filter.OidcClientFilter`.
+
+For example:
 
 [source,java]
 ----
@@ -1750,28 +1832,25 @@ public interface OrdersGraphQLClient {
 }
 ----
 
-To be able to use this with a programmatically created GraphQL client, both
-builders (`VertxDynamicGraphQLClientBuilder` and
-`VertxTypesafeGraphQLClientBuilder`) contain a method `dynamicHeader(String,
-Uni<String>`) that allows you to plug in a header that might change for
-every request. To plug an OIDC client into it, use
+To use this with a programmatically created GraphQL client, both builders, `VertxDynamicGraphQLClientBuilder` and `VertxTypesafeGraphQLClientBuilder`, contain a `dynamicHeader(String, Uni<String>)` method that lets you plug in a header that might change for every request.
+
+To plug an OIDC client into it, use:
 
 [source,java]
 ----
 @Inject
 OidcClients oidcClients;
 
-VertxTypesafeGraphQLClientBuilder builder = ....;
+VertxDynamicGraphQLClientBuilder builder = ....;
 Uni<String> tokenUni = oidcClients.getClient("OIDC_CLIENT_NAME")
     .getTokens().map(t -> "Bearer " + t.getAccessToken());
 builder.dynamicHeader("Authorization", tokenUni);
 VertxDynamicGraphQLClient client = builder.build();
 ----
 
-For dynamic GraphQL clients, you can override the `quarkus.oidc-client-graphql.client-name` configuration property on per-client basis with the `quarkus.oidc-client-graphql."graphql-client".client-name` configuration property.
-For example:
+For dynamic GraphQL clients, you can override the `quarkus.oidc-client-graphql.client-name` configuration property on a per-client basis with the `quarkus.oidc-client-graphql."graphql-client".client-name` configuration property.
 
-Example `application.properties`
+.Example `application.properties`
 [source,properties]
 ----
 quarkus.oidc-client-graphql."dynamic-graphql-client-2".client-name=oidc-client-for-graphql-2
@@ -1786,7 +1865,7 @@ quarkus.oidc-client.oidc-client-for-graphql-2.credentials.client-secret.value=${
 quarkus.oidc-client.oidc-client-for-graphql-2.credentials.client-secret.method=POST
 ----
 
-.Example dynamic GraphQL client
+.An example of dynamic GraphQL client
 [source,java]
 ----
 @Inject
@@ -1804,8 +1883,10 @@ endif::no-quarkus-oidc-client-graphql[]
 [[health-check]]
 == Health Check
 
-When using the `quarkus-smallrye-health` extension, Quarkus can expose health checks for OIDC clients.
-The health check uses OIDC endpoint discovery to validate the connection; therefore, discovery must be enabled.
+When you use the `quarkus-smallrye-health` extension, Quarkus can expose health checks for OIDC clients.
+
+The health check uses OIDC endpoint discovery to validate the connection.
+Therefore, discovery must be enabled.
 
 To activate the health check, set `quarkus.oidc-client.health.enabled` to true and ensure discovery is not disabled:
 


### PR DESCRIPTION
This PR includes a style and grammar check across the "OpenID Connect (OIDC) and OAuth2 client and filters" guide.

The final version is always the result of communication with an SME.
These fixes need to be backported to a branch from which RHBQ and IBMbQ 3.33 docs are about to be built.

Something that also needs an SME check:

Hello, @sberyozkin 

I noticed a few points in the samples that look incomplete or possibly outdated.
Could you please check them and let me know? :)

1. `OidcRequestCustomizer`
The sample uses `@OidcEndpoint(value = Type.TOKEN)`, but I do not see an import for `OidcEndpoint.Type`.
It looks as if the sample is missing that import.

2. `calculateDigest`
The method is declared to return `String`, but the sample body does not return anything.
This looks incomplete unless it is intended as pseudo-code.

3. Request body customization example
The text says that `OidcRequestFilter` can customize the request body by preparing a `Buffer`.
However, the sample appears to pass a `String`, and the `Buffer` import is not used.
Could you please confirm whether the prose or the sample needs to be updated?

4. Programmatic GraphQL client example
The sample creates a `VertxTypesafeGraphQLClientBuilder`, but then assigns the result to `VertxDynamicGraphQLClient`.
This looks inconsistent.
Could you please confirm whether the builder type or the client type is wrong?

Thanks a ton!