### PR TITLE
Add WebDependencyJarBuildItem SPI for extension web assets

### DIFF
--- a/extensions/vertx-http/deployment-spi/src/main/java/io/quarkus/vertx/http/deployment/spi/WebDependencyJarBuildItem.java
+++ b/extensions/vertx-http/deployment-spi/src/main/java/io/quarkus/vertx/http/deployment/spi/WebDependencyJarBuildItem.java
@@ -1,0 +1,33 @@
+package io.quarkus.vertx.http.deployment.spi;
+
+import java.nio.file.Path;
+
+import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.maven.dependency.ArtifactKey;
+
+/**
+ * Produced by extensions that ship web assets (JS modules, CSS, etc.)
+ * following the mvnpm layout convention in their runtime JAR.
+ * <p>
+ * UI framework extensions (web-dependency-locator, web-bundler, etc.)
+ * consume these to discover web dependencies without classpath scanning
+ * or group-ID matching.
+ */
+public final class WebDependencyJarBuildItem extends MultiBuildItem {
+
+    private final ArtifactKey artifactKey;
+    private final Path jarPath;
+
+    public WebDependencyJarBuildItem(ArtifactKey artifactKey, Path jarPath) {
+        this.artifactKey = artifactKey;
+        this.jarPath = jarPath;
+    }
+
+    public ArtifactKey getArtifactKey() {
+        return artifactKey;
+    }
+
+    public Path getJarPath() {
+        return jarPath;
+    }
+}

--- a/extensions/web-dependency-locator/deployment/src/main/java/io/quarkus/webdependency/locator/deployment/WebDependencyLocatorProcessor.java
+++ b/extensions/web-dependency-locator/deployment/src/main/java/io/quarkus/webdependency/locator/deployment/WebDependencyLocatorProcessor.java
@@ -33,6 +33,7 @@ import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.deployment.spi.GeneratedStaticResourceBuildItem;
+import io.quarkus.vertx.http.deployment.spi.WebDependencyJarBuildItem;
 import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 import io.quarkus.webdependency.locator.runtime.WebDependencyLocatorRecorder;
 import io.vertx.core.Handler;
@@ -159,10 +160,25 @@ public class WebDependencyLocatorProcessor {
             BuildProducer<RouteBuildItem> routes,
             BuildProducer<ImportMapBuildItem> im,
             CurateOutcomeBuildItem curateOutcome,
+            List<WebDependencyJarBuildItem> webDependencyJars,
             WebDependencyLocatorRecorder recorder) throws Exception {
 
         LibInfo webjarsLibInfo = getLibInfo(curateOutcome, WEBJARS_PREFIX, WEBJARS_NAME);
         LibInfo mvnpmNameLibInfo = getLibInfo(curateOutcome, MVNPM_PREFIX, MVNPM_NAME);
+
+        // Merge extension-declared web dependency JARs into mvnpm discovery
+        if (!webDependencyJars.isEmpty()) {
+            if (mvnpmNameLibInfo == null) {
+                mvnpmNameLibInfo = new LibInfo(new HashMap<>(), new HashSet<>());
+            }
+            for (WebDependencyJarBuildItem webDep : webDependencyJars) {
+                try {
+                    mvnpmNameLibInfo.jars.add(webDep.getJarPath().toUri().toURL());
+                } catch (MalformedURLException ex) {
+                    throw new RuntimeException(ex);
+                }
+            }
+        }
 
         if (webjarsLibInfo != null || mvnpmNameLibInfo != null) {
 


### PR DESCRIPTION
Extensions that ship web assets (JS modules, CSS) following the mvnpm layout convention — like [quarkus-json-rpc](https://github.com/quarkiverse/quarkus-json-rpc) — are invisible to UI framework extensions (web-bundler, web-dependency-locator) because their Maven group ID doesn't match `org.mvnpm` or `org.webjars.npm`.

This adds a `WebDependencyJarBuildItem` to `vertx-http/deployment-spi` that any extension can produce in a `@BuildStep` to declare it ships web assets. UI framework extensions consume the (potentially empty) list to pick up these dependencies without JAR scanning or manual user configuration.

`WebDependencyLocatorProcessor` is updated as the first consumer — it merges declared JARs into its existing mvnpm import map aggregation.

This is the Quarkus core side of the approach discussed in [quarkiverse/quarkus-web-bundler#427](https://github.com/quarkiverse/quarkus-web-bundler/pull/427). The web-bundler and quarkus-json-rpc sides will follow as separate PRs in their respective repos.

Resolves #53547