### PR TITLE
Fix config crash 36270

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/QuarkusConfigBuilderCustomizer.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/QuarkusConfigBuilderCustomizer.java
@@ -20,6 +20,7 @@ import io.smallrye.config.Priorities;
 import io.smallrye.config.RelocateConfigSourceInterceptor;
 import io.smallrye.config.SmallRyeConfigBuilder;
 import io.smallrye.config.SmallRyeConfigBuilderCustomizer;
+import io.smallrye.config.ConfigValue;
 
 public class QuarkusConfigBuilderCustomizer implements SmallRyeConfigBuilderCustomizer {
     public static final String QUARKUS_PROFILE = "quarkus.profile";
@@ -145,5 +146,16 @@ public class QuarkusConfigBuilderCustomizer implements SmallRyeConfigBuilderCust
 
         // Ignore unmapped quarkus properties, because properties in the same root may be split between build / runtime
         builder.withMappingIgnore("quarkus.**");
+
+        // Filter out keys that end in '.' (from for example environment variables ending in '_')
+        builder.withInterceptors(new ConfigSourceInterceptor() {
+            @Override
+            public ConfigValue getValue(ConfigSourceInterceptorContext context, String name) {
+                if (name != null && name.endsWith(".")) {
+                    return null;
+                }
+                return context.proceed(name);
+            }
+        });
     }
 }


### PR DESCRIPTION
### Description
This PR fixes a `StringIndexOutOfBoundsException` that occurs when environment variables ending with an underscore are provided (converted to a dot by SmallRye Config). This is particularly common in OpenShift Dev Spaces and other cloud-based IDEs where certain environment variable prefixes might be set without a trailing key.

**Key Changes:**
- Added a `ConfigSourceInterceptor` in `QuarkusConfigBuilderCustomizer` to filter out property names ending with a delimiter (`.`). 
- This prevents `SmallRyeConfigBuilder.build()` from crashing during mapping validation when it encounters an empty segment.

### Issue Reference
* Fixes #36270
