### PR TITLE
[3.34] Bump kafka.version from 4.1.1 to 4.1.2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -137,7 +137,7 @@
         <jboss-logging.version>3.6.3.Final</jboss-logging.version>
         <mutiny.version>3.1.1</mutiny.version>
         <jctools-core.version>4.0.5</jctools-core.version>
-        <kafka.version>4.1.1</kafka.version>
+        <kafka.version>4.1.2</kafka.version>
         <lz4.version>1.10.1</lz4.version> <!-- dependency of the kafka-clients that could be overridden by other imported BOMs in the platform -->
         <snappy.version>1.1.10.8</snappy.version>
         <strimzi-test-container.version>0.113.0</strimzi-test-container.version>


### PR DESCRIPTION
https://downloads.apache.org/kafka/4.1.2/RELEASE_NOTES.html