### PR TITLE
Restructure building-native-image guide around reader paths

### DIFF
--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -31,9 +31,9 @@ The solution is in the `getting-started` directory of the Quarkus quickstarts. C
 ====
 
 [[first-native-build]]
-[[container-runtime]]
 == Your first native build with a container runtime
 
+[[container-runtime]]
 IMPORTANT: Docker or podman is required as the container runtime. On Windows, share your project's drive in Docker Desktop's file share settings and restart Docker Desktop before continuing.
 
 If your target is a containerized Linux deployment, Quarkus can build the native executable inside a container runtime, skipping the local GraalVM install. This matches CI environments where minimal host tooling is the norm.
@@ -984,7 +984,6 @@ include at build time.
 Please see the Quarkus Native Reference Guide for more detailed information on these monitoring options.
 
 [[advanced]]
-[[configuration-reference]]
 == Advanced and reference
 
 === Build fully static native executables
@@ -1033,6 +1032,7 @@ This command will generate all the files and configuration needed for the native
 More details on the GraalVM native-image bundle are available in the link:https://www.graalvm.org/{graalvm-docs-version}/reference-manual/native-image/overview/Bundles[GraalVM documentation].
 ====
 
+[[configuration-reference]]
 === Configuring the native executable
 
 There are a lot of different configuration options that can affect how the native executable is generated.

--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -9,9 +9,9 @@ include::_attributes.adoc[]
 :summary: Build native executables with GraalVM or Mandrel.
 :topics: native,graalvm,mandrel
 
-Compile your Quarkus application to a native executable — a standalone binary that starts in milliseconds and uses less memory than JVM mode. Choose native mode when startup latency and memory footprint are strict constraints: serverless cold starts, scale-to-zero autoscaling, edge deployments, or high-density container hosts.
+Compile your Quarkus application to a native executable — a standalone binary that starts in milliseconds and uses less memory than JVM mode.
 
-Native mode is one of three Quarkus runtime options. JVM fast-jar, JVM with xref:aot.adoc[Project Leyden AOT caching] (JDK 24+), and native (Mandrel) each trade cold-start speed, peak throughput, memory footprint, and build cost differently. Choose the one whose trade-off profile matches your workload's binding constraint.
+Native is one of three runtime options Quarkus supports. JVM fast-jar, JVM with xref:aot.adoc[Project Leyden AOT caching] (JDK 24+), and native (Mandrel) each trade cold-start speed, peak throughput, memory footprint, and build cost differently. The table below compares them — pick the mode that matches your workload's most important constraint.
 
 [cols="1,1,1,1,1,2",options="header"]
 |===
@@ -26,20 +26,22 @@ Native mode is one of three Quarkus runtime options. JVM fast-jar, JVM with xref
 
 | xref:aot.adoc[JVM + Leyden AOT cache]
 | ~80 ms (small) to ~900 ms (large)
-| Baseline — same as fast-jar
-| Similar to fast-jar
+| Matches JVM fast-jar
+| Matches JVM fast-jar
 | Standard build plus a training run on a representative workload
 | Cold-start-sensitive but not millisecond-critical; requires JDK 24+; keeps full JVM tooling (debuggers, profilers, JFR)
 
 | Native (Mandrel)
 | ~17 ms (small) to ~240 ms (large)
-| ~50% of JVM
-| 3–5× smaller than JVM
+| ~50% of JVM fast-jar
+| 3–5× smaller than JVM fast-jar
 | 3–10 min build; 4–8 GB build-host RAM
 | Extreme cold start (serverless, scale-to-zero); edge deployments; high-density container hosts where memory is the binding constraint
 |===
 
-Numbers above come from the https://quarkus.io/blog/leyden-2/[Quarkus team's Leyden integration benchmarks] and the https://quarkus.io/blog/new-benchmarks/[Mar 2026 performance post]. Measure your own workload before deciding — the rest of this guide covers the native path; see xref:aot.adoc[the AOT caching guide] for the Leyden path.
+Numbers above come from the https://quarkus.io/blog/leyden-2/[Quarkus team's Leyden integration benchmarks] and the https://quarkus.io/blog/new-benchmarks/[Mar 2026 performance post].
+
+For the Leyden AOT cache path, see xref:aot.adoc[the AOT caching guide]. For the native path, continue below.
 
 Every path below assumes the xref:getting-started.adoc[Getting Started] application as the starting point.
 

--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -11,7 +11,35 @@ include::_attributes.adoc[]
 
 Compile your Quarkus application to a native executable — a standalone binary that starts in milliseconds and uses less memory than JVM mode. Choose native mode when startup latency and memory footprint are strict constraints: serverless cold starts, scale-to-zero autoscaling, edge deployments, or high-density container hosts.
 
-The trade-offs are real. Native executables typically deliver lower peak throughput, use a single-threaded garbage collector, and take longer to build than their JVM counterparts. If startup latency matters but not at the millisecond level, https://quarkus.io/blog/leyden-1/[Quarkus's Project Leyden integration] brings JVM-mode cold-start under 100 ms for many applications and may fit your workload without the added build-pipeline complexity. See the https://quarkus.io/blog/new-benchmarks/[latest Quarkus performance benchmarks] for current measurements — and always measure your own workload before deciding.
+Native mode is one of three Quarkus runtime options. JVM fast-jar, JVM with xref:aot.adoc[Project Leyden AOT caching] (JDK 24+), and native (Mandrel) each trade cold-start speed, peak throughput, memory footprint, and build cost differently. Choose the one whose trade-off profile matches your workload's binding constraint.
+
+[cols="1,1,1,1,1,2",options="header"]
+|===
+| Mode | Cold start | Peak throughput | Memory (RSS) | Build cost | When to choose
+
+| JVM fast-jar
+| ~0.4 s (small REST) to ~3 s (large CRUD)
+| Baseline — highest
+| Highest
+| ~30 s build; no special workflow
+| Long-running services, throughput-critical workloads; teams on pre-JDK-24 runtimes
+
+| xref:aot.adoc[JVM + Leyden AOT cache]
+| ~80 ms (small) to ~900 ms (large)
+| Baseline — same as fast-jar
+| Similar to fast-jar
+| Standard build plus a training run on a representative workload
+| Cold-start-sensitive but not millisecond-critical; requires JDK 24+; keeps full JVM tooling (debuggers, profilers, JFR)
+
+| Native (Mandrel)
+| ~17 ms (small) to ~240 ms (large)
+| ~50% of JVM
+| 3–5× smaller than JVM
+| 3–10 min build; 4–8 GB build-host RAM
+| Extreme cold start (serverless, scale-to-zero); edge deployments; high-density container hosts where memory is the binding constraint
+|===
+
+Numbers above come from the https://quarkus.io/blog/leyden-2/[Quarkus team's Leyden integration benchmarks] and the https://quarkus.io/blog/new-benchmarks/[Mar 2026 performance post]. Measure your own workload before deciding — the rest of this guide covers the native path; see xref:aot.adoc[the AOT caching guide] for the Leyden path.
 
 Every path below assumes the xref:getting-started.adoc[Getting Started] application as the starting point.
 

--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -9,15 +9,124 @@ include::_attributes.adoc[]
 :summary: Build native executables with GraalVM or Mandrel.
 :topics: native,graalvm,mandrel
 
-This guide covers:
+Compile your Quarkus application to a native executable — a standalone binary that starts in milliseconds and uses less memory than JVM mode. Choose native mode when startup latency and memory footprint are strict constraints: serverless cold starts, scale-to-zero autoscaling, edge deployments, or high-density container hosts.
 
-* Compiling the application to a native executable
-* Packaging the native executable in a container
-* Debugging native executable
+The trade-offs are real. Native executables typically deliver lower peak throughput, use a single-threaded garbage collector, and take longer to build than their JVM counterparts. If startup latency matters but not at the millisecond level, https://quarkus.io/blog/leyden-1/[Quarkus's Project Leyden integration] brings JVM-mode cold-start under 100 ms for many applications and may fit your workload without the added build-pipeline complexity. See the https://quarkus.io/blog/new-benchmarks/[latest Quarkus performance benchmarks] for current measurements — and always measure your own workload before deciding.
 
-This guide takes as input the application developed in the xref:getting-started.adoc[Getting Started Guide].
+Every path below assumes the xref:getting-started.adoc[Getting Started] application as the starting point.
 
