### PR TITLE
Wrap shorthand admonition blocks in ==== delimiters

### DIFF
--- a/docs/src/main/asciidoc/assistant.adoc
+++ b/docs/src/main/asciidoc/assistant.adoc
@@ -47,8 +47,9 @@ To enable the Dev Assistant in your Quarkus project, add the `quarkus-chappie` e
 Once added, open the Dev UI to start using the assistant.
 
 [NOTE]
-
+====
 The assistant interfaces are defined in Quarkus "core", but their implementation are located in Quarkiverse (Chappie). You can, if needed, provide an alternative implementation of the assistant.
+====
 
 === Configuration and Providers
 

--- a/docs/src/main/asciidoc/aws-lambda-http.adoc
+++ b/docs/src/main/asciidoc/aws-lambda-http.adoc
@@ -231,10 +231,12 @@ Value               https://234asdf234as.execute-api.us-east-1.amazonaws.com/
 The `Value` attribute is the root URL for your lambda. Copy it to your browser and add `hello` at the end.
 
 [NOTE]
+====
 Responses for binary types will be automatically encoded with base64.  This is different from the behavior using
 `quarkus:dev`, which will return the raw bytes.  Amazon's API has additional restrictions requiring the base64 encoding.
 In general, client code will automatically handle this encoding, but in certain custom situations, you should be aware
 you may need to manually manage that encoding.
+====
 
 == Deploying a native executable
 

--- a/docs/src/main/asciidoc/building-my-first-extension.adoc
+++ b/docs/src/main/asciidoc/building-my-first-extension.adoc
@@ -19,9 +19,11 @@ The extension will expose a customizable HTTP endpoint that simply greets the vi
 
 [NOTE]
 .Disclaimer
+====
 To be sure it's extra clear that you don't need an extension to add a Servlet to your application.
 This guide is a simplified example to explain the concepts of extensions development, see the xref:writing-extensions.adoc[full documentation] if you need more information.
 Keep in mind it's not representative of the power of moving things to build time or simplifying the build of native images.
+====
 
 == Prerequisites
 

--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -857,8 +857,10 @@ Native executables can be debugged using tools such as `gdb`.
 For this to be possible native executables need to be generated with debug symbols.
 
 [NOTE]
+====
 Debug symbol generation is only supported on Linux.
 Windows support is still under development, while macOS is not supported.
+====
 
 To generate debug symbols,
 add `-Dquarkus.native.debug.enabled=true` flag when generating the native executable.

--- a/docs/src/main/asciidoc/getting-started-dev-services.adoc
+++ b/docs/src/main/asciidoc/getting-started-dev-services.adoc
@@ -173,9 +173,11 @@ in a transaction.
 
 [NOTE]
 .GETs should not change application state.
+====
 Generally, you shouldn't do state updates in a `GET` REST method, but here it makes
 trying things out simpler. Let's assume what's being written is a logging "side effect",
 rather than a meaningful state changes!
+====
 
 Try out the updated endpoint by visiting http://localhost:8080/hello?name=Bloom.
 You should see a "Hello Bloom" message.

--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -1535,7 +1535,7 @@ You can use this tag to isolate the `@QuarkusTest` test in a specific execution 
 ----
 
 [NOTE]
---
+=====
 Currently `@QuarkusTest` and `@QuarkusIntegrationTest` should not be run in the same test run.
 
 For Maven, this means that the former should be run by the surefire plugin while the latter should be run by the failsafe plugin.
@@ -1613,7 +1613,7 @@ idea.module {
 }
 ----
 ====
---
+=====
 
 [[test-from-ide]]
 == Running `@QuarkusTest` from an IDE

--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -718,20 +718,26 @@ The Quarkus build uses the `prod` configuration profile:
    as a project's `application-prod.properties`, `application-prod.yaml` and `application-prod.yml` files
 
 [WARNING]
+====
 The above priorities have changed in Quarkus plugin starting with 3.0. Older versions of the Quarkus Gradle plugin
 preferred `application.properties` over settings in the Gradle build.
+====
 
 [NOTE]
+====
 The Quarkus Gradle plugin uses the "standard" Quarkus mechanisms to load and parse configurations. Support for
 `application.(yaml|yml)` has been added in Quarkus 3.0 in addition to `application.properties`. Also new in 3.0
 is that all mechanisms available via SmallRye Config, are implicitly also now available for the Quarkus Gradle
 plugin.
+====
 
 
 [TIP]
+====
 Use the `quarkusShowEffectiveConfig` task to show the effective configuration options used for a Quarkus build. If you
 specify the `--save-config-properties` command line option, the configuration properties are also store in the file
 `build/<final-name>.quarkus-build.properties`.
+====
 
 
 === Gradle caching / task inputs
