### PR TITLE
Use reachability-based registration for Jackson SQL/XML serializers in native image

### DIFF
--- a/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
+++ b/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
@@ -56,6 +56,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.NativeImageFeatureBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
@@ -78,6 +79,7 @@ import io.quarkus.jackson.runtime.JacksonRecorder;
 import io.quarkus.jackson.runtime.JacksonSupport;
 import io.quarkus.jackson.runtime.ObjectMapperProducer;
 import io.quarkus.jackson.runtime.VertxHybridPoolObjectMapperCustomizer;
+import io.quarkus.jackson.runtime.graal.JacksonSerializerRegistrationFeature;
 import io.quarkus.jackson.spi.ClassPathJacksonModuleBuildItem;
 import io.quarkus.jackson.spi.JacksonModuleBuildItem;
 
@@ -133,6 +135,11 @@ public class JacksonProcessor {
     }
 
     @BuildStep
+    NativeImageFeatureBuildItem jacksonSerializerRegistrationFeature() {
+        return new NativeImageFeatureBuildItem(JacksonSerializerRegistrationFeature.class);
+    }
+
+    @BuildStep
     void register(
             CurateOutcomeBuildItem curateOutcomeBuildItem,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
@@ -140,21 +147,13 @@ public class JacksonProcessor {
             BuildProducer<ReflectiveMethodBuildItem> reflectiveMethod,
             BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
         reflectiveClass.produce(
-                ReflectiveClassBuildItem.builder("com.fasterxml.jackson.databind.ser.std.SqlDateSerializer",
-                        "com.fasterxml.jackson.databind.ser.std.SqlTimeSerializer",
-                        "com.fasterxml.jackson.databind.deser.std.DateDeserializers$SqlDateDeserializer",
-                        "com.fasterxml.jackson.databind.deser.std.DateDeserializers$TimestampDeserializer",
-                        "com.fasterxml.jackson.annotation.SimpleObjectIdResolver")
+                ReflectiveClassBuildItem.builder("com.fasterxml.jackson.annotation.SimpleObjectIdResolver")
                         .reason(getClass().getName())
                         .methods().build());
         reflectiveClass.produce(
-                ReflectiveClassBuildItem.builder(
-                        "com.fasterxml.jackson.databind.ser.std.ClassSerializer",
-                        "com.fasterxml.jackson.databind.ext.CoreXMLSerializers",
-                        "com.fasterxml.jackson.databind.ext.CoreXMLDeserializers")
+                ReflectiveClassBuildItem.builder("com.fasterxml.jackson.databind.ser.std.ClassSerializer")
                         .reason(getClass().getName())
-                        .constructors()
-                        .build());
+                        .constructors().build());
 
         if (curateOutcomeBuildItem.getApplicationModel().getDependencies().stream().anyMatch(
                 x -> x.getGroupId().equals("com.fasterxml.jackson.module")

--- a/extensions/jackson/runtime/pom.xml
+++ b/extensions/jackson/runtime/pom.xml
@@ -38,6 +38,11 @@
             <artifactId>vertx-core</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>nativeimage</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/graal/JacksonSerializerRegistrationFeature.java
+++ b/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/graal/JacksonSerializerRegistrationFeature.java
@@ -1,0 +1,67 @@
+package io.quarkus.jackson.runtime.graal;
+
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+
+import javax.xml.datatype.Duration;
+import javax.xml.datatype.XMLGregorianCalendar;
+import javax.xml.namespace.QName;
+
+import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.hosted.RuntimeReflection;
+
+import com.fasterxml.jackson.databind.deser.std.DateDeserializers;
+import com.fasterxml.jackson.databind.ext.CoreXMLDeserializers;
+import com.fasterxml.jackson.databind.ext.CoreXMLSerializers;
+import com.fasterxml.jackson.databind.ser.std.SqlDateSerializer;
+import com.fasterxml.jackson.databind.ser.std.SqlTimeSerializer;
+
+/**
+ * Registers Jackson serializers/deserializers for reflection only when their corresponding
+ * types are reachable during native image analysis. This avoids unconditionally pulling in
+ * {@code java.sql.*} and {@code javax.xml.datatype.*} class hierarchies into the native image.
+ *
+ * See <a href="https://github.com/quarkusio/quarkus/issues/53818">GitHub issue #53818</a>.
+ */
+public class JacksonSerializerRegistrationFeature implements Feature {
+
+    @Override
+    public String getDescription() {
+        return "Conditionally registers Jackson SQL/XML serializers for reflection based on reachability";
+    }
+
+    @Override
+    public void beforeAnalysis(BeforeAnalysisAccess access) {
+        // java.sql serializers/deserializers
+        registerWhenReachable(access, new Class<?>[] { Date.class }, true,
+                SqlDateSerializer.class,
+                DateDeserializers.SqlDateDeserializer.class);
+
+        registerWhenReachable(access, new Class<?>[] { Time.class }, true,
+                SqlTimeSerializer.class);
+
+        registerWhenReachable(access, new Class<?>[] { Timestamp.class }, true,
+                DateDeserializers.TimestampDeserializer.class);
+
+        // CoreXMLSerializers/CoreXMLDeserializers handle XMLGregorianCalendar, QName, and Duration
+        registerWhenReachable(access, new Class<?>[] { XMLGregorianCalendar.class, QName.class, Duration.class }, false,
+                CoreXMLSerializers.class,
+                CoreXMLDeserializers.class);
+    }
+
+    private void registerWhenReachable(BeforeAnalysisAccess access, Class<?>[] triggerClasses,
+            boolean includeMethods, Class<?>... classes) {
+        for (Class<?> triggerClass : triggerClasses) {
+            access.registerReachabilityHandler(a -> {
+                for (Class<?> clazz : classes) {
+                    RuntimeReflection.register(clazz);
+                    RuntimeReflection.register(clazz.getDeclaredConstructors());
+                    if (includeMethods) {
+                        RuntimeReflection.register(clazz.getDeclaredMethods());
+                    }
+                }
+            }, triggerClass);
+        }
+    }
+}


### PR DESCRIPTION
Replace unconditional reflection registration of Jackson SQL/XML serializers with a GraalVM Feature that registers them only when their trigger types are reachable during analysis.

This prevents java.sql.* and javax.xml.datatype.* class hierarchies from being pulled into the native image when they are not used.

- Fixes #53818
