### PR TITLE
[4.0] Switch reactive SQL client tests back to quarkus rest

### DIFF
--- a/extensions/reactive-mssql-client/deployment/pom.xml
+++ b/extensions/reactive-mssql-client/deployment/pom.xml
@@ -50,7 +50,7 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-reactive-routes-deployment</artifactId>
+            <artifactId>quarkus-rest-deployment</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/ChangingCredentialsTestResource.java
+++ b/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/ChangingCredentialsTestResource.java
@@ -4,12 +4,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 import io.quarkus.runtime.StartupEvent;
-import io.quarkus.vertx.web.Route;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.sqlclient.Pool;
 
+@Path("/test")
 public class ChangingCredentialsTestResource {
 
     @Inject
@@ -23,12 +28,14 @@ public class ChangingCredentialsTestResource {
         client.query("CREATE USER user2 FOR LOGIN user2").executeAndAwait();
     }
 
-    @Route(path = "/test", methods = Route.HttpMethod.GET)
-    Uni<String> connect() {
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public Uni<Response> connect() {
         return client.query("SELECT CURRENT_USER").execute()
                 .map(rowSet -> {
                     assertEquals(1, rowSet.size());
-                    return rowSet.iterator().next().getString(0);
+                    return Response.ok(rowSet.iterator().next().getString(0)).build();
                 }).eventually(credentialsProvider::changeProperties);
     }
+
 }

--- a/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/CredentialsTestResource.java
+++ b/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/CredentialsTestResource.java
@@ -2,24 +2,33 @@ package io.quarkus.reactive.mssql.client;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import jakarta.inject.Inject;
+import java.util.concurrent.CompletionStage;
 
-import io.quarkus.vertx.web.Route;
-import io.smallrye.mutiny.Uni;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
 import io.vertx.mutiny.sqlclient.Pool;
 
+@Path("/test")
 public class CredentialsTestResource {
 
     @Inject
     Pool client;
 
-    @Route(path = "/test", methods = Route.HttpMethod.GET)
-    Uni<String> connect() {
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public CompletionStage<String> connect() {
+
         return client.query("SELECT 1").execute()
                 .map(mssqlRowSet -> {
                     assertEquals(1, mssqlRowSet.size());
                     assertEquals(1, mssqlRowSet.iterator().next().getInteger(0));
                     return "OK";
-                });
+                })
+                .subscribeAsCompletionStage();
     }
+
 }

--- a/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/DevModeResource.java
+++ b/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/DevModeResource.java
@@ -1,30 +1,41 @@
 package io.quarkus.reactive.mssql.client;
 
 import java.net.ConnectException;
+import java.sql.SQLException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
-import io.quarkus.vertx.web.Route;
-import io.vertx.ext.web.RoutingContext;
 import io.vertx.sqlclient.Pool;
 
