### PR TITLE
Remove deprecated datasource.jdbc.enable-metrics which was once removed

### DIFF
--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -1832,7 +1832,7 @@ void registerMetrics(AgroalMetricsRecorder recorder,
         // IFF metrics are enabled globally and for the data source
         // (they are enabled for each data source by default if they are also enabled globally)
         if (dataSourcesBuildTimeConfig.metricsEnabled &&
-                aggregatedDataSourceBuildTimeConfig.getJdbcConfig().enableMetrics.orElse(true)) {
+                aggregatedDataSourceBuildTimeConfig.getJdbcConfig().metrics().enabled().orElse(true)) {
             datasourceMetrics.produce(new MetricsFactoryConsumerBuildItem(
                     recorder.registerDataSourceMetrics(aggregatedDataSourceBuildTimeConfig.getName())));
         }

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcBuildTimeConfig.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcBuildTimeConfig.java
@@ -32,15 +32,6 @@ public interface DataSourceJdbcBuildTimeConfig {
     TransactionIntegration transactions();
 
     /**
-     * Enable datasource metrics collection. If unspecified, collecting metrics will be enabled by default if
-     * a metrics extension is active.
-     * <p>
-     * Please use quarkus-micrometer and the quarkus.datasource.metrics.enabled property
-     */
-    @Deprecated(forRemoval = true)
-    Optional<Boolean> enableMetrics();
-
-    /**
      * Enable OpenTelemetry JDBC instrumentation.
      */
     @WithDefault("false")


### PR DESCRIPTION
Removing the `quarkus.datasource.jdbc.enable-metrics`. This property was removed in https://github.com/quarkusio/quarkus/pull/50825 (3.30) and again added in https://github.com/quarkusio/quarkus/pull/49735

Searching in PR which add it and I don't see any usage of it, so it's possible that it was added by mistake when resolving conflicts


Also I spotted that the docs using old example of code so it's updated base on changes in https://github.com/quarkusio/quarkus/pull/50825