### PR TITLE
Mark UBI9_JAVA25 as containsJavaRun

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/images/ContainerImages.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/images/ContainerImages.java
@@ -1,5 +1,7 @@
 package io.quarkus.deployment.images;
 
+import java.util.regex.Pattern;
+
 import io.quarkus.deployment.pkg.builditem.CompiledJavaVersionBuildItem;
 import io.quarkus.deployment.pkg.builditem.CompiledJavaVersionBuildItem.JavaVersion.Status;
 
@@ -72,6 +74,8 @@ public class ContainerImages {
     public static final String QUARKUS_MICRO_IMAGE = UBI9_QUARKUS_MICRO_IMAGE;
 
     // === Runtime images for containers (JVM)
+    private static final Pattern RUN_JAVA_IMAGE_MATCHER = Pattern
+            .compile("^registry\\.access\\.redhat\\.com/ubi\\d+/openjdk-\\d+-runtime(?::[\\w.\\-]+)?$");
 
     // UBI 8 OpenJDK 17 Runtime - https://catalog.redhat.com/software/containers/ubi8/openjdk-17-runtime/618bdc5f843af1624c4e4ba8
     public static final String UBI8_JAVA_17_IMAGE_NAME = "registry.access.redhat.com/ubi8/openjdk-17-runtime";
@@ -164,5 +168,9 @@ public class ContainerImages {
         }
 
         return UBI9_JAVA_17;
+    }
+
+    public static boolean containsRunJava(String baseJvmImage) {
+        return RUN_JAVA_IMAGE_MATCHER.matcher(baseJvmImage).matches();
     }
 }

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
@@ -454,7 +454,7 @@ public class JibProcessor {
         List<String> entrypoint;
         if (jibConfig.jvmEntrypoint().isPresent()) {
             entrypoint = Collections.unmodifiableList(jibConfig.jvmEntrypoint().get());
-        } else if (containsRunJava(baseJvmImage) && maybeJvmStartupOptimizerArchiveResult.isEmpty()) {
+        } else if (ContainerImages.containsRunJava(baseJvmImage) && maybeJvmStartupOptimizerArchiveResult.isEmpty()) {
             // we want to use run-java.sh by default. However, if AppCDS are being used, run-java.sh cannot be used because it would lead to using different JVM args
             // which would mean AppCDS would not be taken into account at all
             entrypoint = List.of(RUN_JAVA_PATH);
@@ -679,14 +679,6 @@ public class JibProcessor {
         } catch (InvalidImageReferenceException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    // TODO: this needs to be a lot more sophisticated
-    private boolean containsRunJava(String baseJvmImage) {
-        return baseJvmImage.startsWith(ContainerImages.UBI8_JAVA_17_IMAGE_NAME) ||
-                baseJvmImage.startsWith(ContainerImages.UBI8_JAVA_21_IMAGE_NAME) ||
-                baseJvmImage.startsWith(ContainerImages.UBI9_JAVA_17_IMAGE_NAME) ||
-                baseJvmImage.startsWith(ContainerImages.UBI9_JAVA_21_IMAGE_NAME);
     }
 
     public JibContainerBuilder addLayer(JibContainerBuilder jibContainerBuilder, List<Path> files,


### PR DESCRIPTION
Adding UBI9_JAVA25 to containerJavaRun in JibProcessor so it would default to the java-run.sh entrypoint.



* Fixes #53786


