### PR TITLE
OpenAPI build failure with mp.openapi.scan.packages

### DIFF
--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -545,6 +545,7 @@ public class SmallRyeOpenApiProcessor {
 
                 return false;
             }
+
         };
 
         return new OpenApiFilteredIndexViewBuildItem(indexView);
@@ -1560,14 +1561,31 @@ public class SmallRyeOpenApiProcessor {
 
             @Override
             public Collection<AnnotationInstance> getAnnotationsWithRepeatable(DotName securityAnnotationName) {
+                // Avoid IndexView#getAnnotationsWithRepeatable as it requires the annotation definition
+                // to be present in the index (to discover the @Repeatable container via reflection).
+                // When MicroProfile filter options like `mp.openapi.scan.*` are in use, the annotation
+                // class may not be visible in the filtered index. Instead, look up both the annotation
+                // and its repeatable container (conventionally named `$List`) directly.
+                DotName containerName = DotName.createSimple(securityAnnotationName.toString() + "$List");
+                Collection<AnnotationInstance> directAnnotations;
+                Collection<AnnotationInstance> containerAnnotations;
                 if (securityTransformer != null) {
-                    return securityTransformer.getAnnotationsWithRepeatable(securityAnnotationName);
+                    directAnnotations = securityTransformer.getAnnotations(securityAnnotationName);
+                    containerAnnotations = securityTransformer.getAnnotations(containerName);
+                } else {
+                    directAnnotations = index.getAnnotations(securityAnnotationName);
+                    containerAnnotations = index.getAnnotations(containerName);
                 }
-                // the annotation definition may not be in the index if the security extension is not on the classpath
-                if (index.getClassByName(securityAnnotationName) == null) {
-                    return Collections.emptyList();
+                List<AnnotationInstance> results = new ArrayList<>(directAnnotations);
+                for (AnnotationInstance container : containerAnnotations) {
+                    AnnotationValue value = container.value();
+                    if (value != null) {
+                        for (AnnotationInstance nested : value.asNestedArray()) {
+                            results.add(AnnotationInstance.create(nested.name(), container.target(), nested.values()));
+                        }
+                    }
                 }
-                return index.getAnnotationsWithRepeatable(securityAnnotationName, index);
+                return results;
             }
 
             @Override

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoSecurityWithScanPackagesTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoSecurityWithScanPackagesTestCase.java
@@ -1,0 +1,40 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+
+/**
+ * Verify that setting {@code mp.openapi.scan.packages} does not cause a build failure
+ * when security annotations like {@code @PermissionsAllowed} are not in the filtered index.
+ *
+ * Reproducer for <a href="https://github.com/quarkusio/quarkus/issues/53471">#53471</a>.
+ */
+class AutoSecurityWithScanPackagesTestCase {
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(ResourceBean.class, OpenApiResourceSecuredAtMethodLevel.class)
+                    .addAsResource(
+                            new StringAsset("""
+                                    quarkus.smallrye-openapi.security-scheme=jwt
+                                    mp.openapi.scan.packages=io.quarkus.smallrye.openapi.test.jaxrs
+                                    """),
+                            "application.properties"));
+
+    @Test
+    void testOpenApiGeneratedWithScanPackages() {
+        RestAssured.given()
+                .header("Accept", "application/json")
+                .when()
+                .get("/q/openapi")
+                .then()
+                .statusCode(200)
+                .body("paths", Matchers.notNullValue());
+    }
+}


### PR DESCRIPTION
When `mp.openapi.scan.packages` is configured, the `FilteredIndexView` only includes classes from the specified packages. When `getAnnotationsWithRepeatable()` is called, Jandex needs to resolve the annotation class definition in the index to find its `@Repeatable` container. If the scan packages filter excludes the annotation's package (e.g. `io.quarkus.security`), Jandex throws `IllegalArgumentException: Index does not contain the annotation definition`.

Instead of relying on Jandex's `getAnnotationsWithRepeatable()` (which requires the annotation definition in the index), directly look for both `@PermissionsAllowed` and its `@PermissionsAllowed.List` container by name, unwrapping nested instances with proper target propagation. This avoids the index dependency entirely.

- Fixes: #53471