### PR TITLE
Delete hibernate sql files on shutdown

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java
@@ -208,10 +208,11 @@ public final class FastBootHibernatePersistenceProvider implements PersistencePr
                 throw new IllegalStateException(
                         "Attempting to boot a deactivated Hibernate ORM persistence unit");
             }
-            RuntimeSettings runtimeSettings = buildRuntimeSettings(persistenceUnitName, recordedState, puConfig);
+            RuntimeSettingsResult runtimeSettingsResult = buildRuntimeSettings(persistenceUnitName, recordedState,
+                    puConfig);
 
             StandardServiceRegistry standardServiceRegistry = rewireMetadataAndExtractServiceRegistry(persistenceUnitName,
-                    recordedState, puConfig, runtimeSettings);
+                    recordedState, puConfig, runtimeSettingsResult.settings());
 
             final Object cdiBeanManager = Arc.container().beanManager();
             final Object validatorFactory = Arc.container().instance("quarkus-hibernate-validator-factory").get();
@@ -220,23 +221,28 @@ public final class FastBootHibernatePersistenceProvider implements PersistencePr
                     persistenceUnit,
                     metadata /* Uses the StandardServiceRegistry references by this! */,
                     standardServiceRegistry /* Mostly ignored! (yet needs to match) */,
-                    runtimeSettings,
+                    runtimeSettingsResult.settings(),
                     validatorFactory, cdiBeanManager, recordedState.getMultiTenancyStrategy(),
                     true,
                     recordedState.getBuildTimeSettings().getSource().getBuiltinFormatMapperBehaviour(),
-                    recordedState.getBuildTimeSettings().getSource().getJsonFormatterCustomizationCheck());
+                    recordedState.getBuildTimeSettings().getSource().getJsonFormatterCustomizationCheck(),
+                    runtimeSettingsResult.importScripts());
         }
 
         log.debug("Found no matching persistence units");
         return null;
     }
 
-    private RuntimeSettings buildRuntimeSettings(String persistenceUnitName, RecordedState recordedState,
+    private record RuntimeSettingsResult(RuntimeSettings settings, SchemaToolingUtil.PreparedImportScripts importScripts) {
+    }
+
+    private RuntimeSettingsResult buildRuntimeSettings(String persistenceUnitName, RecordedState recordedState,
             HibernateOrmRuntimeConfigPersistenceUnit persistenceUnitConfig) {
         final BuildTimeSettings buildTimeSettings = recordedState.getBuildTimeSettings();
         final IntegrationSettings integrationSettings = recordedState.getIntegrationSettings();
         Builder runtimeSettingsBuilder = new Builder(buildTimeSettings, integrationSettings);
-        unzipZipFilesAndReplaceZipsInImportFiles(runtimeSettingsBuilder);
+        SchemaToolingUtil.PreparedImportScripts importScripts = unzipZipFilesAndReplaceZipsInImportFiles(
+                runtimeSettingsBuilder);
 
         Optional<String> dataSourceName = recordedState.getBuildTimeSettings().getSource().getDataSource();
         if (dataSourceName.isPresent()) {
@@ -337,7 +343,7 @@ public final class FastBootHibernatePersistenceProvider implements PersistencePr
             }
         }
 
-        return runtimeSettingsBuilder.build();
+        return new RuntimeSettingsResult(runtimeSettingsBuilder.build(), importScripts);
     }
 
     public static boolean isPostgresOrDB2(BuildTimeSettings buildTimeSettings) {
@@ -346,10 +352,13 @@ public final class FastBootHibernatePersistenceProvider implements PersistencePr
                 || DatabaseKind.isDB2(dbKind.toString());
     }
 
