### PR TITLE
Include extension categories in composed skill frontmatter

### DIFF
--- a/docs/src/main/asciidoc/dev-mcp.adoc
+++ b/docs/src/main/asciidoc/dev-mcp.adoc
@@ -37,7 +37,7 @@ A single JSON‑RPC service can be used for both Dev UI and Dev MCP; methods wit
 
 === Extension skills
 
-Extensions can ship a `quarkus-skill.md` file to provide AI coding agents with extension-specific coding guidelines, testing patterns, and common pitfalls. During the Quarkus build, all skill files are automatically discovered, composed with extension metadata (name, description, guide URL), and aggregated into a single `io.quarkus:quarkus-extension-skills` JAR following the https://agentskills.io/specification[Agent Skills specification]. This JAR is published to Maven Central with each Quarkus release and is compatible with https://www.skillsjars.com[SkillsJars].
+Extensions can ship a `quarkus-skill.md` file to provide AI coding agents with extension-specific coding guidelines, testing patterns, and common pitfalls. During the Quarkus build, all skill files are automatically discovered, composed with extension metadata (name, description, guide URL, categories), and aggregated into a single `io.quarkus:quarkus-extension-skills` JAR following the https://agentskills.io/specification[Agent Skills specification]. This JAR is published to Maven Central with each Quarkus release and is compatible with https://www.skillsjars.com[SkillsJars].
 
 ==== Adding a skill file to your extension
 
@@ -50,7 +50,7 @@ my-extension/deployment/src/main/resources/META-INF/quarkus-skill.md
 
 That's it. No pom.xml changes are needed. The Quarkus build automatically discovers all `quarkus-skill.md` files across all extensions and aggregates them into the `quarkus-extension-skills` artifact.
 
-If your extension's runtime module has a `description` field in `META-INF/quarkus-extension.yaml`, it will be included in the composed skill's YAML frontmatter to help AI agents discover and understand your extension. While optional, providing a description is recommended:
+If your extension's runtime module has a `description` field in `META-INF/quarkus-extension.yaml`, it will be included in the composed skill's YAML frontmatter to help AI agents discover and understand your extension. The `categories` field under `metadata` is also included, allowing AI agents to group skills by category. While optional, providing a description and categories is recommended:
 
 [source,yaml]
 ----
@@ -59,6 +59,8 @@ description: "A concise description of what this extension does"
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
 metadata:
   guide: "https://quarkus.io/guides/my-extension"
+  categories:
+  - "web"
 ----
 
 The file should contain concise, actionable Markdown content. Focus on what an AI agent needs to know to use your extension correctly:
@@ -92,7 +94,7 @@ Example for a hypothetical extension:
 
 The skill file content is **not** shipped as-is. During the Quarkus build, the `aggregate-skills` goal scans the source tree for all `quarkus-skill.md` files and composes each one with extension metadata to produce a `SKILL.md` file at `META-INF/skills/{extension-name}/SKILL.md` inside the aggregated JAR. The composed document follows the https://agentskills.io/specification[Agent Skills specification] and includes:
 
-1. **YAML frontmatter** — the skill name, extension description from `quarkus-extension.yaml`, license, and guide URL as structured metadata for agent discovery.
+1. **YAML frontmatter** — the skill name, extension description from `quarkus-extension.yaml`, license, guide URL, and categories as structured metadata for agent discovery.
 2. **Skill body** — the patterns, testing guidelines, and pitfalls authored by the extension developer.
 3. **Dev MCP tools** — the skill is automatically enriched with an "Available Dev MCP Tools" section listing each MCP tool the extension enables by default, including tool names, descriptions, and parameters. Tools are discovered from runtime methods annotated with both `@JsonRpcDescription` and `@DevMCPEnableByDefault`, and from deployment processor classes annotated with `@DevMcpBuildTimeTool`.
 
@@ -106,6 +108,7 @@ description: "A brief description of the extension from quarkus-extension.yaml"
 license: Apache-2.0
 metadata:
   guide: https://quarkus.io/guides/my-extension
+  categories: "web, data"
 ---
 
 ### Data Access

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/utils/SkillComposer.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/utils/SkillComposer.java
@@ -85,9 +85,15 @@ public final class SkillComposer {
         }
 
         final String guide = getNestedTextValue(extMeta, "metadata", "guide");
