### PR TITLE
Update CONTRIBUTING.md snapshot instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,8 @@ fixes, documentation, examples... But first, read this page (including the small
 - [Reporting an issue](#reporting-an-issue)
 - [Checking an issue is fixed in main](#checking-an-issue-is-fixed-in-main)
   * [Using snapshots](#using-snapshots)
+    + [Using the GitHub Action (CI)](#using-the-github-action-ci)
+    + [Installing snapshots locally](#installing-snapshots-locally)
   * [Building main](#building-main)
   * [Updating the version](#updating-the-version)
 - [Before you contribute](#before-you-contribute)
@@ -102,7 +104,7 @@ what you would expect to see. Don't forget to indicate your Quarkus, Java, Maven
 Sometimes a bug has been fixed in the `main` branch of Quarkus and you want to confirm it is fixed for your own
 application. There are two simple options for testing the `main` branch:
 
-* either use the snapshots we publish daily on <https://central.sonatype.com/repository/maven-snapshots>
+* either use the snapshots we publish daily on <https://github.com/quarkusio/quarkus-ecosystem-ci/releases>
 * or build Quarkus locally
 
 The following is a quick summary aimed at allowing you to quickly test `main`. If you are interested in learning more details, refer to
@@ -110,52 +112,41 @@ the [Build section](#build) and the [Usage section](#usage).
 
 ### Using snapshots
 
-Snapshots are published daily with version `999-SNAPSHOT`, so you will have to wait for a snapshot containing the commits you are interested in.
+Snapshots are published daily with version `999-SNAPSHOT` as GitHub Releases in the
+[quarkusio/quarkus-ecosystem-ci](https://github.com/quarkusio/quarkus-ecosystem-ci/releases) repository.
+Each release contains a `maven-repo.tar.gz` asset with pre-built Maven artifacts.
+You will have to wait for a snapshot containing the commits you are interested in.
 
-Then just add <https://central.sonatype.com/repository/maven-snapshots> as a Maven repository **and** a plugin
-repository in your `settings xml` (which should be placed in the `.m2` directory within your home directory):
+You can browse the available snapshots at <https://github.com/quarkusio/quarkus-ecosystem-ci/releases>.
+Releases follow the naming convention `Quarkus 999-SNAPSHOT (main) (YYYY-MM-DD)`.
 
-```xml
+#### Using the GitHub Action (CI)
 
-<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
-          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
-    <profiles>
-        <profile>
-            <id>quarkus-snapshots</id>
-            <repositories>
-                <repository>
-                    <id>quarkus-snapshots-repository</id>
-                    <url>https://central.sonatype.com/repository/maven-snapshots/</url>
-                    <releases>
-                        <enabled>false</enabled>
-                    </releases>
-                    <snapshots>
-                        <enabled>true</enabled>
-                    </snapshots>
-                </repository>
-            </repositories>
-            <pluginRepositories>
-                <pluginRepository>
-                    <id>quarkus-snapshots-plugin-repository</id>
-                    <url>https://central.sonatype.com/repository/maven-snapshots/</url>
-                    <releases>
-                        <enabled>false</enabled>
-                    </releases>
-                    <snapshots>
-                        <enabled>true</enabled>
-                    </snapshots>
-                </pluginRepository>
-            </pluginRepositories>
-        </profile>
-    </profiles>
-    <activeProfiles>
-        <activeProfile>quarkus-snapshots</activeProfile>
-    </activeProfiles>
-</settings>
+If you are setting up CI, you can use the
+[install-quarkus-snapshots-action](https://github.com/quarkusio/install-quarkus-snapshots-action/)
+to automatically download and install snapshots into your local Maven repository.
+
+#### Installing snapshots locally
+
+> [!NOTE]
+> This script requires the [GitHub CLI](https://cli.github.com/) (`gh`) to be installed and properly configured.
+
+To install snapshots locally, run the following command to download and extract the latest snapshot
+into your local Maven repository:
+
+```sh
+curl -sL https://raw.githubusercontent.com/quarkusio/quarkus-ecosystem-ci/main/setup-quarkus | bash
 ```
 
-You can check the last publication date here: <https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/io/quarkus/quarkus-core/999-SNAPSHOT/>.
+You can also specify a branch (defaults to `main`):
+
+```sh
+curl -sL https://raw.githubusercontent.com/quarkusio/quarkus-ecosystem-ci/main/setup-quarkus | bash -s -- 3.21
+```
+
+> [!TIP]
+> Use `./mvnw -nsu` (or `--no-snapshot-updates`) when building your project to prevent Maven from
+> trying to fetch snapshots from remote repositories, ensuring it uses the locally installed artifacts.
 
 ### Building main
 
@@ -850,12 +841,9 @@ repositories {
 }
 ```
 
-**Note**  Use the following definition in `repositories` section when using daily snapshot builds instead of local builds:
-```gradle
-    maven {
-        url 'https://central.sonatype.com/repository/maven-snapshots/'
-    }
-```
+**Note** When using daily snapshot builds instead of local builds, download and install the snapshots into your local Maven
+repository first (see [Using snapshots](#using-snapshots)), then add `mavenLocal()` to the first position in the
+`repositories` section.
 
 ### MicroProfile TCK's
 


### PR DESCRIPTION
Snapshots are no longer published to central.sonatype.com. They are now available as GitHub Releases in quarkusio/quarkus-ecosystem-ci. Update the guide with instructions for downloading snapshots locally and point to the install-quarkus-snapshots-action for CI usage.

- Follow-up from #53763
