### PR TITLE
Consider runtime ObjectMapper-level strategy when (de)serializing pojo through the generated Jackson reflection-free serializer

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
@@ -318,6 +318,7 @@ public abstract class JacksonCodeGenerator {
 
         final String fieldName;
         final String jsonName;
+        final boolean hasExplicitJsonName;
         final String[] aliases;
         final Type fieldType;
 
@@ -349,7 +350,9 @@ public abstract class JacksonCodeGenerator {
             }
             this.fieldType = fieldType();
             this.fieldName = fieldName();
-            this.jsonName = jsonName(constructor, namingStrategy);
+            JsonNameResult result = jsonName(constructor, namingStrategy);
+            this.jsonName = result.name;
+            this.hasExplicitJsonName = result.explicit;
             this.aliases = jsonAliases();
         }
 
@@ -357,7 +360,9 @@ public abstract class JacksonCodeGenerator {
             readAnnotations(paramInfo);
             this.fieldType = paramInfo.type();
             this.fieldName = paramInfo.name();
-            this.jsonName = jsonName(null, namingStrategy);
+            JsonNameResult result = jsonName(null, namingStrategy);
+            this.jsonName = result.name;
+            this.hasExplicitJsonName = result.explicit;
             this.aliases = jsonAliases();
         }
 
@@ -390,7 +395,10 @@ public abstract class JacksonCodeGenerator {
             return new String[0];
         }
 
