### PR TITLE
Support asciidoc to markdown

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/formatter/JavadocToMarkdownTransformer.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/documentation/config/formatter/JavadocToMarkdownTransformer.java
@@ -31,7 +31,72 @@ public class JavadocToMarkdownTransformer {
         }
 
         // it's Asciidoc, the fun begins...
-        return "";
+        return asciidocToMarkdown(javadoc);
+    }
+
+    private static String asciidocToMarkdown(String asciidoc) {
+        if (asciidoc == null || asciidoc.isBlank()) {
+            return asciidoc;
+        }
+
+        String result = asciidoc;
+
+        // Bold: *text* -> **text**
+        // Note: This is a very simplified regex and might need refinement for nested styles
+        result = result.replaceAll("\\*([^\\*\\s][^\\*]*[^\\*\\s]|[^\\*\\s])\\*", "**$1**");
+
+        // Italics: _text_ -> *text*
+        result = result.replaceAll("_([^\\_\\s][^\\_]*[^\\_\\s]|[^\\_\\s])_", "*$1*");
+
+        // Monospace: `text` -> `text` (usually no change needed if using backticks in both)
+        // But links in Asciidoc: link:url[caption] -> [caption](url)
+        result = result.replaceAll("link:([^\\s\\[]+)\\[([^\\]]*)\\]", "[$2]($1)");
+
+        // Definition lists: `term`:: -> **term**:
+        result = result.replaceAll("`([^`]+)`::", "**$1**:");
+
+        // Basic blockquote/source blocks
+        // [source,...]
+        // ----
+        // code
+        // ----
+        // -> ```\ncode\n```
+        result = result.replaceAll("\\[source,[^\\]]*\\]\\s*\\n----\\n([\\s\\S]*?)\\n----", "```\n$1\n```");
+
+        // Simple table conversion (AsciiDoc !=== to HTML table)
+        result = convertTablesToHtml(result);
+
+        return result.trim();
+    }
+
+    private static String convertTablesToHtml(String asciidoc) {
+        StringBuilder sb = new StringBuilder();
+        String[] lines = asciidoc.split("\\n");
+        boolean inTable = false;
+
+        for (String line : lines) {
+            if (line.trim().equals("!===")) {
+                if (!inTable) {
+                    sb.append("<table>\n");
+                    inTable = true;
+                } else {
+                    sb.append("</table>\n");
+                    inTable = false;
+                }
+                continue;
+            }
+
+            if (inTable) {
+                if (line.trim().startsWith("!")) {
+                    sb.append("  <tr><td>").append(line.trim().substring(1).trim()).append("</td></tr>\n");
+                } else if (line.trim().startsWith("h!")) {
+                    sb.append("  <tr><th>").append(line.trim().substring(2).trim()).append("</th></tr>\n");
+                }
+            } else {
+                sb.append(line).append("\n");
+            }
+        }
+        return sb.toString();
     }
 
     /**

--- a/core/processor/src/test/java/io/quarkus/annotation/processor/documentation/config/formatter/JavadocToMarkdownTransformerTest.java
+++ b/core/processor/src/test/java/io/quarkus/annotation/processor/documentation/config/formatter/JavadocToMarkdownTransformerTest.java
@@ -1,0 +1,40 @@
+package io.quarkus.annotation.processor.documentation.config.formatter;
+ 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+ 
+import org.junit.jupiter.api.Test;
+ 
+import io.quarkus.annotation.processor.documentation.config.model.JavadocFormat;
+ 
+public class JavadocToMarkdownTransformerTest {
+ 
+    @Test
+    public void testAsciidocToMarkdown() {
+        String asciidoc = "*Bold text* and _italics_ with `monospace`.\n" +
+                "link:https://quarkus.io[Quarkus] website.\n" +
+                "`simple`::\n" +
+                "This is a definition.";
+        
+        String expected = "**Bold text** and *italics* with `monospace`.\n" +
+                "[Quarkus](https://quarkus.io) website.\n" +
+                "**simple**:\n" +
+                "This is a definition.";
+        
+        assertEquals(expected, JavadocToMarkdownTransformer.toMarkdown(asciidoc, JavadocFormat.ASCIIDOC));
+    }
+ 
+    @Test
+    public void testTableConversion() {
+        String asciidoc = "!===\n" +
+                "h!Header\n" +
+                "!Cell 1\n" +
+                "!===";
+        
+        String expected = "<table>\n" +
+                "  <tr><th>Header</th></tr>\n" +
+                "  <tr><td>Cell 1</td></tr>\n" +
+                "</table>";
+        
+        assertEquals(expected, JavadocToMarkdownTransformer.toMarkdown(asciidoc, JavadocFormat.ASCIIDOC));
+    }
+}


### PR DESCRIPTION
### Description
This Pull Request implements an initial AsciiDoc to Markdown converter within the `JavadocToMarkdownTransformer`. This is a foundation for improving the rendering of AsciiDoc-formatted Javadoc in IDEs and downstream documentation tools that prefer Markdown.

**Key Changes:**
- Implemented `asciidocToMarkdown` logic in `JavadocToMarkdownTransformer`.
- Added support for core formatting: Bold (`*text*`), Italics (`_text_`), and Monospace.
- Added support for AsciiDoc inline links: `link:url[caption]`.
- Implemented support for **Definition Lists** (using `term::` syntax).
- Added a base parser for complex **AsciiDoc Tables** (`!===` blocks), rendering them as HTML tables to preserve layout in Markdown environments.
- Supported source code blocks (`----`).

### Issue Reference
* Fixes #43287
