### PR TITLE
Fix nested list handling in Javadoc to AsciiDoc converter

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/formatter/JavadocToAsciidocTransformer.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/formatter/JavadocToAsciidocTransformer.java
@@ -62,8 +62,8 @@ public final class JavadocToAsciidocTransformer {
     private static final String SUB_SCRIPT_ASCIDOC_STYLE = "~";
     private static final String SUPER_SCRIPT_ASCIDOC_STYLE = "^";
     private static final String SMALL_ASCIDOC_STYLE = "[.small]";
-    private static final String ORDERED_LIST_ITEM_ASCIDOC_STYLE = " . ";
-    private static final String UNORDERED_LIST_ITEM_ASCIDOC_STYLE = " - ";
+    private static final String ORDERED_LIST_MARKER = ".";
+    private static final String UNORDERED_LIST_MARKER = "*";
     private static final String UNDERLINE_ASCIDOC_STYLE = "[.underline]";
     private static final String LINE_THROUGH_ASCIDOC_STYLE = "[.line-through]";
     private static final String HARD_LINE_BREAK_ASCIDOC_STYLE = " +\n";
@@ -189,17 +189,32 @@ public final class JavadocToAsciidocTransformer {
                     break;
                 case ORDERED_LIST_NODE:
                 case UN_ORDERED_LIST_NODE:
-                    newLine(sb);
+                    if (context.listDepth > 0) {
+                        // Nested list: we're already on a new line from the parent list item,
+                        // no need for an extra newline
+                    } else {
+                        newLine(sb);
+                    }
+                    context.listDepth++;
                     htmlToAsciidoc(sb, childNode, inlineMacroMode, context);
-                    newLine(sb);
-                    newLine(sb);
+                    context.listDepth--;
+                    if (context.listDepth == 0) {
+                        newLine(sb);
+                        newLine(sb);
+                    }
                     break;
                 case LIST_ITEM_NODE:
-                    final String marker = childNode.parentNode().nodeName().equals(ORDERED_LIST_NODE)
-                            ? ORDERED_LIST_ITEM_ASCIDOC_STYLE
-                            : UNORDERED_LIST_ITEM_ASCIDOC_STYLE;
+                    final String listMarker = childNode.parentNode().nodeName().equals(ORDERED_LIST_NODE)
+                            ? ORDERED_LIST_MARKER
+                            : UNORDERED_LIST_MARKER;
                     newLine(sb);
-                    sb.append(marker);
+                    sb.append(' ');
+                    for (int i = 0; i < context.listDepth; i++) {
+                        sb.append(listMarker);
+                    }
+                    sb.append(' ');
+                    // Track that we're in a list item to strip leading whitespace from the first text node
+                    context.firstTextInListItem = true;
                     htmlToAsciidoc(sb, childNode, inlineMacroMode, context);
                     break;
                 case LINK_NODE:
@@ -271,6 +286,16 @@ public final class JavadocToAsciidocTransformer {
 
                     if (text.isEmpty()) {
                         break;
+                    }
+
+                    // Trim leading whitespace for the first text node inside a list item
+                    // (HTML formatting often introduces extra spaces/newlines)
+                    if (context.firstTextInListItem) {
+                        text = text.stripLeading();
+                        context.firstTextInListItem = false;
+                        if (text.isEmpty()) {
+                            break;
+                        }
                     }
 
                     // Indenting the first line of a paragraph by one or more spaces makes the block literal
@@ -553,5 +578,7 @@ public final class JavadocToAsciidocTransformer {
 
         boolean inTable;
         boolean firstTableRow;
+        int listDepth;
+        boolean firstTextInListItem;
     }
 }

--- a/core/processor/src/test/java/io/quarkus/annotation/processor/documentation/config/formatter/JavadocToAsciidocTransformerConfigItemTest.java
+++ b/core/processor/src/test/java/io/quarkus/annotation/processor/documentation/config/formatter/JavadocToAsciidocTransformerConfigItemTest.java
@@ -121,7 +121,7 @@ public class JavadocToAsciidocTransformerConfigItemTest {
                 "<li>2</li>\n" +
                 "</ul>" +
                 "";
-        String expectedOutput = "List:\n\n - 1\n - 2";
+        String expectedOutput = "List:\n\n * 1\n * 2";
         ParsedJavadoc parsed = JavadocUtil.parseConfigItemJavadoc(javaDoc);
         String description = JavadocToAsciidocTransformer.toAsciidoc(parsed.description(), parsed.format());
 
@@ -137,6 +137,84 @@ public class JavadocToAsciidocTransformerConfigItemTest {
                 "</ol>" +
                 "";
         String expectedOutput = "List:\n\n . 1\n . 2";
+        ParsedJavadoc parsed = JavadocUtil.parseConfigItemJavadoc(javaDoc);
+        String description = JavadocToAsciidocTransformer.toAsciidoc(parsed.description(), parsed.format());
+
+        assertEquals(expectedOutput, description);
+    }
+
+    @Test
+    public void parseJavaDocWithNestedUnorderedList() {
+        String javaDoc = "List:" +
+                "<ul>\n" +
+                "<li>First sentence. Second sentence.</li>\n" +
+                "<li>\n" +
+                "And some nested bullet list:\n" +
+                "<ul>\n" +
+                "<li>Element 1 with one sentence. And another sentence.</li>\n" +
+                "<li>Element 2 with sentence 2. And yet another sentence.</li>\n" +
+                "</ul>\n" +
+                "</li>\n" +
+                "</ul>";
+        String expectedOutput = "List:\n\n * First sentence. Second sentence.\n * And some nested bullet list:\n ** Element 1 with one sentence. And another sentence.\n ** Element 2 with sentence 2. And yet another sentence.";
+        ParsedJavadoc parsed = JavadocUtil.parseConfigItemJavadoc(javaDoc);
+        String description = JavadocToAsciidocTransformer.toAsciidoc(parsed.description(), parsed.format());
+
+        assertEquals(expectedOutput, description);
+    }
+
+    @Test
+    public void parseJavaDocWithNestedOrderedList() {
+        String javaDoc = "List:" +
+                "<ol>\n" +
+                "<li>Item 1</li>\n" +
+                "<li>\n" +
+                "Item 2 with nested list:\n" +
+                "<ol>\n" +
+                "<li>Sub 1</li>\n" +
+                "<li>Sub 2</li>\n" +
+                "</ol>\n" +
+                "</li>\n" +
+                "</ol>";
+        String expectedOutput = "List:\n\n . Item 1\n . Item 2 with nested list:\n .. Sub 1\n .. Sub 2";
+        ParsedJavadoc parsed = JavadocUtil.parseConfigItemJavadoc(javaDoc);
+        String description = JavadocToAsciidocTransformer.toAsciidoc(parsed.description(), parsed.format());
+
+        assertEquals(expectedOutput, description);
+    }
+
+    @Test
+    public void parseJavaDocWithDeeplyNestedLists() {
+        String javaDoc = "List:" +
+                "<ul>\n" +
+                "<li>Level 1\n" +
+                "<ul>\n" +
+                "<li>Level 2\n" +
+                "<ul>\n" +
+                "<li>Level 3</li>\n" +
+                "</ul>\n" +
+                "</li>\n" +
+                "</ul>\n" +
+                "</li>\n" +
+                "</ul>";
+        String expectedOutput = "List:\n\n * Level 1\n ** Level 2\n *** Level 3";
+        ParsedJavadoc parsed = JavadocUtil.parseConfigItemJavadoc(javaDoc);
+        String description = JavadocToAsciidocTransformer.toAsciidoc(parsed.description(), parsed.format());
+
+        assertEquals(expectedOutput, description);
+    }
+
+    @Test
+    public void parseJavaDocWithMixedNestedLists() {
+        String javaDoc = "List:" +
+                "<ul>\n" +
+                "<li>Unordered item\n" +
+                "<ol>\n" +
+                "<li>Ordered sub-item</li>\n" +
+                "</ol>\n" +
+                "</li>\n" +
+                "</ul>";
+        String expectedOutput = "List:\n\n * Unordered item\n .. Ordered sub-item";
         ParsedJavadoc parsed = JavadocUtil.parseConfigItemJavadoc(javaDoc);
         String description = JavadocToAsciidocTransformer.toAsciidoc(parsed.description(), parsed.format());
 


### PR DESCRIPTION
## Description

Fixes #50474

The `JavadocToAsciidocTransformer` previously flattened all nested HTML lists (`<ul>`/`<ol>`) to the same level, using the same marker for all items. This resulted in incorrect AsciiDoc output where nested bullet lists were indistinguishable from top-level items.

### Example

This Javadoc:
```java
/**
 * Some javadoc with list of lists:
 * <ul>
 * <li>First sentence. Second sentence.</li>
 * <li>
 * And some nested bullet list:
 * <ul>
 * <li>Element 1 with one sentence.</li>
 * <li>Element 2 with sentence 2.</li>
 * </ul>
 * </li>
 * </ul>
 */
```

**Before** (flattened):
```
Some javadoc with list of lists:

 - First sentence. Second sentence.
 -  And some nested bullet list:

 - Element 1 with one sentence.
 - Element 2 with sentence 2.
```

**After** (proper nesting):
```
Some javadoc with list of lists:

 * First sentence. Second sentence.
 * And some nested bullet list:
 ** Element 1 with one sentence.
 ** Element 2 with sentence 2.
```

### Changes

- Track list nesting depth in the `Context` class
- Use AsciiDoc-standard nested list markers (`*` for unordered, `.` for ordered) repeated according to depth (e.g., `**` for level 2, `***` for level 3)
- Strip leading whitespace from text nodes inside list items to handle HTML formatting artifacts
- Avoid extra blank lines for nested lists (only top-level lists get trailing blank lines)
- Updated existing test to match new marker style
- Added 4 new tests:
  - `parseJavaDocWithNestedUnorderedList` - nested `<ul>` inside `<ul>`
  - `parseJavaDocWithNestedOrderedList` - nested `<ol>` inside `<ol>`
  - `parseJavaDocWithDeeplyNestedLists` - 3 levels of nesting
  - `parseJavaDocWithMixedNestedLists` - `<ol>` inside `<ul>`