### PR TITLE
Include Dev MCP methods in composed skill resources

### DIFF
--- a/docs/src/main/asciidoc/dev-mcp.adoc
+++ b/docs/src/main/asciidoc/dev-mcp.adoc
@@ -35,59 +35,6 @@ image::dev_mcp_settings.png[Dev MCP Settings]
 Extensions can contribute additional tools and resources to the Dev MCP server. The integration is similar to contributing to the xref:dev-ui.adoc[Dev UI], but descriptions are mandatory. 
 A single JSON‑RPC service can be used for both Dev UI and Dev MCP; methods without a description only show up in Dev UI, while methods with a description appear in both.
 
-=== MCP resources
-
-A resource is data exposed by your extension. There are two ways to create a resource.
-
-==== MCP Resources against build time data
-
-Build‑time data that is already exposed to the xref:dev-ui.adoc#optional-build-time-data[Dev UI] can also be made available to Dev MCP. Provide a description when calling `addBuildTimeData()`:
-
-[source,java]
-----
-footerPageBuildItem.addBuildTimeData(
-    "jokes",
-    jokesBuildItem.getJokes(),
-    "Some funny jokes that the user might enjoy"
-);
-----
-
-The extra `description` argument is new: without it the data only appears in the Dev UI. Once supplied, the `jokes` data becomes an MCP resource, however, by default this resource will be disabled. You can change the default by passing in `true` as another parameter after description, that will change this default to be enabled. Users can change this in Dev UI anyway, so this is just a sensible default.
-
-[source,java]
-----
-footerPageBuildItem.addBuildTimeData(
-    "jokes",
-    jokesBuildItem.getJokes(),
-    "Some funny jokes that the user might enjoy",
-    true
-);
-----
-
-==== MCP Resources against a recorded value
-
-To expose recorded values (data produced at runtime by a recorder) as an MCP resource, define a xref:dev-ui.adoc#jsonrpc-against-a-recorded-value[build‑time action] in the deployment module. The action must include a description:
-
-[source,java]
-----
-@BuildStep(onlyIf = IsLocalDevelopment.class)
-BuildTimeActionBuildItem createBuildTimeActions() {
-    BuildTimeActionBuildItem item = new BuildTimeActionBuildItem(); //<1>
-    item.actionBuilder() //<2>
-            .methodName("getMyRecordedValue")
-            .description("A well‑thought‑out description") //<3>
-            .runtime(runtimeValue) //<4>
-            .build();
-    return item;
-}
-----
-<1> Return or produce a `BuildTimeActionBuildItem`.
-<2> Use the builder to configure the action.
-<3> Set a human‑readable description.
-<4> Provide the runtime value returned by your recorder.
-
-By default this resource will be disabled, and the user has to enable it in Dev UI. You can change this default by adding `.enableMcpFunctionByDefault()` in the builder method.
-
 === Extension skills
 
 Extensions can ship a `quarkus-skill.md` file to provide AI coding agents with extension-specific coding guidelines, testing patterns, and common pitfalls. During the Quarkus build, all skill files are automatically discovered, composed with extension metadata (name, description, guide URL), and aggregated into a single `io.quarkus:quarkus-extension-skills` JAR following the https://agentskills.io/specification[Agent Skills specification]. This JAR is published to Maven Central with each Quarkus release and is compatible with https://www.skillsjars.com[SkillsJars].
