### PR TITLE
Bump SmallRye Certificate Generator to 0.9.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <perfmark.version>0.27.0</perfmark.version><!-- dependency of io.grpc:grpc-core not managed in io.grpc:grpc-bom -->
 
         <!-- Used in the build parent and test BOM (for the JUnit plugin) and in the BOM (for the API) -->
-        <smallrye-certificate-generator.version>0.9.2</smallrye-certificate-generator.version>
+        <smallrye-certificate-generator.version>0.9.3</smallrye-certificate-generator.version>
 
         <!-- TestNG version: we don't enforce it in the BOM as it is mostly used in the MP TCKs and we need to use the version from the TCKs -->
         <testng.version>7.8.0</testng.version>


### PR DESCRIPTION
This is mostly to incorporate the hardening fix: https://github.com/smallrye/smallrye-certificate-generator/commit/d01f3a5adccc5ddf3378a6a17e8a757ce24ed988.
