### PR TITLE
Harden OIDC debug logs

### DIFF
--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientCredentialsJwtSecretTestCase.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientCredentialsJwtSecretTestCase.java
@@ -2,10 +2,15 @@ package io.quarkus.oidc.client;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.function.Consumer;
+import java.util.logging.LogRecord;
+import java.util.stream.Collectors;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -40,7 +45,9 @@ public class OidcClientCredentialsJwtSecretTestCase {
             .withApplicationRoot((jar) -> jar
                     .addClasses(testClasses)
                     .addAsResource("application-oidc-client-credentials-jwt-secret.properties", "application.properties"))
-            .addBuildChainCustomizer(buildCustomizer());
+            .addBuildChainCustomizer(buildCustomizer())
+            .setLogRecordPredicate(r -> true)
+            .assertLogRecords(r -> assertLogRecord(r));
 
     @Test
     public void testGetTokenJwtClient() {
@@ -115,5 +122,13 @@ public class OidcClientCredentialsJwtSecretTestCase {
                 }).produces(MainBytecodeRecorderBuildItem.class).produces(SyntheticBeanBuildItem.class).build();
             }
         };
+    }
+
+    private static void assertLogRecord(List<LogRecord> records) {
+        List<LogRecord> clientSecretRecords = records.stream()
+                .filter(r -> r.getMessage().contains("client_assertion=")).collect(Collectors.toList());
+        assertFalse(clientSecretRecords.isEmpty());
+
+        assertTrue(clientSecretRecords.stream().allMatch(r -> r.getMessage().contains("client_assertion=...")));
     }
 }

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientCredentialsTestCase.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientCredentialsTestCase.java
@@ -2,7 +2,13 @@ package io.quarkus.oidc.client;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.logging.LogRecord;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -24,7 +30,9 @@ public class OidcClientCredentialsTestCase {
     static final QuarkusExtensionTest test = new QuarkusExtensionTest()
             .withApplicationRoot((jar) -> jar
                     .addClasses(testClasses)
-                    .addAsResource("application-oidc-client-credentials.properties", "application.properties"));
+                    .addAsResource("application-oidc-client-credentials.properties", "application.properties"))
+            .setLogRecordPredicate(r -> true)
+            .assertLogRecords(r -> assertLogRecord(r));
 
     @Test
     public void testGetTokenDefaultClient() {
@@ -83,5 +91,23 @@ public class OidcClientCredentialsTestCase {
         assertEquals(2, tokens.length);
         assertNotNull(tokens[0]);
         assertEquals("null", tokens[1]);
+    }
+
+    private static void assertLogRecord(List<LogRecord> records) {
+        List<LogRecord> authorizationRecords = records.stream()
+                .filter(r -> (r.getMessage().contains("client_secret=")
+                        || r.getMessage().contains("authorization=Basic")))
+                .collect(Collectors.toList());
+        assertFalse(authorizationRecords.isEmpty());
+
+        List<LogRecord> clientSecretRecords = authorizationRecords.stream()
+                .filter(r -> r.getMessage().contains("client_secret=")).collect(Collectors.toList());
+        assertFalse(clientSecretRecords.isEmpty());
+        assertTrue(clientSecretRecords.stream().allMatch(r -> r.getMessage().contains("client_secret=...")));
+
+        List<LogRecord> authorizationBasicSecretRecords = authorizationRecords.stream()
+                .filter(r -> r.getMessage().contains("authorization=Basic")).collect(Collectors.toList());
+        assertFalse(authorizationBasicSecretRecords.isEmpty());
+        assertTrue(authorizationBasicSecretRecords.stream().allMatch(r -> r.getMessage().contains("authorization=Basic ...")));
     }
 }

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientUserPasswordTestCase.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientUserPasswordTestCase.java
@@ -3,16 +3,23 @@ package io.quarkus.oidc.client;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.LogRecord;
+import java.util.stream.Collectors;
 
+import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkus.oidc.client.runtime.OidcClientImpl;
 import io.quarkus.test.QuarkusExtensionTest;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.restassured.RestAssured;