@@ -147,6 +94,7 @@ The skill file content is **not** shipped as-is. During the Quarkus build, the `
 
 1. **YAML frontmatter** — the skill name, extension description from `quarkus-extension.yaml`, license, and guide URL as structured metadata for agent discovery.
 2. **Skill body** — the patterns, testing guidelines, and pitfalls authored by the extension developer.
+3. **Dev MCP tools** — the skill is automatically enriched with an "Available Dev MCP Tools" section listing each MCP tool the extension enables by default, including tool names, descriptions, and parameters. Tools are discovered from runtime methods annotated with both `@JsonRpcDescription` and `@DevMCPEnableByDefault`, and from deployment processor classes annotated with `@DevMcpBuildTimeTool`.
 
 Example of a composed `SKILL.md`:
 
@@ -162,7 +110,38 @@ metadata:
 
 ### Data Access
 ...
+
+### Available Dev MCP Tools
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `quarkus-my-extension_getData` | Get current status | — |
+| `quarkus-my-extension_updateValue` | Update a value | `name` (required): The name, `value` (required): The new value |
 ----
+
+The Dev MCP tools section is appended during the Quarkus build by the `aggregate-skills` Maven goal. Only tools that are enabled by default are included. All modules are scanned via Jandex on compiled classes. The enriched skills are baked into the `quarkus-extension-skills` JAR published with each Quarkus release.
+
+For **runtime methods**, add both `@JsonRpcDescription` and `@DevMCPEnableByDefault` annotations on the method (see <<MCP Tools against the Runtime classpath>>).
+
+For **deployment build-time actions**, annotate the processor class with `@DevMcpBuildTimeTool`:
+
+[source,java]
+----
+@DevMcpBuildTimeTool(name = "updateProperty", // <1>
+    description = "Update a configuration property", // <2>
+    params = {
+        @DevMcpParam(name = "name", description = "The property name"), // <3>
+        @DevMcpParam(name = "value", description = "The new value")
+    })
+public class ConfigurationProcessor {
+    // ...
+}
+----
+<1> The tool name, matching the `methodName` in the builder chain.
+<2> A human-readable description of what this tool does.
+<3> Parameter descriptions. Use `required = false` for optional parameters.
+
+The annotation is repeatable — add one per tool on the same class. This is the deployment-classpath counterpart of `@JsonRpcDescription` + `@DevMCPEnableByDefault` used on runtime methods.
 
 ==== What NOT to put in the skill file
 
@@ -242,6 +221,59 @@ BuildTimeActionBuildItem createBuildTimeActions() {
 The code in the `function` runs on the deployment classpath. The function can return a plain value, a `CompletionStage` or `CompletableFuture` for asynchronous work.
 
 By default this tool will be disabled, and the user has to enable it in Dev UI. You can change this default by adding `.enableMcpFunctionByDefault()` in the builder method.
+
+=== MCP resources
+
+A resource is data exposed by your extension. There are two ways to create a resource.
+
+==== MCP Resources against build time data
+
+Build‑time data that is already exposed to the xref:dev-ui.adoc#optional-build-time-data[Dev UI] can also be made available to Dev MCP. Provide a description when calling `addBuildTimeData()`:
+
+[source,java]
+----
+footerPageBuildItem.addBuildTimeData(
+    "jokes",
+    jokesBuildItem.getJokes(),
+    "Some funny jokes that the user might enjoy"
+);
+----
+
+The extra `description` argument is new: without it the data only appears in the Dev UI. Once supplied, the `jokes` data becomes an MCP resource, however, by default this resource will be disabled. You can change the default by passing in `true` as another parameter after description, that will change this default to be enabled. Users can change this in Dev UI anyway, so this is just a sensible default.
+
+[source,java]
+----
+footerPageBuildItem.addBuildTimeData(
+    "jokes",
+    jokesBuildItem.getJokes(),
+    "Some funny jokes that the user might enjoy",
+    true
+);
+----
+
+==== MCP Resources against a recorded value
+
+To expose recorded values (data produced at runtime by a recorder) as an MCP resource, define a xref:dev-ui.adoc#jsonrpc-against-a-recorded-value[build‑time action] in the deployment module. The action must include a description:
+
+[source,java]
+----
+@BuildStep(onlyIf = IsLocalDevelopment.class)
+BuildTimeActionBuildItem createBuildTimeActions() {
+    BuildTimeActionBuildItem item = new BuildTimeActionBuildItem(); //<1>
+    item.actionBuilder() //<2>
+            .methodName("getMyRecordedValue")
+            .description("A well‑thought‑out description") //<3>
+            .runtime(runtimeValue) //<4>
+            .build();
+    return item;
+}
+----
+<1> Return or produce a `BuildTimeActionBuildItem`.
+<2> Use the builder to configure the action.
+<3> Set a human‑readable description.
+<4> Provide the runtime value returned by your recorder.
+
+By default this resource will be disabled, and the user has to enable it in Dev UI. You can change this default by adding `.enableMcpFunctionByDefault()` in the builder method.
 
 === JSON‑RPC usage
 

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/DevMcpBuildTimeTool.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/DevMcpBuildTimeTool.java
@@ -1,0 +1,51 @@
+package io.quarkus.devui.spi.buildtime;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Declares a build-time MCP tool that is enabled by default. Place this annotation
+ * on a {@code @BuildStep} processor class to make the tool discoverable via Jandex
+ * scanning at build time.
+ * <p>
+ * This annotation is the deployment-time counterpart of
+ * {@link io.quarkus.runtime.annotations.JsonRpcDescription} +
+ * {@link io.quarkus.runtime.annotations.DevMCPEnableByDefault} used on runtime JSON-RPC methods.
+ * It allows the {@code aggregate-skills} Maven goal to discover build-time MCP tools without
+ * parsing source code.
+ *
+ * <pre>
+ * &#64;DevMcpBuildTimeTool(name = "runTests", description = "Run all tests", params = {
+ *         &#64;DevMcpParam(name = "className", description = "Test class name", required = false)
+ * })
+ * public class TestingProcessor {
+ *     // ...
+ * }
+ * </pre>
+ */
+@Retention(RUNTIME)
+@Target({ TYPE })
+@Documented
+@Repeatable(DevMcpBuildTimeTools.class)
+public @interface DevMcpBuildTimeTool {
+
+    /**
+     * The tool name, matching the {@code methodName} in the {@code BuildTimeActionBuildItem} builder chain.
+     */
+    String name();
+
+    /**
+     * A human-readable description of what this tool does.
+     */
+    String description();
+
+    /**
+     * The parameters this tool accepts. Defaults to no parameters.
+     */
+    DevMcpParam[] params() default {};
+}

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/DevMcpBuildTimeTools.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/DevMcpBuildTimeTools.java
@@ -1,0 +1,19 @@
+package io.quarkus.devui.spi.buildtime;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Container annotation for repeatable {@link DevMcpBuildTimeTool} annotations.
+ */
+@Retention(RUNTIME)
+@Target({ TYPE })
+@Documented
+public @interface DevMcpBuildTimeTools {
+
+    DevMcpBuildTimeTool[] value();
+}

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/DevMcpParam.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/buildtime/DevMcpParam.java
@@ -1,0 +1,29 @@
+package io.quarkus.devui.spi.buildtime;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+
+/**
+ * Describes a parameter of a build-time MCP tool declared via {@link DevMcpBuildTimeTool}.
+ */
+@Retention(RUNTIME)
+@Documented
+public @interface DevMcpParam {
+
+    /**
+     * The parameter name.
+     */
+    String name();
+
+    /**
+     * A human-readable description of this parameter.
+     */
+    String description() default "";
+
+    /**
+     * Whether this parameter is required. Defaults to {@code true}.
+     */
+    boolean required() default true;
+}

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/exception/ExceptionProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/exception/ExceptionProcessor.java
@@ -15,10 +15,16 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.dev.ExceptionNotificationBuildItem;
 import io.quarkus.deployment.dev.RuntimeUpdatesProcessor;
 import io.quarkus.devui.spi.buildtime.BuildTimeActionBuildItem;
+import io.quarkus.devui.spi.buildtime.DevMcpBuildTimeTool;
+import io.quarkus.devui.spi.buildtime.DevMcpParam;
 
 /**
  * Exposes the last exception (compilation, deployment, or runtime) as a Dev MCP tool.
  */
+@DevMcpBuildTimeTool(name = "getLastException", description = "Get the last exception that occurred in this Quarkus application. Returns compilation errors, deployment failures, hot-reload problems, or runtime exceptions with full stack traces and source locations.", params = {
+        @DevMcpParam(name = "maxCauseDepth", description = "Maximum depth for the cause chain (default 5)", required = false)
+})
+@DevMcpBuildTimeTool(name = "clearLastException", description = "Clear the last recorded runtime exception.")
 public class ExceptionProcessor {
 
     private static final String NAMESPACE = "devui-exceptions";

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/logstream/LogStreamProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/logstream/LogStreamProcessor.java
@@ -21,11 +21,13 @@ import io.quarkus.devui.runtime.logstream.LogStreamRecorder;
 import io.quarkus.devui.runtime.logstream.MutinyLogHandler;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.buildtime.BuildTimeActionBuildItem;
+import io.quarkus.devui.spi.buildtime.DevMcpBuildTimeTool;
 import io.quarkus.runtime.RuntimeValue;
 
 /**
  * Processor for Log stream in Dev UI
  */
+@DevMcpBuildTimeTool(name = "forceRestart", description = "Force a Quarkus application restart")
 public class LogStreamProcessor {
 
     private final String namespace = "devui-logstream";

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/ConfigurationProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/ConfigurationProcessor.java
@@ -44,6 +44,8 @@ import io.quarkus.devui.runtime.config.ConfigDevUIRecorder;
 import io.quarkus.devui.runtime.config.ConfigJsonRPCService;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.buildtime.BuildTimeActionBuildItem;
+import io.quarkus.devui.spi.buildtime.DevMcpBuildTimeTool;
+import io.quarkus.devui.spi.buildtime.DevMcpParam;
 import io.quarkus.devui.spi.page.Page;
 import io.quarkus.vertx.http.runtime.devmode.ConfigDescription;
 import io.smallrye.config.ConfigValue;
@@ -52,6 +54,12 @@ import io.smallrye.config.PropertiesConfigSource;
 /**
  * This creates Extensions Page
  */
+@DevMcpBuildTimeTool(name = "updateProperty", description = "Update a configuration in the Quarkus application", params = {
+        @DevMcpParam(name = "name", description = "The name of the configuration to update"),
+        @DevMcpParam(name = "value", description = "The new value for the configuration to update"),
+        @DevMcpParam(name = "profile", description = "The profile of the configuration to update", required = false),
+        @DevMcpParam(name = "target", description = "The target configuration file to update", required = false)
+})
 public class ConfigurationProcessor {
 
     @BuildStep(onlyIf = IsLocalDevelopment.class)

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/DevServicesProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/DevServicesProcessor.java
@@ -17,11 +17,13 @@ import io.quarkus.dev.spi.DevModeType;
 import io.quarkus.devui.deployment.DevUIConfig;
 import io.quarkus.devui.deployment.InternalPageBuildItem;
 import io.quarkus.devui.spi.buildtime.BuildTimeActionBuildItem;
+import io.quarkus.devui.spi.buildtime.DevMcpBuildTimeTool;
 import io.quarkus.devui.spi.page.Page;
 
 /**
  * This creates DevServices Page
  */
+@DevMcpBuildTimeTool(name = "getDevServices", description = "Get all the DevServices started by this Quarkus app, including information on container and the config that is being set automatically")
 public class DevServicesProcessor {
 
     @BuildStep(onlyIf = IsLocalDevelopment.class)

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/ExtensionsProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/ExtensionsProcessor.java
@@ -28,11 +28,20 @@ import io.quarkus.devui.deployment.InternalPageBuildItem;
 import io.quarkus.devui.deployment.extension.Extension;
 import io.quarkus.devui.deployment.extension.ExtensionGroup;
 import io.quarkus.devui.spi.buildtime.BuildTimeActionBuildItem;
+import io.quarkus.devui.spi.buildtime.DevMcpBuildTimeTool;
+import io.quarkus.devui.spi.buildtime.DevMcpParam;
 import io.quarkus.devui.spi.page.Page;
 
 /**
  * This creates Extensions Page
  */
+@DevMcpBuildTimeTool(name = "listInstallableExtensions", description = "Get all extensions that can be added to the current project")
+@DevMcpBuildTimeTool(name = "removeExtension", description = "Remove a certain extension from the current project", params = {
+        @DevMcpParam(name = "extensionArtifactId", description = "The gav string of the extension to remove in format groupId:artifactId:version")
+})
+@DevMcpBuildTimeTool(name = "addExtension", description = "Add a certain extension to the current project", params = {
+        @DevMcpParam(name = "extensionArtifactId", description = "The gav string of the extension to add in format groupId:artifactId:version")
+})
 public class ExtensionsProcessor {
 
     @BuildStep(onlyIf = IsLocalDevelopment.class)

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/OneShotTestingProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/OneShotTestingProcessor.java
@@ -16,12 +16,20 @@ import io.quarkus.deployment.dev.testing.TestRunResults;
 import io.quarkus.deployment.dev.testing.TestSupport;
 import io.quarkus.dev.spi.DevModeType;
 import io.quarkus.devui.spi.buildtime.BuildTimeActionBuildItem;
+import io.quarkus.devui.spi.buildtime.DevMcpBuildTimeTool;
+import io.quarkus.devui.spi.buildtime.DevMcpParam;
 
 /**
  * Registers one-shot synchronous testing tools for AI coding agents.
  * These tools run tests on demand and return results directly,
  * without requiring continuous testing to be started.
  */
+@DevMcpBuildTimeTool(name = "runTests", description = "Run all tests synchronously and return the results. Does not require continuous testing to be started.")
+@DevMcpBuildTimeTool(name = "runAffectedTests", description = "Run tests affected by recent code changes synchronously and return the results. On first call, runs all tests to populate tracing data. Subsequent calls intelligently filter to only affected tests.")
+@DevMcpBuildTimeTool(name = "runTest", description = "Run a specific test synchronously and return the results. Accepts a test class name or class and method.", params = {
+        @DevMcpParam(name = "className", description = "The fully qualified test class name, e.g. com.example.MyTest"),
+        @DevMcpParam(name = "methodName", description = "The test method name to run. If not provided, all tests in the class are run.", required = false)
+})
 public class OneShotTestingProcessor {
 
     private static final String NAMESPACE = "devui-testing";

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/WorkspaceProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/WorkspaceProcessor.java
@@ -37,6 +37,8 @@ import io.quarkus.dev.console.DevConsoleManager;
 import io.quarkus.devui.deployment.DevUIConfig;
 import io.quarkus.devui.deployment.InternalPageBuildItem;
 import io.quarkus.devui.spi.buildtime.BuildTimeActionBuildItem;
+import io.quarkus.devui.spi.buildtime.DevMcpBuildTimeTool;
+import io.quarkus.devui.spi.buildtime.DevMcpParam;
 import io.quarkus.devui.spi.page.Page;
 import io.quarkus.devui.spi.workspace.Action;
 import io.quarkus.devui.spi.workspace.ActionBuilder;
@@ -49,6 +51,14 @@ import io.quarkus.devui.spi.workspace.WorkspaceBuildItem;
 /**
  * This creates the workspace Page
  */
+@DevMcpBuildTimeTool(name = "getWorkspaceItems", description = "Gets all the items in the current workspace of the Quarkus project. Returns a list of workspace items with name and path.")
+@DevMcpBuildTimeTool(name = "getWorkspaceItemContent", description = "Get the content of a certain workspace item. Returns a WorkspaceContent with type, content, and isBinary fields.", params = {
+        @DevMcpParam(name = "path", description = "The path, as a URI in String format, to the workspace item")
+})
+@DevMcpBuildTimeTool(name = "saveWorkspaceItemContent", description = "Add or update an item in the workspace", params = {
+        @DevMcpParam(name = "content", description = "The new or updated content in String format"),
+        @DevMcpParam(name = "path", description = "The path, as a URI in String format, to the workspace item")
+})
 @BuildSteps(onlyIf = IsLocalDevelopment.class)
 public class WorkspaceProcessor {
     private static final Logger LOG = Logger.getLogger(WorkspaceProcessor.class);

--- a/extensions/info/deployment/pom.xml
+++ b/extensions/info/deployment/pom.xml
@@ -19,6 +19,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devui-deployment-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-info</artifactId>
         </dependency>
         <dependency>

--- a/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/InfoProcessor.java
+++ b/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/InfoProcessor.java
@@ -38,6 +38,7 @@ import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
 import io.quarkus.devui.spi.buildtime.BuildTimeActionBuildItem;
+import io.quarkus.devui.spi.buildtime.DevMcpBuildTimeTool;
 import io.quarkus.info.BuildInfo;
 import io.quarkus.info.GitInfo;
 import io.quarkus.info.JavaInfo;
@@ -51,6 +52,7 @@ import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.spi.RouteBuildItem;
 
+@DevMcpBuildTimeTool(name = "getApplicationAndEnvironmentInfo", description = "Information about the environment where this Quarkus application is running. Things like Operating System, Java version, Git information and application details.")
 public class InfoProcessor {
 
     private static final Logger log = Logger.getLogger(InfoProcessor.class);

--- a/independent-projects/extension-maven-plugin/pom.xml
+++ b/independent-projects/extension-maven-plugin/pom.xml
@@ -41,6 +41,7 @@
         <smallrye-beanbag.version>1.6.1</smallrye-beanbag.version>
         <junit.version>6.0.3</junit.version>
         <mockito.version>5.21.0</mockito.version>
+        <version.jandex>3.5.3</version.jandex>
     </properties>
     <build>
         <testResources>
@@ -332,6 +333,11 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-repository-metadata</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>jandex</artifactId>
+            <version>${version.jandex}</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/independent-projects/extension-maven-plugin/src/main/java/io/quarkus/maven/AggregateSkillsMojo.java
+++ b/independent-projects/extension-maven-plugin/src/main/java/io/quarkus/maven/AggregateSkillsMojo.java
@@ -11,7 +11,9 @@ import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
@@ -21,6 +23,16 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.IndexReader;
+import org.jboss.jandex.Indexer;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.MethodParameterInfo;
+import org.jboss.jandex.Type;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -209,19 +221,225 @@ public class AggregateSkillsMojo extends AbstractMojo {
                 .getParent() // src
                 .getParent(); // runtime
         String skillName = readArtifactIdFromPom(runtimeDir.resolve("pom.xml"));
+        Path extensionDir = runtimeDir.getParent();
         if (skillName == null) {
             // Fallback to directory name
-            Path extensionDir = runtimeDir.getParent();
             skillName = extensionDir != null ? extensionDir.getFileName().toString() : "unknown";
         }
 
-        final String composed = SkillComposer.compose(extMeta, rawContent, skillName);
+        // Discover MCP tools from compiled classes and deployment source
+        List<SkillComposer.McpToolInfo> mcpTools = discoverMcpTools(extensionDir);
+
+        final String composed;
+        if (!mcpTools.isEmpty()) {
+            composed = SkillComposer.composeWithTools(extMeta, rawContent, skillName, mcpTools);
+            getLog().debug("Composed skill: " + skillName + " with " + mcpTools.size()
+                    + " MCP tools from " + entry.skillFile);
+        } else {
+            composed = SkillComposer.compose(extMeta, rawContent, skillName);
+            getLog().debug("Composed skill: " + skillName + " from " + entry.skillFile);
+        }
+
         final Path outputPath = outputDirectory.toPath()
                 .resolve(SkillComposer.outputSkillPath(skillName));
         Files.createDirectories(outputPath.getParent());
         Files.writeString(outputPath, composed, StandardCharsets.UTF_8);
+    }
 
-        getLog().debug("Composed skill: " + skillName + " from " + entry.skillFile);
+    /**
+     * Discovers MCP tools from an extension's modules by scanning compiled classes via Jandex:
+     * <ol>
+     * <li>Runtime/runtime-dev modules for {@code @JsonRpcDescription} + {@code @DevMCPEnableByDefault} methods</li>
+     * <li>Deployment module for {@code @DevMcpBuildTimeTool} annotations on processor classes</li>
+     * </ol>
+     */
+    private List<SkillComposer.McpToolInfo> discoverMcpTools(Path extensionDir) {
+        List<SkillComposer.McpToolInfo> tools = new ArrayList<>();
+
+        if (extensionDir == null || !Files.isDirectory(extensionDir)) {
+            return tools;
+        }
+
+        // 1. Scan runtime-dev and runtime compiled classes via Jandex
+        for (String moduleName : List.of("runtime-dev", RUNTIME)) {
+            Path classesDir = extensionDir.resolve(moduleName).resolve("target/classes");
+            if (Files.isDirectory(classesDir)) {
+                tools.addAll(scanAnnotatedMethods(classesDir));
+            }
+        }
+
+        // 2. Scan deployment compiled classes for @DevMcpBuildTimeTool annotations
+        Path deploymentClasses = extensionDir.resolve(DEPLOYMENT).resolve("target/classes");
+        if (Files.isDirectory(deploymentClasses)) {
+            tools.addAll(scanBuildTimeToolAnnotations(deploymentClasses));
+        }
+
+        // Deduplicate by tool name (a method may be discovered from both sources)
+        Map<String, SkillComposer.McpToolInfo> deduplicated = new LinkedHashMap<>();
+        for (SkillComposer.McpToolInfo tool : tools) {
+            deduplicated.putIfAbsent(tool.name(), tool);
+        }
+        return new ArrayList<>(deduplicated.values());
+    }
+
+    // ── Jandex scanning for @JsonRpcDescription methods ──────────────────────
+
+    private static final DotName JSON_RPC_DESCRIPTION = DotName
+            .createSimple("io.quarkus.runtime.annotations.JsonRpcDescription");
+    private static final DotName DEV_MCP_ENABLE_BY_DEFAULT = DotName
+            .createSimple("io.quarkus.runtime.annotations.DevMCPEnableByDefault");
+    private static final DotName OPTIONAL = DotName.createSimple("java.util.Optional");
+
+    /**
+     * Indexes compiled classes in the given directory and extracts methods
+     * annotated with both {@code @JsonRpcDescription} and {@code @DevMCPEnableByDefault}.
+     * Methods without {@code @DevMCPEnableByDefault} are not enabled by default and
+     * are excluded from skill files.
+     */
+    private List<SkillComposer.McpToolInfo> scanAnnotatedMethods(Path classesDir) {
+        List<SkillComposer.McpToolInfo> tools = new ArrayList<>();
+
+        Index index;
+        try {
+            index = indexClasses(classesDir);
+        } catch (IOException e) {
+            getLog().debug("Failed to index classes in " + classesDir + ": " + e.getMessage());
+            return tools;
+        }
+
+        for (AnnotationInstance ann : index.getAnnotations(JSON_RPC_DESCRIPTION)) {
+            if (ann.target().kind() != AnnotationTarget.Kind.METHOD) {
+                continue;
+            }
+
+            MethodInfo method = ann.target().asMethod();
+
+            // Skip constructors, void methods, and non-public methods
+            if (method.name().equals("<init>")
+                    || method.returnType().kind() == Type.Kind.VOID
+                    || !java.lang.reflect.Modifier.isPublic(method.flags())) {
+                continue;
+            }
+
+            // Only include methods that are enabled by default
+            if (!method.hasAnnotation(DEV_MCP_ENABLE_BY_DEFAULT)) {
+                continue;
+            }
+
+            AnnotationValue descValue = ann.value();
+            if (descValue == null || descValue.asString().isBlank()) {
+                continue;
+            }
+
+            // Extract parameter info
+            Map<String, SkillComposer.ParameterInfo> params = new LinkedHashMap<>();
+            for (MethodParameterInfo param : method.parameters()) {
+                boolean required = !OPTIONAL.equals(param.type().name());
+                String paramDesc = null;
+                AnnotationInstance paramAnn = param.annotation(JSON_RPC_DESCRIPTION);
+                if (paramAnn != null && paramAnn.value() != null) {
+                    paramDesc = paramAnn.value().asString();
+                }
+                params.put(param.name(), new SkillComposer.ParameterInfo(paramDesc, required));
+            }
+
+            tools.add(new SkillComposer.McpToolInfo(method.name(), descValue.asString(), params));
+        }
+
+        return tools;
+    }
+
+    /**
+     * Creates a Jandex index by scanning all {@code .class} files in the given directory.
+     */
+    private Index indexClasses(Path classesDir) throws IOException {
+        // First try a pre-built index
+        Path indexFile = classesDir.resolve("META-INF/jandex.idx");
+        if (Files.isRegularFile(indexFile)) {
+            try (InputStream is = Files.newInputStream(indexFile)) {
+                return new IndexReader(is).read();
+            } catch (Exception e) {
+                getLog().debug("Failed to read existing Jandex index, re-indexing: " + e.getMessage());
+            }
+        }
+
+        // Fall back to on-the-fly indexing
+        Indexer indexer = new Indexer();
+        try (var stream = Files.walk(classesDir)) {
+            stream.filter(p -> p.toString().endsWith(".class"))
+                    .forEach(p -> {
+                        try (InputStream is = Files.newInputStream(p)) {
+                            indexer.index(is);
+                        } catch (IOException e) {
+                            getLog().debug("Failed to index " + p + ": " + e.getMessage());
+                        }
+                    });
+        }
+        return indexer.complete();
+    }
+
+    // ── Jandex scanning for @DevMcpBuildTimeTool annotations on deployment classes ──
+
+    private static final DotName DEV_MCP_BUILD_TIME_TOOL = DotName
+            .createSimple("io.quarkus.devui.spi.buildtime.DevMcpBuildTimeTool");
+    private static final DotName DEV_MCP_BUILD_TIME_TOOLS = DotName
+            .createSimple("io.quarkus.devui.spi.buildtime.DevMcpBuildTimeTools");
+
+    /**
+     * Scans compiled deployment classes for {@code @DevMcpBuildTimeTool} annotations
+     * and extracts tool metadata.
+     */
+    private List<SkillComposer.McpToolInfo> scanBuildTimeToolAnnotations(Path classesDir) {
+        Index index;
+        try {
+            index = indexClasses(classesDir);
+        } catch (IOException e) {
+            getLog().debug("Failed to index deployment classes in " + classesDir + ": " + e.getMessage());
+            return new ArrayList<>();
+        }
+        return scanBuildTimeToolAnnotations(index);
+    }
+
+    static List<SkillComposer.McpToolInfo> scanBuildTimeToolAnnotations(Index index) {
+        List<SkillComposer.McpToolInfo> tools = new ArrayList<>();
+
+        // Handle both single and repeatable (container) annotations
+        for (AnnotationInstance ann : index.getAnnotations(DEV_MCP_BUILD_TIME_TOOL)) {
+            tools.add(buildTimeToolFromAnnotation(ann));
+        }
+        for (AnnotationInstance container : index.getAnnotations(DEV_MCP_BUILD_TIME_TOOLS)) {
+            AnnotationValue valueArray = container.value();
+            if (valueArray != null) {
+                for (AnnotationInstance ann : valueArray.asNestedArray()) {
+                    tools.add(buildTimeToolFromAnnotation(ann));
+                }
+            }
+        }
+
+        return tools;
+    }
+
+    private static SkillComposer.McpToolInfo buildTimeToolFromAnnotation(AnnotationInstance ann) {
+        String name = ann.value("name").asString();
+        String description = ann.value("description").asString();
+
+        Map<String, SkillComposer.ParameterInfo> params = new LinkedHashMap<>();
+        AnnotationValue paramsValue = ann.value("params");
+        if (paramsValue != null) {
+            for (AnnotationInstance paramAnn : paramsValue.asNestedArray()) {
+                String paramName = paramAnn.value("name").asString();
+                AnnotationValue paramDescValue = paramAnn.value("description");
+                String paramDesc = paramDescValue != null ? paramDescValue.asString() : null;
+                if (paramDesc != null && paramDesc.isEmpty()) {
+                    paramDesc = null;
+                }
+                AnnotationValue requiredValue = paramAnn.value("required");
+                boolean required = requiredValue == null || requiredValue.asBoolean();
+                params.put(paramName, new SkillComposer.ParameterInfo(paramDesc, required));
+            }
+        }
+
+        return new SkillComposer.McpToolInfo(name, description, params.isEmpty() ? null : params);
     }
 
     /**

--- a/independent-projects/extension-maven-plugin/src/test/java/io/quarkus/devui/spi/buildtime/DevMcpBuildTimeTool.java
+++ b/independent-projects/extension-maven-plugin/src/test/java/io/quarkus/devui/spi/buildtime/DevMcpBuildTimeTool.java
@@ -1,0 +1,22 @@
+package io.quarkus.devui.spi.buildtime;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target({ TYPE })
+@Documented
+@Repeatable(DevMcpBuildTimeTools.class)
+public @interface DevMcpBuildTimeTool {
+
+    String name();
+
+    String description();
+
+    DevMcpParam[] params() default {};
+}

--- a/independent-projects/extension-maven-plugin/src/test/java/io/quarkus/devui/spi/buildtime/DevMcpBuildTimeTools.java
+++ b/independent-projects/extension-maven-plugin/src/test/java/io/quarkus/devui/spi/buildtime/DevMcpBuildTimeTools.java
@@ -1,0 +1,16 @@
+package io.quarkus.devui.spi.buildtime;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target({ TYPE })
+@Documented
+public @interface DevMcpBuildTimeTools {
+
+    DevMcpBuildTimeTool[] value();
+}

--- a/independent-projects/extension-maven-plugin/src/test/java/io/quarkus/devui/spi/buildtime/DevMcpParam.java
+++ b/independent-projects/extension-maven-plugin/src/test/java/io/quarkus/devui/spi/buildtime/DevMcpParam.java
@@ -1,0 +1,17 @@
+package io.quarkus.devui.spi.buildtime;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+
+@Retention(RUNTIME)
+@Documented
+public @interface DevMcpParam {
+
+    String name();
+
+    String description() default "";
+
+    boolean required() default true;
+}

--- a/independent-projects/extension-maven-plugin/src/test/java/io/quarkus/maven/AggregateSkillsMojoTest.java
+++ b/independent-projects/extension-maven-plugin/src/test/java/io/quarkus/maven/AggregateSkillsMojoTest.java
@@ -1,0 +1,97 @@
+package io.quarkus.maven;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.jboss.jandex.Index;
+import org.jboss.jandex.Indexer;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.devtools.utils.SkillComposer;
+import io.quarkus.devui.spi.buildtime.DevMcpBuildTimeTool;
+import io.quarkus.devui.spi.buildtime.DevMcpParam;
+
+public class AggregateSkillsMojoTest {
+
+    @DevMcpBuildTimeTool(name = "simpleAction", description = "A simple action")
+    static class SimpleProcessor {
+    }
+
+    @DevMcpBuildTimeTool(name = "actionWithParams", description = "Action with parameters", params = {
+            @DevMcpParam(name = "className", description = "The test class name"),
+            @DevMcpParam(name = "methodName", description = "The method name", required = false)
+    })
+    static class ProcessorWithParams {
+    }
+
+    @DevMcpBuildTimeTool(name = "firstAction", description = "First action")
+    @DevMcpBuildTimeTool(name = "secondAction", description = "Second action")
+    static class MultiToolProcessor {
+    }
+
+    static class NoAnnotationProcessor {
+    }
+
+    @Test
+    public void scanSimpleAnnotation() throws IOException {
+        Index index = indexClasses(SimpleProcessor.class);
+        List<SkillComposer.McpToolInfo> tools = AggregateSkillsMojo.scanBuildTimeToolAnnotations(index);
+
+        assertEquals(1, tools.size());
+        assertEquals("simpleAction", tools.get(0).name());
+        assertEquals("A simple action", tools.get(0).description());
+        assertNull(tools.get(0).parameters());
+    }
+
+    @Test
+    public void scanAnnotationWithParameters() throws IOException {
+        Index index = indexClasses(ProcessorWithParams.class);
+        List<SkillComposer.McpToolInfo> tools = AggregateSkillsMojo.scanBuildTimeToolAnnotations(index);
+
+        assertEquals(1, tools.size());
+        assertEquals("actionWithParams", tools.get(0).name());
+        assertNotNull(tools.get(0).parameters());
+        assertEquals(2, tools.get(0).parameters().size());
+        assertEquals("The test class name", tools.get(0).parameters().get("className").description());
+        assertTrue(tools.get(0).parameters().get("className").required());
+        assertEquals("The method name", tools.get(0).parameters().get("methodName").description());
+        assertFalse(tools.get(0).parameters().get("methodName").required());
+    }
+
+    @Test
+    public void scanMultipleAnnotations() throws IOException {
+        Index index = indexClasses(MultiToolProcessor.class);
+        List<SkillComposer.McpToolInfo> tools = AggregateSkillsMojo.scanBuildTimeToolAnnotations(index);
+
+        assertEquals(2, tools.size());
+        assertEquals("firstAction", tools.get(0).name());
+        assertEquals("First action", tools.get(0).description());
+        assertEquals("secondAction", tools.get(1).name());
+        assertEquals("Second action", tools.get(1).description());
+    }
+
+    @Test
+    public void scanClassWithoutAnnotation() throws IOException {
+        Index index = indexClasses(NoAnnotationProcessor.class);
+        List<SkillComposer.McpToolInfo> tools = AggregateSkillsMojo.scanBuildTimeToolAnnotations(index);
+
+        assertTrue(tools.isEmpty());
+    }
+
+    private static Index indexClasses(Class<?>... classes) throws IOException {
+        Indexer indexer = new Indexer();
+        for (Class<?> clazz : classes) {
+            String classFile = clazz.getName().replace('.', '/') + ".class";
+            try (var is = clazz.getClassLoader().getResourceAsStream(classFile)) {
+                indexer.index(is);
+            }
+        }
+        return indexer.complete();
+    }
+}

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/utils/SkillComposer.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/utils/SkillComposer.java
@@ -2,7 +2,10 @@ package io.quarkus.devtools.utils;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.StringJoiner;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
@@ -103,6 +106,114 @@ public final class SkillComposer {
     }
 
     /**
+     * Composes a skill document and appends an "Available Dev MCP Tools" section
+     * listing the extension's MCP-enabled methods.
+     *
+     * @param extMeta the parsed {@code quarkus-extension.yaml}
+     * @param rawContent the raw skill file content
+     * @param skillName the skill identifier
+     * @param mcpTools the MCP tools to include; if empty, no tools section is appended
+     */
+    public static String composeWithTools(ObjectNode extMeta, String rawContent, String skillName,
+            List<McpToolInfo> mcpTools) {
+        String enrichedContent = rawContent;
+        if (mcpTools != null && !mcpTools.isEmpty()) {
+            enrichedContent = rawContent.trim() + "\n\n" + formatMcpToolsSection(mcpTools, skillName);
+        }
+        return compose(extMeta, enrichedContent, skillName, "Apache-2.0");
+    }
+
+    /**
+     * Formats a markdown table listing Dev MCP tools for inclusion in a skill file.
+     *
+     * @param tools the MCP tools to format
+     * @param extensionName the extension name used as a prefix for fully qualified tool names
+     */
+    public static String formatMcpToolsSection(List<McpToolInfo> tools, String extensionName) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("### Available Dev MCP Tools\n\n");
+        sb.append("| Tool | Description | Parameters |\n");
+        sb.append("|------|-------------|------------|\n");
+
+        for (McpToolInfo tool : tools) {
+            String fullName = extensionName + "_" + tool.name();
+            sb.append("| `").append(fullName).append("` | ");
+            sb.append(escapeMarkdownTable(tool.description())).append(" | ");
+
+            if (tool.parameters() != null && !tool.parameters().isEmpty()) {
+                StringJoiner pj = new StringJoiner(", ");
+                for (Map.Entry<String, ParameterInfo> param : tool.parameters().entrySet()) {
+                    StringBuilder ps = new StringBuilder();
+                    ps.append("`").append(param.getKey()).append("`");
+                    if (param.getValue().required()) {
+                        ps.append(" (required)");
+                    }
+                    if (param.getValue().description() != null) {
+                        ps.append(": ").append(escapeMarkdownTable(param.getValue().description()));
+                    }
+                    pj.add(ps.toString());
+                }
+                sb.append(pj);
+            } else {
+                sb.append("\u2014");
+            }
+            sb.append(" |\n");
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * Describes an MCP tool discovered from an extension's annotated methods.
+     * Intentionally not a record — this class must be usable from modules targeting JDK 11.
+     */
+    public static final class McpToolInfo {
+        private final String name;
+        private final String description;
+        private final Map<String, ParameterInfo> parameters;
+
+        public McpToolInfo(String name, String description, Map<String, ParameterInfo> parameters) {
+            this.name = name;
+            this.description = description;
+            this.parameters = parameters;
+        }
+
+        public String name() {
+            return name;
+        }
+
+        public String description() {
+            return description;
+        }
+
+        public Map<String, ParameterInfo> parameters() {
+            return parameters;
+        }
+    }
+
+    /**
+     * Describes a parameter of an MCP tool.
+     * Intentionally not a record — this class must be usable from modules targeting JDK 11.
+     */
+    public static final class ParameterInfo {
+        private final String description;
+        private final boolean required;
+
+        public ParameterInfo(String description, boolean required) {
+            this.description = description;
+            this.required = required;
+        }
+
+        public String description() {
+            return description;
+        }
+
+        public boolean required() {
+            return required;
+        }
+    }
+
+    /**
      * Safely extracts a text value from a JSON node, returning {@code null} if
      * the field is missing, null, or not a textual type.
      */
@@ -124,6 +235,10 @@ public final class SkillComposer {
             return null;
         }
         return getTextValue((ObjectNode) parentNode, field);
+    }
+
+    private static String escapeMarkdownTable(String text) {
+        return text.replace("|", "\\|").replace("\n", " ");
     }
 
     private static String escapeYamlString(String value) {

--- a/independent-projects/tools/devtools-common/src/test/java/io/quarkus/devtools/utils/SkillComposerTest.java
+++ b/independent-projects/tools/devtools-common/src/test/java/io/quarkus/devtools/utils/SkillComposerTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.devtools.utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -8,6 +9,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
@@ -179,6 +183,58 @@ public class SkillComposerTest {
         assertThrows(NullPointerException.class, () -> SkillComposer.compose(null, "c", "n"));
         assertThrows(NullPointerException.class, () -> SkillComposer.compose(meta, null, "n"));
         assertThrows(NullPointerException.class, () -> SkillComposer.compose(meta, "c", null));
+    }
+
+    @Test
+    public void formatMcpToolsSectionProducesValidTable() {
+        Map<String, SkillComposer.ParameterInfo> params = new LinkedHashMap<>();
+        params.put("identity", new SkillComposer.ParameterInfo("The job ID", true));
+
+        List<SkillComposer.McpToolInfo> tools = List.of(
+                new SkillComposer.McpToolInfo("getData", "Get scheduler info", null),
+                new SkillComposer.McpToolInfo("pauseJob", "Pause a specific job", params));
+
+        String result = SkillComposer.formatMcpToolsSection(tools, "quarkus-scheduler");
+
+        assertTrue(result.startsWith("### Available Dev MCP Tools\n\n"));
+        assertTrue(result.contains("| `quarkus-scheduler_getData` | Get scheduler info | \u2014 |"));
+        assertTrue(result.contains("| `quarkus-scheduler_pauseJob` | Pause a specific job | "
+                + "`identity` (required): The job ID |"));
+    }
+
+    @Test
+    public void composeWithToolsIncludesToolsSection() throws IOException {
+        String yaml = "name: \"Sched\"\ndescription: \"Job scheduling\"\n";
+        ObjectNode meta = parseYaml(yaml);
+
+        List<SkillComposer.McpToolInfo> tools = List.of(
+                new SkillComposer.McpToolInfo("getData", "Get info", null));
+
+        String result = SkillComposer.composeWithTools(meta, "### Usage\n- Use @Scheduled", "quarkus-scheduler", tools);
+
+        assertTrue(result.contains("### Usage"));
+        assertTrue(result.contains("### Available Dev MCP Tools"));
+        assertTrue(result.contains("| `quarkus-scheduler_getData` | Get info |"));
+    }
+
+    @Test
+    public void composeWithEmptyToolsOmitsSection() throws IOException {
+        String yaml = "name: \"Ext\"\ndescription: \"desc\"\n";
+        ObjectNode meta = parseYaml(yaml);
+
+        String result = SkillComposer.composeWithTools(meta, "body", "quarkus-ext", List.of());
+
+        assertFalse(result.contains("Available Dev MCP Tools"));
+    }
+
+    @Test
+    public void formatMcpToolsEscapesPipeInDescription() {
+        List<SkillComposer.McpToolInfo> tools = List.of(
+                new SkillComposer.McpToolInfo("method", "Returns A | B", null));
+
+        String result = SkillComposer.formatMcpToolsSection(tools, "ext");
+
+        assertTrue(result.contains("Returns A \\| B"));
     }
 
     private static ObjectNode parseYaml(String yaml) throws IOException {


### PR DESCRIPTION
The `aggregate-skills` Maven goal now discovers Dev MCP tools from each extension and appends an "Available Dev MCP Tools" section to the composed skill file. The enriched skills are baked into the `quarkus-extension-skills` JAR at Quarkus build time, so AI agents see the full picture of each extension's coding patterns and dev-time tooling without needing a running application.

### Tool discovery

Tools are discovered from two sources via Jandex scanning of compiled classes:

- **Runtime classpath** — methods annotated with both `@JsonRpcDescription` and `@DevMCPEnableByDefault` in `runtime-dev` and `runtime` modules. Parameters are extracted from method signatures; `Optional` parameters are marked as optional.
- **Deployment classpath** — processor classes annotated with the new `@DevMcpBuildTimeTool` annotation. This repeatable annotation declares tool name, description, and parameters (`@DevMcpParam`) directly on the class, avoiding fragile source parsing.

Tools from both sources are deduplicated by name (runtime wins). Only tools enabled by default are included in skill files.

### New annotations

Three new annotations in `extensions/devui/deployment-spi` (package `io.quarkus.devui.spi.buildtime`):

- `@DevMcpBuildTimeTool` — repeatable, placed on `@BuildStep` processor classes to declare build-time MCP tools discoverable via Jandex
- `@DevMcpBuildTimeTools` — container for the repeatable annotation
- `@DevMcpParam` — describes a tool parameter (name, description, required)

These live in `devui-deployment-spi` rather than `core/runtime` because they are deployment-time metadata for Dev MCP tooling. This also avoids a circular dependency in the build (core/runtime needs extension-maven-plugin as a build plugin, so extension-maven-plugin cannot depend on core/runtime).

### Annotated processors

The following existing processors are annotated with `@DevMcpBuildTimeTool`:

- `ExceptionProcessor` — `getLastException`, `clearLastException`
- `LogStreamProcessor` — `forceRestart`
- `ConfigurationProcessor` — `updateProperty`
- `DevServicesProcessor` — `getDevServices`
- `ExtensionsProcessor` — `listInstallableExtensions`, `removeExtension`, `addExtension`
- `OneShotTestingProcessor` — `runTests`, `runAffectedTests`, `runTest`
- `WorkspaceProcessor` — `getWorkspaceItems`, `getWorkspaceItemContent`, `saveWorkspaceItemContent`
- `InfoProcessor` — `getApplicationAndEnvironmentInfo`

### Example output

For the scheduler extension, the composed skill would include a table like:

```
| Tool | Description | Parameters |
|------|-------------|------------|
| `quarkus-scheduler_getData` | Get information on the scheduler | — |
| `quarkus-scheduler_pauseJob` | Pause a specific job | `identity` (required): The job identification |
| `quarkus-scheduler_executeJob` | Execute a specific job | `methodDescription` (required): The method description |
```

### Documentation

The `dev-mcp.adoc` guide is updated to document:
- The new `@DevMcpBuildTimeTool` annotation with usage examples
- The auto-enrichment of skill files with MCP tools
- Section reorder: Extension skills → MCP tools → MCP resources (reflecting the natural workflow for extension developers)

Resolves #53615