### PR TITLE
Use `<annotationProcessorPathsUseDepMgmt>` in new extension projects

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/extension-base/java/deployment/pom.tpl.qute.xml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/extension-base/java/deployment/pom.tpl.qute.xml
@@ -50,13 +50,9 @@
                                 <path>
                                     <groupId>io.quarkus</groupId>
                                     <artifactId>quarkus-extension-processor</artifactId>
-                                    {#if quarkus.version}
-                                    <version>$\{quarkus.version}</version>
-                                    {#else}
-                                    <version>$\{project.version}</version>
-                                    {/if}
                                 </path>
                             </annotationProcessorPaths>
+                            <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
                         </configuration>
                     </execution>
                 </executions>

--- a/integration-tests/class-transformer/deployment/pom.xml
+++ b/integration-tests/class-transformer/deployment/pom.xml
@@ -39,9 +39,9 @@
                                 <path>
                                     <groupId>io.quarkus</groupId>
                                     <artifactId>quarkus-extension-processor</artifactId>
-                                    <version>${project.version}</version>
                                 </path>
                             </annotationProcessorPaths>
+                            <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
                         </configuration>
                     </execution>
                 </executions>

--- a/integration-tests/devservices/dependent-extension/deployment/pom.xml
+++ b/integration-tests/devservices/dependent-extension/deployment/pom.xml
@@ -58,9 +58,9 @@
                                 <path>
                                     <groupId>io.quarkus</groupId>
                                     <artifactId>quarkus-extension-processor</artifactId>
-                                    <version>${project.version}</version>
                                 </path>
                             </annotationProcessorPaths>
+                            <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
                             <compilerArgs>
                                 <arg>-AgenerateDoc=false</arg>
                             </compilerArgs>

--- a/integration-tests/devservices/dependent-extension/runtime/pom.xml
+++ b/integration-tests/devservices/dependent-extension/runtime/pom.xml
@@ -90,9 +90,9 @@
                                 <path>
                                     <groupId>io.quarkus</groupId>
                                     <artifactId>quarkus-extension-processor</artifactId>
-                                    <version>${project.version}</version>
                                 </path>
                             </annotationProcessorPaths>
+                            <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
                             <compilerArgs>
                                 <arg>-AgenerateDoc=false</arg>
                             </compilerArgs>

--- a/integration-tests/devservices/simple-extension/deployment/pom.xml
+++ b/integration-tests/devservices/simple-extension/deployment/pom.xml
@@ -58,9 +58,9 @@
                                 <path>
                                     <groupId>io.quarkus</groupId>
                                     <artifactId>quarkus-extension-processor</artifactId>
-                                    <version>${project.version}</version>
                                 </path>
                             </annotationProcessorPaths>
+                            <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
                             <compilerArgs>
                                 <arg>-AgenerateDoc=false</arg>
                             </compilerArgs>

--- a/integration-tests/devservices/simple-extension/runtime/pom.xml
+++ b/integration-tests/devservices/simple-extension/runtime/pom.xml
@@ -90,9 +90,9 @@
                                 <path>
                                     <groupId>io.quarkus</groupId>
                                     <artifactId>quarkus-extension-processor</artifactId>
-                                    <version>${project.version}</version>
                                 </path>
                             </annotationProcessorPaths>
+                            <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
                             <compilerArgs>
                                 <arg>-AgenerateDoc=false</arg>
                             </compilerArgs>

--- a/integration-tests/test-extension/extension-that-defines-junit-test-extensions/deployment/pom.xml
+++ b/integration-tests/test-extension/extension-that-defines-junit-test-extensions/deployment/pom.xml
@@ -83,9 +83,9 @@
                                 <path>
                                     <groupId>io.quarkus</groupId>
                                     <artifactId>quarkus-extension-processor</artifactId>
-                                    <version>${project.version}</version>
                                 </path>
                             </annotationProcessorPaths>
+                            <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
                         </configuration>
                     </execution>
                 </executions>

--- a/integration-tests/test-extension/extension-that-defines-junit-test-extensions/runtime/pom.xml
+++ b/integration-tests/test-extension/extension-that-defines-junit-test-extensions/runtime/pom.xml
@@ -126,9 +126,9 @@
                                 <path>
                                     <groupId>io.quarkus</groupId>
                                     <artifactId>quarkus-extension-processor</artifactId>
-                                    <version>${project.version}</version>
                                 </path>
                             </annotationProcessorPaths>
+                            <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
                         </configuration>
                     </execution>
                 </executions>

--- a/integration-tests/test-extension/extension/deployment/pom.xml
+++ b/integration-tests/test-extension/extension/deployment/pom.xml
@@ -88,9 +88,9 @@
                                 <path>
                                     <groupId>io.quarkus</groupId>
                                     <artifactId>quarkus-extension-processor</artifactId>
-                                    <version>${project.version}</version>
                                 </path>
                             </annotationProcessorPaths>
+                            <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
                             <compilerArgs>
                                 <arg>-AgenerateDoc=false</arg>
                             </compilerArgs>

--- a/integration-tests/test-extension/extension/runtime/pom.xml
+++ b/integration-tests/test-extension/extension/runtime/pom.xml
@@ -124,9 +124,9 @@
                                 <path>
                                     <groupId>io.quarkus</groupId>
                                     <artifactId>quarkus-extension-processor</artifactId>
-                                    <version>${project.version}</version>
                                 </path>
                             </annotationProcessorPaths>
+                            <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
                             <compilerArgs>
                                 <arg>-AgenerateDoc=false</arg>
                             </compilerArgs>


### PR DESCRIPTION
Use `<annotationProcessorPathsUseDepMgmt>` in new extension projects

This change covers deployment module for new extension projects
Runtime module was done in https://github.com/quarkusio/quarkus/pull/49508 by @gastaldi some time ago


This could be a candidate for backports into LTS branches.