### PR TITLE
Update javadoc examples for Hibernate ORM mappings

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
@@ -368,8 +368,8 @@ public interface HibernateOrmConfigPersistenceUnit {
          * Can be overridden locally using `@JdbcType`, `@JdbcTypeCode`, and similar annotations.
          * <p>
          * Can also specify the name of the SqlTypes constant field,
-         * for example, `quarkus.hibernate-orm.mapping.type.preferred_instant_jdbc_type=TIMESTAMP`
-         * or `quarkus.hibernate-orm.mapping.type.preferred_instant_jdbc_type=INSTANT`.
+         * for example, `quarkus.hibernate-orm.mapping.instant.preferred-jdbc-type=TIMESTAMP`
+         * or `quarkus.hibernate-orm.mapping.instant.preferred-jdbc-type=INSTANT`.
          *
          * @asciidoclet
          */
@@ -383,7 +383,7 @@ public interface HibernateOrmConfigPersistenceUnit {
          * Can be overridden locally using `@JdbcType`, `@JdbcTypeCode`, and similar annotations.
          * <p>
          * Can also specify the name of the SqlTypes constant field,
-         * for example, `quarkus.hibernate-orm.mapping.type.boolean_jdbc_type=BIT`.
+         * for example, `quarkus.hibernate-orm.mapping.boolean.preferred-jdbc-type=BIT`.
          *
          * @asciidoclet
          */
@@ -397,7 +397,7 @@ public interface HibernateOrmConfigPersistenceUnit {
          * Can be overridden locally using `@JdbcType`, `@JdbcTypeCode`, and similar annotations.
          * <p>
          * Can also specify the name of the SqlTypes constant field,
-         * for example, `quarkus.hibernate-orm.mapping.type.uuid_jdbc_type=CHAR`.
+         * for example, `quarkus.hibernate-orm.mapping.uuid.preferred-jdbc-type=CHAR`.
          *
          * @asciidoclet
          */


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

This PR updates the examples in the Javadoc for Hibernate ORM Mapping configuration reference to correct examples. Currently on the main branch the examples show:
```
 quarkus.hibernate-orm.mapping.type.uuid_jdbc_type=CHAR
```

But the correct example is actually:
```
quarkus.hibernate-orm.mapping.uuid.preferred-jdbc-type=CHAR
```

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

