### PR TITLE
Review for the "Deploying Quarkus applications to OpenShift" guide

### DIFF
--- a/docs/src/main/asciidoc/deploying-to-openshift-docker-howto.adoc
+++ b/docs/src/main/asciidoc/deploying-to-openshift-docker-howto.adoc
@@ -8,19 +8,19 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 include::_attributes.adoc[]
 :diataxis-type: howto
 :categories: cloud, native
-:summary: This guide describes how to build and deploy a Quarkus application on {openshift} by using the Docker build strategy.
+:summary: This guide describes how to build and deploy a {project-name} application on {openshift} by using the Docker build strategy.
 :topics: devops,kubernetes,openshift,cloud,deployment
 :extensions: io.quarkus:quarkus-openshift
 
-As an application developer, you can deploy your applications to {openshift} by using the Docker build strategy as a deployment option.
+As an application developer, you can deploy your applications to {openshift-long} by using the Docker build strategy as a deployment option.
 
-This stategy builds the artifacts outside the {openshift} cluster, locally or in a CI environment, and provides them to the {openshift} build system together with a Dockerfile.
+This strategy builds the artifacts outside the {openshift} cluster, either locally or in a CI environment, and provides them to the {openshift} build system together with a Dockerfile.
 The artifacts include JAR files or a native executable.
-The {openshift} cluster builds the container and provides it as an image stream.
+The {openshift} cluster builds the container image and provides it as an image stream.
 
 This functionality is provided by the `quarkus-openshift` extension.
-If you want to use a custom Dockerfile, add the file to the `src/main/docker` directory or any location inside the module.
-Additionally, set the path to your Dockerfile by using the `quarkus.openshift.jvm-dockerfile` property.
+If you want to use a custom Dockerfile, add the file to the `src/main/docker` directory or another location inside the module.
+Set the path to your Dockerfile with the `quarkus.openshift.jvm-dockerfile` property.
 
 == Prerequisites
 
