### PR TITLE
Extension can be marked as deprecated in quarkus extension

### DIFF
--- a/devtools/gradle/gradle-extension-plugin/build.gradle.kts
+++ b/devtools/gradle/gradle-extension-plugin/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 dependencies {
     implementation(libs.jackson.databind)
     implementation(libs.jackson.dataformat.yaml)
+    implementation(libs.json.schema.validator)
 }
 
 group = "io.quarkus.extension"

--- a/devtools/gradle/gradle-extension-plugin/pom.xml
+++ b/devtools/gradle/gradle-extension-plugin/pom.xml
@@ -43,6 +43,7 @@
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
+
         <dependency>
           <groupId>io.quarkus</groupId>
           <artifactId>quarkus-devtools-common</artifactId>

--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/tasks/ExtensionDescriptorTask.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/tasks/ExtensionDescriptorTask.java
@@ -53,6 +53,7 @@ import io.quarkus.fs.util.ZipUtils;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.maven.dependency.GACT;
+import io.quarkus.platform.tools.ExtensionMetadataValidator;
 
 /**
  * Task that generates extension descriptor files.
@@ -342,6 +343,12 @@ public class ExtensionDescriptorTask extends DefaultTask {
 
         if (!extObject.has("description") && projectInfo.containsKey("description")) {
             extObject.put("description", projectInfo.get("description"));
+        }
+
+        try {
+            ExtensionMetadataValidator.validate(extObject);
+        } catch (IOException e) {
+            throw new GradleException(e.getMessage(), e.getCause());
         }
 
         final DefaultPrettyPrinter prettyPrinter = new DefaultPrettyPrinter();

--- a/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/tasks/ExtensionDescriptorTaskTest.java
+++ b/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/tasks/ExtensionDescriptorTaskTest.java
@@ -177,6 +177,29 @@ public class ExtensionDescriptorTaskTest {
     }
 
     @Test
+    public void shouldFailOnInvalidStatusArray() throws IOException {
+        TestUtils.writeFile(buildFile, TestUtils.getDefaultGradleBuildFileContent(true, Collections.emptyList(), ""));
+        File metaInfDir = new File(testProjectDir, "src/main/resources/META-INF");
+        metaInfDir.mkdirs();
+        String invalid = "name: extension-name\n" +
+                "metadata:\n" +
+                "  status:\n" +
+                "  - stable\n" +
+                "  - deprecated\n";
+        TestUtils.writeFile(new File(metaInfDir, "quarkus-extension.yaml"), invalid);
+
+        BuildResult result = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(testProjectDir)
+                .withArguments("extensionDescriptor", "-S")
+                .buildAndFail();
+
+        assertThat(result.task(":extensionDescriptor").getOutcome()).isEqualTo(TaskOutcome.FAILED);
+        assertThat(result.getOutput()).contains("Invalid quarkus-extension.yaml metadata");
+        assertThat(result.getOutput()).contains("status");
+    }
+
+    @Test
     public void shouldGenerateDescriptorWithCapabilities() throws IOException {
         String buildFileContent = TestUtils.getDefaultGradleBuildFileContent(true, Collections.emptyList(),
                 "capabilities { \n" +

--- a/devtools/gradle/gradle/libs.versions.toml
+++ b/devtools/gradle/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ plugin-publish = "2.1.1"
 
 kotlin = "2.4.0"
 smallrye-config = "3.17.2"
+json-schema-validator = "2.0.1"
 
 junit = "6.1.1"
 assertj = "3.27.7"
@@ -23,6 +24,7 @@ kotlin-gradle-plugin-api = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin
 smallrye-config-yaml = { module = "io.smallrye.config:smallrye-config-source-yaml", version.ref = "smallrye-config" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind" }
 jackson-dataformat-yaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml" }
+json-schema-validator = { module = "com.networknt:json-schema-validator", version.ref = "json-schema-validator" }
 
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 junit-api = { module = "org.junit.jupiter:junit-jupiter-api" }

--- a/docs/src/main/asciidoc/extension-metadata.adoc
+++ b/docs/src/main/asciidoc/extension-metadata.adoc
@@ -51,11 +51,22 @@ metadata:
 <3> Short name that could be used to quickly locate an extension in the catalog of extensions provided by the dev tools to the users
 <4> Keywords that can be used to search for extensions in the extension catalog provided by the dev tools to the users
 <5> Categories the extension should appear under on https://code.quarkus.io[code.quarkus.io]. This field can be omitted, the extension will still be listed on https://code.quarkus.io[code.quarkus.io] but won't be categorized
-<6> Maturity status that could be `stable`, `preview`, `experimental`. It is up to extension maintainers to evaluate the maturity status and communicate it to the users
+<6> Maturity status that could be `stable`, `preview`, `experimental`, `deprecated`. It is up to extension maintainers to evaluate the maturity status and communicate it to the users
 <7> Link to the extension guide or documentation page
 <8> Link to an externally hosted image. This is used in the Quarkus dev tools as the extension icon. It should be square, and any resolution greater than 220 pixels. Supported formats are png, jpeg, tiff, webp, and svg. Alternatively, if you https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/customizing-your-repositorys-social-media-preview[set the social media preview] on the extension's source code repository, the tools will pick up that image.
 <9> https://quarkus.io/guides/extension-codestart[Codestart] information
 <10> Configuration prefix
+
+To mark an extension as deprecated, set the status to `deprecated`:
+
+[source,yaml,subs=attributes+]
+
+
+----
+metadata:
+  status: "deprecated"
+----
+
 
 And here is the final version of the file included in the runtime JAR augmented with other information collected by the Quarkus Maven plugin:
 

--- a/independent-projects/extension-maven-plugin/pom.xml
+++ b/independent-projects/extension-maven-plugin/pom.xml
@@ -351,6 +351,7 @@
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
+
         <dependency>
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>

--- a/independent-projects/extension-maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
+++ b/independent-projects/extension-maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
@@ -77,6 +77,7 @@ import io.quarkus.maven.capabilities.CapabilityConfig;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.maven.dependency.GACTV;
+import io.quarkus.platform.tools.ExtensionMetadataValidator;
 
 /**
  * Generates Quarkus extension descriptor for the runtime artifact.
@@ -369,6 +370,12 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
         addExtensionDependencies(extObject);
 
         completeCodestartArtifact(mapper, extObject);
+
+        try {
+            ExtensionMetadataValidator.validate(extObject);
+        } catch (IOException e) {
+            throw new MojoExecutionException(e.getMessage(), e.getCause());
+        }
 
         final DefaultPrettyPrinter prettyPrinter = new DefaultPrettyPrinter();
         prettyPrinter.indentArraysWith(DefaultIndenter.SYSTEM_LINEFEED_INSTANCE);

--- a/independent-projects/extension-maven-plugin/src/test/java/io/quarkus/maven/ExtensionDescriptorMojoTest.java
+++ b/independent-projects/extension-maven-plugin/src/test/java/io/quarkus/maven/ExtensionDescriptorMojoTest.java
@@ -113,6 +113,46 @@ class ExtensionDescriptorMojoTest extends AbstractMojoTestCase {
     }
 
     @Test
+    public void shouldFailOnInvalidStatusArray()
+            throws Exception {
+        ExtensionDescriptorMojo mojo = makeMojo("simple-pom-with-checks-disabled");
+
+        Path yamlPath = mojo.project.getBasedir().toPath().resolve("target/classes/META-INF/quarkus-extension.yaml");
+        Files.createDirectories(yamlPath.getParent());
+        Files.writeString(yamlPath, ""
+                + "name: \"an arbitrary name\"\n"
+                + "metadata:\n"
+                + "  status:\n"
+                + "  - \"stable\"\n"
+                + "  - \"deprecated\"\n");
+
+        try {
+            Exception thrown = Assertions.assertThrows(MojoExecutionException.class, mojo::execute);
+            Assertions.assertTrue(thrown.getMessage().contains("Invalid quarkus-extension.yaml metadata"),
+                    "Expected schema validation error but got:\n" + thrown.getMessage());
+            Assertions.assertTrue(thrown.getMessage().contains("status"),
+                    "Expected status field to be mentioned but got:\n" + thrown.getMessage());
+        } finally {
+            Files.deleteIfExists(yamlPath);
+        }
+    }
+
+    @Test
+    public void shouldAcceptDeprecatedStatus()
+            throws Exception {
+        ExtensionDescriptorMojo mojo = makeMojo("simple-pom-with-checks-disabled");
+
+        Path yamlPath = mojo.project.getBasedir().toPath().resolve("target/classes/META-INF/quarkus-extension.yaml");
+        Files.createDirectories(yamlPath.getParent());
+        Files.writeString(yamlPath, ""
+                + "name: \"an arbitrary name\"\n"
+                + "metadata:\n"
+                + "  status: \"deprecated\"\n");
+
+        mojo.execute();
+    }
+
+    @Test
     public void shouldReadLocalParentsForScmInfo()
             throws Exception {
 

--- a/independent-projects/tools/devtools-common/pom.xml
+++ b/independent-projects/tools/devtools-common/pom.xml
@@ -67,6 +67,10 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.networknt</groupId>
+            <artifactId>json-schema-validator</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jdk8</artifactId>
         </dependency>

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/tools/ExtensionMetadataValidator.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/tools/ExtensionMetadataValidator.java
@@ -1,0 +1,67 @@
+package io.quarkus.platform.tools;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import com.fasterxml.jackson.core.json.JsonReadFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.networknt.schema.Schema;
+import com.networknt.schema.SchemaRegistry;
+import com.networknt.schema.SpecificationVersion;
+
+import io.quarkus.bootstrap.BootstrapConstants;
+
+/**
+ * Validates extension metadata ({@value BootstrapConstants#QUARKUS_EXTENSION_FILE_NAME}) against the
+ * JSON schema bundled in {@value ToolsConstants#EXTENSION_SCHEMA_RESOURCE}.
+ * <p>
+ * This class is shared by the extension Maven plugin and the extension Gradle plugin so that the
+ * validation logic is not duplicated.
+ */
+public final class ExtensionMetadataValidator {
+
+    private ExtensionMetadataValidator() {
+    }
+
+    /**
+     * Validates the given extension descriptor object against the bundled JSON schema.
+     *
+     * @param extObject the parsed extension descriptor
+     * @throws IOException if the schema cannot be loaded or the descriptor is invalid
+     */
+    public static void validate(ObjectNode extObject) throws IOException {
+        final Schema schema;
+        try (InputStream is = ExtensionMetadataValidator.class.getResourceAsStream(ToolsConstants.EXTENSION_SCHEMA_RESOURCE)) {
+            if (is == null) {
+                throw new IOException(
+                        "Failed to load extension metadata schema from " + ToolsConstants.EXTENSION_SCHEMA_RESOURCE);
+            }
+            final ObjectMapper jsonMapper = JsonMapper.builder()
+                    .enable(SerializationFeature.INDENT_OUTPUT)
+                    .enable(JsonReadFeature.ALLOW_JAVA_COMMENTS)
+                    .enable(JsonReadFeature.ALLOW_LEADING_ZEROS_FOR_NUMBERS)
+                    .build();
+            final JsonNode schemaNode = jsonMapper.readTree(is);
+
+            final SchemaRegistry schemaRegistry = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2020_12);
+            schema = schemaRegistry.getSchema(schemaNode);
+            schema.initializeValidators();
+        }
+
+        final List<com.networknt.schema.Error> errors = schema.validate(extObject);
+        if (!errors.isEmpty()) {
+            final StringBuilder sb = new StringBuilder();
+            sb.append("Invalid ").append(BootstrapConstants.QUARKUS_EXTENSION_FILE_NAME).append(" metadata:");
+            for (com.networknt.schema.Error err : errors) {
+                sb.append(System.lineSeparator()).append("- ").append(err.getInstanceLocation()).append(": ")
+                        .append(err.getMessage());
+            }
+            throw new IOException(sb.toString());
+        }
+    }
+}

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/tools/ToolsConstants.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/tools/ToolsConstants.java
@@ -31,4 +31,6 @@ public interface ToolsConstants {
     String PROP_PROPOSED_MVN_VERSION = "proposed-maven-version";
     String PROP_MVN_WRAPPER_VERSION = "maven-wrapper-version";
     String PROP_GRADLE_WRAPPER_VERSION = "gradle-wrapper-version";
+
+    String EXTENSION_SCHEMA_RESOURCE = "/META-INF/quarkus-extension-schema.json";
 }

