### PR TITLE
Update GitHub Actions Ecosystem workflow to use `quarkusio` repository instead of `quarkiverse`

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/.github/workflows/quarkus-snapshot.tpl.qute.yaml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/.github/workflows/quarkus-snapshot.tpl.qute.yaml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   build:
-    uses: quarkiverse/.github/.github/workflows/quarkus-ecosystem-ci.yml@main
+    uses: quarkusio/.github/.github/workflows/quarkus-ecosystem-ci.yml@main
     secrets: inherit
     with:
       ecosystem_ci_repo_path: quarkiverse-{extension.id}

--- a/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_.github_workflows_quarkus-snapshot.yaml
+++ b/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_.github_workflows_quarkus-snapshot.yaml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   build:
-    uses: quarkiverse/.github/.github/workflows/quarkus-ecosystem-ci.yml@main
+    uses: quarkusio/.github/.github/workflows/quarkus-ecosystem-ci.yml@main
     secrets: inherit
     with:
       ecosystem_ci_repo_path: quarkiverse-my-quarkiverse-ext


### PR DESCRIPTION
This centralizes every change to the ecosystem in a single point