### PR TITLE
Add Maven property for non-platform extension version in generated pom.xml

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/maven/base/pom.tpl.qute.xml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/maven/base/pom.tpl.qute.xml
@@ -28,6 +28,11 @@
         <compiler-plugin.version>{maven-compiler-plugin.version}</compiler-plugin.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>{maven-surefire-plugin.version}</surefire-plugin.version>
+        {#each dependencies}
+        {#if it.version}
+        <{it.artifactId}.version>{it.version}</{it.artifactId}.version>
+        {/if}
+        {/each}
         {#if uberjar}
         <quarkus.package.jar.type>uber-jar</quarkus.package.jar.type>
         {/if}
@@ -98,7 +103,7 @@
             <groupId>{it.groupId}</groupId>
             <artifactId>{it.artifactId}</artifactId>
             {#if it.version}
-            <version>{it.version}</version>
+            <version>$\{{it.artifactId}.version}</version>
             {/if}
         </dependency>
         {/each}

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/CreateProjectWithNonPlatformExtensionTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/CreateProjectWithNonPlatformExtensionTest.java
@@ -2,6 +2,7 @@ package io.quarkus.devtools.project.create;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -51,7 +52,9 @@ public class CreateProjectWithNonPlatformExtensionTest extends MultiplePlatformB
 
         assertModel(projectDir,
                 List.of(mainPlatformBom()),
-                List.of(ArtifactCoords.jar("org.bla", "bla-magic", "5.5.5")),
-                "1.1.1");
+                List.of(ArtifactCoords.jar("org.bla", "bla-magic", "${bla-magic.version}")),
+                Map.of(
+                        "quarkus.platform.version", "1.1.1",
+                        "bla-magic.version", "5.5.5"));
     }
 }


### PR DESCRIPTION
When a non-platform extension (not managed by the BOM) is added to a generated project, its version is currently hardcoded inline in the `<dependency>` block. This PR moves it to a Maven property `<artifactId.version>` in the `<properties>` section and references it as `${artifactId.version}` in the dependency, which is the standard Maven convention for managing third-party versions.

The existing test in `CreateProjectWithNonPlatformExtensionTest` is updated to assert the property-based version.

Fixes #39439