@@ -33,42 +33,42 @@ Additionally, set the path to your Dockerfile by using the `quarkus.openshift.jv
 
 == Procedure
 
-. Set the Docker build strategy in your `application.properties` configuration file:
+. Set the Docker build strategy in your `application.properties` file:
 +
-[source, properties]
+[source,properties]
 ----
 quarkus.openshift.build-strategy=docker
 ----
-. Optional: Set the following properties in the `application.properties` file, based on your environment:
-** If you are using an untrusted certificate, enable certificate trust for the `KubernetesClient`:
+. Optional: Complete one or more of the following configuration steps in the `application.properties` file:
++
+* If you are using an untrusted certificate, enable certificate trust for the `KubernetesClient`:
 +
 [source,properties]
 ----
 quarkus.kubernetes-client.trust-certs=true
 ----
-** To expose the service and create an {openshift} route, set the following property:
+* To expose the service and create an {openshift} route, set the following property:
 +
 [source,properties]
 ----
 quarkus.openshift.route.expose=true
 ----
-** To use a custom Dockerfile instead of the pregenerated Dockerfiles, set the path to your Dockerfile:
+* To use a custom Dockerfile instead of the pre-generated Dockerfiles, set the path to your Dockerfile:
 +
-[source,properties,subs="attributes+,+quotes"]
+[source,properties]
 ----
 quarkus.openshift.jvm-dockerfile=<path_to_your_dockerfile>
 ----
 +
-For example, to specify a custom Dockerfile named `Dockerfile.custom-jvm`:
+For example, to specify a custom Dockerfile named `Dockerfile.custom-jvm`, set the following property:
 +
 [source,properties]
 ----
 quarkus.openshift.jvm-dockerfile=src/main/resources/Dockerfile.custom-jvm
 ----
-
 . Package and deploy your application to the current {openshift} project:
 +
-[source,shell,subs="attributes+,+quotes"]
+[source,shell]
 ----
 ./mvnw clean package -Dquarkus.openshift.deploy=true
 ----
@@ -79,28 +79,27 @@ The following verification steps use the `openshift-helloworld` example applicat
 
 . Display the list of pods associated with your current OpenShift project:
 +
-[source,shell,subs="+quotes",options="nowrap"]
+[source,shell,options="nowrap"]
 ----
 oc get pods
 ----
 +
-[source,shell,subs="+quotes",options="nowrap"]
+[source,text,options="nowrap"]
 ----
 NAME                            READY   STATUS      RESTARTS   AGE
 openshift-helloworld-1-build    0/1     Completed   0          11m
 openshift-helloworld-1-deploy   0/1     Completed   0          10m
 openshift-helloworld-1-gzzrx    1/1     Running     0          10m
 ----
-
-. To get the log output for your application's pod, use the `oc logs -f` command with its name.
-The following example uses the `openshift-helloworld-1-gzzrx` pod name, which corresponds to the latest pod prefixed with the name of your application:
+. To get the log output from your application's pod, run the `oc logs -f` command with the pod name.
+The following example uses the `openshift-helloworld-1-gzzrx` pod name, which corresponds to the latest pod prefixed with the application name:
 +
-[source,shell,subs="+quotes",options="nowrap"]
+[source,shell,options="nowrap"]
 ----
-oc logs -f _openshift-helloworld-1-gzzrx_
+oc logs -f openshift-helloworld-1-gzzrx
 ----
 +
-[source,shell,subs=attributes+]
+[source,text,subs="attributes+"]
 ----
 Starting the Java application using /opt/jboss/container/java/run/run-java.sh ...
 INFO exec -a "java" java -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+ExitOnOutOfMemoryError -cp "." -jar /deployments/quarkus-run.jar
@@ -112,29 +111,27 @@ __  ____  __  _____   ___  __ ____  ______
 2024-09-17 10:23:25,281 INFO  [io.quarkus] (main) Profile prod activated.
 2024-09-17 10:23:25,281 INFO  [io.quarkus] (main) Installed features: [cdi, kubernetes, rest, smallrye-context-propagation, vertx]
 ----
-
-. Get a list of services:
+. Display the list of services:
 +
-[source,shell,subs="+quotes",options="nowrap"]
+[source,shell,options="nowrap"]
 ----
 oc get svc
 ----
 +
-[source,shell,subs="+quotes",options="nowrap"]
+[source,text,options="nowrap"]
 ----
 NAME                   TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                               AGE
 openshift-helloworld   ClusterIP   172.30.64.57     <none>        80/TCP                                14m
 ----
-
 . Get a URL to test your application.
-To do so, ensure you have exposed an {openshift} route by setting the `quarkus.openshift.route.expose=true` property  in the `application.properties` file before building the application.
+To do so, ensure that you exposed an {openshift} route by setting the `quarkus.openshift.route.expose=true` property in the `application.properties` file before building the application:
 +
-[source,shell,subs="+quotes",options="nowrap"]
+[source,shell,options="nowrap"]
 ----
 oc get routes
 ----
 +
-[source,shell,subs="+quotes",options="nowrap"]
+[source,text,options="nowrap"]
 ----
 NAME                   HOST/PORT                                                                   PATH   SERVICES               PORT   TERMINATION   WILDCARD
 openshift-helloworld   openshift-helloworld-username-dev.apps.sandbox-m2.ll9k.p1.openshiftapps.com          openshift-helloworld   http                 None
@@ -142,15 +139,19 @@ openshift-helloworld   openshift-helloworld-username-dev.apps.sandbox-m2.ll9k.p1
 +
 [NOTE]
 ====
-Be aware that the route is now listening on port 80 and is no longer on port 8080.
+Be aware that the route listens on port 80 and no longer listens on port 8080.
 ====
 +
-You can test the application demonstrated in this example with a web browser or a terminal by using `curl` and the complete URL output from `oc get routes`, that is, `\http://openshift-helloworld-username-dev.apps.sandbox-m2.ll9k.p1.openshiftapps.com`.
+You can test the application in this example with a web browser or from a terminal.
+Use the complete URL from `oc get routes`, for example `http://openshift-helloworld-username-dev.apps.sandbox-m2.ll9k.p1.openshiftapps.com`.
 +
-For example: `curl \http://openshift-helloworld-username-dev.apps.sandbox-m2.ll9k.p1.openshiftapps.com`.
+For example:
++
+[source,shell,options="nowrap"]
+----
+curl http://openshift-helloworld-username-dev.apps.sandbox-m2.ll9k.p1.openshiftapps.com
+----
 
 == References
 
 * xref:deploying-to-openshift.adoc[Deploying {project-name} applications to {openshift}]
-
-

