### PR TITLE
Set Datasource Dev Service properties as high-priority

### DIFF
--- a/.github/oracle-test-pilot-jvm-tests.json
+++ b/.github/oracle-test-pilot-jvm-tests.json
@@ -1,0 +1,22 @@
+{
+    "include": [
+        {
+            "category": "19c",
+            "timeout": 20,
+            "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle",
+            "java-version": 17
+        },
+        {
+            "category": "21c",
+            "timeout": 20,
+            "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle",
+            "java-version": 17
+        },
+        {
+            "category": "26ai",
+            "timeout": 20,
+            "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle",
+            "java-version": 17
+        }
+    ]
+}

--- a/.github/oracle-test-pilot-native-tests.json
+++ b/.github/oracle-test-pilot-native-tests.json
@@ -1,0 +1,19 @@
+{
+    "include": [
+        {
+            "category": "19c",
+            "timeout": 15,
+            "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle"
+        },
+        {
+            "category": "21c",
+            "timeout": 15,
+            "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle"
+        },
+        {
+            "category": "26ai",
+            "timeout": 15,
+            "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle"
+        }
+    ]
+}

--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -376,6 +376,10 @@ jobs:
         run: ./.github/verify-tests-json.sh native-tests.json integration-tests/
       - name: Verify virtual-threads-tests.json
         run: ./.github/verify-tests-json.sh virtual-threads-tests.json integration-tests/
+      - name: Verify oracle-test-pilot-jvm-tests.json
+        run: ./.github/verify-tests-json.sh oracle-test-pilot-jvm-tests.json integration-tests/
+      - name: Verify oracle-test-pilot-native-tests.json
+        run: ./.github/verify-tests-json.sh oracle-test-pilot-native-tests.json integration-tests/
       - name: Setup Develocity Build Scan capture
         uses: gradle/develocity-actions/setup-maven@974e8dbcbda40db6828fc35f349c80a7c0e71529 # v2.1
         with:
@@ -485,6 +489,8 @@ jobs:
       native_matrix: ${{ steps.calc-native-matrix.outputs.matrix }}
       jvm_matrix: ${{ steps.calc-jvm-matrix.outputs.matrix }}
       virtual_threads_matrix: ${{ steps.calc-virtual-threads-matrix.outputs.matrix }}
+      otp_jvm_matrix: ${{ steps.calc-otp-jvm-matrix.outputs.matrix }}
+      otp_native_matrix: ${{ steps.calc-otp-native-matrix.outputs.matrix }}
       run_devtools: ${{ steps.calc-run-flags.outputs.run_devtools }}
       run_gradle: ${{ steps.calc-run-flags.outputs.run_gradle }}
       run_maven: ${{ steps.calc-run-flags.outputs.run_maven }}
@@ -512,6 +518,20 @@ jobs:
         run: |
           echo "GIB_IMPACTED_MODULES: ${GIB_IMPACTED_MODULES}"
           json=$(.github/filter-integration-tests-json.sh virtual-threads "${GIB_IMPACTED_MODULES}" | tr -d '\n')
+          echo "${json}"
+          echo "matrix=${json}" >> $GITHUB_OUTPUT
+      - name: Calculate matrix from oracle-test-pilot-jvm-tests.json
+        id: calc-otp-jvm-matrix
+        run: |
+          echo "GIB_IMPACTED_MODULES: ${GIB_IMPACTED_MODULES}"
+          json=$(.github/filter-integration-tests-json.sh oracle-test-pilot-jvm "${GIB_IMPACTED_MODULES}" | tr -d '\n')
+          echo "${json}"
+          echo "matrix=${json}" >> $GITHUB_OUTPUT
+      - name: Calculate matrix from oracle-test-pilot-native-tests.json
+        id: calc-otp-native-matrix
+        run: |
+          echo "GIB_IMPACTED_MODULES: ${GIB_IMPACTED_MODULES}"
+          json=$(.github/filter-integration-tests-json.sh oracle-test-pilot-native "${GIB_IMPACTED_MODULES}" | tr -d '\n')
           echo "${json}"
           echo "matrix=${json}" >> $GITHUB_OUTPUT
       - name: Calculate run flags
