### PR TITLE
Fix 'occured' -> 'occurred' across DevUI i18n and qute template timeout

### DIFF
--- a/extensions/devui/resources/src/main/resources/dev-ui/i18n/en.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/i18n/en.js
@@ -241,7 +241,7 @@ export const templates = {
     'workspace-discard': 'Discard',
     'workspace-unsaved-dialog': 'There are unsaved changes. Do you want to discard or save them?',
     'workspace-check-logs': 'Please check your logs.',
-    'workspace-error': 'An error occured.',
+    'workspace-error': 'An error occurred.',
     'workspace-saved-success': 'saved successfully',
     'workspace-not-saved': 'NOT saved',
     'workspace-no-content': 'has no content',

--- a/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-workspace.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-workspace.js
@@ -527,7 +527,7 @@ export class QwcWorkspace extends observeState(QwcHotReloadElement) {
             if(err.error.message){
                 notifier.showErrorMessage(err.message + ". " + msg('Please check your logs.', { id: 'workspace-check-logs' }));
             }else {
-                notifier.showErrorMessage(msg('An error occured.', { id: 'workspace-error' }) + " " + msg('Please check your logs.', { id: 'workspace-check-logs' }));
+                notifier.showErrorMessage(msg('An error occurred.', { id: 'workspace-error' }) + " " + msg('Please check your logs.', { id: 'workspace-check-logs' }));
             }
         });
     }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateImpl.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateImpl.java
@@ -241,7 +241,7 @@ class TemplateImpl implements Template {
         }
 
         private TemplateException newTimeoutException(long timeout) {
-            return new TemplateException(TemplateImpl.this.toString() + " rendering timeout [" + timeout + "ms] occured");
+            return new TemplateException(TemplateImpl.this.toString() + " rendering timeout [" + timeout + "ms] occurred");
         }
 
         @Override

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/TimeoutTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/TimeoutTest.java
@@ -19,12 +19,12 @@ public class TimeoutTest {
                         // Invalid timeout is ignored
                         .setAttribute("timeout", "bar")
                         .render())
-                .withMessage("Template 1 [generatedId=1] rendering timeout [100ms] occured");
+                .withMessage("Template 1 [generatedId=1] rendering timeout [100ms] occurred");
 
         assertThatExceptionOfType(TemplateException.class)
                 .isThrownBy(
                         () -> engine.parse("{foo}").data("foo", new CompletableFuture<>()).createUni().await().indefinitely())
-                .withMessage("Template 2 [generatedId=2] rendering timeout [100ms] occured");
+                .withMessage("Template 2 [generatedId=2] rendering timeout [100ms] occurred");
 
         assertThatExceptionOfType(ExecutionException.class)
                 .isThrownBy(
@@ -44,7 +44,7 @@ public class TimeoutTest {
         assertThatExceptionOfType(TemplateException.class)
                 .isThrownBy(() -> engine.parse("{foo}").data("foo", new CompletableFuture<>()).setAttribute("timeout", 300)
                         .render())
-                .withMessage("Template 1 [generatedId=1] rendering timeout [300ms] occured");
+                .withMessage("Template 1 [generatedId=1] rendering timeout [300ms] occurred");
     }
 
     @Test
@@ -54,7 +54,7 @@ public class TimeoutTest {
         Uni<String> fooUni = Uni.createFrom().completionStage(new CompletableFuture<>());
         assertThatExceptionOfType(TemplateException.class)
                 .isThrownBy(() -> template.data("foo", fooUni).render())
-                .withMessage("Template 1 [generatedId=1] rendering timeout [100ms] occured");
+                .withMessage("Template 1 [generatedId=1] rendering timeout [100ms] occurred");
     }
 
 }


### PR DESCRIPTION
Fix 5 instances of \`occured\` → \`occurred\` across 4 files.

## Files

| File | Kind |
|------|------|
| \`extensions/devui/resources/src/main/resources/dev-ui/i18n/en.js\` | **User-visible** i18n string \`workspace-error\` |
| \`extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-workspace.js\` | **User-visible** error notification |
| \`independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateImpl.java\` | Qute template rendering timeout error message |
| \`independent-projects/qute/core/src/test/java/io/quarkus/qute/TimeoutTest.java\` (×2) | Test assertions updated to match the corrected error string |

The TimeoutTest assertions are updated to match the new string from \`TemplateImpl\` so existing tests stay green.

## Testing

String-change only. Test assertions verify the new exact string — they'll pass as-is after this PR.