### PR TITLE
Feature/redis cache mget mset

### DIFF
--- a/docs/src/main/asciidoc/cache-redis-reference.adoc
+++ b/docs/src/main/asciidoc/cache-redis-reference.adoc
@@ -162,3 +162,76 @@ quarkus.cache.redis.expensiveResourceCache.use-optimistic-locking=true
 ----
 
 When used, the key is _watched_ and the _SET_ command is executed in a transaction (`MULTI/EXEC`).
+
+[[bulk-operations]]
+== Bulk operations (programmatic API)
+
+The `RedisCache` interface exposes bulk operations that retrieve or store multiple cache entries in a single Redis round-trip.
+These methods are available via programmatic injection of `RedisCache` and complement the annotation-based API.
+
+=== Inject the cache
+
+[source, java]
+----
+@Inject
+@CacheName("my-cache")
+RedisCache cache;
+----
+
+=== Retrieve multiple entries — `getAll`
+
+`getAll` issues a single Redis `MGET` command for all supplied keys and returns only the entries that are currently stored in the cache.
+Keys not found in the cache are absent from the result map — this is not an error.
+
+[source, java]
+----
+// Using an explicit value type
+Uni<Map<String, Person>> hits = cache.getAll(List.of("alice", "bob"), Person.class);
+
+// Using the default value type configured for the cache
+Uni<Map<String, Person>> hits = cache.getAll(List.of("alice", "bob"));
+----
+
+A value loader can be supplied to automatically fetch and write back any missing entries.
+The loader is invoked at most once, receiving the complete set of cache-miss keys:
+
+[source, java]
+----
+// Synchronous loader
+Uni<Map<String, Person>> result = cache.getAll(
+        List.of("alice", "bob", "carol"),
+        Person.class,
+        missingKeys -> personRepository.findAllById(missingKeys));
+
+// Asynchronous loader
+Uni<Map<String, Person>> result = cache.getAllAsync(
+        List.of("alice", "bob", "carol"),
+        Person.class,
+        missingKeys -> personRepository.findAllByIdAsync(missingKeys));
+----
+
+NOTE: Bulk `getAll` / `getAllAsync` with a value loader is not supported when optimistic locking is enabled for the cache.
+An `UnsupportedOperationException` is thrown in that case.
+
+=== Store multiple entries — `putAll`
+
+`putAll` stores all entries from the supplied map in a single Redis operation.
+
+* When no expiration is configured, a single atomic `MSET` command is used.
+* When `expire-after-write` is configured, individual `SET` commands with a per-key TTL are pipelined in a single round-trip, because `MSET` does not support expiration.
+
+[source, java]
+----
+Map<String, Person> people = Map.of(
+        "alice", new Person("Alice", "Smith"),
+        "bob",   new Person("Bob",   "Jones"));
+
+Uni<Void> done = cache.putAll(people);
+----
+
+NOTE: `null` values in the map are not permitted and cause an `IllegalArgumentException`.
+
+=== expire-after-access and bulk reads
+
+When `expire-after-access` is configured, each `getAll` call refreshes the TTL for every key found in the cache.
+Because Redis has no bulk equivalent of `GETEX`, the implementation issues a pipelined batch of `EXPIRE` commands — one per hit key — immediately after the `MGET`.