+@Path("/dev")
 public class DevModeResource {
 
     @Inject
     Pool client;
 
-    @Route(path = "/dev/error", methods = Route.HttpMethod.GET)
-    void getErrorMessage(RoutingContext rc) {
+    @GET
+    @Path("/error")
+    @Produces(MediaType.TEXT_PLAIN)
+    public CompletionStage<Response> getErrorMessage() throws SQLException {
+        CompletableFuture<Response> future = new CompletableFuture<>();
         client.query("SELECT 1").execute().onComplete(ar -> {
             Class<?> expectedExceptionClass = ConnectException.class;
             if (ar.succeeded()) {
-                rc.response().setStatusCode(500).end("Expected SQL query to fail");
+                future.complete(Response.serverError().entity("Expected SQL query to fail").build());
             } else if (!expectedExceptionClass.isAssignableFrom(ar.cause().getClass())) {
-                rc.response().setStatusCode(500)
-                        .end("Expected " + expectedExceptionClass + ", got " + ar.cause().getClass());
+                future.complete(Response.serverError()
+                        .entity("Expected " + expectedExceptionClass + ", got " + ar.cause().getClass()).build());
             } else {
-                rc.response().setStatusCode(200).end(ar.cause().getMessage());
+                future.complete(Response.ok(ar.cause().getMessage()).build());
             }
         });
+        return future;
     }
 }

--- a/extensions/reactive-mysql-client/deployment/pom.xml
+++ b/extensions/reactive-mysql-client/deployment/pom.xml
@@ -71,7 +71,7 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-reactive-routes-deployment</artifactId>
+            <artifactId>quarkus-rest-deployment</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/ChangingCredentialsTestResource.java
+++ b/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/ChangingCredentialsTestResource.java
@@ -3,11 +3,16 @@ package io.quarkus.reactive.mysql.client;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
-import io.quarkus.vertx.web.Route;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.sqlclient.Pool;
 
+@Path("/test")
 public class ChangingCredentialsTestResource {
 
     @Inject
@@ -16,12 +21,14 @@ public class ChangingCredentialsTestResource {
     @Inject
     ChangingCredentialsProvider credentialsProvider;
 
-    @Route(path = "/test", methods = Route.HttpMethod.GET)
-    Uni<String> connect() {
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public Uni<Response> connect() {
         return client.query("SELECT CURRENT_USER").execute()
                 .map(rowSet -> {
                     assertEquals(1, rowSet.size());
-                    return rowSet.iterator().next().getString(0);
+                    return Response.ok(rowSet.iterator().next().getString(0)).build();
                 }).eventually(credentialsProvider::changeProperties);
     }
+
 }

--- a/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/CredentialsTestResource.java
+++ b/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/CredentialsTestResource.java
@@ -2,24 +2,33 @@ package io.quarkus.reactive.mysql.client;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import jakarta.inject.Inject;
+import java.util.concurrent.CompletionStage;
 
-import io.quarkus.vertx.web.Route;
-import io.smallrye.mutiny.Uni;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
 import io.vertx.mutiny.sqlclient.Pool;
 
+@Path("/test")
 public class CredentialsTestResource {
 
     @Inject
     Pool client;
 
-    @Route(path = "/test", methods = Route.HttpMethod.GET)
-    Uni<String> connect() {
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public CompletionStage<String> connect() {
+
         return client.query("SELECT 1").execute()
                 .map(mysqlRowSet -> {
                     assertEquals(1, mysqlRowSet.size());
                     assertEquals(1, mysqlRowSet.iterator().next().getInteger(0));
                     return "OK";
-                });
+                })
+                .subscribeAsCompletionStage();
     }
+
 }

--- a/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/DevModeResource.java
+++ b/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/DevModeResource.java
@@ -1,31 +1,41 @@
 package io.quarkus.reactive.mysql.client;
 
 import java.net.ConnectException;
+import java.sql.SQLException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
-import io.quarkus.vertx.web.Route;
-import io.vertx.ext.web.RoutingContext;
 import io.vertx.sqlclient.Pool;
 
+@Path("/dev")
 public class DevModeResource {
 
     @Inject
     Pool client;
 
-    @Route(path = "/dev/error", methods = Route.HttpMethod.GET)
-    void getErrorMessage(RoutingContext rc) {
+    @GET
+    @Path("/error")
+    @Produces(MediaType.TEXT_PLAIN)
+    public CompletionStage<Response> getErrorMessage() throws SQLException {
+        CompletableFuture<Response> future = new CompletableFuture<>();
         client.query("SELECT 1").execute().onComplete(ar -> {
             Class<?> expectedExceptionClass = ConnectException.class;
             if (ar.succeeded()) {
-                rc.response().setStatusCode(500).end("Expected SQL query to fail");
+                future.complete(Response.serverError().entity("Expected SQL query to fail").build());
             } else if (!expectedExceptionClass.isAssignableFrom(ar.cause().getClass())) {
-                ar.cause().printStackTrace();
-                rc.response().setStatusCode(500)
-                        .end("Expected " + expectedExceptionClass + ", got " + ar.cause().getClass());
+                future.complete(Response.serverError()
+                        .entity("Expected " + expectedExceptionClass + ", got " + ar.cause().getClass()).build());
             } else {
-                rc.response().setStatusCode(200).end(ar.cause().getMessage());
+                future.complete(Response.ok(ar.cause().getMessage()).build());
             }
         });
+        return future;
     }
 }

--- a/extensions/reactive-oracle-client/deployment/pom.xml
+++ b/extensions/reactive-oracle-client/deployment/pom.xml
@@ -64,7 +64,7 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-reactive-routes-deployment</artifactId>
+            <artifactId>quarkus-rest-deployment</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/ChangingCredentialsTestResource.java
+++ b/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/ChangingCredentialsTestResource.java
@@ -4,12 +4,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 import io.quarkus.runtime.StartupEvent;
-import io.quarkus.vertx.web.Route;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.sqlclient.Pool;
 
+@Path("/test")
 public class ChangingCredentialsTestResource {
 
     @Inject
@@ -23,12 +28,14 @@ public class ChangingCredentialsTestResource {
         client.query("GRANT CREATE SESSION TO user2").executeAndAwait();
     }
 
-    @Route(path = "/test", methods = Route.HttpMethod.GET)
-    Uni<String> connect() {
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public Uni<Response> connect() {
         return client.query("SELECT USER FROM DUAL").execute()
                 .map(rowSet -> {
                     assertEquals(1, rowSet.size());
-                    return rowSet.iterator().next().getString(0);
+                    return Response.ok(rowSet.iterator().next().getString(0)).build();
                 }).eventually(credentialsProvider::changeProperties);
     }
+
 }

--- a/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/CredentialsTestResource.java
+++ b/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/CredentialsTestResource.java
@@ -2,24 +2,33 @@ package io.quarkus.reactive.oracle.client;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import jakarta.inject.Inject;
+import java.util.concurrent.CompletionStage;
 
-import io.quarkus.vertx.web.Route;
-import io.smallrye.mutiny.Uni;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
 import io.vertx.mutiny.sqlclient.Pool;
 
+@Path("/test")
 public class CredentialsTestResource {
 
     @Inject
     Pool client;
 
-    @Route(path = "/test", methods = Route.HttpMethod.GET)
-    Uni<String> connect() {
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public CompletionStage<String> connect() {
+
         return client.query("SELECT 1 FROM DUAL").execute()
                 .map(oracleRowSet -> {
                     assertEquals(1, oracleRowSet.size());
                     assertEquals(1, oracleRowSet.iterator().next().getInteger(0));
                     return "OK";
-                });
+                })
+                .subscribeAsCompletionStage();
     }
+
 }

--- a/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/DevModeResource.java
+++ b/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/DevModeResource.java
@@ -1,40 +1,56 @@
 package io.quarkus.reactive.oracle.client;
 
-import jakarta.inject.Inject;
+import java.sql.SQLException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
-import io.quarkus.vertx.web.Route;
-import io.vertx.ext.web.RoutingContext;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
 import io.vertx.oracleclient.OracleException;
 import io.vertx.sqlclient.Pool;
 
+@Path("/dev")
 public class DevModeResource {
 
     @Inject
     Pool client;
 
-    @Route(path = "/dev/error", methods = Route.HttpMethod.GET)
-    void checkConnectionFailure(RoutingContext rc) {
+    @GET
+    @Path("/error")
+    @Produces(MediaType.TEXT_PLAIN)
+    public CompletionStage<Response> checkConnectionFailure() throws SQLException {
+        CompletableFuture<Response> future = new CompletableFuture<>();
         client.query("SELECT 1 FROM DUAL").execute().onComplete(ar -> {
             Class<?> expectedExceptionClass = OracleException.class;
             if (ar.succeeded()) {
-                rc.response().setStatusCode(500).end("Expected SQL query to fail");
+                future.complete(Response.serverError().entity("Expected SQL query to fail").build());
             } else if (!expectedExceptionClass.isAssignableFrom(ar.cause().getClass())) {
-                rc.response().setStatusCode(500)
-                        .end("Expected " + expectedExceptionClass + ", got " + ar.cause().getClass());
+                future.complete(Response.serverError()
+                        .entity("Expected " + expectedExceptionClass + ", got " + ar.cause().getClass()).build());
             } else {
-                rc.response().setStatusCode(200).end();
+                future.complete(Response.ok().build());
             }
         });
+        return future;
     }
 
-    @Route(path = "/dev/connected", methods = Route.HttpMethod.GET)
-    void checkConnectionSuccess(RoutingContext rc) {
+    @GET
+    @Path("/connected")
+    @Produces(MediaType.TEXT_PLAIN)
+    public CompletionStage<Response> checkConnectionSuccess() throws SQLException {
+        CompletableFuture<Response> future = new CompletableFuture<>();
         client.query("SELECT 1 FROM DUAL").execute().onComplete(ar -> {
             if (ar.succeeded()) {
-                rc.response().setStatusCode(200).end();
+                future.complete(Response.ok().build());
             } else {
-                rc.response().setStatusCode(500).end(ar.cause().getMessage());
+                future.complete(Response.serverError().entity(ar.cause().getMessage()).build());
             }
         });
+        return future;
     }
 }

--- a/extensions/reactive-pg-client/deployment/pom.xml
+++ b/extensions/reactive-pg-client/deployment/pom.xml
@@ -42,7 +42,7 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-reactive-routes-deployment</artifactId>
+            <artifactId>quarkus-rest-deployment</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/ChangingCredentialsTestResource.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/ChangingCredentialsTestResource.java
@@ -4,12 +4,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 import io.quarkus.runtime.StartupEvent;
-import io.quarkus.vertx.web.Route;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.sqlclient.Pool;
 
+@Path("/test")
 public class ChangingCredentialsTestResource {
 
     @Inject
@@ -19,16 +24,17 @@ public class ChangingCredentialsTestResource {
     ChangingCredentialsProvider credentialsProvider;
 
     void addUser(@Observes StartupEvent ignored) {
-        client.query("DROP ROLE IF EXISTS user2").executeAndAwait();
         client.query("CREATE USER user2 WITH PASSWORD 'user2' SUPERUSER").executeAndAwait();
     }
 
-    @Route(path = "/test", methods = Route.HttpMethod.GET)
-    Uni<String> connect() {
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public Uni<Response> connect() {
         return client.query("SELECT CURRENT_USER").execute()
                 .map(pgRowSet -> {
                     assertEquals(1, pgRowSet.size());
-                    return pgRowSet.iterator().next().getString(0);
+                    return Response.ok(pgRowSet.iterator().next().getString(0)).build();
                 }).eventually(credentialsProvider::changeProperties);
     }
+
 }

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/ConfigUrlMissingDefaultDatasourceDynamicInjectionTest.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/ConfigUrlMissingDefaultDatasourceDynamicInjectionTest.java
@@ -28,12 +28,6 @@ public class ConfigUrlMissingDefaultDatasourceDynamicInjectionTest {
     @Inject
     InjectableInstance<io.vertx.mutiny.sqlclient.Pool> mutinyPool;
 
-    @Inject
-    InjectableInstance<Pool> vendorPool;
-
-    @Inject
-    InjectableInstance<io.vertx.mutiny.sqlclient.Pool> mutinyVendorPool;
-
     @Test
     public void pool() {
         doTest(pool, pool1 -> pool1.getConnection().toCompletionStage().toCompletableFuture().join());
@@ -42,16 +36,6 @@ public class ConfigUrlMissingDefaultDatasourceDynamicInjectionTest {
     @Test
     public void mutinyPool() {
         doTest(mutinyPool, pool1 -> pool1.getConnection().subscribe().asCompletionStage().join());
-    }
-
-    @Test
-    public void vendorPool() {
-        doTest(vendorPool, PGPool -> PGPool.getConnection().toCompletionStage().toCompletableFuture().join());
-    }
-
-    @Test
-    public void mutinyVendorPool() {
-        doTest(mutinyVendorPool, PGPool -> PGPool.getConnection().subscribe().asCompletionStage().join());
     }
 
     private <T> void doTest(InjectableInstance<T> instance, Consumer<T> action) {

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/CredentialsTestResource.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/CredentialsTestResource.java
@@ -2,24 +2,33 @@ package io.quarkus.reactive.pg.client;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import jakarta.inject.Inject;
+import java.util.concurrent.CompletionStage;
 
-import io.quarkus.vertx.web.Route;
-import io.smallrye.mutiny.Uni;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
 import io.vertx.mutiny.sqlclient.Pool;
 
+@Path("/test")
 public class CredentialsTestResource {
 
     @Inject
     Pool client;
 
-    @Route(path = "/test", methods = Route.HttpMethod.GET)
-    Uni<String> connect() {
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public CompletionStage<String> connect() {
+
         return client.query("SELECT 1").execute()
                 .map(pgRowSet -> {
                     assertEquals(1, pgRowSet.size());
                     assertEquals(1, pgRowSet.iterator().next().getInteger(0));
                     return "OK";
-                });
+                })
+                .subscribeAsCompletionStage();
     }
+
 }

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/DevModeResource.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/DevModeResource.java
@@ -1,31 +1,40 @@
 package io.quarkus.reactive.pg.client;
 
 import java.net.ConnectException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
-import io.quarkus.vertx.web.Route;
-import io.vertx.ext.web.RoutingContext;
 import io.vertx.sqlclient.Pool;
 
+@Path("/dev")
 public class DevModeResource {
 
     @Inject
     Pool client;
 
-    @Route(path = "/dev/error", methods = Route.HttpMethod.GET)
-    void getErrorMessage(RoutingContext rc) {
+    @GET
+    @Path("/error")
+    @Produces(MediaType.TEXT_PLAIN)
+    public CompletionStage<Response> getErrorMessage() {
+        CompletableFuture<Response> future = new CompletableFuture<>();
         client.query("SELECT 1").execute().onComplete(ar -> {
             Class<?> expectedExceptionClass = ConnectException.class;
             if (ar.succeeded()) {
-                rc.response().setStatusCode(500).end("Expected SQL query to fail");
+                future.complete(Response.serverError().entity("Expected SQL query to fail").build());
             } else if (!expectedExceptionClass.isAssignableFrom(ar.cause().getClass())) {
-                ar.cause().printStackTrace();
-                rc.response().setStatusCode(500)
-                        .end("Expected " + expectedExceptionClass + ", got " + ar.cause().getClass());
+                future.complete(Response.serverError()
+                        .entity("Expected " + expectedExceptionClass + ", got " + ar.cause().getClass()).build());
             } else {
-                rc.response().setStatusCode(200).end(ar.cause().getMessage());
+                future.complete(Response.ok(ar.cause().getMessage()).build());
             }
         });
+        return future;
     }
 }

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/LocalhostPgPoolCreator.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/LocalhostPgPoolCreator.java
@@ -2,10 +2,11 @@ package io.quarkus.reactive.pg.client;
 
 import jakarta.inject.Singleton;
 
+import io.quarkus.reactive.datasource.PoolCreator;
 import io.vertx.sqlclient.Pool;
 
 @Singleton
-public class LocalhostPgPoolCreator implements PgPoolCreator {
+public class LocalhostPgPoolCreator implements PoolCreator {
 
     @Override
     public Pool create(Input input) {

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/MultipleDataSourcesAndPgPoolCreatorsTest.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/MultipleDataSourcesAndPgPoolCreatorsTest.java
@@ -12,6 +12,7 @@ import jakarta.inject.Singleton;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkus.reactive.datasource.PoolCreator;
 import io.quarkus.reactive.datasource.ReactiveDataSource;
 import io.quarkus.test.QuarkusExtensionTest;
 import io.vertx.pgclient.PgConnectOptions;
@@ -82,9 +83,8 @@ public class MultipleDataSourcesAndPgPoolCreatorsTest {
     }
 
     @Singleton
-    public static class DefaultPgPoolCreator implements PgPoolCreator {
+    public static class DefaultPgPoolCreator implements PoolCreator {
 
-        // TODO Improve input to be able to direction retrieve the right options?
         @Override
         public Pool create(Input input) {
             assertEquals(10, ((PgConnectOptions) input.connectOptionsList().get(0)).getPipeliningLimit()); // validate that the bean has been called for the proper datasource
@@ -95,7 +95,7 @@ public class MultipleDataSourcesAndPgPoolCreatorsTest {
 
     @Singleton
     @ReactiveDataSource("hibernate")
-    public static class HibernatePgPoolCreator implements PgPoolCreator {
+    public static class HibernatePgPoolCreator implements PoolCreator {
 
         @Override
         public Pool create(Input input) {
@@ -103,6 +103,7 @@ public class MultipleDataSourcesAndPgPoolCreatorsTest {
             return Pool.pool(input.vertx(),
                     ((PgConnectOptions) input.connectOptionsList().get(0)).setHost("localhost").setPort(5431),
                     input.poolOptions());
+
         }
     }
 }

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/MultiplePgPoolCreatorsForSameDatasourceTest.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/MultiplePgPoolCreatorsForSameDatasourceTest.java
@@ -8,6 +8,7 @@ import jakarta.inject.Singleton;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkus.reactive.datasource.PoolCreator;
 import io.quarkus.test.QuarkusExtensionTest;
 import io.vertx.pgclient.PgBuilder;
 import io.vertx.sqlclient.Pool;
@@ -30,11 +31,11 @@ public class MultiplePgPoolCreatorsForSameDatasourceTest {
     }
 
     @Singleton
-    public static class AnotherPgPoolCreator implements PgPoolCreator {
+    public static class AnotherPgPoolCreator implements PoolCreator {
 
         @Override
         public Pool create(Input input) {
-            return PgBuilder.pool().using(input.vertx()).connectingTo(input.connectOptionsList()).with(input.poolOptions())
+            return PgBuilder.pool().with(input.poolOptions()).using(input.vertx()).connectingTo(input.connectOptionsList())
                     .build();
         }
     }

--- a/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/config/TlsConfigUtils.java
+++ b/extensions/tls-registry/runtime/src/main/java/io/quarkus/tls/runtime/config/TlsConfigUtils.java
@@ -161,7 +161,7 @@ public class TlsConfigUtils {
      */
     public static void configure(WebSocketClientOptions options, TlsConfiguration configuration) {
         ClientSSLOptions sslOptions = applyClientSSLOptions(options, configuration);
-        if (sslOptions != null  && sslOptions.getHostnameVerificationAlgorithm() != null
+        if (sslOptions != null && sslOptions.getHostnameVerificationAlgorithm() != null
                 && sslOptions.getHostnameVerificationAlgorithm().equals("NONE")) {
             // Only disable hostname verification if the algorithm is explicitly set to NONE
             log.warnf("Hostname verification DISABLED via hostname-verification-algorithm=NONE");

--- a/vertx.justfile
+++ b/vertx.justfile
@@ -13,6 +13,12 @@ modules := """
     extensions/vertx-http
     extensions/tls-registry
     extensions/mailer
+    extensions/reactive-datasource
+    extensions/reactive-db2-client
+    extensions/reactive-mssql-client
+    extensions/reactive-mysql-client
+    extensions/reactive-oracle-client
+    extensions/reactive-pg-client
     """
 
 # Build the comma-separated list of directories containing a pom.xml


### PR DESCRIPTION
I switched them to Reactive Routes to avoid being blocked. This reverts this migration. 

This reverts commits:
    - 25553dafdb228f85208859998a134b318eee94d3
    - bb3a49953b57dadbddabd316ea3c7f848bc41c8d
    - 89c4b341ff0aa9c7cabc2c09342dbe3fd761a447
    - 25553dafdb228f85208859998a134b318eee94d3