### PR TITLE
Fix typo in Grafana dashboard title

### DIFF
--- a/extensions/observability-devservices/testcontainers/src/main/resources/grafana-dashboard-quarkus-micrometer-opentelemetry.json
+++ b/extensions/observability-devservices/testcontainers/src/main/resources/grafana-dashboard-quarkus-micrometer-opentelemetry.json
@@ -412,7 +412,7 @@
       },
       "id": 163,
       "panels": [],
-      "title": "HTTP Edpoints",
+      "title": "HTTP Endpoints",
       "type": "row"
     },
     {

--- a/extensions/observability-devservices/testcontainers/src/main/resources/grafana-dashboard-quarkus-micrometer-otlp.json
+++ b/extensions/observability-devservices/testcontainers/src/main/resources/grafana-dashboard-quarkus-micrometer-otlp.json
@@ -412,7 +412,7 @@
       },
       "id": 163,
       "panels": [],
-      "title": "HTTP Edpoints",
+      "title": "HTTP Endpoints",
       "type": "row"
     },
     {

--- a/extensions/observability-devservices/testcontainers/src/main/resources/grafana-dashboard-quarkus-micrometer-prometheus.json
+++ b/extensions/observability-devservices/testcontainers/src/main/resources/grafana-dashboard-quarkus-micrometer-prometheus.json
@@ -440,7 +440,7 @@
           "refId": "A"
         }
       ],
-      "title": "HTTP Edpoints",
+      "title": "HTTP Endpoints",
       "type": "row"
     },
     {


### PR DESCRIPTION
Fix a typo in Grafana dashboard row titles: "HTTP Edpoints" → "HTTP Endpoints".

Affected dashboards:
- `grafana-dashboard-quarkus-micrometer-otlp.json`
- `grafana-dashboard-quarkus-micrometer-opentelemetry.json`
- `grafana-dashboard-quarkus-micrometer-prometheus.json`

No functional change.