### PR TITLE
Define some limits for Netty and Vert.x on machines with a lot of cores

### DIFF
--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyBuildTimeConfig.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyBuildTimeConfig.java
@@ -21,4 +21,22 @@ public interface NettyBuildTimeConfig {
      * More details on https://programmer.group/pool-area-of-netty-memory-pool.html.
      */
     OptionalInt allocatorMaxOrder();
+
+    /**
+     * The number of heap arenas used by the Netty allocator.
+     * <p>
+     * When not configured, the default value is computed at runtime based on the number of available processors,
+     * capped to avoid excessive memory usage on machines with many cores:
+     * {@code 2 * min(available processors, 16)}.
+     */
+    OptionalInt allocatorNumHeapArenas();
+
+    /**
+     * The number of direct arenas used by the Netty allocator.
+     * <p>
+     * When not configured, the default value is computed at runtime based on the number of available processors,
+     * capped to avoid excessive memory usage on machines with many cores:
+     * {@code 2 * min(available processors, 16)}.
+     */
+    OptionalInt allocatorNumDirectArenas();
 }

--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -64,6 +64,8 @@ import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.gizmo.TryBlock;
 import io.quarkus.netty.BossEventLoopGroup;
 import io.quarkus.netty.MainEventLoopGroup;
+import io.quarkus.netty.runtime.DefaultNumDirectArenasGenerator;
+import io.quarkus.netty.runtime.DefaultNumHeapArenasGenerator;
 import io.quarkus.netty.runtime.EmptyByteBufStub;
 import io.quarkus.netty.runtime.MachineIdGenerator;
 import io.quarkus.netty.runtime.NettyRecorder;
@@ -88,13 +90,30 @@ class NettyProcessor {
     }
 
     @BuildStep
-    public SystemPropertyBuildItem limitArenaSize(NettyBuildTimeConfig config,
-            List<MinNettyAllocatorMaxOrderBuildItem> minMaxOrderBuildItems) {
+    public void configureAllocator(NettyBuildTimeConfig config,
+            List<MinNettyAllocatorMaxOrderBuildItem> minMaxOrderBuildItems,
+            BuildProducer<SystemPropertyBuildItem> systemProperties,
+            BuildProducer<GeneratedRuntimeSystemPropertyBuildItem> generatedSystemProperties) {
+        // Configure the chunk size via maxOrder
         String maxOrder = calculateMaxOrder(config.allocatorMaxOrder(), minMaxOrderBuildItems, true);
+        systemProperties.produce(new SystemPropertyBuildItem("io.netty.allocator.maxOrder", maxOrder));
 
-        //in native mode we limit the size of the epoll array
-        //if the array overflows the selector just moves the overflow to a map
-        return new SystemPropertyBuildItem("io.netty.allocator.maxOrder", maxOrder);
+        // Configure the number of arenas
+        if (config.allocatorNumHeapArenas().isPresent()) {
+            systemProperties.produce(new SystemPropertyBuildItem("io.netty.allocator.numHeapArenas",
+                    Integer.toString(config.allocatorNumHeapArenas().getAsInt())));
+        } else {
+            generatedSystemProperties.produce(new GeneratedRuntimeSystemPropertyBuildItem(
+                    "io.netty.allocator.numHeapArenas", DefaultNumHeapArenasGenerator.class));
+        }
+
+        if (config.allocatorNumDirectArenas().isPresent()) {
+            systemProperties.produce(new SystemPropertyBuildItem("io.netty.allocator.numDirectArenas",
+                    Integer.toString(config.allocatorNumDirectArenas().getAsInt())));
+        } else {
+            generatedSystemProperties.produce(new GeneratedRuntimeSystemPropertyBuildItem(
+                    "io.netty.allocator.numDirectArenas", DefaultNumDirectArenasGenerator.class));
+        }
     }
 
     @BuildStep

--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/DefaultNumDirectArenasGenerator.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/DefaultNumDirectArenasGenerator.java
@@ -1,0 +1,19 @@
+package io.quarkus.netty.runtime;
+
+import java.util.function.Supplier;
+
+/**
+ * Computes a sensible default for {@code io.netty.allocator.numDirectArenas} at runtime,
+ * capping the value to avoid excessive memory usage on machines with many cores.
+ */
+public final class DefaultNumDirectArenasGenerator implements Supplier<String> {
+
+    private static final int MAX_DEFAULT_ARENA_CPU_COUNT = 16;
+
+    @Override
+    public String get() {
+        int cpus = Runtime.getRuntime().availableProcessors();
+        int arenas = 2 * Math.min(cpus, MAX_DEFAULT_ARENA_CPU_COUNT);
+        return Integer.toString(arenas);
+    }
+}

--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/DefaultNumHeapArenasGenerator.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/DefaultNumHeapArenasGenerator.java
@@ -1,0 +1,19 @@
+package io.quarkus.netty.runtime;
+
+import java.util.function.Supplier;
+
+/**
+ * Computes a sensible default for {@code io.netty.allocator.numHeapArenas} at runtime,
+ * capping the value to avoid excessive memory usage on machines with many cores.
+ */
+public final class DefaultNumHeapArenasGenerator implements Supplier<String> {
+
+    private static final int MAX_DEFAULT_ARENA_CPU_COUNT = 16;
+
+    @Override
+    public String get() {
+        int cpus = Runtime.getRuntime().availableProcessors();
+        int arenas = 2 * Math.min(cpus, MAX_DEFAULT_ARENA_CPU_COUNT);
+        return Integer.toString(arenas);
+    }
+}

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
@@ -426,6 +426,8 @@ public class VertxCoreRecorder {
         return cache;
     }
 
+    private static final int MAX_DEFAULT_EVENT_LOOP_THREADS = 16;
+
     private static int calculateDefaultIOThreads() {
         //we only allow one event loop per 10mb of ram at the most
         //it's hard to say what this number should be, but it is also obvious
@@ -434,7 +436,9 @@ public class VertxCoreRecorder {
         //We used to recommend a default of twice the number of cores,
         //but more recent developments seem to suggest matching the number of cores 1:1
         //being a more reasonable default. It also saves memory.
-        int recommended = ProcessorInfo.availableProcessors();
+        //We also cap the default to avoid creating too many event loops on machines with many cores,
+        //as this leads to excessive memory usage from Netty allocator arenas.
+        int recommended = Math.min(ProcessorInfo.availableProcessors(), MAX_DEFAULT_EVENT_LOOP_THREADS);
         long mem = Runtime.getRuntime().maxMemory();
         long memInMb = mem / (1024 * 1024);
         long maxAllowed = memInMb / 10;


### PR DESCRIPTION
This is more to initialize a discussion at some point.

I still have to measure how beneficial it is. But not sure it's going to be easy given I don't have that many cores :). I'll probably experiment with lower numbers.

Also, need to run CI on this.