-        private String jsonName(MethodInfo constructor, PropertyNamingStrategy namingStrategy) {
+        private record JsonNameResult(String name, boolean explicit) {
+        }
+
+        private JsonNameResult jsonName(MethodInfo constructor, PropertyNamingStrategy namingStrategy) {
             AnnotationInstance jsonProperty = annotations.get(JsonProperty.class.getName());
             if (jsonProperty == null && constructor != null) {
                 jsonProperty = constructor.parameters().stream()
@@ -402,13 +410,13 @@ public abstract class JacksonCodeGenerator {
             if (jsonProperty != null) {
                 AnnotationValue value = jsonProperty.value();
                 if (value != null && !value.asString().isEmpty()) {
-                    return value.asString();
+                    return new JsonNameResult(value.asString(), true);
                 }
             }
             if (namingStrategy != null) {
-                return namingStrategy.nameForField(null, null, fieldName);
+                return new JsonNameResult(namingStrategy.nameForField(null, null, fieldName), true);
             }
-            return fieldName;
+            return new JsonNameResult(fieldName, false);
         }
 
         private String fieldName() {

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonDeserializerFactory.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonDeserializerFactory.java
@@ -1,7 +1,9 @@
 package io.quarkus.resteasy.reactive.jackson.deployment.processor;
 
 import static io.quarkus.gizmo.MethodDescriptor.ofMethod;
+import static org.objectweb.asm.Opcodes.ACC_FINAL;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static org.objectweb.asm.Opcodes.ACC_STATIC;
 
 import java.io.IOException;
 import java.lang.reflect.Modifier;
@@ -29,6 +31,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationConfig;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JavaType;
@@ -36,8 +39,10 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.cfg.MapperConfig;
 import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.introspect.AnnotatedField;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -47,6 +52,7 @@ import io.quarkus.gizmo.BranchResult;
 import io.quarkus.gizmo.BytecodeCreator;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.DescriptorUtils;
+import io.quarkus.gizmo.FieldCreator;
 import io.quarkus.gizmo.FieldDescriptor;
 import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.MethodDescriptor;
@@ -89,31 +95,45 @@ import io.quarkus.resteasy.reactive.jackson.runtime.mappers.JacksonMapperUtil;
  *
  * <pre>{@code
  * public class Person$quarkusjacksondeserializer extends StdDeserializer {
+ *     static final String[] TRANSLATABLE_FIELD_NAMES = new String[] { "firstName", "lastName", "address", "age" };
+ *
  *     public Person$quarkusjacksondeserializer() {
  *         super(Person.class);
  *     }
  *
  *     public Object deserialize(JsonParser jsonParser, DeserializationContext context) throws IOException, JacksonException {
- *         Person person = new Person();
- *         Iterator iterator = ((JsonNode) jsonParser.getCodec().readTree(jsonParser)).fields();
+ *         PropertyNamingStrategy propertyNamingStrategy = context.getConfig().getPropertyNamingStrategy();
+ *         Map<String, String> translatedFields = propertyNamingStrategy == null ? null
+ *                 : JacksonMapperUtil.buildReverseNameIndex(propertyNamingStrategy, TRANSLATABLE_FIELD_NAMES);
  *
- *         while (iterator.hasNext()) {
- *             Map.Entry entry = (Map.iterator) var3.next();
- *             String field = (String) entry.getKey();
- *             JsonNode jsonNode = (JsonNode) entry.getValue();
- *             switch (field) {
- *                 case "firstName":
- *                     person.setFirstName(jsonNode.asText());
- *                     break;
- *                 case "familyName":
- *                     person.setLastName(jsonNode.asText());
- *                     break;
- *                 case "age":
- *                     person.setAge(jsonNode.asInt());
- *                     break;
- *                 case "address":
- *                     person.setAddress(context.readTreeAsValue(jsonNode, Address.class));
- *                     break;
+ *         JsonNode jsonNode = jsonParser.getCodec().readTree(jsonParser);
+ *         Person person = new Person();
+ *         Iterator fields = jsonNode.fields();
+ *
+ *         while (fields.hasNext()) {
+ *             Entry entry = (Entry) fields.next();
+ *             JsonNode jsonValue = (JsonNode) entry.getValue();
+ *             if (!jsonValue.isNull()) {
+ *                 String key = (String) entry.getKey();
+ *                 Object fieldName = translatedFields == null ? key : translatedFields.getOrDefault(key, key);
+ *                 switch (fieldName) {
+ *                     case "firstName":
+ *                         person.setFirstName(jsonNode.asText());
+ *                         break;
+ *                     case "familyName":
+ *                         person.setLastName(jsonNode.asText());
+ *                         break;
+ *                     case "age":
+ *                         person.setAge(jsonNode.asInt());
+ *                         break;
+ *                     case "address":
+ *                         person.setAddress(context.readTreeAsValue(jsonNode, Address.class));
+ *                         break;
+ *                     default:
+ *                         if (context.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)) {
+ *                             throw new JsonMappingException("Unrecognized field \"" + fieldName + "\"");
+ *                         }
+ *                 }
  *             }
  *         }
  *
@@ -228,9 +248,17 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
         }
 
         MethodInfo ctor = ctorOpt.get();
+        ResultHandle strategyHandle = getStrategyHandle(deserialize);
+        PropertyNamingStrategy namingStrategy = getNamingStrategy(classInfo);
+        Set<String> translatableNames = collectTranslatableFieldNames(classInfo, ctor, namingStrategy);
+        ResultHandle reverseIndexHandle = null;
+        if (!translatableNames.isEmpty()) {
+            generateTranslatableFieldNamesStaticField(classCreator, translatableNames);
+            reverseIndexHandle = buildReverseIndexHandle(deserialize, classCreator, strategyHandle);
+        }
         DeserializationData deserData = new DeserializationData(classInfo, ctor, classCreator, deserialize,
                 getJsonNode(deserialize), parseTypeParameters(classInfo, classCreator), new HashSet<>(),
-                getNamingStrategy(classInfo));
+                namingStrategy, strategyHandle, reverseIndexHandle);
 
         ResultHandle deserializedHandle = ctor.parametersCount() == 0
                 ? deserData.methodCreator.newInstance(MethodDescriptor.ofConstructor(deserData.classInfo.name().toString()))
@@ -243,6 +271,14 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
         boolean valid = deserializeObjectFields(deserData, deserializedHandle);
         deserialize.returnValue(deserializedHandle);
         return valid;
+    }
+
+    private static ResultHandle getStrategyHandle(MethodCreator deserialize) {
+        ResultHandle deserCtx = deserialize.getMethodParam(1);
+        ResultHandle config = deserialize.invokeVirtualMethod(
+                ofMethod(DeserializationContext.class, "getConfig", DeserializationConfig.class), deserCtx);
+        return deserialize.invokeVirtualMethod(
+                ofMethod(DeserializationConfig.class, "getPropertyNamingStrategy", PropertyNamingStrategy.class), config);
     }
 
     private static ResultHandle getJsonNode(MethodCreator deserialize) {
@@ -268,7 +304,8 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
                 deserData.constructorFields.add(alias);
             }
 
-            ResultHandle fieldValue = lookupJsonField(deserData.methodCreator, deserData.jsonNode, fieldSpecs);
+            ResultHandle fieldValue = lookupJsonField(deserData.methodCreator, deserData.jsonNode, fieldSpecs,
+                    deserData.strategyHandle);
 
             params[i++] = readValueFromJson(deserData.classCreator, deserData.methodCreator,
                     deserData.methodCreator.getMethodParam(1), fieldSpecs, deserData.typeParametersIndex, fieldValue);
@@ -278,18 +315,21 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
 
     /**
      * Looks up a field value from a JSON node by its primary name, falling back to any @JsonAlias names.
+     * For fields without an explicit JSON name, the lookup name is dynamically resolved through
+     * the ObjectMapper's PropertyNamingStrategy if one is configured at runtime.
      */
-    private static ResultHandle lookupJsonField(BytecodeCreator bytecode, ResultHandle jsonNode, FieldSpecs fieldSpecs) {
+    private static ResultHandle lookupJsonField(BytecodeCreator bytecode, ResultHandle jsonNode, FieldSpecs fieldSpecs,
+            ResultHandle strategyHandle) {
+        ResultHandle lookupName = resolveLookupName(bytecode, fieldSpecs, strategyHandle);
+
         if (fieldSpecs.aliases.length == 0) {
             return bytecode.invokeVirtualMethod(
-                    ofMethod(JsonNode.class, "get", JsonNode.class, String.class), jsonNode,
-                    bytecode.load(fieldSpecs.jsonName));
+                    ofMethod(JsonNode.class, "get", JsonNode.class, String.class), jsonNode, lookupName);
         }
 
         AssignableResultHandle fieldValue = bytecode.createVariable(JsonNode.class);
         bytecode.assign(fieldValue, bytecode.invokeVirtualMethod(
-                ofMethod(JsonNode.class, "get", JsonNode.class, String.class), jsonNode,
-                bytecode.load(fieldSpecs.jsonName)));
+                ofMethod(JsonNode.class, "get", JsonNode.class, String.class), jsonNode, lookupName));
 
         for (String alias : fieldSpecs.aliases) {
             BytecodeCreator fallback = bytecode.ifNull(fieldValue).trueBranch();
@@ -299,6 +339,29 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
         }
 
         return fieldValue;
+    }
+
+    /**
+     * Resolves the JSON field name to use for looking up a value in the JSON node.
+     * For fields with an explicit name (@JsonProperty or @JsonNaming), uses that name directly.
+     * For fields without an explicit name, dynamically translates through the runtime
+     * PropertyNamingStrategy if one is configured on the ObjectMapper.
+     */
+    private static ResultHandle resolveLookupName(BytecodeCreator bytecode, FieldSpecs fieldSpecs,
+            ResultHandle strategyHandle) {
+        if (fieldSpecs.hasExplicitJsonName) {
+            return bytecode.load(fieldSpecs.jsonName);
+        }
+        // strategy != null ? strategy.nameForField(null, null, fieldName) : fieldName
+        AssignableResultHandle resolvedName = bytecode.createVariable(String.class);
+        bytecode.assign(resolvedName, bytecode.load(fieldSpecs.fieldName));
+        BytecodeCreator hasStrategy = bytecode.ifNotNull(strategyHandle).trueBranch();
+        hasStrategy.assign(resolvedName, hasStrategy.invokeVirtualMethod(
+                ofMethod(PropertyNamingStrategy.class, "nameForField", String.class,
+                        MapperConfig.class, AnnotatedField.class, String.class),
+                strategyHandle, hasStrategy.loadNull(), hasStrategy.loadNull(),
+                hasStrategy.load(fieldSpecs.fieldName)));
+        return resolvedName;
     }
 
     private boolean deserializeObjectFields(DeserializationData deserData, ResultHandle objHandle) {
@@ -316,8 +379,7 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
                 .ifTrue(loopCreator.invokeVirtualMethod(ofMethod(JsonNode.class, "isNull", boolean.class), fieldValue))
                 .falseBranch();
 
-        ResultHandle fieldName = fieldReader
-                .invokeInterfaceMethod(ofMethod(Map.Entry.class, "getKey", Object.class), mapEntry);
+        ResultHandle fieldName = translateFieldName(deserData, fieldReader, mapEntry);
         Switch.StringSwitch strSwitch = fieldReader.stringSwitch(fieldName);
 
         // save constructor field names before deserializeFields modifies the set
@@ -353,6 +415,84 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
         });
 
         return result;
+    }
+
+    /**
+     * Generates bytecode that builds a {@code Map<String, String>} reverse-name index once,
+     * before the field iteration loop. The map is {@code null} when no strategy is configured,
+     * so per-field lookups are a simple {@code Map.getOrDefault} call.
+     */
+    private static ResultHandle buildReverseIndexHandle(MethodCreator deserialize, ClassCreator classCreator,
+            ResultHandle strategyHandle) {
+        AssignableResultHandle reverseIndex = deserialize.createVariable(Map.class);
+        deserialize.assign(reverseIndex, deserialize.loadNull());
+        BytecodeCreator hasStrategy = deserialize.ifNotNull(strategyHandle).trueBranch();
+        ResultHandle namesArray = hasStrategy.readStaticField(
+                FieldDescriptor.of(classCreator.getClassName(), TRANSLATABLE_FIELD_NAMES, String[].class));
+        hasStrategy.assign(reverseIndex, hasStrategy.invokeStaticMethod(
+                ofMethod(JacksonMapperUtil.class, "buildReverseNameIndex", Map.class,
+                        PropertyNamingStrategy.class, String[].class),
+                strategyHandle, namesArray));
+        return reverseIndex;
+    }
+
+    private static ResultHandle translateFieldName(DeserializationData deserData, BytecodeCreator fieldReader,
+            ResultHandle mapEntry) {
+        ResultHandle rawFieldName = fieldReader
+                .invokeInterfaceMethod(ofMethod(Map.Entry.class, "getKey", Object.class), mapEntry);
+
+        if (deserData.reverseIndexHandle == null) {
+            return rawFieldName;
+        }
+
+        // Reverse-translate the incoming field name through the pre-built index (O(1) per field)
+        AssignableResultHandle resolved = fieldReader.createVariable(Object.class);
+        fieldReader.assign(resolved, rawFieldName);
+        BytecodeCreator hasIndex = fieldReader.ifNotNull(deserData.reverseIndexHandle).trueBranch();
+        hasIndex.assign(resolved, hasIndex.invokeInterfaceMethod(
+                ofMethod(Map.class, "getOrDefault", Object.class, Object.class, Object.class),
+                deserData.reverseIndexHandle, rawFieldName, rawFieldName));
+        return resolved;
+    }
+
+    private Set<String> collectTranslatableFieldNames(ClassInfo classInfo, MethodInfo constructor,
+            PropertyNamingStrategy namingStrategy) {
+        Set<String> names = new HashSet<>();
+        if (constructor.parametersCount() > 0) {
+            for (MethodParameterInfo paramInfo : constructor.parameters()) {
+                FieldSpecs fieldSpecs = fieldSpecsFromFieldParam(paramInfo, namingStrategy);
+                if (!fieldSpecs.hasExplicitJsonName) {
+                    names.add(fieldSpecs.fieldName);
+                }
+            }
+        }
+        for (FieldInfo fieldInfo : classFields(classInfo)) {
+            FieldSpecs fieldSpecs = fieldSpecsFromField(classInfo, constructor, fieldInfo, namingStrategy);
+            if (fieldSpecs != null && !fieldSpecs.hasExplicitJsonName && !fieldSpecs.isIgnoredField()) {
+                names.add(fieldSpecs.fieldName);
+            }
+        }
+        for (MethodInfo methodInfo : classMethods(classInfo)) {
+            FieldSpecs fieldSpecs = fieldSpecsFromMethod(methodInfo, namingStrategy);
+            if (fieldSpecs != null && !fieldSpecs.hasExplicitJsonName && !fieldSpecs.isIgnoredField()) {
+                names.add(fieldSpecs.fieldName);
+            }
+        }
+        return names;
+    }
+
+    private static void generateTranslatableFieldNamesStaticField(ClassCreator classCreator, Set<String> translatableNames) {
+        MethodCreator clinit = classCreator.getMethodCreator("<clinit>", void.class).setModifiers(ACC_STATIC);
+        ResultHandle namesArray = clinit.newArray(String.class, translatableNames.size());
+        int i = 0;
+        for (String name : translatableNames) {
+            clinit.writeArrayValue(namesArray, i++, clinit.load(name));
+        }
+        FieldCreator fieldCreator = classCreator
+                .getFieldCreator(TRANSLATABLE_FIELD_NAMES, String[].class.getName())
+                .setModifiers(ACC_STATIC | ACC_FINAL);
+        clinit.writeStaticField(fieldCreator.getFieldDescriptor(), namesArray);
+        clinit.returnVoid();
     }
 
     private BranchResult iteratorHasNext(BytecodeCreator creator, ResultHandle iterator) {
@@ -604,9 +744,11 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
         return super.shouldGenerateCodeFor(classInfo) && classInfo.hasNoArgsConstructor();
     }
 
+    private static final String TRANSLATABLE_FIELD_NAMES = "TRANSLATABLE_FIELD_NAMES";
+
     private record DeserializationData(ClassInfo classInfo, MethodInfo constructor, ClassCreator classCreator,
             MethodCreator methodCreator,
             ResultHandle jsonNode, Map<String, Integer> typeParametersIndex, Set<String> constructorFields,
-            PropertyNamingStrategy namingStrategy) {
+            PropertyNamingStrategy namingStrategy, ResultHandle strategyHandle, ResultHandle reverseIndexHandle) {
     }
 }

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.core.SerializableString;
 import com.fasterxml.jackson.core.io.SerializedString;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.SerializationConfig;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
