### PR TITLE
Avoid storing the class tranformer and cache in a static field

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/RuntimeClassTransformerBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/RuntimeClassTransformerBuildItem.java
@@ -1,0 +1,22 @@
+package io.quarkus.deployment.builditem;
+
+import io.quarkus.bootstrap.app.ClassTransformer;
+import io.quarkus.builder.item.SimpleBuildItem;
+import io.smallrye.common.constraint.Assert;
+
+/**
+ * Carries the bytecode transformation function produced during augmentation,
+ * for use by the runtime hot-reload infrastructure (instrumentation-based class redefinition).
+ */
+public final class RuntimeClassTransformerBuildItem extends SimpleBuildItem {
+
+    private final ClassTransformer transformer;
+
+    public RuntimeClassTransformerBuildItem(ClassTransformer transformer) {
+        this.transformer = Assert.checkNotNullParam("transformer", transformer);
+    }
+
+    public ClassTransformer getTransformer() {
+        return transformer;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedDevModeMain.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedDevModeMain.java
@@ -17,7 +17,6 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -27,6 +26,7 @@ import org.jboss.logmanager.handlers.ConsoleHandler;
 
 import io.quarkus.bootstrap.app.AugmentAction;
 import io.quarkus.bootstrap.app.ClassChangeInformation;
+import io.quarkus.bootstrap.app.ClassTransformer;
 import io.quarkus.bootstrap.app.CuratedApplication;
 import io.quarkus.bootstrap.app.RunningQuarkusApplication;
 import io.quarkus.bootstrap.app.StartupAction;
@@ -40,7 +40,6 @@ import io.quarkus.deployment.builditem.ApplicationClassPredicateBuildItem;
 import io.quarkus.deployment.console.ConsoleCommand;
 import io.quarkus.deployment.console.ConsoleStateManager;
 import io.quarkus.deployment.dev.testing.TestSupport;
-import io.quarkus.deployment.steps.ClassTransformingBuildStep;
 import io.quarkus.dev.appstate.ApplicationStartException;
 import io.quarkus.dev.appstate.ApplicationStateNotification;
 import io.quarkus.dev.console.DevConsoleManager;
@@ -258,10 +257,10 @@ public class IsolatedDevModeMain implements BiConsumer<CuratedApplication, Map<S
             }
 
             RuntimeUpdatesProcessor processor = new RuntimeUpdatesProcessor(appRoot, context, compiler,
-                    devModeType, this::restartCallback, null, new BiFunction<String, byte[], byte[]>() {
+                    devModeType, this::restartCallback, null, new ClassTransformer() {
                         @Override
-                        public byte[] apply(String s, byte[] bytes) {
-                            return ClassTransformingBuildStep.transform(s, bytes);
+                        public byte[] transform(String s, byte[] bytes) {
+                            return augmentAction.getClassTransformer().transform(s, bytes);
                         }
                     }, testSupport, deploymentProblem);
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedRemoteDevModeMain.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedRemoteDevModeMain.java
@@ -23,7 +23,6 @@ import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -31,6 +30,7 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.bootstrap.app.AugmentAction;
 import io.quarkus.bootstrap.app.AugmentResult;
+import io.quarkus.bootstrap.app.ClassTransformer;
 import io.quarkus.bootstrap.app.CuratedApplication;
 import io.quarkus.bootstrap.app.JarResult;
 import io.quarkus.bootstrap.runner.Timing;
@@ -39,7 +39,6 @@ import io.quarkus.deployment.dev.remote.RemoteDevClient;
 import io.quarkus.deployment.dev.remote.RemoteDevClientProvider;
 import io.quarkus.deployment.mutability.DevModeTask;
 import io.quarkus.deployment.pkg.jar.FastJarFormat;
-import io.quarkus.deployment.steps.ClassTransformingBuildStep;
 import io.quarkus.dev.spi.DeploymentFailedStartHandler;
 import io.quarkus.dev.spi.DevModeType;
 import io.quarkus.dev.spi.HotReplacementSetup;
@@ -133,10 +132,10 @@ public class IsolatedRemoteDevModeMain implements BiConsumer<CuratedApplication,
                         public void accept(DevModeContext.ModuleInfo moduleInfo, String s) {
                             copiedStaticResources.computeIfAbsent(moduleInfo, ss -> new HashSet<>()).add(s);
                         }
-                    }, new BiFunction<String, byte[], byte[]>() {
+                    }, new ClassTransformer() {
                         @Override
-                        public byte[] apply(String s, byte[] bytes) {
-                            return ClassTransformingBuildStep.transform(s, bytes);
+                        public byte[] transform(String s, byte[] bytes) {
+                            return augmentAction.getClassTransformer().transform(s, bytes);
                         }
                     }, null, deploymentProblem);
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedTestModeMain.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedTestModeMain.java
@@ -12,9 +12,9 @@ import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
 
 import io.quarkus.bootstrap.app.AugmentAction;
+import io.quarkus.bootstrap.app.ClassTransformer;
 import io.quarkus.bootstrap.app.CuratedApplication;
 import io.quarkus.bootstrap.runner.Timing;
 import io.quarkus.deployment.builditem.ConsoleFormatterBannerBuildItem;
@@ -23,7 +23,6 @@ import io.quarkus.deployment.dev.testing.TestSetupBuildItem;
 import io.quarkus.deployment.dev.testing.TestSupport;
 import io.quarkus.deployment.jvm.ResolvedJVMRequirements;
 import io.quarkus.deployment.logging.LoggingSetupBuildItem;
-import io.quarkus.deployment.steps.ClassTransformingBuildStep;
 import io.quarkus.dev.spi.DevModeType;
 import io.quarkus.dev.spi.HotReplacementSetup;
 import io.quarkus.runner.bootstrap.AugmentActionImpl;
@@ -64,10 +63,10 @@ public class IsolatedTestModeMain extends IsolatedDevModeMain {
                         @Override
                         public void accept(DevModeContext.ModuleInfo moduleInfo, String s) {
                         }
-                    }, new BiFunction<String, byte[], byte[]>() {
+                    }, new ClassTransformer() {
                         @Override
-                        public byte[] apply(String s, byte[] bytes) {
-                            return ClassTransformingBuildStep.transform(s, bytes);
+                        public byte[] transform(String s, byte[] bytes) {
+                            return augmentAction.getClassTransformer().transform(s, bytes);
                         }
                     }, testSupport, deploymentProblem);
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
@@ -45,7 +45,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -59,6 +58,7 @@ import org.jboss.jandex.IndexView;
 import org.jboss.jandex.Indexer;
 import org.jboss.logging.Logger;
 
+import io.quarkus.bootstrap.app.ClassTransformer;
 import io.quarkus.bootstrap.runner.DevModeMediator;
 import io.quarkus.bootstrap.runner.Timing;
 import io.quarkus.changeagent.ClassChangeAgent;
@@ -116,7 +116,7 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
     private final List<Runnable> deploymentFailedStartHandlers = new ArrayList<>();
     private final BiConsumer<Set<String>, ClassScanResult> restartCallback;
     private final BiConsumer<DevModeContext.ModuleInfo, String> copyResourceNotification;
-    private final BiFunction<String, byte[], byte[]> classTransformers;
+    private final ClassTransformer classTransformer;
     private final ReentrantLock scanLock = new ReentrantLock();
     private final Lock codeGenLock = CodeGenLock.lockForCompilation();
 
@@ -146,7 +146,7 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
     public RuntimeUpdatesProcessor(Path applicationRoot, DevModeContext context, QuarkusCompiler compiler,
             DevModeType devModeType, BiConsumer<Set<String>, ClassScanResult> restartCallback,
             BiConsumer<DevModeContext.ModuleInfo, String> copyResourceNotification,
-            BiFunction<String, byte[], byte[]> classTransformers,
+            ClassTransformer classTransformer,
             TestSupport testSupport, AtomicReference<Throwable> deploymentProblem) {
         this.applicationRoot = applicationRoot;
         this.context = context;
@@ -154,7 +154,7 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
         this.devModeType = devModeType;
         this.restartCallback = restartCallback;
         this.copyResourceNotification = copyResourceNotification;
-        this.classTransformers = classTransformers;
+        this.classTransformer = classTransformer;
         this.testSupport = testSupport;
         if (testSupport != null) {
             testSupport.addListener(new TestListener() {
@@ -510,7 +510,7 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
                             String name = indexer.indexWithSummary(new ByteArrayInputStream(bytes)).name().toString();
                             defs[index++] = new ClassDefinition(
                                     Thread.currentThread().getContextClassLoader().loadClass(name),
-                                    classTransformers.apply(name, bytes));
+                                    classTransformer.transform(name, bytes));
                         }
                         Index current = indexer.complete();
                         boolean ok = !disableInstrumentationForIndexPredicate.test(current);

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ClassTransformingBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ClassTransformingBuildStep.java
@@ -33,19 +33,21 @@ import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
 
 import io.quarkus.bootstrap.BootstrapDebug;
+import io.quarkus.bootstrap.app.ClassTransformer;
 import io.quarkus.bootstrap.classloading.ClassPathElement;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.deployment.QuarkusClassVisitor;
 import io.quarkus.deployment.QuarkusClassWriter;
+import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
 import io.quarkus.deployment.builditem.ArchiveRootBuildItem;
 import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
-import io.quarkus.deployment.builditem.CuratedApplicationShutdownBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.deployment.builditem.RemovedResourceBuildItem;
+import io.quarkus.deployment.builditem.RuntimeClassTransformerBuildItem;
 import io.quarkus.deployment.builditem.TransformedClassesBuildItem;
 import io.quarkus.deployment.configuration.ClassLoadingConfig;
 import io.quarkus.deployment.index.ConstPoolScanner;
@@ -60,23 +62,11 @@ public class ClassTransformingBuildStep {
 
     private static final Logger log = Logger.getLogger(ClassTransformingBuildStep.class);
 
-    /**
-     * Cache used for dev mode to save the result for classes that have not changed.
-     */
-    private static final Map<String, TransformedClassesBuildItem.TransformedClass> transformedClassesCache = new ConcurrentHashMap<>();
-    private static volatile BiFunction<String, byte[], byte[]> lastTransformers;
-
-    public static byte[] transform(String className, byte[] classData) {
-        if (lastTransformers == null) {
-            return classData;
+    // Cache used for dev mode to save the result for classes that have not changed
+    record TransformedClassesCache(Map<String, TransformedClassesBuildItem.TransformedClass> cache) {
+        TransformedClassesCache() {
+            this(new ConcurrentHashMap<>());
         }
-
-        return lastTransformers.apply(className, classData);
-    }
-
-    private static void reset() {
-        lastTransformers = null;
-        transformedClassesCache.clear();
     }
 
     @BuildStep
@@ -86,10 +76,11 @@ public class ClassTransformingBuildStep {
             CurateOutcomeBuildItem curateOutcomeBuildItem, List<RemovedResourceBuildItem> removedResourceBuildItems,
             ArchiveRootBuildItem archiveRoot, LaunchModeBuildItem launchMode, PackageConfig packageConfig,
             ExecutorService buildExecutor,
-            CuratedApplicationShutdownBuildItem shutdown)
+            BuildProducer<RuntimeClassTransformerBuildItem> runtimeClassTransformerProducer)
             throws ExecutionException, InterruptedException {
         if (bytecodeTransformerBuildItems.isEmpty() && classLoadingConfig.removedResources().isEmpty()
                 && removedResourceBuildItems.isEmpty()) {
+            runtimeClassTransformerProducer.produce(new RuntimeClassTransformerBuildItem(ClassTransformer.IDENTITY));
             return new TransformedClassesBuildItem(Collections.emptyMap());
         }
         final Map<String, List<BytecodeTransformerBuildItem>> bytecodeTransformers = new HashMap<>(
@@ -107,6 +98,14 @@ public class ClassTransformingBuildStep {
                     (oldValue, newValue) -> oldValue | newValue);
         }
 
+        TransformedClassesCache existingCache = liveReloadBuildItem
+                .getContextObject(TransformedClassesCache.class);
+        if (existingCache == null) {
+            existingCache = new TransformedClassesCache();
+            liveReloadBuildItem.setContextObject(TransformedClassesCache.class, existingCache);
+        }
+        final TransformedClassesCache transformedClassesCache = existingCache;
+
         QuarkusClassLoader cl = (QuarkusClassLoader) Thread.currentThread().getContextClassLoader();
         Map<String, Path> transformedToArchive = new ConcurrentHashMap<>();
         // now copy all the contents to the runner jar
@@ -115,10 +114,9 @@ public class ClassTransformingBuildStep {
         final ConcurrentLinkedDeque<Future<TransformedClassesBuildItem.TransformedClass>> transformed = new ConcurrentLinkedDeque<>();
         final Map<Path, Set<TransformedClassesBuildItem.TransformedClass>> transformedClassesByJar = new HashMap<>();
         ClassLoader transformCl = Thread.currentThread().getContextClassLoader();
-        shutdown.addCloseTask(ClassTransformingBuildStep::reset, true);
-        lastTransformers = new BiFunction<String, byte[], byte[]>() {
+        ClassTransformer classTransformer = new ClassTransformer() {
             @Override
-            public byte[] apply(String className, byte[] originalBytes) {
+            public byte[] transform(String className, byte[] originalBytes) {
 
                 List<BytecodeTransformerBuildItem> classTransformers = bytecodeTransformers.get(className);
                 if (classTransformers == null) {
@@ -181,16 +179,17 @@ public class ClassTransformingBuildStep {
                 }
             }
         };
+        runtimeClassTransformerProducer.produce(new RuntimeClassTransformerBuildItem(classTransformer));
         for (Map.Entry<String, List<BytecodeTransformerBuildItem>> entry : bytecodeTransformers
                 .entrySet()) {
             String className = entry.getKey();
             boolean cacheable = !nonCacheable.contains(className);
-            if (cacheable && transformedClassesCache.containsKey(className)) {
+            if (cacheable && transformedClassesCache.cache().containsKey(className)) {
                 if (liveReloadBuildItem.getChangeInformation() != null) {
                     if (!liveReloadBuildItem.getChangeInformation().getChangedClasses().contains(className)) {
                         //we can use the cached transformation
                         handleTransformedClass(transformedToArchive, transformedClassesByJar,
-                                transformedClassesCache.get(className));
+                                transformedClassesCache.cache().get(className));
                         continue;
                     }
                 }
@@ -245,7 +244,7 @@ public class ClassTransformingBuildStep {
                                     classFileName);
                             if (cacheable && launchModeBuildItem.getLaunchMode() == LaunchMode.DEVELOPMENT
                                     && classData != null) {
-                                transformedClassesCache.put(className, transformedClass);
+                                transformedClassesCache.cache().put(className, transformedClass);
                             }
                             return transformedClass;
                         } catch (Throwable e) {

--- a/core/deployment/src/main/java/io/quarkus/runner/bootstrap/AugmentActionImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/runner/bootstrap/AugmentActionImpl.java
@@ -30,6 +30,7 @@ import io.quarkus.bootstrap.app.ArtifactResult;
 import io.quarkus.bootstrap.app.AugmentAction;
 import io.quarkus.bootstrap.app.AugmentResult;
 import io.quarkus.bootstrap.app.ClassChangeInformation;
+import io.quarkus.bootstrap.app.ClassTransformer;
 import io.quarkus.bootstrap.app.CuratedApplication;
 import io.quarkus.bootstrap.app.QuarkusBootstrap;
 import io.quarkus.bootstrap.app.SbomResult;
@@ -47,6 +48,7 @@ import io.quarkus.deployment.builditem.GeneratedFileSystemResourceHandledBuildIt
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.deployment.builditem.MainClassBuildItem;
+import io.quarkus.deployment.builditem.RuntimeClassTransformerBuildItem;
 import io.quarkus.deployment.builditem.TransformedClassesBuildItem;
 import io.quarkus.deployment.jvm.ResolvedJVMRequirements;
 import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
@@ -69,7 +71,8 @@ public class AugmentActionImpl implements AugmentAction {
     private static final Class[] NON_NORMAL_MODE_OUTPUTS = { GeneratedClassBuildItem.class,
             GeneratedResourceBuildItem.class, ApplicationClassNameBuildItem.class,
             MainClassBuildItem.class, GeneratedFileSystemResourceHandledBuildItem.class,
-            TransformedClassesBuildItem.class, ResolvedJVMRequirements.class };
+            TransformedClassesBuildItem.class, RuntimeClassTransformerBuildItem.class,
+            ResolvedJVMRequirements.class };
 
     private final QuarkusBootstrap quarkusBootstrap;
     private final CuratedApplication curatedApplication;
@@ -85,6 +88,7 @@ public class AugmentActionImpl implements AugmentAction {
      *
      */
     private final Map<Class<?>, Object> reloadContext = new ConcurrentHashMap<>();
+    private volatile ClassTransformer classTransformer = ClassTransformer.IDENTITY;
 
     public AugmentActionImpl(CuratedApplication curatedApplication) {
         this(curatedApplication, Collections.emptyList(), Collections.emptyList());
@@ -353,6 +357,7 @@ public class AugmentActionImpl implements AugmentAction {
         try (QuarkusClassLoader classLoader = curatedApplication.createDeploymentClassLoader()) {
             @SuppressWarnings("unchecked")
             BuildResult result = runAugment(true, Collections.emptySet(), null, classLoader, NON_NORMAL_MODE_OUTPUTS);
+            updateClassTransformer(result);
             return new StartupActionImpl(curatedApplication, result);
         }
     }
@@ -368,9 +373,21 @@ public class AugmentActionImpl implements AugmentAction {
             @SuppressWarnings("unchecked")
             BuildResult result = runAugment(!hasStartedSuccessfully, changedResources, classChangeInformation, classLoader,
                     NON_NORMAL_MODE_OUTPUTS);
-
+            updateClassTransformer(result);
             return new StartupActionImpl(curatedApplication, result);
         }
+    }
+
+    private void updateClassTransformer(BuildResult result) {
+        RuntimeClassTransformerBuildItem item = result.consumeOptional(RuntimeClassTransformerBuildItem.class);
+        if (item != null) {
+            this.classTransformer = item.getTransformer();
+        }
+    }
+
+    @Override
+    public ClassTransformer getClassTransformer() {
+        return classTransformer;
     }
 
     private BuildResult runAugment(boolean firstRun, Set<String> changedResources,

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/AugmentAction.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/AugmentAction.java
@@ -21,4 +21,17 @@ public interface AugmentAction {
 
     StartupAction reloadExistingApplication(boolean hasStartedSuccessfully, Set<String> changedResources,
             ClassChangeInformation classChangeInformation);
+
+    /**
+     * Returns the bytecode transformation function from the most recent augmentation,
+     * for use during instrumentation-based hot reload.
+     * <p>
+     * Callers must not cache the result: the transformer is updated after each augmentation,
+     * and {@code RuntimeUpdatesProcessor} is created before the first build completes.
+     *
+     * @return the transformer, never {@code null}
+     */
+    default ClassTransformer getClassTransformer() {
+        return ClassTransformer.IDENTITY;
+    }
 }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/ClassTransformer.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/ClassTransformer.java
@@ -1,0 +1,12 @@
+package io.quarkus.bootstrap.app;
+
+/**
+ * Applies bytecode transformations to a class during instrumentation-based hot reload.
+ */
+@FunctionalInterface
+public interface ClassTransformer {
+
+    ClassTransformer IDENTITY = (name, bytes) -> bytes;
+
+    byte[] transform(String className, byte[] classData);
+}


### PR DESCRIPTION
While I'm not sure we will get to a state where we can actually merge
 #53656, I think it's good cleanup to avoid sharing these in mutable
static fields.

Created as draft as I need a full CI run.