### PR TITLE
Allow using both of Hibernate Reactive's CDI-injected `Session` and `StatelessSession` in the same transaction when using `@Transactional`

### DIFF
--- a/docs/src/main/asciidoc/hibernate-reactive.adoc
+++ b/docs/src/main/asciidoc/hibernate-reactive.adoc
@@ -492,7 +492,7 @@ Mixing both transaction management styles in the same reactive pipeline is not s
 In the future, we'll deprecate the previous annotations provided by Panache and and support only `@Transactional`.
 
 You can inject either `Mutiny.Session` or `Mutiny.StatelessSession`.
-Be careful of injecting both session types in the same bean. Attempting to use both session types within the same transaction will throw an `IllegalStateException`.
+Mixing both session types in the same transaction should work, but should be reserved for exotic use cases implemented by advanced users, as the (stateful) session will not be aware of changes operated through the stateless session, which could thus conflict or be silently erased by (stateful) session writes.
 
 [[transactional-different-pipelines]]
 === Using Declarative Transaction Management in different reactive pipelines

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/stateless/MixStatelessStatefulSessionTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/stateless/MixStatelessStatefulSessionTest.java
@@ -1,0 +1,136 @@
+package io.quarkus.hibernate.orm.stateless;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.hibernate.Session;
+import org.hibernate.StatelessSession;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * Verifies that Hibernate ORM allows mixing regular Session and StatelessSession
+ * within the same transaction.
+ */
+public class MixStatelessStatefulSessionTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(MyEntity.class))
+            .withConfigurationResource("application.properties");
+
+    @Inject
+    Session session;
+
+    @Inject
+    StatelessSession statelessSession;
+
+    @Test
+    public void testRegularSessionThenStatelessSessionInSameTransaction() {
+        // Use regular Session, then StatelessSession in same transaction
+        QuarkusTransaction.requiringNew().run(() -> {
+            MyEntity entity = new MyEntity("testRegular");
+            session.persist(entity);
+            session.flush();
+            // Now use StatelessSession in the same transaction - should work without error
+            List<String> list = statelessSession
+                    .createSelectionQuery("SELECT e.name from MyEntity e WHERE e.name = 'testRegular'", String.class)
+                    .getResultList();
+            assertThat(list).containsOnly("testRegular");
+        });
+
+        // Verify it was persisted
+        QuarkusTransaction.requiringNew().run(() -> {
+            long count = session
+                    .createSelectionQuery("SELECT count(e) from MyEntity e WHERE e.name = 'testRegular'", Long.class)
+                    .getSingleResult();
+            assertThat(count).isEqualTo(1);
+        });
+    }
+
+    @Test
+    public void testStatelessSessionThenRegularSessionInSameTransaction() {
+        // Use StatelessSession, then regular Session in same transaction
+        QuarkusTransaction.requiringNew().run(() -> {
+            MyEntity entity = new MyEntity("testStateless");
+            statelessSession.insert(entity);
+            // Now use regular Session in the same transaction - should work without error
+            List<String> list = session
+                    .createSelectionQuery("SELECT e.name from MyEntity e WHERE e.name = 'testStateless'", String.class)
+                    .getResultList();
+            assertThat(list).containsOnly("testStateless");
+        });
+
+        // Verify it was persisted
+        QuarkusTransaction.requiringNew().run(() -> {
+            long count = session
+                    .createSelectionQuery("SELECT count(e) from MyEntity e WHERE e.name = 'testStateless'", Long.class)
+                    .getSingleResult();
+            assertThat(count).isEqualTo(1);
+        });
+    }
+
+    @Test
+    public void testBothSessionsCommitTogether() {
+        // Make changes via both sessions, verify both commit together
+        QuarkusTransaction.requiringNew().run(() -> {
+            MyEntity entity1 = new MyEntity("commitViaRegular");
+            session.persist(entity1);
+            session.flush();
+
+            MyEntity entity2 = new MyEntity("commitViaStateless");
+            statelessSession.insert(entity2);
+        });
+
+        // Verify both were persisted
+        QuarkusTransaction.requiringNew().run(() -> {
+            long count1 = session
+                    .createSelectionQuery("SELECT count(e) from MyEntity e WHERE e.name = 'commitViaRegular'", Long.class)
+                    .getSingleResult();
+            long count2 = session
+                    .createSelectionQuery("SELECT count(e) from MyEntity e WHERE e.name = 'commitViaStateless'", Long.class)
+                    .getSingleResult();
+            assertThat(count1).isEqualTo(1);
+            assertThat(count2).isEqualTo(1);
+        });
+    }
+
+    @Test
+    public void testBothSessionsRollbackTogether() {
+        // Make changes via both sessions, then rollback - verify both rolled back
+        assertThatThrownBy(() -> {
+            QuarkusTransaction.requiringNew().run(() -> {
+                MyEntity entity1 = new MyEntity("rollbackViaRegular");
+                session.persist(entity1);
+                session.flush();
+
+                MyEntity entity2 = new MyEntity("rollbackViaStateless");
+                statelessSession.insert(entity2);
+
+                throw new RuntimeException("Force rollback");
+            });
+        }).isInstanceOf(RuntimeException.class)
+                .hasMessage("Force rollback");
+
+        // Verify neither was persisted
+        QuarkusTransaction.requiringNew().run(() -> {
+            long count1 = session
+                    .createSelectionQuery("SELECT count(e) from MyEntity e WHERE e.name = 'rollbackViaRegular'", Long.class)
+                    .getSingleResult();
+            long count2 = session
+                    .createSelectionQuery("SELECT count(e) from MyEntity e WHERE e.name = 'rollbackViaStateless'", Long.class)
+                    .getSingleResult();
+            assertThat(count1).isEqualTo(0);
+            assertThat(count2).isEqualTo(0);
+        });
+    }
+}

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/transaction/HibernateReactiveStatelessTransactionsTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/transaction/HibernateReactiveStatelessTransactionsTest.java
@@ -9,7 +9,7 @@ import org.hibernate.reactive.mutiny.Mutiny;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.reactive.transaction.TransactionalInterceptorRequired;
+import io.quarkus.reactive.transaction.runtime.TransactionalInterceptorRequired;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.vertx.RunOnVertxContext;
 import io.quarkus.test.vertx.UniAsserter;

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/transaction/HibernateReactiveTransactionsTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/transaction/HibernateReactiveTransactionsTest.java
@@ -9,7 +9,7 @@ import org.hibernate.reactive.mutiny.Mutiny;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.reactive.transaction.TransactionalInterceptorRequired;
+import io.quarkus.reactive.transaction.runtime.TransactionalInterceptorRequired;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.vertx.RunOnVertxContext;
 import io.quarkus.test.vertx.UniAsserter;

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/transaction/InterleaveTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/transaction/InterleaveTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.hibernate.reactive.runtime.OpenedSessionsState;
-import io.quarkus.reactive.transaction.TransactionalInterceptorRequired;
+import io.quarkus.reactive.transaction.runtime.TransactionalInterceptorRequired;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.vertx.RunOnVertxContext;
 import io.quarkus.test.vertx.UniAsserter;

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/transaction/SupportOnlyRequiredTransactionTypeTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/transaction/SupportOnlyRequiredTransactionTypeTest.java
@@ -7,11 +7,11 @@ import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.reactive.transaction.TransactionalInterceptorMandatory;
-import io.quarkus.reactive.transaction.TransactionalInterceptorNever;
-import io.quarkus.reactive.transaction.TransactionalInterceptorNotSupported;
-import io.quarkus.reactive.transaction.TransactionalInterceptorRequiresNew;
-import io.quarkus.reactive.transaction.TransactionalInterceptorSupports;
+import io.quarkus.reactive.transaction.runtime.TransactionalInterceptorMandatory;
+import io.quarkus.reactive.transaction.runtime.TransactionalInterceptorNever;
+import io.quarkus.reactive.transaction.runtime.TransactionalInterceptorNotSupported;
+import io.quarkus.reactive.transaction.runtime.TransactionalInterceptorRequiresNew;
+import io.quarkus.reactive.transaction.runtime.TransactionalInterceptorSupports;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.vertx.RunOnVertxContext;
 import io.smallrye.mutiny.Uni;

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/transaction/mixing/MixStatelessStatefulSessionTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/transaction/mixing/MixStatelessStatefulSessionTest.java
@@ -14,13 +14,18 @@ import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.vertx.RunOnVertxContext;
 import io.quarkus.test.vertx.UniAsserter;
 import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.sqlclient.Pool;
 