@@ -31,7 +38,9 @@ public class OidcClientUserPasswordTestCase {
     static final QuarkusExtensionTest test = new QuarkusExtensionTest()
             .withApplicationRoot((jar) -> jar
                     .addClasses(testClasses)
-                    .addAsResource("application-oidc-client-user-password.properties", "application.properties"));
+                    .addAsResource("application-oidc-client-user-password.properties", "application.properties"))
+            .setLogRecordPredicate(r -> r.getLoggerName().equals(Logger.getLogger(OidcClientImpl.class).getName()))
+            .assertLogRecords(r -> assertLogRecord(r));
 
     @Test
     public void testPasswordGrantToken() {
@@ -118,5 +127,23 @@ public class OidcClientUserPasswordTestCase {
         assertEquals(2, tokens.length);
         assertNotNull(tokens[0]);
         assertNotNull(tokens[1]);
+    }
+
+    private static void assertLogRecord(List<LogRecord> records) {
+        List<LogRecord> formRecords = records.stream()
+                .filter(r -> (r.getMessage().contains("password=") || r.getMessage().contains("refresh_token=")))
+                .collect(Collectors.toList());
+        assertFalse(formRecords.isEmpty());
+
+        List<LogRecord> passwordRecords = formRecords.stream().filter(r -> r.getMessage().contains("password="))
+                .collect(Collectors.toList());
+        assertFalse(passwordRecords.isEmpty());
+        assertTrue(passwordRecords.stream().allMatch(r -> r.getMessage().contains("password=...")));
+
+        List<LogRecord> refreshTokenRecords = formRecords.stream().filter(r -> r.getMessage().contains("refresh_token="))
+                .collect(Collectors.toList());
+        assertFalse(refreshTokenRecords.isEmpty());
+
+        assertTrue(refreshTokenRecords.stream().allMatch(r -> r.getMessage().contains("refresh_token=...")));
     }
 }

--- a/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-credentials-jwt-secret.properties
+++ b/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-credentials-jwt-secret.properties
@@ -9,3 +9,5 @@ quarkus.oidc-client.jwt.client-id=${quarkus.oidc.client-id}
 quarkus.oidc-client.jwt.credentials.jwt.secret-provider.key=secret-from-vault-for-jwt
 quarkus.oidc-client.jwt.credentials.jwt.signature-algorithm=HS512
 quarkus.oidc-client.jwt.credentials.jwt.audience=${quarkus.oidc.auth-server-url}
+
+quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientImpl".level=DEBUG

