### PR TITLE
Simplify and make more robust the mechanism to discover unsupported Jackson annotations during the generation of reflection-free serializers

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
@@ -25,6 +25,7 @@ import org.jboss.jandex.MethodParameterInfo;
 import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
 import org.jboss.jandex.TypeVariable;
+import org.jboss.logging.Logger;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -45,6 +46,9 @@ import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.resteasy.reactive.jackson.SecureField;
 
 public abstract class JacksonCodeGenerator {
+
+    private static final Logger log = Logger.getLogger(JacksonCodeGenerator.class);
+
     protected final BuildProducer<GeneratedClassBuildItem> generatedClassBuildItemBuildProducer;
     protected final IndexView jandexIndex;
 
@@ -78,8 +82,13 @@ public abstract class JacksonCodeGenerator {
 
     private Optional<String> create(ClassInfo classInfo) {
         String beanClassName = classInfo.name().toString();
-        if (vetoedClass(classInfo, beanClassName) || hasUnknownClassAnnotation(classInfo)
-                || !generatedClassNames.add(beanClassName)) {
+        if (vetoedClass(classInfo, beanClassName) || !generatedClassNames.add(beanClassName)) {
+            return Optional.empty();
+        }
+        Optional<String> unknownAnnotation = findUnknownAnnotation(classInfo);
+        if (unknownAnnotation.isPresent()) {
+            log.infof("Skipping generation of reflection-free Jackson serializer for class %s" +
+                    " because it contains the unsupported Jackson annotation %s", beanClassName, unknownAnnotation.get());
             return Optional.empty();
         }
 
@@ -162,9 +171,11 @@ public abstract class JacksonCodeGenerator {
         return className.startsWith("java.") || className.startsWith("jakarta.") || className.startsWith("io.vertx.core.json.");
     }
 
-    private static boolean hasUnknownClassAnnotation(ClassInfo classInfo) {
-        return classInfo.declaredAnnotations().stream()
-                .anyMatch(a -> FieldSpecs.isUnknownAnnotation(a.name().toString()));
+    private static Optional<String> findUnknownAnnotation(ClassInfo classInfo) {
+        return classInfo.annotations().stream()
+                .map(a -> a.name().toString())
+                .filter(FieldSpecs::isUnknownAnnotation)
+                .findFirst();
     }
 
     protected enum FieldKind {
@@ -440,10 +451,6 @@ public abstract class JacksonCodeGenerator {
                 return methodName.substring(3, 4).toLowerCase() + methodName.substring(4);
             }
             return methodName;
-        }
-
-        boolean hasUnknownAnnotation() {
-            return annotations.keySet().stream().anyMatch(FieldSpecs::isUnknownAnnotation);
         }
 
         boolean isIgnoredField() {

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonDeserializerFactory.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonDeserializerFactory.java
@@ -299,9 +299,6 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
         int i = 0;
         for (MethodParameterInfo paramInfo : deserData.constructor.parameters()) {
             FieldSpecs fieldSpecs = fieldSpecsFromFieldParam(paramInfo, deserData.namingStrategy);
-            if (fieldSpecs.hasUnknownAnnotation()) {
-                return null;
-            }
             deserData.constructorFields.add(fieldSpecs.jsonName);
             for (String alias : fieldSpecs.aliases) {
                 deserData.constructorFields.add(alias);
@@ -540,31 +537,26 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
         AtomicBoolean valid = new AtomicBoolean(true);
 
         for (FieldInfo fieldInfo : classFields(deserData.classInfo)) {
-            if (!deserializeFieldSpecs(deserData, deserializationContext, objHandle, fieldValue,
+            deserializeFieldSpecs(deserData, deserializationContext, objHandle, fieldValue,
                     deserializedFields, strSwitch,
                     fieldSpecsFromField(deserData.classInfo, deserData.constructor, fieldInfo, deserData.namingStrategy),
-                    valid))
-                return false;
+                    valid);
         }
 
         for (MethodInfo methodInfo : classMethods(deserData.classInfo)) {
-            if (!deserializeFieldSpecs(deserData, deserializationContext, objHandle, fieldValue,
-                    deserializedFields, strSwitch, fieldSpecsFromMethod(methodInfo, deserData.namingStrategy), valid))
-                return false;
+            deserializeFieldSpecs(deserData, deserializationContext, objHandle, fieldValue,
+                    deserializedFields, strSwitch, fieldSpecsFromMethod(methodInfo, deserData.namingStrategy), valid);
         }
 
         return valid.get();
     }
 
-    private boolean deserializeFieldSpecs(DeserializationData deserData, ResultHandle deserializationContext,
+    private void deserializeFieldSpecs(DeserializationData deserData, ResultHandle deserializationContext,
             ResultHandle objHandle, ResultHandle fieldValue, Set<String> deserializedFields, Switch.StringSwitch strSwitch,
             FieldSpecs fieldSpecs, AtomicBoolean valid) {
         if (fieldSpecs != null && deserializedFields.add(fieldSpecs.jsonName)) {
             if (fieldSpecs.isIgnoredField()) {
-                return true;
-            }
-            if (fieldSpecs.hasUnknownAnnotation()) {
-                return false;
+                return;
             }
             strSwitch.caseOf(fieldSpecs.jsonName,
                     bytecode -> valid.compareAndSet(true, deserializeField(deserData, bytecode, objHandle,
@@ -575,7 +567,6 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
                                 fieldValue, fieldSpecs, deserializationContext)));
             }
         }
-        return true;
     }
 
     private boolean deserializeField(DeserializationData deserData, BytecodeCreator bytecode,

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
@@ -240,7 +240,7 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
         serialize.invokeVirtualMethod(writeStartObject, ctx.jsonGenerator);
 
         Set<String> serializedFields = new HashSet<>();
-        boolean valid = serializeObjectData(classInfo, classCreator, serialize, ctx, serializedFields);
+        serializeObjectData(classInfo, classCreator, serialize, ctx, serializedFields);
 
         // jsonGenerator.writeEndObject();
         MethodDescriptor writeEndObject = MethodDescriptor.ofMethod(JSON_GEN_CLASS_NAME, "writeEndObject", "void");
@@ -252,7 +252,7 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
 
         classCreator.getMethodCreator("<clinit>", void.class).setModifiers(ACC_STATIC).returnVoid();
 
-        return valid;
+        return true;
     }
 
     private Optional<FieldSpecs> jsonValueFieldSpecs(ClassInfo classInfo) {
@@ -288,14 +288,14 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
         writeFieldValue(jsonValueFieldSpecs, bytecode, ctx, typeName, arg, null);
     }
 
-    private boolean serializeObjectData(ClassInfo classInfo, ClassCreator classCreator, MethodCreator serialize,
+    private void serializeObjectData(ClassInfo classInfo, ClassCreator classCreator, MethodCreator serialize,
             SerializationContext ctx, Set<String> serializedFields) {
         PropertyNamingStrategy namingStrategy = getNamingStrategy(classInfo);
-        return serializeFields(classInfo, classCreator, serialize, ctx, serializedFields, namingStrategy) &&
-                serializeMethods(classInfo, classCreator, serialize, ctx, serializedFields, namingStrategy);
+        serializeFields(classInfo, classCreator, serialize, ctx, serializedFields, namingStrategy);
+        serializeMethods(classInfo, classCreator, serialize, ctx, serializedFields, namingStrategy);
     }
 
-    private boolean serializeFields(ClassInfo classInfo, ClassCreator classCreator, MethodCreator serialize,
+    private void serializeFields(ClassInfo classInfo, ClassCreator classCreator, MethodCreator serialize,
             SerializationContext ctx, Set<String> serializedFields, PropertyNamingStrategy namingStrategy) {
         MethodInfo constructor = findConstructor(classInfo).orElse(null);
 
@@ -305,16 +305,12 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
                 if (fieldSpecs.isIgnoredField()) {
                     continue;
                 }
-                if (fieldSpecs.hasUnknownAnnotation()) {
-                    return false;
-                }
                 writeField(classInfo, fieldSpecs, writeFieldBranch(classCreator, serialize, fieldSpecs, ctx), ctx);
             }
         }
-        return true;
     }
 
-    private boolean serializeMethods(ClassInfo classInfo, ClassCreator classCreator, MethodCreator serialize,
+    private void serializeMethods(ClassInfo classInfo, ClassCreator classCreator, MethodCreator serialize,
             SerializationContext ctx, Set<String> serializedFields, PropertyNamingStrategy namingStrategy) {
         for (MethodInfo methodInfo : classMethods(classInfo)) {
             FieldSpecs fieldSpecs = fieldSpecsFromMethod(methodInfo, namingStrategy);
@@ -322,13 +318,9 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
                 if (fieldSpecs.isIgnoredField()) {
                     continue;
                 }
-                if (fieldSpecs.hasUnknownAnnotation()) {
-                    return false;
-                }
                 writeField(classInfo, fieldSpecs, serialize, ctx);
             }
         }
-        return true;
     }
 
     private FieldSpecs fieldSpecsFromMethod(MethodInfo methodInfo, PropertyNamingStrategy namingStrategy) {

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/AbstractSimpleJsonTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/AbstractSimpleJsonTest.java
@@ -1239,4 +1239,19 @@ public abstract class AbstractSimpleJsonTest {
                 .statusCode(200)
                 .body("FIRST_NAME", CoreMatchers.is("Bob"));
     }
+
+    @Test
+    void anySetter_shouldCaptureUnknownFields() {
+        given()
+                .contentType("application/json")
+                .body("""
+                        {"known": "x", "extra1": "y", "extra2": "z"}
+                        """)
+                .when()
+                .post("/simple/any-setter")
+                .then()
+                .statusCode(200)
+                .body("known", CoreMatchers.is("x"))
+                .body("extras_size", CoreMatchers.is(2));
+    }
 }

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/AnySetterRequest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/AnySetterRequest.java
@@ -1,0 +1,33 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/// Tests that `@JsonAnySetter` on a 2-param method triggers the safety valve fallback.
+/// The common pattern (non-`set*` name, 2 params) is invisible to `isSetterMethod()`.
+public class AnySetterRequest {
+    @JsonProperty("known")
+    private String known;
+
+    private final Map<String, Object> extras = new HashMap<>();
+
+    public String getKnown() {
+        return known;
+    }
+
+    public void setKnown(String known) {
+        this.known = known;
+    }
+
+    @JsonAnySetter
+    public void handleUnknown(String key, Object value) {
+        extras.put(key, value);
+    }
+
+    public Map<String, Object> getExtras() {
+        return extras;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
@@ -720,4 +720,12 @@ public class SimpleJsonResource extends SuperClass<Person> {
     public AnnotationNamingRequest annotationNamingSer() {
         return new AnnotationNamingRequest("Bob");
     }
+
+    @POST
+    @Path("/any-setter")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public String anySetter(AnySetterRequest request) {
+        return "{\"known\":\"" + request.getKnown() + "\",\"extras_size\":" + request.getExtras().size() + "}";
+    }
 }

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
@@ -31,7 +31,7 @@ public class SimpleJsonTest extends AbstractSimpleJsonTest {
                                     ItemJsonValuePublicMethod.class, ItemJsonValuePublicField.class,
                                     ItemJsonValuePrivateMethod.class, ItemJsonValuePrivateField.class, StringWrapper.class,
                                     JsonAliasRecord.class, AnnotationNamingRequest.class, Pair.class, Score.class,
-                                    ProductPrice.class, DefaultValueHolder.class, OptionalHolder.class)
+                                    ProductPrice.class, DefaultValueHolder.class, OptionalHolder.class, AnySetterRequest.class)
                             .addAsResource(new StringAsset("admin-expression=admin\n" +
                                     "user-expression=user\n" +
                                     "birth-date-roles=alice,bob\n" +

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonWithReflectionFreeSerializersTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonWithReflectionFreeSerializersTest.java
@@ -31,7 +31,7 @@ public class SimpleJsonWithReflectionFreeSerializersTest extends AbstractSimpleJ
                                     ItemJsonValuePublicMethod.class, ItemJsonValuePublicField.class,
                                     ItemJsonValuePrivateMethod.class, ItemJsonValuePrivateField.class, StringWrapper.class,
                                     JsonAliasRecord.class, AnnotationNamingRequest.class, Pair.class, Score.class,
-                                    ProductPrice.class, DefaultValueHolder.class, OptionalHolder.class)
+                                    ProductPrice.class, DefaultValueHolder.class, OptionalHolder.class, AnySetterRequest.class)
                             .addAsResource(new StringAsset("admin-expression=admin\n" +
                                     "user-expression=user\n" +
                                     "birth-date-roles=alice,bob\n" +


### PR DESCRIPTION
I'm now also logging when a serializer cannot be generated because of the presence of an unknown annotation. Using this I found that the list of annotations used in out tests that we don't support at the moment is the following:

- `JsonView`
- `JsonValue`
- `JsonIgnoreProperties`
- `JsonAnySetter`

I will check if I can easily add support for at least any of them once this pull request will be merged. 

Related to #53588