### PR TITLE
Auto-configure GCP Error Reporting compatibility when using json logging GCP log format

### DIFF
--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -487,7 +487,7 @@ This format modifies some default field names and adds other fields to align wit
 +
 Fields include `@timestamp`, `log.logger`, `log.level`, `process.pid`, `process.name`, `process.thread.name`, `process.thread.id`, `host.hostname`, `event.sequence`, `error.message`, `error.stack_trace`, `ecs.version`, `data_stream.type`, `service.name`, `service.version`, and `service.environment`.
 * *gcp*: Uses the link:https://cloud.google.com/logging/docs/structured-logging#structured_logging_special_fields[Google Cloud] format.
-This format follows the *default* format.
+This format follows the *default* format. When using GCP format, if `exception-output-type` is set to `DETAILED` (the default), it is automatically upgraded to `DETAILED_AND_FORMATTED` to ensure stack traces appear in the `stack_trace` field.
 +
 When you use xref:opentelemetry-tracing.adoc[OpenTelemetry], Quarkus flattens tracing data present in the `mdc` field and copies it to `spanId`, `traceSampled`, and `trace`, with the `trace` value including a prefix.
 +

--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -504,7 +504,7 @@ This format modifies some default field names and adds other fields to align wit
 +
 Fields include `@timestamp`, `log.logger`, `log.level`, `process.pid`, `process.name`, `process.thread.name`, `process.thread.id`, `host.hostname`, `event.sequence`, `error.message`, `error.stack_trace`, `ecs.version`, `data_stream.type`, `service.name`, `service.version`, and `service.environment`.
 * *gcp*: Uses the link:https://cloud.google.com/logging/docs/structured-logging#structured_logging_special_fields[Google Cloud] format.
-This format follows the *default* format.
+This format follows the *default* format. When using GCP format, if `exception-output-type` is set to `DETAILED` (the default), it is automatically upgraded to `DETAILED_AND_FORMATTED` to ensure stack traces appear in the `stack_trace` field.
 +
 When you use xref:opentelemetry-tracing.adoc[OpenTelemetry], Quarkus flattens tracing data present in the `mdc` field and copies it to `spanId`, `traceSampled`, and `trace`, with the `trace` value including a prefix.
 +

--- a/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/ConsoleJsonFormatterGCPConfigTest.java
+++ b/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/ConsoleJsonFormatterGCPConfigTest.java
@@ -49,10 +49,12 @@ public class ConsoleJsonFormatterGCPConfigTest {
         assertThat(jsonFormatter.getDateTimeFormatter().toString())
                 .isEqualTo(DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneId.systemDefault()).toString());
         assertThat(jsonFormatter.getDateTimeFormatter().getZone()).isEqualTo(ZoneId.systemDefault());
-        assertThat(jsonFormatter.getExceptionOutputType()).isEqualTo(StructuredFormatter.ExceptionOutputType.DETAILED);
+        assertThat(jsonFormatter.getExceptionOutputType())
+                .isEqualTo(StructuredFormatter.ExceptionOutputType.DETAILED_AND_FORMATTED);
         assertThat(jsonFormatter.getRecordDelimiter()).isEqualTo("\n");
         assertThat(jsonFormatter.isPrintDetails()).isFalse();
         assertThat(jsonFormatter.getExcludedKeys()).isEmpty();
+        assertThat(jsonFormatter.getKeyOverrides()).contains("LEVEL=severity", "STACK_TRACE=stack_trace");
         assertThat(jsonFormatter.getAdditionalFields().entrySet()).isNotEmpty();
         assertThat(jsonFormatter.getAdditionalFields().get("trace")).isNotNull();
         assertThat(jsonFormatter.getAdditionalFields().get("spanId")).isNotNull();

--- a/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/LoggingJsonRecorder.java
+++ b/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/LoggingJsonRecorder.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logmanager.PropertyValues;
+import org.jboss.logmanager.formatters.StructuredFormatter;
 import org.jboss.logmanager.formatters.StructuredFormatter.Key;
 
 import io.quarkus.logging.json.runtime.JsonLogConfig.AdditionalFieldConfig.Type;
