### PR TITLE
Support Avro in Dev UI Kafka Client Topics browser

### DIFF
--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
@@ -38,6 +38,7 @@ import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem.Builder;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.Capabilities;
@@ -82,6 +83,9 @@ import io.quarkus.kafka.client.runtime.KafkaRuntimeConfigProducer;
 import io.quarkus.kafka.client.runtime.SnappyRecorder;
 import io.quarkus.kafka.client.runtime.dev.ui.KafkaTopicClient;
 import io.quarkus.kafka.client.runtime.dev.ui.KafkaUiUtils;
+import io.quarkus.kafka.client.runtime.dev.ui.model.converter.KafkaModelConverter;
+import io.quarkus.kafka.client.runtime.dev.ui.model.decoder.AvroDecoder;
+import io.quarkus.kafka.client.runtime.dev.ui.model.decoder.KafkaMessageDecoderRegistry;
 import io.quarkus.kafka.client.runtime.graal.SnappyFeature;
 import io.quarkus.kafka.client.serialization.BufferDeserializer;
 import io.quarkus.kafka.client.serialization.BufferSerializer;
@@ -557,11 +561,19 @@ public class KafkaProcessor {
 
     @BuildStep(onlyIf = IsDevelopment.class)
     public AdditionalBeanBuildItem kafkaClientBeans() {
-        return AdditionalBeanBuildItem.builder()
+        Builder builder = AdditionalBeanBuildItem.builder()
                 .addBeanClass(KafkaTopicClient.class)
                 .addBeanClass(KafkaUiUtils.class)
-                .setUnremovable()
-                .build();
+                .addBeanClass(KafkaModelConverter.class)
+                .addBeanClass(KafkaMessageDecoderRegistry.class)
+                .setUnremovable();
+
+        if (QuarkusClassLoader.isClassPresentAtRuntime("io.apicurio.registry.serde.avro.AvroKafkaDeserializer")
+                || QuarkusClassLoader.isClassPresentAtRuntime("io.apicurio.registry.serde.avro.AvroKafkaDeserializer")) {
+            builder.addBeanClass(AvroDecoder.class);
+        }
+
+        return builder.build();
     }
 
     public static final class HasSnappy implements BooleanSupplier {

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
@@ -41,6 +41,7 @@ import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem.Builder;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.Capabilities;
@@ -84,6 +85,9 @@ import io.quarkus.kafka.client.runtime.KafkaRuntimeConfigProducer;
 import io.quarkus.kafka.client.runtime.SnappyRecorder;
 import io.quarkus.kafka.client.runtime.dev.ui.KafkaTopicClient;
 import io.quarkus.kafka.client.runtime.dev.ui.KafkaUiUtils;
+import io.quarkus.kafka.client.runtime.dev.ui.model.converter.KafkaModelConverter;
+import io.quarkus.kafka.client.runtime.dev.ui.model.decoder.AvroDecoder;
+import io.quarkus.kafka.client.runtime.dev.ui.model.decoder.KafkaMessageDecoderRegistry;
 import io.quarkus.kafka.client.runtime.graal.SnappyFeature;
 import io.quarkus.kafka.client.serialization.BufferDeserializer;
 import io.quarkus.kafka.client.serialization.BufferSerializer;
@@ -566,11 +570,19 @@ public class KafkaProcessor {
 
     @BuildStep(onlyIf = IsDevelopment.class)
     public AdditionalBeanBuildItem kafkaClientBeans() {
-        return AdditionalBeanBuildItem.builder()
+        Builder builder = AdditionalBeanBuildItem.builder()
                 .addBeanClass(KafkaTopicClient.class)
                 .addBeanClass(KafkaUiUtils.class)
-                .setUnremovable()
-                .build();
+                .addBeanClass(KafkaModelConverter.class)
+                .addBeanClass(KafkaMessageDecoderRegistry.class)
+                .setUnremovable();
+
+        if (QuarkusClassLoader.isClassPresentAtRuntime("io.apicurio.registry.serde.avro.AvroKafkaDeserializer")
+                || QuarkusClassLoader.isClassPresentAtRuntime("io.apicurio.registry.serde.avro.AvroKafkaDeserializer")) {
+            builder.addBeanClass(AvroDecoder.class);
+        }
+
+        return builder.build();
     }
 
     public static final class HasSnappy implements BooleanSupplier {

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
@@ -578,7 +578,7 @@ public class KafkaProcessor {
                 .setUnremovable();
 
         if (QuarkusClassLoader.isClassPresentAtRuntime("io.apicurio.registry.serde.avro.AvroKafkaDeserializer")
-                || QuarkusClassLoader.isClassPresentAtRuntime("io.apicurio.registry.serde.avro.AvroKafkaDeserializer")) {
+                || QuarkusClassLoader.isClassPresentAtRuntime("io.confluent.kafka.serializers.KafkaAvroDeserializer")) {
             builder.addBeanClass(AvroDecoder.class);
         }
 

--- a/extensions/kafka-client/deployment/src/main/resources/dev-ui/qwc-kafka-messages.js
+++ b/extensions/kafka-client/deployment/src/main/resources/dev-ui/qwc-kafka-messages.js
@@ -167,6 +167,7 @@ export class QwcKafkaMessages extends observeState(QwcHotReloadElement) {
                     <vaadin-grid-sort-column auto-width
                         path="value"
                         header=${msg('Value', { id: 'quarkus-kafka-client-value' })}
+                        ${columnBodyRenderer(this._valueRenderer, [])}
                         resizable>
                     </vaadin-grid-sort-column>
 
@@ -185,7 +186,7 @@ export class QwcKafkaMessages extends observeState(QwcHotReloadElement) {
                             <div class="code-block">    
                                 <qui-code-block
                                     mode='json'
-                                    content='${message.value}'
+                                    content='${message.value?.value}'
                                     theme='${themeState.theme.name}'>
                                 </qui-code-block>
                             </div>
@@ -208,6 +209,13 @@ export class QwcKafkaMessages extends observeState(QwcHotReloadElement) {
                             </vaadin-grid>
                         </detail-content>
                     </vaadin-split-layout>`;
+    }
+
+    _valueRenderer(message) {
+        return html`<div>
+                    ${message.value?.format !== 'STRING' ? html`<qui-badge small pill><span>${message.value?.format}</span></qui-badge>` : ''}
+                    <span>${message.value?.value}</span>
+                </div>`;
     }
 
     _timestampRenderer(message){

--- a/extensions/kafka-client/runtime-dev/pom.xml
+++ b/extensions/kafka-client/runtime-dev/pom.xml
@@ -19,6 +19,11 @@
             <artifactId>quarkus-kafka-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/extensions/kafka-client/runtime-dev/src/main/java/io/quarkus/kafka/client/runtime/dev/ui/KafkaTopicClient.java
+++ b/extensions/kafka-client/runtime-dev/src/main/java/io/quarkus/kafka/client/runtime/dev/ui/KafkaTopicClient.java
@@ -49,7 +49,8 @@ public class KafkaTopicClient {
     @Inject
     KafkaAdminClient adminClient;
 
-    KafkaModelConverter modelConverter = new KafkaModelConverter();
+    @Inject
+    KafkaModelConverter modelConverter;
 
     @Inject
     @Identifier("default-kafka-broker")

--- a/extensions/kafka-client/runtime-dev/src/main/java/io/quarkus/kafka/client/runtime/dev/ui/model/converter/KafkaModelConverter.java
+++ b/extensions/kafka-client/runtime-dev/src/main/java/io/quarkus/kafka/client/runtime/dev/ui/model/converter/KafkaModelConverter.java
@@ -6,13 +6,22 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.utils.Bytes;
 
+import io.quarkus.kafka.client.runtime.dev.ui.model.decoder.KafkaMessageDecoderRegistry;
 import io.quarkus.kafka.client.runtime.dev.ui.model.response.KafkaMessage;
 
+@ApplicationScoped
 public class KafkaModelConverter {
+
+    @Inject
+    KafkaMessageDecoderRegistry decoderRegistry;
+
     public KafkaMessage convert(ConsumerRecord<Bytes, Bytes> message) {
         return new KafkaMessage(
                 message.topic(),
@@ -22,9 +31,10 @@ public class KafkaModelConverter {
                 Optional.ofNullable(message.key()).map((t) -> {
                     return new String(t.get(), StandardCharsets.UTF_8);
                 }).orElse(null),
-                Optional.ofNullable(message.value()).map((t) -> {
-                    return new String(t.get(), StandardCharsets.UTF_8);
-                }).orElse(null),
+                Optional.ofNullable(message.value())
+                        .map(Bytes::get)
+                        .map(value -> decoderRegistry.decode(message.topic(), value))
+                        .orElse(null),
                 headers(message));
     }
 

--- a/extensions/kafka-client/runtime-dev/src/main/java/io/quarkus/kafka/client/runtime/dev/ui/model/decoder/AvroDecoder.java
+++ b/extensions/kafka-client/runtime-dev/src/main/java/io/quarkus/kafka/client/runtime/dev/ui/model/decoder/AvroDecoder.java
@@ -1,0 +1,134 @@
+package io.quarkus.kafka.client.runtime.dev.ui.model.decoder;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.quarkus.kafka.client.runtime.dev.ui.model.response.KafkaMessageContent;
+
+/**
+ * Detects and decodes Kafka messages serialized in Avro format using a schema registry.
+ * <p>
+ * Avro messages are identified by the Confluent wire format, which prefixes every message
+ * with a 5-byte header: a magic byte ({@code 0x00}) followed by a 4-byte schema ID.
+ * The schema is then fetched from the configured registry and used to deserialize
+ * the binary Avro payload into a human-readable JSON string.
+ * <p>
+ * Two schema registry implementations are supported:
+ * <ul>
+ * <li><b>Confluent Schema Registry</b> - the original registry implementation,
+ * widely used in cloud and enterprise Kafka deployments.</li>
+ * <li><b>Apicurio Registry</b> - an open source registry by Red Hat,
+ * commonly used in OpenShift and Kubernetes environments.
+ * Adopts the same wire format as Confluent for compatibility.</li>
+ * </ul>
+ * <p>
+ * This decoder is part of the Kafka Dev UI decoder chain and is only active in dev mode.
+ * It will silently skip decoding ({@link #canDecode(byte[])} returns {@code false}) if:
+ * <ul>
+ * <li>No schema registry URL is configured</li>
+ * <li>Neither Confluent nor Apicurio serializer library is on the classpath</li>
+ * <li>The message does not start with the Avro magic byte {@code 0x00}</li>
+ * </ul>
+ *
+ * @see KafkaMessageDecoder
+ * @see KafkaMessageDecoderRegistry
+ */
+@ApplicationScoped
+public class AvroDecoder implements KafkaMessageDecoder {
+
+    private static final Logger log = LoggerFactory.getLogger(AvroDecoder.class);
+
+    private static final String FORMAT = "AVRO";
+
+    private static final byte MAGIC_BYTE = 0x00;
+
+    // 1 magic byte + 4 bytes schema ID
+    private static final int HEADER_LENGTH = 5;
+
+    @ConfigProperty(name = "mp.messaging.connector.smallrye-kafka.apicurio.registry.url", defaultValue = "")
+    String apicurioRegistryUrl;
+
+    @ConfigProperty(name = "mp.messaging.connector.smallrye-kafka.schema.registry.url", defaultValue = "")
+    String confluentRegistryUrl;
+
+    private Deserializer<GenericRecord> deserializer;
+
+    // for testing
+    AvroDecoder(Deserializer<GenericRecord> deserializer) {
+        this.deserializer = deserializer;
+    }
+
+    public AvroDecoder() {
+        // default constructor
+    }
+
+    private static boolean isClassPresent(String className) {
+        try {
+            Class.forName(className, false, Thread.currentThread().getContextClassLoader());
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+    @PostConstruct
+    void init() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("specific.avro.reader", false); // GenericRecord, not specific class
+
+        if (!confluentRegistryUrl.isBlank() && isClassPresent("io.confluent.kafka.serializers.KafkaAvroDeserializer")) {
+            config.put("schema.registry.url", confluentRegistryUrl);
+            deserializer = createConfluentDeserializer(config);
+        } else if (!apicurioRegistryUrl.isBlank() && isClassPresent("io.apicurio.registry.serde.avro.AvroKafkaDeserializer")) {
+            config.put("apicurio.registry.url", apicurioRegistryUrl);
+            deserializer = createApicurioDeserializer(config);
+        }
+    }
+
+    @Override
+    public boolean canDecode(byte[] data) {
+        return deserializer != null
+                && data != null
+                && data.length > HEADER_LENGTH
+                && data[0] == MAGIC_BYTE;
+    }
+
+    @Override
+    public KafkaMessageContent decode(String topic, byte[] data) {
+        GenericRecord genericRecord = deserializer.deserialize(topic, data);
+        return new KafkaMessageContent(genericRecord.toString(), FORMAT);
+    }
+
+    private Deserializer<GenericRecord> createApicurioDeserializer(Map<String, Object> config) {
+        return createDeserializer(config, "io.apicurio.registry.serde.avro.AvroKafkaDeserializer");
+    }
+
+    private Deserializer<GenericRecord> createConfluentDeserializer(Map<String, Object> config) {
+        return createDeserializer(config, "io.confluent.kafka.serializers.KafkaAvroDeserializer");
+    }
+
+    @SuppressWarnings("unchecked")
+    private Deserializer<GenericRecord> createDeserializer(Map<String, Object> config, String className) {
+        try {
+            Deserializer<GenericRecord> d = (Deserializer<GenericRecord>) Class
+                    .forName(className)
+                    .getDeclaredConstructor()
+                    .newInstance();
+            d.configure(config, false);
+            return d;
+        } catch (Exception e) {
+            log.error("Failed to create Deserializer for class {}", className, e);
+            return null;
+        }
+    }
+
+}

--- a/extensions/kafka-client/runtime-dev/src/main/java/io/quarkus/kafka/client/runtime/dev/ui/model/decoder/KafkaMessageDecoder.java
+++ b/extensions/kafka-client/runtime-dev/src/main/java/io/quarkus/kafka/client/runtime/dev/ui/model/decoder/KafkaMessageDecoder.java
@@ -1,0 +1,40 @@
+package io.quarkus.kafka.client.runtime.dev.ui.model.decoder;
+
+import io.quarkus.kafka.client.runtime.dev.ui.model.response.KafkaMessageContent;
+
+/**
+ * Strategy interface for decoding raw Kafka message bytes into a human-readable representation.
+ * <p>
+ * Each decoder is responsible for detecting whether it
+ * can handle a given message and decoding it accordingly.
+ * <p>
+ * To add a new decoding strategy, implement this interface and annotate the implementation
+ * with {@code @ApplicationScoped}. The implementation should be registered in
+ * {@link io.quarkus.kafka.client.deployment.KafkaProcessor#kafkaClientBeans()} too.
+ * <p>
+ * Implementations should be stateless or thread-safe, as a single instance is shared
+ * across all {@code decode} calls in the Dev UI.
+ *
+ * @see KafkaMessageDecoderRegistry
+ */
+public interface KafkaMessageDecoder {
+
+    /**
+     * Returns {@code true} if this decoder can handle the given raw message bytes.
+     *
+     * @param data the raw message bytes
+     * @return true if this decoder can handle the given raw message bytes, false otherwise
+     */
+    boolean canDecode(byte[] data);
+
+    /**
+     * Decodes the raw message bytes into a human-readable string representation.
+     * Only called when {@link #canDecode(byte[])} returns {@code true}.
+     *
+     * @param topic the Kafka topic the message was sent to
+     * @param data the raw message bytes
+     * @return the human-readable string representation of the message
+     */
+    KafkaMessageContent decode(String topic, byte[] data);
+
+}

--- a/extensions/kafka-client/runtime-dev/src/main/java/io/quarkus/kafka/client/runtime/dev/ui/model/decoder/KafkaMessageDecoderRegistry.java
+++ b/extensions/kafka-client/runtime-dev/src/main/java/io/quarkus/kafka/client/runtime/dev/ui/model/decoder/KafkaMessageDecoderRegistry.java
@@ -1,0 +1,62 @@
+package io.quarkus.kafka.client.runtime.dev.ui.model.decoder;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import io.quarkus.arc.All;
+import io.quarkus.kafka.client.runtime.dev.ui.model.response.KafkaMessageContent;
+
+/**
+ * Registry that manages and coordinates all {@link KafkaMessageDecoder} implementations.
+ * <p>
+ * Iterates through all registered decoders in order, delegating to the first one
+ * that can handle the given message bytes. Falls back to plain string decoding
+ * if no decoder matches.
+ * <p>
+ * New decoders are automatically picked up via CDI {@code @All} injection.
+ * See {@link KafkaMessageDecoder} for instructions on adding new decode strategies.
+ *
+ * @see KafkaMessageDecoder
+ */
+@ApplicationScoped
+public class KafkaMessageDecoderRegistry {
+
+    @Inject
+    @All
+    List<KafkaMessageDecoder> decoders;
+
+    // For testing
+    public KafkaMessageDecoderRegistry(List<KafkaMessageDecoder> decoders) {
+        this.decoders = decoders;
+    }
+
+    public KafkaMessageDecoderRegistry() {
+        // default constructor
+    }
+
+    /**
+     * Tries to decode the given raw message bytes using the registered decoders.
+     * <p>
+     * If no decoder is found, it falls back to the raw message bytes as a string.
+     * <p>
+     * The first decoder that can decode the message is used.
+     *
+     * @param data the raw message bytes
+     * @return the decoded message content
+     */
+    public KafkaMessageContent decode(String topic, byte[] data) {
+        if (data == null)
+            return null;
+
+        for (KafkaMessageDecoder decoder : decoders) {
+            if (decoder.canDecode(data)) {
+                return decoder.decode(topic, data);
+            }
+        }
+        return new KafkaMessageContent(new String(data, StandardCharsets.UTF_8), "STRING");
+    }
+
+}

--- a/extensions/kafka-client/runtime-dev/src/main/java/io/quarkus/kafka/client/runtime/dev/ui/model/response/KafkaMessage.java
+++ b/extensions/kafka-client/runtime-dev/src/main/java/io/quarkus/kafka/client/runtime/dev/ui/model/response/KafkaMessage.java
@@ -8,11 +8,11 @@ public class KafkaMessage {
     private final long offset;
     private final long timestamp;
     private final String key;
-    private final String value;
+    private final KafkaMessageContent value;
     private final Map<String, String> headers;
 
-    public KafkaMessage(String topic, int partition, long offset, long timestamp, String key, String value,
-            Map<String, String> headers) {
+    public KafkaMessage(String topic, int partition, long offset, long timestamp, String key,
+            KafkaMessageContent value, Map<String, String> headers) {
         this.topic = topic;
         this.partition = partition;
         this.offset = offset;
@@ -42,7 +42,7 @@ public class KafkaMessage {
         return key;
     }
 
-    public String getValue() {
+    public KafkaMessageContent getValue() {
         return value;
     }
 

--- a/extensions/kafka-client/runtime-dev/src/main/java/io/quarkus/kafka/client/runtime/dev/ui/model/response/KafkaMessageContent.java
+++ b/extensions/kafka-client/runtime-dev/src/main/java/io/quarkus/kafka/client/runtime/dev/ui/model/response/KafkaMessageContent.java
@@ -1,0 +1,13 @@
+package io.quarkus.kafka.client.runtime.dev.ui.model.response;
+
+/**
+ * Represents the decoded content of a Kafka message value.
+ *
+ * @param value the human-readable representation of the message bytes.
+ * @param format the format of the decoded value, indicating how it was decoded.
+ *        For example {@code "AVRO"}, {@code "STRING"}.
+ *        New formats can be introduced by implementing
+ *        {@link io.quarkus.kafka.client.runtime.dev.ui.model.decoder.KafkaMessageDecoder}.
+ */
+public record KafkaMessageContent(String value, String format) {
+}

--- a/extensions/kafka-client/runtime-dev/src/test/java/io/quarkus/kafka/client/runtime/dev/ui/model/converter/KafkaModelConverterTest.java
+++ b/extensions/kafka-client/runtime-dev/src/test/java/io/quarkus/kafka/client/runtime/dev/ui/model/converter/KafkaModelConverterTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -14,6 +15,7 @@ import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.Bytes;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.kafka.client.runtime.dev.ui.model.decoder.KafkaMessageDecoderRegistry;
 import io.quarkus.kafka.client.runtime.dev.ui.model.response.KafkaMessage;
 
 class KafkaModelConverterTest {
@@ -40,6 +42,7 @@ class KafkaModelConverterTest {
                 Optional.empty());
 
         KafkaModelConverter converter = new KafkaModelConverter();
+        converter.decoderRegistry = new KafkaMessageDecoderRegistry(List.of());
 
         // When converting the record
         KafkaMessage message = converter.convert(record);
@@ -50,7 +53,7 @@ class KafkaModelConverterTest {
         assertEquals(0, message.getPartition());
         assertEquals(100L, message.getOffset());
         assertEquals("test-key", message.getKey());
-        assertEquals("test-value", message.getValue());
+        assertEquals("test-value", message.getValue().value());
 
         // Headers should contain the last value for duplicate keys
         Map<String, String> convertedHeaders = message.getHeaders();
@@ -81,6 +84,7 @@ class KafkaModelConverterTest {
                 Optional.empty());
 
         KafkaModelConverter converter = new KafkaModelConverter();
+        converter.decoderRegistry = new KafkaMessageDecoderRegistry(List.of());
 
         // When converting the record
         KafkaMessage message = converter.convert(record);
@@ -113,6 +117,7 @@ class KafkaModelConverterTest {
                 Optional.empty());
 
         KafkaModelConverter converter = new KafkaModelConverter();
+        converter.decoderRegistry = new KafkaMessageDecoderRegistry(List.of());
 
         // When converting the record
         KafkaMessage message = converter.convert(record);

--- a/extensions/kafka-client/runtime-dev/src/test/java/io/quarkus/kafka/client/runtime/dev/ui/model/decoder/AvroDecoderTest.java
+++ b/extensions/kafka-client/runtime-dev/src/test/java/io/quarkus/kafka/client/runtime/dev/ui/model/decoder/AvroDecoderTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.kafka.client.runtime.dev.ui.model.decoder;
+
+import org.junit.jupiter.api.Test;
+import org.wildfly.common.Assert;
+
+class AvroDecoderTest {
+
+    @Test
+    void testCanDecodeWithMessageStarting0x00AndOver5length() {
+        AvroDecoder decoder = new AvroDecoder((topic, data) -> null);
+
+        Assert.assertTrue(decoder.canDecode(new byte[10]));
+    }
+
+    @Test
+    void testCanDecodeWithMessageStarting0x00AndUnder5length() {
+        AvroDecoder decoder = new AvroDecoder((topic, data) -> null);
+
+        Assert.assertFalse(decoder.canDecode(new byte[2]));
+    }
+
+    @Test
+    void testCanDecodeWithMessageStarting0x01AndOver5length() {
+        AvroDecoder decoder = new AvroDecoder((topic, data) -> null);
+
+        Assert.assertFalse(decoder.canDecode(new byte[] { 0x01, 0x00, 0x00, 0x00, 0x00, 0x00 }));
+    }
+
+    @Test
+    void testCanDecodeWithMessageNull() {
+        AvroDecoder decoder = new AvroDecoder((topic, data) -> null);
+
+        Assert.assertFalse(decoder.canDecode(null));
+    }
+}

--- a/extensions/kafka-client/runtime-dev/src/test/java/io/quarkus/kafka/client/runtime/dev/ui/model/decoder/KafkaMessageDecoderRegistryTest.java
+++ b/extensions/kafka-client/runtime-dev/src/test/java/io/quarkus/kafka/client/runtime/dev/ui/model/decoder/KafkaMessageDecoderRegistryTest.java
@@ -1,0 +1,101 @@
+package io.quarkus.kafka.client.runtime.dev.ui.model.decoder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.kafka.client.runtime.dev.ui.model.response.KafkaMessageContent;
+
+class KafkaMessageDecoderRegistryTest {
+
+    @Test
+    void testDecodeWithNoDecoders() {
+        KafkaMessageDecoderRegistry registry = new KafkaMessageDecoderRegistry(List.of());
+
+        KafkaMessageContent decoded = registry.decode("test-topic", "test-message".getBytes());
+
+        assertEquals("test-message", decoded.value());
+        assertEquals("STRING", decoded.format());
+    }
+
+    @Test
+    void testDecodeWithDecoderThatCanNotDecode() {
+        KafkaMessageDecoder decoder = new KafkaMessageDecoder() {
+            @Override
+            public boolean canDecode(byte[] data) {
+                return false;
+            }
+
+            @Override
+            public KafkaMessageContent decode(String topic, byte[] data) {
+                return null;
+            }
+        };
+
+        KafkaMessageDecoderRegistry registry = new KafkaMessageDecoderRegistry(List.of(decoder));
+
+        KafkaMessageContent decoded = registry.decode("test-topic", "test-message".getBytes());
+
+        assertEquals("test-message", decoded.value());
+        assertEquals("STRING", decoded.format());
+    }
+
+    @Test
+    void testDecodeWithDecoderThatCanDecode() {
+        KafkaMessageDecoder decoder = new KafkaMessageDecoder() {
+            @Override
+            public boolean canDecode(byte[] data) {
+                return true;
+            }
+
+            @Override
+            public KafkaMessageContent decode(String topic, byte[] data) {
+                return new KafkaMessageContent(new String(data, StandardCharsets.UTF_8), "MY_FORMAT");
+            }
+        };
+
+        KafkaMessageDecoderRegistry registry = new KafkaMessageDecoderRegistry(List.of(decoder));
+
+        KafkaMessageContent decoded = registry.decode("test-topic", "test-message".getBytes());
+
+        assertEquals("test-message", decoded.value());
+        assertEquals("MY_FORMAT", decoded.format());
+    }
+
+    @Test
+    void testDecodeWithDecodersThatCanDecodeFirstShouldApply() {
+        KafkaMessageDecoder decoder1 = new KafkaMessageDecoder() {
+            @Override
+            public boolean canDecode(byte[] data) {
+                return true;
+            }
+
+            @Override
+            public KafkaMessageContent decode(String topic, byte[] data) {
+                return new KafkaMessageContent(new String(data, StandardCharsets.UTF_8), "MY_FORMAT_1");
+            }
+        };
+
+        KafkaMessageDecoder decoder2 = new KafkaMessageDecoder() {
+            @Override
+            public boolean canDecode(byte[] data) {
+                return true;
+            }
+
+            @Override
+            public KafkaMessageContent decode(String topic, byte[] data) {
+                return new KafkaMessageContent(new String(data, StandardCharsets.UTF_8), "MY_FORMAT_2");
+            }
+        };
+
+        KafkaMessageDecoderRegistry registry = new KafkaMessageDecoderRegistry(List.of(decoder1, decoder2));
+
+        KafkaMessageContent decoded = registry.decode("test-topic", "test-message".getBytes());
+
+        assertEquals("test-message", decoded.value());
+        assertEquals("MY_FORMAT_1", decoded.format());
+    }
+}


### PR DESCRIPTION
### Description
This PR adds support for Avro-encoded messages to be displayed in human-readable format in Kafka Dev UI. 

### Relates to
Fixes #44829 

### Implementation 
* Defined an interface `KafkaMessageDecoder` as a strategy interface for decoding raw Kafka message bytes into a human-readable representation. The inteface enables future format extensions other than Avro format.
* Implemented `AvroDecoder` based on `KafkaMessageDecoder` to detect and decode Avro messages. Avro messages are identified by the Confluent wire format, which prefixes every message with a 5-byte header: a magic byte `0x00` followed by a 4-byte schema ID. Under the hood the `AvroDecoder` calls `io.confluent.kafka.serializers.KafkaAvroDeserializer` or `io.apicurio.registry.serde.avro.AvroKafkaDeserializer` depending what is available for the actual decoding. 
* Created `KafkaMessageDecoderRegistry` that manages and coordinates all `KafkaMessageDecoder` implementations. Iterates through all registered decoders in order, delegating to the first one that can handle the given message bytes. Currently the only available implementation is  `AvroDecoder`. If no decoder can decode the message falls back to standard UTF-8 String. 
* Refactored `KafkaMessage` to change `KafkaMessage#value` type from `String` to `KafkaMessageContent`. The `KafkaMessageContent` holds the decoded value along with the format (default to "STRING").
* Refactored `qwc-kafka-messages.js` to support the new `KafkaMessageContent` and display the message correctly.
* Changed `KafkaProcessor.java` to inject the new beans only when Development Mode is enabled.

### Testing
* Tested manually using `quarkus dev` and the quickstart [kafka-avro-schema-quickstart](https://github.com/quarkusio/quarkus-quickstarts/tree/main/kafka-avro-schema-quickstart)
* Tested manually using `quarkus dev` and the quickstart [kafka-quickstart](https://github.com/quarkusio/quarkus-quickstarts/tree/main/kafka-quickstart)
* Added unit tests covering main cases

### Screenshots

#### Original Dev UI
<img width="1867" height="564" alt="before" src="https://github.com/user-attachments/assets/25b13ca0-1ad2-48bc-938c-efd4320e340d" />

#### Dev UI after PR - Avro message
<img width="1867" height="757" alt="avro-decoded" src="https://github.com/user-attachments/assets/648ae60b-756e-4497-b974-f1b82f3cc4b6" />

#### Dev UI after PR -  plain text message
<img width="1867" height="765" alt="plain-string" src="https://github.com/user-attachments/assets/e3d08c33-8536-427b-b02e-d36f983a67a6" />