@@ -868,12 +874,14 @@ The `quarkusAppPartsBuild` and `quarkusDependenciesBuild` tasks do nothing for `
 |===
 
 [NOTE]
+====
 In a local development environment, the cost (think: time) of storing (and retrieving) even bigger cache artifacts is
 lower than the cost of re-building a Quarkus application. This means, that The Quarkus Gradle plugin allows caching
 even potentially big artifacts like uber-jars or native binaries in non-CI environments. In CI environments, which run
 builds against varying states of a code base (think: running CI against every commit on a main branch), adding each
 built (and big) artifact to the build cache would let the build cache become unnecessarily big, which becomes a
 problem for example in GitHub, where the total amount of cached artifacts is limited to 10 GB.
+====
 
 
 [NOTE]

--- a/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
@@ -675,7 +675,9 @@ See also <<quarkus-hibernate-search-orm-elasticsearch_quarkus-hibernate-search-o
 ====
 
 [TIP]
+====
 For more information about configuration of the Hibernate Search ORM extension, refer to the <<configuration-reference,Configuration Reference>>.
+====
 
 == Creating a frontend
 

--- a/docs/src/main/asciidoc/hibernate-search-standalone-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-standalone-elasticsearch.adoc
@@ -605,7 +605,9 @@ See also <<quarkus-hibernate-search-standalone-elasticsearch_quarkus-hibernate-s
 ====
 
 [TIP]
+====
 For more information about configuration of the Hibernate Search Standalone extension, refer to the <<configuration-reference,Configuration Reference>>.
+====
 
 == Creating a frontend
 

--- a/docs/src/main/asciidoc/mailer-reference.adoc
+++ b/docs/src/main/asciidoc/mailer-reference.adoc
@@ -369,12 +369,16 @@ Please note that the password value is evaluated only once, at startup time. If 
 the only way to get the new value would be to restart the application.
 
 [NOTE]
+====
 Do use Vault, you need the https://github.com/quarkiverse/quarkus-vault[Quarkus Vault] extension.
 More details about this extension and its configuration can be found in the https://docs.quarkiverse.io/quarkus-vault/dev/index.html[extension documentation].
+====
 
 
 [TIP]
+====
 For more information about the Mailer configuration please refer to the <<configuration-reference,Configuration Reference>>.
+====
 
 == Configuring TLS
 

--- a/docs/src/main/asciidoc/quarkus-reactive-architecture.adoc
+++ b/docs/src/main/asciidoc/quarkus-reactive-architecture.adoc
@@ -122,7 +122,9 @@ Mutiny provides everything you need to orchestrate asynchronous actions, includi
 It also offers a large set of operators to manipulate individual events and streams of events.
 
 [TIP]
+====
 Find more info about Mutiny and its usage in Quarkus on xref:mutiny-primer.adoc[Mutiny support documentation].
+====
 
 Co-routines are a way to write asynchronous code sequentially.
 It suspends the execution of the code during I/O and registers the rest of the code as the continuation.

--- a/docs/src/main/asciidoc/redis-reference.adoc
+++ b/docs/src/main/asciidoc/redis-reference.adoc
@@ -57,7 +57,9 @@ import io.quarkus.redis.datasource.RedisDataSource;
 More details about the various APIs offered by the quarkus-redis extension are available in the <<apis>> section.
 
 [NOTE]
+====
 To use Redis as a cache backend, refer to the xref:cache-redis-reference.adoc[Redis Cache Backend reference].
+====
 
 [[apis]]
 == One extension, multiple APIs

--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -1931,7 +1931,9 @@ quarkus.proxy.credentials-provider.password-key=passwordKey
 <2> Configure the Credentials Provider to obtain the username and password for the proxy.
 
 [NOTE]
+====
 The Credentials Provider is not used when `quarkus.proxy.password` (for global) or `quarkus.proxy.<named>.password` (for named) is not set.
+====
 
 === Local proxy for dev mode
 

--- a/docs/src/main/asciidoc/security-customization.adoc
+++ b/docs/src/main/asciidoc/security-customization.adoc
@@ -683,9 +683,11 @@ The observers can be either synchronous or asynchronous.
 * `io.quarkus.vertx.http.runtime.security.FormAuthenticationEvent`
 
 [TIP]
+====
 For more information about security events specific to the Quarkus OpenID Connect extension, please see
 the xref:security-oidc-code-flow-authentication.adoc#listen-to-authentication-events[Listening to important authentication events]
 section of the OIDC code flow mechanism for protecting web applications guide.
+====
 
 [source,java]
 ----


### PR DESCRIPTION
## Summary

Across 13 guides in `docs/src/main/asciidoc/`, single-paragraph admonitions use the bare-attribute shorthand (`[NOTE]` / `[TIP]` / `[WARNING]` on a line by itself, followed by a single paragraph, no `====` delimiters). The shorthand form renders in Asciidoctor but:

- produces inconsistent output across renderers (Asciidoctor vs. DITA vs. downstream tooling),
- hinders programmatic content transformation (linters and doc pipelines have to special-case both forms).

Wrap each affected block in the explicit `====` delimited form. **No content changes** — 38 lines added, 0 removed, all of them `====` delimiter lines.

## Files touched (19 blocks across 13 files)

- `aws-lambda-http.adoc`
- `building-my-first-extension.adoc`
- `building-native-image.adoc`
- `getting-started-dev-services.adoc`
- `getting-started-testing.adoc`
- `gradle-tooling.adoc` (4 blocks)
- `hibernate-search-orm-elasticsearch.adoc` (2 blocks)
- `hibernate-search-standalone-elasticsearch.adoc` (2 blocks)
- `mailer-reference.adoc` (2 blocks)
- `quarkus-reactive-architecture.adoc`
- `redis-reference.adoc`
- `rest-client.adoc`
- `security-customization.adoc`