### PR TITLE
[4.0] Migrate the OpenTelemetry extension to Vert.x 5

### DIFF
--- a/extensions/opentelemetry/deployment/pom.xml
+++ b/extensions/opentelemetry/deployment/pom.xml
@@ -160,6 +160,11 @@
             <artifactId>log4j2-jboss-logmanager</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-vertx</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/propagation/OpenTelemetryMpContextPropagationProcessor.java
+++ b/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/propagation/OpenTelemetryMpContextPropagationProcessor.java
@@ -4,7 +4,6 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.opentelemetry.deployment.OpenTelemetryEnabled;
-import io.quarkus.opentelemetry.runtime.propagation.OpenTelemetryMpContextPropagationProvider;
 import io.quarkus.smallrye.context.deployment.spi.ThreadContextProviderBuildItem;
 
 @BuildSteps(onlyIf = OpenTelemetryEnabled.class)
@@ -13,6 +12,6 @@ public class OpenTelemetryMpContextPropagationProcessor {
     @BuildStep
     void registerOpenTelemetryThreadProvider(
             BuildProducer<ThreadContextProviderBuildItem> threadContextProvider) {
-        threadContextProvider.produce(new ThreadContextProviderBuildItem(OpenTelemetryMpContextPropagationProvider.class));
+        //        threadContextProvider.produce(new ThreadContextProviderBuildItem(OpenTelemetryMpContextPropagationProvider.class));
     }
 }

--- a/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/tracing/instrumentation/InstrumentationProcessor.java
+++ b/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/tracing/instrumentation/InstrumentationProcessor.java
@@ -32,7 +32,7 @@ import io.quarkus.opentelemetry.runtime.tracing.instrumentation.resteasy.OpenTel
 import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
 import io.quarkus.resteasy.reactive.server.spi.PreExceptionMapperHandlerBuildItem;
 import io.quarkus.resteasy.reactive.spi.CustomContainerRequestFilterBuildItem;
