### PR TITLE
Fix: correct kafka schema registry placeholder text

### DIFF
--- a/extensions/kafka-client/deployment/src/main/resources/dev-ui/i18n/en.js
+++ b/extensions/kafka-client/deployment/src/main/resources/dev-ui/i18n/en.js
@@ -65,6 +65,5 @@ export const templates = {
     'quarkus-kafka-client-principal': 'Principal',
     'quarkus-kafka-client-permission': 'Permission',
     'quarkus-kafka-client-resource-pattern': 'Resource Pattern',
-    'quarkus-kafka-client-schema-registry-todo': 'TODO: Scheme Registry'
+    'quarkus-kafka-client-schema-registry-todo': 'TODO: Schema Registry'
 };
-

--- a/extensions/kafka-client/deployment/src/main/resources/dev-ui/qwc-kafka-schema-registry.js
+++ b/extensions/kafka-client/deployment/src/main/resources/dev-ui/qwc-kafka-schema-registry.js
@@ -2,9 +2,9 @@ import { LitElement, html, css} from 'lit';
 import { msg, updateWhenLocaleChanges } from 'localization';
 
 /**
- * This component shows the Kafka Scheme Registry
+ * This component shows the Kafka Schema Registry
  */
-export class QwcKafkaSchemeRegistry extends LitElement { 
+export class QwcKafkaSchemaRegistry extends LitElement { 
 
     static styles = css``;
 
@@ -18,8 +18,8 @@ export class QwcKafkaSchemeRegistry extends LitElement {
     }
 
     render() { 
-        return html`<span>${msg('TODO: Scheme Registry', { id: 'quarkus-kafka-client-schema-registry-todo' })}</span>`;
+        return html`<span>${msg('TODO: Schema Registry', { id: 'quarkus-kafka-client-schema-registry-todo' })}</span>`;
     }
 }
 
-customElements.define('qwc-kafka-schema-registry', QwcKafkaSchemeRegistry);
+customElements.define('qwc-kafka-schema-registry', QwcKafkaSchemaRegistry);


### PR DESCRIPTION

**Repo:** quarkusio/quarkus (⭐ 13000)
**Type:** bugfix
**Files changed:** 2
**Lines:** +5/-6

## What
This change fixes a user-visible typo in the Kafka Dev UI schema registry placeholder and aligns the component's internal class name and comment with the existing `schema-registry` terminology. The patch updates the English localization entry and the corresponding Lit component so the Dev UI consistently refers to the feature as "Schema Registry".

## Why
The current Dev UI uses the incorrect term "Scheme Registry", which is visible to users and also leaks into the component source. Correcting the terminology improves the polish of the Kafka extension UI and removes an unnecessary inconsistency in a narrowly scoped way.

## Testing
Verified the final diff locally with `git diff` and `rg` to confirm the outdated `Scheme Registry` string and the old `QwcKafkaSchemeRegistry` identifier no longer appear in the Kafka Dev UI resources. No automated tests were run because this is a small static UI text cleanup.

## Risk
Low / String-only and internal identifier cleanup in a single Dev UI component with no behavioral logic changes.
