### PR TITLE
Bump de.thetaphi:forbiddenapis Maven plugin from 3.4 to 3.10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -188,6 +188,7 @@ updates:
       - dependency-name: io.fabric8:maven-model-helper
       - dependency-name: org.codejive:java-properties
       - dependency-name: org.json:json
+      - dependency-name: de.thetaphi:forbiddenapis
     groups:
       # Only group Hibernate ORM/Search/Reactive as Hibernate Validator is much more independent.
       Hibernate:

--- a/extensions/websockets-next/deployment/pom.xml
+++ b/extensions/websockets-next/deployment/pom.xml
@@ -202,8 +202,7 @@
             <properties>
                 <maven.compiler.target>21</maven.compiler.target>
                 <maven.compiler.source>21</maven.compiler.source>
-                <!-- javaparser 3.25.10 used by impsort-maven-plugin does not define the "language level" for 21 -->
-                <!--maven.compiler.release>21</maven.compiler.release-->
+                <maven.compiler.release>21</maven.compiler.release>
             </properties>
             <build>
                 <plugins>

--- a/independent-projects/parent/pom.xml
+++ b/independent-projects/parent/pom.xml
@@ -42,7 +42,7 @@
         <version.versions.plugin>2.21.0</version.versions.plugin>
         <version.yaml-properties.plugin>1.1.3</version.yaml-properties.plugin>
         <!-- Forbidden API checks -->
-        <version.forbiddenapis-maven-plugin>3.4</version.forbiddenapis-maven-plugin>
+        <version.forbiddenapis-maven-plugin>3.10</version.forbiddenapis-maven-plugin>
         <forbiddenapis-maven-plugin.phase>verify</forbiddenapis-maven-plugin.phase>
 
         <!-- Code format -->


### PR DESCRIPTION
- include forbiddenapis in dependabot config
- remove the unnecessary comment in quarkus-websockets-next for JDK 21 test profile