--- a/extensions/redis-cache/deployment/src/test/java/io/quarkus/cache/redis/deployment/RedisCacheImplTest.java
+++ b/extensions/redis-cache/deployment/src/test/java/io/quarkus/cache/redis/deployment/RedisCacheImplTest.java
@@ -8,13 +8,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
+import jakarta.enterprise.util.TypeLiteral;
 import jakarta.inject.Inject;
 
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -619,6 +623,561 @@ class RedisCacheImplTest {
         assertThatTheKeyDoesNotExist("cache:test-invalidation:clé-3");
         assertThatTheKeyDoesExist("key6");
         assertThat(getAllKeys()).hasSize(1);
+    }
+
+    // ---- Bulk operations: getAll (no loader) ----------------------------------------
+
+    @Test
+    void testGetAll_allHits() {
+        RedisCacheInfo info = new RedisCacheInfo();
+        info.name = "bulk";
+        info.valueType = String.class;
+        info.expireAfterWrite = Optional.of(Duration.ofSeconds(10));
+        RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
+
+        cache.put("k1", "v1").await().indefinitely();
+        cache.put("k2", "v2").await().indefinitely();
+        cache.put("k3", "v3").await().indefinitely();
+
+        Map<String, String> result = cache.getAll(List.of("k1", "k2", "k3"), String.class).await().indefinitely();
+        assertThat(result).hasSize(3)
+                .containsEntry("k1", "v1")
+                .containsEntry("k2", "v2")
+                .containsEntry("k3", "v3");
+    }
+
+    @Test
+    void testGetAll_allMisses_noLoader() {
+        RedisCacheInfo info = new RedisCacheInfo();
+        info.name = "bulk";
+        info.valueType = String.class;
+        info.expireAfterWrite = Optional.of(Duration.ofSeconds(10));
+        RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
+
+        Map<String, String> result = cache.getAll(List.of("k1", "k2", "k3"), String.class).await().indefinitely();
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void testGetAll_mixed_noLoader() {
+        RedisCacheInfo info = new RedisCacheInfo();
+        info.name = "bulk";
+        info.valueType = String.class;
+        info.expireAfterWrite = Optional.of(Duration.ofSeconds(10));
+        RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
+
+        cache.put("k1", "v1").await().indefinitely();
+        cache.put("k3", "v3").await().indefinitely();
+
+        Map<String, String> result = cache.getAll(List.of("k1", "k2", "k3"), String.class).await().indefinitely();
+        assertThat(result).hasSize(2)
+                .containsEntry("k1", "v1")
+                .containsEntry("k3", "v3")
+                .doesNotContainKey("k2");
+    }
+
+    @Test
+    void testGetAll_emptyCollection() {
+        RedisCacheInfo info = new RedisCacheInfo();
+        info.name = "bulk";
+        info.valueType = String.class;
+        info.expireAfterWrite = Optional.of(Duration.ofSeconds(10));
+        RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
+
+        Map<String, String> result = cache.getAll(List.<String> of(), String.class).await().indefinitely();
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void testGetAll_withExpireAfterAccess() throws InterruptedException {
+        RedisCacheInfo info = new RedisCacheInfo();
+        info.name = "bulk-access";
+        info.valueType = String.class;
+        info.expireAfterAccess = Optional.of(Duration.ofSeconds(1));
+        RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
+
+        cache.put("k1", "v1").await().indefinitely();
+        cache.put("k2", "v2").await().indefinitely();
+
+        // First getAll — should trigger a batch of EXPIRE commands for each hit key
+        Map<String, String> result = cache.getAll(List.of("k1", "k2"), String.class).await().indefinitely();
+        assertThat(result).hasSize(2).containsEntry("k1", "v1").containsEntry("k2", "v2");
+
+        // TTL should have been set via the EXPIRE command issued for each hit
+        Response ttl = redis.send(Request.cmd(Command.TTL).arg("cache:bulk-access:k1")).await().indefinitely();
+        assertThat(ttl.toLong()).isGreaterThan(0L);
+
+        // Repeated access within the TTL window resets the expiry each time
+        for (int i = 0; i < 3; i++) {
+            Thread.sleep(500);
+            Map<String, String> refreshed = cache.getAll(List.of("k1", "k2"), String.class).await().indefinitely();
+            assertThat(refreshed).hasSize(2);
+        }
+
+        // After access stops the key should eventually expire.
+        // Use a direct Redis GET (not cache.getOrNull) because getOrNull issues GETEX which would
+        // reset the TTL on every poll and the key would never expire within the polling window.
+        await().until(
+                () -> redis.send(Request.cmd(Command.GET).arg("cache:bulk-access:k1")).await().indefinitely() == null);
+    }
+
+    // ---- Bulk operations: getAll (with sync loader) ---------------------------------
+
+    @Test
+    void testGetAll_allMisses_withLoader() {
+        RedisCacheInfo info = new RedisCacheInfo();
+        info.name = "bulk";
+        info.valueType = String.class;
+        info.expireAfterWrite = Optional.of(Duration.ofSeconds(10));
+        RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
+
+        Map<String, String> result = cache.getAll(
+                List.of("k1", "k2", "k3"),
+                String.class,
+                misses -> {
+                    Map<String, String> loaded = new LinkedHashMap<>();
+                    for (String k : misses) {
+                        loaded.put(k, k.toUpperCase());
+                    }
+                    return loaded;
+                }).await().indefinitely();
+
+        assertThat(result).hasSize(3)
+                .containsEntry("k1", "K1")
+                .containsEntry("k2", "K2")
+                .containsEntry("k3", "K3");
+
+        // Values must have been written back to Redis
+        assertThatTheKeyDoesExist("cache:bulk:k1");
+        assertThatTheKeyDoesExist("cache:bulk:k2");
+        assertThatTheKeyDoesExist("cache:bulk:k3");
+    }
+
+    @Test
+    void testGetAll_mixed_withLoader() {
+        RedisCacheInfo info = new RedisCacheInfo();
+        info.name = "bulk";
+        info.valueType = String.class;
+        info.expireAfterWrite = Optional.of(Duration.ofSeconds(10));
+        RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
+
+        cache.put("k1", "cached-v1").await().indefinitely();
+        cache.put("k3", "cached-v3").await().indefinitely();
+
+        AtomicInteger loaderCallCount = new AtomicInteger(0);
+        Map<String, String> result = cache.getAll(
+                List.of("k1", "k2", "k3"),
+                String.class,
+                misses -> {
+                    loaderCallCount.incrementAndGet();
+                    // Loader should only receive the miss key (k2)
+                    Map<String, String> loaded = new LinkedHashMap<>();
+                    for (String k : misses) {
+                        loaded.put(k, "loaded-" + k);
+                    }
+                    return loaded;
+                }).await().indefinitely();
+
+        assertThat(loaderCallCount.get()).isEqualTo(1);
+        assertThat(result).hasSize(3)
+                .containsEntry("k1", "cached-v1")
+                .containsEntry("k2", "loaded-k2")
+                .containsEntry("k3", "cached-v3");
+    }
+
+    @Test
+    void testGetAll_expireAfterWrite_loaderWriteback() {
+        RedisCacheInfo info = new RedisCacheInfo();
+        info.name = "bulk";
+        info.valueType = String.class;
+        info.expireAfterWrite = Optional.of(Duration.ofSeconds(1));
+        RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
+
+        // Load via the value loader — the write-back must honour expireAfterWrite
+        cache.getAll(
+                List.of("k1", "k2"),
+                String.class,
+                misses -> {
+                    Map<String, String> loaded = new LinkedHashMap<>();
+                    for (String k : misses) {
+                        loaded.put(k, k.toUpperCase());
+                    }
+                    return loaded;
+                }).await().indefinitely();
+
+        assertThatTheKeyDoesExist("cache:bulk:k1");
+
+        // Written-back entries must expire after the configured duration
+        await().until(() -> cache.getOrNull("k1", String.class).await().indefinitely() == null);
+    }
+
+    @Test
+    void testGetAll_nullValueInLoader_throws() {
+        RedisCacheInfo info = new RedisCacheInfo();
+        info.name = "bulk";
+        info.valueType = String.class;
+        info.expireAfterWrite = Optional.of(Duration.ofSeconds(10));
+        RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
+
+        assertThatThrownBy(() -> cache.getAll(
+                List.of("k1", "k2"),
+                String.class,
+                misses -> {
+                    Map<String, String> loaded = new LinkedHashMap<>();
+                    loaded.put("k1", "v1");
+                    loaded.put("k2", null); // null value — must throw
+                    return loaded;
+                }).await().indefinitely())
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testGetAll_loaderNotCalledOnFullHit() {
+        RedisCacheInfo info = new RedisCacheInfo();
+        info.name = "bulk";
+        info.valueType = String.class;
+        info.expireAfterWrite = Optional.of(Duration.ofSeconds(10));
+        RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
+
+        cache.put("k1", "v1").await().indefinitely();
+        cache.put("k2", "v2").await().indefinitely();
+
+        AtomicInteger loaderCallCount = new AtomicInteger(0);
+        Map<String, String> result = cache.getAll(
+                List.of("k1", "k2"),
+                String.class,
+                misses -> {
+                    loaderCallCount.incrementAndGet();
+                    return Map.of(); // should never be called
+                }).await().indefinitely();
+
+        assertThat(loaderCallCount.get()).isEqualTo(0);
+        assertThat(result).containsEntry("k1", "v1").containsEntry("k2", "v2");
+    }
+
+    // ---- Bulk operations: getAllAsync (with async loader) ----------------------------
+
+    @Test
+    void testGetAllAsync_allMisses() {
+        RedisCacheInfo info = new RedisCacheInfo();
+        info.name = "bulk";
+        info.valueType = String.class;
+        info.expireAfterWrite = Optional.of(Duration.ofSeconds(10));
+        RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
+
+        Map<String, String> result = cache.getAllAsync(
+                List.of("k1", "k2", "k3"),
+                String.class,
+                misses -> {
+                    Map<String, String> loaded = new LinkedHashMap<>();
+                    for (String k : misses) {
+                        loaded.put(k, "async-" + k);
+                    }
+                    return Uni.createFrom().item(loaded);
+                }).await().indefinitely();
+
+        assertThat(result).hasSize(3)
+                .containsEntry("k1", "async-k1")
+                .containsEntry("k2", "async-k2")
+                .containsEntry("k3", "async-k3");
+
+        // Values must have been written back to Redis
+        assertThatTheKeyDoesExist("cache:bulk:k1");
+    }
+
+    @Test
+    void testGetAllAsync_mixed() {
+        RedisCacheInfo info = new RedisCacheInfo();
+        info.name = "bulk";
+        info.valueType = String.class;
+        info.expireAfterWrite = Optional.of(Duration.ofSeconds(10));
+        RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
+
+        cache.put("k1", "cached-v1").await().indefinitely();
+
+        AtomicInteger loaderCallCount = new AtomicInteger(0);
+        Map<String, String> result = cache.getAllAsync(
+                List.of("k1", "k2"),
+                String.class,
+                misses -> {
+                    loaderCallCount.incrementAndGet();
+                    Map<String, String> loaded = new LinkedHashMap<>();
+                    for (String k : misses) {
+                        loaded.put(k, "async-" + k);
+                    }
+                    return Uni.createFrom().item(loaded);
+                }).await().indefinitely();
+
+        assertThat(loaderCallCount.get()).isEqualTo(1);
+        assertThat(result).hasSize(2)
+                .containsEntry("k1", "cached-v1")
+                .containsEntry("k2", "async-k2");
+    }
+
+    // ---- Optimistic locking guard ---------------------------------------------------
+
+    @Test
+    void testGetAll_optimisticLocking_throws() {
+        RedisCacheInfo info = new RedisCacheInfo();
+        info.name = "bulk";
+        info.valueType = String.class;
+        info.expireAfterWrite = Optional.of(Duration.ofSeconds(10));
+        info.useOptimisticLocking = true;
+        RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
+
+        assertThatThrownBy(() -> cache.getAll(
+                List.of("k1"),
+                String.class,
+                misses -> Map.of("k1", "v1"))
+                .await().indefinitely())
+                .isInstanceOf(UnsupportedOperationException.class);
+
+        assertThatThrownBy(() -> cache.getAllAsync(
+                List.of("k1"),
+                String.class,
+                misses -> Uni.createFrom().item(Map.of("k1", "v1")))
+                .await().indefinitely())
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    // ---- Bulk operations: putAll ----------------------------------------------------
+
+    @Test
+    void testPutAll_noTTL() {
+        RedisCacheInfo info = new RedisCacheInfo();
+        info.name = "bulk";
+        info.valueType = String.class;
+        // No expireAfterWrite — atomic MSET path
+        RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
+
+        Map<String, String> entries = new LinkedHashMap<>();
+        entries.put("k1", "v1");
+        entries.put("k2", "v2");
+        entries.put("k3", "v3");
+        cache.putAll(entries).await().indefinitely();
+
+        assertThatTheKeyDoesExist("cache:bulk:k1");
+        assertThatTheKeyDoesExist("cache:bulk:k2");
+        assertThatTheKeyDoesExist("cache:bulk:k3");
+
+        assertThat(cache.getOrNull("k1", String.class).await().indefinitely()).isEqualTo("v1");
+        assertThat(cache.getOrNull("k2", String.class).await().indefinitely()).isEqualTo("v2");
+        assertThat(cache.getOrNull("k3", String.class).await().indefinitely()).isEqualTo("v3");
+
+        // Keys stored via MSET should have no expiry (TTL == -1)
+        Response ttl = redis.send(Request.cmd(Command.TTL).arg("cache:bulk:k1")).await().indefinitely();
+        assertThat(ttl.toLong()).isEqualTo(-1L);
+    }
+
+    @Test
+    void testPutAll_withTTL() {
+        RedisCacheInfo info = new RedisCacheInfo();
+        info.name = "bulk";
+        info.valueType = String.class;
+        info.expireAfterWrite = Optional.of(Duration.ofSeconds(1));
+        RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
+
+        Map<String, String> entries = new LinkedHashMap<>();
+        entries.put("k1", "v1");
+        entries.put("k2", "v2");
+        cache.putAll(entries).await().indefinitely();
+
+        assertThatTheKeyDoesExist("cache:bulk:k1");
+        assertThatTheKeyDoesExist("cache:bulk:k2");
+
+        // Keys stored via pipelined SET EX should carry the configured TTL
+        Response ttl = redis.send(Request.cmd(Command.TTL).arg("cache:bulk:k1")).await().indefinitely();
+        assertThat(ttl.toLong()).isGreaterThan(0L);
+
+        // Keys must expire after the configured duration
+        await().until(() -> cache.getOrNull("k1", String.class).await().indefinitely() == null);
+        await().until(() -> cache.getOrNull("k2", String.class).await().indefinitely() == null);
+    }
+
+    @Test
+    void testPutAll_thenGetAll() {
+        RedisCacheInfo info = new RedisCacheInfo();
+        info.name = "bulk";
+        info.valueType = String.class;
+        info.expireAfterWrite = Optional.of(Duration.ofSeconds(10));
+        RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
+
+        Map<String, String> entries = new LinkedHashMap<>();
+        entries.put("k1", "v1");
+        entries.put("k2", "v2");
+        entries.put("k3", "v3");
+        cache.putAll(entries).await().indefinitely();
+
+        Map<String, String> result = cache.getAll(List.of("k1", "k2", "k3"), String.class).await().indefinitely();
+        assertThat(result).isEqualTo(entries);
+    }
+
+    @Test
+    void testPutAll_nullValue_throws() {
+        RedisCacheInfo info = new RedisCacheInfo();
+        info.name = "bulk";
+        info.valueType = String.class;
+        info.expireAfterWrite = Optional.of(Duration.ofSeconds(10));
+        RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
+
+        // TTL path (pipelined SET EX)
+        Map<String, String> withNull = new LinkedHashMap<>();
+        withNull.put("k1", "v1");
+        withNull.put("k2", null);
+        assertThatThrownBy(() -> cache.putAll(withNull).await().indefinitely())
+                .isInstanceOf(IllegalArgumentException.class);
+
+        // No-TTL path (MSET)
+        RedisCacheInfo infoNoTtl = new RedisCacheInfo();
+        infoNoTtl.name = "bulk-no-ttl";
+        infoNoTtl.valueType = String.class;
+        RedisCacheImpl cacheNoTtl = new RedisCacheImpl(infoNoTtl, vertx, redis, BLOCKING_ALLOWED);
+
+        Map<String, String> withNull2 = new LinkedHashMap<>();
+        withNull2.put("k1", "v1");
+        withNull2.put("k2", null);
+        assertThatThrownBy(() -> cacheNoTtl.putAll(withNull2).await().indefinitely())
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    // ---- Type-specialised bulk tests ------------------------------------------------
+
+    @Test
+    void testGetAll_customKeyType() {
+        RedisCacheInfo info = new RedisCacheInfo();
+        info.name = "bulk";
+        info.valueType = String.class;
+        info.keyType = Integer.class;
+        info.expireAfterWrite = Optional.of(Duration.ofSeconds(10));
+        RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
+
+        cache.put(1, "one").await().indefinitely();
+        cache.put(2, "two").await().indefinitely();
+        cache.put(3, "three").await().indefinitely();
+
+        Map<Integer, String> result = cache.getAll(List.of(1, 2, 3), String.class).await().indefinitely();
+        assertThat(result).hasSize(3)
+                .containsEntry(1, "one")
+                .containsEntry(2, "two")
+                .containsEntry(3, "three");
+    }
+
+    @Test
+    void testGetAll_customValueType_POJO() {
+        RedisCacheInfo info = new RedisCacheInfo();
+        info.name = "bulk";
+        info.valueType = Person.class;
+        info.expireAfterWrite = Optional.of(Duration.ofSeconds(10));
+        RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
+
+        Person luke = new Person("luke", "skywalker");
+        Person leia = new Person("leia", "organa");
+        cache.put("luke", luke).await().indefinitely();
+        cache.put("leia", leia).await().indefinitely();
+
+        Map<String, Person> result = cache.getAll(List.of("luke", "leia", "missing"), Person.class)
+                .await().indefinitely();
+        assertThat(result).hasSize(2)
+                .containsEntry("luke", luke)
+                .containsEntry("leia", leia)
+                .doesNotContainKey("missing");
+    }
+
+    @Test
+    void testGetAll_typeLiteral() {
+        RedisCacheInfo info = new RedisCacheInfo();
+        info.name = "bulk";
+        info.valueType = List.class;
+        info.expireAfterWrite = Optional.of(Duration.ofSeconds(10));
+        RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
+
+        TypeLiteral<List<String>> type = new TypeLiteral<>() {
+        };
+
+        cache.put("tags-alice", List.of("admin", "user")).await().indefinitely();
+        cache.put("tags-bob", List.of("user")).await().indefinitely();
+
+        // getAll with TypeLiteral — no loader
+        Map<String, List<String>> result = cache.getAll(List.of("tags-alice", "tags-bob", "tags-missing"), type)
+                .await().indefinitely();
+        assertThat(result).hasSize(2)
+                .containsEntry("tags-alice", List.of("admin", "user"))
+                .containsEntry("tags-bob", List.of("user"))
+                .doesNotContainKey("tags-missing");
+
+        // getAll with TypeLiteral + sync loader
+        Map<String, List<String>> withLoader = cache.getAll(
+                List.of("tags-alice", "tags-carol"),
+                type,
+                misses -> {
+                    Map<String, List<String>> loaded = new LinkedHashMap<>();
+                    for (String k : misses) {
+                        loaded.put(k, List.of("guest"));
+                    }
+                    return loaded;
+                }).await().indefinitely();
+        assertThat(withLoader).hasSize(2)
+                .containsEntry("tags-alice", List.of("admin", "user"))
+                .containsEntry("tags-carol", List.of("guest"));
+    }
+
+    // ---- Missing default type guard -------------------------------------------------
+
+    @Test
+    void testGetAll_missingDefaultType_throws() {
+        RedisCacheInfo info = new RedisCacheInfo();
+        info.name = "bulk-no-type";
+        info.expireAfterWrite = Optional.of(Duration.ofSeconds(10));
+        // No valueType configured — default-type overloads must throw
+        RedisCacheImpl cache = new RedisCacheImpl(info, vertx, redis, BLOCKING_ALLOWED);
+
+        assertThatThrownBy(() -> cache.getAll(List.of("k1")).await().indefinitely())
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> cache.getAll(List.of("k1"), misses -> Map.of("k1", "v1")).await().indefinitely())
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> cache.getAllAsync(List.of("k1"),
+                misses -> Uni.createFrom().item(Map.of("k1", "v1"))).await().indefinitely())
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    // ---- Redis unavailability fallback ----------------------------------------------
+
+    @Test
+    void testGetAll_redisUnavailable_fallback() {
+        // Start a dedicated Redis server so it can be stopped mid-test
+        GenericContainer<?> server = new GenericContainer<>("redis:7").withExposedPorts(6379);
+        server.start();
+        Redis localRedis = Redis.createClient(vertx,
+                "redis://" + server.getHost() + ":" + server.getFirstMappedPort());
+
+        RedisCacheInfo info = new RedisCacheInfo();
+        info.name = "bulk";
+        info.valueType = String.class;
+        info.expireAfterWrite = Optional.of(Duration.ofSeconds(10));
+        RedisCacheImpl cache = new RedisCacheImpl(info, vertx, localRedis, BLOCKING_ALLOWED);
+
+        server.close(); // Bring Redis down before the bulk read
+
+        AtomicInteger loaderCallCount = new AtomicInteger(0);
+        Map<String, String> result = cache.getAll(
+                List.of("k1", "k2"),
+                String.class,
+                misses -> {
+                    loaderCallCount.incrementAndGet();
+                    Map<String, String> loaded = new LinkedHashMap<>();
+                    for (String k : misses) {
+                        loaded.put(k, "fallback-" + k);
+                    }
+                    return loaded;
+                }).await().indefinitely();
+
+        // Loader must have been called once with all keys (full fallback)
+        assertThat(loaderCallCount.get()).isEqualTo(1);
+        assertThat(result).hasSize(2)
+                .containsEntry("k1", "fallback-k1")
+                .containsEntry("k2", "fallback-k2");
+
+        localRedis.close();
     }
 
     private Set<String> getAllKeys() {

--- a/extensions/redis-cache/runtime/src/main/java/io/quarkus/cache/redis/runtime/RedisCache.java
+++ b/extensions/redis-cache/runtime/src/main/java/io/quarkus/cache/redis/runtime/RedisCache.java
@@ -1,5 +1,7 @@
 package io.quarkus.cache.redis.runtime;
 
+import java.util.Collection;
+import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -170,4 +172,181 @@ public interface RedisCache extends Cache {
      * @return a Uni emitting the value cached under {@code key}, or {@code null} if there is no cached value
      */
     <K, V> Uni<V> getOrNull(K key, TypeLiteral<V> type);
+
+    /**
+     * Retrieves all values from the cache for the given collection of keys using a single Redis {@code MGET} command.
+     * Only entries that are currently present in the cache are included in the returned map.
+     * Keys with no cached value are absent from the result — this is not an error.
+     * <p>
+     * Requires the default value type to be configured for this cache. Use
+     * {@link #getAll(Collection, Class)} to specify the type explicitly.
+     *
+     * @param keys the collection of keys to look up; must not be {@code null}
+     * @param <K> the type of key
+     * @param <V> the type of value
+     * @return a {@link Uni} emitting a map of cached key-value pairs; missing keys are absent from the map
+     * @throws UnsupportedOperationException if no default value type is configured for this cache
+     */
+    <K, V> Uni<Map<K, V>> getAll(Collection<K> keys);
+
+    /**
+     * Retrieves all values from the cache for the given collection of keys using a single Redis {@code MGET} command.
+     * Only entries that are currently present in the cache are included in the returned map.
+     * Keys with no cached value are absent from the result — this is not an error.
+     *
+     * @param keys the collection of keys to look up; must not be {@code null}
+     * @param clazz the class of the value
+     * @param <K> the type of key
+     * @param <V> the type of value
+     * @return a {@link Uni} emitting a map of cached key-value pairs; missing keys are absent from the map
+     */
+    <K, V> Uni<Map<K, V>> getAll(Collection<K> keys, Class<V> clazz);
+
+    /**
+     * Retrieves all values from the cache for the given collection of keys using a single Redis {@code MGET} command.
+     * Only entries that are currently present in the cache are included in the returned map.
+     * Keys with no cached value are absent from the result — this is not an error.
+     *
+     * @param keys the collection of keys to look up; must not be {@code null}
+     * @param type the type of the value
+     * @param <K> the type of key
+     * @param <V> the type of value
+     * @return a {@link Uni} emitting a map of cached key-value pairs; missing keys are absent from the map
+     */
+    <K, V> Uni<Map<K, V>> getAll(Collection<K> keys, TypeLiteral<V> type);
+
+    /**
+     * Retrieves all values from the cache for the given collection of keys using a single Redis {@code MGET} command.
+     * For any keys not found in the cache, the {@code valueLoader} is invoked once with the complete set of missing keys.
+     * The loaded values are written back to the cache automatically.
+     * <p>
+     * Requires the default value type to be configured for this cache. Use
+     * {@link #getAll(Collection, Class, Function)} to specify the type explicitly.
+     * <p>
+     * Not supported when optimistic locking is enabled for this cache.
+     *
+     * @param keys the collection of keys to look up; must not be {@code null}
+     * @param valueLoader the function called once with all missing keys to compute their values;
+     *        must not return {@code null} values
+     * @param <K> the type of key
+     * @param <V> the type of value
+     * @return a {@link Uni} emitting a map containing both cached and newly loaded entries
+     * @throws UnsupportedOperationException if no default value type is configured, or if optimistic locking is enabled
+     * @throws IllegalArgumentException if the value loader returns a {@code null} value for any key
+     */
+    <K, V> Uni<Map<K, V>> getAll(Collection<K> keys, Function<Collection<K>, Map<K, V>> valueLoader);
+
+    /**
+     * Retrieves all values from the cache for the given collection of keys using a single Redis {@code MGET} command.
+     * For any keys not found in the cache, the {@code valueLoader} is invoked once with the complete set of missing keys.
+     * The loaded values are written back to the cache automatically.
+     * <p>
+     * Not supported when optimistic locking is enabled for this cache.
+     *
+     * @param keys the collection of keys to look up; must not be {@code null}
+     * @param clazz the class of the value
+     * @param valueLoader the function called once with all missing keys to compute their values;
+     *        must not return {@code null} values
+     * @param <K> the type of key
+     * @param <V> the type of value
+     * @return a {@link Uni} emitting a map containing both cached and newly loaded entries
+     * @throws UnsupportedOperationException if optimistic locking is enabled for this cache
+     * @throws IllegalArgumentException if the value loader returns a {@code null} value for any key
+     */
+    <K, V> Uni<Map<K, V>> getAll(Collection<K> keys, Class<V> clazz, Function<Collection<K>, Map<K, V>> valueLoader);
+
+    /**
+     * Retrieves all values from the cache for the given collection of keys using a single Redis {@code MGET} command.
+     * For any keys not found in the cache, the {@code valueLoader} is invoked once with the complete set of missing keys.
+     * The loaded values are written back to the cache automatically.
+     * <p>
+     * Not supported when optimistic locking is enabled for this cache.
+     *
+     * @param keys the collection of keys to look up; must not be {@code null}
+     * @param type the type of the value
+     * @param valueLoader the function called once with all missing keys to compute their values;
+     *        must not return {@code null} values
+     * @param <K> the type of key
+     * @param <V> the type of value
+     * @return a {@link Uni} emitting a map containing both cached and newly loaded entries
+     * @throws UnsupportedOperationException if optimistic locking is enabled for this cache
+     * @throws IllegalArgumentException if the value loader returns a {@code null} value for any key
+     */
+    <K, V> Uni<Map<K, V>> getAll(Collection<K> keys, TypeLiteral<V> type, Function<Collection<K>, Map<K, V>> valueLoader);
+
+    /**
+     * Retrieves all values from the cache for the given collection of keys using a single Redis {@code MGET} command.
+     * For any keys not found in the cache, the async {@code valueLoader} is invoked once with the complete set of
+     * missing keys. The loaded values are written back to the cache automatically.
+     * <p>
+     * Requires the default value type to be configured for this cache. Use
+     * {@link #getAllAsync(Collection, Class, Function)} to specify the type explicitly.
+     * <p>
+     * Not supported when optimistic locking is enabled for this cache.
+     *
+     * @param keys the collection of keys to look up; must not be {@code null}
+     * @param valueLoader the async function called once with all missing keys to compute their values;
+     *        the emitted map must not contain {@code null} values
+     * @param <K> the type of key
+     * @param <V> the type of value
+     * @return a {@link Uni} emitting a map containing both cached and newly loaded entries
+     * @throws UnsupportedOperationException if no default value type is configured, or if optimistic locking is enabled
+     * @throws IllegalArgumentException if the value loader emits a {@code null} value for any key
+     */
+    <K, V> Uni<Map<K, V>> getAllAsync(Collection<K> keys, Function<Collection<K>, Uni<Map<K, V>>> valueLoader);
+
+    /**
+     * Retrieves all values from the cache for the given collection of keys using a single Redis {@code MGET} command.
+     * For any keys not found in the cache, the async {@code valueLoader} is invoked once with the complete set of
+     * missing keys. The loaded values are written back to the cache automatically.
+     * <p>
+     * Not supported when optimistic locking is enabled for this cache.
+     *
+     * @param keys the collection of keys to look up; must not be {@code null}
+     * @param clazz the class of the value
+     * @param valueLoader the async function called once with all missing keys to compute their values;
+     *        the emitted map must not contain {@code null} values
+     * @param <K> the type of key
+     * @param <V> the type of value
+     * @return a {@link Uni} emitting a map containing both cached and newly loaded entries
+     * @throws UnsupportedOperationException if optimistic locking is enabled for this cache
+     * @throws IllegalArgumentException if the value loader emits a {@code null} value for any key
+     */
+    <K, V> Uni<Map<K, V>> getAllAsync(Collection<K> keys, Class<V> clazz,
+            Function<Collection<K>, Uni<Map<K, V>>> valueLoader);
+
+    /**
+     * Retrieves all values from the cache for the given collection of keys using a single Redis {@code MGET} command.
+     * For any keys not found in the cache, the async {@code valueLoader} is invoked once with the complete set of
+     * missing keys. The loaded values are written back to the cache automatically.
+     * <p>
+     * Not supported when optimistic locking is enabled for this cache.
+     *
+     * @param keys the collection of keys to look up; must not be {@code null}
+     * @param type the type of the value
+     * @param valueLoader the async function called once with all missing keys to compute their values;
+     *        the emitted map must not contain {@code null} values
+     * @param <K> the type of key
+     * @param <V> the type of value
+     * @return a {@link Uni} emitting a map containing both cached and newly loaded entries
+     * @throws UnsupportedOperationException if optimistic locking is enabled for this cache
+     * @throws IllegalArgumentException if the value loader emits a {@code null} value for any key
+     */
+    <K, V> Uni<Map<K, V>> getAllAsync(Collection<K> keys, TypeLiteral<V> type,
+            Function<Collection<K>, Uni<Map<K, V>>> valueLoader);
+
+    /**
+     * Stores all entries from the given map in the cache using a single Redis operation.
+     * <p>
+     * When no expiration is configured, a single atomic {@code MSET} command is used.
+     * When {@code expire-after-write} is configured, individual {@code SET} commands with a TTL are
+     * pipelined in a single round-trip, since {@code MSET} does not support per-key expiry.
+     *
+     * @param map the entries to store; must not be {@code null} and must not contain {@code null} values
+     * @param <K> the type of key
+     * @param <V> the type of value
+     * @return a {@link Uni} emitting {@code null} when the operation completes
+     * @throws IllegalArgumentException if the map contains a {@code null} value
+     */
+    <K, V> Uni<Void> putAll(Map<K, V> map);
 }

--- a/extensions/redis-cache/runtime/src/main/java/io/quarkus/cache/redis/runtime/RedisCacheImpl.java
+++ b/extensions/redis-cache/runtime/src/main/java/io/quarkus/cache/redis/runtime/RedisCacheImpl.java
@@ -4,7 +4,13 @@ import java.lang.reflect.Type;
 import java.net.ConnectException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -124,6 +130,15 @@ public class RedisCacheImpl extends AbstractCache implements RedisCache {
             }).runSubscriptionOn(MutinyHelper.blockingExecutor(vertx.getDelegate(), false));
         } else {
             return Uni.createFrom().item(valueLoader.apply(key));
+        }
+    }
+
+    private <K, V> Uni<Map<K, V>> computeValues(Collection<K> keys,
+            Function<Collection<K>, Map<K, V>> valueLoader, boolean isWorkerThread) {
+        if (isWorkerThread) {
+            return Uni.createFrom().item(() -> valueLoader.apply(keys)).runSubscriptionOn(MutinyHelper.blockingExecutor(vertx.getDelegate(), false));
+        } else {
+            return Uni.createFrom().item(valueLoader.apply(keys));
         }
     }
 
@@ -358,6 +373,247 @@ public class RedisCacheImpl extends AbstractCache implements RedisCache {
                 return doGet(redisConnection, encodedKey, type, marshaller);
             }
         });
