### PR TITLE
Revert "Enable reflection-free Jackson serializers by default"

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonOptimizationConfig.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonOptimizationConfig.java
@@ -17,7 +17,7 @@ public interface JacksonOptimizationConfig {
     /**
      * Enable build time generation of reflection-free Jackson serializers.
      */
-    @WithDefault("true")
+    @WithDefault("false")
     boolean enableReflectionFreeSerializers();
 
     class IsReflectionFreeSerializersEnabled implements BooleanSupplier {


### PR DESCRIPTION
This reverts commit 79d076877fedf4a8f1975f0fcbb3bd956a37cd87.

Our plan is to use AI to generate more tests and improve our coverage and confidence, and ideally make it the default for 3.36.

Per discussion in #53765