### PR TITLE
Remove the tech preview note from reactive-sql-clients.adoc

### DIFF
--- a/docs/src/main/asciidoc/reactive-sql-clients.adoc
+++ b/docs/src/main/asciidoc/reactive-sql-clients.adoc
@@ -20,15 +20,6 @@ Currently, the following database servers are supported:
 * Microsoft SQL Server
 * Oracle
 
-[NOTE]
-====
-The Reactive SQL Client for Oracle is considered _tech preview_.
-
-In _tech preview_ mode, early feedback is requested to mature the idea.
-There is no guarantee of stability in the platform until the solution matures.
-Feedback is welcome on our https://groups.google.com/d/forum/quarkus-dev[mailing list] or as issues in our https://github.com/quarkusio/quarkus/issues[GitHub issue tracker].
-====
-
 In this guide, you will learn how to implement a simple CRUD application exposing data stored in *PostgreSQL* over a RESTful API.
 
 NOTE: Extension and connection pool class names for each client can be found at the bottom of this document.


### PR DESCRIPTION
In fact, this should have been removed as part of https://github.com/quarkusio/quarkus/pull/43462

Related discussion: https://github.com/quarkusio/quarkus/discussions/53508