### PR TITLE
Bring the DevUI extension in vertx.justfile

### DIFF
--- a/vertx.justfile
+++ b/vertx.justfile
@@ -4,6 +4,7 @@ modules := """
     independent-projects/resteasy-reactive
     bom/application
     core
+    extensions/devui
     extensions/arc
     extensions/virtual-threads
     extensions/smallrye-context-propagation


### PR DESCRIPTION
This is used by extensions like hibernate-validator.
