### PR TITLE
[4.0] Vert.x Bootstrap Customizer

### DIFF
--- a/extensions/vertx/deployment-spi/pom.xml
+++ b/extensions/vertx/deployment-spi/pom.xml
@@ -18,6 +18,11 @@
             <artifactId>quarkus-core-deployment</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus.arc</groupId>
             <artifactId>arc-processor</artifactId>
         </dependency>

--- a/extensions/vertx/deployment-spi/src/main/java/io/quarkus/vertx/deployment/spi/VertxBootstrapConsumerBuildItem.java
+++ b/extensions/vertx/deployment-spi/src/main/java/io/quarkus/vertx/deployment/spi/VertxBootstrapConsumerBuildItem.java
@@ -1,0 +1,49 @@
+package io.quarkus.vertx.deployment.spi;
+
+import java.util.function.Consumer;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.builder.item.MultiBuildItem;
+import io.vertx.core.internal.VertxBootstrap;
+
+/**
+ * Provide a consumer of VertxBootstrap to allow customization of
+ * Vert.x bootstrap behavior, e.g. setting tracer factory or metrics.
+ * <p>
+ * Consumers will be called in priority order (lowest to highest)
+ * after VertxOptions customizers have been applied.
+ * <p>
+ * When multiple build items have the same priority, the order of execution
+ * is not guaranteed.
+ * <p>
+ * Unlike {@link VertxOptionsConsumerBuildItem}, there is no runtime alternative. {@link VertxBootstrap} being an
+ * internal API, only extensions can customize it, and they must do so at build time.
+ */
+public final class VertxBootstrapConsumerBuildItem extends MultiBuildItem
+        implements Comparable<VertxBootstrapConsumerBuildItem> {
+    private final Consumer<VertxBootstrap> consumer;
+    private final int priority;
+
+    public VertxBootstrapConsumerBuildItem(Consumer<VertxBootstrap> consumer, int priority) {
+        this.consumer = consumer;
+        this.priority = priority;
+    }
+
+    public Consumer<VertxBootstrap> getConsumer() {
+        return consumer;
+    }
+
+    @Override
+    public int compareTo(VertxBootstrapConsumerBuildItem o) {
+        int priorityComparison = Integer.compare(this.priority, o.priority);
+        if (priorityComparison != 0) {
+            return priorityComparison;
+        }
+        Logger.getLogger(VertxBootstrapConsumerBuildItem.class).warnf(
+                "Two VertxBootstrapConsumerBuildItem have the same priority (%d). The order of execution is not guaranteed. " +
+                        "Consider using different priorities to ensure a deterministic order.",
+                this.priority);
+        return priorityComparison;
+    }
+}

