### PR TITLE
Remove gastaldi from backport branch notifications

### DIFF
--- a/.github/quarkus-github-bot.yml
+++ b/.github/quarkus-github-bot.yml
@@ -43,15 +43,15 @@ triage:
     monitoredCategories: [33575230]
   guardedBranches:
     - ref: '3.33'
-      notify: [jmartisk, gsmet, gastaldi, rsvoboda, aloubyansky]
+      notify: [jmartisk, gsmet, rsvoboda, aloubyansky]
     - ref: '3.27'
-      notify: [jmartisk, gsmet, gastaldi, rsvoboda, aloubyansky]
+      notify: [jmartisk, gsmet, rsvoboda, aloubyansky]
     - ref: '3.20'
-      notify: [jmartisk, gsmet, gastaldi, rsvoboda, aloubyansky]
+      notify: [jmartisk, gsmet, rsvoboda, aloubyansky]
     - ref: '3.15'
-      notify: [jmartisk, gsmet, gastaldi, rsvoboda, aloubyansky]
+      notify: [jmartisk, gsmet, rsvoboda, aloubyansky]
     - ref: '3.8'
-      notify: [jmartisk, gsmet, gastaldi, rsvoboda, aloubyansky]
+      notify: [jmartisk, gsmet, rsvoboda, aloubyansky]
   rules:
     - id: amazon-lambda
       labels: [area/amazon-lambda]


### PR DESCRIPTION
I don't need to be notified by default, unless explicitly asked ;)