### PR TITLE
Improve Quarkiverse extension codestart initial docs structure

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/docs/modules/ROOT/nav.tpl.qute.adoc
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/docs/modules/ROOT/nav.tpl.qute.adoc
@@ -1,1 +1,2 @@
 * xref:index.adoc[Getting started]
+* xref:config-reference.adoc[Configuration Reference]

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/docs/modules/ROOT/pages/config-reference.tpl.qute.adoc
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/docs/modules/ROOT/pages/config-reference.tpl.qute.adoc
@@ -1,0 +1,5 @@
+= Configuration Reference
+
+include::./includes/attributes.adoc[]
+
+include::includes/{namespace.id}{extension.id}.adoc[leveloffset=+1, opts=optional]

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/docs/modules/ROOT/pages/index.tpl.qute.adoc
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/docs/modules/ROOT/pages/index.tpl.qute.adoc
@@ -6,9 +6,9 @@ TIP: Describe what the extension does here.
 
 == Installation
 
-If you want to use this extension, you need to add the `{group-id}:{namespace.id}{extension.id}` extension first to your build file.
+To use this extension, add the `{group-id}:{namespace.id}{extension.id}` dependency to your build file.
 
-For instance, with Maven, add the following dependency to your POM file:
+With Maven, add the following to your `pom.xml`:
 
 [source,xml,subs=attributes+]
 ----
@@ -19,9 +19,13 @@ For instance, with Maven, add the following dependency to your POM file:
 </dependency>
 ----
 
-[[extension-configuration-reference]]
-== Extension Configuration Reference
+With Gradle, add the following to your `build.gradle`:
 
-TIP: Remove this section if you don't have Quarkus configuration properties in your extension.
+[source,gradle,subs=attributes+]
+----
+implementation("{group-id}:{namespace.id}{extension.id}:\{project-version}")
+----
 
-include::includes/{namespace.id}{extension.id}.adoc[leveloffset=+1, opts=optional]
+== Usage
+
+TIP: Add a minimal usage example here.

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/CreateExtensionMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/CreateExtensionMojoIT.java
@@ -124,6 +124,8 @@ public class CreateExtensionMojoIT extends QuarkusPlatformAwareMojoTestBase {
         assertThatMatchSnapshot(testInfo, testDirPath, "quarkus-my-quarkiverse-ext/docs/antora.yml");
         assertThatMatchSnapshot(testInfo, testDirPath, "quarkus-my-quarkiverse-ext/docs/modules/ROOT/nav.adoc");
         assertThatMatchSnapshot(testInfo, testDirPath, "quarkus-my-quarkiverse-ext/docs/modules/ROOT/pages/index.adoc");
+        assertThatMatchSnapshot(testInfo, testDirPath,
+                "quarkus-my-quarkiverse-ext/docs/modules/ROOT/pages/config-reference.adoc");
         assertThatMatchSnapshot(testInfo, testDirPath, "quarkus-my-quarkiverse-ext/integration-tests/pom.xml");
     }
 

--- a/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/dir-tree.snapshot
+++ b/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/dir-tree.snapshot
@@ -46,6 +46,7 @@ quarkus-my-quarkiverse-ext/docs/modules/ROOT/examples/
 quarkus-my-quarkiverse-ext/docs/modules/ROOT/examples/.keepme
 quarkus-my-quarkiverse-ext/docs/modules/ROOT/nav.adoc
 quarkus-my-quarkiverse-ext/docs/modules/ROOT/pages/
+quarkus-my-quarkiverse-ext/docs/modules/ROOT/pages/config-reference.adoc
 quarkus-my-quarkiverse-ext/docs/modules/ROOT/pages/index.adoc
 quarkus-my-quarkiverse-ext/docs/pom.xml
 quarkus-my-quarkiverse-ext/docs/templates/

--- a/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_docs_modules_ROOT_nav.adoc
+++ b/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_docs_modules_ROOT_nav.adoc
@@ -1,1 +1,2 @@
 * xref:index.adoc[Getting started]
+* xref:config-reference.adoc[Configuration Reference]

--- a/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_docs_modules_ROOT_pages_config-reference.adoc
+++ b/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_docs_modules_ROOT_pages_config-reference.adoc
@@ -1,0 +1,5 @@
+= Configuration Reference
+
+include::./includes/attributes.adoc[]
+
+include::includes/quarkus-my-quarkiverse-ext.adoc[leveloffset=+1, opts=optional]

--- a/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_docs_modules_ROOT_pages_index.adoc
+++ b/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_docs_modules_ROOT_pages_index.adoc
@@ -6,9 +6,9 @@ TIP: Describe what the extension does here.
 
 == Installation
 
-If you want to use this extension, you need to add the `io.quarkiverse.my-quarkiverse-ext:quarkus-my-quarkiverse-ext` extension first to your build file.
+To use this extension, add the `io.quarkiverse.my-quarkiverse-ext:quarkus-my-quarkiverse-ext` dependency to your build file.
 
-For instance, with Maven, add the following dependency to your POM file:
+With Maven, add the following to your `pom.xml`:
 
 [source,xml,subs=attributes+]
 ----
@@ -19,9 +19,13 @@ For instance, with Maven, add the following dependency to your POM file:
 </dependency>
 ----
 
-[[extension-configuration-reference]]
-== Extension Configuration Reference
+With Gradle, add the following to your `build.gradle`:
 
-TIP: Remove this section if you don't have Quarkus configuration properties in your extension.
+[source,gradle,subs=attributes+]
+----
+implementation("io.quarkiverse.my-quarkiverse-ext:quarkus-my-quarkiverse-ext:{project-version}")
+----
 
-include::includes/quarkus-my-quarkiverse-ext.adoc[leveloffset=+1, opts=optional]
+== Usage
+
+TIP: Add a minimal usage example here.


### PR DESCRIPTION
Adds a `config-reference.adoc` page to the Quarkiverse extension docs codestart, adds it to the nav, and cleans up `index.adoc` with a basic Maven/Gradle install and Usage structure.

- Fixes: #35367