### PR TITLE
REST + JSON: ignore private methods

### DIFF
--- a/extensions/resteasy-classic/resteasy-common/spi/src/main/java/io/quarkus/resteasy/common/spi/ResteasyDotNames.java
+++ b/extensions/resteasy-classic/resteasy-common/spi/src/main/java/io/quarkus/resteasy/common/spi/ResteasyDotNames.java
@@ -1,5 +1,6 @@
 package io.quarkus.resteasy.common.spi;
 
+import java.lang.reflect.Modifier;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -96,7 +97,10 @@ public final class ResteasyDotNames {
 
         @Override
         public boolean test(MethodInfo methodInfo) {
-            return methodInfo.hasAnnotation(JSON_IGNORE)
+            // Non-public methods are not required by JSON serialisation, and may lead to leaking of implementation
+            // types that we should not register.
+            return !Modifier.isPublic(methodInfo.flags())
+                    || methodInfo.hasAnnotation(JSON_IGNORE)
                     || methodInfo.hasAnnotation(JSONB_TRANSIENT)
                     || methodInfo.hasAnnotation(XML_TRANSIENT);
         }

--- a/extensions/resteasy-reactive/rest-common/deployment/src/main/java/io/quarkus/resteasy/reactive/common/deployment/QuarkusResteasyReactiveDotNames.java
+++ b/extensions/resteasy-reactive/rest-common/deployment/src/main/java/io/quarkus/resteasy/reactive/common/deployment/QuarkusResteasyReactiveDotNames.java
@@ -1,5 +1,6 @@
 package io.quarkus.resteasy.reactive.common.deployment;
 
+import java.lang.reflect.Modifier;
 import java.util.function.Predicate;
 
 import org.jboss.jandex.DotName;
@@ -70,7 +71,10 @@ public class QuarkusResteasyReactiveDotNames {
 
         @Override
         public boolean test(MethodInfo methodInfo) {
-            return methodInfo.hasAnnotation(JSON_IGNORE)
+            // Non-public methods are not required by JSON serialisation, and may lead to leaking of implementation
+            // types that we should not register.
+            return !Modifier.isPublic(methodInfo.flags())
+                    || methodInfo.hasAnnotation(JSON_IGNORE)
                     || methodInfo.hasAnnotation(JSONB_TRANSIENT);
         }
     }


### PR DESCRIPTION
This is not used by serialisers, and exposes internal types to reflection

See #53629

I did not add a specific test for it, as I've one in #53629 that is already fixed by adding JSON ignore annotations. I think I'd rather keep those annotations "just in case" but I'm not entirely sure.

WDYT @gsmet  ?