### PR TITLE
Switch from hibernate-tools-language to hibernate-assistant

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -5529,6 +5529,11 @@
                 <version>${hibernate-orm.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.hibernate.orm</groupId>
+                <artifactId>hibernate-assistant</artifactId>
+                <version>${hibernate-orm.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.hibernate.reactive</groupId>
                 <artifactId>hibernate-reactive-core</artifactId>
                 <version>${hibernate-reactive.version}</version>
@@ -5598,11 +5603,6 @@
                         <artifactId>jandex</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.tool</groupId>
-                <artifactId>hibernate-tools-language</artifactId>
-                <version>${hibernate-tools.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.postgresql</groupId>

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -69,8 +69,6 @@ import org.jboss.jandex.Indexer;
 import org.jboss.logging.Logger;
 import org.jboss.logmanager.Level;
 
-import com.fasterxml.jackson.databind.Module;
-
 import io.quarkus.agroal.spi.JdbcDataSourceBuildItem;
 import io.quarkus.agroal.spi.JdbcDataSourceSchemaReadyBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
@@ -195,6 +193,8 @@ public final class HibernateOrmProcessor {
     private static final String INTEGRATOR_SERVICE_FILE = "META-INF/services/org.hibernate.integrator.spi.Integrator";
 
     private static final String JAKARTA_DATA_REPOSITORY_ANNOTATION = "jakarta.data.repository.Repository";
+
+    private static final String JACKSON_DATABIND_MODULE = "com.fasterxml.jackson.databind.Module";
 
     static {
         // configure ByteBuddy for build reproducibility
@@ -361,7 +361,7 @@ public final class HibernateOrmProcessor {
         }
         // Hibernate's default FormatMapper relying on Jackson requires
         // service loading to discover modules in the classpath.
-        serviceProviders.produce(ServiceProviderBuildItem.allProvidersFromClassPath(Module.class.getName()));
+        serviceProviders.produce(ServiceProviderBuildItem.allProvidersFromClassPath(JACKSON_DATABIND_MODULE));
     }
 
     @BuildStep

--- a/extensions/hibernate-orm/runtime-dev/pom.xml
+++ b/extensions/hibernate-orm/runtime-dev/pom.xml
@@ -26,8 +26,8 @@
             <artifactId>jackson-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hibernate.tool</groupId>
-            <artifactId>hibernate-tools-language</artifactId>
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-assistant</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,6 @@
         <hibernate-reactive.version>3.3.5.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
         <hibernate-validator.version>9.1.0.Final</hibernate-validator.version>
         <hibernate-search.version>8.3.0.Final</hibernate-search.version>
-        <hibernate-tools.version>7.2.12.Final</hibernate-tools.version>
 
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->
         <grpc.version>1.79.0</grpc.version> <!-- when updating, verify if following versions should not be updated too: -->


### PR DESCRIPTION
As that's the new coordinates for this dependency moving forward...
In general Tools version == ORM version; with Hibernate ORM 7.3+ the "hibernate-tools-language" was actually moved into ORM project under the new name 🫣 🙂 

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