--- a/docs/src/main/asciidoc/deploying-to-openshift-native-howto.adoc
+++ b/docs/src/main/asciidoc/deploying-to-openshift-native-howto.adoc
@@ -12,14 +12,15 @@ include::_attributes.adoc[]
 :topics: devops,kubernetes,openshift,cloud,deployment
 :extensions: io.quarkus:quarkus-openshift
 
-You can deploy your native {project-name} applications to {openshift} compiled to native executables by using the Docker build strategy.
+You can deploy your {project-name} applications compiled to native executables to {openshift-long} by using the Docker build strategy.
 
-You must create a native executable for your application that targets a supported operating system and match the architecture.
+You must create a native executable for your application that targets a supported operating system and matches the architecture.
 This means, if you are building on Windows, you create a native Linux executable by using a container runtime, for example, Docker or Podman.
 
 Your Quarkus project includes pregenerated Dockerfiles with instructions.
 If you want to use a custom Dockerfile, add the file to the `src/main/docker` directory or any location inside the module.
-Additionally, if you want to have multiple Docker files and switch between them, set the path to your preferred Dockerfile by using the `quarkus.openshift.native-dockerfile` property.
+
+Additionally, if you want to have multiple Dockerfiles and switch between them, set the path to your preferred Dockerfile by using the `quarkus.openshift.native-dockerfile` property.
 
 [NOTE]
 ====
@@ -37,7 +38,7 @@ This guide describes this strategy by using a Quarkus project with Maven as the 
 
 . Set the Docker build strategy in your `application.properties` configuration file:
 +
-[source, properties]
+[source,properties]
 ----
 quarkus.openshift.build-strategy=docker
 ----
@@ -48,6 +49,7 @@ quarkus.openshift.build-strategy=docker
 quarkus.native.container-build=true
 ----
 . Optional: Set the following properties in the `application.properties` file based on your environment:
++
 ** If you are using an untrusted certificate, enable certificate trust for the `KubernetesClient`:
 +
 [source,properties]
@@ -66,6 +68,7 @@ quarkus.openshift.route.expose=true
 ----
 quarkus.openshift.native-dockerfile=<path_to_your_dockerfile>
 ----
++
 For example, to specify a custom Dockerfile named `Dockerfile.custom-native`:
 +
 [source,properties]
@@ -74,7 +77,7 @@ quarkus.openshift.native-dockerfile=src/main/docker/Dockerfile.custom-native
 ----
 
 ** Specify the container engine:
-***  To build a native executable with Podman:
+*** To build a native executable with Podman:
 +
 [source,properties]
 ----
@@ -89,7 +92,7 @@ quarkus.native.container-runtime=docker
 
 . Finally, build the native executable, package, and deploy your application to {openshift}:
 +
-[source,shell,subs="attributes+,+quotes"]
+[source,shell]
 ----
 ./mvnw clean package -Pnative -Dquarkus.openshift.deploy=true
 ----
@@ -120,4 +123,3 @@ oc logs -f __<pod_name>__
 == References
 
 * xref:deploying-to-openshift.adoc[Deploying {project-name} applications to {openshift}]
-

