### PR TITLE
[3.20] Bump kafka3.version from 3.9.1 to 3.9.2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -138,7 +138,7 @@
         <jboss-logging.version>3.6.1.Final</jboss-logging.version>
         <mutiny.version>2.9.5</mutiny.version>
         <jctools-core.version>4.0.5</jctools-core.version>
-        <kafka3.version>3.9.1</kafka3.version>
+        <kafka3.version>3.9.2</kafka3.version>
         <lz4.version>1.10.1</lz4.version> <!-- dependency of the kafka-clients that could be overridden by other imported BOMs in the platform -->
         <snappy.version>1.1.10.5</snappy.version>
         <strimzi-test-container.version>0.109.2</strimzi-test-container.version>


### PR DESCRIPTION
https://downloads.apache.org/kafka/3.9.2/RELEASE_NOTES.html