### PR TITLE
refactor: implement AsciiDoc-to-Markdown conversion in JavadocToMarkdownTransformer

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/formatter/JavadocToMarkdownTransformer.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/formatter/JavadocToMarkdownTransformer.java
@@ -1,5 +1,6 @@
 package io.quarkus.annotation.processor.documentation.config.formatter;
 
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.github.javaparser.StaticJavaParser;
@@ -13,6 +14,24 @@ import io.quarkus.annotation.processor.documentation.config.model.JavadocFormat;
 public class JavadocToMarkdownTransformer {
 
     private static final Pattern START_OF_LINE = Pattern.compile("^", Pattern.MULTILINE);
+
+    // AsciiDoc code block: ---- ... ----
+    private static final Pattern CODE_BLOCK = Pattern.compile("^-{4,}\\n([\\s\\S]*?)\\n-{4,}$", Pattern.MULTILINE);
+
+    // AsciiDoc link: link:url[text] or https?://url[text]
+    private static final Pattern LINK = Pattern.compile("(?:link:)?(https?://[^\\[\\s]+)\\[([^\\]]*)\\]");
+
+    // AsciiDoc bold: *text* (constrained – not preceded/followed by *)
+    private static final Pattern BOLD = Pattern.compile("(?<!\\*)\\*(?!\\*|\\s)([^*]+?)(?<!\\s)\\*(?!\\*)");
+
+    // AsciiDoc italic: _text_ (constrained)
+    private static final Pattern ITALIC = Pattern.compile("(?<!_)_(?!_|\\s)([^_]+?)(?<!\\s)_(?!_)");
+
+    // AsciiDoc unordered list item at the start of a line
+    private static final Pattern UNORDERED_LIST_ITEM = Pattern.compile("^\\* (.+)$", Pattern.MULTILINE);
+
+    // AsciiDoc ordered list item at the start of a line
+    private static final Pattern ORDERED_LIST_ITEM = Pattern.compile("^\\. (.+)$", Pattern.MULTILINE);
 
     public static String toMarkdown(String javadoc, JavadocFormat format) {
         if (javadoc == null || javadoc.isBlank()) {
@@ -31,7 +50,122 @@ public class JavadocToMarkdownTransformer {
         }
 
         // it's Asciidoc, the fun begins...
-        return "";
+        return asciidocToMarkdown(javadoc);
+    }
+
+    /**
+     * Converts a subset of AsciiDoc syntax to Markdown.
+     * <p>
+     * Handles the most common constructs found in Quarkus configuration documentation:
+     * definition lists, inline formatting (bold, italic), links, code blocks, and lists.
+     */
+    static String asciidocToMarkdown(String asciidoc) {
+        if (asciidoc == null || asciidoc.isBlank()) {
+            return asciidoc;
+        }
+
+        String result = asciidoc;
+
+        // Code blocks first to prevent further processing of their content.
+        // AsciiDoc: ---- ... ---- -> Markdown: ``` ... ```
+        result = CODE_BLOCK.matcher(result).replaceAll("```\n$1\n```");
+
+        // Definition lists: AsciiDoc uses "term::" syntax.
+        // "term::" on its own line -> **term**: <next-line content>
+        // "term:: inline definition"  -> **term**: inline definition
+        result = convertDefinitionLists(result);
+
+        // Links: link:url[text] or https://url[text] -> [text](url)
+        Matcher linkMatcher = LINK.matcher(result);
+        StringBuffer sb = new StringBuffer();
+        while (linkMatcher.find()) {
+            String url = linkMatcher.group(1);
+            String text = linkMatcher.group(2);
+            String replacement = text.isBlank() ? url : "[" + text + "](" + url + ")";
+            linkMatcher.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+        }
+        linkMatcher.appendTail(sb);
+        result = sb.toString();
+
+        // Inline bold: *text* -> **text**
+        result = BOLD.matcher(result).replaceAll("**$1**");
+
+        // Inline italic: _text_ -> *text*
+        result = ITALIC.matcher(result).replaceAll("*$1*");
+
+        // Ordered lists: ". item" -> "1. item"
+        result = ORDERED_LIST_ITEM.matcher(result).replaceAll("1. $1");
+
+        // Unordered lists: "* item" -> "- item"
+        // This must come after bold conversion since *text* is now **text**
+        result = UNORDERED_LIST_ITEM.matcher(result).replaceAll("- $1");
+
+        return result.trim();
+    }
+
+    /**
+     * Converts AsciiDoc definition lists to Markdown bold-term format.
+     * <p>
+     * AsciiDoc definition lists use the {@code ::} delimiter:
+     * <pre>
+     * term::
+     * The definition of the term.
+     *
+     * another-term:: An inline definition.
+     * </pre>
+     * These are converted to:
+     * <pre>
+     * **term**: The definition of the term.
+     *
+     * **another-term**: An inline definition.
+     * </pre>
+     */
+    private static String convertDefinitionLists(String asciidoc) {
+        String[] lines = asciidoc.split("\n", -1);
+        StringBuilder result = new StringBuilder();
+
+        for (int i = 0; i < lines.length; i++) {
+            String line = lines[i];
+            int ddIdx = line.indexOf("::");
+
+            if (ddIdx < 0 || isInsideUrl(line, ddIdx)) {
+                // Not a definition list line
+                result.append(line);
+            } else {
+                String term = line.substring(0, ddIdx).trim();
+                String inlineDef = line.substring(ddIdx + 2).trim();
+
+                result.append("**").append(term).append("**");
+
+                if (!inlineDef.isEmpty()) {
+                    // Definition on the same line: "term:: definition"
+                    result.append(": ").append(inlineDef);
+                } else if (i + 1 < lines.length && !lines[i + 1].isBlank()) {
+                    // Definition on the next line
+                    result.append(": ").append(lines[i + 1].trim());
+                    i++;
+                } else {
+                    // No definition text found
+                    result.append(":");
+                }
+            }
+
+            if (i < lines.length - 1) {
+                result.append("\n");
+            }
+        }
+
+        return result.toString();
+    }
+
+    /**
+     * Returns {@code true} if the {@code ::} at the given index is part of a URL
+     * (i.e., preceded by {@code http} or {@code https}), to avoid misidentifying
+     * URL schemes as AsciiDoc definition list delimiters.
+     */
+    private static boolean isInsideUrl(String line, int ddIdx) {
+        return ddIdx >= 5 && line.substring(0, ddIdx).endsWith("http")
+                || ddIdx >= 6 && line.substring(0, ddIdx).endsWith("https");
     }
 
     /**

--- a/core/processor/src/test/java/io/quarkus/annotation/processor/documentation/config/formatter/JavadocToMarkdownTransformerTest.java
+++ b/core/processor/src/test/java/io/quarkus/annotation/processor/documentation/config/formatter/JavadocToMarkdownTransformerTest.java
@@ -1,0 +1,159 @@
+package io.quarkus.annotation.processor.documentation.config.formatter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+public class JavadocToMarkdownTransformerTest {
+
+    // -------------------------------------------------------------------------
+    // Null / blank input
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void nullInputReturnsNull() {
+        assertNull(JavadocToMarkdownTransformer.asciidocToMarkdown(null));
+    }
+
+    @Test
+    public void blankInputReturnsBlank() {
+        assertEquals("   ", JavadocToMarkdownTransformer.asciidocToMarkdown("   "));
+    }
+
+    // -------------------------------------------------------------------------
+    // Plain text (pass-through)
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void plainTextIsPreserved() {
+        String input = "A simple configuration property.";
+        assertEquals(input, JavadocToMarkdownTransformer.asciidocToMarkdown(input));
+    }
+
+    // -------------------------------------------------------------------------
+    // Inline bold
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void inlineBoldIsSingleAsterisk() {
+        assertEquals("**important**", JavadocToMarkdownTransformer.asciidocToMarkdown("*important*"));
+    }
+
+    @Test
+    public void inlineBoldInSentence() {
+        assertEquals("Use **this** value.", JavadocToMarkdownTransformer.asciidocToMarkdown("Use *this* value."));
+    }
+
+    // -------------------------------------------------------------------------
+    // Inline italic
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void inlineItalicIsUnderscore() {
+        assertEquals("*note*", JavadocToMarkdownTransformer.asciidocToMarkdown("_note_"));
+    }
+
+    @Test
+    public void inlineItalicInSentence() {
+        assertEquals("See *also* the docs.", JavadocToMarkdownTransformer.asciidocToMarkdown("See _also_ the docs."));
+    }
+
+    // -------------------------------------------------------------------------
+    // Inline code (backticks are identical in both formats)
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void inlineCodeIsUnchanged() {
+        assertEquals("`myValue`", JavadocToMarkdownTransformer.asciidocToMarkdown("`myValue`"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Links
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void linkWithTextIsConverted() {
+        assertEquals("[Quarkus](https://quarkus.io)",
+                JavadocToMarkdownTransformer.asciidocToMarkdown("link:https://quarkus.io[Quarkus]"));
+    }
+
+    @Test
+    public void bareUrlWithTextIsConverted() {
+        assertEquals("[the guide](https://quarkus.io/guides/config)",
+                JavadocToMarkdownTransformer.asciidocToMarkdown("https://quarkus.io/guides/config[the guide]"));
+    }
+
+    @Test
+    public void linkWithEmptyTextYieldsUrl() {
+        assertEquals("https://quarkus.io",
+                JavadocToMarkdownTransformer.asciidocToMarkdown("link:https://quarkus.io[]"));
+    }
+
+    @Test
+    public void urlColonIsNotTreatedAsDefinitionList() {
+        String input = "See https://quarkus.io for more information.";
+        assertEquals(input, JavadocToMarkdownTransformer.asciidocToMarkdown(input));
+    }
+
+    // -------------------------------------------------------------------------
+    // Code blocks
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void codeBlockIsConverted() {
+        String input = "Example:\n----\nquarkus.http.port=8080\n----";
+        String expected = "Example:\n```\nquarkus.http.port=8080\n```";
+        assertEquals(expected, JavadocToMarkdownTransformer.asciidocToMarkdown(input));
+    }
+
+    // -------------------------------------------------------------------------
+    // Ordered and unordered lists
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void orderedListItemIsConverted() {
+        String input = "Steps:\n. First step\n. Second step";
+        String expected = "Steps:\n1. First step\n1. Second step";
+        assertEquals(expected, JavadocToMarkdownTransformer.asciidocToMarkdown(input));
+    }
+
+    @Test
+    public void unorderedListItemIsConverted() {
+        String input = "Options:\n* Option A\n* Option B";
+        String expected = "Options:\n- Option A\n- Option B";
+        assertEquals(expected, JavadocToMarkdownTransformer.asciidocToMarkdown(input));
+    }
+
+    // -------------------------------------------------------------------------
+    // Definition lists
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void definitionListTermOnOwnLine() {
+        String input = "`simple`::\nThe default strategy.";
+        String expected = "**`simple`**: The default strategy.";
+        assertEquals(expected, JavadocToMarkdownTransformer.asciidocToMarkdown(input));
+    }
+
+    @Test
+    public void definitionListInlineDefinition() {
+        String input = "`no-alias`:: A strategy without aliases.";
+        String expected = "**`no-alias`**: A strategy without aliases.";
+        assertEquals(expected, JavadocToMarkdownTransformer.asciidocToMarkdown(input));
+    }
+
+    @Test
+    public void definitionListMultipleEntries() {
+        String input = "`simple`::\nThe default, future-proof strategy.\n\n`no-alias`::\nA strategy without index aliases.";
+        String expected = "**`simple`**: The default, future-proof strategy.\n\n**`no-alias`**: A strategy without index aliases.";
+        assertEquals(expected, JavadocToMarkdownTransformer.asciidocToMarkdown(input));
+    }
+
+    @Test
+    public void definitionListTermWithoutDefinition() {
+        String input = "term::";
+        String expected = "**term**:";
+        assertEquals(expected, JavadocToMarkdownTransformer.asciidocToMarkdown(input));
+    }
+}


### PR DESCRIPTION
Fixes #43287

## Summary

The `JavadocToMarkdownTransformer.toMarkdown()` method previously returned an empty string for AsciiDoc-formatted Javadoc. This PR implements a regex-based AsciiDoc → Markdown converter covering the constructs most commonly found in Quarkus configuration documentation.

### Supported conversions

| AsciiDoc | Markdown |
|---|---|
| `term::` (definition list) | `**term**: definition` |
| `*bold*` | `**bold**` |
| `_italic_` | `*italic*` |
| `` `code` `` | `` `code` `` (unchanged) |
| `link:url[text]` / `url[text]` | `[text](url)` |
| `. ordered item` | `1. ordered item` |
| `* unordered item` | `- unordered item` |
| `----\ncode\n----` | ` ```\ncode\n``` ` |

### Not supported (can be follow-up)
- AsciiDoc attribute substitution (`{attr-name}`) — requires passing Maven properties
- Complex tables (`!===` syntax)

### Tests
Added `JavadocToMarkdownTransformerTest` covering all the above conversions, including edge cases (blank input, URL colons not treated as definition list delimiters, links with empty text, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)