### PR TITLE
Add test for import.sql without entities - merge after Hibernate ORM 7.3.2 / 7.4

### DIFF
--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_script/ImportSqlLoadScriptNoEntitiesTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_script/ImportSqlLoadScriptNoEntitiesTestCase.java
@@ -1,0 +1,38 @@
+package io.quarkus.hibernate.orm.sql_load_script;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
+import org.hibernate.StatelessSession;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * Test that import.sql is executed even when no @Entity classes are present.
+ *
+ * @see <a href="https://github.com/quarkusio/quarkus/issues/53413">quarkusio/quarkus#53413</a>
+ */
+public class ImportSqlLoadScriptNoEntitiesTestCase {
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("import-no-entities.sql", "import.sql"));
+
+    @Inject
+    StatelessSession statelessSession;
+
+    @Test
+    @Transactional
+    public void testImportSqlExecutedWithoutEntities() {
+        // import-no-entities.sql
+        String name = statelessSession
+                .createNativeQuery("SELECT name FROM test_data WHERE id = 1", String.class)
+                .getSingleResult();
+        assertThat(name).isEqualTo("imported without entities");
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/resources/import-no-entities.sql
+++ b/extensions/hibernate-orm/deployment/src/test/resources/import-no-entities.sql
@@ -1,0 +1,2 @@
+CREATE TABLE test_data (id INT PRIMARY KEY, name VARCHAR(255));
+INSERT INTO test_data(id, name) VALUES(1, 'imported without entities');


### PR DESCRIPTION
## Summary

- Adds a regression test ensuring `import.sql` is executed even when no `@Entity` classes are present (only `StatelessSession` usage)
- The actual fix was done in Hibernate ORM via [HHH-20321](https://hibernate.atlassian.net/browse/HHH-20321)
- **This PR should be merged after Quarkus upgrades to Hibernate ORM 7.3.2 or 7.4**, which includes the fix

## Test plan

- [ ] Test passes once Hibernate ORM is bumped to 7.3.2+ or 7.4+
- [ ] Test correctly fails on current Hibernate ORM 7.3.0

Fixes: https://github.com/quarkusio/quarkus/issues/53413

🤖 Generated with [Claude Code](https://claude.com/claude-code)