-import io.quarkus.vertx.core.deployment.VertxOptionsConsumerBuildItem;
+import io.quarkus.vertx.deployment.spi.VertxBootstrapConsumerBuildItem;
 
 @BuildSteps(onlyIf = TracerEnabled.class)
 public class InstrumentationProcessor {
@@ -112,21 +112,21 @@ public class InstrumentationProcessor {
 
     @BuildStep(onlyIfNot = MetricsExtensionAvailable.class, onlyIf = VertxHttpAvailable.class)
     @Record(ExecutionTime.STATIC_INIT)
-    VertxOptionsConsumerBuildItem vertxHttpMetricsOptions(InstrumentationRecorder recorder) {
-        return new VertxOptionsConsumerBuildItem(recorder.getVertxHttpMetricsOptions(), LIBRARY_AFTER + 1);
+    VertxBootstrapConsumerBuildItem vertxHttpMetrics(InstrumentationRecorder recorder) {
+        return new VertxBootstrapConsumerBuildItem(recorder.getVertxHttpMetrics(), LIBRARY_AFTER + 1);
     }
 
     @BuildStep(onlyIfNot = { MetricsExtensionAvailable.class, VertxHttpAvailable.class })
     @Record(ExecutionTime.STATIC_INIT)
-    VertxOptionsConsumerBuildItem vertxMetricsOptions(InstrumentationRecorder recorder) {
-        return new VertxOptionsConsumerBuildItem(recorder.getVertxMetricsOptions(), LIBRARY_AFTER + 1);
+    VertxBootstrapConsumerBuildItem vertxMetricsOptions(InstrumentationRecorder recorder) {
+        return new VertxBootstrapConsumerBuildItem(recorder.getVertxMetricsOptions(), LIBRARY_AFTER + 1);
     }
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
-    VertxOptionsConsumerBuildItem vertxTracingOptions(
+    VertxBootstrapConsumerBuildItem vertxTracingOptions(
             InstrumentationRecorder recorder) {
-        return new VertxOptionsConsumerBuildItem(recorder.getVertxTracingOptions(), LIBRARY_AFTER);
+        return new VertxBootstrapConsumerBuildItem(recorder.processVertxBootstrap(), LIBRARY_AFTER);
     }
 
     // RESTEasy and Vert.x web

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/common/exporter/TestSpanExporter.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/common/exporter/TestSpanExporter.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Predicate;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -28,6 +29,15 @@ public class TestSpanExporter implements SpanExporter {
             SpanKind kind,
             Object parentSpanId) {
         List<SpanData> filteredSpans = getSpansByKindAndParentId(spans, kind, parentSpanId);
+        assertEquals(1, filteredSpans.size(), "Received: " + spans);
+        return filteredSpans.get(0);
+    }
+
+    public static SpanData getSpanByKindAndParentId(List<SpanData> spans,
+            SpanKind kind,
+            Object parentSpanId, Predicate<SpanData> additionalFilter) {
+        List<SpanData> filteredSpans = getSpansByKindAndParentId(spans, kind, parentSpanId).stream()
+                .filter(additionalFilter).toList();
         assertEquals(1, filteredSpans.size(), "Received: " + spans);
         return filteredSpans.get(0);
     }

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/GraphQLOpenTelemetryTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/GraphQLOpenTelemetryTest.java
@@ -52,6 +52,7 @@ import io.quarkus.opentelemetry.deployment.common.exporter.TestSpanExporterProvi
 import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 
+@Disabled
 public class GraphQLOpenTelemetryTest {
 
     @RegisterExtension

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/GrpcOpenInstrumentationDisabledTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/GrpcOpenInstrumentationDisabledTest.java
@@ -1,7 +1,9 @@
 package io.quarkus.opentelemetry.deployment.instrumentation;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
+import static io.opentelemetry.api.trace.SpanKind.SERVER;
 import static io.quarkus.opentelemetry.deployment.common.exporter.TestSpanExporter.getSpanByKindAndParentId;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -56,7 +58,7 @@ public class GrpcOpenInstrumentationDisabledTest {
                             "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider"))
             .withConfigurationResource("application-default.properties")
             .overrideConfigKey("quarkus.grpc.clients.hello.host", "localhost")
-            .overrideConfigKey("quarkus.grpc.clients.hello.port", "9001")
+            .overrideConfigKey("quarkus.grpc.clients.hello.port", "8081")
             .overrideConfigKey("quarkus.otel.instrument.grpc", "false");
 
     @Inject
@@ -78,10 +80,14 @@ public class GrpcOpenInstrumentationDisabledTest {
                 .await().atMost(Duration.ofSeconds(5));
         assertEquals("Hello ping", response);
 
-        List<SpanData> spans = spanExporter.getFinishedSpanItems(1);
-        assertEquals(1, spans.size());
+        // gRPC instrumentation is disabled, but HTTP spans are still created by the Vert.x HTTP tracer
+        List<SpanData> spans = spanExporter.getFinishedSpanItems(3);
+        assertEquals(3, spans.size());
 
-        SpanData internal = getSpanByKindAndParentId(spans, INTERNAL, "0000000000000000");
+        final SpanData httpClient = getSpanByKindAndParentId(spans, CLIENT, "0000000000000000");
+        final SpanData httpServer = getSpanByKindAndParentId(spans, SERVER, httpClient.getSpanId());
+
+        SpanData internal = getSpanByKindAndParentId(spans, INTERNAL, httpServer.getSpanId());
         assertEquals("span.internal", internal.getName());
         assertEquals("value", internal.getAttributes().get(stringKey("grpc.internal")));
     }

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/GrpcOpenTelemetryTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/GrpcOpenTelemetryTest.java
@@ -6,8 +6,6 @@ import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 import static io.opentelemetry.api.trace.SpanKind.SERVER;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
-import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
-import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_GRPC_STATUS_CODE;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_METHOD;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SERVICE;
@@ -65,6 +63,7 @@ import io.quarkus.opentelemetry.deployment.common.exporter.InMemoryMetricExporte
 import io.quarkus.opentelemetry.deployment.common.exporter.TestSpanExporter;
 import io.quarkus.opentelemetry.deployment.common.exporter.TestSpanExporterProvider;
 import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.vertx.RunOnVertxContext;
 import io.smallrye.common.annotation.Blocking;
 import io.smallrye.mutiny.Multi;
 
@@ -90,9 +89,9 @@ public class GrpcOpenTelemetryTest {
                             "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider"))
             .withConfigurationResource("application-default.properties")
             .overrideConfigKey("quarkus.grpc.clients.greeter.host", "localhost")
-            .overrideConfigKey("quarkus.grpc.clients.greeter.port", "9001")
+            .overrideConfigKey("quarkus.grpc.clients.greeter.port", "8081")
             .overrideConfigKey("quarkus.grpc.clients.streaming.host", "localhost")
-            .overrideConfigKey("quarkus.grpc.clients.streaming.port", "9001");
+            .overrideConfigKey("quarkus.grpc.clients.streaming.port", "8081");
 
     @Inject
     TestSpanExporter spanExporter;
@@ -109,6 +108,7 @@ public class GrpcOpenTelemetryTest {
     }
 
     @Test
+    @RunOnVertxContext(duplicateContext = true, runOnEventLoop = false)
     void grpc() {
         String response = greeterStub.sayHello(
                 HelloRequest.newBuilder().setName("Naruto").build())
@@ -116,36 +116,45 @@ public class GrpcOpenTelemetryTest {
                 .await().atMost(Duration.ofSeconds(5));
         assertEquals("Hello Naruto", response);
 
-        List<SpanData> spans = spanExporter.getFinishedSpanItems(3);
-        assertEquals(3, spans.size());
+        List<SpanData> spans = spanExporter.getFinishedSpanItems(5);
+        assertEquals(5, spans.size());
 
-        final SpanData client = getSpanByKindAndParentId(spans, CLIENT, "0000000000000000");
-        assertEquals("helloworld.Greeter/SayHello", client.getName());
-        assertEquals("grpc", client.getAttributes().get(RPC_SYSTEM));
-        assertEquals("helloworld.Greeter", client.getAttributes().get(RPC_SERVICE));
-        assertEquals("SayHello", client.getAttributes().get(RPC_METHOD));
-        assertEquals(Status.Code.OK.value(), client.getAttributes().get(RPC_GRPC_STATUS_CODE));
+        final SpanData grpcClient = getSpanByKindAndParentId(spans, CLIENT, "0000000000000000",
+                span -> "grpc".equals(span.getAttributes().get(RPC_SYSTEM)));
+        assertEquals("helloworld.Greeter/SayHello", grpcClient.getName());
+        assertEquals("grpc", grpcClient.getAttributes().get(RPC_SYSTEM));
+        assertEquals("helloworld.Greeter", grpcClient.getAttributes().get(RPC_SERVICE));
+        assertEquals("SayHello", grpcClient.getAttributes().get(RPC_METHOD));
+        assertEquals(Status.Code.OK.value(), grpcClient.getAttributes().get(RPC_GRPC_STATUS_CODE));
 
-        final SpanData server = getSpanByKindAndParentId(spans, SERVER, client.getSpanId());
-        assertEquals("helloworld.Greeter/SayHello", server.getName());
-        assertEquals("grpc", server.getAttributes().get(RPC_SYSTEM));
-        assertEquals("helloworld.Greeter", server.getAttributes().get(RPC_SERVICE));
-        assertEquals("SayHello", server.getAttributes().get(RPC_METHOD));
-        assertEquals(Status.Code.OK.value(), server.getAttributes().get(RPC_GRPC_STATUS_CODE));
-        assertNotNull(server.getAttributes().get(SERVER_PORT));
-        assertNotNull(server.getAttributes().get(SERVER_ADDRESS));
-        assertNotNull(server.getAttributes().get(NETWORK_PEER_PORT));
-        assertNotNull(server.getAttributes().get(NETWORK_PEER_ADDRESS));
+        final SpanData httpClient = getSpanByKindAndParentId(spans, CLIENT, grpcClient.getSpanId(),
+                span -> span.getAttributes().get(RPC_SYSTEM) == null);
 
-        final SpanData internal = getSpanByKindAndParentId(spans, INTERNAL, server.getSpanId());
+        final SpanData httpServer = getSpanByKindAndParentId(spans, SERVER, httpClient.getSpanId(),
+                span -> span.getAttributes().get(RPC_SYSTEM) == null);
+
+        final SpanData grpcServer = getSpanByKindAndParentId(spans, SERVER, httpServer.getSpanId(),
+                span -> "grpc".equals(span.getAttributes().get(RPC_SYSTEM)));
+        assertEquals("helloworld.Greeter/SayHello", grpcServer.getName());
+        assertEquals("grpc", grpcServer.getAttributes().get(RPC_SYSTEM));
+        assertEquals("helloworld.Greeter", grpcServer.getAttributes().get(RPC_SERVICE));
+        assertEquals("SayHello", grpcServer.getAttributes().get(RPC_METHOD));
+        assertEquals(Status.Code.OK.value(), grpcServer.getAttributes().get(RPC_GRPC_STATUS_CODE));
+        assertNotNull(grpcServer.getAttributes().get(NETWORK_PEER_PORT));
+        assertNotNull(grpcServer.getAttributes().get(NETWORK_PEER_ADDRESS));
+
+        final SpanData internal = getSpanByKindAndParentId(spans, INTERNAL, grpcServer.getSpanId());
         assertEquals("span.internal", internal.getName());
         assertEquals("value", internal.getAttributes().get(stringKey("grpc.internal")));
 
-        assertEquals(internal.getTraceId(), server.getTraceId());
-        assertEquals(server.getTraceId(), client.getTraceId());
+        assertEquals(grpcClient.getTraceId(), httpClient.getTraceId());
+        assertEquals(httpClient.getTraceId(), httpServer.getTraceId());
+        assertEquals(httpServer.getTraceId(), grpcServer.getTraceId());
+        assertEquals(grpcServer.getTraceId(), internal.getTraceId());
     }
 
     @Test
+    @RunOnVertxContext(duplicateContext = true, runOnEventLoop = false)
     void error() {
         try {
             greeterStub.sayHello(HelloRequest.newBuilder().setName("error").build())
@@ -157,44 +166,57 @@ public class GrpcOpenTelemetryTest {
             assertTrue(true);
         }
 
-        List<SpanData> spans = spanExporter.getFinishedSpanItems(2);
-        assertEquals(2, spans.size());
-
-        final SpanData client = getSpanByKindAndParentId(spans, CLIENT, "0000000000000000");
-        assertEquals("helloworld.Greeter/SayHello", client.getName());
-        assertEquals("grpc", client.getAttributes().get(RPC_SYSTEM));
-        assertEquals("helloworld.Greeter", client.getAttributes().get(RPC_SERVICE));
-        assertEquals("SayHello", client.getAttributes().get(RPC_METHOD));
-
-        final SpanData server = getSpanByKindAndParentId(spans, SERVER, client.getSpanId());
-        assertEquals("helloworld.Greeter/SayHello", server.getName());
-        assertEquals("grpc", server.getAttributes().get(RPC_SYSTEM));
-        assertEquals("helloworld.Greeter", server.getAttributes().get(RPC_SERVICE));
-        assertEquals("SayHello", server.getAttributes().get(RPC_METHOD));
-        assertEquals(Status.Code.UNKNOWN.value(), server.getAttributes().get(RPC_GRPC_STATUS_CODE));
-        assertNotNull(server.getAttributes().get(SERVER_PORT));
-        assertNotNull(server.getAttributes().get(SERVER_ADDRESS));
-        assertEquals(Status.Code.UNKNOWN.value(), server.getAttributes().get(RPC_GRPC_STATUS_CODE));
-
-        assertEquals(server.getTraceId(), client.getTraceId());
-    }
-
-    @Test
-    void withCdi() {
-        assertEquals("Hello Naruto", helloBean.hello("Naruto"));
-
         List<SpanData> spans = spanExporter.getFinishedSpanItems(4);
         assertEquals(4, spans.size());
 
-        final SpanData first = getSpanByKindAndParentId(spans, INTERNAL, "0000000000000000");
-        final SpanData second = getSpanByKindAndParentId(spans, CLIENT, first.getSpanId());
-        final SpanData third = getSpanByKindAndParentId(spans, SERVER, second.getSpanId());
-        final SpanData fourth = getSpanByKindAndParentId(spans, INTERNAL, third.getSpanId());
+        final SpanData grpcClient = getSpanByKindAndParentId(spans, CLIENT, "0000000000000000",
+                span -> "grpc".equals(span.getAttributes().get(RPC_SYSTEM)));
+        assertEquals("helloworld.Greeter/SayHello", grpcClient.getName());
+        assertEquals("grpc", grpcClient.getAttributes().get(RPC_SYSTEM));
+        assertEquals("helloworld.Greeter", grpcClient.getAttributes().get(RPC_SERVICE));
+        assertEquals("SayHello", grpcClient.getAttributes().get(RPC_METHOD));
 
-        assertThat(first.getTraceId()).isIn(second.getTraceId(), third.getTraceId(), fourth.getTraceId());
+        final SpanData httpClient = getSpanByKindAndParentId(spans, CLIENT, grpcClient.getSpanId(),
+                span -> span.getAttributes().get(RPC_SYSTEM) == null);
+
+        final SpanData httpServer = getSpanByKindAndParentId(spans, SERVER, httpClient.getSpanId(),
+                span -> span.getAttributes().get(RPC_SYSTEM) == null);
+
+        final SpanData grpcServer = getSpanByKindAndParentId(spans, SERVER, httpServer.getSpanId(),
+                span -> "grpc".equals(span.getAttributes().get(RPC_SYSTEM)));
+        assertEquals("helloworld.Greeter/SayHello", grpcServer.getName());
+        assertEquals("grpc", grpcServer.getAttributes().get(RPC_SYSTEM));
+        assertEquals("helloworld.Greeter", grpcServer.getAttributes().get(RPC_SERVICE));
+        assertEquals("SayHello", grpcServer.getAttributes().get(RPC_METHOD));
+        assertEquals(Status.Code.UNKNOWN.value(), grpcServer.getAttributes().get(RPC_GRPC_STATUS_CODE));
+        assertEquals(grpcClient.getTraceId(), grpcServer.getTraceId());
     }
 
     @Test
+    @RunOnVertxContext(duplicateContext = true, runOnEventLoop = false)
+    void withCdi() {
+        assertEquals("Hello Naruto", helloBean.hello("Naruto"));
+
+        List<SpanData> spans = spanExporter.getFinishedSpanItems(6);
+        assertEquals(6, spans.size());
+
+        final SpanData first = getSpanByKindAndParentId(spans, INTERNAL, "0000000000000000");
+        final SpanData grpcClient = getSpanByKindAndParentId(spans, CLIENT, first.getSpanId(),
+                span -> "grpc".equals(span.getAttributes().get(RPC_SYSTEM)));
+        final SpanData httpClient = getSpanByKindAndParentId(spans, CLIENT, grpcClient.getSpanId(),
+                span -> span.getAttributes().get(RPC_SYSTEM) == null);
+        final SpanData httpServer = getSpanByKindAndParentId(spans, SERVER, httpClient.getSpanId(),
+                span -> span.getAttributes().get(RPC_SYSTEM) == null);
+        final SpanData grpcServer = getSpanByKindAndParentId(spans, SERVER, httpServer.getSpanId(),
+                span -> "grpc".equals(span.getAttributes().get(RPC_SYSTEM)));
+        final SpanData internal = getSpanByKindAndParentId(spans, INTERNAL, grpcServer.getSpanId());
+
+        assertThat(first.getTraceId()).isIn(grpcClient.getTraceId(), httpClient.getTraceId(),
+                httpServer.getTraceId(), grpcServer.getTraceId(), internal.getTraceId());
+    }
+
+    @Test
+    @RunOnVertxContext(duplicateContext = true, runOnEventLoop = false)
     void streaming() {
         Multi<Item> request = Multi.createFrom().items(item("Goku"), item("Vegeta"), item("Piccolo"), item("Beerus"),
                 item("Whis"));
@@ -207,30 +229,37 @@ public class GrpcOpenTelemetryTest {
         assertTrue(items.contains("Hello Beerus"));
         assertTrue(items.contains("Hello Whis"));
 
-        List<SpanData> spans = spanExporter.getFinishedSpanItems(2);
-        assertEquals(2, spans.size());
+        List<SpanData> spans = spanExporter.getFinishedSpanItems(4);
+        assertEquals(4, spans.size());
 
-        final SpanData client = getSpanByKindAndParentId(spans, CLIENT, "0000000000000000");
-        assertEquals("streaming.Streaming/Pipe", client.getName());
-        assertEquals("grpc", client.getAttributes().get(RPC_SYSTEM));
-        assertEquals("streaming.Streaming", client.getAttributes().get(RPC_SERVICE));
-        assertEquals("Pipe", client.getAttributes().get(RPC_METHOD));
-        assertEquals(Status.Code.OK.value(), client.getAttributes().get(RPC_GRPC_STATUS_CODE));
+        final SpanData grpcClient = getSpanByKindAndParentId(spans, CLIENT, "0000000000000000",
+                span -> "grpc".equals(span.getAttributes().get(RPC_SYSTEM)));
+        assertEquals("streaming.Streaming/Pipe", grpcClient.getName());
+        assertEquals("grpc", grpcClient.getAttributes().get(RPC_SYSTEM));
+        assertEquals("streaming.Streaming", grpcClient.getAttributes().get(RPC_SERVICE));
+        assertEquals("Pipe", grpcClient.getAttributes().get(RPC_METHOD));
+        assertEquals(Status.Code.OK.value(), grpcClient.getAttributes().get(RPC_GRPC_STATUS_CODE));
 
-        final SpanData server = getSpanByKindAndParentId(spans, SERVER, client.getSpanId());
-        assertEquals("streaming.Streaming/Pipe", server.getName());
-        assertEquals("grpc", server.getAttributes().get(RPC_SYSTEM));
-        assertEquals("streaming.Streaming", server.getAttributes().get(RPC_SERVICE));
-        assertEquals("Pipe", server.getAttributes().get(RPC_METHOD));
-        assertEquals(Status.Code.OK.value(), server.getAttributes().get(RPC_GRPC_STATUS_CODE));
-        assertNotNull(server.getAttributes().get(SERVER_PORT));
-        assertNotNull(server.getAttributes().get(SERVER_ADDRESS));
-        assertEquals("true", server.getAttributes().get(stringKey("grpc.service.propagated")));
+        final SpanData httpClient = getSpanByKindAndParentId(spans, CLIENT, grpcClient.getSpanId(),
+                span -> span.getAttributes().get(RPC_SYSTEM) == null);
 
-        assertEquals(server.getTraceId(), client.getTraceId());
+        final SpanData httpServer = getSpanByKindAndParentId(spans, SERVER, httpClient.getSpanId(),
+                span -> span.getAttributes().get(RPC_SYSTEM) == null);
+
+        final SpanData grpcServer = getSpanByKindAndParentId(spans, SERVER, httpServer.getSpanId(),
+                span -> "grpc".equals(span.getAttributes().get(RPC_SYSTEM)));
+        assertEquals("streaming.Streaming/Pipe", grpcServer.getName());
+        assertEquals("grpc", grpcServer.getAttributes().get(RPC_SYSTEM));
+        assertEquals("streaming.Streaming", grpcServer.getAttributes().get(RPC_SERVICE));
+        assertEquals("Pipe", grpcServer.getAttributes().get(RPC_METHOD));
+        assertEquals(Status.Code.OK.value(), grpcServer.getAttributes().get(RPC_GRPC_STATUS_CODE));
+        assertEquals("true", grpcServer.getAttributes().get(stringKey("grpc.service.propagated")));
+
+        assertEquals(grpcClient.getTraceId(), grpcServer.getTraceId());
     }
 
     @Test
+    @RunOnVertxContext(duplicateContext = true, runOnEventLoop = false)
     void streamingBlocking() {
         Multi<Item> request = Multi.createFrom().items(item("Goku"), item("Vegeta"), item("Piccolo"), item("Beerus"),
                 item("Whis"));
@@ -243,27 +272,33 @@ public class GrpcOpenTelemetryTest {
         assertTrue(items.contains("Hello Beerus"));
         assertTrue(items.contains("Hello Whis"));
 
-        List<SpanData> spans = spanExporter.getFinishedSpanItems(2);
-        assertEquals(2, spans.size());
+        List<SpanData> spans = spanExporter.getFinishedSpanItems(4);
+        assertEquals(4, spans.size());
 
-        final SpanData client = getSpanByKindAndParentId(spans, CLIENT, "0000000000000000");
-        assertEquals("streaming.Streaming/PipeBlocking", client.getName());
-        assertEquals("grpc", client.getAttributes().get(RPC_SYSTEM));
-        assertEquals("streaming.Streaming", client.getAttributes().get(RPC_SERVICE));
-        assertEquals("PipeBlocking", client.getAttributes().get(RPC_METHOD));
-        assertEquals(Status.Code.OK.value(), client.getAttributes().get(RPC_GRPC_STATUS_CODE));
+        final SpanData grpcClient = getSpanByKindAndParentId(spans, CLIENT, "0000000000000000",
+                span -> "grpc".equals(span.getAttributes().get(RPC_SYSTEM)));
+        assertEquals("streaming.Streaming/PipeBlocking", grpcClient.getName());
+        assertEquals("grpc", grpcClient.getAttributes().get(RPC_SYSTEM));
+        assertEquals("streaming.Streaming", grpcClient.getAttributes().get(RPC_SERVICE));
+        assertEquals("PipeBlocking", grpcClient.getAttributes().get(RPC_METHOD));
+        assertEquals(Status.Code.OK.value(), grpcClient.getAttributes().get(RPC_GRPC_STATUS_CODE));
 
-        final SpanData server = getSpanByKindAndParentId(spans, SERVER, client.getSpanId());
-        assertEquals("streaming.Streaming/PipeBlocking", server.getName());
-        assertEquals("grpc", server.getAttributes().get(RPC_SYSTEM));
-        assertEquals("streaming.Streaming", server.getAttributes().get(RPC_SERVICE));
-        assertEquals("PipeBlocking", server.getAttributes().get(RPC_METHOD));
-        assertEquals(Status.Code.OK.value(), server.getAttributes().get(RPC_GRPC_STATUS_CODE));
-        assertNotNull(server.getAttributes().get(SERVER_PORT));
-        assertNotNull(server.getAttributes().get(SERVER_ADDRESS));
-        assertEquals("true", server.getAttributes().get(stringKey("grpc.service.propagated.blocking")));
+        final SpanData httpClient = getSpanByKindAndParentId(spans, CLIENT, grpcClient.getSpanId(),
+                span -> span.getAttributes().get(RPC_SYSTEM) == null);
 
-        assertEquals(server.getTraceId(), client.getTraceId());
+        final SpanData httpServer = getSpanByKindAndParentId(spans, SERVER, httpClient.getSpanId(),
+                span -> span.getAttributes().get(RPC_SYSTEM) == null);
+
+        final SpanData grpcServer = getSpanByKindAndParentId(spans, SERVER, httpServer.getSpanId(),
+                span -> "grpc".equals(span.getAttributes().get(RPC_SYSTEM)));
+        assertEquals("streaming.Streaming/PipeBlocking", grpcServer.getName());
+        assertEquals("grpc", grpcServer.getAttributes().get(RPC_SYSTEM));
+        assertEquals("streaming.Streaming", grpcServer.getAttributes().get(RPC_SERVICE));
+        assertEquals("PipeBlocking", grpcServer.getAttributes().get(RPC_METHOD));
+        assertEquals(Status.Code.OK.value(), grpcServer.getAttributes().get(RPC_GRPC_STATUS_CODE));
+        assertEquals("true", grpcServer.getAttributes().get(stringKey("grpc.service.propagated.blocking")));
+
+        assertEquals(grpcClient.getTraceId(), grpcServer.getTraceId());
     }
 
     @GrpcService

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/GrpcOpenTelemetryTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/GrpcOpenTelemetryTest.java
@@ -200,6 +200,13 @@ public class GrpcOpenTelemetryTest {
         List<SpanData> spans = spanExporter.getFinishedSpanItems(6);
         assertEquals(6, spans.size());
 
+        // dump spans
+//        for (SpanData span : spans) {
+//            System.out.println(
+//                    span.getKind() + " " + span.getName() + " - " + span.getSpanId() + " - " + span.getParentSpanId() + " - "
+//                            + span.getAttributes().get(RPC_SYSTEM) + " - " + span.getAttributes().get(RPC_METHOD));
+//        }
+
         final SpanData first = getSpanByKindAndParentId(spans, INTERNAL, "0000000000000000");
         final SpanData grpcClient = getSpanByKindAndParentId(spans, CLIENT, first.getSpanId(),
                 span -> "grpc".equals(span.getAttributes().get(RPC_SYSTEM)));

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/VertxClientOpenTelemetryTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/VertxClientOpenTelemetryTest.java
@@ -37,10 +37,10 @@ import io.quarkus.opentelemetry.deployment.common.exporter.TestSpanExporterProvi
 import io.quarkus.runtime.StartupEvent;
 import io.quarkus.test.QuarkusExtensionTest;
 import io.quarkus.test.common.http.TestHTTPResource;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.impl.future.CompositeFutureImpl;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
@@ -204,7 +204,8 @@ public class VertxClientOpenTelemetryTest {
                 WebClient webClient = WebClient.create(vertx);
                 Future<HttpResponse<Buffer>> one = webClient.get(port, host, "/hello/naruto").send();
                 Future<HttpResponse<Buffer>> two = webClient.get(port, host, "/hello/goku").send();
-                CompositeFuture.join(one, two).onComplete(event -> rc.response().end());
+
+                CompositeFutureImpl.join(one, two).onComplete(event -> rc.response().end());
             });
             router.get("/hello?name=foo").handler(rc -> rc.response().end("hello foo"));
         }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/QuarkusContextStorage.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/QuarkusContextStorage.java
@@ -12,7 +12,6 @@ import io.opentelemetry.context.ContextStorage;
 import io.opentelemetry.context.Scope;
 import io.smallrye.common.vertx.VertxContext;
 import io.vertx.core.Vertx;
-import io.vertx.core.spi.context.storage.ContextLocal;
 
 /**
  * Bridges the OpenTelemetry ContextStorage with the Vert.x Context. The default OpenTelemetry ContextStorage (based in
@@ -25,7 +24,7 @@ public enum QuarkusContextStorage implements ContextStorage {
 
     private static final Logger log = Logger.getLogger(QuarkusContextStorage.class);
     private static final String OTEL_CONTEXT = QuarkusContextStorage.class.getName() + ".otelContext";
-    private static final ContextLocal<Context> CONTEXT_OVERRIDE = ContextLocal.registerLocal(Context.class);
+    //    private static final ContextLocal<Context> CONTEXT_OVERRIDE = ContextLocal.registerLocal(Context.class);
 
     private static final ContextStorage FALLBACK_CONTEXT_STORAGE = MDCEnabledContextStorage.INSTANCE;
     static Vertx vertx;
@@ -133,10 +132,10 @@ public enum QuarkusContextStorage implements ContextStorage {
     public Context current() {
         io.vertx.core.Context current = getVertxContext();
         if (current != null) {
-            Context override = current.getLocal(CONTEXT_OVERRIDE);
-            if (override != null) {
-                return override;
-            }
+            //            Context override = current.getLocal(CONTEXT_OVERRIDE);
+            //            if (override != null) {
+            //                return override;
+            //            }
             return (Context) VertxContext.localContextData(current).get(OTEL_CONTEXT);
         } else {
             return FALLBACK_CONTEXT_STORAGE.current();
@@ -154,10 +153,10 @@ public enum QuarkusContextStorage implements ContextStorage {
         if (vertxContext == null || !isDuplicatedContext(vertxContext)) {
             return null;
         }
-        Context override = vertxContext.getLocal(CONTEXT_OVERRIDE);
-        if (override != null) {
-            return override;
-        }
+        //        Context override = vertxContext.getLocal(CONTEXT_OVERRIDE);
+        //        if (override != null) {
+        //            return override;
+        //        }
         return (Context) VertxContext.localContextData(vertxContext).get(OTEL_CONTEXT);
     }
 
@@ -167,18 +166,18 @@ public enum QuarkusContextStorage implements ContextStorage {
      * Used by gRPC interceptors whose makeCurrent() scopes get unwound by context propagation.
      */
     public static void setContextOverride(io.vertx.core.Context vertxContext, Context otelContext) {
-        if (vertxContext != null && isDuplicatedContext(vertxContext)) {
-            vertxContext.putLocal(CONTEXT_OVERRIDE, otelContext);
-        }
+        //        if (vertxContext != null && isDuplicatedContext(vertxContext)) {
+        //            vertxContext.putLocal(CONTEXT_OVERRIDE, otelContext);
+        //        }
     }
 
     /**
      * Clears the OTel context override from a Vert.x context.
      */
     public static void clearContextOverride(io.vertx.core.Context vertxContext) {
-        if (vertxContext != null) {
-            vertxContext.removeLocal(CONTEXT_OVERRIDE);
-        }
+        //        if (vertxContext != null) {
+        //            vertxContext.removeLocal(CONTEXT_OVERRIDE);
+        //        }
     }
 
     /**

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/QuarkusContextStorage.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/QuarkusContextStorage.java
@@ -12,6 +12,7 @@ import io.opentelemetry.context.ContextStorage;
 import io.opentelemetry.context.Scope;
 import io.smallrye.common.vertx.VertxContext;
 import io.vertx.core.Vertx;
+import io.vertx.core.spi.context.storage.ContextLocal;
 
 /**
  * Bridges the OpenTelemetry ContextStorage with the Vert.x Context. The default OpenTelemetry ContextStorage (based in
@@ -24,6 +25,7 @@ public enum QuarkusContextStorage implements ContextStorage {
 
     private static final Logger log = Logger.getLogger(QuarkusContextStorage.class);
     private static final String OTEL_CONTEXT = QuarkusContextStorage.class.getName() + ".otelContext";
+    private static final ContextLocal<Context> CONTEXT_OVERRIDE = ContextLocal.registerLocal(Context.class);
 
     private static final ContextStorage FALLBACK_CONTEXT_STORAGE = MDCEnabledContextStorage.INSTANCE;
     static Vertx vertx;
@@ -70,7 +72,7 @@ public enum QuarkusContextStorage implements ContextStorage {
             log.debugv("Setting Otel context: {0}", OpenTelemetryUtil.getSpanData(otelToAttach));
         }
 
-        vertxContext.putLocal(OTEL_CONTEXT, otelToAttach);
+        VertxContext.localContextData(vertxContext).put(OTEL_CONTEXT, otelToAttach);
         OpenTelemetryUtil.setMDCData(otelToAttach, vertxContext);
 
         return new Scope() {
@@ -84,7 +86,7 @@ public enum QuarkusContextStorage implements ContextStorage {
                     // Different references can contain the same span data.
                     // Duplicated contexts can be duplicated.
                     Map<String, String> spanDataBefore = OpenTelemetryUtil.getSpanData(otelBefore);
-                    if (spanDataBefore != null && !spanDataBefore.isEmpty()) {
+                    if (!spanDataBefore.isEmpty()) {
                         log.debug(
                                 "Context in storage not the expected context, Scope.close was not called correctly. Details:" +
                                         " OTel context otelBefore: ref: " + System.identityHashCode(otelBefore) +
@@ -99,7 +101,7 @@ public enum QuarkusContextStorage implements ContextStorage {
                         log.debugv("Closing Otel context: {0}", OpenTelemetryUtil.getSpanData(otelToAttach));
                     }
                     OpenTelemetryUtil.clearMDCData(vertxContext);
-                    vertxContext.removeLocal(OTEL_CONTEXT);
+                    VertxContext.localContextData(vertxContext).remove(OTEL_CONTEXT);
                 } else {
                     if (log.isDebugEnabled()) {
                         log.debugv("Closing Otel context: {0} and restoring previous OTel context: {1}",
@@ -107,7 +109,8 @@ public enum QuarkusContextStorage implements ContextStorage {
                                 OpenTelemetryUtil.getSpanData(otelBeforeAttach));
                     }
                     OpenTelemetryUtil.setMDCData(otelBeforeAttach, vertxContext);
-                    vertxContext.putLocal(OTEL_CONTEXT, otelBeforeAttach);
+                    VertxContext.localContextData(vertxContext).put(OTEL_CONTEXT,
+                            otelBeforeAttach);
                 }
             }
 
@@ -130,7 +133,11 @@ public enum QuarkusContextStorage implements ContextStorage {
     public Context current() {
         io.vertx.core.Context current = getVertxContext();
         if (current != null) {
-            return current.getLocal(OTEL_CONTEXT);
+            Context override = current.getLocal(CONTEXT_OVERRIDE);
+            if (override != null) {
+                return override;
+            }
+            return (Context) VertxContext.localContextData(current).get(OTEL_CONTEXT);
         } else {
             return FALLBACK_CONTEXT_STORAGE.current();
         }
@@ -138,12 +145,40 @@ public enum QuarkusContextStorage implements ContextStorage {
 
     /**
      * Gets the OpenTelemetry Context in a Vert.x Context. The Vert.x Context has to be a duplicate context.
+     * Checks for a context override first (set by gRPC interceptors to survive SmallRye context propagation).
      *
      * @param vertxContext a Vert.x Context.
      * @return the OpenTelemetry Context if exists in the Vert.x Context or null.
      */
     public static Context getOtelContext(io.vertx.core.Context vertxContext) {
-        return vertxContext != null && isDuplicatedContext(vertxContext) ? vertxContext.getLocal(OTEL_CONTEXT) : null;
+        if (vertxContext == null || !isDuplicatedContext(vertxContext)) {
+            return null;
+        }
+        Context override = vertxContext.getLocal(CONTEXT_OVERRIDE);
+        if (override != null) {
+            return override;
+        }
+        return (Context) VertxContext.localContextData(vertxContext).get(OTEL_CONTEXT);
+    }
+
+    /**
+     * Sets an OTel context override on a Vert.x context. This override takes precedence over the normal
+     * OTEL_CONTEXT and survives SmallRye MicroProfile Context Propagation save/restore cycles.
+     * Used by gRPC interceptors whose makeCurrent() scopes get unwound by context propagation.
+     */
+    public static void setContextOverride(io.vertx.core.Context vertxContext, Context otelContext) {
+        if (vertxContext != null && isDuplicatedContext(vertxContext)) {
+            vertxContext.putLocal(CONTEXT_OVERRIDE, otelContext);
+        }
+    }
+
+    /**
+     * Clears the OTel context override from a Vert.x context.
+     */
+    public static void clearContextOverride(io.vertx.core.Context vertxContext) {
+        if (vertxContext != null) {
+            vertxContext.removeLocal(CONTEXT_OVERRIDE);
+        }
     }
 
     /**

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/OTelExporterRecorder.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/OTelExporterRecorder.java
@@ -599,7 +599,7 @@ public class OTelExporterRecorder {
                     for (String cert : trustCert.certs().get()) {
                         pemTrustOptions.addCertPath(cert);
                     }
-                    options.setPemTrustOptions(pemTrustOptions);
+                    options.setTrustOptions(pemTrustOptions);
                 }
             }
         }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxHttpSender.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxHttpSender.java
@@ -35,8 +35,7 @@ import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.core.http.impl.HttpClientBuilderImpl;
-import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.http.PoolOptions;
 import io.vertx.core.tracing.TracingPolicy;
 
 public final class VertxHttpSender implements HttpSender {
@@ -79,9 +78,9 @@ public final class VertxHttpSender implements HttpSender {
                 .setDefaultPort(getPort(baseUri))
                 .setTracingPolicy(TracingPolicy.IGNORE); // needed to avoid tracing the calls from this http client
         clientOptionsCustomizer.accept(httpClientOptions);
-        this.client = (new HttpClientBuilderImpl((VertxInternal) vertx))
+        this.client = vertx.httpClientBuilder()
                 .with(httpClientOptions)
-                .with(httpClientOptions.getPoolOptions())
+                .with(new PoolOptions()) // TODO Do we want to customize pool options?
                 .withConnectHandler(connection -> {
                     connection.exceptionHandler(thw -> {
                         throttlingLogger.log(Level.WARNING, "Connection handler exception: ", thw);
@@ -245,13 +244,12 @@ public final class VertxHttpSender implements HttpSender {
         @Override
         public void handle(HttpClientRequest request) {
 
-            HttpClientRequest clientRequest = request.response(new Handler<>() {
+            request.response().onComplete(new Handler<>() {
                 @Override
                 public void handle(AsyncResult<HttpClientResponse> callResult) {
                     if (callResult.succeeded()) {
                         HttpClientResponse clientResponse = callResult.result();
-                        Throwable cause = callResult.cause();
-                        clientResponse.body(new Handler<>() {
+                        clientResponse.body().onComplete(new Handler<>() {
                             @Override
                             public void handle(AsyncResult<Buffer> bodyResult) {
                                 if (bodyResult.succeeded()) {
@@ -306,13 +304,13 @@ public final class VertxHttpSender implements HttpSender {
                         }
                     }
                 }
-            })
-                    .putHeader("Content-Type", contentType);
+            });
+            request.putHeader("Content-Type", contentType);
 
             Buffer buffer = Buffer.buffer(requestBodyWriter.getContentLength());
             OutputStream os = new BufferOutputStream(buffer);
             if (compressionEnabled) {
-                clientRequest.putHeader("Content-Encoding", "gzip");
+                request.putHeader("Content-Encoding", "gzip");
                 try (var gzos = new GZIPOutputStream(os)) {
                     requestBodyWriter.writeMessage(gzos);
                 } catch (IOException e) {
@@ -328,11 +326,11 @@ public final class VertxHttpSender implements HttpSender {
 
             if (!headers.isEmpty()) {
                 for (var entry : headers.entrySet()) {
-                    clientRequest.putHeader(entry.getKey(), entry.getValue());
+                    request.putHeader(entry.getKey(), entry.getValue());
                 }
             }
 
-            clientRequest.send(buffer);
+            request.send(buffer);
         }
 
         public ClientRequestSuccessHandler newAttempt() {

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/InstrumentationRecorder.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/InstrumentationRecorder.java
@@ -20,9 +20,7 @@ import io.quarkus.opentelemetry.runtime.tracing.instrumentation.vertx.SqlClientI
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.runtime.annotations.RuntimeInit;
-import io.vertx.core.VertxOptions;
-import io.vertx.core.metrics.MetricsOptions;
-import io.vertx.core.tracing.TracingOptions;
+import io.vertx.core.internal.VertxBootstrap;
 
 @Recorder
 public class InstrumentationRecorder {
@@ -41,14 +39,12 @@ public class InstrumentationRecorder {
 
     /* RUNTIME INIT */
     @RuntimeInit
-    public Consumer<VertxOptions> getVertxTracingOptions() {
+    public Consumer<VertxBootstrap> processVertxBootstrap() {
         if (runtimeConfig.getValue().sdkDisabled()) {
-            return vertxOptions -> {
+            return bootstrap -> {
             };
         }
-        TracingOptions tracingOptions = new TracingOptions()
-                .setFactory(FACTORY);
-        return vertxOptions -> vertxOptions.setTracingOptions(tracingOptions);
+        return bootstrap -> bootstrap.tracerFactory(FACTORY);
     }
 
     /* RUNTIME INIT */
@@ -78,19 +74,13 @@ public class InstrumentationRecorder {
     }
 
     /* STATIC INIT */
-    public Consumer<VertxOptions> getVertxHttpMetricsOptions() {
-        MetricsOptions metricsOptions = new MetricsOptions()
-                .setEnabled(true)
-                .setFactory(new OpenTelemetryVertxHttpMetricsFactory());
-        return vertxOptions -> vertxOptions.setMetricsOptions(metricsOptions);
+    public Consumer<VertxBootstrap> getVertxHttpMetrics() {
+        return bootstrap -> bootstrap.metricsFactory(new OpenTelemetryVertxHttpMetricsFactory());
     }
 
     /* STATIC INIT */
-    public Consumer<VertxOptions> getVertxMetricsOptions() {
-        MetricsOptions metricsOptions = new MetricsOptions()
-                .setEnabled(true)
-                .setFactory(new OpenTelemetryVertxMetricsFactory());
-        return vertxOptions -> vertxOptions.setMetricsOptions(metricsOptions);
+    public Consumer<VertxBootstrap> getVertxMetricsOptions() {
+        return bootstrap -> bootstrap.metricsFactory(new OpenTelemetryVertxMetricsFactory());
     }
 
 }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/grpc/GrpcTracingClientInterceptor.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/grpc/GrpcTracingClientInterceptor.java
@@ -16,22 +16,21 @@ import io.grpc.Status;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.context.propagation.TextMapSetter;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.quarkus.grpc.GlobalInterceptor;
+import io.quarkus.opentelemetry.runtime.QuarkusContextStorage;
 import io.quarkus.opentelemetry.runtime.config.runtime.OTelRuntimeConfig;
+import io.vertx.core.Vertx;
 
 @Singleton
 @GlobalInterceptor
 public class GrpcTracingClientInterceptor implements ClientInterceptor {
-    private final OpenTelemetry openTelemetry;
     private final Instrumenter<GrpcRequest, Status> instrumenter;
 
     public GrpcTracingClientInterceptor(final OpenTelemetry openTelemetry, final OTelRuntimeConfig runtimeConfig) {
-        this.openTelemetry = openTelemetry;
-
         InstrumenterBuilder<GrpcRequest, Status> builder = Instrumenter.builder(
                 openTelemetry,
                 INSTRUMENTATION_NAME,
@@ -43,7 +42,7 @@ public class GrpcTracingClientInterceptor implements ClientInterceptor {
                 .addAttributesExtractor(new GrpcStatusCodeExtractor())
                 .setSpanStatusExtractor(new GrpcSpanStatusExtractor());
 
-        this.instrumenter = builder.buildClientInstrumenter(GrpcTextMapSetter.INSTANCE);
+        this.instrumenter = builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
     }
 
     @Override
@@ -55,61 +54,55 @@ public class GrpcTracingClientInterceptor implements ClientInterceptor {
         boolean shouldStart = instrumenter.shouldStart(parentContext, grpcRequest);
         if (shouldStart) {
             Context spanContext = instrumenter.start(parentContext, grpcRequest);
-            try (Scope ignored = spanContext.makeCurrent()) {
-                ClientCall<ReqT, RespT> clientCall = next.newCall(method, callOptions);
-                return new TracingClientCall<>(clientCall, spanContext, grpcRequest);
-            }
+            Scope scope = spanContext.makeCurrent();
+            QuarkusContextStorage.setContextOverride(Vertx.currentContext(), spanContext);
+            ClientCall<ReqT, RespT> clientCall = next.newCall(method, callOptions);
+            return new TracingClientCall<>(clientCall, spanContext, scope, grpcRequest);
         }
 
         return next.newCall(method, callOptions);
     }
 
-    private enum GrpcTextMapSetter implements TextMapSetter<GrpcRequest> {
-        INSTANCE;
-
-        @Override
-        public void set(final GrpcRequest carrier, final String key, final String value) {
-            if (carrier != null && carrier.getMetadata() != null) {
-                carrier.getMetadata().put(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER), value);
-            }
-        }
-    }
-
     private class TracingClientCallListener<ReqT> extends SimpleForwardingClientCallListener<ReqT> {
         private final Context spanContext;
+        private final Scope scope;
         private final GrpcRequest grpcRequest;
 
         public TracingClientCallListener(final ClientCall.Listener<ReqT> delegate, final Context spanContext,
-                final GrpcRequest grpcRequest) {
+                final Scope scope, final GrpcRequest grpcRequest) {
             super(delegate);
             this.spanContext = spanContext;
+            this.scope = scope;
             this.grpcRequest = grpcRequest;
         }
 
         @Override
         public void onClose(final Status status, final Metadata trailers) {
-            instrumenter.end(spanContext, grpcRequest, status, status.getCause());
+            try (scope) {
+                QuarkusContextStorage.clearContextOverride(Vertx.currentContext());
+                instrumenter.end(spanContext, grpcRequest, status, status.getCause());
+            }
             super.onClose(status, trailers);
         }
     }
 
     private class TracingClientCall<ReqT, RespT> extends ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT> {
         private final Context spanContext;
+        private final Scope scope;
         private final GrpcRequest grpcRequest;
 
         protected TracingClientCall(final ClientCall<ReqT, RespT> delegate, final Context spanContext,
-                final GrpcRequest grpcRequest) {
+                final Scope scope, final GrpcRequest grpcRequest) {
             super(delegate);
             this.spanContext = spanContext;
+            this.scope = scope;
             this.grpcRequest = grpcRequest;
         }
 
         @Override
         public void start(final Listener<RespT> responseListener, final Metadata headers) {
             GrpcRequest clientRequest = GrpcRequest.client(grpcRequest.getMethodDescriptor(), headers);
-            openTelemetry.getPropagators().getTextMapPropagator().inject(spanContext, clientRequest,
-                    GrpcTextMapSetter.INSTANCE);
-            super.start(new TracingClientCallListener<>(responseListener, spanContext, clientRequest), headers);
+            super.start(new TracingClientCallListener<>(responseListener, spanContext, scope, clientRequest), headers);
         }
     }
 }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/grpc/GrpcTracingServerInterceptor.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/grpc/GrpcTracingServerInterceptor.java
@@ -4,7 +4,6 @@ import static io.quarkus.opentelemetry.runtime.config.build.OTelBuildConfig.INST
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.util.Collections;
 
 import jakarta.inject.Singleton;
 
@@ -18,16 +17,18 @@ import io.grpc.Status;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.semconv.network.NetworkAttributesExtractor;
 import io.opentelemetry.instrumentation.api.semconv.network.NetworkAttributesGetter;
 import io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesGetter;
 import io.quarkus.grpc.GlobalInterceptor;
+import io.quarkus.opentelemetry.runtime.QuarkusContextStorage;
 import io.quarkus.opentelemetry.runtime.config.runtime.OTelRuntimeConfig;
+import io.vertx.core.Vertx;
 
 @Singleton
 @GlobalInterceptor
@@ -50,7 +51,7 @@ public class GrpcTracingServerInterceptor implements ServerInterceptor {
                 .addAttributesExtractor(new GrpcStatusCodeExtractor())
                 .setSpanStatusExtractor(new GrpcSpanStatusExtractor());
 
-        this.instrumenter = builder.buildServerInstrumenter(new GrpcTextMapGetter());
+        this.instrumenter = builder.buildInstrumenter(SpanKindExtractor.alwaysServer());
     }
 
     @Override
@@ -64,6 +65,7 @@ public class GrpcTracingServerInterceptor implements ServerInterceptor {
         if (shouldStart) {
             Context spanContext = instrumenter.start(parentContext, grpcRequest);
             Scope scope = spanContext.makeCurrent();
+            QuarkusContextStorage.setContextOverride(Vertx.currentContext(), spanContext);
             TracingServerCall<ReqT, RespT> tracingServerCall = new TracingServerCall<>(call, spanContext, scope, grpcRequest);
             return new TracingServerCallListener<>(next.startCall(tracingServerCall, headers), spanContext, scope, grpcRequest);
         }
@@ -99,22 +101,6 @@ public class GrpcTracingServerInterceptor implements ServerInterceptor {
                 return (InetSocketAddress) address;
             }
             return null;
-        }
-    }
-
-    private static class GrpcTextMapGetter implements TextMapGetter<GrpcRequest> {
-        @Override
-        public Iterable<String> keys(final GrpcRequest carrier) {
-            return carrier.getMetadata() != null ? carrier.getMetadata().keys() : Collections.emptySet();
-        }
-
-        @Override
-        public String get(final GrpcRequest carrier, final String key) {
-            if (carrier != null && carrier.getMetadata() != null) {
-                return carrier.getMetadata().get(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER));
-            } else {
-                return null;
-            }
         }
     }
 
@@ -210,11 +196,13 @@ public class GrpcTracingServerInterceptor implements ServerInterceptor {
                 super.close(status, trailers);
             } catch (Exception e) {
                 try (scope) {
+                    QuarkusContextStorage.clearContextOverride(Vertx.currentContext());
                     instrumenter.end(spanContext, grpcRequest, null, e);
                 }
                 throw e;
             }
             try (scope) {
+                QuarkusContextStorage.clearContextOverride(Vertx.currentContext());
                 instrumenter.end(spanContext, grpcRequest, status, status.getCause());
             }
         }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/HttpInstrumenterVertxTracer.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/HttpInstrumenterVertxTracer.java
@@ -10,6 +10,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 
 import org.jboss.logging.Logger;
@@ -200,11 +201,13 @@ public class HttpInstrumenterVertxTracer implements InstrumenterVertxTracer<Http
         @Override
         public String get(final io.opentelemetry.context.Context context, final HttpRequestSpan requestSpan,
                 final HttpResponse response) {
+            Context ctx = requestSpan.getContext();
+            ConcurrentHashMap<String, Object> data = VertxContext.localContextData(ctx);
             // RESTEasy
-            String route = requestSpan.getContext().getLocal("UrlPathTemplate");
+            String route = (String) data.get("UrlPathTemplate");
             if (route == null) {
                 // Vert.x
-                route = requestSpan.getContext().getLocal("VertxRoute");
+                route = (String) data.get("VertxRoute");
             }
 
             if (route != null && route.length() >= 1) {
@@ -541,12 +544,12 @@ public class HttpInstrumenterVertxTracer implements InstrumenterVertxTracer<Http
 
         @Override
         public MultiMap headers() {
-            HeadersAdaptor headers = new HeadersAdaptor(new HeadersMultiMap()) {
+            HeadersAdaptor headers = new HeadersAdaptor(HeadersMultiMap.httpHeaders()) {
                 @Override
-                public MultiMap set(final String name, final String value) {
-                    MultiMap result = super.set(name, value);
+                public HeadersAdaptor set(final String name, final String value) {
+                    super.set(name, value);
                     WriteHeadersHttpRequest.this.headers.accept(name, value);
-                    return result;
+                    return this;
                 }
             };
             if (httpRequest.headers() != null) {

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/InstrumenterVertxTracer.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/InstrumenterVertxTracer.java
@@ -111,13 +111,7 @@ public interface InstrumenterVertxTracer<REQ, RESP> extends VertxTracer<SpanOper
         if (instrumenter.shouldStart(parentContext, (REQ) request)) {
             io.opentelemetry.context.Context spanContext = instrumenter.start(parentContext,
                     writableHeaders((REQ) request, headers));
-            // Create a new scope with an empty termination callback.
-            Scope scope = new Scope() {
-                @Override
-                public void close() {
-
-                }
-            };
+            Scope scope = Scope.noop();
             return spanOperation(context, (REQ) request, toMultiMap(headers), spanContext, scope);
         }
 
@@ -174,7 +168,7 @@ public interface InstrumenterVertxTracer<REQ, RESP> extends VertxTracer<SpanOper
         if (headers instanceof MultiMap) {
             headersMultiMap = (MultiMap) headers;
         } else {
-            headersMultiMap = new HeadersMultiMap();
+            headersMultiMap = HeadersMultiMap.httpHeaders();
             for (final Map.Entry<String, String> header : headers) {
                 headersMultiMap.add(header.getKey(), header.getValue());
             }
@@ -183,12 +177,12 @@ public interface InstrumenterVertxTracer<REQ, RESP> extends VertxTracer<SpanOper
     }
 
     private static MultiMap toMultiMap(BiConsumer<String, String> headers) {
-        return new HeadersAdaptor(new HeadersMultiMap()) {
+        return new HeadersAdaptor(HeadersMultiMap.httpHeaders()) {
             @Override
-            public MultiMap set(final String name, final String value) {
-                MultiMap result = super.set(name, value);
+            public HeadersAdaptor set(final String name, final String value) {
+                super.set(name, value);
                 headers.accept(name, value);
-                return result;
+                return this;
             }
         };
     }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/MetricRequest.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/MetricRequest.java
@@ -3,7 +3,7 @@ package io.quarkus.opentelemetry.runtime.tracing.instrumentation.vertx;
 import java.util.Optional;
 
 import io.vertx.core.Context;
-import io.vertx.core.http.impl.HttpServerRequestInternal;
+import io.vertx.core.internal.http.HttpServerRequestInternal;
 import io.vertx.core.spi.observability.HttpRequest;
 
 public final class MetricRequest {

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/OpenTelemetryVertxHttpMetricsFactory.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/OpenTelemetryVertxHttpMetricsFactory.java
@@ -1,6 +1,7 @@
 package io.quarkus.opentelemetry.runtime.tracing.instrumentation.vertx;
 
 import io.quarkus.vertx.http.runtime.ExtendedQuarkusVertxHttpMetrics;
+import io.smallrye.common.vertx.VertxContext;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.net.SocketAddress;
@@ -43,7 +44,8 @@ public class OpenTelemetryVertxHttpMetricsFactory implements VertxMetricsFactory
         @Override
         public void requestRouted(final MetricRequest requestMetric, final String route) {
             if (route != null) {
-                requestMetric.getContext().ifPresent(context -> context.putLocal("VertxRoute", route));
+                requestMetric.getContext()
+                        .ifPresent(context -> VertxContext.localContextData(context).put("VertxRoute", route));
             }
         }
 

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/OpenTelemetryVertxMetricsFactory.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/OpenTelemetryVertxMetricsFactory.java
@@ -1,5 +1,6 @@
 package io.quarkus.opentelemetry.runtime.tracing.instrumentation.vertx;
 
+import io.smallrye.common.vertx.VertxContext;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.net.SocketAddress;
@@ -40,7 +41,8 @@ public class OpenTelemetryVertxMetricsFactory implements VertxMetricsFactory {
         @Override
         public void requestRouted(final MetricRequest requestMetric, final String route) {
             if (route != null) {
-                requestMetric.getContext().ifPresent(context -> context.putLocal("VertxRoute", route));
+                requestMetric.getContext()
+                        .ifPresent(context -> context.getLocal(VertxContext.DATA_MAP_LOCAL).put("VertxRoute", route));
             }
         }
     }

--- a/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/VertxUtilTest.java
+++ b/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/VertxUtilTest.java
@@ -4,9 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Set;
 
-import javax.net.ssl.SSLPeerUnverifiedException;
-import javax.security.cert.X509Certificate;
-
 import org.junit.jupiter.api.Test;
 
 import io.netty.handler.codec.DecoderResult;
@@ -140,11 +137,6 @@ class VertxUtilTest {
             }
 
             @Override
-            public @Nullable String host() {
-                return "";
-            }
-
-            @Override
             public long bytesRead() {
                 return 0;
             }
@@ -156,7 +148,7 @@ class VertxUtilTest {
 
             @Override
             public MultiMap headers() {
-                HeadersMultiMap entries = new HeadersMultiMap();
+                HeadersMultiMap entries = HeadersMultiMap.httpHeaders();
                 entries.add("host", hostHeader);
                 return entries;
             }
@@ -174,11 +166,6 @@ class VertxUtilTest {
             @Override
             public MultiMap params(boolean semicolonIsNormalChar) {
                 return null;
-            }
-
-            @Override
-            public X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException {
-                return new X509Certificate[0];
             }
 
             @Override

--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/QuarkusRestPathTemplateInterceptor.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/QuarkusRestPathTemplateInterceptor.java
@@ -12,6 +12,8 @@ import jakarta.interceptor.InvocationContext;
 
 import io.quarkus.arc.ArcInvocationContext;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
+import io.smallrye.common.vertx.VertxContext;
+import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.http.HttpServerRequestInternal;
 import io.vertx.ext.web.RoutingContext;
 
@@ -33,8 +35,8 @@ public class QuarkusRestPathTemplateInterceptor {
             // just leave routingContext as null
         }
         if ((annotation != null) && (routingContext != null)) {
-            ((HttpServerRequestInternal) request.getCurrent().request()).context().putLocal("UrlPathTemplate",
-                    annotation.value());
+            ContextInternal ctxt = ((HttpServerRequestInternal) request.getCurrent().request()).context();
+            VertxContext.localContextData(ctxt).put("UrlPathTemplate", annotation.value());
         }
         return context.proceed();
     }

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
@@ -592,17 +592,19 @@ public class VertxCoreRecorder {
                     // The CDI contexts must not be propagated
                     // First test if VertxCurrentContextFactory is actually used
                     if (ignoredKeys != null) {
+                        // Remove ignored keys from the main context
                         ConcurrentMap<String, Object> local = VertxContext.localContextData(vertxContext);
                         if (containsIgnoredKey(ignoredKeys, local)) {
-                            ConcurrentHashMap<String, Object> mdcData = vertxContext.getLocal(VertxMDC.MDC_LOCAL);
-                            vertxContext = (ContextInternal) vertxContext.duplicate();
-                            ConcurrentHashMap<String, Object> data = VertxContext.localContextData(vertxContext);
+                            var dup = vertxContext.duplicate();
+                            ConcurrentHashMap<String, Object> data = VertxContext.localContextData(dup);
                             data.putAll(local);
                             ignoredKeys.forEach(data::remove);
                             VertxContextSafetyToggle.setContextSafe(vertxContext, true);
-                            if (mdcData != null && !mdcData.isEmpty()) {
-                                vertxContext.putLocal(VertxMDC.MDC_LOCAL, new ConcurrentHashMap<>(mdcData));
-                            }
+
+                            // Copy the MDC
+                            ConcurrentHashMap<String, Object> map = VertxMDC.MDC_LOCAL.get(vertxContext,
+                                    ConcurrentHashMap::new);
+                            VertxMDC.MDC_LOCAL.get(dup, ConcurrentHashMap::new).putAll(map);
                         }
                     }
                     vertxContext.beginDispatch();

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
@@ -592,15 +592,17 @@ public class VertxCoreRecorder {
                     // The CDI contexts must not be propagated
                     // First test if VertxCurrentContextFactory is actually used
                     if (ignoredKeys != null) {
-                        // TODO We must also propagate the other context locals, but we cannot list them.
                         ConcurrentMap<String, Object> local = VertxContext.localContextData(vertxContext);
                         if (containsIgnoredKey(ignoredKeys, local)) {
-                            // Duplicate the context, copy the data, remove the request context
+                            ConcurrentHashMap<String, Object> mdcData = vertxContext.getLocal(VertxMDC.MDC_LOCAL);
                             vertxContext = (ContextInternal) vertxContext.duplicate();
                             ConcurrentHashMap<String, Object> data = VertxContext.localContextData(vertxContext);
                             data.putAll(local);
                             ignoredKeys.forEach(data::remove);
                             VertxContextSafetyToggle.setContextSafe(vertxContext, true);
+                            if (mdcData != null && !mdcData.isEmpty()) {
+                                vertxContext.putLocal(VertxMDC.MDC_LOCAL, new ConcurrentHashMap<>(mdcData));
+                            }
                         }
                     }
                     vertxContext.beginDispatch();

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxMDC.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxMDC.java
@@ -350,10 +350,9 @@ public enum VertxMDC implements MDCProvider {
 
         final Map<String, Object> carryover = new HashMap<>();
         final boolean hasDiscardKeys = discardMdcKeys == null || discardMdcKeys.isEmpty();
-        for (Map.Entry<String, Object> entry : VertxMDC.INSTANCE.getEntrySet()) {
+        for (Map.Entry<String, Object> entry : contextualDataMap(vertxContext).entrySet()) {
             final String key = entry.getKey();
             final Object value = entry.getValue();
-            // Not taking chances with null values
             if (key != null && value != null && (hasDiscardKeys || !discardMdcKeys.contains(key))) {
                 carryover.put(key, value);
             }

--- a/vertx.justfile
+++ b/vertx.justfile
@@ -21,6 +21,8 @@ modules := """
     extensions/reactive-oracle-client
     extensions/reactive-pg-client
     extensions/redis-client
+    extensions/grpc
+    extensions/vertx-graphql
     """
 
 # Build the comma-separated list of directories containing a pom.xml


### PR DESCRIPTION
- Rework the context storage
- Change how gRPC tracing is working as we do not have gRPC java anymore (so, we have both the gRPC and HTTP spans, all linked together)

In draft, as we are waiting for SmallRye GraphQL.