### PR TITLE
Fix infinite loop in `AeshConsole.deadlockSafeWrite()` during dev mode shutdown

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/console/AeshConsole.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/console/AeshConsole.java
@@ -197,6 +197,9 @@ public class AeshConsole extends QuarkusConsole {
                     IN_WRITE.set(false);
                     connectionLock.unlock();
                 }
+            } else {
+                //another thread holds the lock; it will drain the queue
+                return;
             }
         }
     }


### PR DESCRIPTION
When `connectionLock.tryLock()` fails, the `for(;;)` loop spins indefinitely. This occurs during shutdown when the Console Shutdown Hook holds the lock while another thread (e.g. application shutdown firing `ShutdownEvent`) tries to log through `AeshConsole`. Return immediately when `tryLock()` fails since the lock-holding thread already drains the entire queue.

- Fixes #53708 
