### PR TITLE
Allow extensions to contribute action buttons to cards

### DIFF
--- a/docs/src/main/asciidoc/dev-ui.adoc
+++ b/docs/src/main/asciidoc/dev-ui.adoc
@@ -287,6 +287,69 @@ For dynamic and streaming labels, the method name is the name of the JsonRPC met
 
 image::dev-ui-extension-card-label-v2.png[alt=Dev UI card labels,role="center"]
 
+===== Optional: Card Actions
+
+You can add action buttons to your extension's card. Unlike page links (which navigate to a page), actions trigger behavior when clicked — they call a JsonRPC method or hit a URL and optionally show the result as a toast notification.
+
+To add an action, use the `addAction` method on `CardPageBuildItem`:
+
+[source,java]
+----
+cardPageBuildItem.addAction(CardAction.actionBuilder() // <1>
+        .title("Clean All") // <2>
+        .icon("font-awesome-solid:broom") // <3>
+        .tooltip("Clean all databases") // <4>
+        .jsonRpcMethodName("cleanAll") // <5>
+        .build());
+----
+<1> Create an action using the `CardAction.actionBuilder()` factory.
+<2> The button label (required).
+<3> A Font Awesome icon displayed next to the label (optional).
+<4> A tooltip shown on hover (optional).
+<5> The JsonRPC method to call when the button is clicked. This uses the same JsonRPC service as page labels — we will discuss how to create JsonRPC services later.
+
+By default, the result of the JsonRPC call is shown as a toast notification. To disable this:
+
+[source,java]
+----
+cardPageBuildItem.addAction(CardAction.actionBuilder()
+        .title("Refresh")
+        .icon("font-awesome-solid:arrows-rotate")
+        .jsonRpcMethodName("refresh")
+        .showResultNotification(false) // <1>
+        .build());
+----
+<1> Set to `false` to suppress the result notification.
+
+You can also create URL actions that send a GET request to a URL:
+
+[source,java]
+----
+cardPageBuildItem.addAction(CardAction.actionBuilder()
+        .title("Ping")
+        .url("/q/health") // <1>
+        .build());
+----
+<1> Use `url()` instead of `jsonRpcMethodName()` to hit a URL endpoint.
+
+You can combine page links and action buttons on the same card:
+
+[source,java]
+----
+CardPageBuildItem cardPageBuildItem = new CardPageBuildItem();
+
+cardPageBuildItem.addPage(Page.webComponentPageBuilder()
+        .title("Datasources")
+        .icon("font-awesome-solid:database")
+        .componentLink("qwc-flyway-datasources.js"));
+
+cardPageBuildItem.addAction(CardAction.actionBuilder()
+        .title("Clean All")
+        .icon("font-awesome-solid:broom")
+        .jsonRpcMethodName("cleanAll")
+        .build());
+----
+
 ==== Footer
 
 Apart from adding a card and a page, extensions can add a tab to the footer. This is useful for things that are happening continuously. A page will disconnect from the DOM (and maybe the backend) when navigating away from that page (or webcomponent), and a log in the footer will be permanently connected to the DOM, as it's always part of the view (or app)

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/page/CardAction.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/page/CardAction.java
@@ -1,0 +1,54 @@
+package io.quarkus.devui.spi.page;
+
+public class CardAction {
+
+    public enum ActionType {
+        JSONRPC,
+        URL
+    }
+
+    private final String title;
+    private final String icon;
+    private final String tooltip;
+    private final ActionType actionType;
+    private final String actionReference;
+    private final boolean showResultNotification;
+
+    CardAction(String title, String icon, String tooltip,
+            ActionType actionType, String actionReference, boolean showResultNotification) {
+        this.title = title;
+        this.icon = icon;
+        this.tooltip = tooltip;
+        this.actionType = actionType;
+        this.actionReference = actionReference;
+        this.showResultNotification = showResultNotification;
+    }
+
+    public static CardActionBuilder actionBuilder() {
+        return new CardActionBuilder();
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getIcon() {
+        return icon;
+    }
+
+    public String getTooltip() {
+        return tooltip;
+    }
+
+    public ActionType getActionType() {
+        return actionType;
+    }
+
+    public String getActionReference() {
+        return actionReference;
+    }
+
+    public boolean isShowResultNotification() {
+        return showResultNotification;
+    }
+}

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/page/CardActionBuilder.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/page/CardActionBuilder.java
@@ -1,0 +1,57 @@
+package io.quarkus.devui.spi.page;
+
+public class CardActionBuilder {
+
+    private String title;
+    private String icon;
+    private String tooltip;
+    private CardAction.ActionType actionType;
+    private String actionReference;
+    private boolean showResultNotification = true;
+
+    CardActionBuilder() {
+    }
+
+    public CardActionBuilder title(String title) {
+        this.title = title;
+        return this;
+    }
+
+    public CardActionBuilder icon(String icon) {
+        this.icon = icon;
+        return this;
+    }
+
+    public CardActionBuilder tooltip(String tooltip) {
+        this.tooltip = tooltip;
+        return this;
+    }
+
+    public CardActionBuilder jsonRpcMethodName(String methodName) {
+        this.actionType = CardAction.ActionType.JSONRPC;
+        this.actionReference = methodName;
+        return this;
+    }
+
+    public CardActionBuilder url(String url) {
+        this.actionType = CardAction.ActionType.URL;
+        this.actionReference = url;
+        return this;
+    }
+
+    public CardActionBuilder showResultNotification(boolean show) {
+        this.showResultNotification = show;
+        return this;
+    }
+
+    public CardAction build() {
+        if (title == null || title.isEmpty()) {
+            throw new RuntimeException("CardAction title is required");
+        }
+        if (actionType == null || actionReference == null || actionReference.isEmpty()) {
+            throw new RuntimeException("CardAction requires either jsonRpcMethodName() or url()");
+        }
+        return new CardAction(title, icon, tooltip,
+                actionType, actionReference, showResultNotification);
+    }
+}

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/page/CardPageBuildItem.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/page/CardPageBuildItem.java
@@ -16,6 +16,7 @@ public final class CardPageBuildItem extends AbstractPageBuildItem {
 
     private Optional<Card> optionalCard = Optional.empty();
     private List<LibraryLink> libraryVersions;
+    private List<CardAction> cardActions;
 
     private String darkLogo;
     private String lightLogo;
@@ -54,6 +55,20 @@ public final class CardPageBuildItem extends AbstractPageBuildItem {
 
     public boolean hasLibraryVersions() {
         return this.libraryVersions != null && !this.libraryVersions.isEmpty();
+    }
+
+    public void addAction(CardAction action) {
+        if (cardActions == null)
+            cardActions = new ArrayList<>();
+        cardActions.add(action);
+    }
+
+    public List<CardAction> getCardActions() {
+        return this.cardActions == null ? Collections.emptyList() : this.cardActions;
+    }
+
+    public boolean hasCardActions() {
+        return this.cardActions != null && !this.cardActions.isEmpty();
     }
 
     public void setLogo(String darkLogo, String lightLogo) {

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/DevUIProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/DevUIProcessor.java
@@ -87,6 +87,7 @@ import io.quarkus.devui.spi.buildtime.jsonrpc.AbstractJsonRpcMethod;
 import io.quarkus.devui.spi.buildtime.jsonrpc.DeploymentJsonRpcMethod;
 import io.quarkus.devui.spi.buildtime.jsonrpc.RecordedJsonRpcMethod;
 import io.quarkus.devui.spi.buildtime.jsonrpc.RuntimeJsonRpcMethod;
+import io.quarkus.devui.spi.page.CardAction;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.FooterPageBuildItem;
 import io.quarkus.devui.spi.page.LibraryLink;
@@ -876,7 +877,9 @@ public class DevUIProcessor {
                                     }
                                 }
 
-                                if (cardPagesMap.containsKey(namespace) && cardPagesMap.get(namespace).hasPages()) { // Active
+                                if (cardPagesMap.containsKey(namespace)
+                                        && (cardPagesMap.get(namespace).hasPages()
+                                                || cardPagesMap.get(namespace).hasCardActions())) { // Active
                                     CardPageBuildItem cardPageBuildItem = cardPagesMap.get(namespace);
 
                                     // Add all card links
@@ -888,6 +891,11 @@ public class DevUIProcessor {
                                         if (!page.isAssistantPage() || assistantIsAvailable) {
                                             extension.addCardPage(page);
                                         }
+                                    }
+
+                                    // Add card actions
+                                    for (CardAction action : cardPageBuildItem.getCardActions()) {
+                                        extension.addCardAction(action);
                                     }
 
                                     // See if there is a custom card component

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/extension/Extension.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/extension/Extension.java
@@ -2,10 +2,12 @@ package io.quarkus.devui.deployment.extension;
 
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
 import io.quarkus.devui.spi.page.Card;
+import io.quarkus.devui.spi.page.CardAction;
 import io.quarkus.devui.spi.page.LibraryLink;
 import io.quarkus.devui.spi.page.Page;
 
@@ -31,6 +33,7 @@ public class Extension {
     private final List<Page> settingPages = new ArrayList<>();
     private final List<Page> unlistedPages = new ArrayList<>();
     private Card card = null; // Custom card
+    private List<CardAction> cardActions = null;
     private List<LibraryLink> libraryLinks = null;
     private String darkLogo = null;
     private String lightLogo = null;
@@ -197,6 +200,16 @@ public class Extension {
 
     public List<Page> getCardPages() {
         return cardPages;
+    }
+
+    public void addCardAction(CardAction action) {
+        if (this.cardActions == null)
+            this.cardActions = new LinkedList<>();
+        this.cardActions.add(action);
+    }
+
+    public List<CardAction> getCardActions() {
+        return cardActions == null ? Collections.emptyList() : cardActions;
     }
 
     public void addMenuPage(Page page) {

--- a/extensions/devui/deployment/src/test/java/io/quarkus/devui/CardActionTest.java
+++ b/extensions/devui/deployment/src/test/java/io/quarkus/devui/CardActionTest.java
@@ -1,0 +1,139 @@
+package io.quarkus.devui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkus.devui.spi.page.CardAction;
+import io.quarkus.devui.spi.page.CardAction.ActionType;
+import io.quarkus.devui.spi.page.CardPageBuildItem;
+
+public class CardActionTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void testJsonRpcActionBuilder() {
+        CardAction action = CardAction.actionBuilder()
+                .title("Clean All")
+                .icon("font-awesome-solid:broom")
+                .tooltip("Clean all databases")
+                .jsonRpcMethodName("cleanAll")
+                .build();
+
+        assertEquals("Clean All", action.getTitle());
+        assertEquals("font-awesome-solid:broom", action.getIcon());
+        assertEquals("Clean all databases", action.getTooltip());
+        assertEquals(ActionType.JSONRPC, action.getActionType());
+        assertEquals("cleanAll", action.getActionReference());
+        assertTrue(action.isShowResultNotification());
+    }
+
+    @Test
+    public void testUrlActionBuilder() {
+        CardAction action = CardAction.actionBuilder()
+                .title("Refresh")
+                .url("/q/refresh")
+                .showResultNotification(false)
+                .build();
+
+        assertEquals("Refresh", action.getTitle());
+        assertEquals(ActionType.URL, action.getActionType());
+        assertEquals("/q/refresh", action.getActionReference());
+        assertFalse(action.isShowResultNotification());
+        assertNull(action.getIcon());
+        assertNull(action.getTooltip());
+    }
+
+    @Test
+    public void testBuilderRequiresTitle() {
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> {
+            CardAction.actionBuilder()
+                    .jsonRpcMethodName("doSomething")
+                    .build();
+        });
+        assertTrue(ex.getMessage().contains("title"));
+    }
+
+    @Test
+    public void testBuilderRequiresAction() {
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> {
+            CardAction.actionBuilder()
+                    .title("No Action")
+                    .build();
+        });
+        assertTrue(ex.getMessage().contains("jsonRpcMethodName"));
+    }
+
+    @Test
+    public void testCardPageBuildItemActions() {
+        CardPageBuildItem item = new CardPageBuildItem();
+        assertFalse(item.hasCardActions());
+        assertTrue(item.getCardActions().isEmpty());
+
+        CardAction action1 = CardAction.actionBuilder()
+                .title("Action 1")
+                .jsonRpcMethodName("method1")
+                .build();
+        CardAction action2 = CardAction.actionBuilder()
+                .title("Action 2")
+                .url("/api/action2")
+                .build();
+
+        item.addAction(action1);
+        item.addAction(action2);
+
+        assertTrue(item.hasCardActions());
+        List<CardAction> actions = item.getCardActions();
+        assertEquals(2, actions.size());
+        assertEquals("Action 1", actions.get(0).getTitle());
+        assertEquals("Action 2", actions.get(1).getTitle());
+    }
+
+    @Test
+    public void testJacksonSerialization() throws Exception {
+        CardAction action = CardAction.actionBuilder()
+                .title("Generate Report")
+                .icon("font-awesome-solid:wand-magic-sparkles")
+                .tooltip("Generate a report")
+                .jsonRpcMethodName("generateReport")
+                .showResultNotification(true)
+                .build();
+
+        String json = mapper.writeValueAsString(action);
+        JsonNode node = mapper.readTree(json);
+
+        assertEquals("Generate Report", node.get("title").asText());
+        assertEquals("font-awesome-solid:wand-magic-sparkles", node.get("icon").asText());
+        assertEquals("Generate a report", node.get("tooltip").asText());
+        assertEquals("JSONRPC", node.get("actionType").asText());
+        assertEquals("generateReport", node.get("actionReference").asText());
+        assertTrue(node.get("showResultNotification").asBoolean());
+    }
+
+    @Test
+    public void testJacksonSerializationWithNullOptionalFields() throws Exception {
+        CardAction action = CardAction.actionBuilder()
+                .title("Simple")
+                .url("/api/simple")
+                .build();
+
+        String json = mapper.writeValueAsString(action);
+        JsonNode node = mapper.readTree(json);
+
+        assertEquals("Simple", node.get("title").asText());
+        assertEquals("URL", node.get("actionType").asText());
+        assertEquals("/api/simple", node.get("actionReference").asText());
+        assertTrue(node.get("icon").isNull());
+        assertTrue(node.get("tooltip").isNull());
+    }
+}

--- a/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-extension-action.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-extension-action.js
@@ -1,0 +1,137 @@
+import { LitElement, html, css } from 'lit';
+import { JsonRpc } from 'jsonrpc';
+import { notifier } from 'notifier';
+import '@vaadin/icon';
+
+export class QwcExtensionAction extends LitElement {
+
+    static styles = css`
+        :host {
+            display: flex;
+            flex-direction: row;
+            align-items: center;
+            padding: 2px 5px;
+        }
+        .actionButton {
+            display: flex;
+            flex-direction: row;
+            justify-content: flex-start;
+            align-items: center;
+            color: var(--lumo-contrast-70pct);
+            font-size: var(--lumo-font-size-s);
+            padding: 2px 5px;
+            cursor: pointer;
+            gap: 5px;
+            border-radius: var(--devui-radius-sm, 6px);
+            border: none;
+            background: none;
+            font-family: inherit;
+            transition: background-color var(--devui-transition-fast, 0.15s ease),
+                        color var(--devui-transition-fast, 0.15s ease);
+        }
+        .actionButton:hover {
+            background-color: var(--lumo-primary-color-10pct);
+            color: var(--lumo-primary-text-color);
+        }
+        .actionButton:disabled {
+            opacity: 0.5;
+            cursor: wait;
+        }
+        .icon {
+            padding-right: 5px;
+            width: var(--lumo-icon-size-s);
+            height: var(--lumo-icon-size-s);
+        }
+        .iconAndName {
+            display: flex;
+            flex-direction: row;
+            justify-content: flex-start;
+            align-items: center;
+        }
+    `;
+
+    static properties = {
+        namespace: { type: String },
+        displayName: { type: String },
+        iconName: { type: String },
+        tooltipContent: { type: String },
+        actionType: { type: String },
+        actionReference: { type: String },
+        showResultNotification: { type: Boolean },
+        _loading: { state: true }
+    };
+
+    constructor() {
+        super();
+        this._loading = false;
+        this.showResultNotification = true;
+    }
+
+    render() {
+        return html`
+            <button class="actionButton"
+                    @click="${this._handleClick}"
+                    title="${this.tooltipContent || ''}"
+                    ?disabled="${this._loading}">
+                <span class="iconAndName">
+                    ${this.iconName && this.iconName !== 'null'
+                        ? html`<vaadin-icon class="icon" icon="${this.iconName}"></vaadin-icon>`
+                        : ''}
+                    ${this.displayName}
+                </span>
+            </button>
+        `;
+    }
+
+    _handleClick() {
+        if (this.actionType === 'JSONRPC') {
+            this._executeJsonRpc();
+        } else if (this.actionType === 'URL') {
+            this._executeUrl();
+        }
+    }
+
+    _executeJsonRpc() {
+        this._loading = true;
+        const jrpc = new JsonRpc(this.namespace);
+        jrpc[this.actionReference]().then(jsonRpcResponse => {
+            this._loading = false;
+            if (this.showResultNotification) {
+                const result = jsonRpcResponse.result;
+                const message = typeof result === 'string'
+                    ? result
+                    : JSON.stringify(result);
+                notifier.showSuccessMessage(message);
+            }
+        }).catch(error => {
+            this._loading = false;
+            notifier.showErrorMessage(
+                this.displayName + ' failed: ' + (error?.error?.message || error)
+            );
+        });
+    }
+
+    _executeUrl() {
+        this._loading = true;
+        fetch(this.actionReference)
+            .then(response => {
+                this._loading = false;
+                if (response.ok) {
+                    if (this.showResultNotification) {
+                        notifier.showSuccessMessage('OK');
+                    }
+                } else {
+                    notifier.showErrorMessage(
+                        this.displayName + ' failed: ' + response.statusText
+                    );
+                }
+            })
+            .catch(error => {
+                this._loading = false;
+                notifier.showErrorMessage(
+                    this.displayName + ' failed: ' + error
+                );
+            });
+    }
+}
+customElements.define('qwc-extension-action', QwcExtensionAction);

--- a/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-extensions.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-extensions.js
@@ -6,6 +6,7 @@ import { observeState } from 'lit-element-state';
 import { allowExtensionManagement } from 'devui-data';
 import 'qwc/qwc-extension.js';
 import 'qwc/qwc-extension-link.js';
+import 'qwc/qwc-extension-action.js';
 import 'qwc/qwc-extension-add.js';
 import { StorageController } from 'storage-controller';
 import '@vaadin/dialog';
@@ -405,6 +406,7 @@ export class QwcExtensions extends observeState(LitElement) {
                         ${msg(extension.description, {id: extension.namespace + '-meta-description'})}
                     </span>
                     ${this._renderCardLinks(extension)}
+                    ${this._renderCardActions(extension)}
                 </div>
                 ${this._renderLibraryVersions(extension)}
             </div>`;
@@ -460,6 +462,24 @@ export class QwcExtensions extends observeState(LitElement) {
                             </qwc-extension-link>
                         `;
         }
+    }
+
+    _renderCardActions(extension){
+        if (extension.cardActions && extension.cardActions.length > 0) {
+            return html`${extension.cardActions.map(action => html`${this._renderCardAction(extension, action)}`)}`;
+        }
+    }
+
+    _renderCardAction(extension, action){
+        return html`<qwc-extension-action
+                        namespace="${extension.namespace}"
+                        displayName="${action.title}"
+                        iconName="${action.icon}"
+                        tooltipContent="${action.tooltip}"
+                        actionType="${action.actionType}"
+                        actionReference="${action.actionReference}"
+                        ?showResultNotification=${action.showResultNotification}>
+                    </qwc-extension-action>`;
     }
 
     _renderLibraryVersions(extension) {


### PR DESCRIPTION
Currently, Dev UI extension cards only support navigational links via `qwc-extension-link`. Extensions that need action buttons (e.g., "Clean All", "Generate Report") must use `setCustomCard()` with a fully custom web component, losing access to card API conveniences like logos, library versions, and descriptions.

This adds a `CardAction` API that lets extensions add action buttons alongside page links on the default card. Actions render as buttons that trigger a JsonRPC method or hit a URL on click, and optionally show the result as a toast notification.

### Usage

```java
card.addAction(CardAction.actionBuilder()
        .title("Clean All")
        .icon("font-awesome-solid:broom")
        .jsonRpcMethodName("cleanAll")
        .build());
```

### Changes

**SPI** (`deployment-spi`):
- New `CardAction` immutable model with `ActionType` enum (JSONRPC, URL)
- New `CardActionBuilder` fluent builder
- `CardPageBuildItem.addAction()` / `getCardActions()` / `hasCardActions()`

**Deployment**:
- `Extension` model gets `cardActions` field (Jackson-serialized to frontend)
- `DevUIProcessor` transfers actions from build items to the Extension model
- Extensions with only actions (no pages) are now correctly classified as active

**Frontend**:
- New `qwc-extension-action.js` Lit web component (button with loading state, JsonRPC/URL execution, toast notifications)
- `qwc-extensions.js` renders actions alongside links in the default card

**Docs & Tests**:
- New "Optional: Card Actions" section in `dev-ui.adoc` with examples
- 7 unit tests covering builder validation, `CardPageBuildItem` integration, and Jackson serialization

Closes #53617