### PR TITLE
Bump Keycloak version to 25.6.7

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -98,7 +98,7 @@
         <junit4.version>4.13.2</junit4.version>
 
         <!-- The image to use for tests that run Keycloak -->
-        <keycloak.server.version>26.5.4</keycloak.server.version>
+        <keycloak.server.version>26.5.7</keycloak.server.version>
         <keycloak.docker.image>quay.io/keycloak/keycloak:${keycloak.server.version}</keycloak.docker.image>
 
         <unboundid-ldap.version>7.0.4</unboundid-ldap.version>


### PR DESCRIPTION
This PR updates to Keycloak 25.6.7, the last one in the 25.6.x line.
We can not currently update to 26.6.0 due to test side-effects but Pedro is helping out with making it possible with one of the next 26.6.x patch releases