+/**
+ * Verifies that Hibernate Reactive allows mixing regular Session and StatelessSession
+ * within the same transaction.
+ */
 public class MixStatelessStatefulSessionTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .withApplicationRoot(jar -> jar.addClasses(Hero.class))
-            .withConfigurationResource("application.properties");
+            .withConfigurationResource("application-reactive-transaction.properties");
 
     @Inject
     Mutiny.Session session;
@@ -28,42 +33,99 @@ public class MixStatelessStatefulSessionTest {
     @Inject
     Mutiny.StatelessSession statelessSession;
 
-    @Test
-    @RunOnVertxContext
-    public void testStatelessSessionThenRegularSessionInTransactional(UniAsserter asserter) {
-        asserter.assertFailedWith(
-                () -> transactionalMethodUsingStatelessSessionThenRegularSession(),
-                e -> assertThat(e)
-                        .isInstanceOf(IllegalStateException.class)
-                        .hasMessageContaining("stateless session for the same Persistence Unit is already opened")
-                        .hasMessageContaining(
-                                "Mixing different kinds of sessions in the same transaction is not supported yet"));
-    }
+    @Inject
+    Pool pool;
 
     @Test
     @RunOnVertxContext
     public void testRegularSessionThenStatelessSessionInTransactional(UniAsserter asserter) {
-        asserter.assertFailedWith(
+        // Use regular Session, then StatelessSession in same transaction - should work without error
+        asserter.execute(() -> assertThat(pool.size()).isEqualTo(1));
+        asserter.assertThat(
                 () -> transactionalMethodUsingRegularSessionThenStatelessSession(),
+                count -> assertThat(count).isNotNull());
+        // Verify pool size is still 1 (connection was shared and released)
+        asserter.execute(() -> assertThat(pool.size()).isEqualTo(1));
+    }
+
+    @Test
+    @RunOnVertxContext
+    public void testStatelessSessionThenRegularSessionInTransactional(UniAsserter asserter) {
+        // Use StatelessSession, then regular Session in same transaction - should work without error
+        asserter.execute(() -> assertThat(pool.size()).isEqualTo(1));
+        asserter.assertThat(
+                () -> transactionalMethodUsingStatelessSessionThenRegularSession(),
+                count -> assertThat(count).isNotNull());
+        // Verify pool size is still 1 (connection was shared and released)
+        asserter.execute(() -> assertThat(pool.size()).isEqualTo(1));
+    }
+
+    @Test
+    @RunOnVertxContext
+    public void testBothSessionsCommitTogether(UniAsserter asserter) {
+        // Make changes via both sessions, verify both commit together
+        asserter.assertThat(
+                () -> transactionalMethodCreatingViaBothSessions("CommitHero1", "CommitHero2"),
+                v -> assertThat(v).isNull());
+
+        // Verify both were persisted
+        asserter.assertThat(
+                () -> transactionalMethodCountingHeroes("CommitHero%"),
+                count -> assertThat(count).isEqualTo(2L));
+    }
+
+    @Test
+    @RunOnVertxContext
+    public void testBothSessionsRollbackTogether(UniAsserter asserter) {
+        // Make changes via both sessions, then throw exception - verify both rolled back
+        asserter.assertFailedWith(
+                () -> transactionalMethodCreatingViaBothSessionsThenFailing("RollbackHero1", "RollbackHero2"),
                 e -> assertThat(e)
-                        .isInstanceOf(IllegalStateException.class)
-                        .hasMessageContaining("session for the same Persistence Unit is already opened")
-                        .hasMessageContaining(
-                                "Mixing different kinds of sessions in the same transaction is not supported yet"));
+                        .isInstanceOf(RuntimeException.class)
+                        .hasMessage("Force rollback"));
+
+        // Verify neither was persisted
+        asserter.assertThat(
+                () -> transactionalMethodCountingHeroes("RollbackHero%"),
+                count -> assertThat(count).isEqualTo(0L));
     }
 
     @Transactional
-    public Uni<Object> transactionalMethodUsingRegularSessionThenStatelessSession() {
-        return session.createQuery("select count(1) from Hero h", Long.class).getSingleResult()
-                .chain(count -> statelessSession.createQuery("select count(1) from Hero h", Long.class)
+    public Uni<Long> transactionalMethodUsingRegularSessionThenStatelessSession() {
+        return session.createSelectionQuery("select count(h) from Hero h", Long.class).getSingleResult()
+                .chain(count -> statelessSession.createSelectionQuery("select count(h) from Hero h", Long.class)
                         .getSingleResult());
     }
 
     @Transactional
-    public Uni<Object> transactionalMethodUsingStatelessSessionThenRegularSession() {
-        return statelessSession.createQuery("select count(1) from Hero h", Long.class).getSingleResult()
-                .chain(count -> session.createQuery("select count(1) from Hero h", Long.class)
+    public Uni<Long> transactionalMethodUsingStatelessSessionThenRegularSession() {
+        return statelessSession.createSelectionQuery("select count(h) from Hero h", Long.class).getSingleResult()
+                .chain(count -> session.createSelectionQuery("select count(h) from Hero h", Long.class)
                         .getSingleResult());
+    }
+
+    @Transactional
+    public Uni<Void> transactionalMethodCreatingViaBothSessions(String name1, String name2) {
+        Hero hero1 = new Hero(name1);
+        return session.persist(hero1)
+                .call(() -> session.flush())
+                .chain(() -> {
+                    Hero hero2 = new Hero(name2);
+                    return statelessSession.insert(hero2);
+                });
+    }
+
+    @Transactional
+    public Uni<Void> transactionalMethodCreatingViaBothSessionsThenFailing(String name1, String name2) {
+        return transactionalMethodCreatingViaBothSessions(name1, name2)
+                .chain(() -> Uni.createFrom().failure(new RuntimeException("Force rollback")));
+    }
+
+    @Transactional
+    public Uni<Long> transactionalMethodCountingHeroes(String namePattern) {
+        return session.createSelectionQuery("select count(h) from Hero h where h.name like :name", Long.class)
+                .setParameter("name", namePattern)
+                .getSingleResult();
     }
 
 }

--- a/extensions/hibernate-reactive/deployment/src/test/resources/application-reactive-transaction.properties
+++ b/extensions/hibernate-reactive/deployment/src/test/resources/application-reactive-transaction.properties
@@ -1,5 +1,8 @@
 quarkus.datasource.db-kind=postgresql
 quarkus.datasource.reactive=true
+# Using max-size=1 ensures that:
+# 1. Connection management is tested properly (connection must be released after transaction)
+# 2. Session types sharing the same connection is verified (tests would hang if separate connections were used)
 quarkus.datasource.reactive.max-size=1
 
 quarkus.hibernate-orm.log.sql=true

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/HibernateReactiveRecorder.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/HibernateReactiveRecorder.java
@@ -1,7 +1,7 @@
 package io.quarkus.hibernate.reactive.runtime;
 
-import static io.quarkus.reactive.transaction.TransactionalInterceptorBase.PERSISTENCE_UNIT_NAME_KEY;
-import static io.quarkus.reactive.transaction.TransactionalInterceptorBase.TRANSACTIONAL_METHOD_KEY;
+import static io.quarkus.reactive.transaction.runtime.TransactionalInterceptorBase.PERSISTENCE_UNIT_NAME_KEY;
+import static io.quarkus.reactive.transaction.runtime.TransactionalInterceptorBase.TRANSACTIONAL_METHOD_KEY;
 
 import java.util.List;
 import java.util.Locale;

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/HibernateReactiveRecorder.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/HibernateReactiveRecorder.java
@@ -134,17 +134,6 @@ public class HibernateReactiveRecorder {
         } else if (context.getLocal(TRANSACTIONAL_METHOD_KEY) == null) {
             throw new IllegalStateException(noSessionFoundErrorMessage());
         } else {
-
-            Optional<OpenedSessionsState.SessionWithKey<Mutiny.StatelessSession>> openedStatelessSession = OPENED_SESSIONS_STATE_STATELESS
-                    .getOpenedSession(
-                            context,
-                            persistenceUnitName);
-
-            if (openedStatelessSession.isPresent()) {
-                throw new IllegalStateException("A stateless session for the same Persistence Unit is already opened."
-                        + "\n\t- Mixing different kinds of sessions in the same transaction is not supported yet.");
-            }
-
             // Store the persistence unit name so that we can close only this session at the end of the interceptor
             context.putLocal(PERSISTENCE_UNIT_NAME_KEY, persistenceUnitName);
 
@@ -179,17 +168,6 @@ public class HibernateReactiveRecorder {
         } else if (context.getLocal(TRANSACTIONAL_METHOD_KEY) == null) {
             throw new IllegalStateException(noSessionFoundErrorMessage());
         } else {
-
-            Optional<OpenedSessionsState.SessionWithKey<Mutiny.Session>> openedRegularSession = OPENED_SESSIONS_STATE
-                    .getOpenedSession(
-                            context,
-                            persistenceUnitName);
-
-            if (openedRegularSession.isPresent()) {
-                throw new IllegalStateException("A (non-stateless) session for the same Persistence Unit is already opened."
-                        + "\n\t- Mixing different kinds of sessions in the same transaction is not supported yet.");
-            }
-
             // Store the persistence unit name so that we can close only this session at the end of the interceptor
             context.putLocal(PERSISTENCE_UNIT_NAME_KEY, persistenceUnitName);
 

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/customized/QuarkusReactiveConnectionPoolInitiator.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/customized/QuarkusReactiveConnectionPoolInitiator.java
@@ -31,7 +31,7 @@ public final class QuarkusReactiveConnectionPoolInitiator
             // nothing to do, but given the separate hierarchies have to handle this here.
             return null;
         }
-        return new QuarkusSqlClientPool(new TransactionalContextPool(pool));
+        return new QuarkusSqlClientPool(new io.quarkus.reactive.transaction.runtime.pool.TransactionalContextPool(pool));
     }
 
 }

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/customized/TransactionalContextPool.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/customized/TransactionalContextPool.java
@@ -1,7 +1,7 @@
 package io.quarkus.hibernate.reactive.runtime.customized;
 
-import static io.quarkus.reactive.transaction.TransactionalInterceptorBase.CURRENT_CONNECTION_KEY;
-import static io.quarkus.reactive.transaction.TransactionalInterceptorBase.TRANSACTIONAL_METHOD_KEY;
+import static io.quarkus.reactive.transaction.runtime.TransactionalInterceptorBase.CURRENT_CONNECTION_KEY;
+import static io.quarkus.reactive.transaction.runtime.TransactionalInterceptorBase.TRANSACTIONAL_METHOD_KEY;
 
 import java.util.function.Function;
 

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/transaction/HibernateActionsStrategy.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/transaction/HibernateActionsStrategy.java
@@ -1,14 +1,14 @@
 package io.quarkus.hibernate.reactive.runtime.transaction;
 
-import static io.quarkus.reactive.transaction.TransactionalInterceptorBase.PERSISTENCE_UNIT_NAME_KEY;
-import static io.quarkus.reactive.transaction.TransactionalInterceptorBase.TRANSACTIONAL_METHOD_KEY;
+import static io.quarkus.reactive.transaction.runtime.TransactionalInterceptorBase.PERSISTENCE_UNIT_NAME_KEY;
+import static io.quarkus.reactive.transaction.runtime.TransactionalInterceptorBase.TRANSACTIONAL_METHOD_KEY;
 
 import java.util.Optional;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
 import io.quarkus.hibernate.reactive.runtime.HibernateReactiveRecorder;
-import io.quarkus.reactive.transaction.ReactiveResource;
+import io.quarkus.reactive.transaction.runtime.ReactiveResource;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Context;
 

--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/interceptor/TransactionalInterceptorBase.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/interceptor/TransactionalInterceptorBase.java
@@ -58,7 +58,7 @@ public abstract class TransactionalInterceptorBase implements Serializable {
 
     private static MethodHandle reactiveInterceptorShouldRun() {
         try {
-            Class<?> vertxContext = Class.forName("io.quarkus.reactive.transaction.TransactionalInterceptorBase", true,
+            Class<?> vertxContext = Class.forName("io.quarkus.reactive.transaction.runtime.TransactionalInterceptorBase", true,
                     Thread.currentThread().getContextClassLoader());
             return MethodHandles.publicLookup().findStatic(vertxContext, "reactiveInterceptorShouldRun",
                     MethodType.methodType(boolean.class));

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/ReactiveTransactionalInterceptor.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/ReactiveTransactionalInterceptor.java
@@ -1,8 +1,8 @@
 package io.quarkus.hibernate.reactive.panache.common.runtime;
 
-import static io.quarkus.reactive.transaction.TransactionalInterceptorBase.REACTIVE_TRANSACTIONAL_METHOD_KEY;
-import static io.quarkus.reactive.transaction.TransactionalInterceptorBase.TRANSACTIONAL_METHOD_KEY;
-import static io.quarkus.reactive.transaction.TransactionalInterceptorBase.proceedUni;
+import static io.quarkus.reactive.transaction.runtime.TransactionalInterceptorBase.REACTIVE_TRANSACTIONAL_METHOD_KEY;
+import static io.quarkus.reactive.transaction.runtime.TransactionalInterceptorBase.TRANSACTIONAL_METHOD_KEY;
+import static io.quarkus.reactive.transaction.runtime.TransactionalInterceptorBase.proceedUni;
 
 import jakarta.annotation.Priority;
 import jakarta.interceptor.AroundInvoke;

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/SessionOperations.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/SessionOperations.java
@@ -1,8 +1,8 @@
 package io.quarkus.hibernate.reactive.panache.common.runtime;
 
 import static io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME;
-import static io.quarkus.reactive.transaction.TransactionalInterceptorBase.SESSION_ON_DEMAND_KEY;
-import static io.quarkus.reactive.transaction.TransactionalInterceptorBase.TRANSACTIONAL_METHOD_KEY;
+import static io.quarkus.reactive.transaction.runtime.TransactionalInterceptorBase.SESSION_ON_DEMAND_KEY;
+import static io.quarkus.reactive.transaction.runtime.TransactionalInterceptorBase.TRANSACTIONAL_METHOD_KEY;
 
 import java.util.ArrayList;
 import java.util.HashSet;

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/WithSessionOnDemandInterceptor.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/WithSessionOnDemandInterceptor.java
@@ -1,7 +1,7 @@
 package io.quarkus.hibernate.reactive.panache.common.runtime;
 
-import static io.quarkus.reactive.transaction.TransactionalInterceptorBase.proceedUni;
-import static io.quarkus.reactive.transaction.TransactionalInterceptorBase.reactiveInterceptorShouldRun;
+import static io.quarkus.reactive.transaction.runtime.TransactionalInterceptorBase.proceedUni;
+import static io.quarkus.reactive.transaction.runtime.TransactionalInterceptorBase.reactiveInterceptorShouldRun;
 
 import jakarta.annotation.Priority;
 import jakarta.interceptor.AroundInvoke;

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/WithTransactionInterceptor.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/WithTransactionInterceptor.java
@@ -1,7 +1,7 @@
 package io.quarkus.hibernate.reactive.panache.common.runtime;
 
-import static io.quarkus.reactive.transaction.TransactionalInterceptorBase.TRANSACTIONAL_METHOD_KEY;
-import static io.quarkus.reactive.transaction.TransactionalInterceptorBase.WITH_TRANSACTION_METHOD_KEY;
+import static io.quarkus.reactive.transaction.runtime.TransactionalInterceptorBase.TRANSACTIONAL_METHOD_KEY;
+import static io.quarkus.reactive.transaction.runtime.TransactionalInterceptorBase.WITH_TRANSACTION_METHOD_KEY;
 
 import jakarta.annotation.Priority;
 import jakarta.interceptor.AroundInvoke;

--- a/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/transaction/MixReactiveTransactionalTest.java
+++ b/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/transaction/MixReactiveTransactionalTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.hibernate.reactive.panache.common.runtime.ReactiveTransactional;
 import io.quarkus.hibernate.reactive.runtime.transaction.HibernateActionsStrategy;
-import io.quarkus.reactive.transaction.TransactionalInterceptorRequired;
+import io.quarkus.reactive.transaction.runtime.TransactionalInterceptorRequired;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.vertx.RunOnVertxContext;
 import io.quarkus.test.vertx.UniAsserter;

--- a/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/transaction/MixWithSessionOnDemandTest.java
+++ b/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/transaction/MixWithSessionOnDemandTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.hibernate.reactive.panache.common.WithSessionOnDemand;
 import io.quarkus.hibernate.reactive.runtime.transaction.HibernateActionsStrategy;
-import io.quarkus.reactive.transaction.TransactionalInterceptorRequired;
+import io.quarkus.reactive.transaction.runtime.TransactionalInterceptorRequired;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.vertx.RunOnVertxContext;
 import io.quarkus.test.vertx.UniAsserter;

--- a/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/transaction/MixWithTransactionTest.java
+++ b/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/transaction/MixWithTransactionTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.hibernate.reactive.panache.common.WithTransaction;
 import io.quarkus.hibernate.reactive.runtime.transaction.HibernateActionsStrategy;
-import io.quarkus.reactive.transaction.TransactionalInterceptorRequired;
+import io.quarkus.reactive.transaction.runtime.TransactionalInterceptorRequired;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.vertx.RunOnVertxContext;
 import io.quarkus.test.vertx.UniAsserter;

--- a/extensions/reactive-transactions/deployment/src/main/java/io/quarkus/hibernate/reactive/transactions/deployment/QuarkusReactiveTransactionsProcessor.java
+++ b/extensions/reactive-transactions/deployment/src/main/java/io/quarkus/hibernate/reactive/transactions/deployment/QuarkusReactiveTransactionsProcessor.java
@@ -2,12 +2,12 @@ package io.quarkus.hibernate.reactive.transactions.deployment;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildStep;
-import io.quarkus.reactive.transaction.TransactionalInterceptorMandatory;
-import io.quarkus.reactive.transaction.TransactionalInterceptorNever;
-import io.quarkus.reactive.transaction.TransactionalInterceptorNotSupported;
-import io.quarkus.reactive.transaction.TransactionalInterceptorRequired;
-import io.quarkus.reactive.transaction.TransactionalInterceptorRequiresNew;
-import io.quarkus.reactive.transaction.TransactionalInterceptorSupports;
+import io.quarkus.reactive.transaction.runtime.TransactionalInterceptorMandatory;
+import io.quarkus.reactive.transaction.runtime.TransactionalInterceptorNever;
+import io.quarkus.reactive.transaction.runtime.TransactionalInterceptorNotSupported;
+import io.quarkus.reactive.transaction.runtime.TransactionalInterceptorRequired;
+import io.quarkus.reactive.transaction.runtime.TransactionalInterceptorRequiresNew;
+import io.quarkus.reactive.transaction.runtime.TransactionalInterceptorSupports;
 
 public class QuarkusReactiveTransactionsProcessor {
 

--- a/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/ReactiveResource.java
+++ b/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/ReactiveResource.java
@@ -1,4 +1,4 @@
-package io.quarkus.reactive.transaction;
+package io.quarkus.reactive.transaction.runtime;
 
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Context;

--- a/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/TransactionalInterceptorBase.java
+++ b/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/TransactionalInterceptorBase.java
@@ -1,4 +1,4 @@
-package io.quarkus.reactive.transaction;
+package io.quarkus.reactive.transaction.runtime;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;

--- a/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/TransactionalInterceptorBase.java
+++ b/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/TransactionalInterceptorBase.java
@@ -11,7 +11,6 @@ import jakarta.transaction.Transactional;
 import org.jboss.logging.Logger;
 
 import io.quarkus.arc.runtime.InterceptorBindings;
-import io.quarkus.reactive.transaction.ReactiveResource;
 import io.quarkus.reactive.transaction.runtime.pool.TransactionalContextPool;
 import io.quarkus.transaction.annotations.Rollback;
 import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle;
@@ -112,12 +111,19 @@ public abstract class TransactionalInterceptorBase {
                 .onItem().invoke(() -> LOG.tracef("Flushed the session before commit/rollback"))
                 .onItemOrFailure().call((result, exception) -> {
                     if (exception != null) {
-                        SqlConnection connection = connectionFromContext();
-                        return actualRollback(connection.transaction(), exception).invoke(() -> {
-                            // onItemOrFailure() will still propagate the chain even with an execption
-                            // we need to rethrow it to make sure the reactive chain fails
-                            throw new RuntimeException("Transaction rolled back due to: ", exception);
-                        });
+                        Uni<SqlConnection> connectionUni = connectionFromContext();
+                        if (connectionUni == null) {
+                            LOG.tracef("Transaction doesn't exist, cannot rollback, propagating original exception");
+                            return Uni.createFrom().failure(
+                                    new RuntimeException("Transaction rolled back due to: ", exception));
+                        }
+                        return connectionUni
+                                .onItem()
+                                .transformToUni(connection -> actualRollback(connection.transaction(), exception).invoke(() -> {
+                                    // onItemOrFailure() will still propagate the chain even with an execption
+                                    // we need to rethrow it to make sure the reactive chain fails
+                                    throw new RuntimeException("Transaction rolled back due to: ", exception);
+                                }));
                     } else {
                         return commit();
                     }
@@ -131,19 +137,22 @@ public abstract class TransactionalInterceptorBase {
             LOG.tracef("Connection doesn't exist, nothing to do here");
             return Uni.createFrom().nullItem();
         }
-        SqlConnection connection = connectionFromContext();
-        LOG.tracef("Closing the connection %s", connection);
-        return toUni(closeFuture);
+        return toUni(closeFuture)
+                .invoke(connection -> LOG.tracef("Closing the connection %s", connection));
     }
 
-    SqlConnection connectionFromContext() {
-        return TransactionalContextPool.getCurrentConnectionFromVertxContext();
+    Uni<SqlConnection> connectionFromContext() {
+        Future<? extends SqlConnection> future = TransactionalContextPool.getCurrentConnectionFromVertxContext();
+        if (future == null) {
+            return null;
+        }
+        return toUni(future);
     }
 
     // Based on org/hibernate/reactive/pool/impl/SqlClientConnection.java:305
     Uni<Void> commit() {
-        SqlConnection connection = connectionFromContext();
-        if (connection == null || connection.transaction() == null) {
+        Uni<SqlConnection> connectionUni = connectionFromContext();
+        if (connectionUni == null) {
             // This might happen if the method is annotated with @Transactional but doesn't flush
             // i.e. a single persist without an explicit .flush()
             // We then avoid committing the transaction here, and we rely on Hibernate Reactive
@@ -152,28 +161,40 @@ public abstract class TransactionalInterceptorBase {
             return Uni.createFrom().nullItem();
         }
 
-        return toUni(connection.transaction().commit())
-                .onFailure().invoke(() -> LOG.tracef("Failed to commit transaction: %s", connection))
-                .invoke(() -> LOG.tracef("Transaction committed: %s", connection));
+        return connectionUni
+                .onItem().transformToUni(connection -> {
+                    if (connection.transaction() == null) {
+                        LOG.tracef("Transaction doesn't exist, so won't commit here");
+                        return Uni.createFrom().nullItem();
+                    }
+                    return toUni(connection.transaction().commit())
+                            .onFailure().invoke(() -> LOG.tracef("Failed to commit transaction: %s", connection))
+                            .invoke(() -> LOG.tracef("Transaction committed: %s", connection));
+                });
     }
 
-    private static <T> Uni<T> toUni(Future<T> future) {
+    private static <T> Uni<T> toUni(Future<? extends T> future) {
         return Uni.createFrom()
                 .emitter(emitter -> future.onComplete(emitter::complete, emitter::fail));
     }
 
     Uni<Void> rollbackOnCancel() {
-        SqlConnection connection = connectionFromContext();
-        Transaction transaction = connection.transaction();
-        return toUni(transaction.rollback())
-                .onFailure().invoke(() -> LOG.tracef("Failed to rollback transaction on cancellation: %s", connection))
-                .invoke(() -> LOG.tracef("Transaction rolled back due to cancellation: %s", transaction));
+        Uni<SqlConnection> connectionUni = connectionFromContext();
+        if (connectionUni == null) {
+            LOG.tracef("Transaction doesn't exist, so won't roll back");
+            return Uni.createFrom().nullItem();
+        }
+        return connectionUni.onItem().transformToUni(connection -> {
+            Transaction transaction = connection.transaction();
+            return toUni(transaction.rollback())
+                    .onFailure()
+                    .invoke(() -> LOG.tracef("Failed to rollback transaction on cancellation: %s", connection))
+                    .invoke(() -> LOG.tracef("Transaction rolled back due to cancellation: %s", transaction));
+        });
     }
 
     // Based on org/hibernate/reactive/pool/impl/SqlClientConnection.java:314
     Uni<Void> rollbackOrCommitBasedOnException(Context context, Transactional annotation, Throwable exception) {
-        SqlConnection connection = connectionFromContext();
-
         for (Class<?> dontRollbackOnClass : annotation.dontRollbackOn()) {
             if (dontRollbackOnClass.isAssignableFrom(exception.getClass())) {
                 LOG.trace("Avoid rollback due to `dontRollbackOn` on `@Transactional` annotation, committing instead");
@@ -181,32 +202,41 @@ public abstract class TransactionalInterceptorBase {
             }
         }
 
-        for (Class<?> rollbackOnClass : annotation.rollbackOn()) {
-            if (rollbackOnClass.isAssignableFrom(exception.getClass())) {
-                LOG.tracef(
-                        "Rollback the transaction due to exception class %s included in `rollbackOn` field on `@Transactional` annotation",
-                        exception.getClass());
-                return actualRollback(connection.transaction(), exception);
-            }
+        Uni<SqlConnection> connectionUni = connectionFromContext();
+        if (connectionUni == null) {
+            LOG.tracef("Transaction doesn't exist, so won't commit or roll back");
+            return Uni.createFrom().nullItem();
         }
+        return connectionUni
+                .onItem().transformToUni(connection -> {
+                    for (Class<?> rollbackOnClass : annotation.rollbackOn()) {
+                        if (rollbackOnClass.isAssignableFrom(exception.getClass())) {
+                            LOG.tracef(
+                                    "Rollback the transaction due to exception class %s included in `rollbackOn` field on `@Transactional` annotation",
+                                    exception.getClass());
+                            return actualRollback(connection.transaction(), exception);
+                        }
+                    }
 
-        Rollback rollbackAnnotation = exception.getClass().getAnnotation(Rollback.class);
-        if (rollbackAnnotation != null) {
-            if (rollbackAnnotation.value()) {
-                LOG.tracef("Rollback the transaction as the exception class %s is annotated with `@Rollback` annotation",
-                        exception.getClass());
-                return actualRollback(connection.transaction(), exception);
-            } else {
-                LOG.tracef(
-                        "Do not rollback the transaction as the exception class %s is annotated with `@Rollback(false)` annotation",
-                        exception.getClass());
-                return invokeBeforeCommitAndCommit(context);
-            }
-        }
+                    Rollback rollbackAnnotation = exception.getClass().getAnnotation(Rollback.class);
+                    if (rollbackAnnotation != null) {
+                        if (rollbackAnnotation.value()) {
+                            LOG.tracef(
+                                    "Rollback the transaction as the exception class %s is annotated with `@Rollback` annotation",
+                                    exception.getClass());
+                            return actualRollback(connection.transaction(), exception);
+                        } else {
+                            LOG.tracef(
+                                    "Do not rollback the transaction as the exception class %s is annotated with `@Rollback(false)` annotation",
+                                    exception.getClass());
+                            return invokeBeforeCommitAndCommit(context);
+                        }
+                    }
 
-        // Default behavior: rollback for RuntimeException and Error (unchecked exceptions)
-        // Note: Mutiny wraps checked exceptions in CompletionException, so they appear as RuntimeException here
-        return actualRollback(connection.transaction(), exception);
+                    // Default behavior: rollback for RuntimeException and Error (unchecked exceptions)
+                    // Note: Mutiny wraps checked exceptions in CompletionException, so they appear as RuntimeException here
+                    return actualRollback(connection.transaction(), exception);
+                });
     }
 
     private Uni<Void> actualRollback(Transaction transaction, Throwable exception) {

--- a/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/TransactionalInterceptorBase.java
+++ b/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/TransactionalInterceptorBase.java
@@ -11,6 +11,8 @@ import jakarta.transaction.Transactional;
 import org.jboss.logging.Logger;
 
 import io.quarkus.arc.runtime.InterceptorBindings;
+import io.quarkus.reactive.transaction.ReactiveResource;
+import io.quarkus.reactive.transaction.runtime.pool.TransactionalContextPool;
 import io.quarkus.transaction.annotations.Rollback;
 import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle;
 import io.smallrye.mutiny.Uni;
@@ -27,10 +29,6 @@ import io.vertx.sqlclient.Transaction;
  * has its own class as the QuarkusReactiveTransaction is a binding type so requires exact match
  */
 public abstract class TransactionalInterceptorBase {
-
-    // Used in this class and in TransactionalContextPool to store and get
-    // the connection with the lazily created Transaction inside the Vert.x Context
-    public static final String CURRENT_CONNECTION_KEY = "reactive.transaction.currentConnection";
 
     // This key is used to indicate the method was annotated with @Transactional
     // And will open a session and a transaction lazily when the first operation requires a reactive session
@@ -127,18 +125,19 @@ public abstract class TransactionalInterceptorBase {
     }
 
     private Uni<?> closeConnection() {
-        SqlConnection connection = connectionFromContext();
-        if (connection == null) {
+        Future<Void> closeFuture = TransactionalContextPool.closeAndClearCurrentConnection();
+        if (closeFuture == null) {
             // io/quarkus/hibernate/reactive/transaction/DisableJTATransactionTest.java:38
             LOG.tracef("Connection doesn't exist, nothing to do here");
             return Uni.createFrom().nullItem();
         }
+        SqlConnection connection = connectionFromContext();
         LOG.tracef("Closing the connection %s", connection);
-        return toUni(connection.close());
+        return toUni(closeFuture);
     }
 
     SqlConnection connectionFromContext() {
-        return Vertx.currentContext().getLocal(CURRENT_CONNECTION_KEY);
+        return TransactionalContextPool.getCurrentConnectionFromVertxContext();
     }
 
     // Based on org/hibernate/reactive/pool/impl/SqlClientConnection.java:305

--- a/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/TransactionalInterceptorMandatory.java
+++ b/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/TransactionalInterceptorMandatory.java
@@ -1,4 +1,4 @@
-package io.quarkus.reactive.transaction;
+package io.quarkus.reactive.transaction.runtime;
 
 import jakarta.annotation.Priority;
 import jakarta.interceptor.AroundInvoke;

--- a/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/TransactionalInterceptorNever.java
+++ b/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/TransactionalInterceptorNever.java
@@ -1,4 +1,4 @@
-package io.quarkus.reactive.transaction;
+package io.quarkus.reactive.transaction.runtime;
 
 import jakarta.annotation.Priority;
 import jakarta.interceptor.AroundInvoke;
@@ -6,10 +6,10 @@ import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.InvocationContext;
 import jakarta.transaction.Transactional;
 
-@Transactional(Transactional.TxType.REQUIRES_NEW)
+@Transactional(Transactional.TxType.NEVER)
 @Interceptor
 @Priority(Interceptor.Priority.PLATFORM_BEFORE + 300)
-public class TransactionalInterceptorRequiresNew extends TransactionalInterceptorBase {
+public class TransactionalInterceptorNever extends TransactionalInterceptorBase {
 
     @AroundInvoke
     public Object intercept(InvocationContext ic) throws Exception {

--- a/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/TransactionalInterceptorNotSupported.java
+++ b/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/TransactionalInterceptorNotSupported.java
@@ -1,4 +1,4 @@
-package io.quarkus.reactive.transaction;
+package io.quarkus.reactive.transaction.runtime;
 
 import jakarta.annotation.Priority;
 import jakarta.interceptor.AroundInvoke;
@@ -6,10 +6,10 @@ import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.InvocationContext;
 import jakarta.transaction.Transactional;
 
-@Transactional(Transactional.TxType.SUPPORTS)
+@Transactional(Transactional.TxType.NOT_SUPPORTED)
 @Interceptor
 @Priority(Interceptor.Priority.PLATFORM_BEFORE + 300)
-public class TransactionalInterceptorSupports extends TransactionalInterceptorBase {
+public class TransactionalInterceptorNotSupported extends TransactionalInterceptorBase {
 
     @AroundInvoke
     public Object intercept(InvocationContext ic) throws Exception {

--- a/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/TransactionalInterceptorRequired.java
+++ b/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/TransactionalInterceptorRequired.java
@@ -1,4 +1,4 @@
-package io.quarkus.reactive.transaction;
+package io.quarkus.reactive.transaction.runtime;
 
 import jakarta.annotation.Priority;
 import jakarta.enterprise.inject.Instance;

--- a/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/TransactionalInterceptorRequired.java
+++ b/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/TransactionalInterceptorRequired.java
@@ -8,8 +8,6 @@ import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.InvocationContext;
 import jakarta.transaction.Transactional;
 
-import io.quarkus.reactive.transaction.ReactiveResource;
-
 @Transactional(Transactional.TxType.REQUIRED)
 @Interceptor
 @Priority(Interceptor.Priority.PLATFORM_BEFORE + 300)

--- a/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/TransactionalInterceptorRequired.java
+++ b/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/TransactionalInterceptorRequired.java
@@ -8,6 +8,8 @@ import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.InvocationContext;
 import jakarta.transaction.Transactional;
 
+import io.quarkus.reactive.transaction.ReactiveResource;
+
 @Transactional(Transactional.TxType.REQUIRED)
 @Interceptor
 @Priority(Interceptor.Priority.PLATFORM_BEFORE + 300)

--- a/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/TransactionalInterceptorRequiresNew.java
+++ b/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/TransactionalInterceptorRequiresNew.java
@@ -1,4 +1,4 @@
-package io.quarkus.reactive.transaction;
+package io.quarkus.reactive.transaction.runtime;
 
 import jakarta.annotation.Priority;
 import jakarta.interceptor.AroundInvoke;
@@ -6,10 +6,10 @@ import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.InvocationContext;
 import jakarta.transaction.Transactional;
 
-@Transactional(Transactional.TxType.NEVER)
+@Transactional(Transactional.TxType.REQUIRES_NEW)
 @Interceptor
 @Priority(Interceptor.Priority.PLATFORM_BEFORE + 300)
-public class TransactionalInterceptorNever extends TransactionalInterceptorBase {
+public class TransactionalInterceptorRequiresNew extends TransactionalInterceptorBase {
 
     @AroundInvoke
     public Object intercept(InvocationContext ic) throws Exception {

--- a/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/TransactionalInterceptorSupports.java
+++ b/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/TransactionalInterceptorSupports.java
@@ -1,4 +1,4 @@
-package io.quarkus.reactive.transaction;
+package io.quarkus.reactive.transaction.runtime;
 
 import jakarta.annotation.Priority;
 import jakarta.interceptor.AroundInvoke;
@@ -6,10 +6,10 @@ import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.InvocationContext;
 import jakarta.transaction.Transactional;
 
-@Transactional(Transactional.TxType.NOT_SUPPORTED)
+@Transactional(Transactional.TxType.SUPPORTS)
 @Interceptor
 @Priority(Interceptor.Priority.PLATFORM_BEFORE + 300)
-public class TransactionalInterceptorNotSupported extends TransactionalInterceptorBase {
+public class TransactionalInterceptorSupports extends TransactionalInterceptorBase {
 
     @AroundInvoke
     public Object intercept(InvocationContext ic) throws Exception {

--- a/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/pool/ConnectionHolder.java
+++ b/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/pool/ConnectionHolder.java
@@ -1,0 +1,61 @@
+package io.quarkus.reactive.transaction.runtime.pool;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+
+import org.jboss.logging.Logger;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.sqlclient.Pool;
+
+/**
+ * Holder for the connection future, ensuring only one connection is created per transaction
+ * even when multiple sessions request it concurrently.
+ */
+class ConnectionHolder {
+
+    private static final Logger LOG = Logger.getLogger(ConnectionHolder.class);
+
+    private static final VarHandle OPENED_HANDLE;
+
+    static {
+        try {
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+            OPENED_HANDLE = lookup.findVarHandle(ConnectionHolder.class, "opened", boolean.class);
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private final Pool delegate;
+    final Promise<TransactionalContextConnection> connectionPromise = Promise.promise();
+    private volatile boolean opened = false;
+
+    ConnectionHolder(Pool delegate) {
+        this.delegate = delegate;
+    }
+
+    /**
+     * Gets the connection, creating it if this is the first call (thread-safe).
+     * Concurrent calls will wait on the same future.
+     */
+    Future<TransactionalContextConnection> getConnection() {
+        if (opened) {
+            return connectionPromise.future();
+        }
+        // Use compareAndSet to ensure only one thread initiates the connection
+        if (OPENED_HANDLE.compareAndSet(this, false, true)) {
+            delegate.getConnection()
+                    .compose(connection -> {
+                        LOG.tracef("New connection, about to start transaction: %s", connection);
+                        return connection.begin().map(t -> {
+                            LOG.tracef("Transaction started: %s", connection);
+                            return new TransactionalContextConnection(connection);
+                        });
+                    })
+                    .onComplete(connectionPromise);
+        }
+        return connectionPromise.future();
+    }
+}

--- a/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/pool/TransactionalContextConnection.java
+++ b/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/pool/TransactionalContextConnection.java
@@ -1,4 +1,4 @@
-package io.quarkus.hibernate.reactive.runtime.customized;
+package io.quarkus.reactive.transaction.runtime.pool;
 
 import org.jboss.logging.Logger;
 
@@ -86,7 +86,8 @@ public class TransactionalContextConnection implements SqlConnection {
 
     @Override
     public void close(Handler<AsyncResult<Void>> handler) {
-        connection.close(handler);
+        LOG.tracef("Calling no-op close on TransactionalContextConnection it will close after the closing of session");
+        handler.handle(Future.succeededFuture());
     }
 
     @Override
@@ -113,5 +114,9 @@ public class TransactionalContextConnection implements SqlConnection {
     public Future<Void> close() {
         LOG.tracef("Calling no-op close on TransactionalContextConnection it will close after the closing of session");
         return Future.succeededFuture();
+    }
+
+    SqlConnection getDelegate() {
+        return connection;
     }
 }

--- a/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/pool/TransactionalContextPool.java
+++ b/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/pool/TransactionalContextPool.java
@@ -1,4 +1,4 @@
-package io.quarkus.hibernate.reactive.runtime.customized;
+package io.quarkus.reactive.transaction.runtime.pool;
 
 import static io.quarkus.reactive.transaction.runtime.TransactionalInterceptorBase.CURRENT_CONNECTION_KEY;
 import static io.quarkus.reactive.transaction.runtime.TransactionalInterceptorBase.TRANSACTIONAL_METHOD_KEY;
@@ -28,6 +28,9 @@ public class TransactionalContextPool implements Pool {
 
     private static final Logger LOG = Logger.getLogger(TransactionalContextPool.class);
 
+    // Key to store the wrapped connection for reuse by multiple sessions
+    private static final String CURRENT_CONNECTION_KEY = "reactive.transaction.currentConnection";
+
     private final Pool delegate;
 
     public TransactionalContextPool(Pool delegate) {
@@ -39,6 +42,13 @@ public class TransactionalContextPool implements Pool {
         if (!shouldOpenTransaction()) {
             delegate.getConnection(handler);
         } else {
+            // Check if a connection already exists in the context (from a previous session in the same transaction)
+            TransactionalContextConnection existingConnection = getCurrentConnectionFromVertxContext();
+            if (existingConnection != null) {
+                LOG.tracef("Reusing existing wrapped connection from context: %s", existingConnection);
+                handler.handle(Future.succeededFuture(existingConnection));
+                return;
+            }
             delegate.getConnection(result -> {
                 if (result.failed()) {
                     handler.handle(result);
@@ -47,8 +57,9 @@ public class TransactionalContextPool implements Pool {
                 var connection = result.result();
                 connection.begin()
                         .map(transaction -> {
-                            storeConnectionInVertxContext(connection);
-                            return (SqlConnection) new TransactionalContextConnection(connection);
+                            TransactionalContextConnection wrappedConnection = new TransactionalContextConnection(connection);
+                            storeConnectionInVertxContext(connection, wrappedConnection);
+                            return (SqlConnection) wrappedConnection;
                         })
                         .andThen(handler);
             });
@@ -60,20 +71,55 @@ public class TransactionalContextPool implements Pool {
         if (!shouldOpenTransaction()) {
             return delegate.getConnection();
         } else {
+            // Check if a connection already exists in the context (from a previous session in the same transaction)
+            TransactionalContextConnection existingConnection = getCurrentConnectionFromVertxContext();
+            if (existingConnection != null) {
+                LOG.tracef("Reusing existing wrapped connection from context: %s", existingConnection);
+                return Future.succeededFuture(existingConnection);
+            }
             return delegate.getConnection()
                     .compose(connection -> {
                         LOG.tracef("New connection, about to start transaction: %s", connection);
                         return connection.begin().map(t -> {
                             LOG.tracef("Transaction started: %s", connection);
-                            storeConnectionInVertxContext(connection);
-                            return new TransactionalContextConnection(connection);
+                            TransactionalContextConnection wrappedConnection = new TransactionalContextConnection(connection);
+                            storeConnectionInVertxContext(connection, wrappedConnection);
+                            return (SqlConnection) wrappedConnection;
                         });
                     });
         }
     }
 
-    private static void storeConnectionInVertxContext(SqlConnection connection) {
-        Vertx.currentContext().putLocal(CURRENT_CONNECTION_KEY, connection);
+    private static void storeConnectionInVertxContext(SqlConnection rawConnection,
+            TransactionalContextConnection wrappedConnection) {
+        Context context = Vertx.currentContext();
+        // Store wrapped connection for reuse by other sessions and to retrieve delegate for closing
+        context.putLocal(CURRENT_CONNECTION_KEY, wrappedConnection);
+    }
+
+    public static TransactionalContextConnection getCurrentConnectionFromVertxContext() {
+        Context context = Vertx.currentContext();
+        return context != null ? context.getLocal(CURRENT_CONNECTION_KEY) : null;
+    }
+
+    /**
+     * Closes the current connection and clears it from the Vertx context.
+     * This should be called by TransactionalInterceptorBase at the end of the transaction.
+     *
+     * @return a Future that completes when the connection is closed, or null if no connection exists
+     */
+    public static Future<Void> closeAndClearCurrentConnection() {
+        TransactionalContextConnection wrappedConnection = getCurrentConnectionFromVertxContext();
+        if (wrappedConnection == null) {
+            return null;
+        }
+        SqlConnection delegateConnection = wrappedConnection.getDelegate();
+        return delegateConnection.close().andThen(ar -> {
+            Context context = Vertx.currentContext();
+            if (context != null) {
+                context.removeLocal(CURRENT_CONNECTION_KEY);
+            }
+        });
     }
 
     private boolean shouldOpenTransaction() {

--- a/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/pool/TransactionalContextPool.java
+++ b/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/pool/TransactionalContextPool.java
@@ -1,6 +1,5 @@
 package io.quarkus.reactive.transaction.runtime.pool;
 
-import static io.quarkus.reactive.transaction.runtime.TransactionalInterceptorBase.CURRENT_CONNECTION_KEY;
 import static io.quarkus.reactive.transaction.runtime.TransactionalInterceptorBase.TRANSACTIONAL_METHOD_KEY;
 
 import java.util.function.Function;
@@ -28,7 +27,7 @@ public class TransactionalContextPool implements Pool {
 
     private static final Logger LOG = Logger.getLogger(TransactionalContextPool.class);
 
-    // Key to store the wrapped connection for reuse by multiple sessions
+    // Key to store the connection holder for reuse by multiple sessions
     private static final String CURRENT_CONNECTION_KEY = "reactive.transaction.currentConnection";
 
     private final Pool delegate;
@@ -42,27 +41,10 @@ public class TransactionalContextPool implements Pool {
         if (!shouldOpenTransaction()) {
             delegate.getConnection(handler);
         } else {
-            // Check if a connection already exists in the context (from a previous session in the same transaction)
-            TransactionalContextConnection existingConnection = getCurrentConnectionFromVertxContext();
-            if (existingConnection != null) {
-                LOG.tracef("Reusing existing wrapped connection from context: %s", existingConnection);
-                handler.handle(Future.succeededFuture(existingConnection));
-                return;
-            }
-            delegate.getConnection(result -> {
-                if (result.failed()) {
-                    handler.handle(result);
-                    return;
-                }
-                var connection = result.result();
-                connection.begin()
-                        .map(transaction -> {
-                            TransactionalContextConnection wrappedConnection = new TransactionalContextConnection(connection);
-                            storeConnectionInVertxContext(connection, wrappedConnection);
-                            return (SqlConnection) wrappedConnection;
-                        })
-                        .andThen(handler);
-            });
+            getOrCreateConnectionHolder()
+                    .getConnection()
+                    .map(conn -> (SqlConnection) conn)
+                    .onComplete(handler);
         }
     }
 
@@ -71,35 +53,36 @@ public class TransactionalContextPool implements Pool {
         if (!shouldOpenTransaction()) {
             return delegate.getConnection();
         } else {
-            // Check if a connection already exists in the context (from a previous session in the same transaction)
-            TransactionalContextConnection existingConnection = getCurrentConnectionFromVertxContext();
-            if (existingConnection != null) {
-                LOG.tracef("Reusing existing wrapped connection from context: %s", existingConnection);
-                return Future.succeededFuture(existingConnection);
-            }
-            return delegate.getConnection()
-                    .compose(connection -> {
-                        LOG.tracef("New connection, about to start transaction: %s", connection);
-                        return connection.begin().map(t -> {
-                            LOG.tracef("Transaction started: %s", connection);
-                            TransactionalContextConnection wrappedConnection = new TransactionalContextConnection(connection);
-                            storeConnectionInVertxContext(connection, wrappedConnection);
-                            return (SqlConnection) wrappedConnection;
-                        });
-                    });
+            return getOrCreateConnectionHolder()
+                    .getConnection()
+                    .map(conn -> (SqlConnection) conn);
         }
     }
 
-    private static void storeConnectionInVertxContext(SqlConnection rawConnection,
-            TransactionalContextConnection wrappedConnection) {
+    /**
+     * Gets or creates the ConnectionHolder for the current context.
+     * The holder ensures only one connection is created even with concurrent access.
+     */
+    private ConnectionHolder getOrCreateConnectionHolder() {
         Context context = Vertx.currentContext();
-        // Store wrapped connection for reuse by other sessions and to retrieve delegate for closing
-        context.putLocal(CURRENT_CONNECTION_KEY, wrappedConnection);
+        ConnectionHolder holder = context.getLocal(CURRENT_CONNECTION_KEY);
+        if (holder == null) {
+            holder = new ConnectionHolder(delegate);
+            context.putLocal(CURRENT_CONNECTION_KEY, holder);
+        }
+        return holder;
     }
 
-    public static TransactionalContextConnection getCurrentConnectionFromVertxContext() {
+    public static Future<? extends SqlConnection> getCurrentConnectionFromVertxContext() {
         Context context = Vertx.currentContext();
-        return context != null ? context.getLocal(CURRENT_CONNECTION_KEY) : null;
+        if (context == null) {
+            return null;
+        }
+        ConnectionHolder holder = context.getLocal(CURRENT_CONNECTION_KEY);
+        if (holder == null) {
+            return null;
+        }
+        return holder.connectionPromise.future();
     }
 
     /**
@@ -109,17 +92,21 @@ public class TransactionalContextPool implements Pool {
      * @return a Future that completes when the connection is closed, or null if no connection exists
      */
     public static Future<Void> closeAndClearCurrentConnection() {
-        TransactionalContextConnection wrappedConnection = getCurrentConnectionFromVertxContext();
-        if (wrappedConnection == null) {
+        Context context = Vertx.currentContext();
+        if (context == null) {
             return null;
         }
-        SqlConnection delegateConnection = wrappedConnection.getDelegate();
-        return delegateConnection.close().andThen(ar -> {
-            Context context = Vertx.currentContext();
-            if (context != null) {
-                context.removeLocal(CURRENT_CONNECTION_KEY);
-            }
-        });
+        ConnectionHolder holder = context.getLocal(CURRENT_CONNECTION_KEY);
+        if (holder == null) {
+            return null;
+        }
+        // Wait for the connection to be available, then close it
+        return holder.connectionPromise.future()
+                .compose(wrappedConnection -> {
+                    SqlConnection delegateConnection = wrappedConnection.getDelegate();
+                    return delegateConnection.close();
+                })
+                .andThen(ar -> context.removeLocal(CURRENT_CONNECTION_KEY));
     }
 
     private boolean shouldOpenTransaction() {


### PR DESCRIPTION
* Fixes #52828

See commit messages for details.