+    }
+
+    @Override
+    public <K, V> Uni<Map<K, V>> getAll(Collection<K> keys) {
+        enforceDefaultType("getAll");
+        return doGetAll(keys, classOfValue);
+    }
+
+    @Override
+    public <K, V> Uni<Map<K, V>> getAll(Collection<K> keys, Class<V> clazz) {
+        return doGetAll(keys, (Type) clazz);
+    }
+
+    @Override
+    public <K, V> Uni<Map<K, V>> getAll(Collection<K> keys, TypeLiteral<V> type) {
+        return doGetAll(keys, type.getType());
+    }
+
+    @Override
+    public <K, V> Uni<Map<K, V>> getAll(Collection<K> keys, Function<Collection<K>, Map<K, V>> valueLoader) {
+        enforceDefaultType("getAll");
+        return doGetAll(keys, classOfValue, valueLoader);
+    }
+
+    @Override
+    public <K, V> Uni<Map<K, V>> getAll(Collection<K> keys, Class<V> clazz,
+            Function<Collection<K>, Map<K, V>> valueLoader) {
+        return doGetAll(keys, (Type) clazz, valueLoader);
+    }
+
+    @Override
+    public <K, V> Uni<Map<K, V>> getAll(Collection<K> keys, TypeLiteral<V> type,
+            Function<Collection<K>, Map<K, V>> valueLoader) {
+        return doGetAll(keys, type.getType(), valueLoader);
+    }
+
+    @Override
+    public <K, V> Uni<Map<K, V>> getAllAsync(Collection<K> keys,
+            Function<Collection<K>, Uni<Map<K, V>>> valueLoader) {
+        enforceDefaultType("getAllAsync");
+        return doGetAllAsync(keys, classOfValue, valueLoader);
+    }
+
+    @Override
+    public <K, V> Uni<Map<K, V>> getAllAsync(Collection<K> keys, Class<V> clazz,
+            Function<Collection<K>, Uni<Map<K, V>>> valueLoader) {
+        return doGetAllAsync(keys, (Type) clazz, valueLoader);
+    }
+
+    @Override
+    public <K, V> Uni<Map<K, V>> getAllAsync(Collection<K> keys, TypeLiteral<V> type,
+            Function<Collection<K>, Uni<Map<K, V>>> valueLoader) {
+        return doGetAllAsync(keys, type.getType(), valueLoader);
+    }
+
+    @Override
+    public <K, V> Uni<Void> putAll(Map<K, V> map) {
+        Objects.requireNonNull(map, "map must not be null");
+        if (map.isEmpty()) {
+            return Uni.createFrom().voidItem();
+        }
+        if (cacheInfo.expireAfterWrite.isPresent()) {
+            long ttlSeconds = cacheInfo.expireAfterWrite.get().toSeconds();
+            List<Request> requests = new ArrayList<>(map.size());
+            for (Map.Entry<K, V> entry : map.entrySet()) {
+                if (entry.getValue() == null) {
+                    throw new IllegalArgumentException("Cannot cache `null` value (key: " + entry.getKey() + ")");
+                }
+                byte[] encodedKey = marshaller.encode(computeActualKey(encodeKey(entry.getKey())));
+                byte[] encodedValue = marshaller.encode(entry.getValue());
+                requests.add(Request.cmd(Command.SET).arg(encodedKey).arg(encodedValue)
+                        .arg("EX").arg(ttlSeconds));
+            }
+            return redis.batch(requests).replaceWithVoid();
+        } else {
+            Request request = Request.cmd(Command.MSET);
+            for (Map.Entry<K, V> entry : map.entrySet()) {
+                if (entry.getValue() == null) {
+                    throw new IllegalArgumentException("Cannot cache `null` value (key: " + entry.getKey() + ")");
+                }
+                request.arg(marshaller.encode(computeActualKey(encodeKey(entry.getKey()))));
+                request.arg(marshaller.encode(entry.getValue()));
+            }
+            return redis.send(request).replaceWithVoid();
+        }
+    }
+
+    /**
+     * Core MGET implementation. Issues a single {@code MGET} for all keys and returns only the
+     * entries that are present in Redis. If {@code expire-after-access} is configured, a batch of
+     * {@code EXPIRE} commands is pipelined after the {@code MGET} to refresh the TTL for each hit.
+     */
+    private <K, V> Uni<Map<K, V>> doGetAll(Collection<K> keys, Type type) {
+        Objects.requireNonNull(keys, "keys must not be null");
+        if (keys.isEmpty()) {
+            return Uni.createFrom().item(Collections.emptyMap());
+        }
+        List<K> keyList = new ArrayList<>(keys);
+
+        Request request = Request.cmd(Command.MGET);
+        for (K key : keyList) {
+            request.arg(marshaller.encode(computeActualKey(encodeKey(key))));
+        }
+
+        return redis.send(request)
+                .map(response -> {
+                    Map<K, V> result = new LinkedHashMap<>();
+                    for (int i = 0; i < keyList.size(); i++) {
+                        V value = marshaller.decode(type, response.get(i));
+                        if (value != null) {
+                            result.put(keyList.get(i), value);
+                        }
+                    }
+                    return result;
+                })
+                .chain(result -> {
+                    if (cacheInfo.expireAfterAccess.isEmpty() || result.isEmpty()) {
+                        return Uni.createFrom().item(result);
+                    }
+                    long ttlSeconds = cacheInfo.expireAfterAccess.get().toSeconds();
+                    List<Request> expireRequests = new ArrayList<>(result.size());
+                    for (K hitKey : result.keySet()) {
+                        expireRequests.add(Request.cmd(Command.EXPIRE)
+                                .arg(marshaller.encode(computeActualKey(encodeKey(hitKey))))
+                                .arg(ttlSeconds));
+                    }
+                    return redis.batch(expireRequests).replaceWith(result);
+                });
+    }
+
+    /**
+     * MGET with a synchronous value loader. Cache misses are loaded in bulk with a single loader
+     * invocation and the results are written back via {@link #putAll}.
+     */
+    private <K, V> Uni<Map<K, V>> doGetAll(Collection<K> keys, Type type,
+            Function<Collection<K>, Map<K, V>> valueLoader) {
+        Objects.requireNonNull(keys, "keys must not be null");
+        if (cacheInfo.useOptimisticLocking) {
+            return Uni.createFrom().failure(new UnsupportedOperationException(
+                    "Cannot use `getAll` method with a value loader when optimistic locking is enabled for cache "
+                            + getName()));
+        }
+        if (keys.isEmpty()) {
+            return Uni.createFrom().item(Collections.emptyMap());
+        }
+        boolean isWorkerThread = blockingAllowedSupplier.get();
+
+        return this.<K, V>doGetAll(keys, type)
+                .onFailure(RedisCacheImpl::isRecomputableError)
+                .recoverWithUni(e -> {
+                    log.warn("Unable to connect to Redis, recomputing cached values", e);
+                    return computeValues(keys, valueLoader, isWorkerThread);
+                })
+                .chain(cached -> {
+                    List<K> missKeys = new ArrayList<>();
+                    for (K key : keys) {
+                        if (!cached.containsKey(key)) {
+                            missKeys.add(key);
+                        }
+                    }
+                    if (missKeys.isEmpty()) {
+                        return Uni.createFrom().item(cached);
+                    }
+                    return computeValues(missKeys, valueLoader, isWorkerThread)
+                            .chain(loaded -> {
+                                for (Map.Entry<K, V> entry : loaded.entrySet()) {
+                                    if (entry.getValue() == null) {
+                                        throw new IllegalArgumentException(
+                                                "Cannot cache `null` value (key: " + entry.getKey() + ")");
+                                    }
+                                }
+                                return putAll(loaded)
+                                        .map(ignored -> {
+                                            Map<K, V> merged = new LinkedHashMap<>();
+                                            for (K key : keys) {
+                                                if (cached.containsKey(key)) {
+                                                    merged.put(key, cached.get(key));
+                                                } else if (loaded.containsKey(key)) {
+                                                    merged.put(key, loaded.get(key));
+                                                }
+                                            }
+                                            return merged;
+                                        });
+                            });
+                });
+    }
+
+    /**
+     * MGET with an asynchronous value loader. Cache misses are loaded in bulk with a single async
+     * loader invocation and the results are written back via {@link #putAll}.
+     */
+    private <K, V> Uni<Map<K, V>> doGetAllAsync(Collection<K> keys, Type type,
+            Function<Collection<K>, Uni<Map<K, V>>> valueLoader) {
+        Objects.requireNonNull(keys, "keys must not be null");
+        if (cacheInfo.useOptimisticLocking) {
+            return Uni.createFrom().failure(new UnsupportedOperationException(
+                    "Cannot use `getAllAsync` method with a value loader when optimistic locking is enabled for cache "
+                            + getName()));
+        }
+        if (keys.isEmpty()) {
+            return Uni.createFrom().item(Collections.emptyMap());
+        }
+
+        return this.<K, V> doGetAll(keys, type)
+                .onFailure(RedisCacheImpl::isRecomputableError)
+                .recoverWithUni(e -> {
+                    log.warn("Unable to connect to Redis, recomputing cached values", e);
+                    return valueLoader.apply(keys);
+                })
+                .chain(cached -> {
+                    List<K> missKeys = new ArrayList<>();
+                    for (K key : keys) {
+                        if (!cached.containsKey(key)) {
+                            missKeys.add(key);
+                        }
+                    }
+                    if (missKeys.isEmpty()) {
+                        return Uni.createFrom().item(cached);
+                    }
+                    return valueLoader.apply(missKeys)
+                            .chain(loaded -> {
+                                for (Map.Entry<K, V> entry : loaded.entrySet()) {
+                                    if (entry.getValue() == null) {
+                                        throw new IllegalArgumentException(
+                                                "Cannot cache `null` value (key: " + entry.getKey() + ")");
+                                    }
+                                }
+                                return putAll(loaded)
+                                        .map(ignored -> {
+                                            Map<K, V> merged = new LinkedHashMap<>();
+                                            for (K key : keys) {
+                                                if (cached.containsKey(key)) {
+                                                    merged.put(key, cached.get(key));
+                                                } else if (loaded.containsKey(key)) {
+                                                    merged.put(key, loaded.get(key));
+                                                }
+                                            }
+                                            return merged;
+                                        });
+                            });
+                });
     }
 
     @Override

