### PR TITLE
Move Hibernate Dev UI from hibernate-tools-language (Tools) to hibernate-assistant (ORM)

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -5505,6 +5505,11 @@
                 <artifactId>hibernate-jpamodelgen</artifactId>
                 <version>${hibernate-orm.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.hibernate.orm</groupId>
+                <artifactId>hibernate-assistant</artifactId>
+                <version>${hibernate-orm.version}</version>
+            </dependency>
             <!-- Workaround for Maven relocations not being supported for
                  annotation processor paths in Maven Compiler Plugin
                  See https://github.com/apache/maven-compiler-plugin/pull/180#issuecomment-1876921475 -->
@@ -5598,11 +5603,6 @@
                         <artifactId>jandex</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.tool</groupId>
-                <artifactId>hibernate-tools-language</artifactId>
-                <version>${hibernate-tools.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.postgresql</groupId>

--- a/extensions/hibernate-orm/deployment/pom.xml
+++ b/extensions/hibernate-orm/deployment/pom.xml
@@ -74,6 +74,12 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-security-spi</artifactId>
         </dependency>
+        <!-- For Hibernate ORM's JSON support; see HibernateOrmProcessor -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson-deployment</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/hibernate-orm/runtime-dev/pom.xml
+++ b/extensions/hibernate-orm/runtime-dev/pom.xml
@@ -26,8 +26,8 @@
             <artifactId>jackson-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hibernate.tool</groupId>
-            <artifactId>hibernate-tools-language</artifactId>
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-assistant</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,6 @@
         <hibernate-reactive.version>3.3.5.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
         <hibernate-validator.version>9.1.0.Final</hibernate-validator.version>
         <hibernate-search.version>8.3.0.Final</hibernate-search.version>
-        <hibernate-tools.version>7.2.12.Final</hibernate-tools.version>
 
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->
         <grpc.version>1.79.0</grpc.version> <!-- when updating, verify if following versions should not be updated too: -->


### PR DESCRIPTION
Because the code was moved there as part of https://hibernate.atlassian.net/browse/HHH-19880, in Hibernate ORM 7.3.

This removes any dependency on Hibernate Tools, which is good because Tools is being merged into Hibernate ORM (see https://github.com/hibernate/hibernate-orm/pull/12144)

Also, add a previously missing optional dependency to quarkus-jackson; we were mistakenly relying on the transitive dependency to jackson-databind through hibernate-tools-language :/

~~Opening as draft because this will likely conflict with #53733, so let's merge that first~~ => Done