### PR TITLE
Use getRecommended() when displaying platforms to be imported in quarkus info command

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/ProjectInfoCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/ProjectInfoCommandHandler.java
@@ -101,7 +101,7 @@ public class ProjectInfoCommandHandler implements QuarkusCommandHandler {
                 for (PlatformInfo platform : providerInfo.values()) {
                     if (platform.getImported() == null) {
                         log.info(String.format(ITEM_FORMAT, "+",
-                                "[ " + MessageFormatter.green(platform.getImported().toCompactCoords()) + "]"));
+                                "[ " + MessageFormatter.green(platform.getRecommended().toCompactCoords()) + "]"));
                     }
                 }
                 recommendationsAvailable = true;


### PR DESCRIPTION
## Summary

Fixes a `NullPointerException` in `quarkus info` / `quarkus:info` Maven goal when the project has extensions whose BOM was not directly imported in the project (a platform BOM that is only recommended but not yet imported).

## Root Cause

In `ProjectInfoCommandHandler.logState()`, the `recommendExtraImports` block:

```java
if (recommendExtraImports) {
    for (PlatformInfo platform : providerInfo.values()) {
        if (platform.getImported() == null) {            // correct: this branch handles "to be imported" platforms
            log.info(String.format(ITEM_FORMAT, "+",
                    "[ " + MessageFormatter.green(platform.getImported().toCompactCoords()) + "]"));
                                //  ^^^^^^^^^^^^^^ BUG: getImported() is null here!
        }
    }
```

The guard condition `platform.getImported() == null` correctly identifies platforms that are recommended but not yet imported. But then the body calls `platform.getImported().toCompactCoords()` — which is `null.toCompactCoords()` — causing:

```
NullPointerException: Cannot invoke "ArtifactCoords.toCompactCoords()"
  because the return value of "PlatformInfo.getImported()" is null
```

## Fix

Use `platform.getRecommended().toCompactCoords()` instead. When `getImported() == null`, `PlatformInfo.isToBeImported()` guarantees `recommended != null` — so `getRecommended()` is always safe to call in this branch.

Fixes #53511