-== Prerequisites
+[[pick-your-path]]
+== Pick your path
+
+Pick the path that matches what you're doing today:
+
+* **I'm building my first native executable of this application.** Follow <<first-native-build,the container-based build>>. You need a JDK, Maven, and a container engine — no C toolchain, no local GraalVM install.
+* **I'm building native executables without a container.** Follow <<local-build,the local GraalVM or Mandrel build>>. Needed for offline environments, custom toolchains, or host-OS binaries.
+* **I already have a working native build.** Jump to <<packaging-for-deployment,Packaging for deployment>> for container images, <<debugging,Debugging, monitoring, and tuning>> for observability, or <<advanced,Advanced and reference>> for flags and reference material.
+
+[TIP]
+.Want the completed example?
+====
+The solution is in the `getting-started` directory of the Quarkus quickstarts. Clone the repo with `git clone {quickstarts-clone-url}` or download an {quickstarts-archive-url}[archive].
+====
+
+[[first-native-build]]
+[[container-runtime]]
+== Your first native build with a container runtime
+
+IMPORTANT: Docker or podman is required as the container runtime. On Windows, share your project's drive in Docker Desktop's file share settings and restart Docker Desktop before continuing.
+
+If your target is a containerized Linux deployment, Quarkus can build the native executable inside a container runtime, skipping the local GraalVM install. This matches CI environments where minimal host tooling is the norm.
+
+Quarkus supports Docker and podman as container runtimes. To build, run:
+
+include::{includes}/devtools/build-native-container.adoc[]
+
+[NOTE]
+.What to expect
+====
+Your first container-based native build typically takes 3–10 minutes and uses 4–8 GB of RAM on the build host. Your fan will likely spin up — that is normal, the build has not hung. If the build exceeds 15 minutes without producing output, see <<debugging,Debugging and tuning>>.
+
+The output is a Linux binary produced inside the builder image. Its architecture matches the builder image you pulled — typically `x86_64` unless you explicitly selected an `arm64` variant. Run the binary in a Linux container that matches that architecture, not directly on your host OS.
+====
+
+[TIP]
+====
+By default, Quarkus automatically detects the container runtime.
+If you want to explicitly select the container runtime, you can do it with:
+
+For Docker:
+
+:build-additional-parameters: -Dquarkus.native.container-runtime=docker
+include::{includes}/devtools/build-native-container-parameters.adoc[]
+:!build-additional-parameters:
+
+For podman:
+
+:build-additional-parameters: -Dquarkus.native.container-runtime=podman
+include::{includes}/devtools/build-native-container-parameters.adoc[]
+:!build-additional-parameters:
+
+These are regular Quarkus config properties, so if you always want to build in a container
+it is recommended you add these to your `application.properties` in order to avoid specifying them every time.
+====
+
+The container runtime produces a 64-bit Linux binary. To run it, use a matching Linux container — not your host OS directly.
+
+[IMPORTANT]
+====
+Starting with Quarkus 3.19+, the _builder_ image used to build the native executable is based on UBI 9.
+It means that the native executable produced by the container build will be based on UBI 9 as well.
+So, if you plan to build a container, make sure that the base image in your `Dockerfile` is compatible with UBI 9.
+The native executable will not run on UBI 8 base images.
+
+You can configure the builder image used for the container build by setting the `quarkus.native.builder-image` property.
+For example, to switch back to an UBI8 _builder image_ you can use:
+
+`quarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:{mandrel-flavor}`
+
+You can see the available tags for UBI8 https://quay.io/repository/quarkus/ubi-quarkus-mandrel-builder-image?tab=tags[here]
+and for UBI9 https://quay.io/repository/quarkus/ubi9-quarkus-mandrel-builder-image?tab=tags[here (UBI 9)])
+
+====
+
+[[tip-quarkus-native-remote-container-build]]
+[TIP]
+====
+If you see the following invalid path error for your application JAR when trying to create a native executable using a container build, even though your JAR was built successfully, you're most likely using a remote daemon for your container runtime.
+----
+Error: Invalid Path entry getting-started-1.0.0-SNAPSHOT-runner.jar
+Caused by: java.nio.file.NoSuchFileException: /project/getting-started-1.0.0-SNAPSHOT-runner.jar
+----
+In this case, use the parameter `-Dquarkus.native.remote-container-build=true` instead of `-Dquarkus.native.container-build=true`.
+
+The reason for this is that the local build driver invoked through `-Dquarkus.native.container-build=true` uses volume mounts to make the JAR available in the build container, but volume mounts do not work with remote daemons. The remote container build driver copies the necessary files instead of mounting them. Note that even though the remote driver also works with local daemons, the local driver should be preferred in the local case because mounting is usually more performant than copying.
+====
+
+
+[TIP]
+====
+Building with GraalVM instead of Mandrel requires a custom builder image parameter to be passed additionally:
+
+:build-additional-parameters: -Dquarkus.native.builder-image=graalvm
+include::{includes}/devtools/build-native-container-parameters.adoc[]
+:!build-additional-parameters:
+
+Please note that the above command points to a floating tag.
+It is highly recommended to use the floating tag,
+so that your builder image remains up-to-date and secure.
+If you absolutely must, you may hard-code to a specific tag
+(see https://quay.io/repository/quarkus/ubi-quarkus-mandrel-builder-image?tab=tags[here (UBI 8)]
+and  https://quay.io/repository/quarkus/ubi9-quarkus-mandrel-builder-image?tab=tags[here (UBI 9)] for available tags),
+but be aware that you won't get security updates that way and it's unsupported.
+====
+
+[[local-build]]
+== Building with a local GraalVM or Mandrel install
+
+Choose this path when you need a native executable for an offline environment, a custom toolchain, or a macOS or Windows host binary.
+
+=== Prerequisites
 
 :prerequisites-docker:
 :prerequisites-graalvm-mandatory:
@@ -91,13 +200,13 @@ and https://github.com/graalvm/mandrel/releases[Mandrel releases].
 [TIP]
 ====
 This step is only required for generating native executables targeting non-Linux operating systems.
-For generating native executables targeting Linux, you can optionally skip this section and <<#container-runtime,use a builder image>> instead.
+For generating native executables targeting Linux, you can optionally skip this section and <<#first-native-build,use a builder image>> instead.
 ====
 
 [TIP]
 ====
 If you cannot install GraalVM, you can use a multi-stage Docker build to run Maven inside a Docker container that embeds GraalVM.
-There is an explanation of how to do this at <<#multistage-docker,the end of this guide>>.
+See the <<multistage-docker,multi-stage Docker build>> section for the full recipe.
 ====
 
 GraalVM {graalvm-version} is required.
@@ -158,21 +267,13 @@ xattr -r -d com.apple.quarantine ${GRAALVM_HOME}/../..
 -----
 ====
 
-== Solution
-
-We recommend that you follow the instructions in the next sections and package the application step by step. However, you can go right to the completed example.
-
-Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {quickstarts-archive-url}[archive].
-
-The solution is located in the `getting-started` directory.
-
-== Producing a native executable
+=== Producing the native executable
 
 The native executable for our application will contain the application code, required libraries, Java APIs, and a reduced version of a VM. The smaller VM base improves the startup time of the application and produces a minimal disk footprint.
 
 image:native-executable-process.png[Creating a native executable]
 
-If you have generated the application from the previous tutorial, you can find in the `pom.xml` the following Maven profile section:
+If the application came from the xref:getting-started.adoc[Getting Started guide], the `pom.xml` already contains this Maven profile section:
 
 [source,xml]
 ----
@@ -202,9 +303,7 @@ By convention `quarkus.native.additional-build-args-append` is meant to be defin
 You can find more information about how to configure the native image building process in the <<configuration-reference>> section below.
 ====
 
-We use a profile because, you will see very soon, packaging the native executable takes a _few_ minutes. You could
-just pass -Dquarkus.native.enabled=true as a property on the command line, however it is better to use a profile as
-this allows native image tests to also be run.
+A Maven profile isolates the long native build from your normal build. Passing `-Dquarkus.native.enabled=true` on the command line works too, but the profile also enables native image tests.
 
 Create a native executable using:
 
@@ -238,18 +337,9 @@ To produce a native executable, this means that the `--enable-preview` flag need
 You can do so by prepending the flag with `-J` and passing it as additional native build argument: `-Dquarkus.native.additional-build-args=-J--enable-preview`.
 ====
 
-=== Build fully static native executables
-
-IMPORTANT: Fully static native executables support is experimental.
-
-On Linux it's possible to package a native executable that doesn't depend on any system shared library.
-There are link:https://www.graalvm.org/{graalvm-docs-version}/reference-manual/native-image/guides/build-static-executables/#prerequisites-and-preparation[some system requirements] to be fulfilled and additional build arguments to be used along with the `native-image` invocation, a minimum is `-Dquarkus.native.additional-build-args="--static","--libc=musl"`.
-
-Compiling fully static binaries is done by statically linking https://musl.libc.org/[musl] instead of `glibc` and should not be used in production without rigorous testing.
-
 == Testing the native executable
 
-Producing a native executable can lead to a few issues, and so it's also a good idea to run some tests against the application running in the native file. The reasoning is explained in the link:getting-started-testing#quarkus-integration-test[Testing Guide].
+Producing a native executable can lead to a few issues, and so it's also a good idea to run some tests against the application running in the native file. The reasoning is explained in the xref:getting-started-testing.adoc#quarkus-integration-test[Testing Guide].
 
 To see the `GreetingResourceIT` run against the native executable, use `./mvnw verify -Dnative`:
 [source,shell,subs=attributes+]
@@ -387,200 +477,8 @@ It is also possible to re-run the tests against a native executable that has alr
 If the process cannot find the native image for some reason, or you want to test a native image that is no longer in the
 target directory you can specify the executable with the `-Dnative.image.path=` system property.
 
-[[container-runtime]]
-== Creating a Linux executable without GraalVM installed
-
-IMPORTANT: Before going further, be sure to have a working container runtime (Docker, podman) environment. If you use Docker
-on Windows you should share your project's drive at Docker Desktop file share settings and restart Docker Desktop.
-
-Quite often one only needs to create a native Linux executable for their Quarkus application (for example in order to run in a containerized environment) and would like to avoid
-the trouble of installing the proper GraalVM version in order to accomplish this task (for example, in CI environments it's common practice
-to install as little software as possible).
-
-To this end, Quarkus provides a very convenient way of creating a native Linux executable by leveraging a container runtime such as Docker or podman.
-The easiest way of accomplishing this task is to execute:
-
-include::{includes}/devtools/build-native-container.adoc[]
-
-[TIP]
-====
-By default, Quarkus automatically detects the container runtime.
-If you want to explicitly select the container runtime, you can do it with:
-
-For Docker:
-
-:build-additional-parameters: -Dquarkus.native.container-runtime=docker
-include::{includes}/devtools/build-native-container-parameters.adoc[]
-:!build-additional-parameters:
-
-For podman:
-
-:build-additional-parameters: -Dquarkus.native.container-runtime=podman
-include::{includes}/devtools/build-native-container-parameters.adoc[]
-:!build-additional-parameters:
-
-These are regular Quarkus config properties, so if you always want to build in a container
-it is recommended you add these to your `application.properties` in order to avoid specifying them every time.
-====
-
-Executable built that way with the container runtime will be a 64-bit Linux executable, so depending on your operating system, it may no longer be runnable.
-
-[IMPORTANT]
-====
-Starting with Quarkus 3.19+, the _builder_ image used to build the native executable is based on UBI 9.
-It means that the native executable produced by the container build will be based on UBI 9 as well.
-So, if you plan to build a container, make sure that the base image in your `Dockerfile` is compatible with UBI 9.
-The native executable will not run on UBI 8 base images.
-
-You can configure the builder image used for the container build by setting the `quarkus.native.builder-image` property.
-For example, to switch back to an UBI8 _builder image_ you can use:
-
-`quarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:{mandrel-flavor}`
-
-You can see the available tags for UBI8 https://quay.io/repository/quarkus/ubi-quarkus-mandrel-builder-image?tab=tags[here]
-and for UBI9 https://quay.io/repository/quarkus/ubi9-quarkus-mandrel-builder-image?tab=tags[here (UBI 9)])
-
-====
-
-[[tip-quarkus-native-remote-container-build]]
-[TIP]
-====
-If you see the following invalid path error for your application JAR when trying to create a native executable using a container build, even though your JAR was built successfully, you're most likely using a remote daemon for your container runtime.
-----
-Error: Invalid Path entry getting-started-1.0.0-SNAPSHOT-runner.jar
-Caused by: java.nio.file.NoSuchFileException: /project/getting-started-1.0.0-SNAPSHOT-runner.jar
-----
-In this case, use the parameter `-Dquarkus.native.remote-container-build=true` instead of `-Dquarkus.native.container-build=true`.
-
-The reason for this is that the local build driver invoked through `-Dquarkus.native.container-build=true` uses volume mounts to make the JAR available in the build container, but volume mounts do not work with remote daemons. The remote container build driver copies the necessary files instead of mounting them. Note that even though the remote driver also works with local daemons, the local driver should be preferred in the local case because mounting is usually more performant than copying.
-====
-
-
-[TIP]
-====
-Building with GraalVM instead of Mandrel requires a custom builder image parameter to be passed additionally:
-
-:build-additional-parameters: -Dquarkus.native.builder-image=graalvm
-include::{includes}/devtools/build-native-container-parameters.adoc[]
-:!build-additional-parameters:
-
-Please note that the above command points to a floating tag.
-It is highly recommended to use the floating tag,
-so that your builder image remains up-to-date and secure.
-If you absolutely must, you may hard-code to a specific tag
-(see https://quay.io/repository/quarkus/ubi-quarkus-mandrel-builder-image?tab=tags[here (UBI 8)]
-and  https://quay.io/repository/quarkus/ubi9-quarkus-mandrel-builder-image?tab=tags[here (UBI 9)] for available tags),
-but be aware that you won't get security updates that way and it's unsupported.
-====
-
-== Creating a container
-
-=== Using the container-image extensions
-
-By far the easiest way to create a container-image from your Quarkus application is to leverage one of the container-image extensions.
-
-If one of those extensions is present, then creating a container image for the native executable is essentially a matter of executing a single command:
-
-[source,bash]
-----
-./mvnw package -Dnative -Dquarkus.native.container-build=true -Dquarkus.container-image.build=true
-----
-
-* `quarkus.native.container-build=true` allows for creating a Linux executable without GraalVM being installed (and is only necessary if you don't have GraalVM installed locally or your local operating system is not Linux)
-
-[NOTE]
-====
-If you're running a remote Docker daemon, you need to replace `quarkus.native.container-build=true` with `quarkus.native.remote-container-build=true`.
-
-See <<tip-quarkus-native-remote-container-build,Creating a Linux executable without GraalVM installed>> for more details.
-====
-
-* `quarkus.container-image.build=true` instructs Quarkus to create a container-image using the final application artifact (which is the native executable in this case)
-
-See the xref:container-image.adoc[Container Image guide] for more details.
-
-=== Manually using the micro base image
-
-You can run the application in a container using the JAR produced by the Quarkus Maven Plugin.
-However, in this section, we focus on creating a container image using the produced native executable.
-
-image:containerization-process.png[Containerization Process]
-
-When using a local GraalVM installation, the native executable targets your local operating system (Linux, macOS, Windows etc).
-However, as a container may not use the same _executable_ format as the one produced by your operating system,
-we will instruct the Maven build to produce an executable by leveraging a container runtime (as described in <<#container-runtime,this section>>):
-
-The produced executable will be a 64-bit Linux executable, so depending on your operating system, it may no longer be runnable.
-However, it's not an issue as we are going to copy it to a container.
-The project generation has provided a `Dockerfile.native-micro` in the `src/main/docker` directory with the following content:
-
-[source,dockerfile]
-----
-FROM quay.io/quarkus/ubi9-quarkus-micro-image:2.0
-WORKDIR /work/
-RUN chown 1001 /work \
-    && chmod "g+rwX" /work \
-    && chown 1001:root /work
-COPY --chown=1001:root --chmod=755 target/*-runner /work/application
-
-EXPOSE 8080
-USER 1001
-
-ENTRYPOINT ["./application", "-Dquarkus.http.host=0.0.0.0"]
-----
-
-[NOTE]
-.Quarkus Micro Image?
-====
-The Quarkus Micro Image is a small container image providing the right set of dependencies to run your native application.
-It is based on https://catalog.redhat.com/software/containers/ubi9-micro/61832b36dd607bfc82e66399?container-tabs=overview[UBI Micro].
-This base image has been tailored to work perfectly in containers.
-
-You can read more about UBI images on:
-
-* https://www.redhat.com/en/blog/introducing-red-hat-universal-base-image[Introduction to Universal Base Image]
-* https://catalog.redhat.com/software/containers/ubi9/ubi/615bcf606feffc5384e8452e[Red Hat Universal Base Image 9]
-
-UBI images can be used without any limitations.
-
-xref:quarkus-runtime-base-image.adoc[This page] explains how to extend the `quarkus-micro` image when your application has specific requirements.
-====
-
-Then, if you didn't delete the generated native executable, you can build the docker image with:
-
-[source,bash]
-----
-docker build -f src/main/docker/Dockerfile.native-micro -t quarkus-quickstart/getting-started .
-----
-
-And finally, run it with:
-
-[source,bash]
-----
-docker run -i --rm -p 8080:8080 quarkus-quickstart/getting-started
-----
-
-=== Manually using the minimal base image
-
-The project generation has also provided a `Dockerfile.native` in the `src/main/docker` directory with the following content:
-
-[source,dockerfile]
-----
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6
-WORKDIR /work/
-RUN chown 1001 /work \
-    && chmod "g+rwX" /work \
-    && chown 1001:root /work
-COPY --chown=1001:root --chmod=0755 target/*-runner /work/application
-
-EXPOSE 8080
-USER 1001
-
-CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
-----
-
-The UBI minimal image is bigger than the micro one mentioned above.
-It contains more utilities such as the `microdnf` package manager.
+[[packaging-for-deployment]]
+== Packaging for deployment
 
 [[multistage-docker]]
 === Using a multi-stage Docker build
@@ -691,6 +589,110 @@ Please see xref:native-and-ssl.adoc#working-with-containers[our Using SSL With N
 ====
 To use GraalVM CE instead of Mandrel, update the `FROM` clause to: `FROM quay.io/quarkus/ubi9-quarkus-graalvmce-builder-image:{graalvm-flavor} AS build`.
 ====
+
+=== Using the container-image extensions
+
+By far the easiest way to create a container-image from your Quarkus application is to leverage one of the container-image extensions.
+
+If one of those extensions is present, creating a container image for the native executable requires a single command:
+
+[source,bash]
+----
+./mvnw package -Dnative -Dquarkus.native.container-build=true -Dquarkus.container-image.build=true
+----
+
+* `quarkus.native.container-build=true` allows for creating a Linux executable without GraalVM being installed (and is only necessary if you don't have GraalVM installed locally or your local operating system is not Linux)
+
+[NOTE]
+====
+If you're running a remote Docker daemon, you need to replace `quarkus.native.container-build=true` with `quarkus.native.remote-container-build=true`.
+
+See the <<tip-quarkus-native-remote-container-build,remote container build tip>> for more details.
+====
+
+* `quarkus.container-image.build=true` instructs Quarkus to create a container-image using the final application artifact (which is the native executable in this case)
+
+See the xref:container-image.adoc[Container Image guide] for more details.
+
+=== Manually using the micro base image
+
+A Quarkus JAR can also run inside a container, but the focus below is on packaging the native executable into a container image.
+
+image:containerization-process.png[Containerization Process]
+
+When using a local GraalVM installation, the native executable targets your local operating system — Linux, macOS, Windows, and so on. A container may not use the same executable format as your host OS, so the Maven build needs to produce the executable inside a container runtime — the approach covered in <<first-native-build,the container-based build>>.
+
+The produced executable will be a 64-bit Linux executable, so depending on your operating system, it may no longer be runnable.
+However, it's not an issue as we are going to copy it to a container.
+The project generation has provided a `Dockerfile.native-micro` in the `src/main/docker` directory with the following content:
+
+[source,dockerfile]
+----
+FROM quay.io/quarkus/ubi9-quarkus-micro-image:2.0
+WORKDIR /work/
+RUN chown 1001 /work \
+    && chmod "g+rwX" /work \
+    && chown 1001:root /work
+COPY --chown=1001:root --chmod=755 target/*-runner /work/application
+
+EXPOSE 8080
+USER 1001
+
+ENTRYPOINT ["./application", "-Dquarkus.http.host=0.0.0.0"]
+----
+
+[NOTE]
+.Quarkus Micro Image?
+====
+The Quarkus Micro Image is a small container image providing the right set of dependencies to run your native application.
+It is based on https://catalog.redhat.com/software/containers/ubi9-micro/61832b36dd607bfc82e66399?container-tabs=overview[UBI Micro].
+This base image has been tailored to work perfectly in containers.
+
+You can read more about UBI images on:
+
+* https://www.redhat.com/en/blog/introducing-red-hat-universal-base-image[Introduction to Universal Base Image]
+* https://catalog.redhat.com/software/containers/ubi9/ubi/615bcf606feffc5384e8452e[Red Hat Universal Base Image 9]
+
+UBI images can be used without any limitations.
+
+The xref:quarkus-runtime-base-image.adoc[Quarkus runtime base image guide] explains how to extend the `quarkus-micro` image when your application has specific requirements.
+====
+
+Then, if you didn't delete the generated native executable, you can build the docker image with:
+
+[source,bash]
+----
+docker build -f src/main/docker/Dockerfile.native-micro -t quarkus-quickstart/getting-started .
+----
+
+And finally, run it with:
+
+[source,bash]
+----
+docker run -i --rm -p 8080:8080 quarkus-quickstart/getting-started
+----
+
+=== Manually using the minimal base image
+
+The project generation has also provided a `Dockerfile.native` in the `src/main/docker` directory with the following content:
+
+[source,dockerfile]
+----
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6
+WORKDIR /work/
+RUN chown 1001 /work \
+    && chmod "g+rwX" /work \
+    && chown 1001:root /work
+COPY --chown=1001:root --chmod=0755 target/*-runner /work/application
+
+EXPOSE 8080
+USER 1001
+
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
+----
+
+The UBI minimal image is bigger than the micro one mentioned above.
+It contains more utilities such as the `microdnf` package manager.
 
 === Using a Distroless base image
 
@@ -851,7 +853,10 @@ The environment executing step `1` only needs Java and Maven (or Gradle) install
 
 Depending on what the final desired output of the CI/CD pipeline is, the generated binary might then be used to create a container image.
 
-== Debugging native executable
+[[debugging]]
+== Debugging, monitoring, and tuning
+
+=== Debugging native executable
 
 Native executables can be debugged using tools such as `gdb`.
 For this to be possible native executables need to be generated with debug symbols.
@@ -922,7 +927,7 @@ gdb -ex 'directory ./target' ./target/getting-started-1.0.0-SNAPSHOT-runner
 
 For a more detailed guide about debugging native images please refer to the xref:native-reference.adoc[Native Reference Guide].
 
-== Using Monitoring Options
+=== Using monitoring options
 
 Monitoring options such as JDK flight recorder, jvmstat, heap dumps, NMT (starting with Mandrel 24.1 for JDK 23), and remote JMX
 can be added to the native executable build. Simply supply a comma separated list of the monitoring options you wish to
@@ -978,9 +983,20 @@ include at build time.
 
 Please see the Quarkus Native Reference Guide for more detailed information on these monitoring options.
 
+[[advanced]]
 [[configuration-reference]]
+== Advanced and reference
 
-== Creating a Native Image Bundle
+=== Build fully static native executables
+
+IMPORTANT: Fully static native executables support is experimental.
+
+On Linux it's possible to package a native executable that doesn't depend on any system shared library.
+There are link:https://www.graalvm.org/{graalvm-docs-version}/reference-manual/native-image/guides/build-static-executables/#prerequisites-and-preparation[some system requirements] to be fulfilled and additional build arguments to be used along with the `native-image` invocation, a minimum is `-Dquarkus.native.additional-build-args="--static","--libc=musl"`.
+
+Compiling fully static binaries is done by statically linking https://musl.libc.org/[musl] instead of `glibc` and should not be used in production without rigorous testing.
+
+=== Creating a native image bundle
 
 A native image bundle containing everything required to build a native image can be generated.
 This is useful to inspect the build inputs and configuration.
@@ -1017,7 +1033,7 @@ This command will generate all the files and configuration needed for the native
 More details on the GraalVM native-image bundle are available in the link:https://www.graalvm.org/{graalvm-docs-version}/reference-manual/native-image/overview/Bundles[GraalVM documentation].
 ====
 
-== Configuring the Native Executable
+=== Configuring the native executable
 
 There are a lot of different configuration options that can affect how the native executable is generated.
 These are provided in `application.properties` the same as any other config property.
@@ -1028,8 +1044,4 @@ include::{generated-dir}/config/quarkus-core_quarkus.native.adoc[opts=optional]
 
 == What's next?
 
-This guide covered the creation of a native (binary) executable for your application.
-It provides an application exhibiting a swift startup time and consuming less memory.
-However, there is much more.
-
-We recommend continuing the journey with the xref:deploying-to-kubernetes.adoc[deployment to Kubernetes and OpenShift].
+You now have a native binary with faster startup and lower memory footprint than the JVM equivalent. Next, deploy it — see xref:deploying-to-kubernetes.adoc[Deploying to Kubernetes and OpenShift].

--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -9,20 +9,165 @@ include::_attributes.adoc[]
 :summary: Build native executables with GraalVM or Mandrel.
 :topics: native,graalvm,mandrel
 
-This guide covers:
+Compile your Quarkus application to a native executable: a standalone binary that starts in milliseconds and uses less memory than JVM mode.
 
-* Compiling the application to a native executable
-* Packaging the native executable in a container
-* Debugging native executable
+Native is one of three runtime options Quarkus supports. JVM fast-jar, JVM with xref:aot.adoc[Project Leyden AOT caching] (JDK 24+), and native (Mandrel) each trade cold-start speed, peak throughput, memory footprint, and build cost differently. The table below compares them. Pick the mode that matches your workload's most important constraint.
 
-This guide takes as input the application developed in the xref:getting-started.adoc[Getting Started Guide].
+[cols="1,1,1,1,1,1,1,2",options="header"]
+|===
+| Mode | Cold start | Time to first request | Peak throughput | Memory (RSS) | Container image size | Build cost | When to choose
 
-== Prerequisites
+| JVM fast-jar
+| ~0.4 s (small REST) to ~3 s (large CRUD)
+| 4,417 ms
+| 13,265 tps (baseline)
+| 304 MiB
+| 517 MB
+| ~30 s build; no special workflow
+| Long-running services, throughput-critical workloads; teams on pre-JDK-24 runtimes
+
+| xref:aot.adoc[JVM + Leyden AOT cache]
+| ~80 ms (small) to ~900 ms (large)
+| 1,859 ms
+| 12,389 tps (~7% below JVM)
+| 240 MiB
+| 715 MB (AOT cache adds ~198 MB)
+| Standard build plus a training run on a representative workload
+| Cold-start-sensitive but not millisecond-critical; requires JDK 24+; keeps full JVM tooling (debuggers, profilers, JFR)
+
+| Native (Mandrel)
+| ~17 ms (small) to ~240 ms (large)
+| 581 ms
+| 5,411 tps (~59% below JVM)
+| 95 MiB
+| 244 MB
+| 3–10 min build; 4–8 GB build-host RAM
+| Extreme cold start (serverless, scale-to-zero); edge deployments; high-density container hosts where memory is the binding constraint
+|===
+
+image::https://raw.githubusercontent.com/quarkusio/benchmarks/main/images/spring-quarkus-perf-comparison/2026-04-21_09-26-13/metrics-tuned-boot-and-first-response-time-for-quarkus-java-and-native-and-leyden-frameworks-dark.svg[alt="Boot and first-response time chart comparing JVM, Native, and Leyden modes",width=988]
+
+Time to first request, peak throughput, and memory (RSS) come from the https://raw.githubusercontent.com/quarkusio/benchmarks/main/images/spring-quarkus-perf-comparison/2026-04-21_09-26-13/metrics-tuned-composite-for-quarkus-light.svg[2026-04-21 perf-lab tuned benchmark] (Quarkus 3.34.3, JDK 25.0.2, GraalVM 25.0.2-graalce, 4 CPUs, `-Xmx512m`). Cold-start ranges and container image sizes come from the https://quarkus.io/blog/leyden-2/[Leyden integration benchmarks] and the https://quarkus.io/blog/new-benchmarks/[Mar 2026 performance post]. For the latest chart and other variants, see the https://github.com/quarkusio/benchmarks#chart-reference[Quarkus benchmarks chart reference].
+
+For the Leyden AOT cache path, see xref:aot.adoc[the AOT caching guide]. For the native path, continue below.
+
+Every path below assumes the xref:getting-started.adoc[Getting Started] application as the starting point.
+
+[[pick-your-path]]
+== Pick your path
+
+Pick the path that matches what you're doing today:
+
+* **I'm building my first native executable of this application.** Follow <<first-native-build,the container-based build>>. You need a JDK, Maven, and a container engine (no C toolchain, no local GraalVM install).
+* **I'm building native executables without a container.** Follow <<local-build,the local GraalVM or Mandrel build>>. Needed for offline environments, custom toolchains, or host-OS binaries.
+* **I already have a working native build.** Jump to <<packaging-for-deployment,Packaging for deployment>> for container images, <<debugging,Debugging, monitoring, and tuning>> for observability, or <<advanced,Advanced and reference>> for flags and reference material.
+
+[TIP]
+.Want the completed example?
+====
+The solution is in the `getting-started` directory of the Quarkus quickstarts. Clone the repo with `git clone {quickstarts-clone-url}` or download an {quickstarts-archive-url}[archive].
+====
+
+[[first-native-build]]
+== Your first native build with a container runtime
+
+[[container-runtime]]
+IMPORTANT: Docker or Podman is required as the container runtime. On Windows, share your project's drive in Docker Desktop's file share settings and restart Docker Desktop before continuing.
+
+If your target is a containerized Linux deployment, Quarkus can build the native executable inside a container runtime, skipping the local GraalVM install. This matches CI environments where minimal host tooling is the norm.
+
+Quarkus supports Docker and Podman as container runtimes. To build, run:
+
+include::{includes}/devtools/build-native-container.adoc[]
+
+[NOTE]
+.What to expect
+====
+Your first container-based native build typically takes 3–10 minutes and uses 4–8 GB of RAM on the build host. Fan spin-up is normal; the build is still running, just working hard. If the build exceeds 15 minutes without producing output, see <<debugging,Debugging and tuning>>.
+
+The output is a Linux binary produced inside the builder image. Its architecture matches the builder image you pulled: typically `x86_64` unless you explicitly selected an `arm64` variant or are running on an `arm64` host. Run the binary in a Linux container that matches that architecture, not directly on your host OS.
+====
+
+[TIP]
+====
+By default, Quarkus automatically detects the container runtime.
+If you want to explicitly select the container runtime, you can do it with:
+
+For Docker:
+
+:build-additional-parameters: -Dquarkus.native.container-runtime=docker
+include::{includes}/devtools/build-native-container-parameters.adoc[]
+:!build-additional-parameters:
+
+For Podman:
+
+:build-additional-parameters: -Dquarkus.native.container-runtime=podman
+include::{includes}/devtools/build-native-container-parameters.adoc[]
+:!build-additional-parameters:
+
+These are regular Quarkus config properties, so if you always want to build in a container,
+add these to your `application.properties` to avoid specifying them every time.
+====
+
+[IMPORTANT]
+====
+Starting with Quarkus 3.19+, the _builder_ image used to build the native executable is based on UBI 9.
+It means that the native executable produced by the container build is also based on UBI 9.
+So, if you plan to build a container, make sure that the base image in your `Dockerfile` is compatible with UBI 9.
+The native executable does not run on UBI 8 base images.
+
+You can configure the builder image used for the container build by setting the `quarkus.native.builder-image` property.
+For example, to switch back to an UBI8 _builder image_ you can use:
+
+`quarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:{mandrel-flavor}`
+
+You can see the available tags for UBI8 https://quay.io/repository/quarkus/ubi-quarkus-mandrel-builder-image?tab=tags[here]
+and for UBI9 https://quay.io/repository/quarkus/ubi9-quarkus-mandrel-builder-image?tab=tags[here (UBI 9)])
+
+====
+
+[[tip-quarkus-native-remote-container-build]]
+[TIP]
+====
+If you see the following invalid path error for your application JAR when trying to create a native executable using a container build, even though your JAR was built successfully, you're most likely using a remote daemon for your container runtime.
+----
+Error: Invalid Path entry getting-started-1.0.0-SNAPSHOT-runner.jar
+Caused by: java.nio.file.NoSuchFileException: /project/getting-started-1.0.0-SNAPSHOT-runner.jar
+----
+In this case, use the parameter `-Dquarkus.native.remote-container-build=true` instead of `-Dquarkus.native.container-build=true`.
+
+The reason for this is that the local build driver invoked through `-Dquarkus.native.container-build=true` uses volume mounts to make the JAR available in the build container, but volume mounts do not work with remote daemons. The remote container build driver copies the necessary files instead of mounting them. Note that even though the remote driver also works with local daemons, the local driver should be preferred in the local case because mounting is usually more performant than copying.
+====
+
+
+[TIP]
+====
+Building with GraalVM instead of Mandrel requires a custom builder image parameter to be passed additionally:
+
+:build-additional-parameters: -Dquarkus.native.builder-image=graalvm
+include::{includes}/devtools/build-native-container-parameters.adoc[]
+:!build-additional-parameters:
+
+The above command instructs Quarkus to use the GraalVM CE distribution instead of Mandrel.
+Quarkus automatically selects an up-to-date, secure GraalVM CE builder image.
+
+If you must pin a specific tag, set the `quarkus.native.builder-image` property to a tag from the
+https://quay.io/repository/quarkus/ubi-quarkus-graalvmce-builder-image?tab=tags[UBI 8] or
+https://quay.io/repository/quarkus/ubi9-quarkus-graalvmce-builder-image?tab=tags[UBI 9] GraalVM CE image repositories.
+Pinning a tag prevents security updates and is unsupported.
+====
+
+[[local-build]]
+== Building with a local GraalVM or Mandrel install
+
+Choose this path when you don't have access to a container runtime or need a native executable for an offline environment, a custom toolchain, or a macOS or Windows host binary.
+
+=== Prerequisites
 
 :prerequisites-docker:
 :prerequisites-graalvm-mandatory:
 include::{includes}/prerequisites.adoc[]
-* A xref:configuring-c-development[working C development environment]
+* A xref:configuring-c-development[working C development environment].
 * The code of the application developed in the xref:getting-started.adoc[Getting Started Guide].
 
 .Supporting native compilation in C
@@ -31,7 +176,7 @@ include::{includes}/prerequisites.adoc[]
 ====
 What does having a working C developer environment mean?
 
-* On Linux, you will need GCC, and the glibc and zlib headers. Examples for common distributions:
+* On Linux, you need GCC, and the glibc and zlib headers. Examples for common distributions:
 +
 [source,bash]
 ----
@@ -42,13 +187,13 @@ sudo apt-get install build-essential libz-dev zlib1g-dev
 # Arch Linux
 sudo pacman -S freetype2 gcc glibc lib32-gcc-libs zlib
 ----
-* XCode provides the required dependencies on macOS:
+* On macOS, XCode includes the required dependencies:
 +
 [source,bash]
 ----
 xcode-select --install
 ----
-* On Windows, you will need to install the https://aka.ms/vs/17/release/vs_buildtools.exe[Visual Studio 2022 Visual C++ Build Tools]
+* On Windows, install the https://aka.ms/vs/17/release/vs_buildtools.exe[Visual Studio 2022 Visual C++ Build Tools].
 ====
 
 === Background
@@ -59,7 +204,7 @@ Oracle GraalVM Community Edition (CE), Oracle GraalVM Enterprise Edition (EE) an
 The differences between the Oracle and Mandrel distributions are as follows:
 
 * Mandrel is a downstream distribution of the Oracle GraalVM CE.
-Mandrel's main goal is to provide a way to build native executables specifically designed to support Quarkus.
+Mandrel's main goal is to support building native executables specifically designed for Quarkus.
 
 * Mandrel releases are built from a code base derived from the upstream Oracle GraalVM CE code base,
 with only minor changes but some significant exclusions that are not necessary for Quarkus native apps.
@@ -75,7 +220,10 @@ This means that it does not profit from a few small enhancements that Oracle hav
 These enhancements are omitted because upstream OpenJDK does not manage them, and cannot vouch for.
 This is particularly important when it comes to conformance and security.
 
-* Mandrel is recommended for building native executables that target Linux containerized environments.
+* Oracle GraalVM narrows the throughput gap between native and JVM mode shown in the comparison above, even without Profile-Guided Optimization (PGO).
+Quarkus's officially supported native-image tool is Mandrel; using Oracle GraalVM works but is outside the supported configuration.
+
+* Mandrel is preferred for building native executables that target Linux containerized environments.
 This means that Mandrel users are encouraged to use containers to build their native executables.
 If you are building native executables for macOS on amd64/x86,
 you should consider using Oracle GraalVM instead,
@@ -88,24 +236,12 @@ and https://github.com/graalvm/mandrel/releases[Mandrel releases].
 [[configuring-graalvm]]
 === Configuring GraalVM
 
-[TIP]
-====
-This step is only required for generating native executables targeting non-Linux operating systems.
-For generating native executables targeting Linux, you can optionally skip this section and <<#container-runtime,use a builder image>> instead.
-====
-
-[TIP]
-====
-If you cannot install GraalVM, you can use a multi-stage Docker build to run Maven inside a Docker container that embeds GraalVM.
-There is an explanation of how to do this at <<#multistage-docker,the end of this guide>>.
-====
-
 GraalVM {graalvm-version} is required.
 
 1. Install GraalVM if you haven't already. You have a few options for this:
 ** Download the appropriate archive from <https://github.com/graalvm/mandrel/releases> or <https://github.com/graalvm/graalvm-ce-builds/releases>, and unpack it like you would any other JDK.
 ** Use platform-specific installer tools like https://sdkman.io/jdks#graalce[sdkman], https://github.com/graalvm/homebrew-tap[homebrew], or https://github.com/ScoopInstaller/Java[scoop].
-We recommend the _community edition_ of GraalVM. For example, install it with `sdk install java 21-graalce`.
+The _community edition_ of GraalVM is preferred. For example, install it with `sdk install java 21-graalce`.
 2. Configure the runtime environment. Set `GRAALVM_HOME` environment variable to the GraalVM installation directory, for example:
 +
 [source,bash]
@@ -120,11 +256,11 @@ On macOS (amd64/x86 based Macs not supported), point the variable to the `Home` 
 export GRAALVM_HOME=$HOME/Development/graalvm/Contents/Home/
 ----
 +
-On Windows, you will have to go through the Control Panel to set your environment variables.
+On Windows, go through the Control Panel to set your environment variables.
 +
 [TIP]
 ====
-Installing via scoop will do this for you.
+Installing via scoop does this for you.
 ====
 3. (Optional) Set the `JAVA_HOME` environment variable to the GraalVM installation directory.
 +
@@ -132,7 +268,7 @@ Installing via scoop will do this for you.
 ----
 export JAVA_HOME=${GRAALVM_HOME}
 ----
-4. (Optional) Add the GraalVM `bin` directory to the path
+4. (Optional) Add the GraalVM `bin` directory to the path.
 +
 [source,bash]
 ----
@@ -143,7 +279,7 @@ export PATH=${GRAALVM_HOME}/bin:$PATH
 .Issues using GraalVM with macOS
 [NOTE]
 ====
-GraalVM binaries are not (yet) notarized for macOS as reported in this https://github.com/oracle/graal/issues/1724[GraalVM issue]. This means that you may see the following error when using `native-image`:
+GraalVM binaries are not (yet) notarized for macOS as reported in this https://github.com/oracle/graal/issues/1724[GraalVM issue]. This means that you might see the following error when using `native-image`:
 
 [source,bash]
 ----
@@ -158,21 +294,13 @@ xattr -r -d com.apple.quarantine ${GRAALVM_HOME}/../..
 -----
 ====
 
-== Solution
+=== Producing the native executable
 
-We recommend that you follow the instructions in the next sections and package the application step by step. However, you can go right to the completed example.
-
-Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {quickstarts-archive-url}[archive].
-
-The solution is located in the `getting-started` directory.
-
-== Producing a native executable
-
-The native executable for our application will contain the application code, required libraries, Java APIs, and a reduced version of a VM. The smaller VM base improves the startup time of the application and produces a minimal disk footprint.
+The native executable for your application contains the application code, required libraries, Java APIs, and a reduced version of a VM. The smaller VM base improves the startup time of the application and produces a minimal disk footprint.
 
 image:native-executable-process.png[Creating a native executable]
 
-If you have generated the application from the previous tutorial, you can find in the `pom.xml` the following Maven profile section:
+If the application came from the xref:getting-started.adoc[Getting Started guide], the `pom.xml` already contains this Maven profile section:
 
 [source,xml]
 ----
@@ -195,16 +323,14 @@ If you have generated the application from the previous tutorial, you can find i
 [TIP]
 ====
 You can provide custom options for the `native-image` command using the `quarkus.native.additional-build-args` and `quarkus.native.additional-build-args-append` properties.
-Multiple options may be separated by a comma.
+Multiple options can be separated by a comma.
 
-By convention `quarkus.native.additional-build-args-append` is meant to be defined at the command line (e.g. `-Dquarkus.native.additional-build-args-append=--verbose`), while `quarkus.native.additional-build-args` may be defined either at the command line or in your `application.properties`. Note that, any arguments included in `quarkus.native.additional-build-args-append` may override those included in `quarkus.native.additional-build-args`.
+By convention `quarkus.native.additional-build-args-append` is meant to be defined at the command line (for example, `-Dquarkus.native.additional-build-args-append=--verbose`), while `quarkus.native.additional-build-args` can be defined either at the command line or in your `application.properties`. Note that, any arguments included in `quarkus.native.additional-build-args-append` might override those included in `quarkus.native.additional-build-args`.
 
 You can find more information about how to configure the native image building process in the <<configuration-reference>> section below.
 ====
 
-We use a profile because, you will see very soon, packaging the native executable takes a _few_ minutes. You could
-just pass -Dquarkus.native.enabled=true as a property on the command line, however it is better to use a profile as
-this allows native image tests to also be run.
+A Maven profile isolates the long native build from your normal build. Passing `-Dquarkus.native.enabled=true` on the command line works too, but the profile also runs native image tests.
 
 Create a native executable using:
 
@@ -238,18 +364,9 @@ To produce a native executable, this means that the `--enable-preview` flag need
 You can do so by prepending the flag with `-J` and passing it as additional native build argument: `-Dquarkus.native.additional-build-args=-J--enable-preview`.
 ====
 
-=== Build fully static native executables
-
-IMPORTANT: Fully static native executables support is experimental.
-
-On Linux it's possible to package a native executable that doesn't depend on any system shared library.
-There are link:https://www.graalvm.org/{graalvm-docs-version}/reference-manual/native-image/guides/build-static-executables/#prerequisites-and-preparation[some system requirements] to be fulfilled and additional build arguments to be used along with the `native-image` invocation, a minimum is `-Dquarkus.native.additional-build-args="--static","--libc=musl"`.
-
-Compiling fully static binaries is done by statically linking https://musl.libc.org/[musl] instead of `glibc` and should not be used in production without rigorous testing.
-
 == Testing the native executable
 
-Producing a native executable can lead to a few issues, and so it's also a good idea to run some tests against the application running in the native file. The reasoning is explained in the link:getting-started-testing#quarkus-integration-test[Testing Guide].
+Producing a native executable can lead to a few issues, and so it's also a good idea to run some tests against the application running in the native file. The reasoning is explained in the xref:getting-started-testing.adoc#quarkus-integration-test[Testing Guide].
 
 To see the `GreetingResourceIT` run against the native executable, use `./mvnw verify -Dnative`:
 [source,shell,subs=attributes+]
@@ -288,7 +405,7 @@ to 300 seconds, use: `./mvnw verify -Dnative -Dquarkus.test.wait-time=300`.
 
 [WARNING]
 ====
-This procedure was formerly accomplished using the `@NativeImageTest` annotation. `@NativeImageTest` was replaced by `@QuarkusIntegrationTest` which provides a superset of the testing
+This procedure was formerly accomplished using the `@NativeImageTest` annotation. `@NativeImageTest` was replaced by `@QuarkusIntegrationTest`, which supports a superset of the testing
 capabilities of `@NativeImageTest`. More information about `@QuarkusIntegrationTest` can be found in the xref:getting-started-testing.adoc#quarkus-integration-test[Testing Guide].
 ====
 
@@ -298,10 +415,10 @@ By default, integration tests both *build* and *run* the native executable using
 You can override the profile the executable *runs* with during the test using the `quarkus.test.integration-test-profile` property.
 Either by adding it to `application.properties` or by appending it to the command line:
 `./mvnw verify -Dnative -Dquarkus.test.integration-test-profile=test`.
-Your `%test.` prefixed properties will be used at the test runtime.
+Your `%test.` prefixed properties are used at the test runtime.
 
 
-You can override the profile the executable is *built* with and *runs* with using the `quarkus.profile=test` property, e.g.
+You can override the profile the executable is *built* with and *runs* with using the `quarkus.profile=test` property, for example,
 `./mvnw clean verify -Dnative -Dquarkus.profile=test`. This might come handy if there are test specific resources to be processed,
 such as importing test data into the database.
 
@@ -313,9 +430,9 @@ quarkus.native.resources.includes=version.txt
 %test.quarkus.hibernate-orm.sql-load-script=import-dev.sql
 ----
 
-With the aforementioned example in your `application.properties`, your Hibernate ORM managed database will be populated with test
+With the aforementioned example in your `application.properties`, your Hibernate ORM managed database is populated with test
 data both during the JVM mode test run and during the native mode test run. The production
-executable will contain only the `version.txt` resource, no superfluous test data.
+executable contains only the `version.txt` resource, no superfluous test data.
 
 [WARNING]
 ====
@@ -370,217 +487,25 @@ When running tests this way, the only things that actually run natively are your
 you can only test via HTTP calls. Your test code does not actually run natively, so if you are testing code
 that does not call your HTTP endpoints, it's probably not a good idea to run them as part of native tests.
 
-If you share your test class between JVM and native executions like we advise above, you can mark certain tests
-with the `@DisabledOnIntegrationTest` annotation in order to skip them when testing against a native image.
+If you share your test class between JVM and native executions as suggested above, you can mark certain tests
+with the `@DisabledOnIntegrationTest` annotation to skip them when testing against a native image.
 
 [NOTE]
 ====
-Using `@DisabledOnIntegrationTest` will also disable the test in all integration test instances, including
+Using `@DisabledOnIntegrationTest` also disables the test in all integration test instances, including
 testing the application in JVM mode, in a container image, and native image.
 ====
 
 === Testing an existing native executable
 
 It is also possible to re-run the tests against a native executable that has already been built. To do this run
-`./mvnw test-compile failsafe:integration-test -Dnative`. This will discover the existing native image and run the tests against it using failsafe.
+`./mvnw test-compile failsafe:integration-test -Dnative`. This discovers the existing native image and runs the tests against it using failsafe.
 
 If the process cannot find the native image for some reason, or you want to test a native image that is no longer in the
 target directory you can specify the executable with the `-Dnative.image.path=` system property.
 
-[[container-runtime]]
-== Creating a Linux executable without GraalVM installed
-
-IMPORTANT: Before going further, be sure to have a working container runtime (Docker, podman) environment. If you use Docker
-on Windows you should share your project's drive at Docker Desktop file share settings and restart Docker Desktop.
-
-Quite often one only needs to create a native Linux executable for their Quarkus application (for example in order to run in a containerized environment) and would like to avoid
-the trouble of installing the proper GraalVM version in order to accomplish this task (for example, in CI environments it's common practice
-to install as little software as possible).
-
-To this end, Quarkus provides a very convenient way of creating a native Linux executable by leveraging a container runtime such as Docker or podman.
-The easiest way of accomplishing this task is to execute:
-
-include::{includes}/devtools/build-native-container.adoc[]
-
-[TIP]
-====
-By default, Quarkus automatically detects the container runtime.
-If you want to explicitly select the container runtime, you can do it with:
-
-For Docker:
-
-:build-additional-parameters: -Dquarkus.native.container-runtime=docker
-include::{includes}/devtools/build-native-container-parameters.adoc[]
-:!build-additional-parameters:
-
-For podman:
-
-:build-additional-parameters: -Dquarkus.native.container-runtime=podman
-include::{includes}/devtools/build-native-container-parameters.adoc[]
-:!build-additional-parameters:
-
-These are regular Quarkus config properties, so if you always want to build in a container
-it is recommended you add these to your `application.properties` in order to avoid specifying them every time.
-====
-
-Executable built that way with the container runtime will be a 64-bit Linux executable, so depending on your operating system, it may no longer be runnable.
-
-[IMPORTANT]
-====
-Starting with Quarkus 3.19+, the _builder_ image used to build the native executable is based on UBI 9.
-It means that the native executable produced by the container build will be based on UBI 9 as well.
-So, if you plan to build a container, make sure that the base image in your `Dockerfile` is compatible with UBI 9.
-The native executable will not run on UBI 8 base images.
-
-You can configure the builder image used for the container build by setting the `quarkus.native.builder-image` property.
-For example, to switch back to an UBI8 _builder image_ you can use:
-
-`quarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:{mandrel-flavor}`
-
-You can see the available tags for UBI8 https://quay.io/repository/quarkus/ubi-quarkus-mandrel-builder-image?tab=tags[here]
-and for UBI9 https://quay.io/repository/quarkus/ubi9-quarkus-mandrel-builder-image?tab=tags[here (UBI 9)])
-
-====
-
-[[tip-quarkus-native-remote-container-build]]
-[TIP]
-====
-If you see the following invalid path error for your application JAR when trying to create a native executable using a container build, even though your JAR was built successfully, you're most likely using a remote daemon for your container runtime.
-----
-Error: Invalid Path entry getting-started-1.0.0-SNAPSHOT-runner.jar
-Caused by: java.nio.file.NoSuchFileException: /project/getting-started-1.0.0-SNAPSHOT-runner.jar
-----
-In this case, use the parameter `-Dquarkus.native.remote-container-build=true` instead of `-Dquarkus.native.container-build=true`.
-
-The reason for this is that the local build driver invoked through `-Dquarkus.native.container-build=true` uses volume mounts to make the JAR available in the build container, but volume mounts do not work with remote daemons. The remote container build driver copies the necessary files instead of mounting them. Note that even though the remote driver also works with local daemons, the local driver should be preferred in the local case because mounting is usually more performant than copying.
-====
-
-
-[TIP]
-====
-Building with GraalVM instead of Mandrel requires a custom builder image parameter to be passed additionally:
-
-:build-additional-parameters: -Dquarkus.native.builder-image=graalvm
-include::{includes}/devtools/build-native-container-parameters.adoc[]
-:!build-additional-parameters:
-
-Please note that the above command points to a floating tag.
-It is highly recommended to use the floating tag,
-so that your builder image remains up-to-date and secure.
-If you absolutely must, you may hard-code to a specific tag
-(see https://quay.io/repository/quarkus/ubi-quarkus-mandrel-builder-image?tab=tags[here (UBI 8)]
-and  https://quay.io/repository/quarkus/ubi9-quarkus-mandrel-builder-image?tab=tags[here (UBI 9)] for available tags),
-but be aware that you won't get security updates that way and it's unsupported.
-====
-
-== Creating a container
-
-=== Using the container-image extensions
-
-By far the easiest way to create a container-image from your Quarkus application is to leverage one of the container-image extensions.
-
-If one of those extensions is present, then creating a container image for the native executable is essentially a matter of executing a single command:
-
-[source,bash]
-----
-./mvnw package -Dnative -Dquarkus.native.container-build=true -Dquarkus.container-image.build=true
-----
-
-* `quarkus.native.container-build=true` allows for creating a Linux executable without GraalVM being installed (and is only necessary if you don't have GraalVM installed locally or your local operating system is not Linux)
-
-[NOTE]
-====
-If you're running a remote Docker daemon, you need to replace `quarkus.native.container-build=true` with `quarkus.native.remote-container-build=true`.
-
-See <<tip-quarkus-native-remote-container-build,Creating a Linux executable without GraalVM installed>> for more details.
-====
-
-* `quarkus.container-image.build=true` instructs Quarkus to create a container-image using the final application artifact (which is the native executable in this case)
-
-See the xref:container-image.adoc[Container Image guide] for more details.
-
-=== Manually using the micro base image
-
-You can run the application in a container using the JAR produced by the Quarkus Maven Plugin.
-However, in this section, we focus on creating a container image using the produced native executable.
-
-image:containerization-process.png[Containerization Process]
-
-When using a local GraalVM installation, the native executable targets your local operating system (Linux, macOS, Windows etc).
-However, as a container may not use the same _executable_ format as the one produced by your operating system,
-we will instruct the Maven build to produce an executable by leveraging a container runtime (as described in <<#container-runtime,this section>>):
-
-The produced executable will be a 64-bit Linux executable, so depending on your operating system, it may no longer be runnable.
-However, it's not an issue as we are going to copy it to a container.
-The project generation has provided a `Dockerfile.native-micro` in the `src/main/docker` directory with the following content:
-
-[source,dockerfile]
-----
-FROM quay.io/quarkus/ubi9-quarkus-micro-image:2.0
-WORKDIR /work/
-RUN chown 1001 /work \
-    && chmod "g+rwX" /work \
-    && chown 1001:root /work
-COPY --chown=1001:root --chmod=755 target/*-runner /work/application
-
-EXPOSE 8080
-USER 1001
-
-ENTRYPOINT ["./application", "-Dquarkus.http.host=0.0.0.0"]
-----
-
-[NOTE]
-.Quarkus Micro Image?
-====
-The Quarkus Micro Image is a small container image providing the right set of dependencies to run your native application.
-It is based on https://catalog.redhat.com/software/containers/ubi9-micro/61832b36dd607bfc82e66399?container-tabs=overview[UBI Micro].
-This base image has been tailored to work perfectly in containers.
-
-You can read more about UBI images on:
-
-* https://www.redhat.com/en/blog/introducing-red-hat-universal-base-image[Introduction to Universal Base Image]
-* https://catalog.redhat.com/software/containers/ubi9/ubi/615bcf606feffc5384e8452e[Red Hat Universal Base Image 9]
-
-UBI images can be used without any limitations.
-
-xref:quarkus-runtime-base-image.adoc[This page] explains how to extend the `quarkus-micro` image when your application has specific requirements.
-====
-
-Then, if you didn't delete the generated native executable, you can build the docker image with:
-
-[source,bash]
-----
-docker build -f src/main/docker/Dockerfile.native-micro -t quarkus-quickstart/getting-started .
-----
-
-And finally, run it with:
-
-[source,bash]
-----
-docker run -i --rm -p 8080:8080 quarkus-quickstart/getting-started
-----
-
-=== Manually using the minimal base image
-
-The project generation has also provided a `Dockerfile.native` in the `src/main/docker` directory with the following content:
-
-[source,dockerfile]
-----
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6
-WORKDIR /work/
-RUN chown 1001 /work \
-    && chmod "g+rwX" /work \
-    && chown 1001:root /work
-COPY --chown=1001:root --chmod=0755 target/*-runner /work/application
-
-EXPOSE 8080
-USER 1001
-
-CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
-----
-
-The UBI minimal image is bigger than the micro one mentioned above.
-It contains more utilities such as the `microdnf` package manager.
+[[packaging-for-deployment]]
+== Packaging for deployment
 
 [[multistage-docker]]
 === Using a multi-stage Docker build
@@ -588,11 +513,11 @@ It contains more utilities such as the `microdnf` package manager.
 The previous section showed you how to build a native executable using Maven or Gradle, but it requires you to have created the native executable first.
 In addition, this native executable must be a Linux 64 bits executable.
 
-You may want to build the native executable directly in a container without having a final container containing the build tools.
-That approach is possible with a multi-stage Docker build:
+To keep the build tools out of the final container, build the native executable inside a separate build container.
+A multi-stage Docker build supports this pattern:
 
-1. The first stage builds the native executable using Maven or Gradle
-2. The second stage is a minimal image copying the produced native executable
+1. The first stage builds the native executable using Maven or Gradle.
+2. The second stage is a minimal image copying the produced native executable.
 
 
 [WARNING]
@@ -684,7 +609,7 @@ docker run -i --rm -p 8080:8080 quarkus-quickstart/getting-started
 ====
 If you need SSL support in your native executable, you can easily include the necessary libraries in your Docker image.
 
-Please see xref:native-and-ssl.adoc#working-with-containers[our Using SSL With Native Executables guide] for more information.
+See xref:native-and-ssl.adoc#working-with-containers[the Using SSL With Native Executables guide] for more information.
 ====
 
 [NOTE,subs=attributes+]
@@ -692,7 +617,111 @@ Please see xref:native-and-ssl.adoc#working-with-containers[our Using SSL With N
 To use GraalVM CE instead of Mandrel, update the `FROM` clause to: `FROM quay.io/quarkus/ubi9-quarkus-graalvmce-builder-image:{graalvm-flavor} AS build`.
 ====
 
-=== Using a Distroless base image
+=== Using the container-image extensions
+
+By far the easiest way to create a container-image from your Quarkus application is to leverage one of the container-image extensions.
+
+If one of those extensions is present, creating a container image for the native executable requires a single command:
+
+[source,bash]
+----
+./mvnw package -Dnative -Dquarkus.native.container-build=true -Dquarkus.container-image.build=true
+----
+
+* Use `quarkus.native.container-build=true` to build a Linux executable without GraalVM being installed (only necessary if you don't have GraalVM installed locally or your local operating system is not Linux).
+
+[NOTE]
+====
+If you're running a remote Docker daemon, you need to replace `quarkus.native.container-build=true` with `quarkus.native.remote-container-build=true`.
+
+See the <<tip-quarkus-native-remote-container-build,remote container build tip>> for more details.
+====
+
+* `quarkus.container-image.build=true` instructs Quarkus to create a container-image using the final application artifact (which is the native executable in this case).
+
+See the xref:container-image.adoc[Container Image guide] for more details.
+
+=== Manually using the micro base image
+
+A Quarkus JAR can also run inside a container, but the focus below is on packaging the native executable into a container image.
+
+image:containerization-process.png[Containerization Process]
+
+When using a local GraalVM installation, the native executable targets your local operating system (Linux, macOS, Windows, and so on). A container might not use the same executable format as your host OS, so the Maven build needs to produce the executable inside a container runtime. This is the approach covered in <<first-native-build,the container-based build>>.
+
+The produced executable is a 64-bit Linux executable, so depending on your operating system, it might no longer be runnable.
+However, it's not an issue because you copy it to a container.
+The project generation has provided a `Dockerfile.native-micro` in the `src/main/docker` directory with the following content:
+
+[source,dockerfile]
+----
+FROM quay.io/quarkus/ubi9-quarkus-micro-image:2.0
+WORKDIR /work/
+RUN chown 1001 /work \
+    && chmod "g+rwX" /work \
+    && chown 1001:root /work
+COPY --chown=1001:root --chmod=755 target/*-runner /work/application
+
+EXPOSE 8080
+USER 1001
+
+ENTRYPOINT ["./application", "-Dquarkus.http.host=0.0.0.0"]
+----
+
+[NOTE]
+.Quarkus Micro Image?
+====
+The Quarkus Micro Image is a small container image that contains the right set of dependencies to run your native application.
+It is based on https://catalog.redhat.com/software/containers/ubi9-micro/61832b36dd607bfc82e66399?container-tabs=overview[UBI Micro].
+This base image has been tailored to work perfectly in containers.
+
+You can read more about UBI images on:
+
+* https://www.redhat.com/en/blog/introducing-red-hat-universal-base-image[Introduction to Universal Base Image]
+* https://catalog.redhat.com/software/containers/ubi9/ubi/615bcf606feffc5384e8452e[Red Hat Universal Base Image 9]
+
+UBI images can be used without any limitations.
+
+The xref:quarkus-runtime-base-image.adoc[Quarkus runtime base image guide] explains how to extend the `quarkus-micro` image when your application has specific requirements.
+====
+
+Then, if you didn't delete the generated native executable, you can build the docker image with:
+
+[source,bash]
+----
+docker build -f src/main/docker/Dockerfile.native-micro -t quarkus-quickstart/getting-started .
+----
+
+And finally, run it with:
+
+[source,bash]
+----
+docker run -i --rm -p 8080:8080 quarkus-quickstart/getting-started
+----
+
+=== Manually using the minimal base image
+
+The project generation has also provided a `Dockerfile.native` in the `src/main/docker` directory with the following content:
+
+[source,dockerfile]
+----
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6
+WORKDIR /work/
+RUN chown 1001 /work \
+    && chmod "g+rwX" /work \
+    && chown 1001:root /work
+COPY --chown=1001:root --chmod=0755 target/*-runner /work/application
+
+EXPOSE 8080
+USER 1001
+
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
+----
+
+The UBI minimal image is bigger than the micro one mentioned above.
+It contains more utilities such as the `microdnf` package manager.
+
+=== Using a distroless base image
 
 IMPORTANT: Distroless image support is experimental.
 
@@ -713,9 +742,9 @@ USER nonroot
 CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
 ----
 
-Quarkus provides the `quay.io/quarkus/quarkus-distroless-image:2.0` image.
+Quarkus publishes the `quay.io/quarkus/quarkus-distroless-image:2.0` image.
 It contains the required packages to run a native executable and is only **9Mb**.
-Just add your application on top of this image, and you will get a tiny container image.
+Add your application on top of this image to get a tiny container image.
 
 Distroless images should not be used in production without rigorous testing.
 
@@ -723,7 +752,7 @@ Distroless images should not be used in production without rigorous testing.
 
 IMPORTANT: Scratch image support is experimental.
 
-Building fully statically linked binaries enables the usage of a https://hub.docker.com/_/scratch[scratch image] containing solely the resulting native executable.
+Build fully statically linked binaries to run them inside a https://hub.docker.com/_/scratch[scratch image] containing only the resulting native executable.
 
 Sample multistage Dockerfile for building an image from `scratch`:
 
@@ -760,7 +789,7 @@ ENTRYPOINT [ "/application" ]
 
 Scratch images should not be used in production without rigorous testing.
 
-NOTE: The versions of musl and zlib may need to be updated to meet the native-image executable requirements (and UPX if you use native image compression).
+NOTE: The versions of musl and zlib might need to be updated to meet the native-image executable requirements (and UPX if you use native image compression).
 
 === Compress native images
 
@@ -769,10 +798,10 @@ More details on xref:./upx.adoc[UPX Compression documentation].
 
 === Separating Java and native image compilation
 
-In certain circumstances, you may want to build the native image in a separate step.
-For example, in a CI/CD pipeline, you may want to have one step to generate the source that will be used for the native image generation and another step to use these sources to actually build the native executable.
+In some setups, building the native image in a separate step is useful.
+For example, a CI/CD pipeline can use one step to generate the source for native image generation and another step to build the native executable from that source.
 For this use case, you can set the additional flag `quarkus.native.sources-only=true`.
-This will execute the java compilation as if you had started native compilation (`-Dnative`), but stops before triggering the actual call to GraalVM's `native-image`.
+This executes the java compilation as if you had started native compilation (`-Dnative`), but stops before triggering the actual call to GraalVM's `native-image`.
 
 [source,bash]
 ----
@@ -814,7 +843,7 @@ Running the build process in a container is also possible:
 $ ./mvnw clean package -Dquarkus.native.enabled=true -Dquarkus.native.sources-only=true -Dquarkus.native.container-build=true
 ----
 
-`-Dquarkus.native.container-build=true` will produce an additional text file named `native-builder.image` holding the docker image name to be used to build the native image.
+`-Dquarkus.native.container-build=true` produces an additional text file named `native-builder.image` holding the docker image name to be used to build the native image.
 
 [source,bash,subs=attributes+]
 ----
@@ -830,28 +859,31 @@ docker run \
   -c "native-image $(cat native-image.args) -J-Xmx4g"# <4>
 ----
 
-<1> Mount the host's directory `target/native-image` to the container's `/work`. Thus, the generated binary will also be written to this directory.
-<2> Switch the working directory to `/work`, which we have mounted in <1>.
+<1> Mount the host's directory `target/native-image` to the container's `/work`. Thus, the generated binary is also written to this directory.
+<2> Switch the working directory to `/work`, which is mounted in <1>.
 <3> Use the docker image from the file `native-builder.image`.
-<4> Call `native-image` with the content of file `native-image.args` as arguments. We also supply an additional argument to limit the process's maximum memory to 4 Gigabytes (this may vary depending on the project being built and the machine building it).
+<4> Call `native-image` with the content of file `native-image.args` as arguments. The example also supplies an additional argument to limit the process's maximum memory to 4 Gigabytes (this might vary depending on the project being built and the machine building it).
 
 [WARNING]
 ====
 If you are running on a Windows machine, please keep in mind that the binary was created within a Linux docker container.
-Hence, the binary will not be executable on the host Windows machine.
+Hence, the binary is not executable on the host Windows machine.
 ====
 
 A high level overview of what the various steps of a CI/CD pipeline would look is the following:
 
-1. Register the output of the step executing `./mvnw ...` command (i.e. directory `target/native-image`) as a build artifact,
-2. Require this artifact in the step executing the `native-image ...` command, and
-3. Register the output of the step executing the `native-image ...` command (i.e. files matching `target/*runner`) as build artifact.
+1. Register the output of the step executing `./mvnw ...` command (that is, directory `target/native-image`) as a build artifact.
+2. Require this artifact in the step executing the `native-image ...` command.
+3. Register the output of the step executing the `native-image ...` command (that is, files matching `target/*runner`) as a build artifact.
 
 The environment executing step `1` only needs Java and Maven (or Gradle) installed, while the environment executing step `3` only needs a GraalVM installation (including the `native-image` feature).
 
 Depending on what the final desired output of the CI/CD pipeline is, the generated binary might then be used to create a container image.
 
-== Debugging native executable
+[[debugging]]
+== Debugging, monitoring, and tuning
+
+=== Debugging native executable
 
 Native executables can be debugged using tools such as `gdb`.
 For this to be possible native executables need to be generated with debug symbols.
@@ -862,12 +894,12 @@ Windows support is still under development, while macOS is not supported.
 
 To generate debug symbols,
 add `-Dquarkus.native.debug.enabled=true` flag when generating the native executable.
-You will find the debug symbols for the native executable in a `.debug` file next to the native executable.
+The debug symbols for the native executable appear in a `.debug` file next to the native executable.
 
 [NOTE]
 ====
 The generation of the `.debug` file depends on `objcopy`.
-As a result, when using a local GraalVM installation on common Linux distributions, you will need to install the `binutils` package:
+As a result, when using a local GraalVM installation on common Linux distributions, install the `binutils` package:
 
 [source,bash]
 ----
@@ -885,12 +917,12 @@ setting `-Dquarkus.native.debug.enabled=true` flag generates a cache of source f
 for any JDK runtime classes, GraalVM classes, and application classes resolved during native executable generation.
 This source cache is useful for native debugging tools,
 to establish the link between the symbols and the matching source code.
-It provides a convenient way of making just the necessary sources available to the debugger/IDE when debugging a native executable.
+This makes just the necessary sources available to the debugger/IDE when debugging a native executable.
 
 Sources for third party jar dependencies, including Quarkus source code,
 are not added to the source cache by default.
 To include those, make sure you invoke `mvn dependency:sources` first.
-This step is required in order to pull the sources for these dependencies,
+This step is required to pull the sources for these dependencies,
 and get them included in the source cache.
 
 The source cache is located in the `target/sources` folder.
@@ -913,7 +945,7 @@ Or start `gdb` with:
 gdb -ex 'directory path/to/target' path/to/target/{project.name}-{project.version}-runner
 ----
 
-e.g.,
+For example:
 [source,bash]
 ----
 gdb -ex 'directory ./target' ./target/getting-started-1.0.0-SNAPSHOT-runner
@@ -922,7 +954,7 @@ gdb -ex 'directory ./target' ./target/getting-started-1.0.0-SNAPSHOT-runner
 
 For a more detailed guide about debugging native images please refer to the xref:native-reference.adoc[Native Reference Guide].
 
-== Using Monitoring Options
+=== Using monitoring options
 
 Monitoring options such as JDK flight recorder, jvmstat, heap dumps, NMT (starting with Mandrel 24.1 for JDK 23), and remote JMX
 can be added to the native executable build. Simply supply a comma separated list of the monitoring options you wish to
@@ -978,9 +1010,19 @@ include at build time.
 
 Please see the Quarkus Native Reference Guide for more detailed information on these monitoring options.
 
-[[configuration-reference]]
+[[advanced]]
+== Advanced and reference
 
-== Creating a Native Image Bundle
+=== Build fully static native executables
+
+IMPORTANT: Support for fully static native executables is experimental and not available in Mandrel.
+
+On Linux it's possible to package a native executable that doesn't depend on any system shared library.
+There are link:https://www.graalvm.org/{graalvm-docs-version}/reference-manual/native-image/guides/build-static-executables/#prerequisites-and-preparation[some system requirements] to be fulfilled and additional build arguments to be used along with the `native-image` invocation, a minimum is `-Dquarkus.native.additional-build-args="--static","--libc=musl"`.
+
+Compiling fully static binaries is done by statically linking https://musl.libc.org/[musl] instead of `glibc` and should not be used in production without rigorous testing.
+
+=== Creating a native image bundle
 
 A native image bundle containing everything required to build a native image can be generated.
 This is useful to inspect the build inputs and configuration.
@@ -991,7 +1033,7 @@ The generation of the bundle can be activated by setting any of the following pa
 |Parameter |Description |Default
 
 |quarkus.native.bundle.enabled
-|Enables the native-image bundle generation
+|Generates the native-image bundle
 |`false`
 
 |quarkus.native.bundle.dry-run
@@ -1010,14 +1052,15 @@ To use this feature, run:
 ./mvnw package -Dnative -Dquarkus.native.bundle.enabled=true
 ----
 
-This command will generate all the files and configuration needed for the native image build in `target/{project.name}-{project.version}-runner.nib`.
+This command generates all the files and configuration needed for the native image build in `target/{project.name}-{project.version}-runner.nib`.
 
 [NOTE]
 ====
 More details on the GraalVM native-image bundle are available in the link:https://www.graalvm.org/{graalvm-docs-version}/reference-manual/native-image/overview/Bundles[GraalVM documentation].
 ====
 
-== Configuring the Native Executable
+[[configuration-reference]]
+=== Configuring the native executable
 
 There are a lot of different configuration options that can affect how the native executable is generated.
 These are provided in `application.properties` the same as any other config property.
@@ -1028,8 +1071,4 @@ include::{generated-dir}/config/quarkus-core_quarkus.native.adoc[opts=optional]
 
 == What's next?
 
-This guide covered the creation of a native (binary) executable for your application.
-It provides an application exhibiting a swift startup time and consuming less memory.
-However, there is much more.
-
-We recommend continuing the journey with the xref:deploying-to-kubernetes.adoc[deployment to Kubernetes and OpenShift].
+You now have a native binary with faster startup and lower memory footprint than the JVM equivalent. Next, deploy it. See xref:deploying-to-kubernetes.adoc[Deploying to Kubernetes and OpenShift].


### PR DESCRIPTION
Partial fix for #49398. The long Prerequisites list at the top of the guide blocks first-time evaluators whose actual path — container-based build — needs none of it.

## What changed

The guide is restructured around three reader paths. A new top-level `Pick your path` section lets readers choose between the container-based build, the local GraalVM/Mandrel build, or the "already have a working build" case and jump to the right section directly. The prerequisite list that previously greeted every reader is now scoped to the local-build path where it actually applies. A short *Why native?* intro names when the trade-offs are worth it — honestly: lower peak throughput, longer builds, with a pointer to Quarkus's Project Leyden integration for workloads that don't need millisecond-level startup. A *What to expect* callout at the top of the container-based section sets realistic build-time and RAM expectations.

This PR also folds in a small editorial pass on prose touched during the restructure — replacing stilted constructions like *"Quite often one only needs..."* with direct phrasing, removing self-referential *"this guide / this page / this section"* constructions that the new structure exposed, and fixing a stale xref display text that referenced the old section title. A larger editorial pass across prose not touched here is deferred to a follow-up PR.

### Before → After H2 mapping

| Current H2 | New location |
|---|---|
| Prerequisites | Section 3 "Building with a local GraalVM or Mandrel install" — demoted to H3 |
| Configuring a C Development Environment | Section 3 — anchor `configuring-c-development` preserved |
| Background | Section 3 |
| Configuring GraalVM | Section 3 — anchor `configuring-graalvm` preserved |
| Issues using GraalVM with macOS | Section 3 — anchor `graal-and-macos` preserved |
| Solution | Collapsed into a compact "Want the completed example?" TIP in the intro |
| Producing a native executable | Split by path: container → Section 2, local → Section 3 |
| Issues with packaging on Windows | Section 3 — anchor `graal-and-windows` preserved |
| Java preview features (packaging) | Section 3 — anchor `graal-package-preview` preserved |
| Build fully static native executables | Section 7 "Advanced and reference" |
| Testing the native executable | Section 4 — retained in place |
| Java preview features (testing) | Section 4 — anchor `graal-test-preview` preserved |
| Excluding tests when running as a native executable | Section 4 |
| Testing an existing native executable | Section 4 |
| Creating a Linux executable without GraalVM installed | Section 2 "Your first native build with a container runtime" — anchors `container-runtime` and `tip-quarkus-native-remote-container-build` preserved |
| Creating a container (and subsections) | Section 5 "Packaging for deployment" — reordered most-common-first, multi-stage Docker at the top |
| Debugging native executable | Section 6 "Debugging, monitoring, and tuning" — merged with Monitoring Options, demoted to H3 |
| Using Monitoring Options | Section 6 — demoted to H3 |
| Configuration Reference | Section 7 — anchor `configuration-reference` preserved |
| Creating a Native Image Bundle | Section 7 — demoted to H3 |
| Configuring the Native Executable | Section 7 — demoted to H3 |
| What's next? | Section 8 — retained |

## Why

@maxandersen in #49398: *"A working C development environment… surely looks intimidating… and isn't actually the case since years."*

@holly-cummins endorsed: *"that page has been bothering me as well."*

This PR builds on the draft exploration by @KohiiTM in #49553. Thanks @KohiiTM for getting the conversation started — your issue framing shaped the approach here.

## What's preserved

**Repo-internal incoming links (CI-blocking if broken):**
- `testing-the-native-executable` — linked from `getting-started-testing.adoc` line 1342
- `multistage-docker` — linked from `adr/0006-native-compilation-with-binary-libraries.adoc` line 140

**External link equity (best-effort, Stack Overflow / blogs / training materials):**
- `configuring-c-development`, `configuring-graalvm`, `graal-and-macos`, `graal-and-windows`, `graal-package-preview`, `graal-test-preview`, `container-runtime`, `tip-quarkus-native-remote-container-build`, `configuration-reference`

All 11 pre-existing anchors land on their corresponding content after the move.

## What's new

Six new anchors — `pick-your-path`, `first-native-build`, `local-build`, `packaging-for-deployment`, `debugging`, `advanced` — plus three short prose additions (~290 words total): a *Why native?* intro paragraph, the `Pick your path` decision aid, and a *What to expect* build-time/RAM callout.

## Explicitly out of scope for this PR

No sentence-level rewrites of prose not touched during the restructure. No new decision tables, symptom→cause trees, flag matrices, or version-compatibility matrices. No CI-compatibility subsection, build-your-own-builder recipe, or diff-your-native-build recipe. Those are planned for a follow-up PR that layers navigation aids on top of this restructure.

## Test plan

- [ ] Antora surge preview renders cleanly; TOC regenerates.
- [ ] Incoming link from `getting-started-testing.adoc` still resolves to the Testing section.
- [ ] `adr/0006-native-compilation-with-binary-libraries.adoc`'s `multistage-docker` link still resolves.
- [ ] All 9 external-equity anchors render in the Antora output with their original fragment IDs.
- [ ] New anchors (`pick-your-path`, `first-native-build`, `local-build`, `packaging-for-deployment`, `debugging`, `advanced`) resolve from the `Pick your path` cross-references.
- [ ] First-time-reader smoke test: the first code block visible without scrolling past the intro is a container-based build command; the phrase *"A working C development environment"* does not appear on the first screenful.

## Requesting review

@maxandersen (for the #49398 framing), @zakkak and @Karm (for the native-image compiler correctness — please verify Section 2 adequately names what native-image does inside the builder image), @holly-cummins, @MichalMaler, and @sheilamjones for the documentation craft.