### PR TITLE
fix: Json.appendValue() falls back to toString() for unrecognized value types

### DIFF
--- a/independent-projects/bootstrap/json/src/main/java/io/quarkus/bootstrap/json/Json.java
+++ b/independent-projects/bootstrap/json/src/main/java/io/quarkus/bootstrap/json/Json.java
@@ -538,7 +538,10 @@ public final class Json {
         } else if (value instanceof Boolean || value instanceof Integer || value instanceof Long) {
             appendable.append(value.toString());
         } else {
-            throw new IllegalStateException("Unsupported value type: " + value);
+            // Fallback: serialize as a JSON string using toString().
+            // Handles types such as java.lang.Module that can appear as extension
+            // dev-mode JVM option values (e.g. enable-native-access=ALL-UNNAMED).
+            appendStringValue(appendable, value.toString());
         }
     }
 

--- a/independent-projects/bootstrap/json/src/test/java/io/quarkus/bootstrap/json/test/JsonSerializerTest.java
+++ b/independent-projects/bootstrap/json/src/test/java/io/quarkus/bootstrap/json/test/JsonSerializerTest.java
@@ -206,6 +206,20 @@ class JsonSerializerTest {
         assertEquals("{\"emoji\":\"Hello 🌍\"}", json);
     }
 
+    @Test
+    void testUnrecognizedValueTypeFallsBackToString() throws IOException {
+        // Regression test for https://github.com/quarkusio/quarkus/issues/53775
+        // Before the fix, appendValue() threw IllegalStateException for unrecognized types.
+        // Extension dev-mode JVM option values (e.g. enable-native-access=ALL-UNNAMED)
+        // can produce java.lang.Module objects that must not crash the serializer.
+        JsonObjectBuilder builder = Json.object();
+        Module unnamedModule = ClassLoader.getSystemClassLoader().getUnnamedModule();
+        ((java.util.Map<String, Object>) builder).put("enable-native-access", unnamedModule);
+        String json = toJson(builder);
+        JsonObject parsed = JsonReader.of(json).read();
+        assertEquals(unnamedModule.toString(), ((JsonString) parsed.get("enable-native-access")).value());
+    }
+
     @Disabled("https://github.com/quarkusio/quarkus/issues/52196")
     @Test
     void testFluentApiIncompatibility() throws IOException {


### PR DESCRIPTION
Fixes #53775

## Problem

`Json.appendValue()` throws `IllegalStateException` for any value type it doesn't explicitly handle:

```java
} else {
    throw new IllegalStateException("Unsupported value type: " + value);
}
```

This crashes `@QuarkusTest` bootstrap on 3.32+ when an extension's dev-mode JVM option value reaches the serializer as a type outside the handled set (`JsonObjectBuilder`, `JsonArrayBuilder`, `String`, `Boolean`, `Integer`, `Long`).

The concrete trigger is `quarkus-langchain4j-jlama`, which declares:

```xml
<devMode>
    <jvmOptions>
        <enable-native-access>ALL-UNNAMED</enable-native-access>
    </jvmOptions>
</devMode>
```

The plugin bakes this into `META-INF/quarkus-extension.properties`. On 3.32+, `ApplicationModelSerializer` reads extension metadata into the app model and serializes it to a JSON cache. The value ends up as a `java.lang.Module` object; `appendValue()` has no case for it and throws:

```
java.lang.IllegalStateException: Unsupported value type: [ALL-UNNAMED]
  at io.quarkus.bootstrap.json.Json.appendValue(Json.java:541)
  at io.quarkus.bootstrap.app.ApplicationModelSerializer.writeJson(...)
```

See also: quarkiverse/quarkus-langchain4j#2375 (the extension removes the `<jvmOptions>` block as an independent fix, but the serializer should be resilient regardless).

## Fix

Fall back to `value.toString()` and serialize as a JSON string for any unrecognized type:

```java
} else {
    appendStringValue(appendable, value.toString());
}
```

This is the correct fallback — the existing comment and precedent from `Boolean`/`Integer`/`Long` already shows that `toString()` is the intended serialization for scalar types.

## Test

Added `testUnrecognizedValueTypeFallsBackToString` in `JsonSerializerTest`, which stores an unnamed `java.lang.Module` via the `Map` interface and asserts it serializes to its `toString()` value rather than throwing.