@@ -1714,10 +1734,299 @@ jobs:
             fi
           done
 
+  oracle-test-pilot-jvm-tests:
+    name: Oracle Test Pilot ${{matrix.category}} - JDK ${{matrix.java-version}}
+    # TODO use Oracle Test Pilot runners
+    runs-on: ubuntu-latest
+    needs: [configure, build-jdk17, calculate-test-jobs]
+    # TODO Oracle Test Pilot involves specific runners that are only available in the main repo; prepend "github.repository == 'quarkusio/quarkus' &&"
+    if: needs.calculate-test-jobs.outputs.otp_jvm_matrix != '{}'
+    env:
+      COMMON_MAVEN_ARGS: ${{ needs.configure.outputs.common-maven-args }}
+    timeout-minutes: ${{matrix.timeout}}
+    strategy:
+      max-parallel: ${{ fromJson(needs.configure.outputs.config).maxParallel || 12 }}
+      fail-fast: false
+      matrix: ${{ fromJson(needs.calculate-test-jobs.outputs.otp_jvm_matrix) }}
+    steps:
+      - name: Gradle Enterprise environment
+        run: |
+          category=$(echo -n '${{matrix.category}}' | tr '[:upper:]' '[:lower:]' | tr -c '[:alnum:]-' '-' | sed -E 's/-+/-/g')
+          echo "GE_TAGS=oracle-test-pilot-${{matrix.category}}-jdk-${{matrix.java-version}}" >> "$GITHUB_ENV"
+          echo "GE_CUSTOM_VALUES=gh-job-name=Oracle Test Pilot ${{matrix.category}} - JDK ${{matrix.java-version}}" >> "$GITHUB_ENV"
+      - uses: actions/checkout@v6
+      - name: Restore Maven Repository
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.m2/repository
+          key: ${{ needs.configure.outputs.m2-cache-key }}
+          restore-keys: |
+            ${{ needs.configure.outputs.m2-monthly-branch-cache-key }}-
+            ${{ needs.configure.outputs.m2-monthly-cache-key }}-
+      - name: Download previously uploaded .m2 content
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: m2-content
+          path: .
+      - name: Extract previously uploaded .m2 content
+        run: tar -xzf m2-content.tgz -C ~
+      - name: Set up JDK 17
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Setup Develocity Build Scan capture
+        uses: gradle/develocity-actions/setup-maven@v2.1
+        with:
+          capture-strategy: ON_DEMAND
+          job-name: "Oracle Test Pilot ${{matrix.category}} - JDK ${{matrix.java-version}}"
+          add-pr-comment: false
+          add-job-summary: false
+          develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          develocity-token-expiry: 6
+      - name: Create Oracle Test Pilot DB
+        id: create_database
+        # TODO Oracle Test Pilot DB creation
+        run: |
+          PASSWORD=Oracle23
+          echo "::add-mask::$PASSWORD"
+          echo "database_password=${PASSWORD}" >> $GITHUB_OUTPUT
+          echo "connection_string_suffix=localhost:1521/freepdb1" >> $GITHUB_OUTPUT
+          docker run --name oracle -d -p 1521:1521 -e ORACLE_PASSWORD=Oracle23Admin \
+            -e APP_USER=quarkus_test \
+            -e APP_USER_PASSWORD=$PASSWORD \
+            --health-cmd healthcheck.sh \
+            --health-interval 5s \
+            --health-timeout 5s \
+            --health-retries 10 \
+            docker.io/gvenzl/oracle-free:23
+          HEALTHSTATUS=""
+          TIMEOUT=300
+          ELAPSED=0
+          until [ "$HEALTHSTATUS" == "healthy" ];
+          do
+          if [ $ELAPSED -ge $TIMEOUT ]; then
+          echo "Timeout waiting for Oracle Free to start after ${TIMEOUT}s"
+          echo "Container logs:"
+          docker logs oracle
+          exit 1
+          fi
+          echo "Waiting for Oracle Free to start... (${ELAPSED}s/${TIMEOUT}s)"
+          sleep 5
+          ELAPSED=$((ELAPSED + 5))
+          HEALTHSTATUS="`docker inspect -f '{{.State.Health.Status}}' oracle`"
+          HEALTHSTATUS=${HEALTHSTATUS##+( )} #Remove longest matching series of spaces from the front
+          HEALTHSTATUS=${HEALTHSTATUS%%+( )} #Remove longest matching series of spaces from the back
+          done
+          sleep 2;
+          echo "Oracle successfully started"
+      #        uses: oracle-actions/setup-testpilot@f620f11f9f26dacfe80ba1823342e3e92604c55f # v1.0.23
+      #        with:
+      #          oci-service: ${{ matrix.category }}
+      #          action: create
+      #          user: quarkus_test
+      - name: Build
+        env:
+          # Begin OTP setup
+          TESTPILOT_MAVEN_ARGS: >-
+            -Doracle.jdbc.url=jdbc:oracle:thin:@${{ steps.create_database.outputs.connection_string_suffix }}?oracle.jdbc.enableQueryResultCache=false
+            -Doracle.reactive.url=vertx-reactive:oracle:thin:@${{ steps.create_database.outputs.connection_string_suffix }}?oracle.jdbc.enableQueryResultCache=false
+            -Doracle.username=quarkus_test
+            -Doracle.password=${{ steps.create_database.outputs.database_password }}
+          RDBMS: ${{ matrix.category }} # TODO may be useless?
+          RUNID: ${{ github.run_number }} # TODO may be useless?
+          API_HOST: "" # TODO may be useless?
+          TESTPILOT_CLIENT_ID: "" # TODO may be useless?
+          TESTPILOT_TOKEN: "" # TODO may be useless?
+          # Needed for TFO (TCP fast open)
+          # TODO uncomment once running on actual testpilot machines
+          #LD_PRELOAD: /home/ubuntu/libtfojdbc1.so
+          #LD_LIBRARY_PATH: /home/ubuntu
+          # End OTP setup
+          TEST_MODULES: ${{matrix.test-modules}}
+          CAPTURE_BUILD_SCAN: true
+        run: |
+          export LANG=en_US && ./mvnw $COMMON_MAVEN_ARGS $COMMON_TEST_MAVEN_ARGS $PTS_MAVEN_ARGS \
+            $JVM_TEST_MAVEN_ARGS $TESTPILOT_MAVEN_ARGS \
+            -f integration-tests -pl "$TEST_MODULES" \
+            clean install
+      - name: Delete Oracle Test Pilot DB
+        if: always()
+        # TODO Oracle Test Pilot DB deletion
+        run: docker rm -f oracle || true
+      #        uses: oracle-actions/setup-testpilot@f620f11f9f26dacfe80ba1823342e3e92604c55f # v1.0.23
+      #        with:
+      #          oci-service: ${{ matrix.category }}
+      #          action: delete
+      #          user: quarkus_test_1
+      - name: Prepare build reports archive
+        if: always()
+        run: |
+          7z a -tzip build-reports.zip -r \
+              'integration-tests/**/target/*-reports/TEST-*.xml' \
+              'integration-tests/**/target/build-report.json' \
+              'integration-tests/**/target/gradle-build-scan-url.txt' \
+              LICENSE
+      - name: Upload build reports
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        if: always()
+        with:
+          name: "build-reports-${{ github.run_attempt }}-Oracle Test Pilot ${{matrix.category}} - JDK ${{matrix.java-version}}"
+          path: |
+            build-reports.zip
+          retention-days: 7
+
+  oracle-test-pilot-native-tests:
+    name: "Oracle Test Pilot ${{matrix.category}} - Native"
+    # TODO use Oracle Test Pilot runners
+    runs-on: ubuntu-latest
+    needs: [configure, build-jdk17, calculate-test-jobs]
+    # TODO Oracle Test Pilot involves specific runners that are only available in the main repo; prepend "github.repository == 'quarkusio/quarkus' &&"
+    if: needs.calculate-test-jobs.outputs.otp_native_matrix != '{}'
+    env:
+      COMMON_MAVEN_ARGS: ${{ needs.configure.outputs.common-maven-args }}
+    timeout-minutes: ${{matrix.timeout}}
+    strategy:
+      max-parallel: ${{ fromJson(needs.configure.outputs.config).maxParallel || 12 }}
+      fail-fast: false
+      matrix: ${{ fromJson(needs.calculate-test-jobs.outputs.otp_native_matrix) }}
+    steps:
+      - name: Gradle Enterprise environment
+        run: |
+          category=$(echo -n '${{matrix.category}}' | tr '[:upper:]' '[:lower:]' | tr -c '[:alnum:]-' '-' | sed -E 's/-+/-/g')
+          echo "GE_TAGS=oracle-test-pilot-${{matrix.category}}-native" >> "$GITHUB_ENV"
+          echo "GE_CUSTOM_VALUES=gh-job-name=Oracle Test Pilot ${{matrix.category}} - Native" >> "$GITHUB_ENV"
+      - uses: actions/checkout@v6
+      - name: Restore Maven Repository
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.m2/repository
+          key: ${{ needs.configure.outputs.m2-cache-key }}
+          restore-keys: |
+            ${{ needs.configure.outputs.m2-monthly-branch-cache-key }}-
+            ${{ needs.configure.outputs.m2-monthly-cache-key }}-
+      - name: Download previously uploaded .m2 content
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: m2-content
+          path: .
+      - name: Extract previously uploaded .m2 content
+        run: tar -xzf m2-content.tgz -C ~
+      - name: Set up JDK 17
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: 17
+      # We do this so we can get better analytics for the downloaded version of the build images
+      - name: Update Docker Client User Agent
+        run: |
+          if [ -f ~/.docker/config.json ]; then
+            cat <<< $(jq '.HttpHeaders += {"User-Agent": "Quarkus-CI-Docker-Client"}' ~/.docker/config.json) > ~/.docker/config.json
+          fi
+      - name: Setup Develocity Build Scan capture
+        uses: gradle/develocity-actions/setup-maven@v2.1
+        with:
+          capture-strategy: ON_DEMAND
+          job-name: "Oracle Test Pilot ${{matrix.category}} - Native"
+          add-pr-comment: false
+          add-job-summary: false
+          develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          develocity-token-expiry: 6
+      - name: Create Oracle Test Pilot DB
+        id: create_database
+      # TODO Oracle Test Pilot DB creation
+        run: |
+          PASSWORD=Oracle23
+          echo "::add-mask::$PASSWORD"
+          echo "database_password=${PASSWORD}" >> $GITHUB_OUTPUT
+          echo "connection_string_suffix=localhost:1521/freepdb1" >> $GITHUB_OUTPUT
+          docker run --name oracle -d -p 1521:1521 -e ORACLE_PASSWORD=Oracle23Admin \
+            -e APP_USER=quarkus_test \
+            -e APP_USER_PASSWORD=$PASSWORD \
+            --health-cmd healthcheck.sh \
+            --health-interval 5s \
+            --health-timeout 5s \
+            --health-retries 10 \
+            docker.io/gvenzl/oracle-free:23
+          HEALTHSTATUS=""
+          TIMEOUT=300
+          ELAPSED=0
+          until [ "$HEALTHSTATUS" == "healthy" ];
+          do
+          if [ $ELAPSED -ge $TIMEOUT ]; then
+          echo "Timeout waiting for Oracle Free to start after ${TIMEOUT}s"
+          echo "Container logs:"
+          docker logs oracle
+          exit 1
+          fi
+          echo "Waiting for Oracle Free to start... (${ELAPSED}s/${TIMEOUT}s)"
+          sleep 5
+          ELAPSED=$((ELAPSED + 5))
+          HEALTHSTATUS="`docker inspect -f '{{.State.Health.Status}}' oracle`"
+          HEALTHSTATUS=${HEALTHSTATUS##+( )} #Remove longest matching series of spaces from the front
+          HEALTHSTATUS=${HEALTHSTATUS%%+( )} #Remove longest matching series of spaces from the back
+          done
+          sleep 2;
+          echo "Oracle successfully started"
+#        uses: oracle-actions/setup-testpilot@f620f11f9f26dacfe80ba1823342e3e92604c55f # v1.0.23
+#        with:
+#          oci-service: ${{ matrix.category }}
+#          action: create
+#          user: quarkus_test
+      - name: Build
+        env:
+          # Begin OTP setup
+          TESTPILOT_MAVEN_ARGS: >-
+            -Doracle.jdbc.url=jdbc:oracle:thin:@${{ steps.create_database.outputs.connection_string_suffix }}?oracle.jdbc.enableQueryResultCache=false
+            -Doracle.reactive.url=vertx-reactive:oracle:thin:@${{ steps.create_database.outputs.connection_string_suffix }}?oracle.jdbc.enableQueryResultCache=false
+            -Doracle.username=quarkus_test
+            -Doracle.password=${{ steps.create_database.outputs.database_password }}
+          RDBMS: ${{ matrix.category }} # TODO may be useless?
+          RUNID: ${{ github.run_number }} # TODO may be useless?
+          API_HOST: "" # TODO may be useless?
+          TESTPILOT_CLIENT_ID: "" # TODO may be useless?
+          TESTPILOT_TOKEN: "" # TODO may be useless?
+          # Needed for TFO (TCP fast open)
+          # TODO uncomment once running on actual testpilot machines
+          #LD_PRELOAD: /home/ubuntu/libtfojdbc1.so
+          #LD_LIBRARY_PATH: /home/ubuntu
+          # End OTP setup
+          TEST_MODULES: ${{matrix.test-modules}}
+          CAPTURE_BUILD_SCAN: true
+        run: |
+          export LANG=en_US && ./mvnw $COMMON_MAVEN_ARGS $COMMON_TEST_MAVEN_ARGS $PTS_MAVEN_ARGS \
+            $TESTPILOT_MAVEN_ARGS $NATIVE_TEST_MAVEN_ARGS -Dquarkus.native.container-build=true \
+            -f integration-tests -pl "$TEST_MODULES"
+      - name: Delete Oracle Test Pilot DB
+        if: always()
+      # TODO Oracle Test Pilot DB deletion
+        run: docker rm -f oracle || true
+#        uses: oracle-actions/setup-testpilot@f620f11f9f26dacfe80ba1823342e3e92604c55f # v1.0.23
+#        with:
+#          oci-service: ${{ matrix.category }}
+#          action: delete
+#          user: quarkus_test_1
+      - name: Prepare build reports archive
+        if: always()
+        run: |
+          7z a -tzip build-reports.zip -r \
+              'integration-tests/**/target/*-reports/TEST-*.xml' \
+              'integration-tests/**/target/build-report.json' \
+              'integration-tests/**/target/gradle-build-scan-url.txt' \
+              LICENSE
+      - name: Upload build reports
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        if: always()
+        with:
+          name: "build-reports-${{ github.run_attempt }}-Oracle Test Pilot ${{matrix.category}} - Native"
+          path: |
+            build-reports.zip
+          retention-days: 7
+
   build-report:
     runs-on: ubuntu-latest
     name: Build report
-    needs: [configure,build-jdk17,jvm-tests,maven-tests,gradle-tests,devtools-tests,kubernetes-tests,quickstarts-tests,platform-tests,tcks-test,native-tests,virtual-thread-native-tests]
+    needs: [configure,build-jdk17,jvm-tests,maven-tests,gradle-tests,devtools-tests,kubernetes-tests,quickstarts-tests,platform-tests,tcks-test,native-tests,virtual-thread-native-tests,oracle-test-pilot-jvm-tests,oracle-test-pilot-native-tests]
     if: always() && needs.configure.outputs.run-ci-build == 'true'
     steps:
       - uses: runs-on/action@15385172809cc0346c6821b00c3c3dd2598785b4 # v2.1.0

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesResultBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesResultBuildItem.java
@@ -234,7 +234,14 @@ public final class DevServicesResultBuildItem extends MultiBuildItem {
 
         if (highPriorityConfig != null) {
             for (String key : highPriorityConfig) {
-                map.put(key, () -> applicationConfigProvider.get(key).apply(startable));
+                map.put(key, () -> {
+                    var function = applicationConfigProvider.get(key);
+                    if (function != null) {
+                        return function.apply(startable);
+                    } else {
+                        return config.get(key);
+                    }
+                });
             }
         }
         return map;

--- a/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesDatasourceProcessor.java
+++ b/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesDatasourceProcessor.java
@@ -11,6 +11,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.jboss.logging.Logger;
+import org.testcontainers.shaded.com.google.common.collect.Sets;
 
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.quarkus.datasource.deployment.spi.DatasourceStartable;
@@ -226,6 +227,8 @@ public class DevServicesDatasourceProcessor {
                         return DevServicesResultBuildItem.owned().feature(feature).startable(() -> startable)
                                 .serviceName(dbName)
                                 .serviceConfig(configForWhichChangesShouldTriggerARestart)
+                                // Workaround for https://github.com/quarkusio/quarkus/issues/53705
+                                .highPriorityConfig(Sets.union(devDebProperties.keySet(), credentials.keySet()))
                                 .config(credentials)
                                 .configProvider(devDebProperties)
                                 .postStartHook((s) -> {

--- a/integration-tests/hibernate-reactive-oracle/pom.xml
+++ b/integration-tests/hibernate-reactive-oracle/pom.xml
@@ -13,6 +13,12 @@
     <name>Quarkus - Integration Tests - Hibernate Reactive - Oracle</name>
     <description>Hibernate Reactive related tests running with the Oracle database</description>
 
+    <properties>
+        <oracle.reactive.url/><!-- Default URL is empty, meaning we'll use dev services -->
+        <oracle.username/>
+        <oracle.password/>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -160,6 +166,36 @@
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <skip>false</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>test-oracle-external</id>
+            <activation>
+                <property>
+                    <name>oracle.reactive.url</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                            <systemPropertyVariables combine.children="append">
+                                <quarkus.test.profile>test,external-db</quarkus.test.profile>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                            <systemPropertyVariables combine.children="append">
+                                <quarkus.test.profile>prod,external-db</quarkus.test.profile>
+                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/integration-tests/hibernate-reactive-oracle/src/main/resources/application.properties
+++ b/integration-tests/hibernate-reactive-oracle/src/main/resources/application.properties
@@ -2,6 +2,11 @@ quarkus.datasource.db-kind=oracle
 
 # Reactive config
 quarkus.datasource.reactive=true
+# When this profile is set (opt-in), we will use an external DB instead of dev services (the default).
+%external-db.quarkus.datasource.reactive.url=${oracle.reactive.url}
+%external-db.quarkus.datasource.username=${oracle.username}
+%external-db.quarkus.datasource.password=${oracle.password}
+%external-db.quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
 quarkus.security.users.embedded.enabled=true
 quarkus.security.users.embedded.users.scott=jb0ss

--- a/integration-tests/hibernate-reactive-oracle/src/main/resources/application.properties
+++ b/integration-tests/hibernate-reactive-oracle/src/main/resources/application.properties
@@ -3,7 +3,7 @@ quarkus.datasource.db-kind=oracle
 # Reactive config
 quarkus.datasource.reactive=true
 # When this profile is set (opt-in), we will use an external DB instead of dev services (the default).
-%external-db.quarkus.datasource.reactive.url=${oracle.reactive.url}
+quarkus.datasource.reactive.url=${oracle.reactive.url}
 %external-db.quarkus.datasource.username=${oracle.username}
 %external-db.quarkus.datasource.password=${oracle.password}
 %external-db.quarkus.hibernate-orm.schema-management.strategy=drop-and-create

--- a/integration-tests/jpa-oracle/pom.xml
+++ b/integration-tests/jpa-oracle/pom.xml
@@ -13,6 +13,12 @@
     <name>Quarkus - Integration Tests - JPA - Oracle</name>
     <description>Module that contains JPA related tests running with the Oracle database</description>
 
+    <properties>
+        <oracle.jdbc.url/><!-- Default is empty, meaning we'll use dev services -->
+        <oracle.username/>
+        <oracle.password/>
+    </properties>
+
     <dependencies>
         <!-- Enables the JPA capabilities -->
         <dependency>
@@ -169,6 +175,36 @@
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <skip>false</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>test-oracle-external</id>
+            <activation>
+                <property>
+                    <name>oracle.jdbc.url</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                            <systemPropertyVariables combine.children="append">
+                                <quarkus.test.profile>test,external-db</quarkus.test.profile>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                            <systemPropertyVariables combine.children="append">
+                                <quarkus.test.profile>prod,external-db</quarkus.test.profile>
+                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/integration-tests/jpa-oracle/src/main/resources/application.properties
+++ b/integration-tests/jpa-oracle/src/main/resources/application.properties
@@ -1,5 +1,10 @@
 quarkus.datasource.db-kind=oracle
 quarkus.datasource.jdbc.additional-jdbc-properties."oracle.jdbc.timezoneAsRegion"=false
+# When this profile is set (opt-in), we will use an external DB instead of dev services (the default).
+%external-db.quarkus.datasource.jdbc.url=${oracle.jdbc.url}
+%external-db.quarkus.datasource.username=${oracle.username}
+%external-db.quarkus.datasource.password=${oracle.password}
+%external-db.quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
 quarkus.datasource.ldap.db-kind=oracle
 quarkus.datasource.ldap.username=SYSTEM

--- a/integration-tests/jpa-oracle/src/main/resources/application.properties
+++ b/integration-tests/jpa-oracle/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 quarkus.datasource.db-kind=oracle
 quarkus.datasource.jdbc.additional-jdbc-properties."oracle.jdbc.timezoneAsRegion"=false
 # When this profile is set (opt-in), we will use an external DB instead of dev services (the default).
-%external-db.quarkus.datasource.jdbc.url=${oracle.jdbc.url}
+quarkus.datasource.jdbc.url=${oracle.jdbc.url}
 %external-db.quarkus.datasource.username=${oracle.username}
 %external-db.quarkus.datasource.password=${oracle.password}
 %external-db.quarkus.hibernate-orm.schema-management.strategy=drop-and-create

--- a/integration-tests/reactive-oracle-client/pom.xml
+++ b/integration-tests/reactive-oracle-client/pom.xml
@@ -14,6 +14,12 @@
 
     <name>Quarkus - Integration Tests - Reactive Oracle Client</name>
 
+    <properties>
+        <oracle.reactive.url/><!-- Default URL is empty, meaning we'll use dev services -->
+        <oracle.username/>
+        <oracle.password/>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -135,6 +141,36 @@
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <skip>false</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>test-oracle-external</id>
+            <activation>
+                <property>
+                    <name>oracle.reactive.url</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                            <systemPropertyVariables combine.children="append">
+                                <quarkus.test.profile>test,external-db</quarkus.test.profile>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                            <systemPropertyVariables combine.children="append">
+                                <quarkus.test.profile>prod,external-db</quarkus.test.profile>
+                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/integration-tests/reactive-oracle-client/src/main/resources/application.properties
+++ b/integration-tests/reactive-oracle-client/src/main/resources/application.properties
@@ -1,4 +1,9 @@
 quarkus.datasource.db-kind=oracle
+# When this profile is set (opt-in), we will use an external DB instead of dev services (the default).
+%external-db.quarkus.datasource.reactive.url=${oracle.reactive.url}
+%external-db.quarkus.datasource.username=${oracle.username}
+%external-db.quarkus.datasource.password=${oracle.password}
+%external-db.quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 #Uncomment to connect over SSL/TLS
 #quarkus.datasource.reactive.trust-all=true
 #quarkus.datasource.reactive.mssql.ssl=true

--- a/integration-tests/reactive-oracle-client/src/main/resources/application.properties
+++ b/integration-tests/reactive-oracle-client/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 quarkus.datasource.db-kind=oracle
 # When this profile is set (opt-in), we will use an external DB instead of dev services (the default).
-%external-db.quarkus.datasource.reactive.url=${oracle.reactive.url}
+quarkus.datasource.reactive.url=${oracle.reactive.url}
 %external-db.quarkus.datasource.username=${oracle.username}
 %external-db.quarkus.datasource.password=${oracle.password}
 %external-db.quarkus.hibernate-orm.schema-management.strategy=drop-and-create

--- a/script.sh
+++ b/script.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+PASSWORD=Oracle23
+echo "database_password=${PASSWORD}"
+echo "connection_string_suffix=localhost:1521/freepdb1"
+docker run --name oracle -d -p 1521:1521 -e ORACLE_PASSWORD=Oracle23Admin \
+  -e APP_USER=quarkus_test \
+  -e APP_USER_PASSWORD=$PASSWORD \
+  --health-cmd healthcheck.sh \
+  --health-interval 5s \
+  --health-timeout 5s \
+  --health-retries 10 \
+  docker.io/gvenzl/oracle-free:23
+HEALTHSTATUS=""
+TIMEOUT=300
+ELAPSED=0
+until [ "$HEALTHSTATUS" == "healthy" ];
+do
+  if [ $ELAPSED -ge $TIMEOUT ]; then
+    echo "Timeout waiting for Oracle Free to start after ${TIMEOUT}s"
+    echo "Container logs:"
+    docker logs oracle
+    exit 1
+  fi
+  echo "Waiting for Oracle Free to start... (${ELAPSED}s/${TIMEOUT}s)"
+  sleep 5
+  ELAPSED=$((ELAPSED + 5))
+  HEALTHSTATUS=$(docker inspect --format='' oracle 2>/dev/null || echo "starting")
+  HEALTHSTATUS="`docker inspect -f '{{.State.Healthcheck.Status}}' oracle`"
+  HEALTHSTATUS=${HEALTHSTATUS##+( )} #Remove longest matching series of spaces from the front
+  HEALTHSTATUS=${HEALTHSTATUS%%+( )} #Remove longest matching series of spaces from the back
+done
+sleep 2;
+echo "Oracle successfully started"


### PR DESCRIPTION
Opening as draft because I'm not sure @holly-cummins will want this merged.

The first commit adds a workaround for #53705

The second commit provides you with a way to check that it works:

* Without the first commit, running `mvn clean verify -Dtest-containers -pl integration-tests/jpa-oracle` would fail (saying something like "the default datasource is deactivated")
* With the first commit, running `mvn clean verify -Dtest-containers -pl integration-tests/jpa-oracle` works correctly (uses dev services), and running `mvn clean verify -Doracle.jdbc.url=foo -pl integration-tests/jpa-oracle` fails as expected, showing the JDBC URL passed as a parameter is actually taken into account.