### PR TITLE
Obey PropertyNamingStrategy defined through class-level @JsonNaming annotation in generated reflection-free Jackson (de)serializers

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
@@ -30,6 +30,8 @@ import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -273,22 +275,37 @@ public abstract class JacksonCodeGenerator {
         return ctorOpt;
     }
 
-    protected FieldSpecs fieldSpecsFromField(ClassInfo classInfo, MethodInfo constructor, FieldInfo fieldInfo) {
+    protected PropertyNamingStrategy getNamingStrategy(ClassInfo classInfo) {
+        AnnotationInstance jsonNaming = classInfo.annotation(JsonNaming.class);
+        if (jsonNaming == null || jsonNaming.value() == null) {
+            return null;
+        }
+        String strategyClassName = jsonNaming.value().asClass().name().toString();
+        try {
+            return (PropertyNamingStrategy) Class.forName(strategyClassName)
+                    .getDeclaredConstructor().newInstance();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    protected FieldSpecs fieldSpecsFromField(ClassInfo classInfo, MethodInfo constructor, FieldInfo fieldInfo,
+            PropertyNamingStrategy namingStrategy) {
         if (Modifier.isStatic(fieldInfo.flags())) {
             return null;
         }
         MethodInfo getterMethodInfo = getterMethodInfo(classInfo, fieldInfo);
         if (getterMethodInfo != null) {
-            return new FieldSpecs(constructor, fieldInfo, getterMethodInfo);
+            return new FieldSpecs(constructor, fieldInfo, getterMethodInfo, namingStrategy);
         }
         if (Modifier.isPublic(fieldInfo.flags())) {
-            return new FieldSpecs(fieldInfo);
+            return new FieldSpecs(fieldInfo, namingStrategy);
         }
         return null;
     }
 
-    protected FieldSpecs fieldSpecsFromFieldParam(MethodParameterInfo paramInfo) {
-        return new FieldSpecs(paramInfo);
+    protected FieldSpecs fieldSpecsFromFieldParam(MethodParameterInfo paramInfo, PropertyNamingStrategy namingStrategy) {
+        return new FieldSpecs(paramInfo, namingStrategy);
     }
 
     protected static class FieldSpecs {
@@ -304,14 +321,18 @@ public abstract class JacksonCodeGenerator {
         FieldInfo fieldInfo;
 
         FieldSpecs(FieldInfo fieldInfo) {
-            this(null, fieldInfo, null);
+            this(null, fieldInfo, null, null);
+        }
+
+        FieldSpecs(FieldInfo fieldInfo, PropertyNamingStrategy namingStrategy) {
+            this(null, fieldInfo, null, namingStrategy);
         }
 
         FieldSpecs(MethodInfo methodInfo) {
-            this(null, null, methodInfo);
+            this(null, null, methodInfo, null);
         }
 
-        FieldSpecs(MethodInfo constructor, FieldInfo fieldInfo, MethodInfo methodInfo) {
+        FieldSpecs(MethodInfo constructor, FieldInfo fieldInfo, MethodInfo methodInfo, PropertyNamingStrategy namingStrategy) {
             if (fieldInfo != null) {
                 this.fieldInfo = fieldInfo;
                 readAnnotations(fieldInfo);
@@ -322,15 +343,15 @@ public abstract class JacksonCodeGenerator {
             }
             this.fieldType = fieldType();
             this.fieldName = fieldName();
-            this.jsonName = jsonName(constructor);
+            this.jsonName = jsonName(constructor, namingStrategy);
             this.aliases = jsonAliases();
         }
 
-        FieldSpecs(MethodParameterInfo paramInfo) {
+        FieldSpecs(MethodParameterInfo paramInfo, PropertyNamingStrategy namingStrategy) {
             readAnnotations(paramInfo);
             this.fieldType = paramInfo.type();
             this.fieldName = paramInfo.name();
-            this.jsonName = jsonName(null);
+            this.jsonName = jsonName(null, namingStrategy);
             this.aliases = jsonAliases();
         }
 
@@ -363,7 +384,7 @@ public abstract class JacksonCodeGenerator {
             return new String[0];
         }
 
-        private String jsonName(MethodInfo constructor) {
+        private String jsonName(MethodInfo constructor, PropertyNamingStrategy namingStrategy) {
             AnnotationInstance jsonProperty = annotations.get(JsonProperty.class.getName());
             if (jsonProperty == null && constructor != null) {
                 jsonProperty = constructor.parameters().stream()
@@ -377,6 +398,9 @@ public abstract class JacksonCodeGenerator {
                 if (value != null && !value.asString().isEmpty()) {
                     return value.asString();
                 }
+            }
+            if (namingStrategy != null) {
+                return namingStrategy.nameForField(null, null, fieldName);
             }
             return fieldName;
         }

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonDeserializerFactory.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonDeserializerFactory.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.type.TypeFactory;
@@ -228,7 +229,8 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
 
         MethodInfo ctor = ctorOpt.get();
         DeserializationData deserData = new DeserializationData(classInfo, ctor, classCreator, deserialize,
-                getJsonNode(deserialize), parseTypeParameters(classInfo, classCreator), new HashSet<>());
+                getJsonNode(deserialize), parseTypeParameters(classInfo, classCreator), new HashSet<>(),
+                getNamingStrategy(classInfo));
 
         ResultHandle deserializedHandle = ctor.parametersCount() == 0
                 ? deserData.methodCreator.newInstance(MethodDescriptor.ofConstructor(deserData.classInfo.name().toString()))
@@ -257,7 +259,7 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
         ResultHandle[] params = new ResultHandle[deserData.constructor.parameters().size()];
         int i = 0;
         for (MethodParameterInfo paramInfo : deserData.constructor.parameters()) {
-            FieldSpecs fieldSpecs = fieldSpecsFromFieldParam(paramInfo);
+            FieldSpecs fieldSpecs = fieldSpecsFromFieldParam(paramInfo, deserData.namingStrategy);
             if (fieldSpecs.hasUnknownAnnotation()) {
                 return null;
             }
@@ -400,14 +402,15 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
 
         for (FieldInfo fieldInfo : classFields(deserData.classInfo)) {
             if (!deserializeFieldSpecs(deserData, deserializationContext, objHandle, fieldValue,
-                    deserializedFields, strSwitch, fieldSpecsFromField(deserData.classInfo, deserData.constructor, fieldInfo),
+                    deserializedFields, strSwitch,
+                    fieldSpecsFromField(deserData.classInfo, deserData.constructor, fieldInfo, deserData.namingStrategy),
                     valid))
                 return false;
         }
 
         for (MethodInfo methodInfo : classMethods(deserData.classInfo)) {
             if (!deserializeFieldSpecs(deserData, deserializationContext, objHandle, fieldValue,
-                    deserializedFields, strSwitch, fieldSpecsFromMethod(methodInfo), valid))
+                    deserializedFields, strSwitch, fieldSpecsFromMethod(methodInfo, deserData.namingStrategy), valid))
                 return false;
         }
 
@@ -449,8 +452,8 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
         return true;
     }
 
-    private FieldSpecs fieldSpecsFromMethod(MethodInfo methodInfo) {
-        return isSetterMethod(methodInfo) ? new FieldSpecs(methodInfo) : null;
+    private FieldSpecs fieldSpecsFromMethod(MethodInfo methodInfo, PropertyNamingStrategy namingStrategy) {
+        return isSetterMethod(methodInfo) ? new FieldSpecs(null, null, methodInfo, namingStrategy) : null;
     }
 
     private boolean isSetterMethod(MethodInfo methodInfo) {
@@ -603,6 +606,7 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
 
     private record DeserializationData(ClassInfo classInfo, MethodInfo constructor, ClassCreator classCreator,
             MethodCreator methodCreator,
-            ResultHandle jsonNode, Map<String, Integer> typeParametersIndex, Set<String> constructorFields) {
+            ResultHandle jsonNode, Map<String, Integer> typeParametersIndex, Set<String> constructorFields,
+            PropertyNamingStrategy namingStrategy) {
     }
 }

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.SerializableString;
 import com.fasterxml.jackson.core.io.SerializedString;
 import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
@@ -262,16 +263,17 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
 
     private boolean serializeObjectData(ClassInfo classInfo, ClassCreator classCreator, MethodCreator serialize,
             SerializationContext ctx, Set<String> serializedFields) {
-        return serializeFields(classInfo, classCreator, serialize, ctx, serializedFields) &&
-                serializeMethods(classInfo, classCreator, serialize, ctx, serializedFields);
+        PropertyNamingStrategy namingStrategy = getNamingStrategy(classInfo);
+        return serializeFields(classInfo, classCreator, serialize, ctx, serializedFields, namingStrategy) &&
+                serializeMethods(classInfo, classCreator, serialize, ctx, serializedFields, namingStrategy);
     }
 
     private boolean serializeFields(ClassInfo classInfo, ClassCreator classCreator, MethodCreator serialize,
-            SerializationContext ctx, Set<String> serializedFields) {
+            SerializationContext ctx, Set<String> serializedFields, PropertyNamingStrategy namingStrategy) {
         MethodInfo constructor = findConstructor(classInfo).orElse(null);
 
         for (FieldInfo fieldInfo : classFields(classInfo)) {
-            FieldSpecs fieldSpecs = fieldSpecsFromField(classInfo, constructor, fieldInfo);
+            FieldSpecs fieldSpecs = fieldSpecsFromField(classInfo, constructor, fieldInfo, namingStrategy);
             if (fieldSpecs != null && serializedFields.add(fieldSpecs.jsonName)) {
                 if (fieldSpecs.isIgnoredField()) {
                     continue;
@@ -286,9 +288,9 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
     }
 
     private boolean serializeMethods(ClassInfo classInfo, ClassCreator classCreator, MethodCreator serialize,
-            SerializationContext ctx, Set<String> serializedFields) {
+            SerializationContext ctx, Set<String> serializedFields, PropertyNamingStrategy namingStrategy) {
         for (MethodInfo methodInfo : classMethods(classInfo)) {
-            FieldSpecs fieldSpecs = fieldSpecsFromMethod(methodInfo);
+            FieldSpecs fieldSpecs = fieldSpecsFromMethod(methodInfo, namingStrategy);
             if (fieldSpecs != null && serializedFields.add(fieldSpecs.jsonName)) {
                 if (fieldSpecs.isIgnoredField()) {
                     continue;
@@ -302,8 +304,10 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
         return true;
     }
 
-    private FieldSpecs fieldSpecsFromMethod(MethodInfo methodInfo) {
-        return !Modifier.isStatic(methodInfo.flags()) && isGetterMethod(methodInfo) ? new FieldSpecs(methodInfo) : null;
+    private FieldSpecs fieldSpecsFromMethod(MethodInfo methodInfo, PropertyNamingStrategy namingStrategy) {
+        return !Modifier.isStatic(methodInfo.flags()) && isGetterMethod(methodInfo)
+                ? new FieldSpecs(null, null, methodInfo, namingStrategy)
+                : null;
     }
 
     private boolean isJsonValueMethod(MethodInfo methodInfo) {

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/AbstractSimpleJsonTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/AbstractSimpleJsonTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.resteasy.reactive.jackson.deployment.test;
 
+import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.is;
@@ -1081,5 +1082,29 @@ public abstract class AbstractSimpleJsonTest {
                 .post("/simple/greeting")
                 .then()
                 .statusCode(400);
+    }
+
+    @Test
+    void naming_annotationUpperSnake_shouldDeserialize() {
+        given()
+                .contentType("application/json")
+                .body("""
+                        {"FIRST_NAME": "Bob"}
+                        """)
+                .when()
+                .post("/simple/annotation-naming")
+                .then()
+                .statusCode(200)
+                .body("values", CoreMatchers.is("Bob"));
+    }
+
+    @Test
+    void naming_annotationUpperSnake_shouldSerialize() {
+        given()
+                .when()
+                .get("/simple/annotation-naming-ser")
+                .then()
+                .statusCode(200)
+                .body("FIRST_NAME", CoreMatchers.is("Bob"));
     }
 }

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/AnnotationNamingRequest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/AnnotationNamingRequest.java
@@ -1,0 +1,10 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+/// Uses `@JsonNaming` with `UPPER_SNAKE_CASE` (deliberately different from the global
+/// `SNAKE_CASE`) to test that class-level naming annotations are respected independently.
+@JsonNaming(PropertyNamingStrategies.UpperSnakeCaseStrategy.class)
+public record AnnotationNamingRequest(String firstName) {
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
@@ -642,4 +642,19 @@ public class SimpleJsonResource extends SuperClass<Person> {
     public JsonAliasRecord echoJsonAliasRecord(JsonAliasRecord record) {
         return record;
     }
+
+    @POST
+    @Path("/annotation-naming")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public String annotationNaming(AnnotationNamingRequest request) {
+        return "{\"values\":\"" + request.firstName() + "\"}";
+    }
+
+    @GET
+    @Path("/annotation-naming-ser")
+    @Produces(MediaType.APPLICATION_JSON)
+    public AnnotationNamingRequest annotationNamingSer() {
+        return new AnnotationNamingRequest("Bob");
+    }
 }

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
@@ -30,7 +30,7 @@ public class SimpleJsonTest extends AbstractSimpleJsonTest {
                                     PrimitiveTypesBean.class, PrimitiveTypesRecord.class, TokenResponse.class,
                                     ItemJsonValuePublicMethod.class, ItemJsonValuePublicField.class,
                                     ItemJsonValuePrivateMethod.class, ItemJsonValuePrivateField.class, StringWrapper.class,
-                                    JsonAliasRecord.class)
+                                    JsonAliasRecord.class, AnnotationNamingRequest.class)
                             .addAsResource(new StringAsset("admin-expression=admin\n" +
                                     "user-expression=user\n" +
                                     "birth-date-roles=alice,bob\n" +

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonWithReflectionFreeSerializersTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonWithReflectionFreeSerializersTest.java
@@ -30,7 +30,7 @@ public class SimpleJsonWithReflectionFreeSerializersTest extends AbstractSimpleJ
                                     PrimitiveTypesBean.class, PrimitiveTypesRecord.class, TokenResponse.class,
                                     ItemJsonValuePublicMethod.class, ItemJsonValuePublicField.class,
                                     ItemJsonValuePrivateMethod.class, ItemJsonValuePrivateField.class, StringWrapper.class,
-                                    JsonAliasRecord.class)
+                                    JsonAliasRecord.class, AnnotationNamingRequest.class)
                             .addAsResource(new StringAsset("admin-expression=admin\n" +
                                     "user-expression=user\n" +
                                     "birth-date-roles=alice,bob\n" +


### PR DESCRIPTION
This pull request fixes part of point 1. of the issues reported in #53588 

In particular it follows the `PropertyNamingStrategy` when defined as class-level `@JsonNaming` annotation. 

This fix does NOT address `ObjectMapper`-level `PropertyNamingStrategy` that requires a runtime approach (consulting SerializerProvider.getConfig().getPropertyNamingStrategy() inside the generated serialize/deserialize method), which is a separate and a bit complex change. I will try to address this issue in a separated pull request once this one will be merged.

/cc @geoand @gsmet @lloydmeta