--- a/extensions/redis-cache/runtime/src/main/java/io/quarkus/cache/redis/runtime/RedisCacheImpl.java
+++ b/extensions/redis-cache/runtime/src/main/java/io/quarkus/cache/redis/runtime/RedisCacheImpl.java
@@ -136,7 +136,8 @@ public class RedisCacheImpl extends AbstractCache implements RedisCache {
     private <K, V> Uni<Map<K, V>> computeValues(Collection<K> keys,
             Function<Collection<K>, Map<K, V>> valueLoader, boolean isWorkerThread) {
         if (isWorkerThread) {
-            return Uni.createFrom().item(() -> valueLoader.apply(keys)).runSubscriptionOn(MutinyHelper.blockingExecutor(vertx.getDelegate(), false));
+            return Uni.createFrom().item(() -> valueLoader.apply(keys))
+                    .runSubscriptionOn(MutinyHelper.blockingExecutor(vertx.getDelegate(), false));
         } else {
             return Uni.createFrom().item(valueLoader.apply(keys));
         }
@@ -520,7 +521,7 @@ public class RedisCacheImpl extends AbstractCache implements RedisCache {
         }
         boolean isWorkerThread = blockingAllowedSupplier.get();
 
-        return this.<K, V>doGetAll(keys, type)
+        return this.<K, V> doGetAll(keys, type)
                 .onFailure(RedisCacheImpl::isRecomputableError)
                 .recoverWithUni(e -> {
                     log.warn("Unable to connect to Redis, recomputing cached values", e);


### PR DESCRIPTION
Add bulk getAll/getAllAsync operations to RedisCache backed by Redis MGET.

Currently, fetching multiple keys from RedisCache requires N individual GET 
calls. This PR adds three new methods to the RedisCache interface that use 
a single MGET command instead, reducing Redis round-trips for bulk lookups.

Changes:
- Added getAll(Collection<K>, Class<V>) — returns only cache hits
- Added getAll(Collection<K>, Class<V>, Function) — synchronous value loader for misses, writes back with TTL
- Added getAllAsync(Collection<K>, Class<V>, Function) — async variant of above
- Implemented in RedisCacheImpl using MGET for reads and SET-with-expiry for write-back (not MSET, to preserve TTL per key)

Tests cover: all hits, all misses, partial hit/miss, and TTL correctness on loader write-back.

* Fixes #53597