### PR TITLE
Disable JDBC connection tracing by default

### DIFF
--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -672,6 +672,14 @@ Even with all the tracing infrastructure in place, the datasource tracing is not
 quarkus.datasource.jdbc.telemetry=true
 ----
 
+By default, only SQL statement executions are traced.
+Connection acquisition from the datasource (`getConnection()` calls) is not traced.
+To also trace connection acquisition, enable it explicitly:
+[source,properties]
+----
+quarkus.datasource.jdbc.telemetry.trace-connection=true
+----
+
 === Narayana transaction manager integration
 
 Integration is automatic if the Narayana JTA extension is also available.

--- a/docs/src/main/asciidoc/opentelemetry-tracing.adoc
+++ b/docs/src/main/asciidoc/opentelemetry-tracing.adoc
@@ -208,6 +208,8 @@ quarkus.datasource.db-kind=postgresql
 quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/mydatabase
 ----
 
+For more details check the xref:datasource.adoc#datasource-tracing[Datasource tracing] documentation.
+
 == Additional configuration
 Some use cases will require custom configuration of OpenTelemetry.
 These sections will outline what is necessary to properly configure it.

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AgroalOpenTelemetryWrapper.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AgroalOpenTelemetryWrapper.java
@@ -1,7 +1,5 @@
 package io.quarkus.agroal.runtime;
 
-import java.util.function.Function;
-
 import jakarta.inject.Inject;
 
 import io.agroal.api.AgroalDataSource;
@@ -9,15 +7,17 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.jdbc.datasource.JdbcTelemetry;
 import io.opentelemetry.instrumentation.jdbc.datasource.OpenTelemetryDataSource;
 
-public class AgroalOpenTelemetryWrapper implements Function<AgroalDataSource, AgroalDataSource> {
+public class AgroalOpenTelemetryWrapper {
 
     @Inject
     OpenTelemetry openTelemetry;
 
-    @Override
-    public AgroalDataSource apply(AgroalDataSource originalDataSource) {
+    public AgroalDataSource wrap(AgroalDataSource originalDataSource,
+            DataSourceJdbcRuntimeConfig dataSourceJdbcRuntimeConfig) {
         OpenTelemetryDataSource otelDataSource = (OpenTelemetryDataSource) JdbcTelemetry
-                .create(openTelemetry)
+                .builder(openTelemetry)
+                .setDataSourceInstrumenterEnabled(dataSourceJdbcRuntimeConfig.telemetryTraceConnection())
+                .build()
                 .wrap(originalDataSource);
         return new OpenTelemetryAgroalDataSource(originalDataSource, otelDataSource);
     }

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcRuntimeConfig.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcRuntimeConfig.java
@@ -180,4 +180,12 @@ public interface DataSourceJdbcRuntimeConfig {
     @ConfigDocDefault("false if quarkus.datasource.jdbc.telemetry=false and true if quarkus.datasource.jdbc.telemetry=true")
     Optional<Boolean> telemetry();
 
+    /**
+     * Enable tracing of the connection acquisition from the datasource.
+     * When enabled, a span is created for each {@code getConnection()} call.
+     */
+    @WithName("telemetry.trace-connection")
+    @WithDefault("false")
+    boolean telemetryTraceConnection();
+
 }

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
@@ -232,7 +232,7 @@ public class DataSources {
                 otelEnabled) {
             // activate OpenTelemetry JDBC instrumentation by wrapping AgroalDatasource
             // use an optional CDI bean as we can't reference optional OpenTelemetry classes here
-            dataSource = agroalOpenTelemetryWrapper.get().apply(dataSource);
+            dataSource = agroalOpenTelemetryWrapper.get().wrap(dataSource, dataSourceJdbcRuntimeConfig);
         }
 
         return dataSource;

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/Db2OpenTelemetryJdbcInstrumentationTest.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/Db2OpenTelemetryJdbcInstrumentationTest.java
@@ -16,4 +16,9 @@ public class Db2OpenTelemetryJdbcInstrumentationTest extends OpenTelemetryJdbcIn
         testQueryTraced("db2", "Db2Hit");
     }
 
+    @Test
+    void testDb2ConnectionNotTraced() {
+        testConnectionNotTraced("db2");
+    }
+
 }

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/H2OpenTelemetryTraceConnectionJdbcInstrumentationTest.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/H2OpenTelemetryTraceConnectionJdbcInstrumentationTest.java
@@ -1,0 +1,18 @@
+package io.quarkus.it.opentelemetry;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@QuarkusTestResource(value = H2DatabaseTestResource.class, restrictToAnnotatedClass = true)
+@TestProfile(H2TraceConnectionProfile.class)
+public class H2OpenTelemetryTraceConnectionJdbcInstrumentationTest extends OpenTelemetryJdbcInstrumentationTest {
+
+    @Test
+    void testH2ConnectionTraced() {
+        testConnectionTraced("h2");
+    }
+}

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/H2TraceConnectionProfile.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/H2TraceConnectionProfile.java
@@ -1,0 +1,13 @@
+package io.quarkus.it.opentelemetry;
+
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class H2TraceConnectionProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of("quarkus.datasource.h2.jdbc.telemetry.trace-connection", "true");
+    }
+}

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/MariaDbOpenTelemetryJdbcInstrumentationTest.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/MariaDbOpenTelemetryJdbcInstrumentationTest.java
@@ -14,4 +14,9 @@ public class MariaDbOpenTelemetryJdbcInstrumentationTest extends OpenTelemetryJd
         testQueryTraced("mariadb", "MariaDbHit");
     }
 
