### PR TITLE
Fix NPE when POSTing to a no-input funq function in funqy-knative-events

### DIFF
--- a/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/MappingTest.java
+++ b/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/MappingTest.java
@@ -100,6 +100,14 @@ public class MappingTest {
     }
 
     @Test
+    public void testNoopPost() {
+        RestAssured.given().contentType("application/json")
+                .body("{}")
+                .post("/noop")
+                .then().statusCode(204);
+    }
+
+    @Test
     public void testDefaultMapping() {
         RestAssured.given().contentType("application/json")
                 .header("ce-id", UUID.randomUUID().toString())

--- a/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/NoInputPostWarningTest.java
+++ b/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/NoInputPostWarningTest.java
@@ -1,0 +1,34 @@
+package io.quarkus.funqy.test;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.logging.Level;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+
+public class NoInputPostWarningTest {
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar.addClasses(PrimitiveFunctions.class))
+            .setLogRecordPredicate(logRecord -> logRecord.getLevel().intValue() >= Level.WARNING.intValue()
+                    && logRecord.getLoggerName().startsWith("io.quarkus.funqy"))
+            .assertLogRecords(logRecords -> {
+                boolean match = logRecords.stream()
+                        .anyMatch(logRecord -> logRecord.getMessage().contains("does not accept input"));
+                if (!match) {
+                    fail("Expected warning about ignored request body was not logged.");
+                }
+            });
+
+    @Test
+    public void testPostWithBodyToNoInputFunction() {
+        RestAssured.given().contentType("application/json")
+                .body("{}")
+                .post("/noop")
+                .then().statusCode(204);
+    }
+}

--- a/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/VertxRequestHandler.java
+++ b/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/VertxRequestHandler.java
@@ -485,7 +485,12 @@ public class VertxRequestHandler implements Handler<RoutingContext> {
             Buffer buff = routingContext.body().buffer();
             try {
                 Object input = null;
-                if (invoker.hasInput() && buff != null && buff.length() > 0) {
+                if (!invoker.hasInput()) {
+                    if (buff != null && buff.length() > 0) {
+                        log.warn("Request body ignored: function '" + invoker.getName()
+                                + "' does not accept input");
+                    }
+                } else if (buff != null && buff.length() > 0) {
                     ByteBufInputStream in = new ByteBufInputStream(buff.getByteBuf());
                     ObjectReader reader = (ObjectReader) invoker.getBindingContext().get(DATA_OBJECT_READER);
                     try {

--- a/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/VertxRequestHandler.java
+++ b/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/VertxRequestHandler.java
@@ -485,7 +485,7 @@ public class VertxRequestHandler implements Handler<RoutingContext> {
             Buffer buff = routingContext.body().buffer();
             try {
                 Object input = null;
-                if (buff.length() > 0) {
+                if (invoker.hasInput() && buff != null && buff.length() > 0) {
                     ByteBufInputStream in = new ByteBufInputStream(buff.getByteBuf());
                     ObjectReader reader = (ObjectReader) invoker.getBindingContext().get(DATA_OBJECT_READER);
                     try {


### PR DESCRIPTION
## Summary

- Fixed the issue where call to parametric-less function with POST+non-empty-body caused exception to be thrown and 500 to be returned. Now the body is just ignored and we print a warning to the log.