### PR TITLE
Centralize container images in one place

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -122,6 +122,8 @@
         <pulsar.image>docker.io/apachepulsar/pulsar:3.2.4</pulsar.image>
         <redis.image>docker.io/library/redis:7</redis.image>
         <infinispan.image>quay.io/infinispan/server:latest</infinispan.image>
+        <mailpit.image>docker.io/axllent/mailpit:latest</mailpit.image>
+        <fake-smtp-server.image>docker.io/reachfive/fake-smtp-server:latest</fake-smtp-server.image>
 
         <!-- Code Coverage Properties-->
         <jacoco.agent.argLine></jacoco.agent.argLine>
@@ -454,6 +456,25 @@
                             <!-- some dev tools tests need the following properties -->
                             <project.version>${project.version}</project.version>
                             <project.groupId>${project.groupId}</project.groupId>
+
+                            <!-- Container Image Properties -->
+                            <elasticsearch.image>${elasticsearch.image}</elasticsearch.image>
+                            <opensearch.image>${opensearch.image}</opensearch.image>
+                            <postgres.image>${postgres.image}</postgres.image>
+                            <postgis.image>${postgis.image}</postgis.image>
+                            <pgvector.image>${pgvector.image}</pgvector.image>
+                            <mariadb.image>${mariadb.image}</mariadb.image>
+                            <db2.image>${db2.image}</db2.image>
+                            <mssql.image>${mssql.image}</mssql.image>
+                            <mysql.image>${mysql.image}</mysql.image>
+                            <oracle.image>${oracle.image}</oracle.image>
+                            <mongo.image>${mongo.image}</mongo.image>
+                            <keycloak.docker.image>${keycloak.docker.image}</keycloak.docker.image>
+                            <pulsar.image>${pulsar.image}</pulsar.image>
+                            <rabbitmq.image>${rabbitmq.image}</rabbitmq.image>
+                            <redis.image>${redis.image}</redis.image>
+                            <mailpit.image>${mailpit.image}</mailpit.image>
+                            <fake-smtp-server.image>${fake-smtp-server.image}</fake-smtp-server.image>
                         </systemPropertyVariables>
                         <!-- limit the amount of memory surefire can use, 1500m should be plenty-->
                         <!-- set tmpdir as early as possible because surefire sets it too late for JDK16 -->
@@ -482,6 +503,25 @@
                             <!-- some dev tools tests need the following properties -->
                             <project.version>${project.version}</project.version>
                             <project.groupId>${project.groupId}</project.groupId>
+
+                            <!-- Container Image Properties -->
+                            <elasticsearch.image>${elasticsearch.image}</elasticsearch.image>
+                            <opensearch.image>${opensearch.image}</opensearch.image>
+                            <postgres.image>${postgres.image}</postgres.image>
+                            <postgis.image>${postgis.image}</postgis.image>
+                            <pgvector.image>${pgvector.image}</pgvector.image>
+                            <mariadb.image>${mariadb.image}</mariadb.image>
+                            <db2.image>${db2.image}</db2.image>
+                            <mssql.image>${mssql.image}</mssql.image>
+                            <mysql.image>${mysql.image}</mysql.image>
+                            <oracle.image>${oracle.image}</oracle.image>
+                            <mongo.image>${mongo.image}</mongo.image>
+                            <keycloak.docker.image>${keycloak.docker.image}</keycloak.docker.image>
+                            <pulsar.image>${pulsar.image}</pulsar.image>
+                            <rabbitmq.image>${rabbitmq.image}</rabbitmq.image>
+                            <redis.image>${redis.image}</redis.image>
+                            <mailpit.image>${mailpit.image}</mailpit.image>
+                            <fake-smtp-server.image>${fake-smtp-server.image}</fake-smtp-server.image>
                         </systemPropertyVariables>
                         <!-- set tmpdir as early as possible because failsafe sets it too late for JDK16 -->
                         <argLine>-Djava.io.tmpdir="${project.build.directory}" ${failsafe.argLine.additional}</argLine>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -125,7 +125,6 @@
         <redis.image>docker.io/library/redis:7</redis.image>
         <infinispan.image>quay.io/infinispan/server:latest</infinispan.image>
         <mailpit.image>docker.io/axllent/mailpit:latest</mailpit.image>