+    @Test
+    void testMariaDbConnectionNotTraced() {
+        testConnectionNotTraced("mariadb");
+    }
+
 }

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/OpenTelemetryJdbcInstrumentationTest.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/OpenTelemetryJdbcInstrumentationTest.java
@@ -80,4 +80,61 @@ public abstract class OpenTelemetryJdbcInstrumentationTest {
             assertTrue(getSpans().isEmpty(), "No spans should be recorded when OpenTelemetry is disabled.");
         });
     }
+
+    protected void testConnectionNotTraced(String dbKind) {
+        given()
+                .queryParam("id", 2)
+                .when().post("/hit/" + dbKind)
+                .then()
+                .statusCode(200)
+                .body("message", Matchers.equalTo("Hit message."));
+
+        Awaitility.await().atMost(Duration.ofSeconds(55)).untilAsserted(() -> {
+            List<Map<String, Object>> spans = getSpans();
+            assertFalse(spans.isEmpty());
+
+            // Verify no connection acquisition span is present (only statement spans with db.operation)
+            for (Map<String, Object> spanData : spans) {
+                if (spanData.get("attributes") instanceof Map) {
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> attributes = (Map<String, Object>) spanData.get("attributes");
+                    if (attributes.containsKey("db.system") && !attributes.containsKey("db.operation")) {
+                        throw new AssertionError(
+                                "Connection acquisition span should not be present when trace-connection is disabled. "
+                                        + "Span attributes: " + attributes);
+                    }
+                }
+            }
+        });
+    }
+
+    protected void testConnectionTraced(String dbKind) {
+        given()
+                .queryParam("id", 1)
+                .when().post("/hit/" + dbKind)
+                .then()
+                .statusCode(200)
+                .body("message", Matchers.equalTo("Hit message."));
+
+        Awaitility.await().atMost(Duration.ofSeconds(55)).untilAsserted(() -> {
+            List<Map<String, Object>> spans = getSpans();
+            assertFalse(spans.isEmpty());
+
+            // Verify at least one connection acquisition span IS present
+            // (has db.system but no db.operation)
+            boolean connectionSpanFound = false;
+            for (Map<String, Object> spanData : spans) {
+                if (spanData.get("attributes") instanceof Map) {
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> attributes = (Map<String, Object>) spanData.get("attributes");
+                    if (attributes.containsKey("db.system") && !attributes.containsKey("db.operation")) {
+                        connectionSpanFound = true;
+                        break;
+                    }
+                }
+            }
+            assertTrue(connectionSpanFound,
+                    "Connection acquisition span should be present when trace-connection is enabled.");
+        });
+    }
 }

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/OracleOpenTelemetryJdbcInstrumentationTest.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/OracleOpenTelemetryJdbcInstrumentationTest.java
@@ -18,6 +18,11 @@ public class OracleOpenTelemetryJdbcInstrumentationTest extends OpenTelemetryJdb
         testQueryTraced("oracle", "OracleHit");
     }
 
+    @Test
+    void testOracleConnectionNotTraced() {
+        testConnectionNotTraced("oracle");
+    }
+
     public static class SomeProfile implements QuarkusTestProfile {
         public SomeProfile() {
         }

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/PostgresOpenTelemetryJdbcInstrumentationTest.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/PostgresOpenTelemetryJdbcInstrumentationTest.java
@@ -14,4 +14,9 @@ public class PostgresOpenTelemetryJdbcInstrumentationTest extends OpenTelemetryJ
         testQueryTraced("postgresql", "PgHit");
     }
 
+    @Test
+    void testPostgreSqlConnectionNotTraced() {
+        testConnectionNotTraced("postgresql");
+    }
+
 }


### PR DESCRIPTION
### Breaking change 

The OTel Agent JDBC instrumentation doesn't track the connection span by default and we should align because we are creating more spans than needed.
A new config was added to emit the connection span, if needed:
```
quarkus.datasource.jdbc.telemetry.trace-connection=true
```