--- a/docs/src/main/asciidoc/deploying-to-openshift-s2i-howto.adoc
+++ b/docs/src/main/asciidoc/deploying-to-openshift-s2i-howto.adoc
@@ -35,15 +35,13 @@ You can deploy {project-name} applications to {openshift} with Java {jdk-version
 
 == Procedure
 
-. Open the `pom.xml` file, and set the Java version.
+. Open the `pom.xml` file, and set the Java version, where `${java.version}` is {jdk-version-all}.
 +
 [source,xml,subs=attributes+]
 ----
-<maven.compiler.source>${java.version}</maven.compiler.source>
-<maven.compiler.target>${java.version}</maven.compiler.target>
+<maven.compiler.release>${java.version}</maven.compiler.release>
 ----
-where ${java.version} is {jdk-version-all}.
-+
+
 . Package your application, by entering the following command:
 +
 [source,shell]
@@ -66,22 +64,22 @@ JAVA_APP_JAR=/deployments/quarkus-run.jar
 
 . Import the supported {openshift} image.
 +
-Java {jdk-version-earliest}:
+* Java {jdk-version-earliest}:
 +
-[source,subs="attributes+,+quotes"]
+[source,terminal,subs="attributes+",options="nowrap"]
 ----
 oc import-image {name-image-ubi9-open-jdk-17-short} --from={name-image-ubi9-open-jdk-17} --confirm
 ----
-Java {jdk-version-other}:
+* Java {jdk-version-other}:
 +
-[source,subs="attributes+,+quotes"]
+[source,terminal,subs="attributes+",options="nowrap"]
 ----
 oc import-image {name-image-ubi9-open-jdk-21-short} --from={name-image-ubi9-open-jdk-21} --confirm
 ----
 +
-Java {jdk-version-latest}:
+* Java {jdk-version-latest}:
 +
-[source,subs="attributes+,+quotes"]
+[source,terminal,subs="attributes+",options="nowrap"]
 ----
 oc import-image {name-image-ubi9-open-jdk-25-short} --from={name-image-ubi9-open-jdk-25} --confirm
 ----
@@ -100,32 +98,39 @@ For information about this image, see link:https://catalog.redhat.com/en/softwar
 
 . Build the project, create the application, and deploy the {openshift} service.
 +
-Java {jdk-version-earliest}:
+* Java {jdk-version-earliest}:
 +
-[source,xml,subs="attributes+,+quotes"]
+[source,terminal,subs="attributes+",options="nowrap"]
 ----
 oc new-app registry.access.redhat.com/ubi9/openjdk-17~<git_path> --name=<project_name>
 ----
-Java {jdk-version-other}:
+* Java {jdk-version-other}:
 +
-[source,xml,subs="attributes+,+quotes"]
+[source,terminal,subs="attributes+",options="nowrap"]
 ----
 oc new-app registry.access.redhat.com/ubi9/openjdk-21~<git_path> --name=<project_name>
 ----
 +
-Java {jdk-version-latest}:
+* Java {jdk-version-latest}:
 +
-[source,xml,subs="attributes+,+quotes"]
+[source,terminal,subs="attributes+",options="nowrap"]
 ----
 oc new-app registry.access.redhat.com/ubi9/openjdk-25~<git_path> --name=<project_name>
 ----
 +
-* Replace `<git_path>` with the path of the Git repository that hosts your Quarkus project.
-For example, for Java {jdk-version-other}: `oc new-app registry.access.redhat.com/ubi9/openjdk-21~https://github.com/johndoe/code-with-quarkus.git --name=code-with-quarkus`.
+.. Replace `<git_path>` with the path of the Git repository that hosts your Quarkus project.
++
+For example, for Java {jdk-version-other}:
++
+[source,terminal,subs="attributes+",options="nowrap"]
+----
+oc new-app registry.access.redhat.com/ubi9/openjdk-21~https://github.com/johndoe/code-with-quarkus.git --name=code-with-quarkus
+----
+{nbsp}
 +
 If you do not have SSH keys configured for the Git repository, when specifying the Git path, use the HTTPS URL instead of the SSH URL.
 
-* Replace `<project_name>` with the name of your application.
+.. Replace `<project_name>` with the name of your application.
 +
 [NOTE]
 ====
@@ -134,14 +139,14 @@ If you are deploying on IBM Z infrastructure, enter `oc new-app ubi9/openjdk-21~
 
 . To deploy an updated version of the project, push changes to the Git repository, and then run:
 +
-[source,xml,subs="attributes+,+quotes"]
+[source,terminal,subs="attributes+",options="nowrap"]
 ----
 oc start-build <project_name>
 ----
 +
 . To expose a route to the application, run the following command:
 +
-[source,shell,subs="attributes+,+quotes"]
+[source,terminal,subs="attributes+"]
 ----
 oc expose svc <project_name>
 ----
@@ -150,13 +155,13 @@ oc expose svc <project_name>
 
 . List the pods associated with your current {openshift} project:
 +
-[source,shell,subs="attributes+,+quotes"]
+[source,terminal,subs="attributes+"]
 ----
 oc get pods
 ----
 . To get the log output for your application's pod, run the following command, replacing `<pod_name>` with the name of the latest pod prefixed by your application name:
 +
-[source,shell,subs="attributes+,+quotes"]
+[source,terminal,subs="attributes+"]
 ----
 oc logs -f <pod_name>
 ----

--- a/docs/src/main/asciidoc/deploying-to-openshift.adoc
+++ b/docs/src/main/asciidoc/deploying-to-openshift.adoc
@@ -85,7 +85,6 @@ However, if you want to continue to use `DeploymentConfig`, it is still possible
 . To add the `quarkus-openshift` extension to your project, use one of the following methods:
 * Configure the `pom.xml` file:
 +
-.pom.xml
 [source,xml,subs="+quotes,attributes+"]
 ----
 <dependency>
@@ -160,14 +159,14 @@ oc login
 oc project -q
 ----
 . Use one of the following steps to go to the required {openshift} project:
-.. If the project already exists, switch to the project:
+* If the project already exists, switch to the project:
 +
 [source,shell]
 ----
 oc project <project_name>
 ----
 +
-.. If the project does not exist, create a new project:
+* If the project does not exist, create a new project:
 +
 [source,shell]
 ----
@@ -180,7 +179,7 @@ You can build and deploy by using any of the following deployment options:
 
 * xref:deploying-to-openshift-howto.adoc[With a single step]
 * xref:deploying-to-openshift-docker-howto.adoc[By using a Docker build strategy]
-* xref:deploying-to-openshift-S2I-howto.adoc[By using a Source-to-Image (S2I) strategy]
+* xref:deploying-to-openshift-s2i-howto.adoc[By using a Source-to-Image (S2I) strategy]
 * xref:deploying-to-openshift-native-howto.adoc[Compiled to native executables]
 
 ifndef::no-configuring-application-manually[]
@@ -203,7 +202,7 @@ For example:
 
 [source,properties]
 ----
-quarkus.openshift.base-jvm-image=image-registry.openshift-image-registry.svc:5000/some-project/openjdk-11:17.1.16.
+quarkus.openshift.base-jvm-image=image-registry.openshift-image-registry.svc:5000/some-project/openjdk-17:17.1.16
 ----
 
 [NOTE]
@@ -493,31 +492,6 @@ A conflict between two definitions, for example, mistakenly assigning both a val
 You can fix the issue before you deploy your application to your cluster, where it might be more difficult to diagnose the source of the issue.
 
 Similarly, two redundant definitions, for example, defining an injection from the same secret twice, does not cause an issue but reports a warning to inform you that you might not have intended to duplicate that definition.
-
-[[env-vars-backwards]]
-===== Backwards compatibility
-
-Previous versions of the OpenShift extension supported a different syntax to add environment variables.
-The older syntax is still supported but is deprecated, and it is advised that you migrate to the new syntax.
-
-.Old syntax versus new syntax
-|====
-|                               |Old                                                    | New                                                 |
-| Plain variable                |`quarkus.openshift.env-vars.my-env-var.value=foobar`  | `quarkus.openshift.env.vars.my-env-var=foobar`     |
-| From field                    |`quarkus.openshift.env-vars.my-env-var.field=foobar`  | `quarkus.openshift.env.fields.my-env-var=foobar`   |
-| All from `ConfigMap`          |`quarkus.openshift.env-vars.xxx.configmap=foobar`     | `quarkus.openshift.env.configmaps=foobar`          |
-| All from `Secret`             |`quarkus.openshift.env-vars.xxx.secret=foobar`        | `quarkus.openshift.env.secrets=foobar`             |
-| From one `Secret` field       |`quarkus.openshift.env-vars.foo.secret=foobar`        | `quarkus.openshift.env.mapping.foo.from-secret=foobar` |
-|                               |`quarkus.openshift.env-vars.foo.value=field`          | `quarkus.openshift.env.mapping.foo.with-key=field` |
-| From one `ConfigMap` field    |`quarkus.openshift.env-vars.foo.configmap=foobar`     | `quarkus.openshift.env.mapping.foo.from-configmap=foobar` |
-|                               |`quarkus.openshift.env-vars.foo.value=field`          | `quarkus.openshift.env.mapping.foo.with-key=field` |
-|====
-
-[NOTE]
-====
- If you redefine the same variable by using the new syntax while keeping the old syntax, only the new version is kept, and a warning will be issued to alert you of the problem.
- For example, if you define both `quarkus.openshift.env-vars.my-env-var.value=foobar` and `quarkus.openshift.env.vars.my-env-var=newValue`, the extension generates an environment variable `MY_ENV_VAR=newValue` and issues a warning.
-====
 
 === Mounting volumes
 


### PR DESCRIPTION
This PR brings a review of several parts of the Deploying to OCP guide.
I also removes unnecessary section about backwards compatibility added around 2020: https://github.com/quarkusio/quarkus/pull/13501/changes

This is part ot the review process for the 3.33 product release.
The final version is always reached after an SME review.