### PR TITLE
Avoid adding duplicate META-INF/ directories

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/ParallelCommonsCompressArchiveCreator.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/ParallelCommonsCompressArchiveCreator.java
@@ -47,6 +47,7 @@ public class ParallelCommonsCompressArchiveCreator implements ArchiveCreator {
 
     private static final Logger LOG = Logger.getLogger(ParallelCommonsCompressArchiveCreator.class);
 
+    private static final String META_INF = "META-INF/";
     private static final Set<String> MANIFESTS = Set.of("META-INF/MANIFEST.MF", "META-INF\\MANIFEST.MF");
     private static final Set<String> VERSIONS = Set.of("META-INF/versions/", "META-INF\\versions\\");
 
@@ -107,7 +108,8 @@ public class ParallelCommonsCompressArchiveCreator implements ArchiveCreator {
         if (!directory.endsWith("/")) {
             directory += "/";
         }
-        if (addedFiles.putIfAbsent(directory, source) != null) {
+        if (addedFiles.putIfAbsent(directory, source) != null || META_INF.equals(directory)) {
+            // we only add a directory entry once and we ignore the META-INF/ directory as it will be forcefully added as the first entry of the Zip file
             return;
         }
         addDirectoryEntry(new ZipArchiveEntry(directory));
@@ -281,13 +283,17 @@ public class ParallelCommonsCompressArchiveCreator implements ArchiveCreator {
     @Override
     public void close() {
         try (archive) {
-            if (manifest != null) {
-                // we add the manifest directly to the final archive to make sure it is the first element added
-                ZipArchiveEntry metaInfArchiveEntry = new ZipArchiveEntry("META-INF/");
+            if (manifest != null || addedFiles.containsKey(META_INF)) {
+                // we always add the META-INF/ entry first
+                ZipArchiveEntry metaInfArchiveEntry = new ZipArchiveEntry(META_INF);
                 normalizeTimestampsAndPermissions(metaInfArchiveEntry);
                 archive.putArchiveEntry(metaInfArchiveEntry);
                 archive.closeArchiveEntry();
+            }
 
+            if (manifest != null) {
+                // we add the manifest directly to the final archive to make sure it is the first element added
+                // (except for the META-INF/ directory that is allowed first)
                 ByteArrayOutputStream baos = new ByteArrayOutputStream();
                 manifest.write(baos);
                 byte[] manifestBytes = baos.toByteArray();

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/PackageIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/PackageIT.java
@@ -288,6 +288,7 @@ public class PackageIT extends MojoTestBase {
         assertThat(jars).hasSize(1);
         File uberJar = jars.get(0);
         assertMultiReleaseJar(uberJar);
+        assertNoDuplicateEntries(uberJar);
         ensureManifestOfJarIsReadableByJarInputStream(uberJar);
     }
 
@@ -317,6 +318,22 @@ public class PackageIT extends MojoTestBase {
             Assertions.assertTrue(jarFile.isMultiRelease(), "uber-jar " + uberJar
                     + " was expected to be a multi-release jar but wasn't");
         }
+    }
+
+    private void assertNoDuplicateEntries(File jar) throws IOException {
+        Set<String> entries = new HashSet<>();
+        List<String> duplicates = new ArrayList<>();
+        try (ZipInputStream zis = new ZipInputStream(new FileInputStream(jar))) {
+            ZipEntry entry;
+            while ((entry = zis.getNextEntry()) != null) {
+                if (!entries.add(entry.getName())) {
+                    duplicates.add(entry.getName());
+                }
+            }
+        }
+        assertThat(duplicates)
+                .as("uber-jar " + jar + " should not contain duplicate entries")
+                .isEmpty();
     }
 
     @Test


### PR DESCRIPTION
The fix to create the whole tree to a file to fix resource loading actually introduced an issue as we were creating two META-INF/ directories: one as the first entry of the zip, and possibly one for any other entry that would be into the META-INF/ directory.

We now make sure that we only add it once.

The issue was caused by the fix in: https://github.com/quarkusio/quarkus/pull/52496 .

Fixes #53742
