### PR TITLE
Add SkillProcessor to compose extension skill MCP resources with categories

### DIFF
--- a/docs/src/main/asciidoc/dev-mcp.adoc
+++ b/docs/src/main/asciidoc/dev-mcp.adoc
@@ -143,11 +143,67 @@ public class ConfigurationProcessor {
 
 The annotation is repeatable — add one per tool on the same class. This is the deployment-classpath counterpart of `@JsonRpcDescription` + `@DevMCPEnableByDefault` used on runtime methods.
 
+By default this resource will be disabled, and the user has to enable it in Dev UI. You can change this default by adding `.enableMcpFunctionByDefault()` in the builder method.
+
+=== Extension skills
+
+Extensions can ship a `quarkus-skill.md` file to provide AI coding agents with extension-specific coding guidelines, testing patterns, and common pitfalls. At build time, these skill files are automatically combined with the extension's metadata (name, description, guide URL) and configuration properties to produce a rich MCP resource.
+
+==== Adding a skill file to your extension
+
+Place a `quarkus-skill.md` file in your extension's deployment module at:
+
+[source]
+----
+my-extension/deployment/src/main/resources/META-INF/quarkus-skill.md
+----
+
+The file should contain concise, actionable Markdown content. Focus on what an AI agent needs to know to use your extension correctly:
+
+- **Key patterns** — how to use the main APIs, annotations, and CDI beans.
+- **Testing** — how to write tests using `@QuarkusTest`, Dev Services, and extension-specific test utilities.
+- **Common pitfalls** — mistakes that agents (and developers) frequently make.
+
+Example for a hypothetical extension:
+
+[source,markdown]
+----
+### Data Access
+
+- Inject `MyClient` with `@Inject` — it is an `@ApplicationScoped` CDI bean.
+- Use `client.query("...")` for read operations.
+- Always wrap write operations in `@Transactional`.
+
+### Testing
+
+- Use `@QuarkusTest` — Dev Services starts a backing service automatically.
+- Inject `MyClient` in tests for direct assertions.
+
+### Common Pitfalls
+
+- Do NOT create `MyClient` manually with `new` — always let CDI inject it.
+- Do NOT set the connection URL without a `%prod.` profile prefix — this disables Dev Services.
+----
+
+==== What gets composed
+
+The skill file content is **not** exposed as-is. At build time, the `SkillProcessor` composes a single MCP resource per extension by combining:
+
+1. **Extension metadata** — name, description, guide URL, and categories from `quarkus-extension.yaml`.
+2. **Skill content** — the `quarkus-skill.md` file authored by the extension developer.
+3. **Configuration reference** — all configuration properties matching the extension's `config` prefixes (from `quarkus-extension.yaml`), with types, defaults, and descriptions.
+
+The composed resource is exposed as a Dev MCP resource with `text/markdown` MIME type and is enabled by default.
+
 ==== What NOT to put in the skill file
 
-- **Extension description or guide links** — these are automatically added from `quarkus-extension.yaml`.
-- **Configuration properties** — reference the guide instead. A link is auto-generated.
+- **Configuration properties** — these are auto-included from the config metadata. Do not duplicate them.
+- **Extension description or guide links** — these come from `quarkus-extension.yaml`.
 - **Obvious instructions** — focus on Quarkus-specific patterns and gotchas, not generic advice.
+
+==== Requirements
+
+The skill file is only picked up if your extension's `quarkus-extension.yaml` contains a `name` field. Extensions without a name (internal extensions) are skipped.
 
 === MCP tools
 

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/SkillProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/SkillProcessor.java
@@ -1,0 +1,438 @@
+package io.quarkus.devui.deployment;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Scanner;
+import java.util.Set;
+
+import org.jboss.logging.Logger;
+import org.yaml.snakeyaml.Yaml;
+
+import io.quarkus.bootstrap.BootstrapConstants;
+import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.ConfigDescriptionBuildItem;
+import io.quarkus.deployment.pkg.builditem.BuildSystemTargetBuildItem;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.devui.spi.buildtime.BuildTimeData;
+import io.quarkus.maven.dependency.DependencyFlags;
+import io.quarkus.maven.dependency.ResolvedDependency;
+
+/**
+ * Scans active extensions for {@code META-INF/quarkus-skill.md} files and composes
+ * MCP resources that combine the skill content with extension metadata and configuration
+ * properties.
+ * <p>
+ * Additionally, writes composed skills as Agent Skills spec-compliant {@code SKILL.md} files
+ * to the project's {@code .agents/skills/} directory so that any compatible AI coding agent
+ * (Claude Code, Cursor, Copilot, etc.) can discover them via filesystem scanning.
+ * <p>
+ * This enables AI coding agents to receive extension-specific coding guidelines, testing
+ * patterns, and configuration reference in a single resource.
+ */
+public class SkillProcessor {
+
+    private static final Logger log = Logger.getLogger(SkillProcessor.class);
+
+    private static final String SKILL_PATH = "META-INF/quarkus-skill.md";
+    private static final String SKILLS_NAMESPACE_PREFIX = "skills-";
+    private static final String AGENTS_SKILLS_DIR = ".agents/skills";
+    private static final String QUARKUS_SKILL_PREFIX = "io-quarkus-";
+
+    @BuildStep(onlyIf = IsDevelopment.class)
+    void collectExtensionSkills(
+            CurateOutcomeBuildItem curateOutcomeBuildItem,
+            BuildSystemTargetBuildItem buildSystemTarget,
+            List<ConfigDescriptionBuildItem> configDescriptionBuildItems,
+            BuildProducer<BuildTimeConstBuildItem> buildTimeConstProducer) {
+
+        Yaml yaml = new Yaml();
+        // Group skill data by groupId so MCP resource names become: skills-<groupId>_<artifactId>
+        Map<String, Map<String, BuildTimeData>> skillDataByGroup = new HashMap<>();
+        Map<String, String> agentSkills = new HashMap<>();
+
+        // Build a lookup of deployment dependencies so we can find skill files in deployment jars
+        Map<String, ResolvedDependency> deploymentDeps = new HashMap<>();
+        for (ResolvedDependency dep : curateOutcomeBuildItem.getApplicationModel()
+                .getDependencies(DependencyFlags.DEPLOYMENT_CP)) {
+            deploymentDeps.put(dep.getGroupId() + ":" + dep.getArtifactId(), dep);
+        }
+
+        for (ResolvedDependency runtimeExt : curateOutcomeBuildItem.getApplicationModel()
+                .getDependencies(DependencyFlags.RUNTIME_EXTENSION_ARTIFACT)) {
+
+            // Read extension metadata
+            ExtensionInfo extInfo = readExtensionMetadata(runtimeExt, yaml);
+            if (extInfo == null) {
+                continue;
+            }
+
+            // Read skill file from the deployment artifact, falling back to the runtime artifact
+            String deploymentKey = runtimeExt.getGroupId() + ":" + runtimeExt.getArtifactId() + "-deployment";
+            ResolvedDependency deploymentDep = deploymentDeps.get(deploymentKey);
+            String skillContent = deploymentDep != null ? readSkillFile(deploymentDep) : null;
+            if (skillContent == null) {
+                skillContent = readSkillFile(runtimeExt);
+            }
+            if (skillContent == null) {
+                continue;
+            }
+
+            // Gather config properties for this extension
+            List<ConfigDescriptionBuildItem> extensionConfigs = filterConfigsForExtension(
+                    configDescriptionBuildItems, extInfo.configPrefixes);
+
+            // Compose the full skill resource
+            String composed = composeSkillResource(extInfo, skillContent, extensionConfigs);
+
+            String namespace = toSkillNamespace(runtimeExt);
+            String resourceName = toSkillResourceName(runtimeExt);
+            skillDataByGroup
+                    .computeIfAbsent(namespace, k -> new HashMap<>())
+                    .put(resourceName, new BuildTimeData(
+                            composed,
+                            "Coding skill and guidelines for " + extInfo.name
+                                    + ". Contains patterns, testing guidelines, and configuration reference.",
+                            true,
+                            "text/markdown"));
+
+            // Also prepare for .agents/skills/ output
+            String agentSkillName = toAgentSkillName(runtimeExt);
+            String agentSkillContent = composeAgentSkillFile(agentSkillName, extInfo, composed);
+            agentSkills.put(agentSkillName, agentSkillContent);
+
+            log.debugf("Registered skill resource for extension: %s", extInfo.name);
+        }
+
+        for (Map.Entry<String, Map<String, BuildTimeData>> entry : skillDataByGroup.entrySet()) {
+            buildTimeConstProducer.produce(new BuildTimeConstBuildItem(entry.getKey(), entry.getValue()));
+        }
+
+        // Write .agents/skills/ files (including base Quarkus skill)
+        Path projectRoot = buildSystemTarget.getOutputDirectory().getParent();
+        if (projectRoot != null && Files.exists(projectRoot)) {
+            agentSkills.put("quarkus", composeBaseQuarkusSkill());
+            writeAgentSkills(projectRoot, agentSkills);
+        }
+    }
+
+    private ExtensionInfo readExtensionMetadata(ResolvedDependency runtimeExt, Yaml yaml) {
+        ExtensionInfo[] result = new ExtensionInfo[1];
+        runtimeExt.getContentTree().accept(BootstrapConstants.EXTENSION_METADATA_PATH, visit -> {
+            if (visit == null) {
+                return;
+            }
+            try {
+                String content;
+                try (Scanner scanner = new Scanner(Files.newBufferedReader(visit.getPath(), StandardCharsets.UTF_8))) {
+                    scanner.useDelimiter("\\A");
+                    content = scanner.hasNext() ? scanner.next() : null;
+                }
+                if (content == null) {
+                    return;
+                }
+                Map<String, Object> extMap = yaml.load(content);
+                if (extMap == null || !extMap.containsKey("name")) {
+                    return;
+                }
+
+                ExtensionInfo info = new ExtensionInfo();
+                info.name = (String) extMap.get("name");
+                info.description = (String) extMap.getOrDefault("description", null);
+
+                Map<String, Object> metadata = (Map<String, Object>) extMap.getOrDefault("metadata", null);
+                if (metadata != null) {
+                    info.guide = (String) metadata.getOrDefault("guide", null);
+                    info.categories = (List<String>) metadata.getOrDefault("categories", null);
+                    info.configPrefixes = (List<String>) metadata.getOrDefault("config", null);
+                    info.quickstart = (String) metadata.getOrDefault("quickstart", null);
+                    info.keywords = (List<String>) metadata.getOrDefault("keywords", null);
+                    info.status = (String) metadata.getOrDefault("status", null);
+                }
+                result[0] = info;
+            } catch (IOException e) {
+                log.debugf("Failed to read extension metadata from %s: %s",
+                        runtimeExt.toCompactCoords(), e.getMessage());
+            }
+        });
+        return result[0];
+    }
+
+    private String readSkillFile(ResolvedDependency dependency) {
+        String[] result = new String[1];
+        dependency.getContentTree().accept(SKILL_PATH, visit -> {
+            if (visit == null) {
+                return;
+            }
+            try {
+                result[0] = Files.readString(visit.getPath(), StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                log.debugf("Failed to read skill file from %s: %s",
+                        dependency.toCompactCoords(), e.getMessage());
+            }
+        });
+        return result[0];
+    }
+
+    private List<ConfigDescriptionBuildItem> filterConfigsForExtension(
+            List<ConfigDescriptionBuildItem> allConfigs, List<String> configPrefixes) {
+        if (configPrefixes == null || configPrefixes.isEmpty()) {
+            return List.of();
+        }
+        List<ConfigDescriptionBuildItem> matched = new ArrayList<>();
+        for (ConfigDescriptionBuildItem config : allConfigs) {
+            for (String prefix : configPrefixes) {
+                if (config.getPropertyName().startsWith(prefix)) {
+                    matched.add(config);
+                    break;
+                }
+            }
+        }
+        return matched;
+    }
+
+    private String composeSkillResource(ExtensionInfo extInfo, String skillContent,
+            List<ConfigDescriptionBuildItem> configs) {
+        StringBuilder sb = new StringBuilder();
+
+        // Header with extension metadata
+        sb.append("# ").append(extInfo.name).append("\n\n");
+
+        if (extInfo.description != null && !extInfo.description.isBlank()) {
+            sb.append("> ").append(extInfo.description).append("\n");
+        }
+        if (extInfo.guide != null && !extInfo.guide.isBlank()) {
+            sb.append("> Guide: ").append(extInfo.guide).append("\n");
+        }
+        if (extInfo.quickstart != null && !extInfo.quickstart.isBlank()) {
+            sb.append("> Quickstart: https://github.com/quarkusio/quarkus-quickstarts/tree/development/")
+                    .append(extInfo.quickstart).append("\n");
+        }
+        if (extInfo.categories != null && !extInfo.categories.isEmpty()) {
+            sb.append("> Categories: ").append(String.join(", ", extInfo.categories)).append("\n");
+        }
+        sb.append("\n");
+
+        // Skill content (the extension-authored guidelines)
+        sb.append("## Patterns and Guidelines\n\n");
+        sb.append(skillContent.trim()).append("\n\n");
+
+        // Configuration reference
+        if (!configs.isEmpty()) {
+            sb.append("## Configuration Reference\n\n");
+            sb.append("| Property | Type | Default | Description |\n");
+            sb.append("|----------|------|---------|-------------|\n");
+
+            // Sort by property name for readability
+            configs.stream()
+                    .sorted(Comparator.comparing(ConfigDescriptionBuildItem::getPropertyName))
+                    .forEach(config -> {
+                        String name = escapeMarkdownPipe(config.getPropertyName());
+                        String type = config.getValueTypeName() != null
+                                ? escapeMarkdownPipe(simplifyTypeName(config.getValueTypeName()))
+                                : "";
+                        String defaultVal = config.getDefaultValue() != null
+                                ? escapeMarkdownPipe(config.getDefaultValue())
+                                : "";
+                        String docs = config.getDocs() != null
+                                ? escapeMarkdownPipe(truncateDescription(config.getDocs()))
+                                : "";
+                        sb.append("| `").append(name).append("` | ").append(type)
+                                .append(" | ").append(defaultVal)
+                                .append(" | ").append(docs).append(" |\n");
+                    });
+        }
+
+        return sb.toString();
+    }
+
+    // --- Agent Skills spec (.agents/skills/) support ---
+
+    /**
+     * Derives an Agent Skills spec-compliant name from the dependency's groupId and artifactId.
+     * Uses the artifact coordinates to guarantee uniqueness (extension display names can collide).
+     * The spec requires: lowercase, hyphens only, no consecutive hyphens,
+     * no leading/trailing hyphens, max 64 chars.
+     */
+    private String toAgentSkillName(ResolvedDependency dep) {
+        String raw = dep.getGroupId() + "-" + dep.getArtifactId();
+        String normalized = raw.toLowerCase()
+                .replaceAll("[^a-z0-9]+", "-")
+                .replaceAll("-{2,}", "-")
+                .replaceAll("^-|-$", "");
+        if (normalized.length() > 64) {
+            normalized = normalized.substring(0, 64).replaceAll("-$", "");
+        }
+        return normalized;
+    }
+
+    /**
+     * Composes a SKILL.md file with YAML frontmatter per the Agent Skills spec.
+     */
+    private String composeAgentSkillFile(String skillName, ExtensionInfo extInfo, String composedContent) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("---\n");
+        sb.append("name: ").append(skillName).append("\n");
+        sb.append("description: >-\n  Coding patterns, testing guidelines, and configuration reference for the ")
+                .append(extInfo.name).append(" Quarkus extension.\n");
+        if (extInfo.categories != null && !extInfo.categories.isEmpty()) {
+            sb.append("categories: \"").append(String.join(", ", extInfo.categories)).append("\"\n");
+        }
+        if ((extInfo.guide != null && !extInfo.guide.isBlank())
+                || (extInfo.quickstart != null && !extInfo.quickstart.isBlank())) {
+            sb.append("metadata:\n");
+            if (extInfo.guide != null && !extInfo.guide.isBlank()) {
+                sb.append("  guide: \"").append(extInfo.guide).append("\"\n");
+            }
+            if (extInfo.quickstart != null && !extInfo.quickstart.isBlank()) {
+                sb.append("  quickstart: \"https://github.com/quarkusio/quarkus-quickstarts/tree/development/")
+                        .append(extInfo.quickstart).append("\"\n");
+            }
+        }
+        sb.append("---\n\n");
+        sb.append(composedContent);
+        return sb.toString();
+    }
+
+    private static final String BASE_SKILL_RESOURCE = "META-INF/quarkus-base-skill.md";
+
+    /**
+     * Reads the base Quarkus skill from a resource file.
+     * This covers fundamentals applicable to all Quarkus projects.
+     */
+    private String composeBaseQuarkusSkill() {
+        try (InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(BASE_SKILL_RESOURCE)) {
+            if (is != null) {
+                return new String(is.readAllBytes(), StandardCharsets.UTF_8);
+            }
+        } catch (IOException e) {
+            log.warnf("Failed to read base skill resource %s: %s", BASE_SKILL_RESOURCE, e.getMessage());
+        }
+        log.warn("Base Quarkus skill resource not found: " + BASE_SKILL_RESOURCE);
+        return "";
+    }
+
+    /**
+     * Writes Agent Skills spec-compliant SKILL.md files to the project's .agents/skills/ directory.
+     * Cleans up previously generated Quarkus skill directories that are no longer needed.
+     */
+    private void writeAgentSkills(Path projectRoot, Map<String, String> skills) {
+        Path skillsDir = projectRoot.resolve(AGENTS_SKILLS_DIR);
+
+        try {
+            // Clean up old Quarkus-generated skills
+            Set<String> currentSkillNames = new HashSet<>(skills.keySet());
+            if (Files.isDirectory(skillsDir)) {
+                try (DirectoryStream<Path> stream = Files.newDirectoryStream(skillsDir, QUARKUS_SKILL_PREFIX + "*")) {
+                    for (Path dir : stream) {
+                        if (Files.isDirectory(dir) && !currentSkillNames.contains(dir.getFileName().toString())) {
+                            // This skill was generated before but the extension is no longer present
+                            Path skillFile = dir.resolve("SKILL.md");
+                            Files.deleteIfExists(skillFile);
+                            Files.deleteIfExists(dir);
+                            log.debugf("Removed stale agent skill: %s", dir.getFileName());
+                        }
+                    }
+                }
+            }
+
+            // Write current skills
+            for (Map.Entry<String, String> entry : skills.entrySet()) {
+                Path skillDir = skillsDir.resolve(entry.getKey());
+                Files.createDirectories(skillDir);
+                Path skillFile = skillDir.resolve("SKILL.md");
+                Files.writeString(skillFile, entry.getValue(), StandardCharsets.UTF_8);
+            }
+
+            log.debugf("Wrote %d agent skills to %s", skills.size(), skillsDir);
+        } catch (IOException e) {
+            log.warnf("Failed to write agent skills to %s: %s", skillsDir, e.getMessage());
+        }
+    }
+
+    // --- Utility methods ---
+
+    /**
+     * Derives the MCP namespace from the groupId, e.g. "io.quarkus" becomes "skills-io-quarkus".
+     */
+    private String toSkillNamespace(ResolvedDependency dep) {
+        String groupIdHyphenated = dep.getGroupId().replace('.', '-');
+        return SKILLS_NAMESPACE_PREFIX + groupIdHyphenated;
+    }
+
+    /**
+     * Derives the MCP resource key from the artifactId in camelCase.
+     * The build-time data system uses {@code namespace_constname} format with underscore
+     * as separator, so const names must not contain underscores or hyphens.
+     */
+    private String toSkillResourceName(ResolvedDependency dep) {
+        String[] words = dep.getArtifactId().toLowerCase().split("[^a-z0-9]+");
+        StringBuilder sb = new StringBuilder();
+        for (String word : words) {
+            if (word.isEmpty()) {
+                continue;
+            }
+            if (sb.isEmpty()) {
+                sb.append(word);
+            } else {
+                sb.append(Character.toUpperCase(word.charAt(0)));
+                if (word.length() > 1) {
+                    sb.append(word.substring(1));
+                }
+            }
+        }
+        return sb.toString();
+    }
+
+    private String simplifyTypeName(String typeName) {
+        if (typeName == null) {
+            return "";
+        }
+        // Strip java.lang. and java.util. prefixes for readability
+        return typeName
+                .replace("java.lang.", "")
+                .replace("java.util.", "")
+                .replace("java.time.", "");
+    }
+
+    private String escapeMarkdownPipe(String text) {
+        if (text == null) {
+            return "";
+        }
+        return text.replace("|", "\\|").replace("\n", " ").replace("\r", "");
+    }
+
+    private String truncateDescription(String docs) {
+        if (docs == null) {
+            return "";
+        }
+        // Strip HTML tags and truncate for table readability
+        String clean = docs.replaceAll("<[^>]+>", "").trim();
+        if (clean.length() > 200) {
+            return clean.substring(0, 197) + "...";
+        }
+        return clean;
+    }
+
+    private static class ExtensionInfo {
+        String name;
+        String description;
+        String guide;
+        String quickstart;
+        List<String> categories;
+        List<String> configPrefixes;
+        List<String> keywords;
+        String status;
+    }
+}

--- a/extensions/devui/deployment/src/main/resources/META-INF/quarkus-base-skill.md
+++ b/extensions/devui/deployment/src/main/resources/META-INF/quarkus-base-skill.md
@@ -1,0 +1,75 @@
+---
+name: quarkus
+description: >-
+  Core Quarkus development patterns, project structure, configuration, testing,
+  and dev mode. Use this skill when working on any Quarkus application.
+metadata:
+  guide: "https://quarkus.io/guides/"
+---
+
+# Quarkus
+
+> Quarkus is a Kubernetes-native Java framework tailored for GraalVM and HotSpot.
+> Guide: https://quarkus.io/guides/
+
+## Project Structure
+
+- `src/main/java/` — application code.
+- `src/main/resources/application.properties` — configuration.
+- `src/main/resources/META-INF/resources/` — static web resources.
+- `src/test/java/` — tests.
+
+## Dev Mode
+
+- Run with `./mvnw quarkus:dev` (Maven) or `./gradlew quarkusDev` (Gradle).
+- **Hot reload**: code changes are picked up automatically on the next request — do NOT restart.
+- **Continuous testing**: tests run automatically when code changes. Press `r` in the console to re-run.
+- **Dev UI**: available at `/q/dev-ui` — browse extensions, configuration, and tools.
+- **Dev Services**: backing services (databases, message brokers, etc.) are started automatically as containers.
+
+## Configuration
+
+- Use `application.properties` for configuration.
+- Profile-specific config: prefix with `%dev.`, `%test.`, or `%prod.`.
+- Environment variables: `QUARKUS_HTTP_PORT=9090` maps to `quarkus.http.port`.
+- Use `@ConfigProperty(name = "my.prop")` to inject config values into beans.
+- Use `@ConfigMapping` for type-safe config groups.
+
+## CDI (Dependency Injection)
+
+- Quarkus uses ArC, a build-time CDI implementation.
+- Annotate classes with `@ApplicationScoped`, `@RequestScoped`, or `@Singleton` to make them CDI beans.
+- Inject with `@Inject` on fields or constructors.
+- Use `@Produces` methods for beans needing custom initialization.
+- Beans are discovered at build time — unscoped classes are NOT beans.
+
+## REST Endpoints
+
+- Use Jakarta REST annotations: `@Path`, `@GET`, `@POST`, `@PUT`, `@DELETE`.
+- Return POJOs — Jackson serialization is automatic with `quarkus-rest-jackson`.
+- Use `@Valid` with Hibernate Validator for input validation.
+- Inject services with `@Inject`.
+
+## Testing
+
+- Use `@QuarkusTest` for integration tests — starts the full application.
+- Use REST Assured for HTTP endpoint testing (pre-configured with the test port).
+- Use `@QuarkusComponentTest` for lightweight CDI-only tests.
+- Use `@InjectMock` to mock CDI beans in tests.
+- Use `@TestTransaction` to auto-rollback database changes.
+- Dev Services provide test databases, message brokers, etc. automatically — no manual setup.
+- ALWAYS write tests for every feature.
+
+## Building
+
+- `./mvnw package` — build a JAR (fast-jar format).
+- `./mvnw package -Dnative` — build a native executable (requires GraalVM or container build).
+- The app runs from `target/quarkus-app/quarkus-run.jar`.
+
+## Common Pitfalls
+
+- Do NOT use `new` to create CDI beans — always inject them.
+- Do NOT set `quarkus.datasource.jdbc.url` without a profile prefix — this disables Dev Services.
+- Do NOT restart dev mode after code changes — hot reload handles it.
+- Do NOT skip writing tests — use `@QuarkusTest` for every feature.
+- Prefer Quarkus extensions over manual library integration — extensions are optimized for build-time processing and native image.

--- a/extensions/devui/deployment/src/test/java/io/quarkus/devui/devmcp/SkillResourceTest.java
+++ b/extensions/devui/deployment/src/test/java/io/quarkus/devui/devmcp/SkillResourceTest.java
@@ -1,0 +1,205 @@
+package io.quarkus.devui.devmcp;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.startsWith;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Comparator;
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.devui.testrunner.HelloResource;
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.ValidatableResponse;
+
+/**
+ * Tests that extension skill resources (from {@code META-INF/quarkus-skill.md} files)
+ * are correctly composed and exposed via the Dev MCP server.
+ */
+public class SkillResourceTest {
+
+    private static Path TEMP_HOME;
+    private static String OLD_USER_HOME;
+
+    @RegisterExtension
+    static final QuarkusDevModeTest test = createDevModeTest();
+
+    private static QuarkusDevModeTest createDevModeTest() {
+        try {
+            TEMP_HOME = Files.createTempDirectory("devmcp-skill-test-");
+            Path quarkusDir = TEMP_HOME.resolve(".quarkus");
+            Files.createDirectories(quarkusDir);
+            Path props = quarkusDir.resolve("dev-mcp.properties");
+            Files.writeString(props, "enabled=true\n",
+                    StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+
+            OLD_USER_HOME = System.getProperty("user.home");
+            System.setProperty("user.home", TEMP_HOME.toString());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to set up Dev MCP test HOME", e);
+        }
+
+        return new QuarkusDevModeTest()
+                .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                        .addClasses(HelloResource.class));
+    }
+
+    @AfterAll
+    static void cleanupHome() {
+        if (OLD_USER_HOME != null) {
+            System.setProperty("user.home", OLD_USER_HOME);
+        }
+        if (TEMP_HOME != null) {
+            try {
+                Files.walk(TEMP_HOME)
+                        .sorted(Comparator.reverseOrder())
+                        .forEach(p -> {
+                            try {
+                                Files.deleteIfExists(p);
+                            } catch (IOException ignored) {
+                            }
+                        });
+            } catch (IOException ignored) {
+            }
+        }
+    }
+
+    @Test
+    public void testSkillResourcesAppearInList() {
+        // ArC is always on the classpath and has a quarkus-skill.md file,
+        // so we should see at least one skills- resource
+        String jsonBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 1,
+                      "method": "resources/list"
+                    }
+                """;
+
+        ValidatableResponse response = RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .body(jsonBody)
+                .when()
+                .post("/q/dev-mcp")
+                .then()
+                .statusCode(200)
+                .body("id", equalTo(1))
+                .body("result.resources.name", hasItem(startsWith("skills-")));
+
+        // Verify the skill resource has a description
+        List<String> descriptions = response.extract()
+                .jsonPath()
+                .getList("result.resources.findAll { it.name.startsWith('skills-') }.description");
+        org.junit.jupiter.api.Assertions.assertFalse(descriptions.isEmpty(),
+                "Should have at least one skill resource");
+        for (String desc : descriptions) {
+            org.junit.jupiter.api.Assertions.assertTrue(
+                    desc.contains("Coding skill and guidelines"),
+                    "Skill resource description should contain 'Coding skill and guidelines', got: " + desc);
+        }
+    }
+
+    @Test
+    public void testSkillResourceCanBeRead() {
+        // First, find a skill resource URI
+        String listBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 2,
+                      "method": "resources/list"
+                    }
+                """;
+
+        String skillUri = RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .body(listBody)
+                .when()
+                .post("/q/dev-mcp")
+                .then()
+                .statusCode(200)
+                .extract()
+                .jsonPath()
+                .getString("result.resources.find { it.name.startsWith('skills-') }.uri");
+
+        org.junit.jupiter.api.Assertions.assertNotNull(skillUri,
+                "Should find at least one skill resource URI");
+
+        // Now read the skill resource
+        String readBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 3,
+                      "method": "resources/read",
+                      "params": {
+                           "uri": "%s"
+                      }
+                    }
+                """.formatted(skillUri);
+
+        String content = RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .body(readBody)
+                .when()
+                .post("/q/dev-mcp")
+                .then()
+                .statusCode(200)
+                .body("id", equalTo(3))
+                .body("result.contents", notNullValue())
+                .body("result.contents", hasSize(1))
+                .body("result.contents[0].uri", equalTo(skillUri))
+                .extract()
+                .jsonPath()
+                .getString("result.contents[0].text");
+
+        org.junit.jupiter.api.Assertions.assertNotNull(content, "Skill resource content should not be null");
+
+        // The composed content should contain the extension name as a header
+        // and the "Patterns and Guidelines" section from the skill file
+        org.junit.jupiter.api.Assertions.assertTrue(
+                content.contains("Patterns and Guidelines"),
+                "Skill content should contain 'Patterns and Guidelines' section, got: "
+                        + content.substring(0, Math.min(200, content.length())));
+    }
+
+    @Test
+    public void testSkillResourceHasMarkdownMimeType() {
+        String listBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 4,
+                      "method": "resources/list"
+                    }
+                """;
+
+        String mimeType = RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .body(listBody)
+                .when()
+                .post("/q/dev-mcp")
+                .then()
+                .statusCode(200)
+                .extract()
+                .jsonPath()
+                .getString("result.resources.find { it.name.startsWith('skills-') }.mimeType");
+
+        org.junit.jupiter.api.Assertions.assertEquals("text/markdown", mimeType,
+                "Skill resources should have text/markdown MIME type");
+    }
+}


### PR DESCRIPTION
Adds the `SkillProcessor` build step that reads `quarkus-skill.md` files from extension deployment modules, combines them with extension metadata (name, description, guide URL, categories) from `quarkus-extension.yaml`, and exposes them as Dev MCP resources.

Categories from extension metadata are written into the SKILL.md frontmatter so the [quarkus-agent-mcp](https://github.com/quarkusio/quarkus-agent-mcp) server can group skills by category (see [quarkus-agent-mcp#65](https://github.com/quarkusio/quarkus-agent-mcp/pull/65)).

This PR only adds the infrastructure — individual `quarkus-skill.md` files should be added by extension owners.