### PR TITLE
[3.33] [Manual backport]: Little asciidoc markup fix for one of the OIDC guide's procedure

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
@@ -231,7 +231,7 @@ quarkus.oidc.credentials.jwt.token-path=/var/run/secrets/tokens <2>
 ----
 <1> Use a JWT bearer token to authenticate the OIDC provider client.
 For more information, see the link:https://www.rfc-editor.org/rfc/rfc7523#section-2.2[Using JWTs for Client Authentication] section.
-<2> Path to a JWT bearer token. 
+<2> Path to a JWT bearer token.
 Quarkus loads a new token from the filesystem and reloads it when the token expires.
 
 ==== Additional JWT authentication options
@@ -408,7 +408,7 @@ public class OidcDiscoveryRequestCustomizer implements OidcRequestFilter {
 
 `OidcRequestContextProperties` can be used to access request properties.
 Currently, you can use a `tenand_id` key to access the OIDC tenant ID and a `grant_type` key to access the grant type that the OIDC provider uses to acquire tokens.
-The `grant_type` can only be set to either an `authorization_code` or `refresh_token` grant type when requests are made to the token endpoint. 
+The `grant_type` can only be set to either an `authorization_code` or `refresh_token` grant type when requests are made to the token endpoint.
 It is `null` in all other cases.
 
 `OidcRequestFilter` can customize a request body by preparing an instance of `io.vertx.mutiny.core.buffer.Buffer`
@@ -1112,10 +1112,10 @@ When the user is redirected back to Quarkus to complete the authorization code f
 
 The default state cookie age is 5 minutes, and you can change it with a `quarkus.oidc.authentication.state-cookie-age` Duration property.
 
-Quarkus creates a unique state cookie name every time a new authorization code flow is started to support multi-tab authentication. 
+Quarkus creates a unique state cookie name every time a new authorization code flow is started to support multi-tab authentication.
 Many concurrent authentication requests on behalf of the same user can cause multiple state cookies to be created.
 
-If you do not want to allow your users to use multiple browser tabs to authenticate, disable this by specifying `quarkus.oidc.authentication.allow-multiple-code-flows=false`. 
+If you do not want to allow your users to use multiple browser tabs to authenticate, disable this by specifying `quarkus.oidc.authentication.allow-multiple-code-flows=false`.
 This action also ensures that the same state cookie name is created for every new user authentication.
 
 [[token-state-manager]]
@@ -2235,13 +2235,13 @@ It also sets up two users: `alice` with `admin` and `user` roles, and `bob` with
 
 . Prepare the `application.properties` file.
 +
-If starting from an empty `application.properties` file, `Dev Services for Keycloak` automatically registers the following properties:
+* If starting from an empty `application.properties` file, `Dev Services for Keycloak` automatically registers the following properties:
 +
-* `quarkus.oidc.auth-server-url`, which points to the running test container.
-* `quarkus.oidc.client-id=quarkus-app`.
-* `quarkus.oidc.credentials.secret=secret`.
+** `quarkus.oidc.auth-server-url`, which points to the running test container.
+** `quarkus.oidc.client-id=quarkus-app`.
+** `quarkus.oidc.credentials.secret=secret`.
 +
-If you already have the required `quarkus-oidc` properties configured, associate `quarkus.oidc.auth-server-url` with the `prod` profile.
+* If you already have the required `quarkus-oidc` properties configured, associate `quarkus.oidc.auth-server-url` with the `prod` profile.
 This ensures that `Dev Services for Keycloak` starts the container as expected.
 +
 For example:
@@ -2250,8 +2250,8 @@ For example:
 ----
 %prod.quarkus.oidc.auth-server-url=http://localhost:8180/realms/quarkus
 ----
-
-To import a custom realm file into Keycloak before running the tests, configure `Dev services for Keycloak`:
++
+. Optional: To import a custom realm file into Keycloak before running the tests, configure `Dev services for Keycloak`:
 +
 [source,properties]
 ----


### PR DESCRIPTION
This is a manual back-port of: https://github.com/quarkusio/quarkus/pull/53598
This PR needs to be included in 3.33 for the product release.

After creating this PR, the backport label is removed from the original PR against `main`.