### PR TITLE
Fix ConfigProvider.getConfig() regression in @BeforeAll with @QuarkusIntegrationTest

### DIFF
--- a/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/HttpServerIT.java
+++ b/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/HttpServerIT.java
@@ -1,7 +1,27 @@
 package io.quarkus.it.vertx;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
 public class HttpServerIT extends HttpServerTest {
+
+    static int beforeAllPort;
+
+    @BeforeAll
+    static void configAvailableInBeforeAll() {
+        beforeAllPort = ConfigProvider.getConfig().getValue("quarkus.http.port", Integer.class);
+        assertTrue(beforeAllPort > 0);
+    }
+
+    @Test
+    void beforeAllConfigMatchesTestConfig() {
+        assertEquals(8081, beforeAllPort);
+    }
 }

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
@@ -146,6 +146,7 @@ public class QuarkusIntegrationTestExtension extends AbstractQuarkusTestWithCont
     @Override
     public void beforeAll(ExtensionContext context) throws Exception {
         ensureStarted(context);
+        ThreadLocalConfigSourceProvider.set(ConfigInjector.get(context));
         invokeBeforeClassCallbacks(context.getRequiredTestClass());
     }
 


### PR DESCRIPTION
## Description

Since Quarkus 3.35 (main), `ConfigProvider.getConfig().getValue("quarkus.http.test-port", Integer.class)` throws `NoSuchElementException` when called from a `@BeforeAll` method in a `@QuarkusIntegrationTest` class. It still works correctly with `@QuarkusTest`.

### Root Cause

The `ThreadLocalConfigSourceProvider` (which overrides `ConfigProvider.getConfig()` to return the test config with test port values) was only being set in `postProcessTestInstance()`. In the JUnit lifecycle, `postProcessTestInstance()` runs **after** the user's `@BeforeAll` method, so the test config was not yet active during `@BeforeAll` execution.

For `@QuarkusTest`, this works because the `@BeforeAll` method runs inside the Quarkus classloader via `interceptBeforeAllMethod` → `runExtensionMethod`, where the config is already set up. `@QuarkusIntegrationTest` doesn't use this mechanism — its `@BeforeAll` runs directly in the JUnit classloader.

### Fix

Set `ThreadLocalConfigSourceProvider` in `QuarkusIntegrationTestExtension.beforeAll()`, right after `ensureStarted()` has created and registered the test Config. This ensures it is available for user `@BeforeAll` methods.

The same `ThreadLocalConfigSourceProvider.set()` call still happens in `postProcessTestInstance()` (via `IntegrationTestUtil.doProcessTestInstance`), which is harmless — it just sets the same value again.

----

- Fixes: #53692