### PR TITLE
Revert "Publish our snapshots to a GitHub repository"

### DIFF
--- a/.github/mvn-settings.xml
+++ b/.github/mvn-settings.xml
@@ -1,12 +1,5 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
-  <servers>
-    <server>
-      <id>github-quarkus</id>
-      <username>${env.GITHUB_ACTOR}</username>
-      <password>${env.GITHUB_TOKEN}</password>
-    </server>
-  </servers>
   <profiles>
     <profile>
       <id>google-mirror</id>
@@ -39,11 +32,15 @@
     </profile>
     <profile>
       <id>snapshots</id>
+      <properties>
+        <!-- https://docs.aws.amazon.com/codeartifact/latest/ug/maven-troubleshooting.html#disable-parallel-puts -->
+        <aether.connector.basic.parallelPut>false</aether.connector.basic.parallelPut>
+      </properties>
       <repositories>
         <repository>
-          <id>github-quarkus</id>
-          <name>Quarkus GitHub Packages Snapshots</name>
-          <url>https://maven.pkg.github.com/quarkusio/quarkus</url>
+          <id>sonatype-maven-central</id>
+          <name>Sonatype Maven Central Snapshots</name>
+          <url>https://central.sonatype.com/repository/maven-snapshots/</url>
           <layout>default</layout>
           <releases>
             <enabled>false</enabled>
@@ -57,9 +54,9 @@
       </repositories>
       <pluginRepositories>
         <pluginRepository>
-          <id>github-quarkus</id>
-          <name>Quarkus GitHub Packages Snapshots</name>
-          <url>https://maven.pkg.github.com/quarkusio/quarkus</url>
+          <id>sonatype-maven-central</id>
+          <name>Sonatype Maven Central Snapshots</name>
+          <url>https://central.sonatype.com/repository/maven-snapshots/</url>
           <layout>default</layout>
           <releases>
             <enabled>false</enabled>

--- a/.github/release-settings.xml
+++ b/.github/release-settings.xml
@@ -16,15 +16,6 @@
                 <njord.snapshotUrl>njord:template:snapshot-sca</njord.snapshotUrl>
             </configuration>
         </server>
-        <server>
-            <id>github</id>
-            <username>${env.GITHUB_ACTOR}</username>
-            <password>${env.GITHUB_TOKEN}</password>
-            <configuration>
-                <njord.publisher>deploy</njord.publisher>
-                <njord.snapshotUrl>njord:template:snapshot-sca</njord.snapshotUrl>
-            </configuration>
-        </server>
     </servers>
 
     <!-- Enable Google mirror to avoid hammering Maven Central -->
@@ -60,6 +51,10 @@
         </profile>
         <profile>
           <id>snapshots</id>
+          <properties>
+            <!-- https://docs.aws.amazon.com/codeartifact/latest/ug/maven-troubleshooting.html#disable-parallel-puts -->
+            <aether.connector.basic.parallelPut>false</aether.connector.basic.parallelPut>
+          </properties>
         </profile>
     </profiles>
     <activeProfiles>

--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -3,7 +3,7 @@ name: Quarkus Deploy Snapshots
 permissions:
   contents: read
   issues: write
-  packages: write
+  packages: read
 
 on:
   schedule:
@@ -55,7 +55,9 @@ jobs:
             ${{ steps.cache-key.outputs.m2-monthly-cache-key }}-
       - name: Build and Deploy
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_API_TOKEN }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
         run: |
           ./mvnw -e -B --no-transfer-progress --settings .github/release-settings.xml \
             -Dnjord.autoPublish \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,7 @@ what you would expect to see. Don't forget to indicate your Quarkus, Java, Maven
 Sometimes a bug has been fixed in the `main` branch of Quarkus and you want to confirm it is fixed for your own
 application. There are two simple options for testing the `main` branch:
 