@@ -84,24 +85,50 @@ import io.quarkus.resteasy.reactive.jackson.runtime.mappers.JacksonMapperUtil;
  *         super(Person.class);
  *     }
  *
- *     public void serialize(Object var1, JsonGenerator var2, SerializerProvider var3) throws IOException {
- *         Person var4 = (Person) var1;
- *         var2.writeStartObject();
- *         var2.writeFieldName(SerializedStrings$quarkusjacksonserializer.age);
- *         int var5 = var4.getAge();
- *         var2.writeNumber(var5);
- *         var2.writeFieldName(SerializedStrings$quarkusjacksonserializer.firstName);
- *         String var6 = var4.getFirstName();
- *         var2.writeString(var6);
- *         var2.writeFieldName(SerializedStrings$quarkusjacksonserializer.familyName);
- *         String var7 = var4.getLastName();
- *         var2.writeString(var7);
- *         if (JacksonMapperUtil.includeSecureField(address_ROLES_ALLOWED)) {
- *             var2.writeFieldName(SerializedStrings$quarkusjacksonserializer.address);
- *             Address var9 = var4.getAddress();
- *             JacksonSerializationUtils.serializePojo(var9, var2, var3);
+ *     public void serialize(Object object, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+ *             throws IOException {
+ *         Person person = (Person) object;
+ *         SerializationInclude serializationInclude = SerializationInclude.decode(object, serializerProvider);
+ *         PropertyNamingStrategy propertyNamingStrategy = serializerProvider.getConfig().getPropertyNamingStrategy();
+ *         jsonGenerator.writeStartObject();
+ *         if (JacksonMapperUtil.includeSecureField(serializerProvider, address_ROLES_ALLOWED)) {
+ *             Address address = person.getAddress();
+ *             if (serializationInclude.shouldSerialize(address)) {
+ *                 JacksonMapperUtil.writeFieldName(jsonGenerator, propertyNamingStrategy, "address",
+ *                         SerializedStrings$quarkusjacksonserializer.address);
+ *                 JacksonMapperUtil.serializePojo(address, jsonGenerator, serializerProvider);
+ *             }
  *         }
- *         var2.writeEndObject();
+ *
+ *         int age = person.getAge();
+ *         if (serializationInclude.shouldSerialize(age)) {
+ *             JacksonMapperUtil.writeFieldName(jsonGenerator, propertyNamingStrategy, "age",
+ *                     SerializedStrings$quarkusjacksonserializer.age);
+ *             jsonGenerator.writeNumber(age);
+ *         }
+ *
+ *         String firstName = person.getFirstName();
+ *         if (serializationInclude.shouldSerialize(firstName)) {
+ *             JacksonMapperUtil.writeFieldName(jsonGenerator, propertyNamingStrategy, "firstName",
+ *                     SerializedStrings$quarkusjacksonserializer.firstName);
+ *             jsonGenerator.writeString(firstName);
+ *         }
+ *
+ *         String familyName = person.getLastName();
+ *         if (serializationInclude.shouldSerialize(familyName)) {
+ *             // familyName has an explicit json name, so we ignore the property naming strategy
+ *             jsonGenerator.writeFieldName(SerializedStrings$quarkusjacksonserializer.familyName);
+ *             jsonGenerator.writeString(familyName);
+ *         }
+ *
+ *         String lastName = person.getLastName();
+ *         if (serializationInclude.shouldSerialize(lastName)) {
+ *             JacksonMapperUtil.writeFieldName(jsonGenerator, propertyNamingStrategy, "lastName",
+ *                     SerializedStrings$quarkusjacksonserializer.lastName);
+ *             jsonGenerator.writeString(lastName);
+ *         }
+ *
+ *         jsonGenerator.writeEndObject();
  *     }
  * }
  *
@@ -348,7 +375,7 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
                     : bytecode;
 
             if (pkgName != null) {
-                writeFieldName(fieldSpecs, primitiveBytecode, ctx.jsonGenerator, pkgName);
+                writeFieldName(fieldSpecs, primitiveBytecode, ctx, pkgName);
             }
 
             MethodDescriptor primitiveWriter = MethodDescriptor.ofMethod(JSON_GEN_CLASS_NAME, primitiveMethodName, "void",
@@ -358,7 +385,7 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
         } else {
             if (pkgName != null) {
                 registerTypeToBeGenerated(fieldSpecs.fieldType, typeName);
-                writeFieldName(fieldSpecs, bytecode, ctx.jsonGenerator, pkgName);
+                writeFieldName(fieldSpecs, bytecode, ctx, pkgName);
             }
 
             MethodDescriptor serializePojoMethod = MethodDescriptor.ofMethod(JacksonMapperUtil.class.getName(),
@@ -376,14 +403,22 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
         return bytecode.ifTrue(included).trueBranch();
     }
 
-    private static void writeFieldName(FieldSpecs fieldSpecs, BytecodeCreator bytecode, ResultHandle jsonGenerator,
+    private static void writeFieldName(FieldSpecs fieldSpecs, BytecodeCreator bytecode, SerializationContext ctx,
             String pkgName) {
-        MethodDescriptor writeFieldName = MethodDescriptor.ofMethod(JSON_GEN_CLASS_NAME, "writeFieldName", void.class,
-                SerializableString.class);
         ResultHandle serStringHandle = bytecode.readStaticField(
                 FieldDescriptor.of(pkgName + "." + SER_STRINGS_CLASS_NAME, fieldSpecs.jsonName,
                         SerializedString.class.getName()));
-        bytecode.invokeVirtualMethod(writeFieldName, jsonGenerator, serStringHandle);
+
+        if (fieldSpecs.hasExplicitJsonName) {
+            MethodDescriptor writeFieldName = MethodDescriptor.ofMethod(JSON_GEN_CLASS_NAME, "writeFieldName", void.class,
+                    SerializableString.class);
+            bytecode.invokeVirtualMethod(writeFieldName, ctx.jsonGenerator, serStringHandle);
+        } else {
+            MethodDescriptor writeFieldNameUtil = MethodDescriptor.ofMethod(JacksonMapperUtil.class, "writeFieldName",
+                    void.class, JsonGenerator.class, PropertyNamingStrategy.class, String.class, SerializableString.class);
+            bytecode.invokeStaticMethod(writeFieldNameUtil, ctx.jsonGenerator, ctx.strategyHandle,
+                    bytecode.load(fieldSpecs.fieldName), serStringHandle);
+        }
     }
 
     private String writeMethodForPrimitiveFields(String typeName) {
@@ -456,10 +491,10 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
     }
 
     private record SerializationContext(ResultHandle valueHandle, ResultHandle jsonGenerator, ResultHandle serializerProvider,
-            ResultHandle includeHandle) {
+            ResultHandle includeHandle, ResultHandle strategyHandle) {
         SerializationContext(MethodCreator serialize, String beanClassName) {
             this(valueHandle(serialize, beanClassName), serialize.getMethodParam(1), serialize.getMethodParam(2),
-                    includeHandle(serialize));
+                    includeHandle(serialize), strategyHandle(serialize));
         }
 
         private static ResultHandle valueHandle(MethodCreator serialize, String beanClassName) {
@@ -470,6 +505,16 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
             MethodDescriptor decodeInclude = MethodDescriptor.ofMethod(JacksonMapperUtil.SerializationInclude.class, "decode",
                     JacksonMapperUtil.SerializationInclude.class, Object.class, SerializerProvider.class);
             return serialize.invokeStaticMethod(decodeInclude, serialize.getMethodParam(0), serialize.getMethodParam(2));
+        }
+
+        private static ResultHandle strategyHandle(MethodCreator serialize) {
+            ResultHandle config = serialize.invokeVirtualMethod(
+                    MethodDescriptor.ofMethod(SerializerProvider.class, "getConfig", SerializationConfig.class),
+                    serialize.getMethodParam(2));
+            return serialize.invokeVirtualMethod(
+                    MethodDescriptor.ofMethod(SerializationConfig.class, "getPropertyNamingStrategy",
+                            PropertyNamingStrategy.class),
+                    config);
         }
     }
 }

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/GlobalNamingRequest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/GlobalNamingRequest.java
@@ -1,0 +1,11 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/// A simple record with camelCase field names and NO {@code @JsonNaming} annotation.
+/// Relies solely on the global {@code PropertyNamingStrategy} configured on the ObjectMapper.
+/// The {@code yearsOld} field has an explicit {@code @JsonProperty("age")} which must
+/// take precedence over the global strategy (i.e. it must NOT be translated to {@code years_old}
+/// by the strategy — it already is {@code age} via the annotation).
+public record GlobalNamingRequest(String firstName, String lastName, @JsonProperty("age") int yearsOld) {
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/GlobalNamingResource.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/GlobalNamingResource.java
@@ -1,0 +1,26 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/global-naming")
+public class GlobalNamingResource {
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public String echo(GlobalNamingRequest request) {
+        return "{\"values\":\"" + request.firstName() + " " + request.lastName() + " " + request.yearsOld() + "\"}";
+    }
+
+    @GET
+    @Path("/ser")
+    @Produces(MediaType.APPLICATION_JSON)
+    public GlobalNamingRequest get() {
+        return new GlobalNamingRequest("Alice", "Smith", 30);
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/GlobalNamingWithReflectionFreeSerializersTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/GlobalNamingWithReflectionFreeSerializersTest.java
@@ -1,0 +1,73 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import static io.restassured.RestAssured.given;
+
+import java.util.function.Supplier;
+
+import org.hamcrest.CoreMatchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * Reproducer for <a href="https://github.com/quarkusio/quarkus/issues/53588">quarkusio/quarkus#53588</a> (point 1):
+ * reflection-free Jackson serializers/deserializers ignore the ObjectMapper-level
+ * {@code PropertyNamingStrategy} configured via {@code ObjectMapperCustomizer}.
+ *
+ * <p>
+ * This test sets up a global {@code SNAKE_CASE} strategy through {@link SnakeCaseObjectMapperCustomizer}
+ * and verifies that a plain record ({@link GlobalNamingRequest}) with camelCase field names
+ * serializes/deserializes using snake_case JSON field names.
+ *
+ * <p>
+ * Expected: both tests pass (snake_case names are used in JSON).
+ * <br>
+ * Actual (bug): the generated reflection-free serializer/deserializer ignores the global strategy
+ * and uses the raw Java field names (camelCase), causing assertion failures.
+ */
+public class GlobalNamingWithReflectionFreeSerializersTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(GlobalNamingRequest.class, GlobalNamingResource.class,
+                                    SnakeCaseObjectMapperCustomizer.class)
+                            .addAsResource(new StringAsset(
+                                    "quarkus.rest.jackson.optimization.enable-reflection-free-serializers=true\n"),
+                                    "application.properties");
+                }
+            });
+
+    @Test
+    void naming_globalSnakeCase_shouldDeserialize() {
+        given()
+                .contentType("application/json")
+                .body("""
+                        {"first_name": "Alice", "last_name": "Smith", "age": 30}
+                        """)
+                .when()
+                .post("/global-naming")
+                .then()
+                .statusCode(200)
+                .body("values", CoreMatchers.is("Alice Smith 30"));
+    }
+
+    @Test
+    void naming_globalSnakeCase_shouldSerialize() {
+        given()
+                .when()
+                .get("/global-naming/ser")
+                .then()
+                .statusCode(200)
+                .body("first_name", CoreMatchers.is("Alice"))
+                .body("last_name", CoreMatchers.is("Smith"))
+                .body("age", CoreMatchers.is(30));
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SnakeCaseObjectMapperCustomizer.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SnakeCaseObjectMapperCustomizer.java
@@ -1,0 +1,17 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import jakarta.inject.Singleton;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+
+import io.quarkus.jackson.ObjectMapperCustomizer;
+
+@Singleton
+public class SnakeCaseObjectMapperCustomizer implements ObjectMapperCustomizer {
+
+    @Override
+    public void customize(ObjectMapper objectMapper) {
+        objectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/mappers/JacksonMapperUtil.java
+++ b/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/mappers/JacksonMapperUtil.java
@@ -4,16 +4,19 @@ import java.io.IOException;
 import java.lang.reflect.Array;
 import java.lang.reflect.Type;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.SerializableString;
 import com.fasterxml.jackson.databind.BeanProperty;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.SerializerProvider;
 
 import io.quarkus.arc.Arc;
@@ -54,6 +57,34 @@ public class JacksonMapperUtil {
             }
         }
         return false;
+    }
+
+    /**
+     * Writes a field name to the JSON generator, translating through the ObjectMapper's
+     * {@link PropertyNamingStrategy} if one is configured.
+     * When no strategy is set, the pre-encoded {@code defaultName} is used for zero overhead.
+     */
+    public static void writeFieldName(JsonGenerator gen, PropertyNamingStrategy strategy,
+            String javaFieldName, SerializableString defaultName) throws IOException {
+        if (strategy == null) {
+            gen.writeFieldName(defaultName);
+        } else {
+            gen.writeFieldName(strategy.nameForField(null, null, javaFieldName));
+        }
+    }
+
+    /**
+     * Builds a reverse-translation index mapping strategy-translated JSON field names back to
+     * Java field names. Called once at the start of deserialization so that per-field lookups
+     * are O(1) via {@link Map#getOrDefault} instead of O(n) scans.
+     */
+    public static Map<String, String> buildReverseNameIndex(PropertyNamingStrategy strategy,
+            String[] translatableFieldNames) {
+        Map<String, String> index = new HashMap<>();
+        for (String javaName : translatableFieldNames) {
+            index.put(strategy.nameForField(null, null, javaName), javaName);
+        }
+        return index;
     }
 
     /**


### PR DESCRIPTION
This pull request fixes the second part of the issue 1. reported here #53588

This fix requires runtime resolution since the `ObjectMapper`-level strategy is only known at runtime. First of all this runtime resolution has to skip all fields explicitly annotated with `@JsonProperty` which are immune to runtime strategy. All other fields are flagged as translatable. Then the following algorithms are applied:

- For seriailzation: At the start of `serialize()`, gets the strategy from `SerializerProvider.getConfig().` For translatable fields, instead of writing the static SerializedString directly, calls the new utility method `JacksonMapperUtil.writeFieldName` that translate the field name using the `PropertyNamingStrategy` if any or uses the pre-encoded default if not.

- For deseriailzation: At the start of `deserialize()`, get the strategy from DeserializationContext.getConfig() and if present creates a translation map that will be used to reverse-translate the incoming field name and use the proper setter method to set the value in the pojo to be deserialized.

This runtime resolution only applies when the class does NOT have `@JsonNaming` which is already handled at build time and takes precedence per Jackson semantics.

A sample of the code generated for both serialization and deserialization is available in the javadocs of the respective factories.