--- a/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-credentials.properties
+++ b/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-credentials.properties
@@ -23,3 +23,5 @@ quarkus.oidc-client.named-2.credentials.client-secret.provider.name=${quarkus.oi
 quarkus.oidc-client.named-2.credentials.client-secret.provider.keyring-name=named-2-client-secret
 quarkus.oidc-client.named-2.credentials.client-secret.provider.key=${quarkus.oidc-client.credentials.client-secret.provider.key}
 quarkus.oidc-client.named-2.credentials.client-secret.method=post
+
+quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientImpl".level=DEBUG

--- a/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-user-password.properties
+++ b/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-user-password.properties
@@ -15,3 +15,5 @@ quarkus.oidc-client.public.client-id=quarkus-public-app
 quarkus.oidc-client.public.grant.type=password
 quarkus.oidc-client.public.grant-options.password.username=alice
 quarkus.oidc-client.public.grant-options.password.password=alice
+
+quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientImpl".level=DEBUG

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
@@ -266,8 +266,12 @@ public class OidcClientImpl implements OidcClient {
             }
         }
         if (LOG.isDebugEnabled()) {
-            LOG.debugf("%s token: url : %s, headers: %s, request params: %s", op.operation(), request.uri(), request.headers(),
-                    body);
+            String logMessage = """
+                    %s token: url : %s, headers: %s, request params: %s
+                    """.formatted(op.operation(), request.uri(),
+                    OidcCommonUtils.maskAuthorizationHeader(request.headers()),
+                    OidcCommonUtils.maskFormData(body));
+            LOG.debug(logMessage);
         }
         // Retry up to three times with a one-second delay between the retries if the connection is closed
         Buffer buffer = OidcCommonUtils.encodeForm(body);

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -86,10 +86,73 @@ public class OidcCommonUtils {
     static final String HTTP_SCHEME = "http";
 
     private static final Logger LOG = Logger.getLogger(OidcCommonUtils.class);
+    private static final String AUTHORIZATION_HEADER = String.valueOf(HttpHeaders.AUTHORIZATION);
     private static final BlockingTaskRunner<Void> VOID_BLOCKING_TASK_RUNNER = new BlockingTaskRunner<>();
 
     private OidcCommonUtils() {
 
+    }
+
+    public static MultiMap maskAuthorizationHeader(MultiMap headers) {
+        String authorizationHeader = headers.get(AUTHORIZATION_HEADER);
+        if (authorizationHeader == null) {
+            return headers;
+        }
+
+        StringBuilder maskedAuthorization = new StringBuilder();
+        int idx = authorizationHeader.indexOf(' ');
+        final String scheme = idx > 0 ? authorizationHeader.substring(0, idx) : null;
+        // In the Quarkus OIDC to OIDC provider requests, if Authorization header is present,
+        // it can only be a non-null scheme, either Basic or Bearer, if set by Quarkus OIDC.
+        // In some cases, custom filters might add their own Authorization header to deal with the provider
+        // specific authentication requirements for accessing typically public endpoints such as a discovery endpoint
+        // and theoretically, they might set Authorization without a scheme - unlikely but we check it just in case.
+        if (scheme != null) {
+            maskedAuthorization.append(scheme).append(' ');
+        }
+        maskedAuthorization.append("...");
+
+        MultiMap debugHeaders = MultiMap.caseInsensitiveMultiMap().addAll(headers);
+        debugHeaders.set(AUTHORIZATION_HEADER, maskedAuthorization);
+        return debugHeaders;
+    }
+
+    public static MultiMap maskFormData(MultiMap formParams) {
+
+        MultiMap debugFormParams = MultiMap.caseInsensitiveMultiMap().addAll(formParams);
+        if (formParams.contains(OidcConstants.CLIENT_SECRET)) {
+            debugFormParams.set(OidcConstants.CLIENT_SECRET, "...");
+        }
+        if (formParams.contains(OidcConstants.CLIENT_ASSERTION)) {
+            debugFormParams.set(OidcConstants.CLIENT_ASSERTION, "...");
+        }
+        if (formParams.contains(OidcConstants.PASSWORD_GRANT_PASSWORD)) {
+            debugFormParams.set(OidcConstants.PASSWORD_GRANT_PASSWORD, "...");
+        }
+        if (formParams.contains(OidcConstants.CODE_FLOW_CODE)) {
+            debugFormParams.set(OidcConstants.CODE_FLOW_CODE, "...");
+        }
+        if (formParams.contains(OidcConstants.PKCE_CODE_VERIFIER)) {
+            debugFormParams.set(OidcConstants.PKCE_CODE_VERIFIER, "...");
+        }
+        if (formParams.contains(OidcConstants.REFRESH_TOKEN_VALUE)) {
+            debugFormParams.set(OidcConstants.REFRESH_TOKEN_VALUE, "...");
+        }
+        return debugFormParams;
+    }
+
+    public static JsonObject maskJsonTokens(JsonObject jsonObject) {
+        JsonObject maskedJson = jsonObject.copy();
+        if (maskedJson.containsKey(OidcConstants.ACCESS_TOKEN_VALUE)) {
+            maskedJson.put(OidcConstants.ACCESS_TOKEN_VALUE, "...");
+        }
+        if (maskedJson.containsKey(OidcConstants.REFRESH_TOKEN_VALUE)) {
+            maskedJson.put(OidcConstants.REFRESH_TOKEN_VALUE, "...");
+        }
+        if (maskedJson.containsKey(OidcConstants.ID_TOKEN_VALUE)) {
+            maskedJson.put(OidcConstants.ID_TOKEN_VALUE, "...");
+        }
+        return maskedJson;
     }
 
     public static void verifyEndpointUrl(String endpointUrl) {

--- a/extensions/oidc-common/runtime/src/test/java/io/quarkus/oidc/common/runtime/OidcCommonUtilsTest.java
+++ b/extensions/oidc-common/runtime/src/test/java/io/quarkus/oidc/common/runtime/OidcCommonUtilsTest.java
@@ -14,8 +14,115 @@ import org.junit.jupiter.api.Test;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.ProxyOptions;
+import io.vertx.mutiny.core.MultiMap;
 
 public class OidcCommonUtilsTest {
+
+    @Test
+    public void testMaskAuthorizationBasicScheme() throws Exception {
+        MultiMap headers = MultiMap.caseInsensitiveMultiMap().set("Authorization", "Basic base64encoded");
+
+        MultiMap maskedHeaders = OidcCommonUtils.maskAuthorizationHeader(headers);
+        assertEquals("Basic ...", maskedHeaders.get("Authorization"));
+
+        assertEquals("Basic base64encoded", headers.get("Authorization"));
+    }
+
+    @Test
+    public void testMaskAuthorizationBearerScheme() throws Exception {
+        MultiMap headers = MultiMap.caseInsensitiveMultiMap().set("authorization", "Bearer token");
+
+        MultiMap maskedHeaders = OidcCommonUtils.maskAuthorizationHeader(headers);
+        assertEquals("Bearer ...", maskedHeaders.get("Authorization"));
+
+        assertEquals("Bearer token", headers.get("Authorization"));
+    }
+
+    @Test
+    public void testMaskAuthorizationWithoutScheme() throws Exception {
+        MultiMap headers = MultiMap.caseInsensitiveMultiMap().set("Authorization", "API-Key");
+
+        MultiMap maskedHeaders = OidcCommonUtils.maskAuthorizationHeader(headers);
+        assertEquals("...", maskedHeaders.get("Authorization"));
+
+        assertEquals("API-Key", headers.get("Authorization"));
+    }
+
+    @Test
+    public void testMaskClientSecretFormData() throws Exception {
+        MultiMap form = MultiMap.caseInsensitiveMultiMap().set("client_secret", "secret");
+
+        MultiMap maskedForm = OidcCommonUtils.maskFormData(form);
+        assertEquals("...", maskedForm.get("client_secret"));
+
+        assertEquals("secret", form.get("client_secret"));
+    }
+
+    @Test
+    public void testMaskClientAssertionFormData() throws Exception {
+        MultiMap form = MultiMap.caseInsensitiveMultiMap().set("client_assertion", "ey.token.signature");
+
+        MultiMap maskedForm = OidcCommonUtils.maskFormData(form);
+        assertEquals("...", maskedForm.get("client_assertion"));
+
+        assertEquals("ey.token.signature", form.get("client_assertion"));
+    }
+
+    @Test
+    public void testMaskPasswordGrantPasswordFormData() throws Exception {
+        MultiMap form = MultiMap.caseInsensitiveMultiMap().set("password", "secret");
+
+        MultiMap maskedForm = OidcCommonUtils.maskFormData(form);
+        assertEquals("...", maskedForm.get("password"));
+
+        assertEquals("secret", form.get("password"));
+    }
+
+    @Test
+    public void testMaskRefreshTokenFormData() throws Exception {
+        MultiMap form = MultiMap.caseInsensitiveMultiMap().set("refresh_token", "rt");
+
+        MultiMap maskedForm = OidcCommonUtils.maskFormData(form);
+        assertEquals("...", maskedForm.get("refresh_token"));
+
+        assertEquals("rt", form.get("refresh_token"));
+    }
+
+    @Test
+    public void testMaskAuthorizationCodeFormData() throws Exception {
+        MultiMap form = MultiMap.caseInsensitiveMultiMap().set("code", "somecode");
+
+        MultiMap maskedForm = OidcCommonUtils.maskFormData(form);
+        assertEquals("...", maskedForm.get("code"));
+
+        assertEquals("somecode", form.get("code"));
+    }
+
+    @Test
+    public void testMaskPkceCodeVerifierFormData() throws Exception {
+        MultiMap form = MultiMap.caseInsensitiveMultiMap().set("code_verifier", "somecode");
+
+        MultiMap maskedForm = OidcCommonUtils.maskFormData(form);
+        assertEquals("...", maskedForm.get("code_verifier"));
+
+        assertEquals("somecode", form.get("code_verifier"));
+    }
+
+    @Test
+    public void testMaskJsonTokensResponse() throws Exception {
+        JsonObject json = new JsonObject()
+                .put("access_token", "at").put("refresh_token", "rt").put("id_token", "id");
+
+        JsonObject maskedJson = OidcCommonUtils.maskJsonTokens(json);
+        assertEquals("...", maskedJson.getString("access_token"));
+        assertEquals("...", maskedJson.getString("refresh_token"));
+        assertEquals("...", maskedJson.getString("id_token"));
+
+        assertEquals("at", json.getString("access_token"));
+        assertEquals("rt", json.getString("refresh_token"));
+        assertEquals("id", json.getString("id_token"));
+
+    }
 
     @Test
     public void testProxyOptionsWithHostWithoutScheme() throws Exception {

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowCredentialsProviderRefreshTest.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowCredentialsProviderRefreshTest.java
@@ -59,10 +59,7 @@ public class CodeFlowCredentialsProviderRefreshTest {
                                             quarkus.oidc.named.logout.path=${quarkus.oidc.logout.path}
                                             quarkus.oidc.named.authentication.pkce-required=${quarkus.oidc.authentication.pkce-required}
                                             quarkus.oidc.named.credentials.client-secret.method=post
-
-                                            quarkus.log.category."org.htmlunit.javascript.host.css.CSSStyleSheet".level=FATAL
-                                            quarkus.log.category."org.htmlunit.css".level=FATAL
-                                            quarkus.log.file.enabled=true
+                                            quarkus.log.category."org.htmlunit".level=ERROR
                                             """),
                             "application.properties"));
 

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowRuntimeCredentialsProviderTest.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowRuntimeCredentialsProviderTest.java
@@ -1,10 +1,15 @@
 package io.quarkus.oidc.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.function.Consumer;
+import java.util.logging.LogRecord;
+import java.util.stream.Collectors;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -42,7 +47,9 @@ public class CodeFlowRuntimeCredentialsProviderTest {
             .withApplicationRoot((jar) -> jar
                     .addClasses(TEST_CLASSES)
                     .addAsResource("application-runtime-cred-provider.properties", "application.properties"))
-            .addBuildChainCustomizer(buildCustomizer());
+            .addBuildChainCustomizer(buildCustomizer())
+            .setLogRecordPredicate(r -> true)
+            .assertLogRecords(r -> assertLogRecord(r));
 
     @Test
     public void testRuntimeCredentials() throws IOException, InterruptedException {
@@ -60,6 +67,15 @@ public class CodeFlowRuntimeCredentialsProviderTest {
 
             assertEquals("alice", page.getBody().asNormalizedText());
         }
+    }
+
+    private static void assertLogRecord(List<LogRecord> records) {
+        List<LogRecord> authorizationRecords = records.stream()
+                .filter(r -> r.getMessage().contains("authorization=Basic")).collect(Collectors.toList());
+        assertFalse(authorizationRecords.isEmpty());
+
+        // Verify only masked authorization headers are logged
+        assertTrue(authorizationRecords.stream().allMatch(r -> r.getMessage().contains("authorization=Basic ...")));
     }
 
     private static Consumer<BuildChainBuilder> buildCustomizer() {

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowVerifyAccessTokenDisabledTest.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowVerifyAccessTokenDisabledTest.java
@@ -1,8 +1,13 @@
 package io.quarkus.oidc.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.logging.LogRecord;
+import java.util.stream.Collectors;
 
 import org.htmlunit.SilentCssErrorHandler;
 import org.htmlunit.WebClient;
@@ -22,7 +27,9 @@ public class CodeFlowVerifyAccessTokenDisabledTest {
     static final QuarkusExtensionTest test = new QuarkusExtensionTest()
             .withApplicationRoot((jar) -> jar
                     .addClasses(ProtectedResourceWithoutJwtAccessToken.class)
-                    .addAsResource("application-verify-access-token-disabled.properties", "application.properties"));
+                    .addAsResource("application-verify-access-token-disabled.properties", "application.properties"))
+            .setLogRecordPredicate(r -> true)
+            .assertLogRecords(r -> assertLogRecord(r));
 
     @Test
     public void testVerifyAccessTokenDisabled() throws IOException, InterruptedException {
@@ -43,6 +50,33 @@ public class CodeFlowVerifyAccessTokenDisabledTest {
 
             webClient.getCookieManager().clearCookies();
         }
+    }
+
+    private static void assertLogRecord(List<LogRecord> records) {
+        List<LogRecord> authorizationRecords = records.stream()
+                .filter(r -> (r.getMessage().contains("client_secret=")
+                        || r.getMessage().contains("code=")
+                        || r.getMessage().contains("code_verifier=")))
+                .collect(Collectors.toList());
+        assertFalse(authorizationRecords.isEmpty());
+
+        List<LogRecord> clientSecretRecords = authorizationRecords.stream()
+                .filter(r -> r.getMessage().contains("client_secret=")).collect(Collectors.toList());
+        assertFalse(clientSecretRecords.isEmpty());
+
+        assertTrue(clientSecretRecords.stream().allMatch(r -> r.getMessage().contains("client_secret=...")));
+
+        List<LogRecord> codeRecords = authorizationRecords.stream()
+                .filter(r -> r.getMessage().contains("code=")).collect(Collectors.toList());
+        assertFalse(codeRecords.isEmpty());
+
+        assertTrue(codeRecords.stream().allMatch(r -> r.getMessage().contains("code=...")));
+
+        List<LogRecord> codeVerifierRecords = authorizationRecords.stream()
+                .filter(r -> r.getMessage().contains("code_verifier=")).collect(Collectors.toList());
+        assertFalse(codeVerifierRecords.isEmpty());
+
+        assertTrue(codeVerifierRecords.stream().allMatch(r -> r.getMessage().contains("code_verifier=...")));
     }
 
     private WebClient createWebClient() {

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowVerifyInjectedAccessTokenDisabledTest.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowVerifyInjectedAccessTokenDisabledTest.java
@@ -1,8 +1,13 @@
 package io.quarkus.oidc.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.logging.LogRecord;
+import java.util.stream.Collectors;
 
 import org.htmlunit.SilentCssErrorHandler;
 import org.htmlunit.WebClient;
@@ -22,7 +27,9 @@ public class CodeFlowVerifyInjectedAccessTokenDisabledTest {
     static final QuarkusExtensionTest test = new QuarkusExtensionTest()
             .withApplicationRoot((jar) -> jar
                     .addClasses(ProtectedResourceWithJwtAccessToken.class)
-                    .addAsResource("application-verify-injected-access-token-disabled.properties", "application.properties"));
+                    .addAsResource("application-verify-injected-access-token-disabled.properties", "application.properties"))
+            .setLogRecordPredicate(r -> true)
+            .assertLogRecords(r -> assertLogRecord(r));
 
     @Test
     public void testVerifyAccessTokenDisabled() throws IOException, InterruptedException {
@@ -43,6 +50,30 @@ public class CodeFlowVerifyInjectedAccessTokenDisabledTest {
 
             webClient.getCookieManager().clearCookies();
         }
+    }
+
+    private static void assertLogRecord(List<LogRecord> records) {
+        List<LogRecord> authorizationRecords = records.stream()
+                .filter(r -> (r.getMessage().contains("\"access_token\":")
+                        || r.getMessage().contains("\"refresh_token\":")
+                        || r.getMessage().contains("\"id_token\":")))
+                .collect(Collectors.toList());
+        assertFalse(authorizationRecords.isEmpty());
+
+        List<LogRecord> accessTokenRecords = authorizationRecords.stream()
+                .filter(r -> r.getMessage().contains("\"access_token\":")).collect(Collectors.toList());
+        assertFalse(accessTokenRecords.isEmpty());
+        assertTrue(accessTokenRecords.stream().allMatch(r -> r.getMessage().contains("\"access_token\":\"...\"")));
+
+        List<LogRecord> refreshTokenRecords = authorizationRecords.stream()
+                .filter(r -> r.getMessage().contains("\"refresh_token\":")).collect(Collectors.toList());
+        assertFalse(refreshTokenRecords.isEmpty());
+        assertTrue(refreshTokenRecords.stream().allMatch(r -> r.getMessage().contains("\"refresh_token\":\"...\"")));
+
+        List<LogRecord> idTokenRecords = authorizationRecords.stream()
+                .filter(r -> r.getMessage().contains("\"id_token\":")).collect(Collectors.toList());
+        assertFalse(idTokenRecords.isEmpty());
+        assertTrue(idTokenRecords.stream().allMatch(r -> r.getMessage().contains("\"id_token\":\"...\"")));
     }
 
     private WebClient createWebClient() {

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeTenantReauthenticateTestCase.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeTenantReauthenticateTestCase.java
@@ -1,8 +1,13 @@
 package io.quarkus.oidc.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+import java.util.logging.LogRecord;
+import java.util.stream.Collectors;
 
 import org.htmlunit.SilentCssErrorHandler;
 import org.htmlunit.TextPage;
@@ -32,7 +37,9 @@ public class CodeTenantReauthenticateTestCase {
     static final QuarkusExtensionTest test = new QuarkusExtensionTest()
             .withApplicationRoot((jar) -> jar
                     .addClasses(testClasses)
-                    .addAsResource("application-tenant-reauthenticate.properties", "application.properties"));
+                    .addAsResource("application-tenant-reauthenticate.properties", "application.properties"))
+            .setLogRecordPredicate(r -> true)
+            .assertLogRecords(r -> assertLogRecord(r));
 
     @Test
     public void testDefaultTenant() throws Exception {
@@ -170,5 +177,11 @@ public class CodeTenantReauthenticateTestCase {
         String sessionCookie = "q_session" + (tenantId == null ? "" : "_" + tenantId);
 
         return webClient.getCookieManager().getCookie(sessionCookie);
+    }
+
+    private static void assertLogRecord(List<LogRecord> records) {
+        List<LogRecord> userInfoRecords = records.stream()
+                .filter(r -> r.getMessage().contains("UserInfo request succeeded")).collect(Collectors.toList());
+        assertFalse(userInfoRecords.isEmpty());
     }
 }

--- a/extensions/oidc/deployment/src/test/resources/application-runtime-cred-provider.properties
+++ b/extensions/oidc/deployment/src/test/resources/application-runtime-cred-provider.properties
@@ -9,6 +9,7 @@ quarkus.oidc.credentials.client-secret.provider.key=runtime-secret-from-vault
 quarkus.oidc.application-type=web-app
 quarkus.oidc.logout.path=/protected/logout
 quarkus.oidc.authentication.pkce-required=true
-quarkus.log.category."org.htmlunit.javascript.host.css.CSSStyleSheet".level=FATAL
-quarkus.log.category."org.htmlunit.css".level=FATAL
 quarkus.log.file.enabled=true
+
+quarkus.log.category."io.quarkus.oidc.runtime.OidcProviderClientImpl".level=DEBUG
+quarkus.log.category."org.htmlunit".level=ERROR

--- a/extensions/oidc/deployment/src/test/resources/application-tenant-reauthenticate.properties
+++ b/extensions/oidc/deployment/src/test/resources/application-tenant-reauthenticate.properties
@@ -5,6 +5,7 @@ quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus
 quarkus.oidc.client-id=quarkus-web-app
 quarkus.oidc.credentials.secret=secret
 quarkus.oidc.application-type=web-app
+quarkus.oidc.authentication.user-info-required=true
 
 quarkus.oidc.tenant-resolver.auth-server-url=${keycloak.url}/realms/quarkus
 quarkus.oidc.tenant-resolver.client-id=quarkus-web-app

--- a/extensions/oidc/deployment/src/test/resources/application-verify-access-token-disabled.properties
+++ b/extensions/oidc/deployment/src/test/resources/application-verify-access-token-disabled.properties
@@ -3,5 +3,10 @@ quarkus.keycloak.devservices.enabled=false
 
 quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus
 quarkus.oidc.client-id=quarkus-web-app
-quarkus.oidc.credentials.secret=secret
+quarkus.oidc.credentials.client-secret.value=secret
+quarkus.oidc.credentials.client-secret.method=post
 quarkus.oidc.application-type=web-app
+quarkus.oidc.authentication.pkce-required=true
+
+quarkus.log.category."io.quarkus.oidc.runtime.OidcProviderClientImpl".level=DEBUG
+quarkus.log.category."org.htmlunit".level=ERROR

--- a/extensions/oidc/deployment/src/test/resources/application-verify-injected-access-token-disabled.properties
+++ b/extensions/oidc/deployment/src/test/resources/application-verify-injected-access-token-disabled.properties
@@ -6,3 +6,6 @@ quarkus.oidc.client-id=quarkus-web-app
 quarkus.oidc.credentials.secret=secret
 quarkus.oidc.application-type=web-app
 quarkus.oidc.authentication.verify-access-token=false
+
+quarkus.log.category."io.quarkus.oidc.runtime.OidcProviderClientImpl".level=DEBUG
+quarkus.log.category."org.htmlunit".level=ERROR

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClientImpl.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClientImpl.java
@@ -179,7 +179,7 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
                         if (OidcUtils.isApplicationJwtContentType(response.contentType())) {
                             if (oidcConfig.jwks().resolveEarly()) {
                                 try {
-                                    LOG.debugf("Verifying the signed UserInfo with the local JWK keys: %s", response.data());
+                                    LOG.debugf("Verifying the signed UserInfo with the local JWK keys");
                                     return Uni.createFrom().item(
                                             new UserInfo(
                                                     oidcProvider.verifyJwtToken(response.data(), true, false,
@@ -210,7 +210,7 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
     }
 
     private Uni<UserInfoResponse> doGetUserInfo(OidcRequestContextProperties requestProps, String token, List<String> cookies) {
-        LOG.debugf("Get UserInfo on: %s auth: %s", metadata.getUserInfoUri(), OidcConstants.BEARER_SCHEME + " " + token);
+        LOG.debugf("Get UserInfo on: %s, Authorization: %s", metadata.getUserInfoUri(), OidcConstants.BEARER_SCHEME + " ...");
 
         HttpRequest<Buffer> request = client.getAbs(metadata.getUserInfoUri());
         if (!cookies.isEmpty()) {
@@ -247,8 +247,11 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
                         .filterHttpResponse(requestProps, resp, responseFilters, PUSHED_AUTHORIZATION_REQUEST)
                         .flatMap(buffer -> {
                             if (resp.statusCode() == 201) {
-                                LOG.debugf("Request succeeded: %s", resp.bodyAsJsonObject());
-                                return Uni.createFrom().item(buffer.toJsonObject());
+                                JsonObject jsonObject = buffer.toJsonObject();
+                                if (LOG.isDebugEnabled()) {
+                                    LOG.debugf("Request succeeded: %s", OidcCommonUtils.maskJsonTokens(jsonObject));
+                                }
+                                return Uni.createFrom().item(jsonObject);
                             }
                             return Uni.createFrom()
                                     .failure(responseException(metadata.getPushedAuthorizationRequestUri(), resp, buffer));
@@ -421,13 +424,12 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
             }
         }
         if (LOG.isDebugEnabled()) {
-            if (op == TokenOperation.PAR) {
-                LOG.debugf("%s: url : %s, headers: %s, request params: %s", op.operation(), request.uri(),
-                        request.headers(), formBody);
-            } else {
-                LOG.debugf("%s token: url : %s, headers: %s, request params: %s", op.operation(), request.uri(),
-                        request.headers(), formBody);
-            }
+            String logMessage = """
+                    %s %s: url : %s, headers: %s, request params: %s
+                    """.formatted(op.operation(), (op == TokenOperation.PAR ? "" : "token"), request.uri(),
+                    OidcCommonUtils.maskAuthorizationHeader(request.headers()),
+                    OidcCommonUtils.maskFormData(formBody));
+            LOG.debug(logMessage);
         }
         // Retry up to three times with a one-second delay between the retries if the connection is closed.
         var preparedResponse = filterHttpRequest(requestProps, endpointType, request, buffer)
@@ -541,8 +543,14 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
         return OidcCommonUtils.filterHttpResponse(requestProps, resp, responseFilters, endpoint)
                 .flatMap(buffer -> {
                     if (resp.statusCode() == 200) {
-                        LOG.debugf("Request succeeded: %s", resp.bodyAsJsonObject());
-                        return Uni.createFrom().item(buffer.toJsonObject());
+                        JsonObject jsonObject = buffer.toJsonObject();
+                        if (LOG.isDebugEnabled()) {
+                            String logMessage = """
+                                    Request succeeded: %s
+                                    """.formatted(OidcCommonUtils.maskJsonTokens(jsonObject));
+                            LOG.debug(logMessage);
+                        }
+                        return Uni.createFrom().item(jsonObject);
                     } else if (resp.statusCode() == 302) {
                         return Uni.createFrom().failure(OidcCommonUtils.createOidcClientRedirectException(resp));
                     } else {
@@ -556,7 +564,11 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
         return OidcCommonUtils.filterHttpResponse(requestProps, resp, responseFilters, endpoint)
                 .flatMap(buffer -> {
                     if (resp.statusCode() == 200) {
-                        LOG.debugf("Request succeeded: %s", resp.bodyAsString());
+                        if (endpoint == OidcEndpoint.Type.USERINFO) {
+                            LOG.debugf("UserInfo request succeeded");
+                        } else {
+                            LOG.debugf("Request succeeded: %s", resp.bodyAsString());
+                        }
                         return Uni.createFrom().item(buffer.toString());
                     } else if (resp.statusCode() == 302) {
                         return Uni.createFrom().failure(OidcCommonUtils.createOidcClientRedirectException(resp));

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
@@ -517,7 +517,7 @@ public class CodeFlowAuthorizationTest {
                                         StandardCharsets.UTF_8))) {
                             String line;
                             while ((line = reader.readLine()) != null) {
-                                if (line.contains("Verifying the signed UserInfo with the local JWK keys: ey")) {
+                                if (line.contains("Verifying the signed UserInfo with the local JWK keys")) {
                                     lineConfirmingVerificationDetected = true;
                                 } else if (line.contains("Response contains signed UserInfo")) {
                                     signedUserInfoResponseFilterMessageDetected = true;


### PR DESCRIPTION
This PR  hardens OIDC `debug` logging that captures the communication between Quarkus OIDC and  OIDC providers.

Debug logging is important for seeing what is happening in various requests/responses flowing between Quarkus OIDC and  OIDC providers, but some pieces of information can be quite sensitive for them to appear unmasked in these logs.

I have reviewed various pieces of information that are logged in the debug mode.
 
Anything that is considered not sensitive or even a public knowledge, for example, the discovery metadata, verification keys - all available on OIDC public endpoints, is still logged in the debug mode.

Some pieces like OIDC client secrets (passed as form params or with `Authorization: Basic`), short term client assertions, authorization code and PKCE code verifier, tokens - either those returned in the token grant response or the access used to request `UserInfo` with `Authorization: Bearer`, or refresh token, or UserInfo itself, all of these information pieces are sensitive enough for them to be in debug logs. 

This PR masks all of these values in `quarkus-oidc` and `quarkus-oidc-client`, tests all these masks across various tests.

It would've been much simpler just not to log anything at all, but it is really useful to have informative debug OIDC logs, to see which client id is used to access which OIDC endpoint, etc.

I had to update the way some log messages are logged for them captured in the test log records. Also, in `OidcCommonUtilsTest` I verify the masking the values does not override original input that is used for the actual OIDC work.

Some further hardening may follow, but the current updates are quite comprehensive.

- Fixes: #53561 