### PR TITLE
Sync assertj version to 3.27.7 in gradle test

### DIFF
--- a/integration-tests/gradle/src/main/resources/java-platform-with-eager-resolution-project/library/build.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/java-platform-with-eager-resolution-project/library/build.gradle.kts
@@ -10,6 +10,6 @@ javaPlatform.allowDependencies()
 dependencies{
     api(enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}"))
     constraints{
-        api("org.assertj:assertj-core:3.26.3")
+        api("org.assertj:assertj-core:3.27.7")
     }
 }


### PR DESCRIPTION
Sync assertj version to 3.27.7 in gradle test

To be in sync with
```xml
build-parent/pom.xml:        <assertj.version>3.27.7</assertj.version>
devtools/gradle/gradle/libs.versions.toml:assertj = "3.27.7"
independent-projects/arc/pom.xml:        <version.assertj>3.27.7</version.assertj>
independent-projects/bootstrap/pom.xml:        <assertj.version>3.27.7</assertj.version>
independent-projects/junit-virtual-threads/pom.xml:        <assertj.version>3.27.7</assertj.version>
independent-projects/qute/pom.xml:        <version.assertj>3.27.7</version.assertj>
independent-projects/resteasy-reactive/pom.xml:        <assertj.version>3.27.7</assertj.version>
independent-projects/tools/pom.xml:        <assertj.version>3.27.7</assertj.version>
```
