### PR TITLE
Gradle - Use same pattern everywhere to get effective config

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/AbstractQuarkusExtension.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/AbstractQuarkusExtension.java
@@ -6,7 +6,6 @@ import static java.util.Collections.emptyList;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -22,11 +21,9 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.process.JavaForkOptions;
 
-import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.deployment.pkg.NativeConfig;
 import io.quarkus.deployment.pkg.PackageConfig;
 import io.quarkus.gradle.dsl.Manifest;
-import io.quarkus.maven.dependency.ResolvedDependency;
 
 /**
  * This base class exists to hide internal properties, make those only available in the {@link io.quarkus.gradle.tasks}
@@ -122,34 +119,6 @@ public abstract class AbstractQuarkusExtension {
         return baseConfig().nativeConfig();
     }
 
-    protected EffectiveConfig buildEffectiveConfiguration(ApplicationModel appModel) {
-        ResolvedDependency appArtifact = appModel.getAppArtifact();
-
-        Map<String, Object> properties = new HashMap<>();
-        exportCustomManifestProperties(properties);
-
-        Set<File> resourcesDirs = getSourceSet(project, SourceSet.MAIN_SOURCE_SET_NAME).getResources().getSourceDirectories()
-                .getFiles();
-
-        Map<String, String> defaultProperties = new HashMap<>();
-        String userIgnoredEntries = String.join(",", ignoredEntries.get());
-        if (!userIgnoredEntries.isEmpty()) {
-            defaultProperties.put("quarkus.package.jar.user-configured-ignored-entries", userIgnoredEntries);
-        }
-        defaultProperties.putIfAbsent("quarkus.application.name", appArtifact.getArtifactId());
-        defaultProperties.putIfAbsent("quarkus.application.version", appArtifact.getVersion());
-
-        return EffectiveConfig.builder()
-                .withPlatformProperties(appModel.getPlatformProperties())
-                .withTaskProperties(properties)
-                .withBuildProperties(quarkusBuildProperties.get())
-                .withProjectProperties(project.getProperties())
-                .withDefaultProperties(defaultProperties)
-                .withSourceDirectories(resourcesDirs)
-                .withProfile(quarkusProfile())
-                .build();
-    }
-
     private String quarkusProfile() {
         String profile = System.getProperty(QUARKUS_PROFILE);
         if (profile == null) {
@@ -174,20 +143,6 @@ public abstract class AbstractQuarkusExtension {
         return mainSourceSet.getCompileClasspath().plus(mainSourceSet.getRuntimeClasspath())
                 .plus(mainSourceSet.getAnnotationProcessorPath())
                 .plus(mainSourceSet.getResources());
-    }
-
-    private void exportCustomManifestProperties(Map<String, Object> properties) {
-        for (Map.Entry<String, Object> attribute : baseConfig().manifest().getAttributes().entrySet()) {
-            properties.put(toManifestAttributeKey(attribute.getKey()),
-                    attribute.getValue());
-        }
-
-        for (Map.Entry<String, Attributes> section : baseConfig().manifest().getSections().entrySet()) {
-            for (Map.Entry<String, Object> attribute : section.getValue().entrySet()) {
-                properties
-                        .put(toManifestSectionAttributeKey(section.getKey(), attribute.getKey()), attribute.getValue());
-            }
-        }
     }
 
     protected static String toManifestAttributeKey(String key) {

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/BuildAotEnhancedImage.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/BuildAotEnhancedImage.java
@@ -65,7 +65,7 @@ public abstract class BuildAotEnhancedImage extends QuarkusBuildTask {
         getLogger().debug("Found AOT file '{}'; proceeding to build AOT enhanced container image", aotFilePath);
 
         ApplicationModel appModel = resolveAppModelForBuild();
-        Map<String, String> quarkusProperties = extension().buildEffectiveConfiguration(appModel).getValues();
+        Map<String, String> quarkusProperties = effectiveProvider().buildEffectiveConfiguration(appModel, Map.of()).getValues();
 
         WorkQueue workQueue = workQueue(quarkusProperties, getExtensionView().getBuildForkOptions().get());
 

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/Deploy.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/Deploy.java
@@ -96,12 +96,12 @@ public abstract class Deploy extends QuarkusBuildTask {
     public void checkRequiredExtensions() {
         ApplicationModel appModel = resolveAppModelForBuild();
         Properties sysProps = new Properties();
-        sysProps.putAll(extension().buildEffectiveConfiguration(appModel).getQuarkusValues());
+        sysProps.putAll(effectiveProvider().buildEffectiveConfiguration(appModel, Map.of()).getQuarkusValues());
         try (CuratedApplication curatedApplication = QuarkusBootstrap.builder()
                 .setBaseClassLoader(getClass().getClassLoader())
                 .setExistingModel(appModel)
                 .setTargetDirectory(getProject().getLayout().getBuildDirectory().getAsFile().get().toPath())
-                .setBaseName(extension().finalName())
+                .setBaseName(getExtensionView().getFinalName().get())
                 .setBuildSystemProperties(sysProps)
                 .setAppArtifact(appModel.getAppArtifact())
                 .setLocalProjectDiscovery(false)

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusRun.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusRun.java
@@ -103,12 +103,12 @@ public abstract class QuarkusRun extends QuarkusBuildTask {
     public void runQuarkus() {
         ApplicationModel appModel = resolveAppModelForBuild();
         Properties sysProps = new Properties();
-        sysProps.putAll(extension().buildEffectiveConfiguration(appModel).getQuarkusValues());
+        sysProps.putAll(effectiveProvider().buildEffectiveConfiguration(appModel, Map.of()).getQuarkusValues());
         try (CuratedApplication curatedApplication = QuarkusBootstrap.builder()
                 .setBaseClassLoader(getClass().getClassLoader())
                 .setExistingModel(appModel)
                 .setTargetDirectory(getProject().getLayout().getBuildDirectory().getAsFile().get().toPath())
-                .setBaseName(extension().finalName())
+                .setBaseName(getExtensionView().getFinalName().get())
                 .setBuildSystemProperties(sysProps)
                 .setAppArtifact(appModel.getAppArtifact())
                 .setLocalProjectDiscovery(false)


### PR DESCRIPTION
We used to have two ways to build the effective config and it was inconsistently used in various tasks.

We now only have one and it's used everywhere.

@radcortez this is a follow-up for the failures in https://github.com/quarkusio/quarkus/pull/53581 . And the reason why things were failing as we weren't using the latest fixes to effective config in some of the tasks.

Now let's hope it won't create more problems than it solves :).