### PR TITLE
Add configuration option for change log table name in liquibase mongodb

### DIFF
--- a/extensions/liquibase/liquibase-mongodb/runtime/src/main/java/io/quarkus/liquibase/mongodb/LiquibaseMongodbFactory.java
+++ b/extensions/liquibase/liquibase-mongodb/runtime/src/main/java/io/quarkus/liquibase/mongodb/LiquibaseMongodbFactory.java
@@ -131,6 +131,13 @@ public class LiquibaseMongodbFactory {
             if (liquibaseMongodbConfig.defaultSchemaName().isPresent()) {
                 database.setDefaultSchemaName(liquibaseMongodbConfig.defaultSchemaName().get());
             }
+            if (liquibaseMongodbConfig.databaseChangeLogTableName().isPresent()) {
+                database.setDatabaseChangeLogTableName(liquibaseMongodbConfig.databaseChangeLogTableName().get());
+            }
+            if (liquibaseMongodbConfig.databaseChangeLogLockTableName().isPresent()) {
+                database.setDatabaseChangeLogLockTableName(
+                        liquibaseMongodbConfig.databaseChangeLogLockTableName().get());
+            }
             Liquibase liquibase = new Liquibase(parsedChangeLog, resourceAccessor, database);
 
             for (Map.Entry<String, String> entry : liquibaseMongodbConfig.changeLogParameters().entrySet()) {

--- a/extensions/liquibase/liquibase-mongodb/runtime/src/main/java/io/quarkus/liquibase/mongodb/runtime/LiquibaseMongodbClientConfig.java
+++ b/extensions/liquibase/liquibase-mongodb/runtime/src/main/java/io/quarkus/liquibase/mongodb/runtime/LiquibaseMongodbClientConfig.java
@@ -42,6 +42,16 @@ public interface LiquibaseMongodbClientConfig {
     Map<String, String> changeLogParameters();
 
     /**
+     * The liquibase change log lock table name. Name of table to use for tracking concurrent Liquibase usage.
+     */
+    Optional<String> databaseChangeLogLockTableName();
+
+    /**
+     * The liquibase change log table name. Name of table to use for tracking change history.
+     */
+    Optional<String> databaseChangeLogTableName();
+
+    /**
      * The list of contexts
      */
     Optional<List<String>> contexts();

--- a/integration-tests/liquibase-mongodb/src/main/resources/application.properties
+++ b/integration-tests/liquibase-mongodb/src/main/resources/application.properties
@@ -9,6 +9,8 @@ quarkus.mongodb.fruit-client.hosts=localhost:27018
 
 quarkus.liquibase-mongodb.users.change-log=liquibase/users.xml
 quarkus.liquibase-mongodb.users.migrate-at-start=true
+quarkus.liquibase-mongodb.users.database-change-log-table-name=UserChangelog
+quarkus.liquibase-mongodb.users.database-change-log-lock-table-name=UserChangelogLock
 quarkus.mongodb.users.database=users
 quarkus.mongodb.users.hosts=localhost:27019
 

--- a/integration-tests/liquibase-mongodb/src/test/java/io/quarkus/it/liquibase/mongodb/UserResourceTest.java
+++ b/integration-tests/liquibase-mongodb/src/test/java/io/quarkus/it/liquibase/mongodb/UserResourceTest.java
@@ -51,4 +51,18 @@ class UserResourceTest {
                 .collect(Collectors.toSet());
         Assertions.assertTrue(names.contains("emailIdx"));
     }
+
+    @Test
+    public void validateChangeLogTableName() {
+        long entries = mongoClient.getDatabase("users").getCollection("UserChangelog").countDocuments();
+
+        Assertions.assertEquals(1, entries);
+    }
+
+    @Test
+    public void validateChangeLogLockTableName() {
+        long entries = mongoClient.getDatabase("users").getCollection("UserChangelogLock").countDocuments();
+
+        Assertions.assertEquals(1, entries);
+    }
 }


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

This PR adds configuration options for liquibase mongodb to allow changing the default change log (lock) table name.
The same config name and description is used from the normal liquibase extension, to have consistency / parity with config name.

My use case is mostly to have the option to separate two change logs in the same database from each other via different collection names (The best option would probably be to have two databases, but that's a constrain I cannot move).
It also allows to give the change log collection name a consistent naming format with other collections.

Beside the integration test, I also created a very small testing application to manually check if the change log collection was created correctly: https://github.com/DerFrZocker/examples/tree/quarkusio/quarkus/liquibase-mongodb-change-log-name

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