-        <fake-smtp-server.image>docker.io/reachfive/fake-smtp-server:latest</fake-smtp-server.image>
 
         <!-- Code Coverage Properties-->
         <jacoco.agent.argLine></jacoco.agent.argLine>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -124,6 +124,8 @@
         <pulsar.image>docker.io/apachepulsar/pulsar:3.2.4</pulsar.image>
         <redis.image>docker.io/library/redis:7</redis.image>
         <infinispan.image>quay.io/infinispan/server:latest</infinispan.image>
+        <mailpit.image>docker.io/axllent/mailpit:latest</mailpit.image>
+        <fake-smtp-server.image>docker.io/reachfive/fake-smtp-server:latest</fake-smtp-server.image>
 
         <!-- Code Coverage Properties-->
         <jacoco.agent.argLine></jacoco.agent.argLine>

--- a/integration-tests/mailer/src/test/java/io/quarkus/it/mailer/MailpitFullTlsTestResource.java
+++ b/integration-tests/mailer/src/test/java/io/quarkus/it/mailer/MailpitFullTlsTestResource.java
@@ -19,7 +19,7 @@ import io.smallrye.certs.Format;
 
 public class MailpitFullTlsTestResource implements QuarkusTestResourceLifecycleManager {
 
-    public GenericContainer<?> server = new GenericContainer<>("axllent/mailpit")
+    public GenericContainer<?> server = new GenericContainer<>(System.getProperty("mailpit.image", "axllent/mailpit"))
             .withExposedPorts(8025, 1025);
 
     static {

--- a/integration-tests/mailer/src/test/java/io/quarkus/it/mailer/MailpitFullTlsTestResource.java
+++ b/integration-tests/mailer/src/test/java/io/quarkus/it/mailer/MailpitFullTlsTestResource.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Assertions;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.MountableFile;
 
+import io.quarkus.test.common.DockerImageNames;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import io.restassured.RestAssured;
 import io.smallrye.certs.CertificateGenerator;
@@ -19,7 +20,7 @@ import io.smallrye.certs.Format;
 
 public class MailpitFullTlsTestResource implements QuarkusTestResourceLifecycleManager {
 
-    public GenericContainer<?> server = new GenericContainer<>("axllent/mailpit")
+    public GenericContainer<?> server = new GenericContainer<>(DockerImageNames.getImage("mailpit.image"))
             .withExposedPorts(8025, 1025);
 
     static {

--- a/integration-tests/mailer/src/test/java/io/quarkus/it/mailer/MailpitTestResource.java
+++ b/integration-tests/mailer/src/test/java/io/quarkus/it/mailer/MailpitTestResource.java
@@ -22,7 +22,7 @@ import io.smallrye.certs.Format;
  */
 public class MailpitTestResource implements QuarkusTestResourceLifecycleManager {
 
-    public GenericContainer<?> server = new GenericContainer<>("axllent/mailpit")
+    public GenericContainer<?> server = new GenericContainer<>(System.getProperty("mailpit.image", "axllent/mailpit"))
             .withExposedPorts(8025, 1025);
 
     static {

--- a/integration-tests/mailer/src/test/java/io/quarkus/it/mailer/MailpitTestResource.java
+++ b/integration-tests/mailer/src/test/java/io/quarkus/it/mailer/MailpitTestResource.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Assertions;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.MountableFile;
 
+import io.quarkus.test.common.DockerImageNames;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import io.restassured.RestAssured;
 import io.smallrye.certs.CertificateGenerator;
@@ -22,7 +23,7 @@ import io.smallrye.certs.Format;
  */
 public class MailpitTestResource implements QuarkusTestResourceLifecycleManager {
 
-    public GenericContainer<?> server = new GenericContainer<>("axllent/mailpit")
+    public GenericContainer<?> server = new GenericContainer<>(DockerImageNames.getImage("mailpit.image"))
             .withExposedPorts(8025, 1025);
 
     static {

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/Db2LifecycleManager.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/Db2LifecycleManager.java
@@ -7,12 +7,13 @@ import org.jboss.logging.Logger;
 import org.testcontainers.containers.Db2Container;
 import org.testcontainers.utility.DockerImageName;
 
+import io.quarkus.test.common.DockerImageNames;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
 public class Db2LifecycleManager implements QuarkusTestResourceLifecycleManager {
     private static final Logger LOGGER = Logger.getLogger(Db2LifecycleManager.class);
     private static final String QUARKUS = "quarkus";
-    private static final String DB2_IMAGE = System.getProperty("db2.image");
+    private static final String DB2_IMAGE = DockerImageNames.getImage("db2.image");
     private StartedDb2Container db2Container;
 
     @Override

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/MariaDbLifecycleManager.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/MariaDbLifecycleManager.java
@@ -7,12 +7,13 @@ import org.jboss.logging.Logger;
 import org.testcontainers.containers.MariaDBContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import io.quarkus.test.common.DockerImageNames;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
 public class MariaDbLifecycleManager implements QuarkusTestResourceLifecycleManager {
     private static final Logger LOGGER = Logger.getLogger(MariaDbLifecycleManager.class);
     private static final String QUARKUS = "quarkus";
-    private static final String MARIADB_IMAGE = System.getProperty("mariadb.image");
+    private static final String MARIADB_IMAGE = DockerImageNames.getImage("mariadb.image");
     private StartedMariaDBContainer mariaDbContainer;
 
     @Override

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/PostgreSqlLifecycleManager.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/PostgreSqlLifecycleManager.java
@@ -7,12 +7,13 @@ import org.jboss.logging.Logger;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import io.quarkus.test.common.DockerImageNames;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
 public class PostgreSqlLifecycleManager implements QuarkusTestResourceLifecycleManager {
     private static final Logger LOGGER = Logger.getLogger(PostgreSqlLifecycleManager.class);
     private static final String QUARKUS = "quarkus";
-    private static final String POSTGRES_IMAGE = System.getProperty("postgres.image");
+    private static final String POSTGRES_IMAGE = DockerImageNames.getImage("postgres.image");
     private StartedPostgresContainer postgresContainer;
 
     @Override

--- a/integration-tests/reactive-messaging-pulsar/src/test/java/io/quarkus/it/pulsar/PulsarContainer.java
+++ b/integration-tests/reactive-messaging-pulsar/src/test/java/io/quarkus/it/pulsar/PulsarContainer.java
@@ -13,7 +13,7 @@ import com.github.dockerjava.api.command.InspectContainerResponse;
 
 public class PulsarContainer extends GenericContainer<PulsarContainer> {
 
-    public static final DockerImageName PULSAR_IMAGE = DockerImageName.parse("apachepulsar/pulsar:3.2.4");
+    public static final DockerImageName PULSAR_IMAGE = DockerImageName.parse(System.getProperty("pulsar.image", "apachepulsar/pulsar:3.2.4"));
 
     public static final String STARTER_SCRIPT = "/run_pulsar.sh";
 

--- a/integration-tests/reactive-messaging-pulsar/src/test/java/io/quarkus/it/pulsar/PulsarContainer.java
+++ b/integration-tests/reactive-messaging-pulsar/src/test/java/io/quarkus/it/pulsar/PulsarContainer.java
@@ -11,9 +11,11 @@ import org.testcontainers.utility.DockerImageName;
 
 import com.github.dockerjava.api.command.InspectContainerResponse;
 
+import io.quarkus.test.common.DockerImageNames;
+
 public class PulsarContainer extends GenericContainer<PulsarContainer> {
 
-    public static final DockerImageName PULSAR_IMAGE = DockerImageName.parse("apachepulsar/pulsar:3.2.4");
+    public static final DockerImageName PULSAR_IMAGE = DockerImageName.parse(DockerImageNames.getImage("pulsar.image"));
 
     public static final String STARTER_SCRIPT = "/run_pulsar.sh";
 

--- a/integration-tests/reactive-messaging-rabbitmq-dyn/src/test/java/io/quarkus/it/rabbitmq/RabbitMQConnectorDynCredsTest.java
+++ b/integration-tests/reactive-messaging-rabbitmq-dyn/src/test/java/io/quarkus/it/rabbitmq/RabbitMQConnectorDynCredsTest.java
@@ -33,7 +33,7 @@ public class RabbitMQConnectorDynCredsTest {
             String username = "tester";
             String password = RandomStringUtils.insecure().next(10);
 
-            rabbit = new RabbitMQContainer(DockerImageName.parse("rabbitmq:3.12-management"))
+            rabbit = new RabbitMQContainer(DockerImageName.parse(System.getProperty("rabbitmq.image", "rabbitmq:3.12-management")))
                     .withNetwork(Network.SHARED)
                     .withNetworkAliases("rabbitmq")
                     .withUser(username, password)

--- a/integration-tests/reactive-messaging-rabbitmq-dyn/src/test/java/io/quarkus/it/rabbitmq/RabbitMQConnectorDynCredsTest.java
+++ b/integration-tests/reactive-messaging-rabbitmq-dyn/src/test/java/io/quarkus/it/rabbitmq/RabbitMQConnectorDynCredsTest.java
@@ -15,6 +15,7 @@ import org.testcontainers.containers.RabbitMQContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import io.quarkus.it.rabbitmq.RabbitMQConnectorDynCredsTest.RabbitMQResource;
+import io.quarkus.test.common.DockerImageNames;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import io.quarkus.test.junit.QuarkusTest;
@@ -33,7 +34,8 @@ public class RabbitMQConnectorDynCredsTest {
             String username = "tester";
             String password = RandomStringUtils.insecure().next(10);
 
-            rabbit = new RabbitMQContainer(DockerImageName.parse("rabbitmq:3.12-management"))
+            rabbit = new RabbitMQContainer(DockerImageName.parse(DockerImageNames.getImage("rabbitmq.image"))
+                    .asCompatibleSubstituteFor("rabbitmq"))
                     .withNetwork(Network.SHARED)
                     .withNetworkAliases("rabbitmq")
                     .withUser(username, password)

--- a/integration-tests/redis-cache/pom.xml
+++ b/integration-tests/redis-cache/pom.xml
@@ -157,7 +157,7 @@
                         <configuration>
                             <images>
                                 <image>
-                                    <name>redis:5.0.8-alpine</name>
+                                    <name>${redis.image}</name>
                                     <alias>quarkus-test-redis</alias>
                                     <run>
                                         <ports>

--- a/test-framework/common/pom.xml
+++ b/test-framework/common/pom.xml
@@ -57,6 +57,25 @@
 
     </dependencies>
 
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>quarkus-test-container-images.properties</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>quarkus-test-container-images.properties</exclude>
+                </excludes>
+            </resource>
+        </resources>
+    </build>
+
     <repositories>
         <repository>
             <id>central</id>

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DockerImageNames.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DockerImageNames.java
@@ -1,0 +1,57 @@
+package io.quarkus.test.common;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Properties;
+import java.util.TreeMap;
+
+public final class DockerImageNames {
+
+    private static final Map<String, String> IMAGES = new TreeMap<>();
+
+    static {
+        InputStream in = Thread.currentThread().getContextClassLoader()
+                .getResourceAsStream("quarkus-test-container-images.properties");
+        if (in == null) {
+            in = DockerImageNames.class.getClassLoader()
+                    .getResourceAsStream("quarkus-test-container-images.properties");
+        }
+        if (in == null) {
+            throw new IllegalStateException("quarkus-test-container-images.properties not found on classpath");
+        }
+        try (InputStream propertiesStream = in) {
+            Properties properties = new Properties();
+            properties.load(propertiesStream);
+            for (String name : properties.stringPropertyNames()) {
+                IMAGES.put(name, properties.getProperty(name));
+            }
+        } catch (IOException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private DockerImageNames() {
+    }
+
+    /**
+     * Resolves a docker image name for the given key.
+     * System properties take precedence over the defaults defined in quarkus-test-container-images.properties.
+     *
+     * @param key the property key (e.g. "postgres.image")
+     * @return the docker image name
+     * @throws IllegalArgumentException if no image name is defined for the given key
+     */
+    public static String getImage(String key) {
+        String override = System.getProperty(key);
+        if (override != null) {
+            return override;
+        }
+        String value = IMAGES.get(key);
+        if (value == null) {
+            throw new IllegalArgumentException(
+                    "No docker image defined for key: " + key + ". Valid Docker images: " + IMAGES.keySet());
+        }
+        return value;
+    }
+}

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DockerImageNames.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DockerImageNames.java
@@ -2,13 +2,13 @@ package io.quarkus.test.common;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-import java.util.TreeMap;
 
 public final class DockerImageNames {
 
-    private static final Map<String, String> IMAGES = new TreeMap<>();
+    private static final Map<String, String> IMAGES = new HashMap<>();
 
     static {
         InputStream in = Thread.currentThread().getContextClassLoader()
@@ -50,7 +50,8 @@ public final class DockerImageNames {
         String value = IMAGES.get(key);
         if (value == null) {
             throw new IllegalArgumentException(
-                    "No docker image defined for key: " + key + ". Valid Docker images: " + IMAGES.keySet());
+                    "No docker image defined for key: " + key + ". Valid Docker images: "
+                            + IMAGES.keySet().stream().sorted().toList());
         }
         return value;
     }

--- a/test-framework/common/src/main/resources/quarkus-test-container-images.properties
+++ b/test-framework/common/src/main/resources/quarkus-test-container-images.properties
@@ -14,4 +14,3 @@ pulsar.image=${pulsar.image}
 rabbitmq.image=${rabbitmq.image}
 redis.image=${redis.image}
 mailpit.image=${mailpit.image}
-fake-smtp-server.image=${fake-smtp-server.image}

--- a/test-framework/common/src/main/resources/quarkus-test-container-images.properties
+++ b/test-framework/common/src/main/resources/quarkus-test-container-images.properties
@@ -1,0 +1,17 @@
+elasticsearch.image=${elasticsearch.image}
+opensearch.image=${opensearch.image}
+postgres.image=${postgres.image}
+postgis.image=${postgis.image}
+pgvector.image=${pgvector.image}
+mariadb.image=${mariadb.image}
+db2.image=${db2.image}
+mssql.image=${mssql.image}
+mysql.image=${mysql.image}
+oracle.image=${oracle.image}
+mongo.image=${mongo.image}
+keycloak.docker.image=${keycloak.docker.image}
+pulsar.image=${pulsar.image}
+rabbitmq.image=${rabbitmq.image}
+redis.image=${redis.image}
+mailpit.image=${mailpit.image}
+fake-smtp-server.image=${fake-smtp-server.image}


### PR DESCRIPTION
refactor: centralize integration test container images using Maven resource filtering

- Reverted custom surefire/failsafe systemPropertyVariables in build-parent/pom.xml.
- Created central classpath properties registry test-framework/common/src/main/resources/quarkus-test-container-images.properties.
- Enabled Maven resource filtering for the registry in test-framework/common/pom.xml.
- Created DockerImageNames utility in quarkus-test-common to load properties dynamically with classloader fallbacks.
- Migrated integration tests to use DockerImageNames.getImage(...) instead of System.getProperty with duplicated fallback values.