-* either use the snapshots we publish daily on [GitHub Packages](https://github.com/quarkusio/quarkus/packages)
+* either use the snapshots we publish daily on <https://central.sonatype.com/repository/maven-snapshots>
 * or build Quarkus locally
 
 The following is a quick summary aimed at allowing you to quickly test `main`. If you are interested in learning more details, refer to
@@ -114,36 +114,23 @@ the [Build section](#build) and the [Usage section](#usage).
 
 ### Using snapshots
 
-Snapshots are published daily with version `999-SNAPSHOT` to GitHub Packages, so you will have to wait for a snapshot containing the commits you are interested in.
+Snapshots are published daily with version `999-SNAPSHOT`, so you will have to wait for a snapshot containing the commits you are interested in.
 
-> **Note:** GitHub Packages requires authentication even for reading public packages.
-> You will need a GitHub Personal Access Token with the `read:packages` scope.
-> You can create one at <https://github.com/settings/tokens>.
-
-Add the GitHub Packages repository as a Maven repository **and** a plugin
-repository in your `settings.xml` (which should be placed in the `.m2` directory within your home directory).
-Replace `YOUR_GITHUB_USERNAME` and `YOUR_GITHUB_TOKEN` with your credentials
-(you can also use environment variables or [Maven password encryption](https://maven.apache.org/guides/mini/guide-encryption.html) to avoid storing credentials in plain text):
+Then just add <https://central.sonatype.com/repository/maven-snapshots> as a Maven repository **and** a plugin
+repository in your `settings xml` (which should be placed in the `.m2` directory within your home directory):
 
 ```xml
 
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
-    <servers>
-        <server>
-            <id>github-quarkus</id>
-            <username>YOUR_GITHUB_USERNAME</username>
-            <password>YOUR_GITHUB_TOKEN</password>
-        </server>
-    </servers>
     <profiles>
         <profile>
             <id>quarkus-snapshots</id>
             <repositories>
                 <repository>
-                    <id>github-quarkus</id>
-                    <url>https://maven.pkg.github.com/quarkusio/quarkus</url>
+                    <id>quarkus-snapshots-repository</id>
+                    <url>https://central.sonatype.com/repository/maven-snapshots/</url>
                     <releases>
                         <enabled>false</enabled>
                     </releases>
@@ -154,8 +141,8 @@ Replace `YOUR_GITHUB_USERNAME` and `YOUR_GITHUB_TOKEN` with your credentials
             </repositories>
             <pluginRepositories>
                 <pluginRepository>
-                    <id>github-quarkus</id>
-                    <url>https://maven.pkg.github.com/quarkusio/quarkus</url>
+                    <id>quarkus-snapshots-plugin-repository</id>
+                    <url>https://central.sonatype.com/repository/maven-snapshots/</url>
                     <releases>
                         <enabled>false</enabled>
                     </releases>
@@ -171,6 +158,8 @@ Replace `YOUR_GITHUB_USERNAME` and `YOUR_GITHUB_TOKEN` with your credentials
     </activeProfiles>
 </settings>
 ```
+
+You can check the last publication date here: <https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/io/quarkus/quarkus-core/999-SNAPSHOT/>.
 
 ### Building main
 
@@ -865,14 +854,10 @@ repositories {
 }
 ```
 
-**Note**  Use the following definition in `repositories` section when using daily snapshot builds instead of local builds (requires authentication, see [Using snapshots](#using-snapshots)):
+**Note**  Use the following definition in `repositories` section when using daily snapshot builds instead of local builds:
 ```gradle
     maven {
-        url 'https://maven.pkg.github.com/quarkusio/quarkus'
-        credentials {
-            username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_USERNAME")
-            password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
-        }
+        url 'https://central.sonatype.com/repository/maven-snapshots/'
     }
 ```
 

--- a/independent-projects/parent/pom.xml
+++ b/independent-projects/parent/pom.xml
@@ -120,9 +120,9 @@
             <url>https://repo.maven.apache.org/maven2</url>
         </repository>
         <snapshotRepository>
-            <id>github</id>
+            <id>quarkus-publish</id>
             <name>Quarkus Snapshots</name>
-            <url>https://maven.pkg.github.com/quarkusio/quarkus</url>
+            <url>https://central.sonatype.com/repository/maven-snapshots</url>
         </snapshotRepository>
     </distributionManagement>
 


### PR DESCRIPTION
This reverts commit 0ff4e16252775d62eeefe9a038a39d7495675e87.

This patch is causing issues with our releases and given it doesn't work either, we'd better drop it.