### PR TITLE
Drop temporary Gradle configuration once it has been processed

### DIFF
--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/dependency/QuarkusComponentVariants.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/dependency/QuarkusComponentVariants.java
@@ -378,6 +378,8 @@ public class QuarkusComponentVariants {
         for (var dep : config.getResolvedConfiguration().getFirstLevelModuleDependencies()) {
             processDependency(null, dep, visited, true);
         }
+        // drop the temporary configuration
+        project.getConfigurations().remove(config);
     }
 
     private void processDependency(ProcessedDependency parent,


### PR DESCRIPTION
These configurations are created to evaluate dependency conditions and they should never be used after this phase.