### PR TITLE
Bump the minimum officially supported GraalVM version to 25.0

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/GraalVM.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/GraalVM.java
@@ -123,7 +123,7 @@ public final class GraalVM {
          * The minimum version of GraalVM supported by Quarkus.
          * Versions prior to this are expected to cause major issues.
          */
-        public static final Version MINIMUM = VERSION_23_1_0;
+        public static final Version MINIMUM = VERSION_25_0_0;
         /**
          * The current version of GraalVM supported by Quarkus.
          * This version is the one actively being tested and is expected to give the best experience.


### PR DESCRIPTION
As discussed in https://github.com/quarkusio/quarkus/issues/53514 maintaining full support for GraalVM/Mandrel 23.1 for JDK 21 requires quite some overhead.

By bumping the minimum supported version we are essentially saying that we no longer officially support GraalVM/Mandrel 23.1 for JDK 21 on `main`. That doesn't mean that we are going to explicitly remove support for it (yet). Instead, it means that we don't plan to fix any reported bugs that are specific to older GraalVM/Mandrel versions than Mandrel 25.

GraalVM/Mandrel 25.0 was released in September 2025 and was made the default version used by Quarkus in January 2026 (starting with Quarkus 3.31), it is also the default version used by the latest Quarkus LTS release, 3.33 released in March 2026.

Creating as draft for now, to get the discussion started, since (as mentioned in https://github.com/quarkusio/quarkus/issues/53514#issuecomment-4222580510):

> defining this policy is definitely something that should be carefully taken at the project level, and not buried in an issue :).