### PR TITLE
Handle edge-case with kapt plugin missing generated sources

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -533,9 +533,10 @@ public class QuarkusPlugin implements Plugin<Project> {
 
         project.getPlugins().withId("org.jetbrains.kotlin.jvm", plugin -> {
             quarkusDev.configure(task -> task.shouldPropagateJavaCompilerArgs(false));
+            SourceSetContainer ssc = project.getExtensions().getByType(SourceSetContainer.class);
+            final SourceSet generatedSourceSet = ssc.getByName(QuarkusGenerateCode.QUARKUS_GENERATED_SOURCES);
+            final SourceSet generatedTestSourceSet = ssc.getByName(QuarkusGenerateCode.QUARKUS_TEST_GENERATED_SOURCES);
             tasks.named("compileKotlin", task -> {
-                final SourceSet generatedSourceSet = project.getExtensions().getByType(SourceSetContainer.class)
-                        .getByName(QuarkusGenerateCode.QUARKUS_GENERATED_SOURCES);
                 addCodeGenSourceDirs(task, generatedSourceSet);
                 task.dependsOn(quarkusGenerateCode);
                 task.mustRunAfter(quarkusGenerateCodeDev);
@@ -548,17 +549,31 @@ public class QuarkusPlugin implements Plugin<Project> {
                 }
             });
             tasks.named("compileTestKotlin", task -> {
-                final SourceSet generatedSourceSet = project.getExtensions().getByType(SourceSetContainer.class)
-                        .getByName(QuarkusGenerateCode.QUARKUS_TEST_GENERATED_SOURCES);
-                addCodeGenSourceDirs(task, generatedSourceSet);
+                addCodeGenSourceDirs(task, generatedTestSourceSet);
                 task.dependsOn(quarkusGenerateCodeTests);
-                if (tasks.contains(new NamedImpl(generatedSourceSet.getCompileJavaTaskName()))) {
-                    task.mustRunAfter(tasks.named(generatedSourceSet.getCompileJavaTaskName()));
+                if (tasks.contains(new NamedImpl(generatedTestSourceSet.getCompileJavaTaskName()))) {
+                    task.mustRunAfter(tasks.named(generatedTestSourceSet.getCompileJavaTaskName()));
                 }
-                final String generatedSourcesCompileTaskName = generatedSourceSet.getCompileTaskName("kotlin");
+                final String generatedSourcesCompileTaskName = generatedTestSourceSet.getCompileTaskName("kotlin");
                 if (tasks.contains(new NamedImpl(generatedSourcesCompileTaskName))) {
                     task.mustRunAfter(tasks.named(generatedSourcesCompileTaskName));
                 }
+            });
+            // kapt stub tasks don't inherit the source dirs injected into compileKotlin, so wire them explicitly.
+            // TODO: perhaps we should prioritize IDE devX and proper wiring into the main SS, and invert
+            //  the handling here: kapt should be the base case, and KSP should be the edge-case.
+            //  See issues [1] and [2] for full context.
+            //  * [1] https://github.com/quarkusio/quarkus/issues/29698
+            //  * [2] https://github.com/quarkusio/quarkus/issues/50486
+            project.getPlugins().withId("org.jetbrains.kotlin.kapt", kaptPlugin -> {
+                tasks.matching(t -> t.getName().equals("kaptGenerateStubsKotlin")).configureEach(task -> {
+                    addCodeGenSourceDirs(task, generatedSourceSet);
+                    task.dependsOn(quarkusGenerateCode);
+                });
+                tasks.matching(t -> t.getName().equals("kaptGenerateStubsTestKotlin")).configureEach(task -> {
+                    addCodeGenSourceDirs(task, generatedTestSourceSet);
+                    task.dependsOn(quarkusGenerateCodeTests);
+                });
             });
         });
     }

--- a/integration-tests/gradle/src/main/resources/kotlin-kapt-grpc-mapstruct/build.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/kotlin-kapt-grpc-mapstruct/build.gradle.kts
@@ -1,0 +1,46 @@
+plugins {
+    kotlin("jvm")
+    kotlin("plugin.allopen")
+    id("io.quarkus")
+    kotlin("kapt")
+}
+
+repositories {
+    mavenLocal {
+        content {
+            includeGroupByRegex("io.quarkus.*")
+            includeGroup("org.hibernate.orm")
+        }
+    }
+    mavenCentral()
+}
+
+val quarkusPlatformGroupId: String by project
+val quarkusPlatformArtifactId: String by project
+val quarkusPlatformVersion: String by project
+val mapstructVersion: String by project
+
+dependencies {
+    implementation(enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}"))
+    implementation("io.quarkus:quarkus-kotlin")
+    implementation("io.quarkus:quarkus-arc")
+    implementation("io.quarkus:quarkus-grpc")
+    implementation("com.google.protobuf:protobuf-kotlin")
+    implementation("org.mapstruct:mapstruct:${mapstructVersion}")
+    kapt("org.mapstruct:mapstruct-processor:${mapstructVersion}")
+}
+
+group = "org.acme"
+version = "1.0.0-SNAPSHOT"
+
+allOpen {
+    annotation("jakarta.ws.rs.Path")
+    annotation("jakarta.enterprise.context.ApplicationScoped")
+    annotation("io.quarkus.test.junit.QuarkusTest")
+}
+
+kotlin {
+    compilerOptions {
+        javaParameters = true
+    }
+}

--- a/integration-tests/gradle/src/main/resources/kotlin-kapt-grpc-mapstruct/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/kotlin-kapt-grpc-mapstruct/gradle.properties
@@ -1,0 +1,5 @@
+quarkusPluginId=io.quarkus
+quarkusPlatformGroupId=io.quarkus
+quarkusPlatformArtifactId=quarkus-bom
+kotlinVersion=${kotlin.version}
+mapstructVersion=${mapstruct.version}

--- a/integration-tests/gradle/src/main/resources/kotlin-kapt-grpc-mapstruct/settings.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/kotlin-kapt-grpc-mapstruct/settings.gradle.kts
@@ -1,0 +1,22 @@
+pluginManagement {
+    val quarkusPluginVersion: String by settings
+    val quarkusPluginId: String by settings
+    val kotlinVersion: String by settings
+    repositories {
+        mavenLocal {
+            content {
+                includeGroupByRegex("io.quarkus.*")
+                includeGroup("org.hibernate.orm")
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+        id(quarkusPluginId) version quarkusPluginVersion
+        kotlin("jvm") version kotlinVersion
+        kotlin("plugin.allopen") version kotlinVersion
+        kotlin("kapt") version kotlinVersion
+    }
+}
+rootProject.name = "kotlin-kapt-grpc-mapstruct"

--- a/integration-tests/gradle/src/main/resources/kotlin-kapt-grpc-mapstruct/src/main/kotlin/org/acme/DemoMapper.kt
+++ b/integration-tests/gradle/src/main/resources/kotlin-kapt-grpc-mapstruct/src/main/kotlin/org/acme/DemoMapper.kt
@@ -1,0 +1,9 @@
+package org.acme
+
+import org.acme.HelloWorldProto
+import org.mapstruct.Mapper
+
+@Mapper
+interface DemoMapper {
+    fun map(request: HelloWorldProto.HelloRequest): HelloRequestModel
+}

--- a/integration-tests/gradle/src/main/resources/kotlin-kapt-grpc-mapstruct/src/main/kotlin/org/acme/HelloRequestModel.kt
+++ b/integration-tests/gradle/src/main/resources/kotlin-kapt-grpc-mapstruct/src/main/kotlin/org/acme/HelloRequestModel.kt
@@ -1,0 +1,3 @@
+package org.acme
+
+data class HelloRequestModel(val name: String)

--- a/integration-tests/gradle/src/main/resources/kotlin-kapt-grpc-mapstruct/src/main/proto/helloworld.proto
+++ b/integration-tests/gradle/src/main/resources/kotlin-kapt-grpc-mapstruct/src/main/proto/helloworld.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+option java_package = "org.acme";
+option java_outer_classname = "HelloWorldProto";
+
+service Greeter {
+  rpc SayHello (HelloRequest) returns (HelloReply) {}
+}
+
+message HelloRequest {
+  string name = 1;
+}
+
+message HelloReply {
+  string message = 1;
+}

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/KaptGrpcMapStructTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/KaptGrpcMapStructTest.java
@@ -1,0 +1,19 @@
+package io.quarkus.gradle;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that kapt annotation processors (e.g. MapStruct) can resolve types from Quarkus-generated
+ * sources (e.g. gRPC stubs). Previously, kaptGenerateStubsKotlin did not inherit the codegen source
+ * dirs injected into compileKotlin, causing MapStruct to fail with an unresolved type error.
+ */
+public class KaptGrpcMapStructTest extends QuarkusGradleWrapperTestBase {
+
+    @Test
+    public void testKaptWithGrpcAndMapStruct() throws Exception {
+        final File projectDir = getProjectDir("kotlin-kapt-grpc-mapstruct");
+        runGradleWrapper(projectDir, "clean", "build");
+    }
+}


### PR DESCRIPTION
Since the generated sources are no longer registered as input dirs for main source set, annotation processing (in this case, mapstruct via kapt) couldn't see those sources. This led to compilation failures.

This is not a legitimate fix, rather a band-aid.

Addresses #50486.