### PR TITLE
fix: undertow compression uses addHeadersEndHandler instead of addEndHandler

### DIFF
--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
@@ -443,13 +443,11 @@ public class UndertowDeploymentRecorder {
                 // Note that we can't add an end handler in a separate HttpCompressionHandler because VertxHttpExchange does set
                 // its own end handler and so the end handlers added previously are just ignored...
                 if (!compressMediaTypes.isEmpty()) {
-                    event.addEndHandler(new Handler<AsyncResult<Void>>() {
+                    event.addHeadersEndHandler(new Handler<Runnable>() {
 
                         @Override
-                        public void handle(AsyncResult<Void> result) {
-                            if (result.succeeded()) {
-                                HttpCompressionHandler.compressIfNeeded(event, compressMediaTypes);
-                            }
+                        public void handle(Runnable result) {
+                            HttpCompressionHandler.compressIfNeeded(event, compressMediaTypes);
                         }
                     });
                 }


### PR DESCRIPTION
Fixes #53645

This PR was created autonomously by the RedOS coding factory (ENG agent). Part of our daily OSS contribution program targeting Java AI projects.

## Summary

The Undertow servlet integration was using `RoutingContext.addEndHandler()` to trigger compression, which fires **after** the response has been written to the channel. The correct API is `RoutingContext.addHeadersEndHandler()`, which fires during `prepareHeaders()` **before** the response message is created and written.

This bug causes compression to work only by accident on Vert.x 4.x due to synchronized monitor coupling in `ConnectionBase.writeToChannel()` / `Http1xServerResponse.end()`. With lock-free or decoupled-lock write paths (needed to fix eclipse-vertx/vert.x#6063), or with Vert.x 5.x (which uses `OutboundMessageQueue` / MPSC-based queue), the write executes before the end handler and the encoder sees `Content-Encoding: identity` and skips compression.

The fix changes `addEndHandler(new Handler<AsyncResult<Void>>())` to `addHeadersEndHandler(new Handler<Runnable>())`, which fires at the correct point in the HTTP response lifecycle regardless of the write strategy used.

This is the same class of bug that caused the revert of eclipse-vertx/vert.x#5619 (see quarkusio/quarkus#5687).