### PR TITLE
[4.0] Migration of quarkus-mongodb-client to Vert.x 5

### DIFF
--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClients.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClients.java
@@ -72,7 +72,8 @@ import io.quarkus.mongodb.reactive.ReactiveMongoClient;
 import io.quarkus.tls.TlsConfiguration;
 import io.quarkus.tls.TlsConfigurationRegistry;
 import io.vertx.core.Vertx;
-import io.vertx.core.buffer.impl.VertxByteBufAllocator;
+import io.vertx.core.impl.buffer.VertxByteBufAllocator;
+import io.vertx.core.internal.VertxInternal;
 
 /**
  * This class is sort of a producer for {@link MongoClient} and {@link ReactiveMongoClient}.
@@ -413,7 +414,7 @@ public class MongoClients {
     private void configureNettyTransport(MongoClientSettings.Builder settings) {
         var nettyStreaming = TransportSettings.nettyBuilder()
                 .allocator(VertxByteBufAllocator.POOLED_ALLOCATOR)
-                .eventLoopGroup(vertx.nettyEventLoopGroup())
+                .eventLoopGroup(((VertxInternal) vertx).nettyEventLoopGroup())
                 .socketChannelClass(NioSocketChannel.class).build();
         settings.transportSettings(nettyStreaming);
     }

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/dns/MongoDnsClient.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/dns/MongoDnsClient.java
@@ -29,8 +29,8 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.dns.DnsClientOptions;
+import io.vertx.core.dns.SrvRecord;
 import io.vertx.mutiny.core.Vertx;
-import io.vertx.mutiny.core.dns.SrvRecord;
 
 @RegisterForReflection
 public class MongoDnsClient implements DnsClient {


### PR DESCRIPTION
Migration of quarkus-mongodb-client to Vert.x 5