### PR TITLE
Exclude org.jboss.resteasy.microprofile:microprofile-rest-client in narayana-lra

### DIFF
--- a/extensions/narayana-lra/runtime/pom.xml
+++ b/extensions/narayana-lra/runtime/pom.xml
@@ -55,6 +55,10 @@
                     <groupId>org.jboss.resteasy</groupId>
                     <artifactId>resteasy-client</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.resteasy.microprofile</groupId>
+                    <artifactId>microprofile-rest-client</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
LRA client 1.1.0.Final brought new RESTEasy dependency that breaks narayana-lra if we include Quarkus REST. We need to add a quickstart for both cases.