### PR TITLE
Make some OIDC authentication failure messages more verbose

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BearerAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BearerAuthenticationMechanism.java
@@ -77,11 +77,11 @@ public class BearerAuthenticationMechanism extends AbstractOidcAuthenticationMec
 
             List<String> proofs = context.request().headers().getAll(OidcConstants.DPOP_SCHEME);
             if (proofs == null || proofs.isEmpty()) {
-                LOG.warn("DPOP proof header must be present to verify the DPOP access token binding");
+                LOG.warn("DPoP proof header must be present to verify the DPoP access token binding");
                 throw new AuthenticationFailedException(tokenMap(token));
             }
             if (proofs.size() != 1) {
-                LOG.warn("Only a single DPOP proof header is accepted");
+                LOG.warnf("Only a single DPoP proof header is accepted, %d headers are available", proofs.size());
                 throw new AuthenticationFailedException(tokenMap(token));
             }
             String proof = proofs.get(0);
@@ -91,20 +91,20 @@ public class BearerAuthenticationMechanism extends AbstractOidcAuthenticationMec
             JsonObject proofJwtClaims = OidcCommonUtils.decodeJwtContent(proof);
 
             if (!OidcConstants.DPOP_TOKEN_TYPE.equals(proofJwtHeaders.getString(OidcConstants.TOKEN_TYPE_HEADER))) {
-                LOG.warn("Invalid DPOP proof token type ('typ') header");
+                LOG.warn("Invalid DPoP proof token type ('typ') header");
                 throw new AuthenticationFailedException(tokenMap(token));
             }
 
             // Check HTTP method and request URI
             String proofHttpMethod = proofJwtClaims.getString(OidcConstants.DPOP_HTTP_METHOD);
             if (proofHttpMethod == null) {
-                LOG.warn("DPOP proof HTTP method claim is missing");
+                LOG.warn("DPoP proof HTTP method claim is missing");
                 throw new AuthenticationFailedException(tokenMap(token));
             }
 
             String httpMethod = context.request().method().name();
             if (!httpMethod.equals(proofHttpMethod)) {
-                LOG.warnf("DPOP proof HTTP method claim %s does not match the request HTTP method %s", proofHttpMethod,
+                LOG.warnf("DPoP proof HTTP method claim %s does not match the request HTTP method %s", proofHttpMethod,
                         httpMethod);
                 throw new AuthenticationFailedException(tokenMap(token));
             }
@@ -112,7 +112,7 @@ public class BearerAuthenticationMechanism extends AbstractOidcAuthenticationMec
             // Check HTTP request URI
             String proofHttpRequestUri = proofJwtClaims.getString(OidcConstants.DPOP_HTTP_REQUEST_URI);
             if (proofHttpRequestUri == null) {
-                LOG.warn("DPOP proof HTTP request uri claim is missing");
+                LOG.warn("DPoP proof HTTP request uri claim is missing");
                 throw new AuthenticationFailedException(tokenMap(token));
             }
 
@@ -122,7 +122,7 @@ public class BearerAuthenticationMechanism extends AbstractOidcAuthenticationMec
                 httpRequestUri = httpRequestUri.substring(0, queryIndex);
             }
             if (!httpRequestUri.equals(proofHttpRequestUri)) {
-                LOG.warnf("DPOP proof HTTP request uri claim %s does not match the request HTTP uri %s", proofHttpRequestUri,
+                LOG.warnf("DPoP proof HTTP request uri claim %s does not match the request HTTP uri %s", proofHttpRequestUri,
                         httpRequestUri);
                 throw new AuthenticationFailedException(tokenMap(token));
             }
@@ -130,13 +130,13 @@ public class BearerAuthenticationMechanism extends AbstractOidcAuthenticationMec
             if (dPoPNonceProvider != null) {
                 String proofNonce = proofJwtClaims.getString(OidcConstants.NONCE);
                 if (proofNonce == null) {
-                    LOG.debug("Required DPOP proof nonce claim is missing");
+                    LOG.debug("Required DPoP proof nonce claim is missing");
                     throw new AuthenticationFailedException(Map.of(
                             OidcConstants.ACCESS_TOKEN_VALUE, token,
                             OidcConstants.USE_DPOP_NONCE, Boolean.TRUE));
                 }
                 if (!dPoPNonceProvider.isValid(proofNonce)) {
-                    LOG.tracef("DPOP proof nonce claim '%s' is not valid", proofNonce);
+                    LOG.tracef("DPoP proof nonce claim '%s' is invalid", proofNonce);
                     throw new AuthenticationFailedException(Map.of(
                             OidcConstants.ACCESS_TOKEN_VALUE, token,
                             OidcConstants.INVALID_DPOP_PROOF, Boolean.TRUE));

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
@@ -191,10 +191,17 @@ public class OidcProvider implements Closeable {
         if (!enforceExpReq) {
             // Expiry check was skipped during the initial verification but if the logout token contains the exp claim
             // then it must be verified
-            if (isTokenExpired(result.localVerificationResult.getLong(Claims.exp.name()))) {
-                String error = String.format("Logout token for client %s has expired", oidcConfig.clientId().get());
-                LOG.debugf(error);
-                throw new InvalidJwtException(error, List.of(new ErrorCodeValidator.Error(ErrorCodes.EXPIRED, error)), null);
+            final Long exp = result.localVerificationResult.getLong(Claims.exp.name());
+            if (exp != null) {
+                final long secondsAfterExpiry = now() / 1000 - (exp + getLifespanGrace());
+                if (secondsAfterExpiry > 0) {
+                    String error = """
+                            Logout token issued to client %s expired %d seconds ago""".formatted(oidcConfig.clientId().get(),
+                            secondsAfterExpiry);
+                    LOG.debug(error);
+                    throw new InvalidJwtException(error, List.of(new ErrorCodeValidator.Error(ErrorCodes.EXPIRED, error)),
+                            null);
+                }
             }
         }
         return result;
@@ -433,7 +440,7 @@ public class OidcProvider implements Closeable {
                                 try {
                                     actualClaimValueArray = requireNonNull(introspectionResult.getArray(requiredClaimName));
                                 } catch (Exception ignored) {
-                                    LOG.debugf("Introspection claim %s is neither string or array", requiredClaimName);
+                                    LOG.debugf("Introspection claim %s is neither string nor array", requiredClaimName);
                                     throw new AuthenticationFailedException(tokenMap(token, idToken));
                                 }
                                 requiredClaimValuesLoop: for (String requiredClaimValue : requiredClaimValues) {
@@ -461,18 +468,20 @@ public class OidcProvider implements Closeable {
     }
 
     private void verifyTokenExpiry(String token, boolean idToken, Long exp) {
-        if (isTokenExpired(exp)) {
-            String error = String.format("Token issued to client %s has expired", oidcConfig.clientId().get());
-            LOG.debugf(error);
+        if (exp == null) {
+            return;
+        }
+        final long secondsAfterExpiry = now() / 1000 - (exp + getLifespanGrace());
+        if (secondsAfterExpiry > 0) {
+            String error = """
+                    Token issued to client %s expired %d seconds ago""".formatted(oidcConfig.clientId().get(),
+                    secondsAfterExpiry);
+            LOG.debug(error);
             throw new AuthenticationFailedException(
                     new InvalidJwtException(error,
                             List.of(new ErrorCodeValidator.Error(ErrorCodes.EXPIRED, error)), null),
                     tokenMap(token, idToken));
         }
-    }
-
-    private boolean isTokenExpired(Long exp) {
-        return exp != null && now() / 1000 > exp + getLifespanGrace();
     }
 
     private int getLifespanGrace() {


### PR DESCRIPTION
This PR makes a few authentication exception messages more verbose, I reviewed all of OIDC ones, and I think right now, there is a right amount of information in each of them, but we can continue tuning.

In particular, this PR updates an expired token message to inform how many seconds ago the token expired, and tunes a few DPoP log messages 