### PR TITLE
Security Hardening of the TLS registry extension

### DIFF
--- a/docs/src/main/asciidoc/tls-registry-reference.adoc
+++ b/docs/src/main/asciidoc/tls-registry-reference.adoc
@@ -1560,6 +1560,24 @@ quarkus tls lets-encrypt issue-certificate \
 <2> Provide your contact email address that Let's Encrypt can use to contact you in case of any issues with your Let's Encrypt account.
 <3> Set your application management URL, which you can use to handle ACME challenges.
 Use `https://localhost:8443/` if you choose not to enable a management router in the <<lets-encrypt-prerequisites,Let's Encrypt prerequisites>> step.
++
+Additional options are available:
++
+[source,shell]
+----
+  --acme-server-url=<url>         Custom ACME production server URL (default: Let's Encrypt production)
+  --acme-staging-server-url=<url> Custom ACME staging server URL (default: Let's Encrypt staging)
+  --staging                       Use staging environment (default: false)
+  --insecure                      Disable SSL certificate validation for the management endpoint (INSECURE - development/testing only)
+----
++
+These options allow you to:
++
+* Use alternative ACME providers such as link:https://zerossl.com/[ZeroSSL] or custom ACME servers to issue certificates from different providers.
+* Test with staging environments to avoid rate limits during development.
+* Disable SSL validation for testing with self-signed management certificates (not recommended for production).
++
+NOTE: If `--staging` is set to `true`, the TLS registry CLI uses the staging server URL, which is either the default Let's Encrypt staging server or the custom staging server provided with `--acme-staging-server-url`.
 
 . During the processing of the `issue-certificate` command, the TLS registry CLI performs the following tasks:
 
@@ -1589,13 +1607,84 @@ Run the following command to renew your Let's Encrypt certificate and set your d
 [source,shell]
 ----
 quarkus tls lets-encrypt renew-certificate \
-  --domain=<domain-dns-name>
+  --domain=<domain-dns-name> \
+  --management-url=https://localhost:9000
 ----
 
 During this command, the TLS registry CLI reads the Let's Encrypt account information recorded during the <<lets-encrypt-issue-certificate,Issue certificates with Let's Encrypt>> step, issues a Let's Encrypt certificate request, and communicates with the Quarkus application to resolve ACME challenges.
 
 After the `renew-certificate` command renews the Let's Encrypt certificate chain and private key, the TLS registry CLI converts them to PEM format and copies them to the `.letsencrypt` folder.
 The TLS registry detects the new certificate and private key and reloads them automatically.
+
+Additional options are available to support alternative ACME providers:
+
+[source,shell]
+----
+  --acme-server-url=<url>         Custom ACME production server URL (default: Let's Encrypt production)
+  --acme-staging-server-url=<url> Custom ACME staging server URL (default: Let's Encrypt staging)
+  --insecure                      Disable SSL certificate validation for the management endpoint (INSECURE - development/testing only)
+----
+
+For example, to renew a certificate from ZeroSSL:
+
+[source,shell]
+----
+quarkus tls lets-encrypt renew-certificate \
+  --domain=<domain-dns-name> \
+  --management-url=https://localhost:9000 \
+  --acme-server-url=https://acme.zerossl.com/v2/DV90
+----
+
+=== Using alternative ACME providers
+
+While Let's Encrypt is the default ACME provider, you can use other ACME-compatible certificate authorities by specifying custom server URLs.
+This is useful for:
+
+* **Disaster recovery**: Failover to different providers if Let's Encrypt experiences outages
+* **Regional requirements**: Use providers that better serve specific geographic regions
+* **Organizational policies**: Comply with company requirements for specific CAs
+* **Testing**: Use custom staging servers during development
+
+==== Supported ACME providers
+
+The following ACME providers are known to work with Quarkus:
+
+[cols="1,2,2"]
+|===
+|Provider |Production URL |Staging URL
+
+|Let's Encrypt (default)
+|`https://acme-v02.api.letsencrypt.org/directory`
+|`https://acme-staging-v02.api.letsencrypt.org/directory`
+
+|ZeroSSL
+|`https://acme.zerossl.com/v2/DV90`
+|N/A (use Let's Encrypt staging for testing)
+
+|BuyPass Go
+|`https://api.buypass.com/acme/directory`
+|`https://api.test4.buypass.no/acme/directory`
+
+|Google Trust Services
+|`https://dv.acme-v02.api.pki.goog/directory`
+|`https://dv.acme-v02.test-api.pki.goog/directory`
+|===
+
+==== Example: Using ZeroSSL
+
+To issue a certificate from ZeroSSL instead of Let's Encrypt:
+
+[source,shell]
+----
+quarkus tls lets-encrypt issue-certificate \
+  --domain=example.com \
+  --email=admin@example.com \
+  --management-url=https://localhost:9000 \
+  --acme-server-url=https://acme.zerossl.com/v2/DV90
+----
+
+IMPORTANT: Each ACME provider may have different rate limits, account requirements, and supported features.
+Consult the provider's documentation before using them in production.
 
 [[lets-encrypt-ngrok]]
 === Testing with ngrok

--- a/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/GenerateCertificateCommand.java
+++ b/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/GenerateCertificateCommand.java
@@ -70,6 +70,11 @@ public class GenerateCertificateCommand implements Callable<Integer> {
     public Integer call() throws Exception {
         LOGGER.info("\uD83D\uDD0E Looking for the Quarkus Dev CA certificate...");
 
+        if ("password".equals(password)) {
+            LOGGER.warn("⚠️  WARNING: Using default password 'password' for keystore");
+            LOGGER.warn("⚠️  This is INSECURE for production use");
+        }
+
         if (!CA_FILE.exists() || !PK_FILE.exists() || selfSigned) {
             LOGGER.info("\uD83C\uDFB2 Quarkus Dev CA certificate not found. Generating a self-signed certificate...");
             generateSelfSignedCertificate();

--- a/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/GenerateCertificateCommand.java
+++ b/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/GenerateCertificateCommand.java
@@ -5,6 +5,7 @@ import static io.quarkus.tls.cli.Constants.PK_FILE;
 import static io.quarkus.tls.cli.DotEnvHelper.addOrReplaceProperty;
 import static io.quarkus.tls.cli.DotEnvHelper.readDotEnvFile;
 import static io.quarkus.tls.cli.letsencrypt.LetsEncryptConstants.DOT_ENV_FILE;
+import static io.quarkus.tls.cli.letsencrypt.LetsEncryptHelpers.AUDIT;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -97,12 +98,14 @@ public class GenerateCertificateCommand implements Callable<Integer> {
         if (!Files.exists(directory)) {
             Files.createDirectories(directory);
         }
+        AUDIT.debug("Generating self-signed certificate - name: " + name + ", cn: " + cn);
         new CertificateGenerator(directory, renew).generate(new CertificateRequest()
                 .withName(name)
                 .withCN(cn)
                 .withPassword(password)
                 .withDuration(Duration.ofDays(365))
                 .withFormat(Format.PKCS12));
+        AUDIT.debug("Self-signed certificate written to: " + directory.resolve(name + "-keystore.p12"));
         LOGGER.infof("✅ Self-signed certificate generated successfully and exported into `%s-keystore.p12`", name);
         printConfig(directory.resolve(name + "-keystore.p12"), password);
 
@@ -118,6 +121,7 @@ public class GenerateCertificateCommand implements Callable<Integer> {
             List<String> dotEnvContent = readDotEnvFile();
             addOrReplaceProperty(dotEnvContent, "%dev.quarkus.tls.key-store.p12.path", certificatePathProperty);
             addOrReplaceProperty(dotEnvContent, "%dev.quarkus.tls.key-store.p12.password", password);
+            AUDIT.debug("Writing TLS keystore configuration to .env file: " + DOT_ENV_FILE.getAbsolutePath());
             Files.write(DOT_ENV_FILE.toPath(), dotEnvContent);
         } catch (IOException e) {
             LOGGER.error("Failed to read .env file", e);
@@ -159,6 +163,7 @@ public class GenerateCertificateCommand implements Callable<Integer> {
         if (!Files.exists(directory)) {
             Files.createDirectories(directory);
         }
+        AUDIT.debug("Generating CA-signed certificate - name: " + name + ", cn: " + cn);
         new CertificateGenerator(directory, renew).generate(new CertificateRequest()
                 .withName(name)
                 .withCN(cn)
@@ -166,6 +171,7 @@ public class GenerateCertificateCommand implements Callable<Integer> {
                 .withDuration(Duration.ofDays(365))
                 .withFormat(Format.PKCS12)
                 .signedWith(issuerCert, issuerPrivateKey));
+        AUDIT.debug("CA-signed certificate written to: " + directory.resolve(name + "-keystore.p12"));
 
     }
 }

--- a/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/letsencrypt/AcmeClient.java
+++ b/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/letsencrypt/AcmeClient.java
@@ -38,14 +38,24 @@ public class AcmeClient extends AcmeClientSpi {
     public AcmeClient(String managementUrl,
             String managementUser,
             String managementPassword,
-            String managementKey) {
+            String managementKey,
+            boolean insecureMode) {
         this.vertx = Vertx.vertx();
         LOGGER.infof("\uD83D\uDD35 Creating AcmeClient with %s", managementUrl);
 
         // It will need to become configurable to support mTLS, etc
         options = new WebClientOptions();
         if (managementUrl.startsWith("https://")) {
-            options.setSsl(true).setTrustAll(true).setVerifyHost(false);
+            options.setSsl(true);
+
+            // Only disable SSL validation if explicitly requested for development/testing
+            if (insecureMode) {
+                LOGGER.warn("⚠️  WARNING: SSL certificate validation is DISABLED");
+                LOGGER.warn("⚠️  This is INSECURE and should only be used for development/testing");
+                LOGGER.warn("⚠️  NEVER use --insecure flag in production environments");
+                options.setTrustAll(true).setVerifyHost(false);
+            }
+            // Otherwise, use system trust store for proper SSL validation (secure default)
         }
         this.managementClient = WebClient.create(vertx, options);
         if (managementUrl.endsWith("/q/lets-encrypt")) {

--- a/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/letsencrypt/AcmeClient.java
+++ b/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/letsencrypt/AcmeClient.java
@@ -1,5 +1,7 @@
 package io.quarkus.tls.cli.letsencrypt;
 
+import static io.quarkus.tls.cli.letsencrypt.LetsEncryptHelpers.AUDIT;
+
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -59,6 +61,8 @@ public class AcmeClient extends AcmeClientSpi {
 
             // Only disable SSL validation if explicitly requested for development/testing
             if (insecureMode) {
+                AUDIT.error("SSL certificate validation DISABLED for management endpoint: " + managementUrl);
+                AUDIT.error("This configuration is INSECURE and must not be used in production");
                 LOGGER.warn("⚠️  WARNING: SSL certificate validation is DISABLED");
                 LOGGER.warn("⚠️  This is INSECURE and should only be used for development/testing");
                 LOGGER.warn("⚠️  NEVER use --insecure flag in production environments");
@@ -79,7 +83,7 @@ public class AcmeClient extends AcmeClientSpi {
         this.managementKey = managementKey;
     }
 
-    private void checkRateLimit() {
+    private void checkRateLimit(String operation) {
         long now = System.currentTimeMillis();
         long windowStart = windowStartTime.get();
 
@@ -91,8 +95,10 @@ public class AcmeClient extends AcmeClientSpi {
 
         int currentCount = requestCount.incrementAndGet();
         if (currentCount > MAX_REQUESTS_PER_MINUTE) {
-            LOGGER.error("⚠️  Rate limit exceeded: " + currentCount + " requests in the last minute");
-            LOGGER.error("⚠️  Maximum allowed: " + MAX_REQUESTS_PER_MINUTE + " requests per minute");
+            AUDIT.warn("Rate limit exceeded - operation: " + operation + ", requests: " + currentCount + "/"
+                    + MAX_REQUESTS_PER_MINUTE + ", endpoint: " + challengeUrl);
+            LOGGER.warn("⚠️  Rate limit exceeded: " + currentCount + " requests in the last minute");
+            LOGGER.warn("⚠️  Maximum allowed: " + MAX_REQUESTS_PER_MINUTE + " requests per minute");
             throw new RuntimeException(
                     "Rate limit exceeded: too many ACME challenge requests. Wait 60 seconds and try again.");
         }
@@ -137,6 +143,7 @@ public class AcmeClient extends AcmeClientSpi {
         AcmeChallenge selectedChallenge = null;
         for (AcmeChallenge challenge : challenges) {
             if (challenge.getType() == AcmeChallenge.Type.HTTP_01) {
+                AUDIT.info("Selected HTTP-01 challenge for domain validation");
                 LOGGER.debug("HTTP 01 challenge is selected");
                 selectedChallenge = challenge;
                 break;
@@ -149,6 +156,7 @@ public class AcmeClient extends AcmeClientSpi {
         // ensure the token is valid before proceeding
         String token = selectedChallenge.getToken();
         if (!token.matches(TOKEN_REGEX)) {
+            AUDIT.error("Invalid challenge token format - rejecting");
             throw new RuntimeException("Invalid certificate authority challenge");
         }
 
@@ -156,7 +164,7 @@ public class AcmeClient extends AcmeClientSpi {
         String selectedChallengeString = selectedChallenge.getKeyAuthorization(account);
 
         // Check rate limit before uploading challenge
-        checkRateLimit();
+        checkRateLimit("challenge-upload");
 
         // respond to the http challenge
         if (managementClient != null) {
@@ -166,12 +174,15 @@ public class AcmeClient extends AcmeClientSpi {
             HttpRequest<Buffer> request = managementClient.getAbs(challengeUrl);
             request.addQueryParam("challenge-resource", token).addQueryParam("challenge-content", selectedChallengeString);
             addKeyAndUser(request);
+            AUDIT.info("Uploading challenge to management endpoint - token: " + token.substring(0, Math.min(8, token.length()))
+                    + "..., endpoint: " + challengeUrl);
             LOGGER.debugf("Sending token %s and challenge content to the management challenge endpoint", token,
                     selectedChallengeString);
 
             HttpResponse<Buffer> response = await(request.send());
 
             if (response.statusCode() != 204) {
+                AUDIT.error("Failed to upload challenge - status: " + response.statusCode() + ", endpoint: " + challengeUrl);
                 LOGGER.error("⚠️ Failed to upload challenge content to the management challenge endpoint, status code: "
                         + response.statusCode());
                 throw new RuntimeException("Failed to respond to certificate authority challenge");
@@ -197,7 +208,7 @@ public class AcmeClient extends AcmeClientSpi {
         LOGGER.debugf("Requesting the management challenge endpoint to delete a challenge resource %s", token);
 
         // Check rate limit before cleanup
-        checkRateLimit();
+        checkRateLimit("challenge-cleanup");
 
         HttpRequest<Buffer> request = managementClient.deleteAbs(challengeUrl);
         addKeyAndUser(request);
@@ -211,7 +222,8 @@ public class AcmeClient extends AcmeClientSpi {
         LOGGER.info(
                 "\uD83D\uDD35 Notifying management challenge endpoint that a new certificate chain and private key are ready");
 
-        checkRateLimit();
+        // Check rate limit before notification
+        checkRateLimit("certificate-notification");
 
         HttpRequest<Buffer> request = managementClient.postAbs(certsUrl);
         addKeyAndUser(request);
@@ -223,10 +235,13 @@ public class AcmeClient extends AcmeClientSpi {
 
     private void addKeyAndUser(HttpRequest<Buffer> request) {
         if (managementKey != null) {
+            AUDIT.info("Using API key authentication for management endpoint");
             request.addQueryParam("key", managementKey);
-        }
-        if (managementUser != null && managementPassword != null) {
+        } else if (managementUser != null && managementPassword != null) {
+            AUDIT.info("Using basic authentication for management endpoint (user: " + managementUser + ")");
             request.basicAuthentication(managementUser, managementPassword);
+        } else {
+            AUDIT.warn("No authentication credentials provided for management endpoint");
         }
     }
 

--- a/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/letsencrypt/AcmeClient.java
+++ b/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/letsencrypt/AcmeClient.java
@@ -2,6 +2,8 @@ package io.quarkus.tls.cli.letsencrypt;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.jboss.logging.Logger;
 import org.wildfly.security.x500.cert.acme.AcmeAccount;
@@ -24,6 +26,10 @@ public class AcmeClient extends AcmeClientSpi {
 
     private static final String TOKEN_REGEX = "[A-Za-z0-9_-]+";
 
+    // Rate limiting: max 10 requests per minute to prevent DoS and Let's Encrypt rate limit exhaustion
+    private static final int MAX_REQUESTS_PER_MINUTE = 10;
+    private static final long RATE_LIMIT_WINDOW_MS = 60_000; // 1 minute
+
     private final String challengeUrl;
     private final String certsUrl;
     private final WebClientOptions options;
@@ -34,6 +40,9 @@ public class AcmeClient extends AcmeClientSpi {
     final String managementKey;
 
     private final WebClient managementClient;
+
+    private final AtomicInteger requestCount = new AtomicInteger(0);
+    private final AtomicLong windowStartTime = new AtomicLong(System.currentTimeMillis());
 
     public AcmeClient(String managementUrl,
             String managementUser,
@@ -70,6 +79,25 @@ public class AcmeClient extends AcmeClientSpi {
         this.managementKey = managementKey;
     }
 
+    private void checkRateLimit() {
+        long now = System.currentTimeMillis();
+        long windowStart = windowStartTime.get();
+
+        if (now - windowStart >= RATE_LIMIT_WINDOW_MS) {
+            if (windowStartTime.compareAndSet(windowStart, now)) {
+                requestCount.set(0);
+            }
+        }
+
+        int currentCount = requestCount.incrementAndGet();
+        if (currentCount > MAX_REQUESTS_PER_MINUTE) {
+            LOGGER.error("⚠️  Rate limit exceeded: " + currentCount + " requests in the last minute");
+            LOGGER.error("⚠️  Maximum allowed: " + MAX_REQUESTS_PER_MINUTE + " requests per minute");
+            throw new RuntimeException(
+                    "Rate limit exceeded: too many ACME challenge requests. Wait 60 seconds and try again.");
+        }
+    }
+
     public boolean checkReadiness() {
 
         // Check status
@@ -85,17 +113,17 @@ public class AcmeClient extends AcmeClientSpi {
                 }
                 case 404 -> {
                     LOGGER.error(
-                            "⚠\uFE0F Let's Encrypt challenge endpoint is not found, make sure that the build-time property `quarkus.tls.lets-encrypt.enabled` is set to `true`");
+                            "⚠️ Let's Encrypt challenge endpoint is not found, make sure that the build-time property `quarkus.tls.lets-encrypt.enabled` is set to `true`");
                     return false;
                 }
                 default -> {
-                    LOGGER.warn("⚠\uFE0F Unexpected status code from the management challenge endpoint: " + status);
+                    LOGGER.warn("⚠️ Unexpected status code from the management challenge endpoint: " + status);
                     return false;
                 }
             }
         } catch (Exception e) {
             LOGGER.debug("Failed to check the management challenge endpoint status", e);
-            LOGGER.error("⚠\uFE0F Quarkus management endpoint is not ready, make sure the Quarkus application is running.");
+            LOGGER.error("⚠️ Quarkus management endpoint is not ready, make sure the Quarkus application is running.");
             return false;
         }
 
@@ -127,6 +155,9 @@ public class AcmeClient extends AcmeClientSpi {
         LOGGER.debugf("Preparing a selected challenge content for token %s", token);
         String selectedChallengeString = selectedChallenge.getKeyAuthorization(account);
 
+        // Check rate limit before uploading challenge
+        checkRateLimit();
+
         // respond to the http challenge
         if (managementClient != null) {
             //TODO: Use JsonObject once POST is supported
@@ -141,7 +172,7 @@ public class AcmeClient extends AcmeClientSpi {
             HttpResponse<Buffer> response = await(request.send());
 
             if (response.statusCode() != 204) {
-                LOGGER.error("⚠\uFE0F Failed to upload challenge content to the management challenge endpoint, status code: "
+                LOGGER.error("⚠️ Failed to upload challenge content to the management challenge endpoint, status code: "
                         + response.statusCode());
                 throw new RuntimeException("Failed to respond to certificate authority challenge");
             } else {
@@ -165,6 +196,9 @@ public class AcmeClient extends AcmeClientSpi {
 
         LOGGER.debugf("Requesting the management challenge endpoint to delete a challenge resource %s", token);
 
+        // Check rate limit before cleanup
+        checkRateLimit();
+
         HttpRequest<Buffer> request = managementClient.deleteAbs(challengeUrl);
         addKeyAndUser(request);
         HttpResponse<Buffer> response = await(request.send());
@@ -176,6 +210,9 @@ public class AcmeClient extends AcmeClientSpi {
     public void certificateChainAndKeyAreReady() {
         LOGGER.info(
                 "\uD83D\uDD35 Notifying management challenge endpoint that a new certificate chain and private key are ready");
+
+        checkRateLimit();
+
         HttpRequest<Buffer> request = managementClient.postAbs(certsUrl);
         addKeyAndUser(request);
         HttpResponse<Buffer> response = await(request.send());

--- a/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/letsencrypt/LetsEncryptHelpers.java
+++ b/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/letsencrypt/LetsEncryptHelpers.java
@@ -30,7 +30,12 @@ import io.vertx.core.json.JsonObject;
 
 public class LetsEncryptHelpers {
 
+    public static final String DEFAULT_ACME_URL = "https://acme-v02.api.letsencrypt.org/directory";
+    public static final String DEFAULT_ACME_STAGING_URL = "https://acme-staging-v02.api.letsencrypt.org/directory";
+    public static final String TLS_AUDIT_LOG = "io.quarkus.tls.audit";
+
     static Logger LOGGER = Logger.getLogger(LetsEncryptHelpers.class);
+    public static Logger AUDIT = Logger.getLogger(LetsEncryptHelpers.TLS_AUDIT_LOG);
 
     public static void writePrivateKeyAndCertificateChainsAsPem(PrivateKey pk, X509Certificate[] chain, File privateKeyFile,
             File certificateChainFile) throws Exception {
@@ -41,7 +46,10 @@ public class LetsEncryptHelpers {
             throw new IllegalArgumentException("The certificate chain cannot be null or empty");
         }
 
+        AUDIT.debug("Writing private key to file: " + privateKeyFile.getAbsolutePath());
         CertificateUtils.writePrivateKeyToPem(pk, null, privateKeyFile);
+
+        AUDIT.debug("Writing certificate chain to file: " + certificateChainFile.getAbsolutePath());
 
         if (chain.length == 1) {
             CertificateUtils.writeCertificateToPEM(chain[0], certificateChainFile);
@@ -76,9 +84,21 @@ public class LetsEncryptHelpers {
 
         // Use defaults if not specified
         String serverUrl = acmeServerUrl != null ? acmeServerUrl
-                : "https://acme-v02.api.letsencrypt.org/directory";
+                : DEFAULT_ACME_URL;
         String stagingServerUrl = acmeStagingServerUrl != null ? acmeStagingServerUrl
-                : "https://acme-staging-v02.api.letsencrypt.org/directory";
+                : DEFAULT_ACME_STAGING_URL;
+
+        // Warn about custom ACME servers (potential supply chain risk)
+        if (acmeServerUrl != null && !acmeServerUrl.equals(DEFAULT_ACME_URL)) {
+            AUDIT.warn("Using custom ACME server URL (not Let's Encrypt): " + acmeServerUrl);
+        }
+        if (acmeStagingServerUrl != null
+                && !acmeStagingServerUrl.equals(DEFAULT_ACME_STAGING_URL)) {
+            AUDIT.warn("Using custom ACME staging server URL: " + acmeStagingServerUrl);
+        }
+
+        AUDIT.info("Creating ACME account - email: " + contactEmail + ", staging: " + staging + ", server: "
+                + (staging ? stagingServerUrl : serverUrl));
 
         AcmeAccount acmeAccount = AcmeAccount.builder()
                 .setTermsOfServiceAgreed(true)
@@ -89,15 +109,18 @@ public class LetsEncryptHelpers {
 
         try {
             if (!acmeClient.createAccount(acmeAccount, staging)) {
+                AUDIT.info("ACME account already exists - email: " + contactEmail + ", staging: " + staging);
                 LOGGER.infof("\uD83D\uDD35 %s Let's Encrypt account %s already exists",
                         (staging ? "Staging" : "Production"),
                         contactEmail);
             } else {
+                AUDIT.info("ACME account created successfully - email: " + contactEmail + ", staging: " + staging);
                 LOGGER.infof("\uD83D\uDD35 %s Let's Encrypt account %s has been created",
                         (staging ? "Staging" : "Production"),
                         contactEmail);
             }
         } catch (AcmeException ex) {
+            AUDIT.error("Failed to create ACME account - email: " + contactEmail + ", staging: " + staging, ex);
             LOGGER.error("⚠️ Failed to create Let's Encrypt account");
             throw new RuntimeException(ex);
         }
@@ -138,6 +161,7 @@ public class LetsEncryptHelpers {
         // and require an account alias/id during operations requiring an account
         java.nio.file.Path accountPath = Paths.get(letsEncryptPath + "/account.json");
         try {
+            AUDIT.debug("Writing ACME account to file: " + accountPath.toString());
             Files.copy(new ByteArrayInputStream(accountJson.encode().getBytes(StandardCharsets.US_ASCII)), accountPath,
                     StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException ex) {
@@ -155,19 +179,31 @@ public class LetsEncryptHelpers {
             String acmeServerUrl,
             String acmeStagingServerUrl) {
         AcmeAccount acmeAccount = getAccount(letsEncryptPath, acmeServerUrl, acmeStagingServerUrl);
+
+        AUDIT.info("Requesting certificate - domain: " + domain + ", staging: " + staging + ", server: "
+                + (acmeServerUrl != null ? acmeServerUrl : "default"));
+
         X509CertificateChainAndSigningKey certChainAndPrivateKey;
         try {
             certChainAndPrivateKey = acmeClient.obtainCertificateChain(acmeAccount, staging, domain);
+            AUDIT.info("Certificate chain obtained successfully - domain: " + domain + ", chain-length: "
+                    + certChainAndPrivateKey.getCertificateChain().length);
         } catch (AcmeException t) {
-            throw new RuntimeException(t.getMessage());
+            AUDIT.error("Failed to obtain certificate - domain: " + domain + ", staging: " + staging, t);
+            throw new RuntimeException("Failed to obtain certificate: " + t.getMessage(), t);
         }
         LOGGER.info("\uD83D\uDD35 Certificate and private key issued, converting them to PEM files");
+
+        AUDIT.info("Writing certificate to: " + certChainPemLoc.getAbsolutePath());
+        AUDIT.info("Writing private key to: " + privateKeyPemLoc.getAbsolutePath());
 
         try {
             LetsEncryptHelpers.writePrivateKeyAndCertificateChainsAsPem(certChainAndPrivateKey.getSigningKey(),
                     certChainAndPrivateKey.getCertificateChain(), privateKeyPemLoc, certChainPemLoc);
         } catch (Exception ex) {
-            throw new RuntimeException("Failure to copy certificate pem");
+            AUDIT.error("Failed to write certificate files - cert: " + certChainPemLoc + ", key: "
+                    + privateKeyPemLoc, ex);
+            throw new RuntimeException("Failure to copy certificate pem: " + ex.getMessage(), ex);
         }
     }
 
@@ -176,9 +212,9 @@ public class LetsEncryptHelpers {
 
         // Use defaults if not specified
         String serverUrl = acmeServerUrl != null ? acmeServerUrl
-                : "https://acme-v02.api.letsencrypt.org/directory";
+                : DEFAULT_ACME_URL;
         String stagingServerUrl = acmeStagingServerUrl != null ? acmeStagingServerUrl
-                : "https://acme-staging-v02.api.letsencrypt.org/directory";
+                : DEFAULT_ACME_STAGING_URL;
 
         JsonObject json = readAccountJson(letsEncryptPath);
         AcmeAccount.Builder builder = AcmeAccount.builder().setTermsOfServiceAgreed(true)
@@ -252,6 +288,8 @@ public class LetsEncryptHelpers {
     public static void deactivateAccount(AcmeClient acmeClient, File letsEncryptPath, boolean staging,
             String acmeServerUrl, String acmeStagingServerUrl) throws IOException {
         AcmeAccount acmeAccount = getAccount(letsEncryptPath, acmeServerUrl, acmeStagingServerUrl);
+
+        AUDIT.info("Deactivating ACME account - staging: " + staging + ", account-path: " + letsEncryptPath);
         LOGGER.infof("Deactivating %s ACME account", (staging ? "staging" : "production"));
         acmeClient.deactivateAccount(acmeAccount, staging);
 
@@ -259,9 +297,9 @@ public class LetsEncryptHelpers {
 
         java.nio.file.Path accountPath = Paths.get(letsEncryptPath + "/account.json");
         Files.deleteIfExists(accountPath);
+        AUDIT.info("ACME account deactivated and account file deleted from: " + letsEncryptPath);
     }
 
-    @SuppressWarnings("ResultOfMethodCallIgnored")
     public static void adjustPermissions(File certFile, File keyFile) {
         // Certificate can be world-readable (public data)
         if (!certFile.setReadable(true, false)) {
@@ -272,9 +310,15 @@ public class LetsEncryptHelpers {
         }
 
         // Private key MUST be owner-only readable/writable (chmod 600)
-        keyFile.setReadable(false, false); // Remove group/world read
-        keyFile.setWritable(false, false); // Remove group/world write
-        keyFile.setExecutable(false, false); // Remove group/world execute
+        if (!keyFile.setReadable(false, false)) { // Remove group/world read
+            LOGGER.warnf("Failed to set key file readable only by the owner: %s", keyFile.getAbsolutePath());
+        }
+        if (!keyFile.setWritable(false, false)) { // Remove group/world write
+            LOGGER.warnf("Failed to set key file writable only by the owner : %s", keyFile.getAbsolutePath());
+        }
+        if (!keyFile.setExecutable(false, false)) { // Remove group/world execute
+            LOGGER.warnf("Failed to set key file executable by owner only: %s", keyFile.getAbsolutePath());
+        }
 
         // Then set owner-only permissions
         if (!keyFile.setReadable(true, true)) { // Owner-only read
@@ -286,6 +330,7 @@ public class LetsEncryptHelpers {
                     "This is a critical security requirement to protect the private key.");
         }
 
+        AUDIT.debug("Set secure permissions on private key file: " + keyFile.getAbsolutePath() + " (owner-only: rw-------)");
         LOGGER.debug("Set secure permissions on private key file (owner-only: rw-------)");
     }
 }

--- a/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/letsencrypt/LetsEncryptHelpers.java
+++ b/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/letsencrypt/LetsEncryptHelpers.java
@@ -90,7 +90,7 @@ public class LetsEncryptHelpers {
                         contactEmail);
             }
         } catch (AcmeException ex) {
-            LOGGER.error("⚠\uFE0F Failed to create Let's Encrypt account");
+            LOGGER.error("⚠️ Failed to create Let's Encrypt account");
             throw new RuntimeException(ex);
         }
 
@@ -241,18 +241,31 @@ public class LetsEncryptHelpers {
         Files.deleteIfExists(accountPath);
     }
 
+    @SuppressWarnings("ResultOfMethodCallIgnored")
     public static void adjustPermissions(File certFile, File keyFile) {
+        // Certificate can be world-readable (public data)
         if (!certFile.setReadable(true, false)) {
             LOGGER.error("Failed to set certificate file readable");
         }
         if (!certFile.setWritable(true, true)) {
-            LOGGER.error("Failed to set certificate file as not writable");
+            LOGGER.error("Failed to set certificate file writable by owner only");
         }
-        if (!keyFile.setReadable(true, false)) {
-            LOGGER.error("Failed to set key file as readable");
+
+        // Private key MUST be owner-only readable/writable (chmod 600)
+        keyFile.setReadable(false, false); // Remove group/world read
+        keyFile.setWritable(false, false); // Remove group/world write
+        keyFile.setExecutable(false, false); // Remove group/world execute
+
+        // Then set owner-only permissions
+        if (!keyFile.setReadable(true, true)) { // Owner-only read
+            throw new SecurityException("Failed to set private key file readable by owner only. " +
+                    "This is a critical security requirement to protect the private key.");
         }
-        if (!keyFile.setWritable(true, true)) {
-            LOGGER.error("Failed to set key file as not writable");
+        if (!keyFile.setWritable(true, true)) { // Owner-only write
+            throw new SecurityException("Failed to set private key file writable by owner only. " +
+                    "This is a critical security requirement to protect the private key.");
         }
+
+        LOGGER.debug("Set secure permissions on private key file (owner-only: rw-------)");
     }
 }

--- a/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/letsencrypt/LetsEncryptHelpers.java
+++ b/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/letsencrypt/LetsEncryptHelpers.java
@@ -69,13 +69,21 @@ public class LetsEncryptHelpers {
     public static String createAccount(AcmeClient acmeClient,
             String letsEncryptPath,
             boolean staging,
-            String contactEmail) {
-        LOGGER.infof("\uD83D\uDD35 Creating %s Let's Encrypt account", (staging ? "staging" : "production"));
+            String contactEmail,
+            String acmeServerUrl,
+            String acmeStagingServerUrl) {
+        LOGGER.infof("\uD83D\uDD35 Creating %s ACME account", (staging ? "staging" : "production"));
+
+        // Use defaults if not specified
+        String serverUrl = acmeServerUrl != null ? acmeServerUrl
+                : "https://acme-v02.api.letsencrypt.org/directory";
+        String stagingServerUrl = acmeStagingServerUrl != null ? acmeStagingServerUrl
+                : "https://acme-staging-v02.api.letsencrypt.org/directory";
 
         AcmeAccount acmeAccount = AcmeAccount.builder()
                 .setTermsOfServiceAgreed(true)
-                .setServerUrl("https://acme-v02.api.letsencrypt.org/directory") // TODO Should this be configurable?
-                .setStagingServerUrl("https://acme-staging-v02.api.letsencrypt.org/directory") // TODO Should this be configurable?
+                .setServerUrl(serverUrl)
+                .setStagingServerUrl(stagingServerUrl)
                 .setContactUrls(new String[] { "mailto:" + contactEmail })
                 .build();
 
@@ -143,8 +151,10 @@ public class LetsEncryptHelpers {
             boolean staging,
             String domain,
             File certChainPemLoc,
-            File privateKeyPemLoc) {
-        AcmeAccount acmeAccount = getAccount(letsEncryptPath);
+            File privateKeyPemLoc,
+            String acmeServerUrl,
+            String acmeStagingServerUrl) {
+        AcmeAccount acmeAccount = getAccount(letsEncryptPath, acmeServerUrl, acmeStagingServerUrl);
         X509CertificateChainAndSigningKey certChainAndPrivateKey;
         try {
             certChainAndPrivateKey = acmeClient.obtainCertificateChain(acmeAccount, staging, domain);
@@ -161,13 +171,19 @@ public class LetsEncryptHelpers {
         }
     }
 
-    private static AcmeAccount getAccount(File letsEncryptPath) {
+    private static AcmeAccount getAccount(File letsEncryptPath, String acmeServerUrl, String acmeStagingServerUrl) {
         LOGGER.debugf("Getting account from %s", letsEncryptPath);
+
+        // Use defaults if not specified
+        String serverUrl = acmeServerUrl != null ? acmeServerUrl
+                : "https://acme-v02.api.letsencrypt.org/directory";
+        String stagingServerUrl = acmeStagingServerUrl != null ? acmeStagingServerUrl
+                : "https://acme-staging-v02.api.letsencrypt.org/directory";
 
         JsonObject json = readAccountJson(letsEncryptPath);
         AcmeAccount.Builder builder = AcmeAccount.builder().setTermsOfServiceAgreed(true)
-                .setServerUrl("https://acme-v02.api.letsencrypt.org/directory")
-                .setStagingServerUrl("https://acme-staging-v02.api.letsencrypt.org/directory");
+                .setServerUrl(serverUrl)
+                .setStagingServerUrl(stagingServerUrl);
 
         String keyAlgorithm = json.getString("key-algorithm");
         builder.setKeyAlgorithmName(keyAlgorithm);
@@ -224,15 +240,19 @@ public class LetsEncryptHelpers {
             boolean staging,
             String domain,
             File certChainPemLoc,
-            File privateKeyPemLoc) {
-        LOGGER.infof("\uD83D\uDD35 Renewing %s Let's Encrypt certificate chain and private key",
+            File privateKeyPemLoc,
+            String acmeServerUrl,
+            String acmeStagingServerUrl) {
+        LOGGER.infof("\uD83D\uDD35 Renewing %s ACME certificate chain and private key",
                 (staging ? "staging" : "production"));
-        issueCertificate(acmeClient, letsEncryptPath, staging, domain, certChainPemLoc, privateKeyPemLoc);
+        issueCertificate(acmeClient, letsEncryptPath, staging, domain, certChainPemLoc, privateKeyPemLoc,
+                acmeServerUrl, acmeStagingServerUrl);
     }
 
-    public static void deactivateAccount(AcmeClient acmeClient, File letsEncryptPath, boolean staging) throws IOException {
-        AcmeAccount acmeAccount = getAccount(letsEncryptPath);
-        LOGGER.infof("Deactivating %s Let's Encrypt account", (staging ? "staging" : "production"));
+    public static void deactivateAccount(AcmeClient acmeClient, File letsEncryptPath, boolean staging,
+            String acmeServerUrl, String acmeStagingServerUrl) throws IOException {
+        AcmeAccount acmeAccount = getAccount(letsEncryptPath, acmeServerUrl, acmeStagingServerUrl);
+        LOGGER.infof("Deactivating %s ACME account", (staging ? "staging" : "production"));
         acmeClient.deactivateAccount(acmeAccount, staging);
 
         LOGGER.infof("Removing account file from %s", letsEncryptPath);

--- a/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/letsencrypt/LetsEncryptIssueCommand.java
+++ b/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/letsencrypt/LetsEncryptIssueCommand.java
@@ -63,7 +63,7 @@ public class LetsEncryptIssueCommand implements Callable<Integer> {
     String acmeStagingServerUrl;
 
     @Override
-    public Integer call() throws Exception {
+    public Integer call() {
         AcmeClient client = new AcmeClient(managementUrl, managementUser, managementPassword, tlsConfigurationName, insecure);
 
         // Step 0 - Verification

--- a/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/letsencrypt/LetsEncryptIssueCommand.java
+++ b/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/letsencrypt/LetsEncryptIssueCommand.java
@@ -50,9 +50,13 @@ public class LetsEncryptIssueCommand implements Callable<Integer> {
             "--staging" }, description = "Whether to use the staging environment of Let's Encrypt", defaultValue = "false")
     boolean staging;
 
+    @CommandLine.Option(names = {
+            "--insecure" }, description = "Disable SSL certificate validation for the management endpoint (INSECURE - development/testing only)", defaultValue = "false")
+    boolean insecure;
+
     @Override
     public Integer call() throws Exception {
-        AcmeClient client = new AcmeClient(managementUrl, managementUser, managementPassword, tlsConfigurationName);
+        AcmeClient client = new AcmeClient(managementUrl, managementUser, managementPassword, tlsConfigurationName, insecure);
 
         // Step 0 - Verification
         // - Make sure the .letsencrypt directory exists

--- a/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/letsencrypt/LetsEncryptIssueCommand.java
+++ b/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/letsencrypt/LetsEncryptIssueCommand.java
@@ -54,6 +54,14 @@ public class LetsEncryptIssueCommand implements Callable<Integer> {
             "--insecure" }, description = "Disable SSL certificate validation for the management endpoint (INSECURE - development/testing only)", defaultValue = "false")
     boolean insecure;
 
+    @CommandLine.Option(names = {
+            "--acme-server-url" }, description = "Custom ACME production server URL (default: Let's Encrypt production)")
+    String acmeServerUrl;
+
+    @CommandLine.Option(names = {
+            "--acme-staging-server-url" }, description = "Custom ACME staging server URL (default: Let's Encrypt staging)")
+    String acmeStagingServerUrl;
+
     @Override
     public Integer call() throws Exception {
         AcmeClient client = new AcmeClient(managementUrl, managementUser, managementPassword, tlsConfigurationName, insecure);
@@ -82,11 +90,12 @@ public class LetsEncryptIssueCommand implements Callable<Integer> {
         }
 
         // Step 1 - Account
-        createAccount(client, LETS_ENCRYPT_DIR.getAbsolutePath(), staging, email);
+        createAccount(client, LETS_ENCRYPT_DIR.getAbsolutePath(), staging, email, acmeServerUrl, acmeStagingServerUrl);
 
         // Step 2 - run the challenge to obtain first certificate
-        LOGGER.infof("\uD83D\uDD35 Requesting initial certificate from %s Let's Encrypt", (staging ? "staging" : ""));
-        issueCertificate(client, LETS_ENCRYPT_DIR, staging, domain, CERT_FILE, KEY_FILE);
+        LOGGER.infof("\uD83D\uDD35 Requesting initial certificate from %s ACME server", (staging ? "staging" : "production"));
+        issueCertificate(client, LETS_ENCRYPT_DIR, staging, domain, CERT_FILE, KEY_FILE, acmeServerUrl,
+                acmeStagingServerUrl);
         adjustPermissions(CERT_FILE, KEY_FILE);
 
         // Step 3 - Reload certificate

--- a/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/letsencrypt/LetsEncryptPrepareCommand.java
+++ b/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/letsencrypt/LetsEncryptPrepareCommand.java
@@ -8,6 +8,7 @@ import static io.quarkus.tls.cli.letsencrypt.LetsEncryptConstants.CERT_FILE;
 import static io.quarkus.tls.cli.letsencrypt.LetsEncryptConstants.DOT_ENV_FILE;
 import static io.quarkus.tls.cli.letsencrypt.LetsEncryptConstants.KEY_FILE;
 import static io.quarkus.tls.cli.letsencrypt.LetsEncryptConstants.LETS_ENCRYPT_DIR;
+import static io.quarkus.tls.cli.letsencrypt.LetsEncryptHelpers.AUDIT;
 
 import java.nio.file.Files;
 import java.time.Duration;
@@ -40,6 +41,7 @@ public class LetsEncryptPrepareCommand implements Callable<Integer> {
         // Step 1 - Create .letsencrypt directory
         if (!LETS_ENCRYPT_DIR.exists()) {
             if (LETS_ENCRYPT_DIR.mkdir()) {
+                AUDIT.debug("Created Let's Encrypt directory: " + LETS_ENCRYPT_DIR.getAbsolutePath());
                 LOGGER.infof("✅ Created .letsencrypt directory: %s",
                         LETS_ENCRYPT_DIR.getAbsolutePath());
             }
@@ -61,6 +63,7 @@ public class LetsEncryptPrepareCommand implements Callable<Integer> {
 
         if (!certExistingAndStillValid) {
             // Generate a self-signed certificate (for the challenge
+            AUDIT.debug("Generating self-signed certificate for Let's Encrypt challenge - domain: " + domain);
             CertificateGenerator generator = new CertificateGenerator(LETS_ENCRYPT_DIR.toPath(), true);
             CertificateRequest request = new CertificateRequest()
                     .withCN(domain)
@@ -69,6 +72,7 @@ public class LetsEncryptPrepareCommand implements Callable<Integer> {
                     .withFormat(Format.PEM)
                     .withName("lets-encrypt");
             generator.generate(request);
+            AUDIT.debug("Self-signed certificate generated successfully: " + CERT_FILE.getAbsolutePath());
         } else {
             LOGGER.infof("✅ Certificate already exists and is still valid: %s",
                     CERT_FILE.getAbsolutePath());
@@ -89,6 +93,7 @@ public class LetsEncryptPrepareCommand implements Callable<Integer> {
         addOrReplaceProperty(dotEnvContent, prefix + ".key-store.pem.acme.cert", CERT_FILE.getAbsolutePath());
         addOrReplaceProperty(dotEnvContent, prefix + ".key-store.pem.acme.key", KEY_FILE.getAbsolutePath());
 
+        AUDIT.debug("Writing TLS configuration to .env file: " + DOT_ENV_FILE.getAbsolutePath());
         Files.write(DOT_ENV_FILE.toPath(), dotEnvContent);
         LOGGER.infof("✅ .env file configured for Let's Encrypt: %s", DOT_ENV_FILE.getAbsolutePath());
         LOGGER.infof(

--- a/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/letsencrypt/LetsEncryptRenewCommand.java
+++ b/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/letsencrypt/LetsEncryptRenewCommand.java
@@ -42,9 +42,13 @@ public class LetsEncryptRenewCommand implements Callable<Integer> {
             "--staging" }, description = "Whether to use the staging environment of Let's Encrypt", defaultValue = "false")
     boolean staging;
 
+    @CommandLine.Option(names = {
+            "--insecure" }, description = "Disable SSL certificate validation for the management endpoint (INSECURE - development/testing only)", defaultValue = "false")
+    boolean insecure;
+
     @Override
     public Integer call() throws Exception {
-        AcmeClient client = new AcmeClient(managementUrl, managementUser, managementPassword, tlsConfigurationName);
+        AcmeClient client = new AcmeClient(managementUrl, managementUser, managementPassword, tlsConfigurationName, insecure);
 
         // Step 0 - Verification
         // - Make sure the .letsencrypt directory exists

--- a/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/letsencrypt/LetsEncryptRenewCommand.java
+++ b/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/letsencrypt/LetsEncryptRenewCommand.java
@@ -56,6 +56,11 @@ public class LetsEncryptRenewCommand implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
+        if (insecure) {
+            AUDIT.error("SSL certificate validation DISABLED via --insecure flag for management endpoint: " + managementUrl);
+            AUDIT.error("This configuration is INSECURE and must not be used in production");
+        }
+
         AcmeClient client = new AcmeClient(managementUrl, managementUser, managementPassword, tlsConfigurationName, insecure);
 
         // Step 0 - Verification

--- a/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/letsencrypt/LetsEncryptRenewCommand.java
+++ b/extensions/tls-registry/cli/src/main/java/io/quarkus/tls/cli/letsencrypt/LetsEncryptRenewCommand.java
@@ -46,6 +46,14 @@ public class LetsEncryptRenewCommand implements Callable<Integer> {
             "--insecure" }, description = "Disable SSL certificate validation for the management endpoint (INSECURE - development/testing only)", defaultValue = "false")
     boolean insecure;
 
+    @CommandLine.Option(names = {
+            "--acme-server-url" }, description = "Custom ACME production server URL (default: Let's Encrypt production)")
+    String acmeServerUrl;
+
+    @CommandLine.Option(names = {
+            "--acme-staging-server-url" }, description = "Custom ACME staging server URL (default: Let's Encrypt staging)")
+    String acmeStagingServerUrl;
+
     @Override
     public Integer call() throws Exception {
         AcmeClient client = new AcmeClient(managementUrl, managementUser, managementPassword, tlsConfigurationName, insecure);
@@ -74,7 +82,8 @@ public class LetsEncryptRenewCommand implements Callable<Integer> {
         }
 
         // Step 1 - Renew
-        renewCertificate(client, LETS_ENCRYPT_DIR, staging, domain, CERT_FILE, KEY_FILE);
+        renewCertificate(client, LETS_ENCRYPT_DIR, staging, domain, CERT_FILE, KEY_FILE, acmeServerUrl,
+                acmeStagingServerUrl);
         adjustPermissions(CERT_FILE, KEY_FILE);
 
         // Step 2 - Reload certificate

--- a/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/CertificateRecorder.java
+++ b/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/CertificateRecorder.java
@@ -12,6 +12,8 @@ import java.util.function.Supplier;
 import jakarta.enterprise.inject.AmbiguousResolutionException;
 import jakarta.enterprise.inject.Default;
 
+import org.jboss.logging.Logger;
+
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.InstanceHandle;
 import io.quarkus.runtime.RuntimeValue;
@@ -29,6 +31,8 @@ import io.vertx.core.Vertx;
 
 @Recorder
 public class CertificateRecorder implements TlsConfigurationRegistry {
+
+    private static final Logger LOGGER = Logger.getLogger(CertificateRecorder.class);
 
     private final Map<String, TlsConfiguration> certificates = new ConcurrentHashMap<>();
     private volatile TlsCertificateUpdater reloader;
@@ -123,6 +127,8 @@ public class CertificateRecorder implements TlsConfigurationRegistry {
         if (config.trustAll() && ts != null) {
             throw new IllegalStateException("The trust-all option cannot be used when a trust-store is configured");
         } else if (config.trustAll()) {
+            LOGGER.warnf("TLS certificate validation disabled via trust-all configuration - name: %s", name);
+            LOGGER.warn("This configuration is INSECURE and must not be used in production");
             ts = new TrustStoreAndTrustOptions(null, TrustAllOptions.INSTANCE);
         }
         return new VertxCertificateHolder(vertx, name, config, ks, ts);

--- a/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/VertxCertificateHolder.java
+++ b/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/VertxCertificateHolder.java
@@ -255,6 +255,8 @@ public class VertxCertificateHolder implements TlsConfiguration {
                 return false;
             }
         } else if (config.trustAll()) {
+            LOGGER.warnf("TLS certificate validation disabled via trust-all configuration during reload - name: %s", name);
+            LOGGER.warn("This configuration is INSECURE and must not be used in production");
             trustStoreUpdateResult = new TrustStoreAndTrustOptions(null, TrustAllOptions.INSTANCE);
         }
 

--- a/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/config/TlsConfigUtils.java
+++ b/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/config/TlsConfigUtils.java
@@ -132,6 +132,8 @@ public class TlsConfigUtils {
         if (configuration.getHostnameVerificationAlgorithm().isPresent()
                 && configuration.getHostnameVerificationAlgorithm().get().equals("NONE")) {
             // Only disable hostname verification if the algorithm is explicitly set to NONE
+            log.warnf("Hostname verification disabled via hostname-verification-algorithm=NONE");
+            log.warn("This configuration is INSECURE and must not be used in production");
             options.setVerifyHost(false);
         }
     }
@@ -147,6 +149,8 @@ public class TlsConfigUtils {
         if (configuration.getHostnameVerificationAlgorithm().isPresent()
                 && configuration.getHostnameVerificationAlgorithm().get().equals("NONE")) {
             // Only disable hostname verification if the algorithm is explicitly set to NONE
+            log.warnf("Hostname verification DISABLED via hostname-verification-algorithm=NONE");
+            log.warn("This configuration is INSECURE and must not be used in production");
             options.setVerifyHost(false);
         }
     }


### PR DESCRIPTION

**Let's encrypt:**
- Explicit insecure parameter for the let's encrypt command line
- Enforce file permission on certificates 
- Warn when the default password (`password`) is unchanged
- Implement a rate limit strategy when interacting with the ACME client (recommended, see https://letsencrypt.org/docs/rate-limits/)
- Allows configuring alternative ACME servers
- Log security events

**Main extension:**

- Proper logging of insecure configuration (trust all and disabled hostname verification)


All the commits are independent. 