@@ -121,7 +122,12 @@ public class LoggingJsonRecorder {
         if (!dateFormat.equals("default")) {
             formatter.setDateFormat(dateFormat);
         }
-        formatter.setExceptionOutputType(config.exceptionOutputType());
+        if (JsonConfig.LogFormat.GCP == config.logFormat()
+                && config.exceptionOutputType() == StructuredFormatter.ExceptionOutputType.DETAILED) {
+            formatter.setExceptionOutputType(StructuredFormatter.ExceptionOutputType.DETAILED_AND_FORMATTED);
+        } else {
+            formatter.setExceptionOutputType(config.exceptionOutputType());
+        }
         formatter.setPrintDetails(config.printDetails());
         config.recordDelimiter().ifPresent(formatter::setRecordDelimiter);
         final String zoneId = config.zoneId();
@@ -167,6 +173,7 @@ public class LoggingJsonRecorder {
     private OverridableJsonConfig addGCPFieldOverrides(OverridableJsonConfig overridableJsonConfig) {
         EnumMap<Key, String> keyOverrides = PropertyValues.stringToEnumMap(Key.class, overridableJsonConfig.keyOverrides());
         keyOverrides.putIfAbsent(Key.LEVEL, "severity");
+        keyOverrides.putIfAbsent(Key.STACK_TRACE, "stack_trace");
 
         Set<String> excludedKeys = new HashSet<>(overridableJsonConfig.excludedKeys());
         Map<String, AdditionalField> additionalFields = new LinkedHashMap<>(overridableJsonConfig.additionalFields());

--- a/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/LoggingJsonRecorder.java
+++ b/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/LoggingJsonRecorder.java
@@ -149,14 +149,19 @@ public class LoggingJsonRecorder {
         if (!dateFormat.equals("default")) {
             formatter.setDateFormat(dateFormat);
         }
-        // ECS requires a flat rendered stack trace string in error.stack_trace.
-        // The FORMATTED output type writes the stack trace via Key.STACK_TRACE (mapped
-        // to "error.stack_trace" by addEcsFieldOverrides) and suppresses the structured
-        // "exception" object that DETAILED would produce.
-        if (JsonConfig.LogFormat.ECS == config.logFormat()) {
-            formatter.setExceptionOutputType(StructuredFormatter.ExceptionOutputType.FORMATTED);
-        } else {
-            formatter.setExceptionOutputType(config.exceptionOutputType());
+        switch (config.logFormat()) {
+            case ECS:
+                formatter.setExceptionOutputType(StructuredFormatter.ExceptionOutputType.FORMATTED);
+                break;
+            case GCP:
+                formatter.setExceptionOutputType(
+                        config.exceptionOutputType() == StructuredFormatter.ExceptionOutputType.DETAILED
+                                ? StructuredFormatter.ExceptionOutputType.DETAILED_AND_FORMATTED
+                                : config.exceptionOutputType());
+                break;
+            default:
+                formatter.setExceptionOutputType(config.exceptionOutputType());
+                break;
         }
         formatter.setPrintDetails(config.printDetails());
         config.recordDelimiter().ifPresent(formatter::setRecordDelimiter);
@@ -207,6 +212,7 @@ public class LoggingJsonRecorder {
     private OverridableJsonConfig addGCPFieldOverrides(OverridableJsonConfig overridableJsonConfig) {
         EnumMap<Key, String> keyOverrides = PropertyValues.stringToEnumMap(Key.class, overridableJsonConfig.keyOverrides());
         keyOverrides.putIfAbsent(Key.LEVEL, "severity");
+        keyOverrides.putIfAbsent(Key.STACK_TRACE, "stack_trace");
 
         Set<String> excludedKeys = new HashSet<>(overridableJsonConfig.excludedKeys());
         Map<String, AdditionalField> additionalFields = new LinkedHashMap<>(overridableJsonConfig.additionalFields());


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
-->

When deploying a Quarkus app to GCP Cloud Run with JSON logging (`quarkus.log.console.json.log-format=gcp`), GCP Error Reporting fails to recognize exceptions. Two issues cause this:

1. **Exception format** — GCP requires stack traces in `Throwable.printStackTrace()` format ([ReportedErrorEvent spec](https://docs.cloud.google.com/error-reporting/reference/rest/v1beta1/projects.events/report#ReportedErrorEvent)), but default `detailed` is a non-compliant format. Fix: `exception-output-type=formatted`.
2. **Field naming** — GCP expects `stack_trace`, but json logging outputs `stackTrace`. Fix: `key-overrides=STACK_TRACE=stack_trace`. [GCP Log entry requirements](https://docs.cloud.google.com/error-reporting/docs/formatting-error-messages#format-log-entry)

This PR automatically applies both settings when `log-format=gcp` is set, so users don't need to configure them manually.

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