-    private void unzipZipFilesAndReplaceZipsInImportFiles(Builder runtimeSettingsBuilder) {
-        String newValue = SchemaToolingUtil.unzipZipFilesAndReplaceZips(
+    private SchemaToolingUtil.PreparedImportScripts unzipZipFilesAndReplaceZipsInImportFiles(
+            Builder runtimeSettingsBuilder) {
+        SchemaToolingUtil.PreparedImportScripts importScripts = SchemaToolingUtil.unzipZipFilesAndReplaceZips(
                 (String) runtimeSettingsBuilder.get(AvailableSettings.JAKARTA_HBM2DDL_LOAD_SCRIPT_SOURCE));
-        runtimeSettingsBuilder.put(AvailableSettings.JAKARTA_HBM2DDL_LOAD_SCRIPT_SOURCE, newValue);
+        runtimeSettingsBuilder.put(AvailableSettings.JAKARTA_HBM2DDL_LOAD_SCRIPT_SOURCE,
+                importScripts.getRewrittenValue());
+        return importScripts;
     }
 
     private StandardServiceRegistry rewireMetadataAndExtractServiceRegistry(String persistenceUnitName, RecordedState rs,

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/SchemaToolingUtil.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/SchemaToolingUtil.java
@@ -1,27 +1,43 @@
 package io.quarkus.hibernate.orm.runtime;
 
+import java.io.IOException;
 import java.net.URL;
 import java.nio.file.DirectoryStream;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+
+import org.jboss.logging.Logger;
 
 import io.quarkus.fs.util.ZipUtils;
 
 public class SchemaToolingUtil {
+
+    private static final Logger log = Logger.getLogger(SchemaToolingUtil.class);
     private static final String SQL_LOAD_SCRIPT_UNZIPPED_DIR_PREFIX = "import-sql-unzip-";
 
-    public static String unzipZipFilesAndReplaceZips(String commaSeparatedFileNames) {
+    public static PreparedImportScripts unzipZipFilesAndReplaceZips(String commaSeparatedFileNames) {
         List<String> unzippedFilesNames = new ArrayList<>();
+        List<TempDirCleanup> cleanups = new ArrayList<>();
         if (commaSeparatedFileNames != null) {
             String[] fileNames = commaSeparatedFileNames.split(",");
             for (String fileName : fileNames) {
                 if (fileName.endsWith(".zip")) {
                     try {
                         Path unzipDir = Files.createTempDirectory(SQL_LOAD_SCRIPT_UNZIPPED_DIR_PREFIX);
+                        Thread hook = new Thread(
+                                () -> recursiveDeleteQuietly(unzipDir),
+                                "shutdown-hook-delete-" + unzipDir.getFileName());
+                        Runtime.getRuntime().addShutdownHook(hook);
+                        cleanups.add(new TempDirCleanup(unzipDir, hook));
+
                         URL resource = Thread.currentThread()
                                 .getContextClassLoader()
                                 .getResource(fileName);
@@ -40,9 +56,59 @@ public class SchemaToolingUtil {
                     unzippedFilesNames.add(fileName);
                 }
             }
-            return String.join(",", unzippedFilesNames);
+            return new PreparedImportScripts(String.join(",", unzippedFilesNames), cleanups);
         } else {
-            return null;
+            return new PreparedImportScripts(null, Collections.emptyList());
+        }
+    }
+
+    static void recursiveDeleteQuietly(Path dir) {
+        try {
+            Files.walkFileTree(dir, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    Files.deleteIfExists(file);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path d, IOException exc) throws IOException {
+                    Files.deleteIfExists(d);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (IOException e) {
+            log.debugf(e, "Failed to delete temporary import-script directory %s", dir);
+        }
+    }
+
+    private record TempDirCleanup(Path dir, Thread shutdownHook) {
+    }
+
+    public static final class PreparedImportScripts implements AutoCloseable {
+
+        private final String rewrittenValue;
+        private final List<TempDirCleanup> cleanups;
+
+        private PreparedImportScripts(String rewrittenValue, List<TempDirCleanup> cleanups) {
+            this.rewrittenValue = rewrittenValue;
+            this.cleanups = cleanups;
+        }
+
+        public String getRewrittenValue() {
+            return rewrittenValue;
+        }
+
+        @Override
+        public void close() {
+            for (TempDirCleanup cleanup : cleanups) {
+                recursiveDeleteQuietly(cleanup.dir());
+                try {
+                    Runtime.getRuntime().removeShutdownHook(cleanup.shutdownHook());
+                } catch (IllegalStateException e) {
+                    // JVM is already shutting down – the hook will execute (or already has), nothing to do.
+                }
+            }
         }
     }
 }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/SchemaToolingUtil.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/SchemaToolingUtil.java
@@ -22,43 +22,52 @@ public class SchemaToolingUtil {
 
     private static final Logger log = Logger.getLogger(SchemaToolingUtil.class);
     private static final String SQL_LOAD_SCRIPT_UNZIPPED_DIR_PREFIX = "import-sql-unzip-";
+    private static final String SQL_LOAD_SCRIPT_SHUTDOWN_HOOK_NAME = "shutdown-hook-delete-import-sql-temp-dirs";
 
     public static PreparedImportScripts unzipZipFilesAndReplaceZips(String commaSeparatedFileNames) {
         List<String> unzippedFilesNames = new ArrayList<>();
-        List<TempDirCleanup> cleanups = new ArrayList<>();
-        if (commaSeparatedFileNames != null) {
-            String[] fileNames = commaSeparatedFileNames.split(",");
-            for (String fileName : fileNames) {
-                if (fileName.endsWith(".zip")) {
-                    try {
-                        Path unzipDir = Files.createTempDirectory(SQL_LOAD_SCRIPT_UNZIPPED_DIR_PREFIX);
-                        Thread hook = new Thread(
-                                () -> recursiveDeleteQuietly(unzipDir),
-                                "shutdown-hook-delete-" + unzipDir.getFileName());
-                        Runtime.getRuntime().addShutdownHook(hook);
-                        cleanups.add(new TempDirCleanup(unzipDir, hook));
+        List<Path> unzipDirs = new ArrayList<>();
+        RuntimeException failure = null;
+        try {
+            if (commaSeparatedFileNames != null) {
+                String[] fileNames = commaSeparatedFileNames.split(",");
+                for (String fileName : fileNames) {
+                    if (fileName.endsWith(".zip")) {
+                        try {
+                            Path unzipDir = Files.createTempDirectory(SQL_LOAD_SCRIPT_UNZIPPED_DIR_PREFIX);
+                            unzipDirs.add(unzipDir);
 
-                        URL resource = Thread.currentThread()
-                                .getContextClassLoader()
-                                .getResource(fileName);
-                        Path zipFile = Paths.get(resource.toURI());
-                        ZipUtils.unzip(zipFile, unzipDir);
-                        try (DirectoryStream<Path> paths = Files.newDirectoryStream(unzipDir)) {
-                            for (Path path : paths) {
-                                unzippedFilesNames.add(path.toAbsolutePath().toString());
+                            URL resource = Thread.currentThread()
+                                    .getContextClassLoader()
+                                    .getResource(fileName);
+                            Path zipFile = Paths.get(resource.toURI());
+                            ZipUtils.unzip(zipFile, unzipDir);
+                            try (DirectoryStream<Path> paths = Files.newDirectoryStream(unzipDir)) {
+                                for (Path path : paths) {
+                                    unzippedFilesNames.add(path.toAbsolutePath().toString());
+                                }
                             }
+                        } catch (Exception e) {
+                            throw new IllegalStateException(String.format(Locale.ROOT, "Error unzipping import file %s: %s",
+                                    fileName, e.getMessage()), e);
                         }
-                    } catch (Exception e) {
-                        throw new IllegalStateException(String.format(Locale.ROOT, "Error unzipping import file %s: %s",
-                                fileName, e.getMessage()), e);
+                    } else {
+                        unzippedFilesNames.add(fileName);
                     }
-                } else {
-                    unzippedFilesNames.add(fileName);
+                }
+                return new PreparedImportScripts(String.join(",", unzippedFilesNames), unzipDirs);
+            } else {
+                return new PreparedImportScripts(null, Collections.emptyList());
+            }
+        } catch (RuntimeException e) {
+            failure = e;
+            throw e;
+        } finally {
+            if (failure != null) {
+                for (Path unzipDir : unzipDirs) {
+                    recursiveDeleteQuietly(unzipDir);
                 }
             }
-            return new PreparedImportScripts(String.join(",", unzippedFilesNames), cleanups);
-        } else {
-            return new PreparedImportScripts(null, Collections.emptyList());
         }
     }
 
@@ -82,17 +91,23 @@ public class SchemaToolingUtil {
         }
     }
 
-    private record TempDirCleanup(Path dir, Thread shutdownHook) {
-    }
-
     public static final class PreparedImportScripts implements AutoCloseable {
 
         private final String rewrittenValue;
-        private final List<TempDirCleanup> cleanups;
+        private final List<Path> unzipDirs;
+        private final Thread shutdownHook;
 
-        private PreparedImportScripts(String rewrittenValue, List<TempDirCleanup> cleanups) {
+        private PreparedImportScripts(String rewrittenValue, List<Path> unzipDirs) {
             this.rewrittenValue = rewrittenValue;
-            this.cleanups = cleanups;
+            this.unzipDirs = List.copyOf(unzipDirs);
+            if (this.unzipDirs.isEmpty()) {
+                this.shutdownHook = null;
+            } else {
+                this.shutdownHook = new Thread(
+                        () -> this.unzipDirs.forEach(SchemaToolingUtil::recursiveDeleteQuietly),
+                        SQL_LOAD_SCRIPT_SHUTDOWN_HOOK_NAME);
+                Runtime.getRuntime().addShutdownHook(shutdownHook);
+            }
         }
 
         public String getRewrittenValue() {
@@ -100,14 +115,20 @@ public class SchemaToolingUtil {
         }
 
         @Override
+        public String toString() {
+            return String.valueOf(rewrittenValue);
+        }
+
+        @Override
         public void close() {
-            for (TempDirCleanup cleanup : cleanups) {
-                recursiveDeleteQuietly(cleanup.dir());
-                try {
-                    Runtime.getRuntime().removeShutdownHook(cleanup.shutdownHook());
-                } catch (IllegalStateException e) {
-                    // JVM is already shutting down – the hook will execute (or already has), nothing to do.
-                }
+            unzipDirs.forEach(SchemaToolingUtil::recursiveDeleteQuietly);
+            if (shutdownHook == null) {
+                return;
+            }
+            try {
+                Runtime.getRuntime().removeShutdownHook(shutdownHook);
+            } catch (IllegalStateException e) {
+                // JVM is already shutting down – the hook will execute (or already has), nothing to do.
             }
         }
     }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootEntityManagerFactoryBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootEntityManagerFactoryBuilder.java
@@ -36,6 +36,7 @@ import io.quarkus.hibernate.orm.JsonFormat;
 import io.quarkus.hibernate.orm.XmlFormat;
 import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
 import io.quarkus.hibernate.orm.runtime.RuntimeSettings;
+import io.quarkus.hibernate.orm.runtime.SchemaToolingUtil;
 import io.quarkus.hibernate.orm.runtime.customized.BuiltinFormatMapperBehaviour;
 import io.quarkus.hibernate.orm.runtime.customized.JsonFormatterCustomizationCheck;
 import io.quarkus.hibernate.orm.runtime.migration.MultiTenancyStrategy;
@@ -58,6 +59,7 @@ public class FastBootEntityManagerFactoryBuilder implements EntityManagerFactory
 
     protected final MultiTenancyStrategy multiTenancyStrategy;
     protected final boolean shouldApplySchemaMigration;
+    private final SchemaToolingUtil.PreparedImportScripts importScripts;
 
     public FastBootEntityManagerFactoryBuilder(
             QuarkusPersistenceUnitDescriptor puDescriptor,
@@ -65,7 +67,8 @@ public class FastBootEntityManagerFactoryBuilder implements EntityManagerFactory
             StandardServiceRegistry standardServiceRegistry, RuntimeSettings runtimeSettings, Object validatorFactory,
             Object cdiBeanManager, MultiTenancyStrategy multiTenancyStrategy, boolean shouldApplySchemaMigration,
             BuiltinFormatMapperBehaviour builtinFormatMapperBehaviour,
-            JsonFormatterCustomizationCheck jsonFormatterCustomizationCheck) {
+            JsonFormatterCustomizationCheck jsonFormatterCustomizationCheck,
+            SchemaToolingUtil.PreparedImportScripts importScripts) {
         this.puDescriptor = puDescriptor;
         this.metadata = metadata;
         this.standardServiceRegistry = standardServiceRegistry;
@@ -76,6 +79,7 @@ public class FastBootEntityManagerFactoryBuilder implements EntityManagerFactory
         this.shouldApplySchemaMigration = shouldApplySchemaMigration;
         this.builtinFormatMapperBehaviour = builtinFormatMapperBehaviour;
         this.jsonFormatterCustomizationCheck = jsonFormatterCustomizationCheck;
+        this.importScripts = importScripts;
     }
 
     @Override
@@ -97,6 +101,8 @@ public class FastBootEntityManagerFactoryBuilder implements EntityManagerFactory
                     metadata.getTypeConfiguration().getMetadataBuildingContext().getBootstrapContext());
         } catch (Exception e) {
             throw persistenceException("Unable to build Hibernate SessionFactory", e);
+        } finally {
+            closeImportScripts();
         }
     }
 
@@ -107,8 +113,16 @@ public class FastBootEntityManagerFactoryBuilder implements EntityManagerFactory
 
     @Override
     public void generateSchema() {
-        throw new UnsupportedOperationException(
-                "This isn't used for schema generation - see SessionFactoryObserverForSchemaExport instead");
+        try {
+            throw new UnsupportedOperationException(
+                    "This isn't used for schema generation - see SessionFactoryObserverForSchemaExport instead");
+        } finally {
+            closeImportScripts();
+        }
+    }
+
+    protected final void closeImportScripts() {
+        importScripts.close();
     }
 
     protected PersistenceException persistenceException(String message, Exception cause) {

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/FastBootHibernateReactivePersistenceProvider.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/FastBootHibernateReactivePersistenceProvider.java
@@ -179,7 +179,8 @@ public final class FastBootHibernateReactivePersistenceProvider implements Persi
             final IntegrationSettings integrationSettings = recordedState.getIntegrationSettings();
             RuntimeSettings.Builder runtimeSettingsBuilder = new RuntimeSettings.Builder(buildTimeSettings,
                     integrationSettings);
-            unzipZipFilesAndReplaceZipsInImportFiles(runtimeSettingsBuilder);
+            SchemaToolingUtil.PreparedImportScripts importScripts = unzipZipFilesAndReplaceZipsInImportFiles(
+                    runtimeSettingsBuilder);
 
             HibernateOrmRuntimeConfigPersistenceUnit persistenceUnitConfig = hibernateOrmRuntimeConfig.persistenceUnits()
                     .get(persistenceUnit.getName());
@@ -275,17 +276,21 @@ public final class FastBootHibernateReactivePersistenceProvider implements Persi
                     validatorFactory, cdiBeanManager, recordedState.getMultiTenancyStrategy(),
                     !blockingSessionFactoryExists,
                     recordedState.getBuildTimeSettings().getSource().getBuiltinFormatMapperBehaviour(),
-                    recordedState.getBuildTimeSettings().getSource().getJsonFormatterCustomizationCheck());
+                    recordedState.getBuildTimeSettings().getSource().getJsonFormatterCustomizationCheck(),
+                    importScripts);
         }
 
         log.debug("Found no matching persistence units");
         return null;
     }
 
-    private void unzipZipFilesAndReplaceZipsInImportFiles(Builder runtimeSettingsBuilder) {
-        String newValue = SchemaToolingUtil.unzipZipFilesAndReplaceZips(
+    private SchemaToolingUtil.PreparedImportScripts unzipZipFilesAndReplaceZipsInImportFiles(
+            Builder runtimeSettingsBuilder) {
+        SchemaToolingUtil.PreparedImportScripts importScripts = SchemaToolingUtil.unzipZipFilesAndReplaceZips(
                 (String) runtimeSettingsBuilder.get(AvailableSettings.JAKARTA_HBM2DDL_LOAD_SCRIPT_SOURCE));
-        runtimeSettingsBuilder.put(AvailableSettings.JAKARTA_HBM2DDL_LOAD_SCRIPT_SOURCE, newValue);
+        runtimeSettingsBuilder.put(AvailableSettings.JAKARTA_HBM2DDL_LOAD_SCRIPT_SOURCE,
+                importScripts.getRewrittenValue());
+        return importScripts;
     }
 
     private StandardServiceRegistry rewireMetadataAndExtractServiceRegistry(String persistenceUnitName,

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/FastBootReactiveEntityManagerFactoryBuilder.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/FastBootReactiveEntityManagerFactoryBuilder.java
@@ -9,6 +9,7 @@ import org.hibernate.reactive.session.impl.ReactiveSessionFactoryImpl;
 
 import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
 import io.quarkus.hibernate.orm.runtime.RuntimeSettings;
+import io.quarkus.hibernate.orm.runtime.SchemaToolingUtil;
 import io.quarkus.hibernate.orm.runtime.boot.FastBootEntityManagerFactoryBuilder;
 import io.quarkus.hibernate.orm.runtime.boot.QuarkusPersistenceUnitDescriptor;
 import io.quarkus.hibernate.orm.runtime.customized.BuiltinFormatMapperBehaviour;
@@ -24,10 +25,11 @@ public final class FastBootReactiveEntityManagerFactoryBuilder extends FastBootE
             Object cdiBeanManager, MultiTenancyStrategy strategy,
             boolean shouldApplySchemaMigration,
             BuiltinFormatMapperBehaviour builtinFormatMapperBehaviour,
-            JsonFormatterCustomizationCheck jsonFormatterCustomizationCheck) {
+            JsonFormatterCustomizationCheck jsonFormatterCustomizationCheck,
+            SchemaToolingUtil.PreparedImportScripts importScripts) {
         super(puDescriptor, metadata, standardServiceRegistry, runtimeSettings, validatorFactory,
                 cdiBeanManager, strategy, shouldApplySchemaMigration, builtinFormatMapperBehaviour,
-                jsonFormatterCustomizationCheck);
+                jsonFormatterCustomizationCheck, importScripts);
     }
 
     @Override
@@ -40,6 +42,8 @@ public final class FastBootReactiveEntityManagerFactoryBuilder extends FastBootE
             return new ReactiveSessionFactoryImpl(metadata, options, metadata.getBootstrapContext());
         } catch (Exception e) {
             throw persistenceException("Unable to build Hibernate Reactive SessionFactory", e);
+        } finally {
+            closeImportScripts();
         }
     }
 }


### PR DESCRIPTION
Fixes quarkusio#49006

## Description

Hibernate ORM: clean up unzipped SQL import script temp directories after startup


## Changes

- Introduce `PreparedImportScripts`, an AutoCloseable that:
  - Holds the rewritten comma-separated filename value
  - Registers a JVM shutdown hook per temp dir as a safety net
  - Deletes all temp dirs and removes the shutdown hooks when closed


This ensures proper cleanup of temporary directories and prevents disk space leaks during application startup.