### PR TITLE
Update SmallRye Config to 3.17.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -46,7 +46,7 @@
         <microprofile-lra.version>2.0.2</microprofile-lra.version>
         <microprofile-openapi.version>4.1.1</microprofile-openapi.version>
         <smallrye-common.version>2.17.0</smallrye-common.version>
-        <smallrye-config.version>3.16.0</smallrye-config.version>
+        <smallrye-config.version>3.17.0</smallrye-config.version>
         <smallrye-health.version>4.3.0</smallrye-health.version>
         <smallrye-open-api.version>4.3.0</smallrye-open-api.version>
         <smallrye-graphql.version>2.18.0</smallrye-graphql.version>

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/Deploy.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/Deploy.java
@@ -96,7 +96,7 @@ public abstract class Deploy extends QuarkusBuildTask {
     public void checkRequiredExtensions() {
         ApplicationModel appModel = resolveAppModelForBuild();
         Properties sysProps = new Properties();
-        sysProps.putAll(extension().buildEffectiveConfiguration(appModel).getValues());
+        sysProps.putAll(extension().buildEffectiveConfiguration(appModel).getQuarkusValues());
         try (CuratedApplication curatedApplication = QuarkusBootstrap.builder()
                 .setBaseClassLoader(getClass().getClassLoader())
                 .setExistingModel(appModel)

--- a/devtools/gradle/gradle/libs.versions.toml
+++ b/devtools/gradle/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 plugin-publish = "2.1.1"
 
 kotlin = "2.3.10"
-smallrye-config = "3.16.0"
+smallrye-config = "3.17.0"
 
 junit = "6.0.3"
 assertj = "3.27.7"


### PR DESCRIPTION
SmallRye Config Release notes:
<br>
  <blockquote>
      <h2>3.17.0</h2>
      <ul>
          <li><a href="https://github.com/smallrye/smallrye-config/pull/1503">#1503</a> Release 3.17.0</li>
          <li><a href="https://github.com/smallrye/smallrye-config/pull/1502">#1502</a> Use PropertyNamesMatcher to report unknowns</li>
          <li><a href="https://github.com/smallrye/smallrye-config/pull/1501">#1501</a> Update documentation dependencies</li>
          <li><a href="https://github.com/smallrye/smallrye-config/pull/1500">#1500</a> Bump io.smallrye.common:smallrye-common-bom from 2.17.0 to 2.17.1</li>
          <li><a href="https://github.com/smallrye/smallrye-config/pull/1499">#1499</a> Bump io.sundr:sundr-maven-plugin from 0.230.2 to 0.240.1</li>
          <li><a href="https://github.com/smallrye/smallrye-config/pull/1498">#1498</a> Some micro optimizations for EnvConfigSource</li>
          <li><a href="https://github.com/smallrye/smallrye-config/pull/1497">#1497</a> Generate direct ctor call for ConfigMapping nested elements</li>
          <li><a href="https://github.com/smallrye/smallrye-config/pull/1496">#1496</a> Improve PropertyNamesMatcher and use it instead of structures that use PropertyName</li>
          <li><a href="https://github.com/smallrye/smallrye-config/pull/1493">#1493</a> Bump requests from 2.32.4 to 2.33.0 in /documentation</li>
          <li><a href="https://github.com/smallrye/smallrye-config/pull/1492">#1492</a> Prevent greedy wildcard from consuming star segments in PropertyName equals</li>
          <li><a href="https://github.com/smallrye/smallrye-config/pull/1491">#1491</a> Add withMappingIgnorePrefix() API for optimized prefix filtering</li>
          <li><a href="https://github.com/smallrye/smallrye-config/pull/1490">#1490</a> Optimize reportUnknown() to avoid PropertyName HashSet collisions</li>
          <li><a href="https://github.com/smallrye/smallrye-config/pull/1489">#1489</a> Micro-optimizations in SmallRyeConfig property iteration</li>
          <li><a href="https://github.com/smallrye/smallrye-config/pull/1488">#1488</a> Bump kotlin.version from 2.3.10 to 2.3.20</li>
          <li><a href="https://github.com/smallrye/smallrye-config/pull/1487">#1487</a> Bump io.smallrye.common:smallrye-common-bom from 2.16.0 to 2.17.0</li>
          <li><a href="https://github.com/smallrye/smallrye-config/pull/1485">#1485</a> Provide a fast path for StringUtil#split()</li>
          <li><a href="https://github.com/smallrye/smallrye-config/pull/1484">#1484</a> Bump org.apache.maven.plugins:maven-shade-plugin from 3.6.1 to 3.6.2</li>
          <li><a href="https://github.com/smallrye/smallrye-config/pull/1483">#1483</a> Bump io.github.dmlloyd.maven:module-services-plugin from 1.2 to 1.3</li>
          <li><a href="https://github.com/smallrye/smallrye-config/pull/1482">#1482</a> Bump actions/upload-artifact from 6 to 7</li>
          <li><a href="https://github.com/smallrye/smallrye-config/pull/1481">#1481</a> Bump org.yaml:snakeyaml from 2.5 to 2.6</li>
          <li><a href="https://github.com/smallrye/smallrye-config/pull/1480">#1480</a> Bump com.typesafe:config from 1.4.5 to 1.4.6</li>
          <li><a href="https://github.com/smallrye/smallrye-config/pull/1479">#1479</a> Bump io.fabric8:docker-maven-plugin from 0.48.0 to 0.48.1</li>
          <li><a href="https://github.com/smallrye/smallrye-config/pull/1478">#1478</a> Bump io.smallrye.common:smallrye-common-bom from 2.15.0 to 2.16.0</li>
          <li><a href="https://github.com/smallrye/smallrye-config/pull/1477">#1477</a> Bump kotlin.version from 2.3.0 to 2.3.10</li>
          <li><a href="https://github.com/smallrye/smallrye-config/pull/1476">#1476</a> Immutable profiles</li>
          <li><a href="https://github.com/smallrye/smallrye-config/pull/1475">#1475</a> ASM dependency should be optional</li>
      </ul>
  </blockquote>