### PR TITLE
Arc regex property matching

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BuildTimeEnabledProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BuildTimeEnabledProcessor.java
@@ -423,7 +423,7 @@ public class BuildTimeEnabledProcessor {
             if (regexPattern != null) {
                 return regexPattern.matcher(actualValue).matches();
             }
-            return expectedStringValue.equalsIgnoreCase(actualValue);
+            return expectedStringValue.equals(actualValue);
         }
 
         static BuildProperty from(AnnotationInstance instance) {

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BuildTimeEnabledProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BuildTimeEnabledProcessor.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import jakarta.enterprise.inject.Vetoed;
@@ -39,6 +40,7 @@ import io.quarkus.arc.processor.DotNames;
 import io.quarkus.arc.profile.IfBuildProfile;
 import io.quarkus.arc.profile.UnlessBuildProfile;
 import io.quarkus.arc.properties.IfBuildProperty;
+import io.quarkus.arc.properties.StringValueMatch;
 import io.quarkus.arc.properties.UnlessBuildProperty;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -388,17 +390,20 @@ public class BuildTimeEnabledProcessor {
         private final String propertyName;
         private final String expectedStringValue;
         private final boolean enableIfMissing;
+        private final Pattern regexPattern;
 
-        private BuildProperty(String propertyName, String expectedStringValue, boolean enableIfMissing) {
+        private BuildProperty(String propertyName, String expectedStringValue, boolean enableIfMissing,
+                StringValueMatch match) {
             this.propertyName = propertyName;
             this.expectedStringValue = expectedStringValue;
             this.enableIfMissing = enableIfMissing;
+            this.regexPattern = match == StringValueMatch.REGEX ? Pattern.compile(expectedStringValue) : null;
         }
 
         boolean enabled(Config config) {
             Optional<String> optionalValue = config.getOptionalValue(propertyName, String.class);
             if (optionalValue.isPresent()) {
-                return expectedStringValue.equalsIgnoreCase(optionalValue.get());
+                return matches(optionalValue.get());
             } else {
                 return enableIfMissing;
             }
@@ -408,10 +413,17 @@ public class BuildTimeEnabledProcessor {
             // cannot just negate `enabled()`, that would change the meaning of `enableIfMissing`
             Optional<String> optionalValue = config.getOptionalValue(propertyName, String.class);
             if (optionalValue.isPresent()) {
-                return !expectedStringValue.equalsIgnoreCase(optionalValue.get());
+                return !matches(optionalValue.get());
             } else {
                 return enableIfMissing;
             }
+        }
+
+        private boolean matches(String actualValue) {
+            if (regexPattern != null) {
+                return regexPattern.matcher(actualValue).matches();
+            }
+            return expectedStringValue.equalsIgnoreCase(actualValue);
         }
 
         static BuildProperty from(AnnotationInstance instance) {
@@ -419,8 +431,11 @@ public class BuildTimeEnabledProcessor {
             String expectedStringValue = instance.value("stringValue").asString();
             AnnotationValue enableIfMissingValue = instance.value("enableIfMissing");
             boolean enableIfMissing = enableIfMissingValue != null && enableIfMissingValue.asBoolean();
+            AnnotationValue matchValue = instance.value("match");
+            StringValueMatch match = matchValue != null ? StringValueMatch.valueOf(matchValue.asEnum())
+                    : StringValueMatch.EQ;
 
-            return new BuildProperty(propertyName, expectedStringValue, enableIfMissing);
+            return new BuildProperty(propertyName, expectedStringValue, enableIfMissing, match);
         }
     }
 }

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/LookupConditionsProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/LookupConditionsProcessor.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -22,6 +21,7 @@ import org.jboss.jandex.IndexView;
 
 import io.quarkus.arc.lookup.LookupIfProperty;
 import io.quarkus.arc.lookup.LookupUnlessProperty;
+import io.quarkus.arc.processor.BeanGenerator;
 import io.quarkus.arc.processor.BeanInfo;
 import io.quarkus.arc.processor.DotNames;
 import io.quarkus.arc.processor.StereotypeInfo;
@@ -133,112 +133,112 @@ public class LookupConditionsProcessor {
             validateRegex(ann);
         }
 
-        generators.produce(new SuppressConditionGeneratorBuildItem(
-                new BiFunction<BeanInfo, ClassCreator, Consumer<BlockCreator>>() {
-                    final AtomicInteger patternCounter = new AtomicInteger();
+        generators.produce(new SuppressConditionGeneratorBuildItem(new Consumer<>() {
+            final AtomicInteger patternCounter = new AtomicInteger();
 
-                    @Override
-                    public Consumer<BlockCreator> apply(BeanInfo bean, ClassCreator cc) {
-                        Optional<AnnotationTarget> maybeTarget = bean.getTarget();
-                        if (maybeTarget.isPresent()) {
-                            AnnotationTarget target = maybeTarget.get();
-                            List<AnnotationInstance> ifPropertyList = new ArrayList<>(
-                                    target.declaredAnnotationsWithRepeatable(LOOK_UP_IF_PROPERTY, index));
-                            List<AnnotationInstance> unlessPropertyList = new ArrayList<>(
-                                    target.declaredAnnotationsWithRepeatable(LOOK_UP_UNLESS_PROPERTY, index));
-                            for (StereotypeInfo stereotype : bean.getStereotypes()) {
-                                var conditions = lookupConditionStereotypes.get(stereotype.getName());
-                                if (conditions != null) {
-                                    ifPropertyList.addAll(conditions.ifAnnotations());
-                                    unlessPropertyList.addAll(conditions.unlessAnnotations());
-                                }
-                            }
-                            if (!ifPropertyList.isEmpty() || !unlessPropertyList.isEmpty()) {
-                                // pre-create static Pattern fields for all REGEX annotations on this bean
-                                List<StaticFieldVar> ifPatternFields = new ArrayList<>();
-                                for (AnnotationInstance ann : ifPropertyList) {
-                                    ifPatternFields.add(createPatternFieldIfRegex(cc, ann));
-                                }
-                                List<StaticFieldVar> unlessPatternFields = new ArrayList<>();
-                                for (AnnotationInstance ann : unlessPropertyList) {
-                                    unlessPatternFields.add(createPatternFieldIfRegex(cc, ann));
-                                }
+            @Override
+            public void accept(BeanGenerator.SuppressConditionGeneration suppressConditionGeneration) {
+                BeanInfo bean = suppressConditionGeneration.bean();
+                Optional<AnnotationTarget> maybeTarget = bean.getTarget();
+                if (maybeTarget.isEmpty()) {
+                    return;
+                }
+                AnnotationTarget target = maybeTarget.get();
+                List<AnnotationInstance> ifPropertyList = new ArrayList<>(
+                        target.declaredAnnotationsWithRepeatable(LOOK_UP_IF_PROPERTY, index));
+                List<AnnotationInstance> unlessPropertyList = new ArrayList<>(
+                        target.declaredAnnotationsWithRepeatable(LOOK_UP_UNLESS_PROPERTY, index));
+                for (StereotypeInfo stereotype : bean.getStereotypes()) {
+                    var conditions = lookupConditionStereotypes.get(stereotype.getName());
+                    if (conditions != null) {
+                        ifPropertyList.addAll(conditions.ifAnnotations());
+                        unlessPropertyList.addAll(conditions.unlessAnnotations());
+                    }
+                }
 
-                                return new Consumer<BlockCreator>() {
-                                    @Override
-                                    public void accept(BlockCreator suppressed) {
-                                        // if at least one condition fails, we mark the bean as suppressed
-                                        // this means all conditions must pass, which is how we implement
-                                        // the documented "logical AND of all conditions" behavior
-                                        for (int i = 0; i < ifPropertyList.size(); i++) {
-                                            AnnotationInstance ifProperty = ifPropertyList.get(i);
-                                            String propertyName = ifProperty.value(NAME).asString();
-                                            String expectedStringValue = ifProperty.value(STRING_VALUE).asString();
-                                            AnnotationValue lookupIfMissingValue = ifProperty.value(LOOKUP_IF_MISSING);
-                                            boolean lookupIfMissing = lookupIfMissingValue != null
-                                                    && lookupIfMissingValue.asBoolean();
-                                            StaticFieldVar patternField = ifPatternFields.get(i);
-                                            Expr result;
-                                            if (patternField != null) {
-                                                result = suppressed.invokeStatic(SUPPRESS_IF_PROPERTY_REGEX,
-                                                        Const.of(propertyName),
-                                                        suppressed.getStaticField(patternField.desc()),
-                                                        Const.of(lookupIfMissing));
-                                            } else {
-                                                result = suppressed.invokeStatic(SUPPRESS_IF_PROPERTY,
-                                                        Const.of(propertyName),
-                                                        Const.of(expectedStringValue),
-                                                        Const.of(lookupIfMissing));
-                                            }
-                                            suppressed.if_(result, BlockCreator::returnTrue);
-                                        }
-                                        for (int i = 0; i < unlessPropertyList.size(); i++) {
-                                            AnnotationInstance unlessProperty = unlessPropertyList.get(i);
-                                            String propertyName = unlessProperty.value(NAME).asString();
-                                            String expectedStringValue = unlessProperty.value(STRING_VALUE).asString();
-                                            AnnotationValue lookupIfMissingValue = unlessProperty.value(LOOKUP_IF_MISSING);
-                                            boolean lookupIfMissing = lookupIfMissingValue != null
-                                                    && lookupIfMissingValue.asBoolean();
-                                            StaticFieldVar patternField = unlessPatternFields.get(i);
-                                            Expr result;
-                                            if (patternField != null) {
-                                                result = suppressed.invokeStatic(SUPPRESS_UNLESS_PROPERTY_REGEX,
-                                                        Const.of(propertyName),
-                                                        suppressed.getStaticField(patternField.desc()),
-                                                        Const.of(lookupIfMissing));
-                                            } else {
-                                                result = suppressed.invokeStatic(SUPPRESS_UNLESS_PROPERTY,
-                                                        Const.of(propertyName),
-                                                        Const.of(expectedStringValue),
-                                                        Const.of(lookupIfMissing));
-                                            }
-                                            suppressed.if_(result, BlockCreator::returnTrue);
-                                        }
-                                    }
-                                };
-                            }
-                        }
-                        return null;
+                if (!ifPropertyList.isEmpty() || !unlessPropertyList.isEmpty()) {
+                    ClassCreator cc = suppressConditionGeneration.beanClass();
+
+                    // pre-create static Pattern fields for all REGEX annotations on this bean
+                    List<StaticFieldVar> ifPatternFields = new ArrayList<>();
+                    for (AnnotationInstance ann : ifPropertyList) {
+                        ifPatternFields.add(createPatternFieldIfRegex(cc, ann));
+                    }
+                    List<StaticFieldVar> unlessPatternFields = new ArrayList<>();
+                    for (AnnotationInstance ann : unlessPropertyList) {
+                        unlessPatternFields.add(createPatternFieldIfRegex(cc, ann));
                     }
 
-                    private StaticFieldVar createPatternFieldIfRegex(ClassCreator cc, AnnotationInstance ann) {
-                        if (getMatch(ann) == StringValueMatch.REGEX) {
-                            String regex = ann.value(STRING_VALUE).asString();
-                            String fieldName = "REGEX_PATTERN_" + patternCounter.getAndIncrement();
-                            return cc.staticField(fieldName, sfc -> {
-                                sfc.setType(Pattern.class);
-                                sfc.final_();
-                                sfc.private_();
-                                sfc.setInitializer(bc -> {
-                                    bc.yield(bc.invokeStatic(
-                                            MethodDesc.of(Pattern.class, "compile", Pattern.class, String.class),
-                                            Const.of(regex)));
-                                });
-                            });
+                    BlockCreator bc = suppressConditionGeneration.method();
+
+                    // if at least one condition fails, we mark the bean as suppressed
+                    // this means all conditions must pass, which is how we implement
+                    // the documented "logical AND of all conditions" behavior
+                    for (int i = 0; i < ifPropertyList.size(); i++) {
+                        AnnotationInstance ifProperty = ifPropertyList.get(i);
+                        String propertyName = ifProperty.value(NAME).asString();
+                        String expectedStringValue = ifProperty.value(STRING_VALUE).asString();
+                        AnnotationValue lookupIfMissingValue = ifProperty.value(LOOKUP_IF_MISSING);
+                        boolean lookupIfMissing = lookupIfMissingValue != null
+                                && lookupIfMissingValue.asBoolean();
+                        StaticFieldVar patternField = ifPatternFields.get(i);
+                        Expr result;
+                        if (patternField != null) {
+                            result = bc.invokeStatic(SUPPRESS_IF_PROPERTY_REGEX,
+                                    Const.of(propertyName),
+                                    bc.getStaticField(patternField.desc()),
+                                    Const.of(lookupIfMissing));
+                        } else {
+                            result = bc.invokeStatic(SUPPRESS_IF_PROPERTY,
+                                    Const.of(propertyName),
+                                    Const.of(expectedStringValue),
+                                    Const.of(lookupIfMissing));
                         }
-                        return null;
+                        bc.if_(result, BlockCreator::returnTrue);
                     }
-                }));
+                    for (int i = 0; i < unlessPropertyList.size(); i++) {
+                        AnnotationInstance unlessProperty = unlessPropertyList.get(i);
+                        String propertyName = unlessProperty.value(NAME).asString();
+                        String expectedStringValue = unlessProperty.value(STRING_VALUE).asString();
+                        AnnotationValue lookupIfMissingValue = unlessProperty.value(LOOKUP_IF_MISSING);
+                        boolean lookupIfMissing = lookupIfMissingValue != null
+                                && lookupIfMissingValue.asBoolean();
+                        StaticFieldVar patternField = unlessPatternFields.get(i);
+                        Expr result;
+                        if (patternField != null) {
+                            result = bc.invokeStatic(SUPPRESS_UNLESS_PROPERTY_REGEX,
+                                    Const.of(propertyName),
+                                    bc.getStaticField(patternField.desc()),
+                                    Const.of(lookupIfMissing));
+                        } else {
+                            result = bc.invokeStatic(SUPPRESS_UNLESS_PROPERTY,
+                                    Const.of(propertyName),
+                                    Const.of(expectedStringValue),
+                                    Const.of(lookupIfMissing));
+                        }
+                        bc.if_(result, BlockCreator::returnTrue);
+                    }
+                }
+            }
+
+            private StaticFieldVar createPatternFieldIfRegex(ClassCreator cc, AnnotationInstance ann) {
+                if (getMatch(ann) == StringValueMatch.REGEX) {
+                    String regex = ann.value(STRING_VALUE).asString();
+                    String fieldName = "REGEX_PATTERN_" + patternCounter.getAndIncrement();
+                    return cc.staticField(fieldName, sfc -> {
+                        sfc.setType(Pattern.class);
+                        sfc.final_();
+                        sfc.private_();
+                        sfc.setInitializer(bc -> {
+                            bc.yield(bc.invokeStatic(
+                                    MethodDesc.of(Pattern.class, "compile", Pattern.class, String.class),
+                                    Const.of(regex)));
+                        });
+                    });
+                }
+                return null;
+            }
+        }));
     }
 
     private static StringValueMatch getMatch(AnnotationInstance annotation) {

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/LookupConditionsProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/LookupConditionsProcessor.java
@@ -7,8 +7,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
-import java.util.function.Function;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
@@ -22,13 +25,16 @@ import io.quarkus.arc.lookup.LookupUnlessProperty;
 import io.quarkus.arc.processor.BeanInfo;
 import io.quarkus.arc.processor.DotNames;
 import io.quarkus.arc.processor.StereotypeInfo;
+import io.quarkus.arc.properties.StringValueMatch;
 import io.quarkus.arc.runtime.SuppressConditions;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.gizmo2.Const;
 import io.quarkus.gizmo2.Expr;
+import io.quarkus.gizmo2.StaticFieldVar;
 import io.quarkus.gizmo2.creator.BlockCreator;
+import io.quarkus.gizmo2.creator.ClassCreator;
 import io.quarkus.gizmo2.desc.MethodDesc;
 
 public class LookupConditionsProcessor {
@@ -45,11 +51,18 @@ public class LookupConditionsProcessor {
     private static final String NAME = "name";
     private static final String STRING_VALUE = "stringValue";
     private static final String LOOKUP_IF_MISSING = "lookupIfMissing";
+    private static final String MATCH = "match";
 
     private static final MethodDesc SUPPRESS_IF_PROPERTY = MethodDesc.of(SuppressConditions.class, "suppressIfProperty",
             boolean.class, String.class, String.class, boolean.class);
     private static final MethodDesc SUPPRESS_UNLESS_PROPERTY = MethodDesc.of(SuppressConditions.class, "suppressUnlessProperty",
             boolean.class, String.class, String.class, boolean.class);
+    private static final MethodDesc SUPPRESS_IF_PROPERTY_REGEX = MethodDesc.of(SuppressConditions.class,
+            "suppressIfPropertyRegex",
+            boolean.class, String.class, Pattern.class, boolean.class);
+    private static final MethodDesc SUPPRESS_UNLESS_PROPERTY_REGEX = MethodDesc.of(SuppressConditions.class,
+            "suppressUnlessPropertyRegex",
+            boolean.class, String.class, Pattern.class, boolean.class);
 
     @BuildStep
     LookupConditionsStereotypesBuildItem findLookupConditionStereotypes(CombinedIndexBuildItem combinedIndex) {
@@ -107,59 +120,144 @@ public class LookupConditionsProcessor {
     @BuildStep
     void suppressConditionsGenerators(BuildProducer<SuppressConditionGeneratorBuildItem> generators,
             LookupConditionsStereotypesBuildItem lookupConditionStereotypes,
-            BeanArchiveIndexBuildItem beanArchiveIndex) {
+            BeanArchiveIndexBuildItem beanArchiveIndex,
+            CombinedIndexBuildItem combinedIndex) {
         IndexView index = beanArchiveIndex.getIndex();
 
-        generators.produce(new SuppressConditionGeneratorBuildItem(new Function<BeanInfo, Consumer<BlockCreator>>() {
-            @Override
-            public Consumer<BlockCreator> apply(BeanInfo bean) {
-                Optional<AnnotationTarget> maybeTarget = bean.getTarget();
-                if (maybeTarget.isPresent()) {
-                    AnnotationTarget target = maybeTarget.get();
-                    List<AnnotationInstance> ifPropertyList = new ArrayList<>(
-                            target.declaredAnnotationsWithRepeatable(LOOK_UP_IF_PROPERTY, index));
-                    List<AnnotationInstance> unlessPropertyList = new ArrayList<>(
-                            target.declaredAnnotationsWithRepeatable(LOOK_UP_UNLESS_PROPERTY, index));
-                    for (StereotypeInfo stereotype : bean.getStereotypes()) {
-                        var conditions = lookupConditionStereotypes.get(stereotype.getName());
-                        if (conditions != null) {
-                            ifPropertyList.addAll(conditions.ifAnnotations());
-                            unlessPropertyList.addAll(conditions.unlessAnnotations());
-                        }
-                    }
-                    if (!ifPropertyList.isEmpty() || !unlessPropertyList.isEmpty()) {
-                        return new Consumer<BlockCreator>() {
-                            @Override
-                            public void accept(BlockCreator suppressed) {
-                                // if at least one condition fails, we mark the bean as suppressed
-                                // this means all conditions must pass, which is how we implement
-                                // the documented "logical AND of all conditions" behavior
-                                for (AnnotationInstance ifProperty : ifPropertyList) {
-                                    String propertyName = ifProperty.value(NAME).asString();
-                                    String expectedStringValue = ifProperty.value(STRING_VALUE).asString();
-                                    AnnotationValue lookupIfMissingValue = ifProperty.value(LOOKUP_IF_MISSING);
-                                    boolean lookupIfMissing = lookupIfMissingValue != null
-                                            && lookupIfMissingValue.asBoolean();
-                                    Expr result = suppressed.invokeStatic(SUPPRESS_IF_PROPERTY, Const.of(propertyName),
-                                            Const.of(expectedStringValue), Const.of(lookupIfMissing));
-                                    suppressed.if_(result, BlockCreator::returnTrue);
-                                }
-                                for (AnnotationInstance unlessProperty : unlessPropertyList) {
-                                    String propertyName = unlessProperty.value(NAME).asString();
-                                    String expectedStringValue = unlessProperty.value(STRING_VALUE).asString();
-                                    AnnotationValue lookupIfMissingValue = unlessProperty.value(LOOKUP_IF_MISSING);
-                                    boolean lookupIfMissing = lookupIfMissingValue != null
-                                            && lookupIfMissingValue.asBoolean();
-                                    Expr result = suppressed.invokeStatic(SUPPRESS_UNLESS_PROPERTY, Const.of(propertyName),
-                                            Const.of(expectedStringValue), Const.of(lookupIfMissing));
-                                    suppressed.if_(result, BlockCreator::returnTrue);
+        for (AnnotationInstance ann : combinedIndex.getComputingIndex()
+                .getAnnotationsWithRepeatable(LOOK_UP_IF_PROPERTY, combinedIndex.getComputingIndex())) {
+            validateRegex(ann);
+        }
+        for (AnnotationInstance ann : combinedIndex.getComputingIndex()
+                .getAnnotationsWithRepeatable(LOOK_UP_UNLESS_PROPERTY, combinedIndex.getComputingIndex())) {
+            validateRegex(ann);
+        }
+
+        generators.produce(new SuppressConditionGeneratorBuildItem(
+                new BiFunction<BeanInfo, ClassCreator, Consumer<BlockCreator>>() {
+                    final AtomicInteger patternCounter = new AtomicInteger();
+
+                    @Override
+                    public Consumer<BlockCreator> apply(BeanInfo bean, ClassCreator cc) {
+                        Optional<AnnotationTarget> maybeTarget = bean.getTarget();
+                        if (maybeTarget.isPresent()) {
+                            AnnotationTarget target = maybeTarget.get();
+                            List<AnnotationInstance> ifPropertyList = new ArrayList<>(
+                                    target.declaredAnnotationsWithRepeatable(LOOK_UP_IF_PROPERTY, index));
+                            List<AnnotationInstance> unlessPropertyList = new ArrayList<>(
+                                    target.declaredAnnotationsWithRepeatable(LOOK_UP_UNLESS_PROPERTY, index));
+                            for (StereotypeInfo stereotype : bean.getStereotypes()) {
+                                var conditions = lookupConditionStereotypes.get(stereotype.getName());
+                                if (conditions != null) {
+                                    ifPropertyList.addAll(conditions.ifAnnotations());
+                                    unlessPropertyList.addAll(conditions.unlessAnnotations());
                                 }
                             }
-                        };
+                            if (!ifPropertyList.isEmpty() || !unlessPropertyList.isEmpty()) {
+                                // pre-create static Pattern fields for all REGEX annotations on this bean
+                                List<StaticFieldVar> ifPatternFields = new ArrayList<>();
+                                for (AnnotationInstance ann : ifPropertyList) {
+                                    ifPatternFields.add(createPatternFieldIfRegex(cc, ann));
+                                }
+                                List<StaticFieldVar> unlessPatternFields = new ArrayList<>();
+                                for (AnnotationInstance ann : unlessPropertyList) {
+                                    unlessPatternFields.add(createPatternFieldIfRegex(cc, ann));
+                                }
+
+                                return new Consumer<BlockCreator>() {
+                                    @Override
+                                    public void accept(BlockCreator suppressed) {
+                                        // if at least one condition fails, we mark the bean as suppressed
+                                        // this means all conditions must pass, which is how we implement
+                                        // the documented "logical AND of all conditions" behavior
+                                        for (int i = 0; i < ifPropertyList.size(); i++) {
+                                            AnnotationInstance ifProperty = ifPropertyList.get(i);
+                                            String propertyName = ifProperty.value(NAME).asString();
+                                            String expectedStringValue = ifProperty.value(STRING_VALUE).asString();
+                                            AnnotationValue lookupIfMissingValue = ifProperty.value(LOOKUP_IF_MISSING);
+                                            boolean lookupIfMissing = lookupIfMissingValue != null
+                                                    && lookupIfMissingValue.asBoolean();
+                                            StaticFieldVar patternField = ifPatternFields.get(i);
+                                            Expr result;
+                                            if (patternField != null) {
+                                                result = suppressed.invokeStatic(SUPPRESS_IF_PROPERTY_REGEX,
+                                                        Const.of(propertyName),
+                                                        suppressed.getStaticField(patternField.desc()),
+                                                        Const.of(lookupIfMissing));
+                                            } else {
+                                                result = suppressed.invokeStatic(SUPPRESS_IF_PROPERTY,
+                                                        Const.of(propertyName),
+                                                        Const.of(expectedStringValue),
+                                                        Const.of(lookupIfMissing));
+                                            }
+                                            suppressed.if_(result, BlockCreator::returnTrue);
+                                        }
+                                        for (int i = 0; i < unlessPropertyList.size(); i++) {
+                                            AnnotationInstance unlessProperty = unlessPropertyList.get(i);
+                                            String propertyName = unlessProperty.value(NAME).asString();
+                                            String expectedStringValue = unlessProperty.value(STRING_VALUE).asString();
+                                            AnnotationValue lookupIfMissingValue = unlessProperty.value(LOOKUP_IF_MISSING);
+                                            boolean lookupIfMissing = lookupIfMissingValue != null
+                                                    && lookupIfMissingValue.asBoolean();
+                                            StaticFieldVar patternField = unlessPatternFields.get(i);
+                                            Expr result;
+                                            if (patternField != null) {
+                                                result = suppressed.invokeStatic(SUPPRESS_UNLESS_PROPERTY_REGEX,
+                                                        Const.of(propertyName),
+                                                        suppressed.getStaticField(patternField.desc()),
+                                                        Const.of(lookupIfMissing));
+                                            } else {
+                                                result = suppressed.invokeStatic(SUPPRESS_UNLESS_PROPERTY,
+                                                        Const.of(propertyName),
+                                                        Const.of(expectedStringValue),
+                                                        Const.of(lookupIfMissing));
+                                            }
+                                            suppressed.if_(result, BlockCreator::returnTrue);
+                                        }
+                                    }
+                                };
+                            }
+                        }
+                        return null;
                     }
-                }
-                return null;
+
+                    private StaticFieldVar createPatternFieldIfRegex(ClassCreator cc, AnnotationInstance ann) {
+                        if (getMatch(ann) == StringValueMatch.REGEX) {
+                            String regex = ann.value(STRING_VALUE).asString();
+                            String fieldName = "REGEX_PATTERN_" + patternCounter.getAndIncrement();
+                            return cc.staticField(fieldName, sfc -> {
+                                sfc.setType(Pattern.class);
+                                sfc.final_();
+                                sfc.private_();
+                                sfc.setInitializer(bc -> {
+                                    bc.yield(bc.invokeStatic(
+                                            MethodDesc.of(Pattern.class, "compile", Pattern.class, String.class),
+                                            Const.of(regex)));
+                                });
+                            });
+                        }
+                        return null;
+                    }
+                }));
+    }
+
+    private static StringValueMatch getMatch(AnnotationInstance annotation) {
+        AnnotationValue matchValue = annotation.value(MATCH);
+        if (matchValue != null) {
+            return StringValueMatch.valueOf(matchValue.asEnum());
+        }
+        return StringValueMatch.EQ;
+    }
+
+    private static void validateRegex(AnnotationInstance annotation) {
+        if (getMatch(annotation) == StringValueMatch.REGEX) {
+            String stringValue = annotation.value(STRING_VALUE).asString();
+            try {
+                Pattern.compile(stringValue);
+            } catch (PatternSyntaxException e) {
+                throw new IllegalArgumentException(
+                        "Invalid regex pattern '" + stringValue + "' in " + annotation + ": " + e.getMessage(), e);
             }
-        }));
+        }
     }
 }

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/SuppressConditionGeneratorBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/SuppressConditionGeneratorBuildItem.java
@@ -1,25 +1,29 @@
 package io.quarkus.arc.deployment;
 
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 import io.quarkus.arc.InjectableBean;
 import io.quarkus.arc.processor.BeanInfo;
 import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.gizmo2.creator.BlockCreator;
+import io.quarkus.gizmo2.creator.ClassCreator;
 
 /**
  * This build item can be used to contribute logic to the generated method body of {@link InjectableBean#isSuppressed()}.
+ * <p>
+ * The generator function receives a {@link BeanInfo} and a {@link ClassCreator} (to allow adding static fields)
+ * and returns a {@link Consumer} that contributes to the {@code isSuppressed()} method body.
  */
 final class SuppressConditionGeneratorBuildItem extends MultiBuildItem {
 
-    private final Function<BeanInfo, Consumer<BlockCreator>> generator;
+    private final BiFunction<BeanInfo, ClassCreator, Consumer<BlockCreator>> generator;
 
-    public SuppressConditionGeneratorBuildItem(Function<BeanInfo, Consumer<BlockCreator>> generator) {
+    public SuppressConditionGeneratorBuildItem(BiFunction<BeanInfo, ClassCreator, Consumer<BlockCreator>> generator) {
         this.generator = generator;
     }
 
-    public Function<BeanInfo, Consumer<BlockCreator>> getGenerator() {
+    public BiFunction<BeanInfo, ClassCreator, Consumer<BlockCreator>> getGenerator() {
         return generator;
     }
 

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/SuppressConditionGeneratorBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/SuppressConditionGeneratorBuildItem.java
@@ -1,29 +1,25 @@
 package io.quarkus.arc.deployment;
 
-import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
 import io.quarkus.arc.InjectableBean;
-import io.quarkus.arc.processor.BeanInfo;
+import io.quarkus.arc.processor.BeanGenerator;
 import io.quarkus.builder.item.MultiBuildItem;
-import io.quarkus.gizmo2.creator.BlockCreator;
-import io.quarkus.gizmo2.creator.ClassCreator;
 
 /**
  * This build item can be used to contribute logic to the generated method body of {@link InjectableBean#isSuppressed()}.
- * <p>
- * The generator function receives a {@link BeanInfo} and a {@link ClassCreator} (to allow adding static fields)
- * and returns a {@link Consumer} that contributes to the {@code isSuppressed()} method body.
+ *
+ * @see BeanGenerator.SuppressConditionGeneration
  */
 final class SuppressConditionGeneratorBuildItem extends MultiBuildItem {
 
-    private final BiFunction<BeanInfo, ClassCreator, Consumer<BlockCreator>> generator;
+    private final Consumer<BeanGenerator.SuppressConditionGeneration> generator;
 
-    public SuppressConditionGeneratorBuildItem(BiFunction<BeanInfo, ClassCreator, Consumer<BlockCreator>> generator) {
+    public SuppressConditionGeneratorBuildItem(Consumer<BeanGenerator.SuppressConditionGeneration> generator) {
         this.generator = generator;
     }
 
-    public BiFunction<BeanInfo, ClassCreator, Consumer<BlockCreator>> getGenerator() {
+    public Consumer<BeanGenerator.SuppressConditionGeneration> getGenerator() {
         return generator;
     }
 

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/lookup/LookupIfPropertyInvalidRegexTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/lookup/LookupIfPropertyInvalidRegexTest.java
@@ -1,0 +1,43 @@
+package io.quarkus.arc.test.lookup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.lookup.LookupIfProperty;
+import io.quarkus.arc.properties.StringValueMatch;
+import io.quarkus.runtime.util.ExceptionUtil;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class LookupIfPropertyInvalidRegexTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(ServiceAlpha.class))
+            .overrideConfigKey("service.version", "1.0.0")
+            .assertException(t -> {
+                Throwable rootCause = ExceptionUtil.getRootCause(t);
+                assertThat(rootCause)
+                        .isInstanceOf(IllegalArgumentException.class)
+                        .hasMessageContaining("[invalid(");
+            });
+
+    @Test
+    public void testFailure() {
+        fail();
+    }
+
+    @LookupIfProperty(name = "service.version", stringValue = "[invalid(", match = StringValueMatch.REGEX)
+    @Singleton
+    static class ServiceAlpha {
+
+        public String ping() {
+            return "alpha";
+        }
+    }
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/lookup/LookupIfPropertyRegexTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/lookup/LookupIfPropertyRegexTest.java
@@ -1,0 +1,140 @@
+package io.quarkus.arc.test.lookup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.lookup.LookupIfProperty;
+import io.quarkus.arc.properties.StringValueMatch;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class LookupIfPropertyRegexTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Client.class, Service.class,
+                            ServiceAlpha.class, ServiceBravo.class,
+                            ServiceCharlie.class, ServiceDelta.class))
+            .overrideConfigKey("service.version", "1.5.3");
+
+    @Inject
+    Client client;
+
+    @Test
+    public void testRegexMatch() {
+        // ServiceAlpha uses regex "^1\\.\\d+\\.\\d+$" which matches "1.5.3" -> NOT suppressed
+        assertThat(client.alphaAvailable()).isTrue();
+        assertThat(client.alpha().ping()).isEqualTo("alpha");
+    }
+
+    @Test
+    public void testRegexNoMatch() {
+        // ServiceBravo uses regex "^2\\.\\d+\\.\\d+$" which does not match "1.5.3" -> suppressed
+        assertThat(client.bravoAvailable()).isFalse();
+    }
+
+    @Test
+    public void testRegexPropertyMissing() {
+        // ServiceCharlie checks a property that doesn't exist, lookupIfMissing=false -> suppressed
+        assertThat(client.charlieAvailable()).isFalse();
+    }
+
+    @Test
+    public void testRegexPropertyMissingWithLookupIfMissing() {
+        // ServiceDelta checks a property that doesn't exist, lookupIfMissing=true -> NOT suppressed
+        assertThat(client.deltaAvailable()).isTrue();
+        assertThat(client.delta().ping()).isEqualTo("delta");
+    }
+
+    @Singleton
+    static class Client {
+
+        @Inject
+        Instance<ServiceAlpha> alphaInstance;
+
+        @Inject
+        Instance<ServiceBravo> bravoInstance;
+
+        @Inject
+        Instance<ServiceCharlie> charlieInstance;
+
+        @Inject
+        Instance<ServiceDelta> deltaInstance;
+
+        boolean alphaAvailable() {
+            return alphaInstance.isResolvable();
+        }
+
+        ServiceAlpha alpha() {
+            return alphaInstance.get();
+        }
+
+        boolean bravoAvailable() {
+            return bravoInstance.isResolvable();
+        }
+
+        boolean charlieAvailable() {
+            return charlieInstance.isResolvable();
+        }
+
+        boolean deltaAvailable() {
+            return deltaInstance.isResolvable();
+        }
+
+        ServiceDelta delta() {
+            return deltaInstance.get();
+        }
+    }
+
+    interface Service {
+
+        String ping();
+    }
+
+    // regex matches "1.5.3" -> NOT suppressed
+    @LookupIfProperty(name = "service.version", stringValue = "^1\\.\\d+\\.\\d+$", match = StringValueMatch.REGEX)
+    @Singleton
+    static class ServiceAlpha implements Service {
+
+        public String ping() {
+            return "alpha";
+        }
+    }
+
+    // regex does NOT match "1.5.3" -> suppressed
+    @LookupIfProperty(name = "service.version", stringValue = "^2\\.\\d+\\.\\d+$", match = StringValueMatch.REGEX)
+    @Singleton
+    static class ServiceBravo implements Service {
+
+        public String ping() {
+            return "bravo";
+        }
+    }
+
+    // property "service.nonexistent" missing, lookupIfMissing=false -> suppressed
+    @LookupIfProperty(name = "service.nonexistent", stringValue = ".*", match = StringValueMatch.REGEX)
+    @Dependent
+    static class ServiceCharlie implements Service {
+
+        public String ping() {
+            return "charlie";
+        }
+    }
+
+    // property "service.nonexistent2" missing, lookupIfMissing=true -> NOT suppressed
+    @LookupIfProperty(name = "service.nonexistent2", stringValue = ".*", match = StringValueMatch.REGEX, lookupIfMissing = true)
+    @Singleton
+    static class ServiceDelta implements Service {
+
+        public String ping() {
+            return "delta";
+        }
+    }
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/lookup/LookupMixedMatchConditionsTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/lookup/LookupMixedMatchConditionsTest.java
@@ -1,0 +1,78 @@
+package io.quarkus.arc.test.lookup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.lookup.LookupIfProperty;
+import io.quarkus.arc.properties.StringValueMatch;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class LookupMixedMatchConditionsTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar.addClasses(AlphaService.class, BravoService.class, CharlieService.class))
+            .overrideConfigKey("service.enabled", "true")
+            .overrideConfigKey("service.version", "1.5.3");
+
+    @Inject
+    Instance<AlphaService> alpha;
+
+    @Inject
+    Instance<BravoService> bravo;
+
+    @Inject
+    Instance<CharlieService> charlie;
+
+    @Test
+    public void testBothConditionsPass() {
+        // EQ matches "true", REGEX matches "1.5.3" -> both pass, NOT suppressed
+        assertThat(alpha.isResolvable()).isTrue();
+        assertThat(alpha.get().ping()).isEqualTo("alpha");
+    }
+
+    @Test
+    public void testEqPassesRegexFails() {
+        // EQ matches "true", REGEX "^2\\..*" does NOT match "1.5.3" -> suppressed
+        assertThat(bravo.isResolvable()).isFalse();
+    }
+
+    @Test
+    public void testEqFailsRegexPasses() {
+        // EQ "false" does NOT match "true", REGEX matches "1.5.3" -> suppressed
+        assertThat(charlie.isResolvable()).isFalse();
+    }
+
+    @LookupIfProperty(name = "service.enabled", stringValue = "true")
+    @LookupIfProperty(name = "service.version", stringValue = "^1\\.\\d+\\.\\d+$", match = StringValueMatch.REGEX)
+    @Singleton
+    static class AlphaService {
+        public String ping() {
+            return "alpha";
+        }
+    }
+
+    @LookupIfProperty(name = "service.enabled", stringValue = "true")
+    @LookupIfProperty(name = "service.version", stringValue = "^2\\..*", match = StringValueMatch.REGEX)
+    @Singleton
+    static class BravoService {
+        public String ping() {
+            return "bravo";
+        }
+    }
+
+    @LookupIfProperty(name = "service.enabled", stringValue = "false")
+    @LookupIfProperty(name = "service.version", stringValue = "^1\\.\\d+\\.\\d+$", match = StringValueMatch.REGEX)
+    @Singleton
+    static class CharlieService {
+        public String ping() {
+            return "charlie";
+        }
+    }
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/lookup/LookupRegexOnProducersTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/lookup/LookupRegexOnProducersTest.java
@@ -1,0 +1,68 @@
+package io.quarkus.arc.test.lookup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.lookup.LookupIfProperty;
+import io.quarkus.arc.lookup.LookupUnlessProperty;
+import io.quarkus.arc.properties.StringValueMatch;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class LookupRegexOnProducersTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Client.class, Service.class, ServiceProducer.class))
+            .overrideConfigKey("service.version", "1.5.3");
+
+    @Inject
+    Client client;
+
+    @Test
+    public void testProducerRegexMatch() {
+        // producer "alpha" uses regex that matches "1.5.3" -> NOT suppressed
+        assertThat(client.pingService()).isEqualTo("alpha");
+    }
+
+    @Singleton
+    static class Client {
+
+        @Inject
+        Instance<Service> service;
+
+        String pingService() {
+            return service.get().ping();
+        }
+    }
+
+    interface Service {
+
+        String ping();
+    }
+
+    @Singleton
+    static class ServiceProducer {
+
+        // regex matches "1.5.3" -> NOT suppressed
+        @LookupIfProperty(name = "service.version", stringValue = "^1\\.\\d+\\.\\d+$", match = StringValueMatch.REGEX)
+        @Produces
+        public Service alpha() {
+            return () -> "alpha";
+        }
+
+        // regex matches "1.5.3" -> suppressed (unless = exclude on match)
+        @LookupUnlessProperty(name = "service.version", stringValue = "^1\\..*", match = StringValueMatch.REGEX)
+        @Produces
+        public Service bravo() {
+            return () -> "bravo";
+        }
+    }
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/lookup/LookupUnlessPropertyRegexTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/lookup/LookupUnlessPropertyRegexTest.java
@@ -1,0 +1,87 @@
+package io.quarkus.arc.test.lookup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.lookup.LookupUnlessProperty;
+import io.quarkus.arc.properties.StringValueMatch;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class LookupUnlessPropertyRegexTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Client.class, Service.class,
+                            ServiceAlpha.class, ServiceBravo.class))
+            .overrideConfigKey("service.version", "2.0.1");
+
+    @Inject
+    Client client;
+
+    @Test
+    public void testRegexMatchSuppresses() {
+        // ServiceAlpha uses regex "^2\\..*" which matches "2.0.1" -> suppressed (unless = exclude on match)
+        assertThat(client.alphaAvailable()).isFalse();
+    }
+
+    @Test
+    public void testRegexNoMatchNotSuppressed() {
+        // ServiceBravo uses regex "^3\\..*" which does not match "2.0.1" -> NOT suppressed
+        assertThat(client.bravoAvailable()).isTrue();
+        assertThat(client.bravo().ping()).isEqualTo("bravo");
+    }
+
+    @Singleton
+    static class Client {
+
+        @Inject
+        Instance<ServiceAlpha> alphaInstance;
+
+        @Inject
+        Instance<ServiceBravo> bravoInstance;
+
+        boolean alphaAvailable() {
+            return alphaInstance.isResolvable();
+        }
+
+        boolean bravoAvailable() {
+            return bravoInstance.isResolvable();
+        }
+
+        ServiceBravo bravo() {
+            return bravoInstance.get();
+        }
+    }
+
+    interface Service {
+
+        String ping();
+    }
+
+    // regex matches "2.0.1" -> suppressed
+    @LookupUnlessProperty(name = "service.version", stringValue = "^2\\..*", match = StringValueMatch.REGEX)
+    @Singleton
+    static class ServiceAlpha implements Service {
+
+        public String ping() {
+            return "alpha";
+        }
+    }
+
+    // regex does NOT match "2.0.1" -> NOT suppressed
+    @LookupUnlessProperty(name = "service.version", stringValue = "^3\\..*", match = StringValueMatch.REGEX)
+    @Singleton
+    static class ServiceBravo implements Service {
+
+        public String ping() {
+            return "bravo";
+        }
+    }
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/properties/IfBuildPropertyInvalidRegexTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/properties/IfBuildPropertyInvalidRegexTest.java
@@ -1,0 +1,42 @@
+package io.quarkus.arc.test.properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.properties.IfBuildProperty;
+import io.quarkus.arc.properties.StringValueMatch;
+import io.quarkus.runtime.util.ExceptionUtil;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class IfBuildPropertyInvalidRegexTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(ServiceAlpha.class))
+            .overrideConfigKey("build.version", "1.0.0")
+            .assertException(t -> {
+                Throwable rootCause = ExceptionUtil.getRootCause(t);
+                assertThat(rootCause)
+                        .isInstanceOf(java.util.regex.PatternSyntaxException.class);
+            });
+
+    @Test
+    public void testFailure() {
+        fail();
+    }
+
+    @IfBuildProperty(name = "build.version", stringValue = "[invalid(", match = StringValueMatch.REGEX)
+    @Singleton
+    static class ServiceAlpha {
+
+        public String ping() {
+            return "alpha";
+        }
+    }
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/properties/IfBuildPropertyRegexTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/properties/IfBuildPropertyRegexTest.java
@@ -1,0 +1,117 @@
+package io.quarkus.arc.test.properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.properties.IfBuildProperty;
+import io.quarkus.arc.properties.StringValueMatch;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class IfBuildPropertyRegexTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Client.class, Service.class,
+                            ServiceAlpha.class, ServiceBravo.class,
+                            ServiceCharlie.class))
+            .overrideConfigKey("build.version", "1.4.7");
+
+    @Inject
+    Client client;
+
+    @Test
+    public void testRegexMatch() {
+        // ServiceAlpha uses regex "^1\\.(4|5|6)\\.\\d+$" which matches "1.4.7" -> enabled
+        assertThat(client.alphaAvailable()).isTrue();
+        assertThat(client.alpha().ping()).isEqualTo("alpha");
+    }
+
+    @Test
+    public void testRegexNoMatch() {
+        // ServiceBravo uses regex "^2\\.\\d+\\.\\d+$" which does not match "1.4.7" -> disabled/vetoed
+        assertThat(client.bravoAvailable()).isFalse();
+    }
+
+    @Test
+    public void testRegexPropertyMissing() {
+        // ServiceCharlie checks missing property with enableIfMissing=true -> enabled
+        assertThat(client.charlieAvailable()).isTrue();
+        assertThat(client.charlie().ping()).isEqualTo("charlie");
+    }
+
+    @ApplicationScoped
+    static class Client {
+
+        @Inject
+        Instance<ServiceAlpha> alphaInstance;
+
+        @Inject
+        Instance<ServiceBravo> bravoInstance;
+
+        @Inject
+        Instance<ServiceCharlie> charlieInstance;
+
+        boolean alphaAvailable() {
+            return alphaInstance.isResolvable();
+        }
+
+        ServiceAlpha alpha() {
+            return alphaInstance.get();
+        }
+
+        boolean bravoAvailable() {
+            return bravoInstance.isResolvable();
+        }
+
+        boolean charlieAvailable() {
+            return charlieInstance.isResolvable();
+        }
+
+        ServiceCharlie charlie() {
+            return charlieInstance.get();
+        }
+    }
+
+    interface Service {
+
+        String ping();
+    }
+
+    // regex matches "1.4.7" -> enabled
+    @IfBuildProperty(name = "build.version", stringValue = "^1\\.(4|5|6)\\.\\d+$", match = StringValueMatch.REGEX)
+    @Singleton
+    static class ServiceAlpha implements Service {
+
+        public String ping() {
+            return "alpha";
+        }
+    }
+
+    // regex does NOT match "1.4.7" -> disabled/vetoed
+    @IfBuildProperty(name = "build.version", stringValue = "^2\\.\\d+\\.\\d+$", match = StringValueMatch.REGEX)
+    @Singleton
+    static class ServiceBravo implements Service {
+
+        public String ping() {
+            return "bravo";
+        }
+    }
+
+    // property missing, enableIfMissing=true -> enabled
+    @IfBuildProperty(name = "build.nonexistent", stringValue = ".*", match = StringValueMatch.REGEX, enableIfMissing = true)
+    @Singleton
+    static class ServiceCharlie implements Service {
+
+        public String ping() {
+            return "charlie";
+        }
+    }
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/properties/UnlessBuildPropertyRegexTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/properties/UnlessBuildPropertyRegexTest.java
@@ -1,0 +1,88 @@
+package io.quarkus.arc.test.properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.properties.StringValueMatch;
+import io.quarkus.arc.properties.UnlessBuildProperty;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class UnlessBuildPropertyRegexTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Client.class, Service.class,
+                            ServiceAlpha.class, ServiceBravo.class))
+            .overrideConfigKey("build.mode", "staging");
+
+    @Inject
+    Client client;
+
+    @Test
+    public void testRegexMatchDisables() {
+        // ServiceAlpha uses regex "stag.*" which matches "staging" -> disabled/vetoed
+        assertThat(client.alphaAvailable()).isFalse();
+    }
+
+    @Test
+    public void testRegexNoMatchEnables() {
+        // ServiceBravo uses regex "^prod.*" which does not match "staging" -> enabled
+        assertThat(client.bravoAvailable()).isTrue();
+        assertThat(client.bravo().ping()).isEqualTo("bravo");
+    }
+
+    @ApplicationScoped
+    static class Client {
+
+        @Inject
+        Instance<ServiceAlpha> alphaInstance;
+
+        @Inject
+        Instance<ServiceBravo> bravoInstance;
+
+        boolean alphaAvailable() {
+            return alphaInstance.isResolvable();
+        }
+
+        boolean bravoAvailable() {
+            return bravoInstance.isResolvable();
+        }
+
+        ServiceBravo bravo() {
+            return bravoInstance.get();
+        }
+    }
+
+    interface Service {
+
+        String ping();
+    }
+
+    // regex matches "staging" -> disabled
+    @UnlessBuildProperty(name = "build.mode", stringValue = "stag.*", match = StringValueMatch.REGEX)
+    @Singleton
+    static class ServiceAlpha implements Service {
+
+        public String ping() {
+            return "alpha";
+        }
+    }
+
+    // regex does NOT match "staging" -> enabled
+    @UnlessBuildProperty(name = "build.mode", stringValue = "^prod.*", match = StringValueMatch.REGEX)
+    @Singleton
+    static class ServiceBravo implements Service {
+
+        public String ping() {
+            return "bravo";
+        }
+    }
+}

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/lookup/LookupIfProperty.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/lookup/LookupIfProperty.java
@@ -8,6 +8,8 @@ import java.lang.annotation.Target;
 
 import jakarta.enterprise.inject.Instance;
 
+import io.quarkus.arc.properties.StringValueMatch;
+
 /**
  * Indicates that a bean should only be obtained by programmatic lookup if the property matches the provided value.
  * <p>
@@ -75,6 +77,14 @@ public @interface LookupIfProperty {
      * has not been specified at all.
      */
     boolean lookupIfMissing() default false;
+
+    /**
+     * Defines how the {@code stringValue} is matched against the actual property value.
+     * <p>
+     * By default, exact string equality ({@link StringValueMatch#EQ}) is used.
+     * Set to {@link StringValueMatch#REGEX} to interpret {@code stringValue} as a regular expression.
+     */
+    StringValueMatch match() default StringValueMatch.EQ;
 
     @Retention(RetentionPolicy.RUNTIME)
     @Target({ ElementType.METHOD, ElementType.TYPE, ElementType.FIELD })

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/lookup/LookupUnlessProperty.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/lookup/LookupUnlessProperty.java
@@ -8,6 +8,8 @@ import java.lang.annotation.Target;
 
 import jakarta.enterprise.inject.Instance;
 
+import io.quarkus.arc.properties.StringValueMatch;
+
 /**
  * Indicates that a bean should only be obtained by programmatic lookup if the property does not match the provided value.
  * <p>
@@ -75,6 +77,14 @@ public @interface LookupUnlessProperty {
      * has not been specified at all.
      */
     boolean lookupIfMissing() default false;
+
+    /**
+     * Defines how the {@code stringValue} is matched against the actual property value.
+     * <p>
+     * By default, exact string equality ({@link StringValueMatch#EQ}) is used.
+     * Set to {@link StringValueMatch#REGEX} to interpret {@code stringValue} as a regular expression.
+     */
+    StringValueMatch match() default StringValueMatch.EQ;
 
     @Retention(RetentionPolicy.RUNTIME)
     @Target({ ElementType.METHOD, ElementType.TYPE, ElementType.FIELD })

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/properties/IfBuildProperty.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/properties/IfBuildProperty.java
@@ -36,6 +36,14 @@ public @interface IfBuildProperty {
      */
     boolean enableIfMissing() default false;
 
+    /**
+     * Defines how the {@code stringValue} is matched against the actual property value.
+     * <p>
+     * By default, exact string equality ({@link StringValueMatch#EQ}) is used.
+     * Set to {@link StringValueMatch#REGEX} to interpret {@code stringValue} as a regular expression.
+     */
+    StringValueMatch match() default StringValueMatch.EQ;
+
     @Retention(RetentionPolicy.RUNTIME)
     @Target({ ElementType.METHOD, ElementType.TYPE, ElementType.FIELD })
     @interface List {

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/properties/StringValueMatch.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/properties/StringValueMatch.java
@@ -7,7 +7,7 @@ package io.quarkus.arc.properties;
 public enum StringValueMatch {
 
     /**
-     * Exact string equality (the default).
+     * Exact, case-sensitive string equality (the default).
      */
     EQ,
 

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/properties/StringValueMatch.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/properties/StringValueMatch.java
@@ -1,0 +1,21 @@
+package io.quarkus.arc.properties;
+
+/**
+ * Defines how the {@code stringValue} of a property condition annotation is matched against
+ * the actual property value.
+ */
+public enum StringValueMatch {
+
+    /**
+     * Exact string equality (the default).
+     */
+    EQ,
+
+    /**
+     * The {@code stringValue} is interpreted as a regular expression and the actual
+     * property value is matched against it using {@link java.util.regex.Pattern#matches(String, CharSequence)}.
+     * <p>
+     * The pattern must match the entire property value (equivalent to {@code ^pattern$}).
+     */
+    REGEX;
+}

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/properties/UnlessBuildProperty.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/properties/UnlessBuildProperty.java
@@ -36,6 +36,14 @@ public @interface UnlessBuildProperty {
      */
     boolean enableIfMissing() default false;
 
+    /**
+     * Defines how the {@code stringValue} is matched against the actual property value.
+     * <p>
+     * By default, exact string equality ({@link StringValueMatch#EQ}) is used.
+     * Set to {@link StringValueMatch#REGEX} to interpret {@code stringValue} as a regular expression.
+     */
+    StringValueMatch match() default StringValueMatch.EQ;
+
     @Retention(RetentionPolicy.RUNTIME)
     @Target({ ElementType.METHOD, ElementType.TYPE, ElementType.FIELD })
     @interface List {

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/SuppressConditions.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/SuppressConditions.java
@@ -1,6 +1,7 @@
 package io.quarkus.arc.runtime;
 
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
@@ -30,4 +31,23 @@ public final class SuppressConditions {
         }
     }
 
+    public static boolean suppressIfPropertyRegex(String propertyName, Pattern pattern, boolean lookupIfMissing) {
+        Config config = ConfigProviderResolver.instance().getConfig();
+        Optional<String> optionalValue = config.getOptionalValue(propertyName, String.class);
+        if (optionalValue.isPresent()) {
+            return !pattern.matcher(optionalValue.get()).matches();
+        } else {
+            return !lookupIfMissing;
+        }
+    }
+
+    public static boolean suppressUnlessPropertyRegex(String propertyName, Pattern pattern, boolean lookupIfMissing) {
+        Config config = ConfigProviderResolver.instance().getConfig();
+        Optional<String> optionalValue = config.getOptionalValue(propertyName, String.class);
+        if (optionalValue.isPresent()) {
+            return pattern.matcher(optionalValue.get()).matches();
+        } else {
+            return !lookupIfMissing;
+        }
+    }
 }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanConfiguratorBase.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanConfiguratorBase.java
@@ -531,7 +531,7 @@ public abstract class BeanConfiguratorBase<THIS extends BeanConfiguratorBase<THI
 
     public interface CreateGeneration {
         /**
-         * {@return the generated class of the synthetic bean}
+         * {@return the generated implementation of {@link InjectableBean} for the synthetic bean}
          * This class contains the generated {@code create} method.
          *
          * @see #createMethod()
@@ -562,7 +562,7 @@ public abstract class BeanConfiguratorBase<THIS extends BeanConfiguratorBase<THI
 
     public interface DestroyGeneration {
         /**
-         * {@return the generated class of the synthetic bean}
+         * {@return the generated implementation of {@link InjectableBean} for the synthetic bean}
          * This class contains the generated {@code destroy} method.
          *
          * @see #destroyMethod()
@@ -600,7 +600,7 @@ public abstract class BeanConfiguratorBase<THIS extends BeanConfiguratorBase<THI
 
     public interface CheckActiveGeneration {
         /**
-         * {@return the generated class of the synthetic bean}
+         * {@return the generated implementation of {@link InjectableBean} for the synthetic bean}
          * This class contains the generated {@code checkActive} method.
          *
          * @see #checkActiveMethod()

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -110,13 +111,13 @@ public class BeanGenerator extends AbstractGenerator {
     protected final Map<BeanInfo, String> beanToGeneratedName;
     protected final Map<BeanInfo, String> beanToGeneratedBaseName;
     protected final Predicate<DotName> injectionPointAnnotationsPredicate;
-    protected final List<Function<BeanInfo, Consumer<BlockCreator>>> suppressConditionGenerators;
+    protected final List<BiFunction<BeanInfo, ClassCreator, Consumer<BlockCreator>>> suppressConditionGenerators;
 
     public BeanGenerator(AnnotationLiteralProcessor annotationLiterals, Predicate<DotName> applicationClassPredicate,
             PrivateMembersCollector privateMembers, boolean generateSources, ReflectionRegistration reflectionRegistration,
             Set<String> existingClasses, Map<BeanInfo, String> beanToGeneratedName,
             Predicate<DotName> injectionPointAnnotationsPredicate,
-            List<Function<BeanInfo, Consumer<BlockCreator>>> suppressConditionGenerators) {
+            List<BiFunction<BeanInfo, ClassCreator, Consumer<BlockCreator>>> suppressConditionGenerators) {
         super(generateSources, reflectionRegistration);
         this.annotationLiterals = annotationLiterals;
         this.applicationClassPredicate = applicationClassPredicate;
@@ -1950,8 +1951,8 @@ public class BeanGenerator extends AbstractGenerator {
         cc.method("isSuppressed", mc -> {
             mc.returning(boolean.class);
             mc.body(bc -> {
-                for (Function<BeanInfo, Consumer<BlockCreator>> generator : suppressConditionGenerators) {
-                    Consumer<BlockCreator> condition = generator.apply(bean);
+                for (BiFunction<BeanInfo, ClassCreator, Consumer<BlockCreator>> generator : suppressConditionGenerators) {
+                    Consumer<BlockCreator> condition = generator.apply(bean, cc);
                     if (condition != null) {
                         condition.accept(bc);
                     }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -111,13 +110,13 @@ public class BeanGenerator extends AbstractGenerator {
     protected final Map<BeanInfo, String> beanToGeneratedName;
     protected final Map<BeanInfo, String> beanToGeneratedBaseName;
     protected final Predicate<DotName> injectionPointAnnotationsPredicate;
-    protected final List<BiFunction<BeanInfo, ClassCreator, Consumer<BlockCreator>>> suppressConditionGenerators;
+    protected final List<Consumer<SuppressConditionGeneration>> suppressConditionGenerators;
 
     public BeanGenerator(AnnotationLiteralProcessor annotationLiterals, Predicate<DotName> applicationClassPredicate,
             PrivateMembersCollector privateMembers, boolean generateSources, ReflectionRegistration reflectionRegistration,
             Set<String> existingClasses, Map<BeanInfo, String> beanToGeneratedName,
             Predicate<DotName> injectionPointAnnotationsPredicate,
-            List<BiFunction<BeanInfo, ClassCreator, Consumer<BlockCreator>>> suppressConditionGenerators) {
+            List<Consumer<SuppressConditionGeneration>> suppressConditionGenerators) {
         super(generateSources, reflectionRegistration);
         this.annotationLiterals = annotationLiterals;
         this.applicationClassPredicate = applicationClassPredicate;
@@ -1951,11 +1950,24 @@ public class BeanGenerator extends AbstractGenerator {
         cc.method("isSuppressed", mc -> {
             mc.returning(boolean.class);
             mc.body(bc -> {
-                for (BiFunction<BeanInfo, ClassCreator, Consumer<BlockCreator>> generator : suppressConditionGenerators) {
-                    Consumer<BlockCreator> condition = generator.apply(bean, cc);
-                    if (condition != null) {
-                        condition.accept(bc);
+                SuppressConditionGeneration generation = new SuppressConditionGeneration() {
+                    @Override
+                    public BeanInfo bean() {
+                        return bean;
                     }
+
+                    @Override
+                    public ClassCreator beanClass() {
+                        return cc;
+                    }
+
+                    @Override
+                    public BlockCreator method() {
+                        return bc;
+                    }
+                };
+                for (Consumer<SuppressConditionGeneration> generator : suppressConditionGenerators) {
+                    generator.accept(generation);
                 }
                 bc.returnFalse();
             });
@@ -2245,5 +2257,26 @@ public class BeanGenerator extends AbstractGenerator {
         String className() {
             return className;
         }
+    }
+
+    public interface SuppressConditionGeneration {
+        /**
+         * {@return the bean}
+         */
+        BeanInfo bean();
+
+        /**
+         * {@return the generated implementation of {@link InjectableBean} for the bean}
+         * This class contains the generated {@code isSuppressed} method.
+         *
+         * @see #method()
+         */
+        ClassCreator beanClass();
+
+        /**
+         * {@return the {@link BlockCreator} for the {@code isSuppressed} method}
+         * This method is supposed to determine whether the bean is suppressed.
+         */
+        BlockCreator method();
     }
 }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanProcessor.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanProcessor.java
@@ -18,6 +18,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -42,6 +43,7 @@ import io.quarkus.arc.processor.ResourceOutput.Resource.SpecialType;
 import io.quarkus.arc.processor.bcextensions.ExtensionsEntryPoint;
 import io.quarkus.gizmo2.Expr;
 import io.quarkus.gizmo2.creator.BlockCreator;
+import io.quarkus.gizmo2.creator.ClassCreator;
 
 /**
  * An integrator should create a new instance of the bean processor using the convenient {@link Builder} and then invoke the
@@ -87,7 +89,7 @@ public class BeanProcessor {
     private final boolean allowMocking;
     private final boolean transformUnproxyableClasses;
     private final Predicate<BeanDeployment> optimizeContexts;
-    private final List<Function<BeanInfo, Consumer<BlockCreator>>> suppressConditionGenerators;
+    private final List<BiFunction<BeanInfo, ClassCreator, Consumer<BlockCreator>>> suppressConditionGenerators;
 
     // This predicate is used to filter annotations for InjectionPoint metadata
     // Note that we do create annotation literals for all annotations for an injection point that resolves to a @Dependent bean that injects the InjectionPoint metadata
@@ -631,7 +633,7 @@ public class BeanProcessor {
         final List<InterceptorBindingRegistrar> interceptorBindingRegistrars;
         final List<StereotypeRegistrar> stereotypeRegistrars;
         final List<BeanDeploymentValidator> beanDeploymentValidators;
-        final List<Function<BeanInfo, Consumer<BlockCreator>>> suppressConditionGenerators;
+        final List<BiFunction<BeanInfo, ClassCreator, Consumer<BlockCreator>>> suppressConditionGenerators;
 
         boolean removeUnusedBeans = false;
         final List<Predicate<BeanInfo>> removalExclusions;
@@ -977,7 +979,7 @@ public class BeanProcessor {
          * @param generator
          * @return self
          */
-        public Builder addSuppressConditionGenerator(Function<BeanInfo, Consumer<BlockCreator>> generator) {
+        public Builder addSuppressConditionGenerator(BiFunction<BeanInfo, ClassCreator, Consumer<BlockCreator>> generator) {
             this.suppressConditionGenerators.add(generator);
             return this;
         }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanProcessor.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanProcessor.java
@@ -18,7 +18,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -42,8 +41,6 @@ import io.quarkus.arc.processor.ResourceOutput.Resource;
 import io.quarkus.arc.processor.ResourceOutput.Resource.SpecialType;
 import io.quarkus.arc.processor.bcextensions.ExtensionsEntryPoint;
 import io.quarkus.gizmo2.Expr;
-import io.quarkus.gizmo2.creator.BlockCreator;
-import io.quarkus.gizmo2.creator.ClassCreator;
 
 /**
  * An integrator should create a new instance of the bean processor using the convenient {@link Builder} and then invoke the
@@ -89,7 +86,7 @@ public class BeanProcessor {
     private final boolean allowMocking;
     private final boolean transformUnproxyableClasses;
     private final Predicate<BeanDeployment> optimizeContexts;
-    private final List<BiFunction<BeanInfo, ClassCreator, Consumer<BlockCreator>>> suppressConditionGenerators;
+    private final List<Consumer<BeanGenerator.SuppressConditionGeneration>> suppressConditionGenerators;
 
     // This predicate is used to filter annotations for InjectionPoint metadata
     // Note that we do create annotation literals for all annotations for an injection point that resolves to a @Dependent bean that injects the InjectionPoint metadata
@@ -633,7 +630,7 @@ public class BeanProcessor {
         final List<InterceptorBindingRegistrar> interceptorBindingRegistrars;
         final List<StereotypeRegistrar> stereotypeRegistrars;
         final List<BeanDeploymentValidator> beanDeploymentValidators;
-        final List<BiFunction<BeanInfo, ClassCreator, Consumer<BlockCreator>>> suppressConditionGenerators;
+        final List<Consumer<BeanGenerator.SuppressConditionGeneration>> suppressConditionGenerators;
 
         boolean removeUnusedBeans = false;
         final List<Predicate<BeanInfo>> removalExclusions;
@@ -979,7 +976,7 @@ public class BeanProcessor {
          * @param generator
          * @return self
          */
-        public Builder addSuppressConditionGenerator(BiFunction<BeanInfo, ClassCreator, Consumer<BlockCreator>> generator) {
+        public Builder addSuppressConditionGenerator(Consumer<BeanGenerator.SuppressConditionGeneration> generator) {
             this.suppressConditionGenerators.add(generator);
             return this;
         }


### PR DESCRIPTION
Fixes #53757 

There are two commits.

First one adds the regex functionality. In order to avoid computing the regex repeatedly, I have added a static field into the generated bean. This however required me to change `SuppressConditionGeneratorBuildItem` to gain access to the `ClassCreator`. I am not sure if that's acceptable given it's theoretically a "public" build item.


Second commit fixes an inconsistency we already had in code regarding case-sensitivity.
For build-time properties, we were using case-insensitive approach ([code](https://github.com/quarkusio/quarkus/blob/main/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BuildTimeEnabledProcessor.java#L401)) whereas runtime was using case sensitive ([code](https://github.com/quarkusio/quarkus/blob/main/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/SuppressConditions.java#L17)).
I believe this was an oversight although it is theoretically breaking :shrug: 