--- a/independent-projects/tools/devtools-common/src/main/resources/META-INF/quarkus-extension-schema.json
+++ b/independent-projects/tools/devtools-common/src/main/resources/META-INF/quarkus-extension-schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://quarkus.io/schemas/quarkus-extension-schema.json",
+  "title": "Quarkus Extension Descriptor (minimal)",
+  "description": "Minimal schema for META-INF/quarkus-extension.yaml focusing on validated core metadata fields.",
+  "type": "object",
+  "properties": {
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "stable",
+            "preview",
+            "experimental",
+            "deprecated"
+          ],
+          "description": "Maturity status. Must be a single string (not an array)."
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -62,6 +62,7 @@
         <system-stubs-jupiter.version>2.0.2</system-stubs-jupiter.version>
         <awaitility.version>4.3.0</awaitility.version>
         <java-properties.version>0.0.7</java-properties.version>
+        <networknt-schema-validator.version>2.0.1</networknt-schema-validator.version>
     </properties>
     <modules>
         <module>registry-client</module>
@@ -184,6 +185,11 @@
                 <groupId>org.codejive</groupId>
                 <artifactId>java-properties</artifactId>
                 <version>${java-properties.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.networknt</groupId>
+                <artifactId>json-schema-validator</artifactId>
+                <version>${networknt-schema-validator.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>


### PR DESCRIPTION
## Summary

  Fix https://github.com/quarkusio/quarkus/issues/52765

- Add a  JSON Schema for `META-INF/quarkus-extension.yaml` to define `metadata.status` as a single value and include `deprecated`.
- Validate `quarkus-extension.yaml` against the schema during extension packaging in both the Maven mojo and the Gradle task .
- Add regression tests for Maven and Gradle that reject `metadata.status` as an array (e.g. ["stable","deprecated"]) and accept `metadata.status: "deprecated"`.
- Update the extension metadata guide to document `deprecated` as a supported status and show an example.

## Test plan
- [x] `./mvnw -pl independent-projects/extension-maven-plugin -DskipTests compile`
- [x] `./mvnw -pl devtools/gradle/gradle-extension-plugin -DskipTests compile`
- [x] `./mvnw -pl independent-projects/extension-maven-plugin test -Dtest=ExtensionDescriptorMojoTest` (after installing devtools-common to local repo)
- [x] `./mvnw -pl devtools/gradle/gradle-extension-plugin test -Dtest=ExtensionDescriptorTaskTest`

## Notes
- Uses `com.networknt:json-schema-validator:2.0.1` (Jackson 2 / Java 11 compatible) for validation.
- Validation is enforced at packaging time; downstream consumers can continue to be permissive with existing published metadata.