### PR TITLE
Use Gradle ValueSource to isolate system property access from configuration

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/AbstractQuarkusExtension.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/AbstractQuarkusExtension.java
@@ -5,7 +5,7 @@ import static java.util.Collections.emptyList;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -18,6 +18,7 @@ import org.gradle.api.java.archives.Attributes;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.process.JavaForkOptions;
 
@@ -66,20 +67,41 @@ public abstract class AbstractQuarkusExtension {
     }
 
     private BaseConfig buildBaseConfig() {
-        // Using common code to construct the "base config", which is all the configuration (system properties,
-        // environment, application.properties/yaml/yml, project properties) that is available in a Gradle task's
-        // _configuration phase_.
+        // Using a ValueSource to construct the "base config" map. The ValueSource wraps all
+        // SmallRyeConfig construction (which internally calls System.getProperties()) in an
+        // opaque boundary, so Gradle's configuration cache does not track individual system
+        // property accesses as inputs. Only the final result map is compared between builds.
         Set<File> resourcesDirs = getSourceSet(project, SourceSet.MAIN_SOURCE_SET_NAME).getResources().getSourceDirectories()
                 .getFiles();
 
-        EffectiveConfig effectiveConfig = EffectiveConfig.builder()
-                .withTaskProperties(Collections.emptyMap())
-                .withBuildProperties(quarkusBuildProperties.get())
-                .withProjectProperties(project.getProperties())
-                .withSourceDirectories(resourcesDirs)
-                .withProfile(quarkusProfile())
-                .build();
-        return new BaseConfig(effectiveConfig);
+        // Filter project properties to quarkus-relevant ones to avoid tracking all project
+        // properties as configuration cache inputs.
+        Map<String, String> filteredProjectProperties = getQuarkusRelevantProjectProperties();
+
+        Provider<Map<String, String>> configMapProvider = project.getProviders()
+                .of(QuarkusConfigValueSource.class, spec -> {
+                    spec.getParameters().getBuildProperties().set(quarkusBuildProperties);
+                    spec.getParameters().getProjectProperties().set(filteredProjectProperties);
+                    spec.getParameters().getSourceDirectories().set(resourcesDirs);
+                    spec.getParameters().getProfile().set(quarkusProfile());
+                });
+
+        return new BaseConfig(configMapProvider.get());
+    }
+
+    /**
+     * Returns only quarkus-relevant project properties, to avoid registering all project
+     * properties as configuration cache inputs.
+     */
+    private Map<String, String> getQuarkusRelevantProjectProperties() {
+        Map<String, String> result = new HashMap<>();
+        for (Map.Entry<String, ?> entry : project.getProperties().entrySet()) {
+            if (entry.getValue() != null
+                    && (entry.getKey().startsWith("quarkus.") || entry.getKey().startsWith("platform.quarkus."))) {
+                result.put(entry.getKey(), entry.getValue().toString());
+            }
+        }
+        return result;
     }
 
     public BaseConfig baseConfig() {
@@ -120,9 +142,10 @@ public abstract class AbstractQuarkusExtension {
     }
 
     private String quarkusProfile() {
-        String profile = System.getProperty(QUARKUS_PROFILE);
+        // Use Gradle Provider API for CC-compatible single property lookups
+        String profile = project.getProviders().systemProperty(QUARKUS_PROFILE).getOrNull();
         if (profile == null) {
-            profile = System.getenv("QUARKUS_PROFILE");
+            profile = project.getProviders().environmentVariable("QUARKUS_PROFILE").getOrNull();
         }
         if (profile == null) {
             profile = quarkusBuildProperties.get().get(QUARKUS_PROFILE);

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/BaseConfig.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/BaseConfig.java
@@ -7,9 +7,14 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import io.quarkus.deployment.configuration.ConfigCompatibility;
 import io.quarkus.deployment.pkg.NativeConfig;
 import io.quarkus.deployment.pkg.PackageConfig;
 import io.quarkus.gradle.dsl.Manifest;
+import io.quarkus.runtime.configuration.QuarkusConfigBuilderCustomizer;
+import io.smallrye.config.PropertiesConfigSource;
+import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.SmallRyeConfigBuilder;
 
 /**
  * Required parts of the configuration used to <em>configure</em> a Quarkus build task, does not contain settings
@@ -25,18 +30,39 @@ final class BaseConfig {
     private final NativeConfig nativeConfig;
     private final Map<String, String> values;
 
-    // Note: EffectiveConfig has all the code to load the configurations from all the sources.
-    BaseConfig(EffectiveConfig config) {
+    /**
+     * Constructs a BaseConfig from a pre-resolved configuration map, typically produced by
+     * {@link QuarkusConfigValueSource}.
+     * <p>
+     * A lightweight {@link SmallRyeConfig} is built from the map to provide typed access to
+     * {@link PackageConfig} and {@link NativeConfig} mappings. This SmallRyeConfig does NOT
+     * use {@code addSystemSources()} or {@code addDefaultSources()} — all values come from
+     * the pre-computed map, avoiding any {@code System.getProperties()} access that would
+     * interfere with Gradle's configuration cache.
+     */
+    BaseConfig(Map<String, String> configValues) {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withCustomizers(new QuarkusConfigBuilderCustomizer())
+                .addDiscoveredConverters()
+                .addDefaultInterceptors()
+                .addDiscoveredInterceptors()
+                .addDiscoveredSecretKeysHandlers()
+                .withSources(new PropertiesConfigSource(configValues, "valueSourceConfig", 400))
+                .withMapping(PackageConfig.class)
+                .withMapping(NativeConfig.class)
+                .withInterceptors(ConfigCompatibility.FrontEnd.nonLoggingInstance(), ConfigCompatibility.BackEnd.instance())
+                .build();
+
         manifest = new Manifest();
-        packageConfig = config.getConfig().getConfigMapping(PackageConfig.class);
-        nativeConfig = config.getConfig().getConfigMapping(NativeConfig.class);
+        packageConfig = config.getConfigMapping(PackageConfig.class);
+        nativeConfig = config.getConfigMapping(NativeConfig.class);
 
         // populate the Gradle Manifest object
         PackageConfig.JarConfig.ManifestConfig manifestConfig = packageConfig.jar().manifest();
         manifest.attributes(manifestConfig.attributes());
         manifestConfig.sections().forEach((section, attribs) -> manifest.attributes(attribs, section));
 
-        values = config.getValues();
+        values = configValues;
     }
 
     PackageConfig packageConfig() {
@@ -58,22 +84,27 @@ final class BaseConfig {
     Map<String, String> cachingRelevantProperties(List<String> propertyPatterns) {
         List<Pattern> patterns = propertyPatterns.stream().map(s -> "^(" + s + ")$").map(Pattern::compile)
                 .collect(Collectors.toList());
-        readMissingEnvVariables(propertyPatterns);
-        Predicate<Map.Entry<String, ?>> keyPredicate = e -> patterns.stream().anyMatch(p -> p.matcher(e.getKey()).matches());
-        return values.entrySet().stream()
-                .filter(keyPredicate)
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (s, s2) -> {
-                    throw new IllegalArgumentException("Duplicate key");
-                }, TreeMap::new));
-    }
+        TreeMap<String, String> result = new TreeMap<>();
 
-    /**
-     * Reads missing environment variables that have been defined as `cachingRelevantProperties`.
-     * This ensures that the configuration cache tracks these variables as inputs and detects changes in them.
-     */
-    private void readMissingEnvVariables(List<String> cachingRelevantProperties) {
-        cachingRelevantProperties.stream()
-                .filter(name -> !values.containsKey(name))
-                .forEach(name -> System.getenv(name));
+        Predicate<Map.Entry<String, ?>> keyPredicate = e -> patterns.stream().anyMatch(p -> p.matcher(e.getKey()).matches());
+        values.entrySet().stream()
+                .filter(keyPredicate)
+                .forEach(e -> result.put(e.getKey(), e.getValue()));
+
+        // For caching-relevant properties not found in the values map, check environment variables.
+        // This ensures that user-declared caching properties (like env vars) are still tracked as
+        // task inputs and cause rebuilds when their values change.
+        // Note: System.getenv(name) is a single env var lookup, which is CC-compatible — Gradle
+        // only tracks that specific env var, not all env vars.
+        for (String name : propertyPatterns) {
+            if (!result.containsKey(name)) {
+                String envValue = System.getenv(name);
+                if (envValue != null) {
+                    result.put(name, envValue);
+                }
+            }
+        }
+
+        return result;
     }
 }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusConfigValueSource.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusConfigValueSource.java
@@ -1,0 +1,99 @@
+package io.quarkus.gradle.tasks;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
+import org.gradle.api.provider.ValueSource;
+import org.gradle.api.provider.ValueSourceParameters;
+
+/**
+ * A Gradle {@link ValueSource} that builds the Quarkus configuration map in isolation from
+ * Gradle's configuration cache input tracking.
+ * <p>
+ * Gradle instruments {@code System.getProperties()} to track all system property accesses as
+ * configuration cache inputs. SmallRyeConfig internally accesses system properties when building
+ * its config sources and iterating property names. By wrapping this work in a {@code ValueSource},
+ * the individual system property accesses are invisible to the configuration cache — Gradle only
+ * tracks the final result map as a single opaque input.
+ * <p>
+ * The result is re-evaluated on every build. If the result changes (i.e., the effective
+ * configuration has changed), the configuration cache entry is invalidated. This provides
+ * correct invalidation behavior without false positives from unrelated system property changes.
+ * <p>
+ * The returned map is filtered to only include quarkus-relevant properties and a small set of
+ * stable JVM properties needed for expression expansion. Volatile system properties (like
+ * {@code java.vm.version}) are excluded to prevent spurious cache invalidation.
+ */
+public abstract class QuarkusConfigValueSource
+        implements ValueSource<Map<String, String>, QuarkusConfigValueSource.Params> {
+
+    /**
+     * JVM system properties included in the output for expression expansion in
+     * config mapping defaults (e.g., {@code quarkus.native.java-home} defaults to {@code ${java.home}}).
+     * These are stable across builds (tied to JVM installation, not build invocation).
+     */
+    private static final String[] EXPRESSION_EXPANSION_PROPERTIES = { "java.home", "user.home" };
+
+    interface Params extends ValueSourceParameters {
+        MapProperty<String, String> getBuildProperties();
+
+        MapProperty<String, String> getProjectProperties();
+
+        SetProperty<File> getSourceDirectories();
+
+        Property<String> getProfile();
+    }
+
+    @Nullable
+    @Override
+    public Map<String, String> obtain() {
+        Params params = getParameters();
+
+        Set<File> sourceDirs = params.getSourceDirectories().getOrElse(Collections.emptySet());
+
+        // Build EffectiveConfig with full system sources inside this ValueSource boundary.
+        // All System.getProperties() access happens here and is invisible to CC input tracking.
+        EffectiveConfig effectiveConfig = EffectiveConfig.builder()
+                .withTaskProperties(Collections.emptyMap())
+                .withBuildProperties(params.getBuildProperties().getOrElse(Collections.emptyMap()))
+                .withProjectProperties(params.getProjectProperties().getOrElse(Collections.emptyMap()))
+                .withSourceDirectories(sourceDirs)
+                .withProfile(params.getProfile().getOrElse("prod"))
+                .build();
+
+        // Filter the full config map to only quarkus-relevant properties.
+        // The full map includes ALL system properties (from SysPropConfigSource), which would
+        // cause the ValueSource result to change when unrelated properties change — defeating
+        // the purpose of using a ValueSource. We filter to keep the output stable.
+        Map<String, String> fullMap = effectiveConfig.getValues();
+        Map<String, String> filtered = new HashMap<>();
+
+        for (Map.Entry<String, String> entry : fullMap.entrySet()) {
+            String key = entry.getKey();
+            if (key.startsWith("quarkus.")
+                    || key.startsWith("platform.quarkus.")
+                    || key.startsWith("smallrye.config.")) {
+                filtered.put(key, entry.getValue());
+            }
+        }
+
+        // Include stable JVM properties needed for expression expansion when BaseConfig
+        // reconstructs a SmallRyeConfig from this map.
+        for (String prop : EXPRESSION_EXPANSION_PROPERTIES) {
+            String value = System.getProperty(prop);
+            if (value != null) {
+                filtered.putIfAbsent(prop, value);
+            }
+        }
+
+        return Collections.unmodifiableMap(filtered);
+    }
+}

--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/TasksConfigurationCacheCompatibilityTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/TasksConfigurationCacheCompatibilityTest.java
@@ -15,11 +15,14 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -104,19 +107,48 @@ public class TasksConfigurationCacheCompatibilityTest {
 
     }
 
+    @Test
+    public void configurationCacheIsReusedWhenUnrelatedSystemPropertyChanges() throws IOException, URISyntaxException {
+        URL url = getClass().getClassLoader().getResource("io/quarkus/gradle/tasks/configurationcache/main");
+        FileUtils.copyDirectory(new File(url.toURI()), testProjectDir.toFile());
+        FileUtils.copyFile(new File("../gradle.properties"), testProjectDir.resolve("gradle.properties").toFile());
+
+        buildResult(":help", "--configuration-cache");
+
+        // First build: store configuration cache entry with -Da=1
+        BuildResult firstBuild = buildResult(QUARKUS_BUILD_TASK_NAME,
+                Arrays.asList("--configuration-cache", "-Da=1"));
+        assertTrue(firstBuild.getOutput().contains("Configuration cache entry stored"),
+                "First build should store configuration cache entry");
+
+        // Second build: change unrelated system property to -Da=2
+        // The configuration cache should still be reused because the ValueSource filters
+        // out non-quarkus system properties from its result.
+        BuildResult secondBuild = buildResult(QUARKUS_BUILD_TASK_NAME,
+                Arrays.asList("--configuration-cache", "-Da=2"));
+        assertTrue(secondBuild.getOutput().contains("Reusing configuration cache."),
+                "Configuration cache should be reused when only unrelated system properties change");
+    }
+
     private BuildResult buildResult(String task, String configurationCacheCommand) {
+        return buildResult(task, List.of(configurationCacheCommand));
+    }
+
+    private BuildResult buildResult(String task, List<String> extraArgs) {
+        List<String> args = new java.util.ArrayList<>();
+        args.add(task);
+        args.add("--info");
+        args.add("--stacktrace");
+        args.add("--build-cache");
+        args.addAll(extraArgs);
         return GradleRunner.create()
                 .withPluginClasspath()
                 .withProjectDir(testProjectDir.toFile())
-                .withArguments(task, "--info", "--stacktrace", "--build-cache", configurationCacheCommand)
+                .withArguments(args)
                 .build();
     }
 
     private BuildResult buildResult(String task) {
-        return GradleRunner.create()
-                .withPluginClasspath()
-                .withProjectDir(testProjectDir.toFile())
-                .withArguments(task, "--info", "--stacktrace", "--build-cache")
-                .build();
+        return buildResult(task, List.of());
     }
 }


### PR DESCRIPTION
Implementation based on comment https://github.com/quarkusio/quarkus/pull/53006#issuecomment-4244742684

  - Introduced `QuarkusConfigValueSource`, a Gradle `ValueSource` that wraps SmallRyeConfig                                                                                                                      
    construction in an opaque boundary — system property accesses inside `obtain()` are not
    tracked as individual configuration cache inputs                                                                                                                                                             
  - The ValueSource output is filtered to only quarkus-relevant properties (`quarkus.*`,                                                                                                                         
    `platform.quarkus.*`) plus stable JVM properties needed for expression expansion                                                                                                                             
    (`java.home`, `user.home`), preventing spurious CC invalidation from volatile system                                                                                                                         
    properties                                                                                                                                                                                                   
  - `BaseConfig` now reconstructs a lightweight SmallRyeConfig from the pre-resolved map                                                                                                                         
    (no `addSystemSources()`) to provide typed `PackageConfig`/`NativeConfig` access                                                                                                                             
  - Updated `quarkusProfile()` to use Gradle Provider API and filtered project properties                                                                                                                        
    to quarkus-prefixed only   