### PR TITLE
Add a test for a custom service-loaded constraint

### DIFF
--- a/docs/src/main/asciidoc/validation.adoc
+++ b/docs/src/main/asciidoc/validation.adoc
@@ -594,7 +594,7 @@ Quarkus provides a default `ValidatorFactory` that you can customize using confi
 This `ValidatorFactory` is carefully initialized to support native executables
 using a bootstrap that is Quarkus-specific.
 
-Creating a `ValidatorFactory` by yourself it not supported in native executables
+Creating a `ValidatorFactory` by yourself is not supported in native executables
 and if you try to do so,
 you will get an  error similar to `jakarta.validation.NoProviderFoundException: Unable to create a Configuration, because no
 Jakarta Bean Validation provider could be found. Add a provider like Hibernate Validator (RI) to your

--- a/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/HibernateValidatorTestResource.java
+++ b/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/HibernateValidatorTestResource.java
@@ -114,6 +114,7 @@ public class HibernateValidatorTestResource
         ResultBuilder result = new ResultBuilder();
 
         result.append(formatViolations(validator.validate(new MyOtherBean(null))));
+        result.append(formatViolations(validator.validate(new MyOtherBean("fail"))));
         result.append(formatViolations(validator.validate(new MyOtherBean("name"))));
 
         return result.build();

--- a/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/custom/MyOtherBean.java
+++ b/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/custom/MyOtherBean.java
@@ -1,5 +1,6 @@
 package io.quarkus.it.hibernate.validator.custom;
 
+@MyServiceLoadedConstraint
 @MyCustomConstraint
 public class MyOtherBean {
 

--- a/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/custom/MyServiceLoadedConstraint.java
+++ b/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/custom/MyServiceLoadedConstraint.java
@@ -1,0 +1,21 @@
+package io.quarkus.it.hibernate.validator.custom;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Target({ ElementType.TYPE_USE, ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {})
+public @interface MyServiceLoadedConstraint {
+    String message() default "{MyServiceLoadedConstraint.message}";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/custom/MyServiceLoadedConstraintValidator.java
+++ b/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/custom/MyServiceLoadedConstraintValidator.java
@@ -1,0 +1,15 @@
+package io.quarkus.it.hibernate.validator.custom;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class MyServiceLoadedConstraintValidator implements ConstraintValidator<MyServiceLoadedConstraint, MyOtherBean> {
+
+    @Override
+    public boolean isValid(MyOtherBean value, ConstraintValidatorContext context) {
+        if (value == null || value.getName() == null) {
+            return true;
+        }
+        return !"fail".equalsIgnoreCase(value.getName());
+    }
+}

--- a/integration-tests/hibernate-validator/src/main/resources/META-INF/services/jakarta.validation.ConstraintValidator
+++ b/integration-tests/hibernate-validator/src/main/resources/META-INF/services/jakarta.validation.ConstraintValidator
@@ -1,0 +1,1 @@
+io.quarkus.it.hibernate.validator.custom.MyServiceLoadedConstraintValidator

--- a/integration-tests/hibernate-validator/src/main/resources/ValidationMessages.properties
+++ b/integration-tests/hibernate-validator/src/main/resources/ValidationMessages.properties
@@ -2,3 +2,4 @@ MyCustomConstraint.message = invalid MyOtherBean
 InjectedConstraintValidatorConstraint.message = InjectedConstraintValidatorConstraint violation
 InjectedRuntimeConstraintValidatorConstraint.message = InjectedRuntimeConstraintValidatorConstraint violation
 pattern.message=Value is not in line with the pattern
+MyServiceLoadedConstraint.message = service-loaded invalid MyOtherBean

--- a/integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
+++ b/integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
@@ -77,6 +77,7 @@ public class HibernateValidatorFunctionalityTest {
     public void testCustomClassLevelConstraint() throws Exception {
         StringBuilder expected = new StringBuilder();
         expected.append("failed:  (invalid MyOtherBean)").append("\n");
+        expected.append("failed:  (service-loaded invalid MyOtherBean)").append("\n");
         expected.append("passed");
 
         RestAssured.when()


### PR DESCRIPTION
I was looking at the skills PR and noticed that we are not mentioning the service loader option to create new constraints even though that's the approach we were leaning towards in HV for a while.. 

Sooo this PR adds a test and I was wondering if we should add it to the guide as well ? 🙈 

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

