### PR TITLE
Fix #53770: Remove quotes from serialized app model path on Windows

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeMojo.java
@@ -122,8 +122,7 @@ public class GenerateCodeMojo extends QuarkusBootstrapMojo {
                             Properties properties = mavenProject().getProperties();
                             String argLine = properties.getProperty("argLine", "");
                             properties.setProperty("argLine", argLine +
-                                    " -D" + BootstrapConstants.SERIALIZED_TEST_APP_MODEL + "=\"" + serializedTestAppModelPath
-                                    + "\"");
+                                    " -D" + BootstrapConstants.SERIALIZED_TEST_APP_MODEL + "=" + serializedTestAppModelPath);
                         } catch (IOException e) {
                             getLog().warn("Failed to serialize application model", e);
                         }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapAppModelFactory.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapAppModelFactory.java
@@ -287,7 +287,12 @@ public class BootstrapAppModelFactory {
         final String serializedModel = test ? System.getProperty(BootstrapConstants.SERIALIZED_TEST_APP_MODEL)
                 : System.getProperty(BootstrapConstants.SERIALIZED_APP_MODEL);
         if (serializedModel != null) {
-            final Path p = Paths.get(serializedModel);
+            // Strip surrounding quotes that may be present from Maven argLine expansion on Windows
+            String modelPath = serializedModel;
+            if (modelPath.length() > 1 && modelPath.startsWith("\"") && modelPath.endsWith("\"")) {
+                modelPath = modelPath.substring(1, modelPath.length() - 1);
+            }
+            final Path p = Paths.get(modelPath);
             if (Files.exists(p)) {
                 try {
                     return new CurationResult(ApplicationModelSerializer.deserialize(p));


### PR DESCRIPTION
Fixes #53770

The Maven `GenerateCodeMojo` wrapped the serialized test app model path in literal double quotes when appending to `argLine`. On Windows, these quotes are not stripped by the shell and end up in the system property value, causing `InvalidPathException: Illegal char <"> at index 0`.

System properties passed via `-D` do not need shell quoting — the JVM handles them directly. The Gradle plugin already passes the path without quotes (`QuarkusDev.java` line 555).

**Changes:**
- `GenerateCodeMojo.java` — removed `\"` wrapping from the argLine property value
- `BootstrapAppModelFactory.java` — added defensive quote stripping on the consumer side, so older Maven plugin versions that still produce quoted paths do not break