--- a/extensions/vertx/deployment-spi/src/main/java/io/quarkus/vertx/deployment/spi/VertxOptionsConsumerBuildItem.java
+++ b/extensions/vertx/deployment-spi/src/main/java/io/quarkus/vertx/deployment/spi/VertxOptionsConsumerBuildItem.java
@@ -16,16 +16,16 @@ import io.vertx.core.VertxOptions;
  * after VertxConfiguration has been read and applied.
  */
 public final class VertxOptionsConsumerBuildItem extends MultiBuildItem implements Comparable<VertxOptionsConsumerBuildItem> {
-    private final Consumer<VertxOptions> optionsConsumer;
+    private final Consumer<VertxOptions> consumer;
     private final int priority;
 
-    public VertxOptionsConsumerBuildItem(Consumer<VertxOptions> optionsConsumer, int priority) {
-        this.optionsConsumer = optionsConsumer;
+    public VertxOptionsConsumerBuildItem(Consumer<VertxOptions> consumer, int priority) {
+        this.consumer = consumer;
         this.priority = priority;
     }
 
     public Consumer<VertxOptions> getConsumer() {
-        return optionsConsumer;
+        return consumer;
     }
 
     @Override

--- a/extensions/vertx/deployment-spi/src/main/java/io/quarkus/vertx/deployment/spi/VertxOptionsConsumerBuildItem.java
+++ b/extensions/vertx/deployment-spi/src/main/java/io/quarkus/vertx/deployment/spi/VertxOptionsConsumerBuildItem.java
@@ -1,6 +1,8 @@
-package io.quarkus.vertx.core.deployment;
+package io.quarkus.vertx.deployment.spi;
 
 import java.util.function.Consumer;
+
+import org.jboss.logging.Logger;
 
 import io.quarkus.builder.item.MultiBuildItem;
 import io.vertx.core.VertxOptions;
@@ -28,6 +30,14 @@ public final class VertxOptionsConsumerBuildItem extends MultiBuildItem implemen
 
     @Override
     public int compareTo(VertxOptionsConsumerBuildItem o) {
-        return Integer.compare(this.priority, o.priority);
+        int priorityComparison = Integer.compare(this.priority, o.priority);
+        if (priorityComparison != 0) {
+            return priorityComparison;
+        }
+        Logger.getLogger(VertxOptionsConsumerBuildItem.class).warnf(
+                "Two VertxOptionsConsumerBuildItems have the same priority (%d). The order of execution is not guaranteed. " +
+                        "Consider using different priorities to ensure a deterministic order.",
+                this.priority);
+        return priorityComparison;
     }
 }

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
@@ -57,6 +57,7 @@ import io.quarkus.vertx.core.runtime.VertxCoreRecorder;
 import io.quarkus.vertx.core.runtime.VertxLogDelegateFactory;
 import io.quarkus.vertx.core.runtime.context.SafeVertxContextInterceptor;
 import io.quarkus.vertx.deployment.VertxBuildConfig;
+import io.quarkus.vertx.deployment.spi.VertxOptionsConsumerBuildItem;
 import io.quarkus.vertx.mdc.provider.LateBoundMDCProvider;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Vertx;

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
@@ -57,12 +57,14 @@ import io.quarkus.vertx.core.runtime.VertxCoreRecorder;
 import io.quarkus.vertx.core.runtime.VertxLogDelegateFactory;
 import io.quarkus.vertx.core.runtime.context.SafeVertxContextInterceptor;
 import io.quarkus.vertx.deployment.VertxBuildConfig;
+import io.quarkus.vertx.deployment.spi.VertxBootstrapConsumerBuildItem;
 import io.quarkus.vertx.deployment.spi.VertxOptionsConsumerBuildItem;
 import io.quarkus.vertx.mdc.provider.LateBoundMDCProvider;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.impl.SysProps;
+import io.vertx.core.internal.VertxBootstrap;
 import io.vertx.core.spi.VerticleFactory;
 
 class VertxCoreProcessor {
@@ -138,6 +140,7 @@ class VertxCoreProcessor {
             VertxCoreRecorder recorder,
             LaunchModeBuildItem launchMode,
             ShutdownContextBuildItem shutdown,
+            List<VertxBootstrapConsumerBuildItem> vertxBootstrapConsumers,
             List<VertxOptionsConsumerBuildItem> vertxOptionsConsumers,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
             BuildProducer<EventLoopSupplierBuildItem> eventLoops,
@@ -147,14 +150,20 @@ class VertxCoreProcessor {
         // Override the Mutiny infrastructure ScheduledExecutorService to dispatch scheduled operations to a Vert.x timer
         recorder.wrapMainExecutorForMutiny(executorBuildItem.getExecutorProxy());
 
-        List<Consumer<VertxOptions>> consumers = vertxOptionsConsumers.stream()
+        List<Consumer<VertxBootstrap>> bootstrapCustomizer = vertxBootstrapConsumers.stream()
+                .sorted()
+                .map(VertxBootstrapConsumerBuildItem::getConsumer)
+                .toList();
+
+        List<Consumer<VertxOptions>> optionsCustomizer = vertxOptionsConsumers.stream()
                 .sorted()
                 .map(VertxOptionsConsumerBuildItem::getConsumer)
                 .toList();
 
         List<VerticleFactory> verticleFactories = loadServices(VerticleFactory.class);
 
-        Supplier<Vertx> vertx = recorder.configureVertx(launchMode.getLaunchMode(), shutdown, consumers,
+        Supplier<Vertx> vertx = recorder.configureVertx(launchMode.getLaunchMode(), shutdown,
+                bootstrapCustomizer, optionsCustomizer,
                 verticleFactories, executorBuildItem.getExecutorProxy());
         syntheticBeans.produce(SyntheticBeanBuildItem.configure(Vertx.class)
                 .types(Vertx.class)

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/customizers/BuildTimeVertxBootstrapCustomizerOrderTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/customizers/BuildTimeVertxBootstrapCustomizerOrderTest.java
@@ -1,0 +1,63 @@
+package io.quarkus.vertx.customizers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.vertx.deployment.spi.VertxBootstrapConsumerBuildItem;
+import io.vertx.core.internal.VertxBootstrap;
+
+public class BuildTimeVertxBootstrapCustomizerOrderTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .setArchiveProducer(() -> ShrinkWrap
+                    .create(JavaArchive.class))
+            .addBuildChainCustomizer(builder -> {
+                builder.addBuildStep(context -> {
+                    context.produce(new VertxBootstrapConsumerBuildItem(CustomizerWithPriority1000.INSTANCE, 1000));
+                }).produces(VertxBootstrapConsumerBuildItem.class).build();
+
+                builder.addBuildStep(context -> {
+                    context.produce(new VertxBootstrapConsumerBuildItem(CustomizerWithPriority2000.INSTANCE, 2000));
+                }).produces(VertxBootstrapConsumerBuildItem.class).build();
+
+            });
+
+    @Test
+    public void testThatTheCustomizersAreCalledInOrder() {
+        assertThat(calls).containsExactly("1000", "2000");
+    }
+
+    public static final List<String> calls = new ArrayList<>();
+
+    public static class CustomizerWithPriority1000 implements Consumer<VertxBootstrap> {
+
+        public static final CustomizerWithPriority1000 INSTANCE = new CustomizerWithPriority1000();
+
+        @Override
+        public void accept(VertxBootstrap bootstrap) {
+            assertThat(bootstrap).isNotNull();
+            calls.add("1000");
+        }
+    }
+
+    public static class CustomizerWithPriority2000 implements Consumer<VertxBootstrap> {
+
+        public static final CustomizerWithPriority2000 INSTANCE = new CustomizerWithPriority2000();
+
+        @Override
+        public void accept(VertxBootstrap bootstrap) {
+            assertThat(bootstrap).isNotNull();
+            calls.add("2000");
+        }
+    }
+}

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/customizers/BuildTimeVertxBootstrapCustomizerSamePriorityTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/customizers/BuildTimeVertxBootstrapCustomizerSamePriorityTest.java
@@ -1,0 +1,70 @@
+package io.quarkus.vertx.customizers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.logging.Level;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.vertx.deployment.spi.VertxBootstrapConsumerBuildItem;
+import io.vertx.core.internal.VertxBootstrap;
+
+public class BuildTimeVertxBootstrapCustomizerSamePriorityTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .setArchiveProducer(() -> ShrinkWrap
+                    .create(JavaArchive.class))
+            .addBuildChainCustomizer(builder -> {
+                builder.addBuildStep(context -> {
+                    context.produce(new VertxBootstrapConsumerBuildItem(CustomizerWithPriority1000.INSTANCE, 1000));
+                }).produces(VertxBootstrapConsumerBuildItem.class).build();
+
+                builder.addBuildStep(context -> {
+                    context.produce(
+                            new VertxBootstrapConsumerBuildItem(AnotherCustomizerWithPriority1000.INSTANCE, 1000));
+                }).produces(VertxBootstrapConsumerBuildItem.class).build();
+
+            })
+            .setLogRecordPredicate(lr -> lr.getLevel().intValue() >= Level.WARNING.intValue())
+            .assertLogRecords(logRecords -> {
+                assertThat(logRecords).anySatisfy(logRecord -> logRecord.getMessage().contains(
+                        "Two VertxBootstrapConsumerBuildItem have the same priority (1000)."));
+            });
+
+    @Test
+    public void testThatTheCustomizersAreCalledInOrder() {
+        assertThat(calls).containsExactly("1000", "1000");
+    }
+
+    public static final List<String> calls = new ArrayList<>();
+
+    public static class CustomizerWithPriority1000 implements Consumer<VertxBootstrap> {
+
+        public static final CustomizerWithPriority1000 INSTANCE = new CustomizerWithPriority1000();
+
+        @Override
+        public void accept(VertxBootstrap bootstrap) {
+            assertThat(bootstrap).isNotNull();
+            calls.add("1000");
+        }
+    }
+
+    public static class AnotherCustomizerWithPriority1000 implements Consumer<VertxBootstrap> {
+
+        public static final AnotherCustomizerWithPriority1000 INSTANCE = new AnotherCustomizerWithPriority1000();
+
+        @Override
+        public void accept(VertxBootstrap bootstrap) {
+            assertThat(bootstrap).isNotNull();
+            calls.add("1000");
+        }
+    }
+}

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/customizers/BuildTimeVertxBootstrapCustomizerTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/customizers/BuildTimeVertxBootstrapCustomizerTest.java
@@ -1,0 +1,51 @@
+package io.quarkus.vertx.customizers;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+import jakarta.inject.Inject;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.vertx.deployment.spi.VertxBootstrapConsumerBuildItem;
+import io.vertx.core.internal.VertxBootstrap;
+import io.vertx.mutiny.core.Vertx;
+
+public class BuildTimeVertxBootstrapCustomizerTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .setArchiveProducer(() -> ShrinkWrap
+                    .create(JavaArchive.class))
+            .addBuildChainCustomizer(builder -> {
+                builder.addBuildStep(context -> {
+                    context.produce(new VertxBootstrapConsumerBuildItem(MyVertxBootstrapCustomizer.INSTANCE, 3000));
+                }).produces(VertxBootstrapConsumerBuildItem.class).build();
+            });
+
+    @Inject
+    Vertx vertx;
+
+    @Test
+    public void testThatTheCustomizerIsCalled() {
+        Assertions.assertThat(CALLED).isTrue();
+    }
+
+    public static final AtomicBoolean CALLED = new AtomicBoolean();
+
+    public static class MyVertxBootstrapCustomizer implements Consumer<VertxBootstrap> {
+
+        public static final MyVertxBootstrapCustomizer INSTANCE = new MyVertxBootstrapCustomizer();
+
+        @Override
+        public void accept(VertxBootstrap bootstrap) {
+            Assertions.assertThat(bootstrap).isNotNull();
+            CALLED.set(true);
+        }
+    }
+}

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/customizers/BuildTimeVertxOptionsCustomizerOrderTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/customizers/BuildTimeVertxOptionsCustomizerOrderTest.java
@@ -1,0 +1,63 @@
+package io.quarkus.vertx.customizers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.vertx.deployment.spi.VertxOptionsConsumerBuildItem;
+import io.vertx.core.VertxOptions;
+
+public class BuildTimeVertxOptionsCustomizerOrderTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .setArchiveProducer(() -> ShrinkWrap
+                    .create(JavaArchive.class))
+            .addBuildChainCustomizer(builder -> {
+                builder.addBuildStep(context -> {
+                    context.produce(new VertxOptionsConsumerBuildItem(CustomizerWithPriority1000.INSTANCE, 1000));
+                }).produces(VertxOptionsConsumerBuildItem.class).build();
+
+                builder.addBuildStep(context -> {
+                    context.produce(new VertxOptionsConsumerBuildItem(CustomizerWithPriority2000.INSTANCE, 2000));
+                }).produces(VertxOptionsConsumerBuildItem.class).build();
+
+            });
+
+    @Test
+    public void testThatTheCustomizersAreCalledInOrder() {
+        assertThat(calls).containsExactly("1000", "2000");
+    }
+
+    public static final List<String> calls = new ArrayList<>();
+
+    public static class CustomizerWithPriority1000 implements Consumer<VertxOptions> {
+
+        public static final CustomizerWithPriority1000 INSTANCE = new CustomizerWithPriority1000();
+
+        @Override
+        public void accept(VertxOptions options) {
+            assertThat(options).isNotNull();
+            calls.add("1000");
+        }
+    }
+
+    public static class CustomizerWithPriority2000 implements Consumer<VertxOptions> {
+
+        public static final CustomizerWithPriority2000 INSTANCE = new CustomizerWithPriority2000();
+
+        @Override
+        public void accept(VertxOptions options) {
+            assertThat(options).isNotNull();
+            calls.add("2000");
+        }
+    }
+}

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/customizers/BuildTimeVertxOptionsCustomizerSamePriorityTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/customizers/BuildTimeVertxOptionsCustomizerSamePriorityTest.java
@@ -1,0 +1,69 @@
+package io.quarkus.vertx.customizers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.logging.Level;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.vertx.deployment.spi.VertxOptionsConsumerBuildItem;
+import io.vertx.core.VertxOptions;
+
+public class BuildTimeVertxOptionsCustomizerSamePriorityTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .setArchiveProducer(() -> ShrinkWrap
+                    .create(JavaArchive.class))
+            .addBuildChainCustomizer(builder -> {
+                builder.addBuildStep(context -> {
+                    context.produce(new VertxOptionsConsumerBuildItem(CustomizerWithPriority1000.INSTANCE, 1000));
+                }).produces(VertxOptionsConsumerBuildItem.class).build();
+
+                builder.addBuildStep(context -> {
+                    context.produce(new VertxOptionsConsumerBuildItem(AnotherCustomizerWithPriority1000.INSTANCE, 1000));
+                }).produces(VertxOptionsConsumerBuildItem.class).build();
+
+            })
+            .setLogRecordPredicate(lr -> lr.getLevel().intValue() >= Level.WARNING.intValue())
+            .assertLogRecords(logRecords -> {
+                assertThat(logRecords).anySatisfy(logRecord -> logRecord.getMessage().contains(
+                        "Two VertxOptionsConsumerBuildItems have the same priority (1000)."));
+            });
+
+    @Test
+    public void testThatTheCustomizersAreCalledInOrder() {
+        assertThat(calls).containsExactly("1000", "1000");
+    }
+
+    public static final List<String> calls = new ArrayList<>();
+
+    public static class CustomizerWithPriority1000 implements Consumer<VertxOptions> {
+
+        public static final CustomizerWithPriority1000 INSTANCE = new CustomizerWithPriority1000();
+
+        @Override
+        public void accept(VertxOptions options) {
+            assertThat(options).isNotNull();
+            calls.add("1000");
+        }
+    }
+
+    public static class AnotherCustomizerWithPriority1000 implements Consumer<VertxOptions> {
+
+        public static final AnotherCustomizerWithPriority1000 INSTANCE = new AnotherCustomizerWithPriority1000();
+
+        @Override
+        public void accept(VertxOptions options) {
+            assertThat(options).isNotNull();
+            calls.add("1000");
+        }
+    }
+}

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/customizers/BuildTimeVertxOptionsCustomizerTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/customizers/BuildTimeVertxOptionsCustomizerTest.java
@@ -1,0 +1,51 @@
+package io.quarkus.vertx.customizers;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+import jakarta.inject.Inject;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.vertx.deployment.spi.VertxOptionsConsumerBuildItem;
+import io.vertx.core.VertxOptions;
+import io.vertx.mutiny.core.Vertx;
+
+public class BuildTimeVertxOptionsCustomizerTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .setArchiveProducer(() -> ShrinkWrap
+                    .create(JavaArchive.class))
+            .addBuildChainCustomizer(builder -> {
+                builder.addBuildStep(context -> {
+                    context.produce(new VertxOptionsConsumerBuildItem(MyVertxOptionCustomizer.INSTANCE, 3000));
+                }).produces(VertxOptionsConsumerBuildItem.class).build();
+            });
+
+    @Inject
+    Vertx vertx;
+
+    @Test
+    public void testThatTheCustomizerIsCalled() {
+        Assertions.assertThat(CALLED).isTrue();
+    }
+
+    public static final AtomicBoolean CALLED = new AtomicBoolean();
+
+    public static class MyVertxOptionCustomizer implements Consumer<VertxOptions> {
+
+        public static final MyVertxOptionCustomizer INSTANCE = new MyVertxOptionCustomizer();
+
+        @Override
+        public void accept(VertxOptions options) {
+            Assertions.assertThat(options).isNotNull();
+            CALLED.set(true);
+        }
+    }
+}

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/customizers/VertxOptionsCustomizerTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/customizers/VertxOptionsCustomizerTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusExtensionTest;
 import io.quarkus.vertx.VertxOptionsCustomizer;
 import io.vertx.core.VertxOptions;
