### PR TITLE
Update SmallRye Config to 3.17.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -46,7 +46,7 @@
         <microprofile-lra.version>2.0.2</microprofile-lra.version>
         <microprofile-openapi.version>4.1.1</microprofile-openapi.version>
         <smallrye-common.version>2.17.0</smallrye-common.version>
-        <smallrye-config.version>3.17.0</smallrye-config.version>
+        <smallrye-config.version>3.17.1</smallrye-config.version>
         <smallrye-health.version>4.3.0</smallrye-health.version>
         <smallrye-open-api.version>4.3.0</smallrye-open-api.version>
         <smallrye-graphql.version>2.18.0</smallrye-graphql.version>

--- a/devtools/gradle/gradle/libs.versions.toml
+++ b/devtools/gradle/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 plugin-publish = "2.1.1"
 
 kotlin = "2.3.10"
-smallrye-config = "3.17.0"
+smallrye-config = "3.17.1"
 
 junit = "6.0.3"
 assertj = "3.27.7"


### PR DESCRIPTION
SmallRye Config Release notes:
<br>
  <blockquote>
      <h2>3.17.1</h2>
      <ul>
          <li><a href="https://github.com/smallrye/smallrye-config/pull/1509">#1509</a> Release 3.17.1</li>
          <li><a href="https://github.com/smallrye/smallrye-config/pull/1508">#1508</a> Apply BeanStyleGetters to defaults</li>
          <li><a href="https://github.com/smallrye/smallrye-config/pull/1507">#1507</a> Do not include wildcard names in the list of property names of the DefaultValuesConfigSource</li>
          <li><a href="https://github.com/smallrye/smallrye-config/pull/1506">#1506</a> Fix PropertyNamesMatcher.get returning wrong value for null-valued pattern matches</li>
          <li><a href="https://github.com/smallrye/smallrye-config/pull/1505">#1505</a> Fix PropertyNamesMatcher matching wildcard input segments against named children</li>
      </ul>
  </blockquote>

For Quarkus:
- https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/SmallRye.20Config.203.2E17.2E0.20breaking.20change/with/586162394
- https://github.com/quarkiverse/quarkiverse/issues/219#issuecomment-4266319438
- https://github.com/quarkiverse/quarkus-langchain4j/issues/2340