### PR TITLE
Use relative path for the serialized app model path

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeMojo.java
@@ -126,11 +126,14 @@ public class GenerateCodeMojo extends QuarkusBootstrapMojo {
 
                             //Pass the application model to the Surefire/Failsafe test process as a system property,
                             //so it doesn't have to do a workspace search to find it. Same as we do for Gradle.
+                            // Use a relative path to avoid quoting issues with spaces and backslashes
+                            // in absolute paths on Windows when passed through Surefire's argLine tokenizer.
+                            Path relativeAppModelPath = baseDir().toPath().relativize(serializedTestAppModelPath);
                             Properties properties = mavenProject().getProperties();
                             String argLine = properties.getProperty("argLine", "");
                             properties.setProperty("argLine", argLine +
-                                    " -D" + BootstrapConstants.SERIALIZED_TEST_APP_MODEL + "=\"" + serializedTestAppModelPath
-                                    + "\"");
+                                    " -D" + BootstrapConstants.SERIALIZED_TEST_APP_MODEL + "="
+                                    + relativeAppModelPath);
                         } catch (IOException e) {
                             getLog().warn("Failed to serialize application model", e);
                         }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapAppModelFactory.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapAppModelFactory.java
@@ -287,7 +287,10 @@ public class BootstrapAppModelFactory {
         final String serializedModel = test ? System.getProperty(BootstrapConstants.SERIALIZED_TEST_APP_MODEL)
                 : System.getProperty(BootstrapConstants.SERIALIZED_APP_MODEL);
         if (serializedModel != null) {
-            final Path p = Paths.get(serializedModel);
+            Path p = Paths.get(serializedModel);
+            if (!p.isAbsolute() && projectRoot != null) {
+                p = projectRoot.resolve(p);
+            }
             if (Files.exists(p)) {
                 try {
                     return new CurationResult(ApplicationModelSerializer.deserialize(p));


### PR DESCRIPTION
We had a lot of quoting issues and went back and forth between various solutions, all with their own bugs.

Using a relative path solves the issue in most cases.

I have only handled the Maven case as it's not an issue on the Gradle side and I'm not sure the fix would be simple there.

Fixes #53770 

Created as draft as I did some naive manual testing on a project but I want a full CI run.