-import io.vertx.core.file.FileSystemOptions;
 import io.vertx.mutiny.core.Vertx;
 
 public class VertxOptionsCustomizerTest {
@@ -31,8 +30,6 @@ public class VertxOptionsCustomizerTest {
     @Test
     public void testCustomizer() {
         Assertions.assertThat(customizer.wasInvoked()).isTrue();
-        String test = vertx.fileSystem().createTempDirectoryAndAwait("test");
-        Assertions.assertThat(test).contains("target", "test");
     }
 
     @ApplicationScoped
@@ -43,7 +40,7 @@ public class VertxOptionsCustomizerTest {
         @Override
         public void accept(VertxOptions options) {
             invoked = true;
-            options.setFileSystemOptions(new FileSystemOptions().setFileCacheDir("target"));
+
         }
 
         public boolean wasInvoked() {

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/customizers/VertxOptionsCustomizerTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/customizers/VertxOptionsCustomizerTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusExtensionTest;
 import io.quarkus.vertx.VertxOptionsCustomizer;
 import io.vertx.core.VertxOptions;
-import io.vertx.mutiny.core.Vertx;
 
 public class VertxOptionsCustomizerTest {
 
@@ -20,9 +19,6 @@ public class VertxOptionsCustomizerTest {
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .setArchiveProducer(() -> ShrinkWrap
                     .create(JavaArchive.class).addClasses(MyCustomizer.class));
-
-    @Inject
-    Vertx vertx;
 
     @Inject
     MyCustomizer customizer;

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
@@ -108,13 +108,15 @@ public class VertxCoreRecorder {
     }
 
     public Supplier<Vertx> configureVertx(LaunchMode launchMode, ShutdownContext shutdown,
-            List<Consumer<VertxOptions>> customizers,
+            List<Consumer<VertxBootstrap>> bootstrapCustomizers, List<Consumer<VertxOptions>> optionsCustomizers,
             List<VerticleFactory> verticleFactories, ExecutorService executorProxy) {
         // The wrapper previously here to prevent the executor to be shutdown prematurely is moved to higher level to the io.quarkus.runtime.ExecutorRecorder
         QuarkusExecutorFactory.sharedExecutor = executorProxy;
 
         if (launchMode != LaunchMode.DEVELOPMENT) {
-            vertx = new VertxSupplier(launchMode, vertxConfig.getValue(), customizers, threadPoolConfig.getValue(), shutdown,
+            vertx = new VertxSupplier(launchMode, vertxConfig.getValue(), new ArrayList<>(bootstrapCustomizers),
+                    new ArrayList<>(optionsCustomizers),
+                    threadPoolConfig.getValue(), shutdown,
                     verticleFactories);
             // we need this to be part of the last shutdown tasks because closing it early (basically before Arc)
             // could cause problem to beans that rely on Vert.x and contain shutdown tasks
@@ -128,7 +130,9 @@ public class VertxCoreRecorder {
             });
         } else {
             if (vertx == null) {
-                vertx = new VertxSupplier(launchMode, vertxConfig.getValue(), customizers, threadPoolConfig.getValue(),
+                vertx = new VertxSupplier(launchMode, vertxConfig.getValue(), new ArrayList<>(bootstrapCustomizers),
+                        new ArrayList<>(optionsCustomizers),
+                        threadPoolConfig.getValue(),
                         shutdown, verticleFactories);
             } else if (vertx.v != null) {
                 tryCleanTccl();
@@ -218,7 +222,7 @@ public class VertxCoreRecorder {
         return vertx;
     }
 
-    public static Vertx initialize(VertxConfiguration conf, VertxOptionsCustomizer customizer,
+    public static Vertx initialize(VertxConfiguration conf, VertxCustomizer customizer,
             ThreadPoolConfig threadPoolConfig, ShutdownContext shutdown,
             LaunchMode launchMode, List<VerticleFactory> verticleFactories) {
 
@@ -246,6 +250,10 @@ public class VertxCoreRecorder {
                 .options(options.setDisableTCCL(true))
                 .executorServiceFactory(new QuarkusExecutorFactory(conf, launchMode))
                 .threadFactory(vertxThreadFactory);
+
+        if (customizer != null) {
+            customizer.customize(bootstrap);
+        }
 
         vertx = bootstrap.init().vertx();
 
@@ -626,7 +634,8 @@ public class VertxCoreRecorder {
     }
 
     public static Supplier<Vertx> recoverFailedStart(VertxConfiguration config, ThreadPoolConfig threadPoolConfig) {
-        return vertx = new VertxSupplier(LaunchMode.DEVELOPMENT, config, Collections.emptyList(), threadPoolConfig, null,
+        return vertx = new VertxSupplier(LaunchMode.DEVELOPMENT, config, Collections.emptyList(), Collections.emptyList(),
+                threadPoolConfig, null,
                 List.of());
 
     }
@@ -641,19 +650,21 @@ public class VertxCoreRecorder {
     static class VertxSupplier implements Supplier<Vertx> {
         final LaunchMode launchMode;
         final VertxConfiguration config;
-        final VertxOptionsCustomizer customizer;
+        final VertxCustomizer customizer;
         final ThreadPoolConfig threadPoolConfig;
         final ShutdownContext shutdown;
         final List<VerticleFactory> verticleFactories;
         Vertx v;
 
-        VertxSupplier(LaunchMode launchMode, VertxConfiguration config, List<Consumer<VertxOptions>> customizers,
+        VertxSupplier(LaunchMode launchMode, VertxConfiguration config,
+                List<Consumer<VertxBootstrap>> bootstrapCustomizers,
+                List<Consumer<VertxOptions>> optionCustomizers,
                 ThreadPoolConfig threadPoolConfig,
                 ShutdownContext shutdown,
                 List<VerticleFactory> verticleFactories) {
             this.launchMode = launchMode;
             this.config = config;
-            this.customizer = new VertxOptionsCustomizer(customizers);
+            this.customizer = new VertxCustomizer(bootstrapCustomizers, optionCustomizers);
             this.threadPoolConfig = threadPoolConfig;
             this.shutdown = shutdown;
             this.verticleFactories = verticleFactories;
@@ -668,10 +679,13 @@ public class VertxCoreRecorder {
         }
     }
 
-    public static class VertxOptionsCustomizer {
-        final List<Consumer<VertxOptions>> optionCustomizers;
+    public static class VertxCustomizer {
+        private final List<Consumer<VertxBootstrap>> bootstrapCustomizers;
+        private final List<Consumer<VertxOptions>> optionCustomizers;
 
-        VertxOptionsCustomizer(List<Consumer<VertxOptions>> optionCustomizers) {
+        VertxCustomizer(List<Consumer<VertxBootstrap>> bootstrapCustomizers,
+                List<Consumer<VertxOptions>> optionCustomizers) {
+            this.bootstrapCustomizers = bootstrapCustomizers;
             this.optionCustomizers = optionCustomizers;
             // Append runtime customizers at the end of the list.
             if (Arc.container() != null) {
@@ -680,6 +694,8 @@ public class VertxCoreRecorder {
                 for (InstanceHandle<io.quarkus.vertx.VertxOptionsCustomizer> customizer : instances) {
                     optionCustomizers.add(customizer.get());
                 }
+
+                // No Runtime customization of the VertxBootstrap, it's an internal Vert.x API.
             }
         }
 
@@ -688,6 +704,13 @@ public class VertxCoreRecorder {
                 x.accept(options);
             }
             return options;
+        }
+
+        VertxBootstrap customize(VertxBootstrap bootstrap) {
+            for (Consumer<VertxBootstrap> x : bootstrapCustomizers) {
+                x.accept(bootstrap);
+            }
+            return bootstrap;
         }
     }
 

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
@@ -29,7 +29,12 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.util.concurrent.FastThreadLocal;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.InstanceHandle;
-import io.quarkus.runtime.*;
+import io.quarkus.runtime.ExecutorRecorder;
+import io.quarkus.runtime.IOThreadDetector;
+import io.quarkus.runtime.LaunchMode;
+import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.ShutdownContext;
+import io.quarkus.runtime.ThreadPoolConfig;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.runtime.shutdown.ShutdownConfig;
 import io.quarkus.vertx.core.runtime.config.AddressResolverConfiguration;
@@ -223,7 +228,6 @@ public class VertxCoreRecorder {
             convertToVertxOptions(conf, options, threadPoolConfig, shutdown);
         }
 
-        // Allow extension customizers to do their thing
         if (customizer != null) {
             customizer.customize(options);
         }
@@ -263,7 +267,7 @@ public class VertxCoreRecorder {
 
     /**
      * Depending on the launch mode we may need to handle the TCCL differently.
-     *
+     * <p>
      * For dev mode it can change, so we don't want to capture the original TCCL (as this would be a leak). For other modes we
      * just want a fixed TCCL, and leaks are not an issue.
      *
@@ -665,21 +669,22 @@ public class VertxCoreRecorder {
     }
 
     public static class VertxOptionsCustomizer {
-        final List<Consumer<VertxOptions>> customizers;
+        final List<Consumer<VertxOptions>> optionCustomizers;
 
-        VertxOptionsCustomizer(List<Consumer<VertxOptions>> customizers) {
-            this.customizers = customizers;
+        VertxOptionsCustomizer(List<Consumer<VertxOptions>> optionCustomizers) {
+            this.optionCustomizers = optionCustomizers;
+            // Append runtime customizers at the end of the list.
             if (Arc.container() != null) {
                 List<InstanceHandle<io.quarkus.vertx.VertxOptionsCustomizer>> instances = Arc.container()
                         .listAll(io.quarkus.vertx.VertxOptionsCustomizer.class);
                 for (InstanceHandle<io.quarkus.vertx.VertxOptionsCustomizer> customizer : instances) {
-                    customizers.add(customizer.get());
+                    optionCustomizers.add(customizer.get());
                 }
             }
         }
 
         VertxOptions customize(VertxOptions options) {
-            for (Consumer<VertxOptions> x : customizers) {
+            for (Consumer<VertxOptions> x : optionCustomizers) {
                 x.accept(options);
             }
             return options;

--- a/extensions/vertx/runtime/src/test/java/io/quarkus/vertx/core/runtime/VertxCoreProducerTest.java
+++ b/extensions/vertx/runtime/src/test/java/io/quarkus/vertx/core/runtime/VertxCoreProducerTest.java
@@ -1,7 +1,7 @@
 package io.quarkus.vertx.core.runtime;
 
 import java.time.Duration;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -17,7 +17,7 @@ import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ThreadPoolConfig;
 import io.quarkus.runtime.configuration.DurationConverter;
-import io.quarkus.vertx.core.runtime.VertxCoreRecorder.VertxOptionsCustomizer;
+import io.quarkus.vertx.core.runtime.VertxCoreRecorder.VertxCustomizer;
 import io.quarkus.vertx.core.runtime.config.AddressResolverConfiguration;
 import io.quarkus.vertx.core.runtime.config.VertxConfiguration;
 import io.vertx.core.Vertx;
@@ -119,7 +119,7 @@ public class VertxCoreProducerTest {
             }
         };
 
-        VertxOptionsCustomizer customizers = new VertxOptionsCustomizer(Arrays.asList(
+        VertxCustomizer customizers = new VertxCustomizer(Collections.emptyList(), List.of(
                 new Consumer<VertxOptions>() {
                     @Override
                     public void accept(VertxOptions vertxOptions) {
@@ -140,7 +140,7 @@ public class VertxCoreProducerTest {
     @Test
     public void shouldInvokeCustomizers() {
         final AtomicBoolean called = new AtomicBoolean(false);
-        VertxOptionsCustomizer customizers = new VertxOptionsCustomizer(Arrays.asList(
+        VertxCustomizer customizers = new VertxCustomizer(Collections.emptyList(), List.of(
                 new Consumer<VertxOptions>() {
                     @Override
                     public void accept(VertxOptions vertxOptions) {
@@ -157,7 +157,7 @@ public class VertxCoreProducerTest {
         final String cacheDir = System.getProperty("user.dir");
         try {
             System.setProperty(SysProps.FILE_CACHE_DIR.name, cacheDir);
-            VertxOptionsCustomizer customizers = new VertxOptionsCustomizer(List.of(
+            VertxCustomizer customizers = new VertxCustomizer(Collections.emptyList(), List.of(
                     vertxOptions -> {
                         Assertions.assertNotNull(vertxOptions.getFileSystemOptions());
                         Assertions.assertEquals(cacheDir, vertxOptions.getFileSystemOptions().getFileCacheDir());

--- a/extensions/vertx/runtime/src/test/java/io/quarkus/vertx/core/runtime/VertxCoreRecorderConfigurationTest.java
+++ b/extensions/vertx/runtime/src/test/java/io/quarkus/vertx/core/runtime/VertxCoreRecorderConfigurationTest.java
@@ -3,7 +3,9 @@ package io.quarkus.vertx.core.runtime;
 import java.time.Duration;
 import java.util.List;
 import java.util.OptionalInt;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -12,8 +14,9 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.RuntimeValue;
-import io.quarkus.vertx.core.runtime.VertxCoreRecorder.VertxOptionsCustomizer;
+import io.quarkus.vertx.core.runtime.VertxCoreRecorder.VertxCustomizer;
 import io.vertx.core.VertxOptions;
+import io.vertx.core.internal.VertxBootstrap;
 
 public class VertxCoreRecorderConfigurationTest {
 
@@ -32,7 +35,7 @@ public class VertxCoreRecorderConfigurationTest {
     private VertxOptions initializeAndCapture(VertxCoreProducerTest.DefaultVertxConfiguration config,
             VertxCoreProducerTest.DefaultThreadPoolConfig threadPoolConfig) {
         AtomicReference<VertxOptions> captured = new AtomicReference<>();
-        VertxOptionsCustomizer customizer = new VertxOptionsCustomizer(List.of(captured::set));
+        VertxCustomizer customizer = new VertxCustomizer(List.of(), List.of(captured::set));
         VertxCoreRecorder.initialize(config, customizer, threadPoolConfig, null, LaunchMode.TEST,
                 List.of());
         return captured.get();
@@ -138,5 +141,24 @@ public class VertxCoreRecorderConfigurationTest {
     public void defaultEventLoopPoolSizeIsNotExplicitlySet() {
         VertxOptions opts = initializeAndCapture(new VertxCoreProducerTest.DefaultVertxConfiguration());
         Assertions.assertTrue(opts.getEventLoopPoolSize() > 0);
+    }
+
+    @Test
+    public void shouldCallBootstrapCustomizer() {
+        AtomicBoolean bootstrapCustomized = new AtomicBoolean(false);
+        Consumer<VertxBootstrap> bootstrapConsumer = bootstrap -> {
+            Assertions.assertNotNull(bootstrap);
+            bootstrapCustomized.set(true);
+        };
+
+        AtomicReference<VertxOptions> captured = new AtomicReference<>();
+        VertxCustomizer customizer = new VertxCustomizer(
+                List.of(bootstrapConsumer), List.of(captured::set));
+        VertxCoreRecorder.initialize(new VertxCoreProducerTest.DefaultVertxConfiguration(),
+                customizer, new VertxCoreProducerTest.DefaultThreadPoolConfig(), null,
+                LaunchMode.TEST, List.of());
+
+        Assertions.assertTrue(bootstrapCustomized.get());
+        Assertions.assertNotNull(captured.get());
     }
 }


### PR DESCRIPTION
Implement the possibility to customize the VertxBootstrap

- Because it's an internal API, only extensions will be able to do this.
- Move VertxOptionsConsumerBuildItem to the deployment-spi module
- Also warn if 2 build time customizers have the same priority to enforce build reproducibility.

This is required to migrate the OTel extension to Vert.x 5. 