-        if (guide != null && !guide.isBlank()) {
+        final String categories = getNestedArrayAsString(extMeta, "metadata", "categories");
+        if ((guide != null && !guide.isBlank()) || (categories != null && !categories.isBlank())) {
             sb.append("metadata:\n");
-            sb.append("  guide: \"").append(escapeYamlString(guide)).append("\"\n");
+            if (guide != null && !guide.isBlank()) {
+                sb.append("  guide: \"").append(escapeYamlString(guide)).append("\"\n");
+            }
+            if (categories != null && !categories.isBlank()) {
+                sb.append("  categories: \"").append(escapeYamlString(categories)).append("\"\n");
+            }
         }
 
         sb.append("---\n\n");
@@ -235,6 +241,29 @@ public final class SkillComposer {
             return null;
         }
         return getTextValue((ObjectNode) parentNode, field);
+    }
+
+    /**
+     * Extracts a nested array (e.g. {@code metadata.categories}) and joins its text
+     * elements with {@code ", "}, returning {@code null} if the path is missing or empty.
+     */
+    private static String getNestedArrayAsString(ObjectNode node, String parent, String field) {
+        var parentNode = node.get(parent);
+        if (parentNode == null || parentNode.isNull() || !parentNode.isObject()) {
+            return null;
+        }
+        var arrayNode = parentNode.get(field);
+        if (arrayNode == null || arrayNode.isNull() || !arrayNode.isArray() || arrayNode.isEmpty()) {
+            return null;
+        }
+        StringJoiner joiner = new StringJoiner(", ");
+        for (var element : arrayNode) {
+            if (element.isTextual()) {
+                joiner.add(element.asText());
+            }
+        }
+        String result = joiner.toString();
+        return result.isEmpty() ? null : result;
     }
 
     private static String escapeMarkdownTable(String text) {

--- a/independent-projects/tools/devtools-common/src/test/java/io/quarkus/devtools/utils/SkillComposerTest.java
+++ b/independent-projects/tools/devtools-common/src/test/java/io/quarkus/devtools/utils/SkillComposerTest.java
@@ -90,14 +90,59 @@ public class SkillComposerTest {
     }
 
     @Test
-    public void composeWithoutGuideOmitsMetadataBlock() throws IOException {
+    public void composeWithoutGuideOrCategoriesOmitsMetadataBlock() throws IOException {
         String yaml = "name: \"No Guide\"\ndescription: \"Something\"\n";
         ObjectNode meta = parseYaml(yaml);
 
         String result = SkillComposer.compose(meta, "body", "quarkus-noguide");
 
-        assertTrue(!result.contains("metadata:"));
-        assertTrue(!result.contains("guide:"));
+        assertFalse(result.contains("metadata:"));
+        assertFalse(result.contains("guide:"));
+        assertFalse(result.contains("categories:"));
+    }
+
+    @Test
+    public void composeWithCategoriesIncludesThem() throws IOException {
+        String yaml = "name: \"REST\"\n"
+                + "description: \"Build RESTful APIs\"\n"
+                + "metadata:\n"
+                + "  guide: https://quarkus.io/guides/rest\n"
+                + "  categories:\n"
+                + "  - \"web\"\n"
+                + "  - \"reactive\"\n";
+        ObjectNode meta = parseYaml(yaml);
+
+        String result = SkillComposer.compose(meta, "body", "quarkus-rest");
+
+        assertTrue(result.contains("metadata:\n"));
+        assertTrue(result.contains("  guide: \"https://quarkus.io/guides/rest\"\n"));
+        assertTrue(result.contains("  categories: \"web, reactive\"\n"));
+    }
+
+    @Test
+    public void composeWithCategoriesOnlyNoGuide() throws IOException {
+        String yaml = "name: \"Ext\"\n"
+                + "description: \"desc\"\n"
+                + "metadata:\n"
+                + "  categories:\n"
+                + "  - \"data\"\n";
+        ObjectNode meta = parseYaml(yaml);
+
+        String result = SkillComposer.compose(meta, "body", "quarkus-ext");
+
+        assertTrue(result.contains("metadata:\n"));
+        assertFalse(result.contains("guide:"));
+        assertTrue(result.contains("  categories: \"data\"\n"));
+    }
+
+    @Test
+    public void composeWithoutCategoriesOmitsThem() throws IOException {
+        String yaml = "name: \"No Cat\"\ndescription: \"Something\"\n";
+        ObjectNode meta = parseYaml(yaml);
+
+        String result = SkillComposer.compose(meta, "body", "quarkus-nocat");
+
+        assertFalse(result.contains("categories:"));
     }
 
     @Test


### PR DESCRIPTION
The `SkillComposer` now reads `metadata.categories` from `quarkus-extension.yaml` and writes it into the composed `SKILL.md` frontmatter as a comma-separated string under `metadata.categories`. This is the producer side for [quarkus-agent-mcp#65](https://github.com/quarkusio/quarkus-agent-mcp/pull/65), which reads these categories to group skills by category when listing them.

Extensions that already declare categories in their `quarkus-extension.yaml` (most do) will automatically get them included — no changes needed from extension owners.

Example output in composed `SKILL.md`:
```yaml
---
name: "quarkus-rest"
description: "Build RESTful APIs"
license: "Apache-2.0"
metadata:
  guide: "https://quarkus.io/guides/rest"
  categories: "web, reactive"
---
```