### PR TITLE
Fix native integration narayana-lra LRAParticipantTestNativeIT test

### DIFF
--- a/integration-tests/narayana-lra/src/test/java/io/quarkus/it/lra/LRAParticipantTest.java
+++ b/integration-tests/narayana-lra/src/test/java/io/quarkus/it/lra/LRAParticipantTest.java
@@ -14,8 +14,9 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Arrays;
 
-import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.lra.annotation.LRAStatus;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.common.http.TestHTTPEndpoint;
@@ -26,8 +27,13 @@ import io.restassured.response.Response;
 @TestHTTPEndpoint(TransactionalResource.class)
 public class LRAParticipantTest {
 
-    @ConfigProperty(name = "quarkus.lra.coordinator-url")
     private String coordinatorEndpoint;
+
+    @BeforeEach
+    public void setup() {
+        this.coordinatorEndpoint = ConfigProvider.getConfig()
+                .getValue("quarkus.lra.coordinator-url", String.class);
+    }
 
     // test that the JAX-RS ServerLRAFilter can start and end an LRA in a single business method
     @Test


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

When running the native LRA test the `LRAParticipantTest.coordinatorEndpoin` getting the `JUnit @ConfigProperty is not supported in @QuarkusIntegrationTest tests. Offending field is io.quarkus.it.lra.LRAParticipantTest.coordinatorEndpoint` error

This should fix it.

You can check that it failing with main and 3.33 using the `mvn clean verify -f integration-tests/narayana-lra --fail-at-end -Dtest-containers -Dstart-containers -Dnative`
