### PR TITLE
Use addHeadersEndHandler instead of addEndHandler for Undertow compression

### DIFF
--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/compress/CompressionEnabledTestCase.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/compress/CompressionEnabledTestCase.java
@@ -3,7 +3,7 @@ package io.quarkus.undertow.test.compress;
 import static io.restassured.RestAssured.get;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusExtensionTest;
@@ -16,7 +16,7 @@ public class CompressionEnabledTestCase {
                     .addClasses(SimpleServlet.class))
             .overrideConfigKey("quarkus.http.enable-compression", "true");
 
-    @Test
+    @RepeatedTest(1000)
     public void testCompressed() throws Exception {
         String bodyStr = get(SimpleServlet.SERVLET_ENDPOINT).then().statusCode(200).header("Content-Encoding", "gzip").extract()
                 .asString();

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
@@ -109,7 +109,6 @@ import io.undertow.servlet.spec.ServletContextImpl;
 import io.undertow.util.AttachmentKey;
 import io.undertow.util.ImmediateAuthenticationMechanismFactory;
 import io.undertow.vertx.VertxHttpExchange;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 
@@ -440,16 +439,12 @@ public class UndertowDeploymentRecorder {
                         event.getBody());
                 exchange.setPushHandler(VertxHttpRecorder.getRootHandler());
 
-                // Note that we can't add an end handler in a separate HttpCompressionHandler because VertxHttpExchange does set
-                // its own end handler and so the end handlers added previously are just ignored...
                 if (!compressMediaTypes.isEmpty()) {
-                    event.addEndHandler(new Handler<AsyncResult<Void>>() {
+                    event.addHeadersEndHandler(new Handler<Void>() {
 
                         @Override
-                        public void handle(AsyncResult<Void> result) {
-                            if (result.succeeded()) {
-                                HttpCompressionHandler.compressIfNeeded(event, compressMediaTypes);
-                            }
+                        public void handle(Void result) {
+                            HttpCompressionHandler.compressIfNeeded(event, compressMediaTypes);
                         }
                     });
                 }


### PR DESCRIPTION
This is necessary to re-revert https://github.com/eclipse-vertx/vert.x/pull/5619 and fix https://github.com/eclipse-vertx/vert.x/issues/6063#issuecomment-4247345661 as well.

In `UndertowDeploymentRecorder.java` (around line 443):

```java
// Note that we can't add an end handler in a separate HttpCompressionHandler because VertxHttpExchange does set
// its own end handler and so the end handlers added previously are just ignored...
if (!compressMediaTypes.isEmpty()) {
    event.addEndHandler(new Handler<AsyncResult<Void>>() {
        @Override
        public void handle(AsyncResult<Void> result) {
            if (result.succeeded()) {
                HttpCompressionHandler.compressIfNeeded(event, compressMediaTypes);
            }
        }
    });
}
```

The comment explains why `HttpCompressionHandler` (which correctly uses `addHeadersEndHandler`) can't be used as a separate handler: `VertxHttpExchange` sets its own end handler on the response, which replaces previously added end handlers.

However, `addHeadersEndHandler` does **not** have this problem because `VertxHttpExchange` does not set `headersEndHandler` on the response.

FYI other handlers, does it right already: https://github.com/quarkusio/quarkus/blob/1cb7a63b55d120b909d38afc92c2da828c72cf7e/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLCompressionHandler.java

- Fixes: #53645