### PR TITLE
Tree-shake the CLI

### DIFF
--- a/devtools/cli/pom.xml
+++ b/devtools/cli/pom.xml
@@ -12,6 +12,7 @@
 
     <properties>
         <quarkus.package.jar.type>uber-jar</quarkus.package.jar.type>
+        <quarkus.package.jar.tree-shake.mode>classes</quarkus.package.jar.tree-shake.mode>
     </properties>
 
     <artifactId>quarkus-cli</artifactId>


### PR DESCRIPTION
Remove not used classes from the CLI.
```
[INFO] [io.quarkus.deployment.pkg.steps.JarTreeShaker] Tree-shaking removed 4575 unreachable classes from 89 dependencies, saving 13.5 MB (35.0%)
```
