### PR TITLE
Bump webauthn4j.version from 0.28.0.RELEASE to 0.30.3.RELEASE

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -216,7 +216,7 @@
         <prometheus.version>0.16.0</prometheus.version>
         <!-- Dev UI -->
         <importmap.version>1.0.11</importmap.version>
-        <webauthn4j.version>0.28.0.RELEASE</webauthn4j.version>
+        <webauthn4j.version>0.30.3.RELEASE</webauthn4j.version>
     </properties>
 
     <pluginRepositories>


### PR DESCRIPTION
This update adds support for FIDO Registry v2.3, including SMART_CARD attachment hint and SYNC_FABRIC key protection type. Without this update, parsing the latest FIDO MDS3 Blob (v242+) fails with InvalidFormatException due to unrecognized "smart-card" value in attachmentHint.

Note: 0.31.x was not used because it migrated to Jackson 3 (tools.jackson), which conflicts with Quarkus's Jackson 2 stack. 0.30.3 is a Jackson 2-based release with the same FIDO Registry v2.3 support.