### PR TITLE
GraphQL client TLS reload

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -49,7 +49,7 @@
         <smallrye-config.version>3.17.2</smallrye-config.version>
         <smallrye-health.version>4.3.0</smallrye-health.version>
         <smallrye-open-api.version>4.3.0</smallrye-open-api.version>
-        <smallrye-graphql.version>2.18.0</smallrye-graphql.version>
+        <smallrye-graphql.version>2.18.1</smallrye-graphql.version>
         <smallrye-fault-tolerance.version>6.11.1</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>4.6.3</smallrye-jwt.version>
         <smallrye-context-propagation.version>2.3.0</smallrye-context-propagation.version>

--- a/extensions/smallrye-graphql-client/deployment/src/main/java/io/quarkus/smallrye/graphql/client/deployment/SmallRyeGraphQLClientProcessor.java
+++ b/extensions/smallrye-graphql-client/deployment/src/main/java/io/quarkus/smallrye/graphql/client/deployment/SmallRyeGraphQLClientProcessor.java
@@ -42,6 +42,7 @@ import io.quarkus.deployment.builditem.AdditionalIndexedClassesBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageProxyDefinitionBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
@@ -50,6 +51,7 @@ import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.smallrye.graphql.client.runtime.GraphQLClientBuildConfig;
 import io.quarkus.smallrye.graphql.client.runtime.GraphQLClientCertificateUpdateEventListener;
 import io.quarkus.smallrye.graphql.client.runtime.GraphQLClientSupport;
+import io.quarkus.smallrye.graphql.client.runtime.GraphQLClientTlsCleanupDestroyer;
 import io.quarkus.smallrye.graphql.client.runtime.SmallRyeGraphQLClientRecorder;
 import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
 import io.smallrye.graphql.client.model.ClientModels;
@@ -154,6 +156,7 @@ public class SmallRyeGraphQLClientProcessor {
                     .scope(scope == null ? BuiltinScope.APPLICATION.getInfo() : scope.getInfo())
                     .addInjectionPoint(ClassType.create(DotName.createSimple(ClientModels.class)))
                     .createWith(recorder.typesafeClientSupplier(apiClass))
+                    .destroyer(GraphQLClientTlsCleanupDestroyer.class)
                     .unremovable()
                     .done();
             syntheticBeans.produce(bean);
@@ -257,8 +260,10 @@ public class SmallRyeGraphQLClientProcessor {
     @BuildStep
     @Record(RUNTIME_INIT)
     void setGlobalVertxInstance(CoreVertxBuildItem vertxBuildItem,
-            SmallRyeGraphQLClientRecorder recorder) {
+            SmallRyeGraphQLClientRecorder recorder,
+            ShutdownContextBuildItem shutdown) {
         recorder.setGlobalVertxInstance(vertxBuildItem.getVertx());
+        recorder.cleanUp(shutdown);
     }
 
     @BuildStep

--- a/extensions/smallrye-graphql-client/deployment/src/test/java/io/quarkus/smallrye/graphql/client/deployment/ssl/DynamicGraphQLClientTlsReloadApplicationScopedTest.java
+++ b/extensions/smallrye-graphql-client/deployment/src/test/java/io/quarkus/smallrye/graphql/client/deployment/ssl/DynamicGraphQLClientTlsReloadApplicationScopedTest.java
@@ -1,0 +1,136 @@
+package io.quarkus.smallrye.graphql.client.deployment.ssl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+import jakarta.enterprise.event.Event;
+import jakarta.inject.Inject;
+
+import org.assertj.core.api.Assertions;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.tls.CertificateUpdatedEvent;
+import io.quarkus.tls.TlsConfiguration;
+import io.quarkus.tls.TlsConfigurationRegistry;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.junit5.Certificate;
+import io.smallrye.certs.junit5.Certificates;
+import io.smallrye.graphql.client.GraphQLClient;
+import io.smallrye.graphql.client.Response;
+import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClient;
+import io.vertx.core.http.HttpServer;
+
+/**
+ * Tests TLS certificate reload for dynamic GraphQL clients.
+ * Dynamic clients are application-scoped (created once and cached in {@code NamedDynamicClients}),
+ * so reload must work via {@code httpClient.updateSSLOptions()}.
+ */
+@Certificates(baseDir = "target/certs", certificates = {
+        @Certificate(name = "wrong-test-reload", password = "password", formats = Format.PKCS12, client = true),
+        @Certificate(name = "test-reload", password = "password", formats = Format.PKCS12, client = true)
+})
+public class DynamicGraphQLClientTlsReloadApplicationScopedTest {
+
+    private static final int PORT = 63805;
+    private static final SSLTestingTools TOOLS = new SSLTestingTools();
+    private static final String EXPECTED_RESPONSE = "HelloWorld";
+    private static HttpServer server;
+
+    private static final File temp = new File("target/test-certificates-" + UUID.randomUUID());
+
+    private static final String CONFIGURATION = """
+            # No config - overridden in the test
+            """;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class)
+                            .add(new StringAsset(CONFIGURATION), "application.properties")
+                            .addClasses(SSLTestingTools.class))
+            .overrideRuntimeConfigKey("loc", temp.getAbsolutePath())
+            .overrideRuntimeConfigKey("quarkus.smallrye-graphql-client.my-client.tls-configuration-name", "my-tls-client")
+            .overrideRuntimeConfigKey("quarkus.tls.my-tls-client.key-store.p12.path", temp.getAbsolutePath() + "/tls.p12")
+            .overrideRuntimeConfigKey("quarkus.tls.my-tls-client.key-store.p12.password", "password")
+            .overrideRuntimeConfigKey("quarkus.smallrye-graphql-client.my-client.url", "https://127.0.0.1:" + PORT)
+            .overrideRuntimeConfigKey("quarkus.tls.my-tls-client.trust-all", "true")
+            .setBeforeAllCustomizer(() -> {
+                try {
+                    temp.mkdirs();
+                    Files.copy(new File("target/certs/wrong-test-reload-client-keystore.p12").toPath(),
+                            new File(temp, "/tls.p12").toPath());
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+    @Inject
+    @GraphQLClient("my-client")
+    DynamicGraphQLClient client;
+
+    @Inject
+    TlsConfigurationRegistry registry;
+
+    @ConfigProperty(name = "loc")
+    File certs;
+
+    @Inject
+    Event<CertificateUpdatedEvent> event;
+
+    @BeforeAll
+    static void setupServer() throws Exception {
+        server = TOOLS.runServer("target/certs/test-reload-keystore.p12",
+                "password", "target/certs/test-reload-server-truststore.p12",
+                "password");
+    }
+
+    @Test
+    void testReloading() throws IOException, ExecutionException, InterruptedException {
+        TlsConfiguration tlsClient = registry.get("my-tls-client").orElseThrow();
+        try {
+            client.executeSync("{ result }");
+            Assertions.fail("Should fail with wrong keystore");
+        } catch (Exception ex) {
+            assertHasCauseContainingMessage(ex, "certificate_unknown");
+        }
+
+        Files.copy(new File("target/certs/test-reload-client-keystore.p12").toPath(),
+                new File(certs, "/tls.p12").toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+
+        assertThat(tlsClient.reload()).isTrue();
+        event.fire(new CertificateUpdatedEvent("my-tls-client", tlsClient));
+
+        Response response = client.executeSync("{ result }");
+        assertThat(response.getData().getString("result")).isEqualTo(EXPECTED_RESPONSE);
+    }
+
+    @AfterAll
+    static void closeServer() {
+        server.close();
+        TOOLS.close();
+    }
+
+    private void assertHasCauseContainingMessage(Throwable t, String message) {
+        Throwable throwable = t;
+        while (throwable.getCause() != null) {
+            throwable = throwable.getCause();
+            if (throwable.getMessage().contains(message)) {
+                return;
+            }
+        }
+        throw new RuntimeException("Unexpected exception", t);
+    }
+}

--- a/extensions/smallrye-graphql-client/deployment/src/test/java/io/quarkus/smallrye/graphql/client/deployment/ssl/TypesafeGraphQLClientTlsRegistryCleanupTest.java
+++ b/extensions/smallrye-graphql-client/deployment/src/test/java/io/quarkus/smallrye/graphql/client/deployment/ssl/TypesafeGraphQLClientTlsRegistryCleanupTest.java
@@ -1,0 +1,133 @@
+package io.quarkus.smallrye.graphql.client.deployment.ssl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.graphql.Query;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.smallrye.graphql.client.runtime.SmallRyeGraphQLClientRecorder;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.junit5.Certificate;
+import io.smallrye.certs.junit5.Certificates;
+import io.smallrye.graphql.client.typesafe.api.GraphQLClientApi;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpServer;
+
+/**
+ * Verifies that when a request-scoped GraphQL client is destroyed,
+ * its HttpClient is removed from the TLS reload registry in
+ * {@link SmallRyeGraphQLClientRecorder}, preventing a memory leak.
+ */
+@Certificates(baseDir = "target/certs", certificates = {
+        @Certificate(name = "test-reload", password = "password", formats = Format.PKCS12, client = true)
+})
+public class TypesafeGraphQLClientTlsRegistryCleanupTest {
+
+    private static final int PORT = 63805;
+    private static final SSLTestingTools TOOLS = new SSLTestingTools();
+    private static HttpServer server;
+
+    private static final File temp = new File("target/test-certificates-" + UUID.randomUUID());
+
+    private static final String CONFIGURATION = """
+            # No config - overridden in the test
+            """;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class)
+                            .add(new StringAsset(CONFIGURATION), "application.properties")
+                            .addClasses(MyApi.class, SSLTestingTools.class))
+            .overrideRuntimeConfigKey("loc", temp.getAbsolutePath())
+            .overrideRuntimeConfigKey("quarkus.smallrye-graphql-client.my-client.tls-configuration-name", "my-tls-client")
+            .overrideRuntimeConfigKey("quarkus.tls.my-tls-client.key-store.p12.path", temp.getAbsolutePath() + "/tls.p12")
+            .overrideRuntimeConfigKey("quarkus.tls.my-tls-client.key-store.p12.password", "password")
+            .overrideRuntimeConfigKey("quarkus.smallrye-graphql-client.my-client.url", "https://127.0.0.1:" + PORT)
+            .overrideRuntimeConfigKey("quarkus.tls.my-tls-client.trust-all", "true")
+            .setBeforeAllCustomizer(() -> {
+                try {
+                    temp.mkdirs();
+                    Files.copy(new File("target/certs/test-reload-client-keystore.p12").toPath(),
+                            new File(temp, "/tls.p12").toPath());
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+    @GraphQLClientApi(configKey = "my-client")
+    @RequestScoped
+    private interface MyApi {
+        @Query
+        String getResult();
+    }
+
+    @Inject
+    MyApi myApi;
+
+    @BeforeAll
+    static void setupServer() throws Exception {
+        server = TOOLS.runServer("target/certs/test-reload-keystore.p12",
+                "password", "target/certs/test-reload-server-truststore.p12",
+                "password");
+    }
+
+    @Test
+    void httpClientRemovedFromRegistryAfterRequestScopeEnds() throws Exception {
+        List<HttpClient> clientsBefore = getRegisteredHttpClients("my-tls-client");
+        int sizeBefore = clientsBefore.size();
+
+        // First request context: creates a request-scoped client and its HttpClient
+        Arc.container().requestContext().activate();
+        try {
+            myApi.getResult();
+        } finally {
+            Arc.container().requestContext().terminate();
+        }
+        // After context terminates, the HttpClient should have been cleaned up
+        assertThat(getRegisteredHttpClients("my-tls-client")).hasSize(sizeBefore);
+
+        // Second request context: creates another request-scoped client
+        Arc.container().requestContext().activate();
+        try {
+            myApi.getResult();
+        } finally {
+            Arc.container().requestContext().terminate();
+        }
+        // Still the same size — no accumulation
+        assertThat(getRegisteredHttpClients("my-tls-client")).hasSize(sizeBefore);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<HttpClient> getRegisteredHttpClients(String tlsConfigName) throws Exception {
+        Field field = SmallRyeGraphQLClientRecorder.class.getDeclaredField("tlsConfigNameToVertxHttpClients");
+        field.setAccessible(true);
+        Map<String, List<HttpClient>> map = (Map<String, List<HttpClient>>) field.get(null);
+        List<HttpClient> list = map.get(tlsConfigName);
+        return list != null ? List.copyOf(list) : List.of();
+    }
+
+    @AfterAll
+    static void closeServer() {
+        server.close();
+        TOOLS.close();
+    }
+}

--- a/extensions/smallrye-graphql-client/deployment/src/test/java/io/quarkus/smallrye/graphql/client/deployment/ssl/TypesafeGraphQLClientTlsReloadApplicationScopedTest.java
+++ b/extensions/smallrye-graphql-client/deployment/src/test/java/io/quarkus/smallrye/graphql/client/deployment/ssl/TypesafeGraphQLClientTlsReloadApplicationScopedTest.java
@@ -1,0 +1,139 @@
+package io.quarkus.smallrye.graphql.client.deployment.ssl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.UUID;
+
+import jakarta.enterprise.event.Event;
+import jakarta.inject.Inject;
+
+import org.assertj.core.api.Assertions;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.graphql.Query;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.tls.CertificateUpdatedEvent;
+import io.quarkus.tls.TlsConfiguration;
+import io.quarkus.tls.TlsConfigurationRegistry;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.junit5.Certificate;
+import io.smallrye.certs.junit5.Certificates;
+import io.smallrye.graphql.client.typesafe.api.GraphQLClientApi;
+import io.vertx.core.http.HttpServer;
+
+/**
+ * Tests TLS certificate reload for application-scoped GraphQL clients.
+ * Unlike the request-scoped tests, this verifies that reload works via
+ * {@code httpClient.updateSSLOptions()} on the live HttpClient instance,
+ * rather than relying on client proxy recreation.
+ */
+@Certificates(baseDir = "target/certs", certificates = {
+        @Certificate(name = "wrong-test-reload", password = "password", formats = Format.PKCS12, client = true),
+        @Certificate(name = "test-reload", password = "password", formats = Format.PKCS12, client = true)
+})
+public class TypesafeGraphQLClientTlsReloadApplicationScopedTest {
+
+    private static final int PORT = 63805;
+    private static final SSLTestingTools TOOLS = new SSLTestingTools();
+    private static final String EXPECTED_RESPONSE = "HelloWorld";
+    private static HttpServer server;
+
+    private static final File temp = new File("target/test-certificates-" + UUID.randomUUID());
+
+    private static final String CONFIGURATION = """
+            # No config - overridden in the test
+            """;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class)
+                            .add(new StringAsset(CONFIGURATION), "application.properties")
+                            .addClasses(MyApi.class, SSLTestingTools.class))
+            .overrideRuntimeConfigKey("loc", temp.getAbsolutePath())
+            .overrideRuntimeConfigKey("quarkus.smallrye-graphql-client.my-client.tls-configuration-name", "my-tls-client")
+            .overrideRuntimeConfigKey("quarkus.tls.my-tls-client.key-store.p12.path", temp.getAbsolutePath() + "/tls.p12")
+            .overrideRuntimeConfigKey("quarkus.tls.my-tls-client.key-store.p12.password", "password")
+            .overrideRuntimeConfigKey("quarkus.smallrye-graphql-client.my-client.url", "https://127.0.0.1:" + PORT)
+            .overrideRuntimeConfigKey("quarkus.tls.my-tls-client.trust-all", "true")
+            .setBeforeAllCustomizer(() -> {
+                try {
+                    temp.mkdirs();
+                    Files.copy(new File("target/certs/wrong-test-reload-client-keystore.p12").toPath(),
+                            new File(temp, "/tls.p12").toPath());
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+    @GraphQLClientApi(configKey = "my-client")
+    private interface MyApi {
+        @Query
+        String getResult();
+    }
+
+    @Inject
+    MyApi myApi;
+
+    @Inject
+    TlsConfigurationRegistry registry;
+
+    @ConfigProperty(name = "loc")
+    File certs;
+
+    @Inject
+    Event<CertificateUpdatedEvent> event;
+
+    @BeforeAll
+    static void setupServer() throws Exception {
+        server = TOOLS.runServer("target/certs/test-reload-keystore.p12",
+                "password", "target/certs/test-reload-server-truststore.p12",
+                "password");
+    }
+
+    @Test
+    void testReloading() throws IOException {
+        TlsConfiguration tlsClient = registry.get("my-tls-client").orElseThrow();
+        try {
+            myApi.getResult();
+            Assertions.fail("Should fail with wrong keystore");
+        } catch (Exception ex) {
+            assertHasCauseContainingMessage(ex, "certificate_unknown");
+        }
+
+        Files.copy(new File("target/certs/test-reload-client-keystore.p12").toPath(),
+                new File(certs, "/tls.p12").toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+
+        assertThat(tlsClient.reload()).isTrue();
+        event.fire(new CertificateUpdatedEvent("my-tls-client", tlsClient));
+
+        assertThat(myApi.getResult()).isEqualTo(EXPECTED_RESPONSE);
+    }
+
+    @AfterAll
+    static void closeServer() {
+        server.close();
+        TOOLS.close();
+    }
+
+    private void assertHasCauseContainingMessage(Throwable t, String message) {
+        Throwable throwable = t;
+        while (throwable.getCause() != null) {
+            throwable = throwable.getCause();
+            if (throwable.getMessage().contains(message)) {
+                return;
+            }
+        }
+        throw new RuntimeException("Unexpected exception", t);
+    }
+}

--- a/extensions/smallrye-graphql-client/runtime/src/main/java/io/quarkus/smallrye/graphql/client/runtime/GraphQLClientCertificateUpdateEventListener.java
+++ b/extensions/smallrye-graphql-client/runtime/src/main/java/io/quarkus/smallrye/graphql/client/runtime/GraphQLClientCertificateUpdateEventListener.java
@@ -2,16 +2,24 @@ package io.quarkus.smallrye.graphql.client.runtime;
 
 import static io.quarkus.tls.runtime.config.TlsConfig.DEFAULT_NAME;
 
+import java.util.List;
+import java.util.Map;
+
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
 import org.jboss.logging.Logger;
 
+import io.quarkus.arc.Arc;
 import io.quarkus.tls.CertificateUpdatedEvent;
 import io.quarkus.tls.TlsConfiguration;
+import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClient;
 import io.smallrye.graphql.client.impl.GraphQLClientConfiguration;
 import io.smallrye.graphql.client.impl.GraphQLClientsConfiguration;
+import io.smallrye.graphql.client.impl.dynamic.cdi.NamedDynamicClients;
+import io.smallrye.graphql.client.vertx.dynamic.VertxDynamicGraphQLClient;
+import io.vertx.core.http.HttpClient;
 
 @Singleton
 public class GraphQLClientCertificateUpdateEventListener {
@@ -39,6 +47,59 @@ public class GraphQLClientCertificateUpdateEventListener {
                         }
                     });
                 });
+
+        updateLiveHttpClients(updatedTlsConfigurationName, updatedTlsConfiguration);
+    }
+
+    private void updateLiveHttpClients(String tlsConfigName, TlsConfiguration updatedTlsConfiguration) {
+        // Update typesafe clients registered via the recorder
+        List<HttpClient> httpClients = SmallRyeGraphQLClientRecorder.clientsUsingTlsConfig(tlsConfigName);
+        for (HttpClient httpClient : httpClients) {
+            doUpdateSSLOptions(httpClient, tlsConfigName, updatedTlsConfiguration);
+        }
+
+        // Update dynamic clients created via NamedDynamicClients
+        updateDynamicClients(tlsConfigName, updatedTlsConfiguration);
+    }
+
+    private void updateDynamicClients(String tlsConfigName, TlsConfiguration updatedTlsConfiguration) {
+        NamedDynamicClients namedDynamicClients = Arc.container().instance(NamedDynamicClients.class).get();
+        if (namedDynamicClients == null) {
+            return;
+        }
+        Map<String, DynamicGraphQLClient> createdClients = namedDynamicClients.getCreatedClients();
+        if (createdClients == null || createdClients.isEmpty()) {
+            return;
+        }
+        graphQLClientsConfig.clients().forEach((configKey, clientConfig) -> {
+            boolean matches = clientConfig.tlsConfigurationName()
+                    .map(name -> name.equals(tlsConfigName))
+                    .orElse(DEFAULT_NAME.equals(tlsConfigName));
+            if (matches) {
+                DynamicGraphQLClient client = createdClients.get(configKey);
+                if (client instanceof VertxDynamicGraphQLClient) {
+                    HttpClient httpClient = ((VertxDynamicGraphQLClient) client).getHttpClient();
+                    if (httpClient != null) {
+                        doUpdateSSLOptions(httpClient, tlsConfigName, updatedTlsConfiguration);
+                    }
+                }
+            }
+        });
+    }
+
+    private void doUpdateSSLOptions(HttpClient httpClient, String tlsConfigName,
+            TlsConfiguration updatedTlsConfiguration) {
+        httpClient.updateSSLOptions(updatedTlsConfiguration.getSSLOptions()).onComplete(result -> {
+            if (result.succeeded()) {
+                LOG.infof(
+                        "SSL options updated on live HttpClient for GraphQL client(s) using TLS configuration '%s'",
+                        tlsConfigName);
+            } else {
+                LOG.errorf(result.cause(),
+                        "Failed to update SSL options on live HttpClient for GraphQL client(s) using TLS configuration '%s'",
+                        tlsConfigName);
+            }
+        });
     }
 
     private void updateConfiguration(String tlsBucketName, TlsConfiguration updatedTlsConfiguration,
@@ -50,6 +111,6 @@ public class GraphQLClientCertificateUpdateEventListener {
         graphQLClientConfiguration
                 .setTlsTrustStoreOptions(updatedTlsConfiguration.getTrustStoreOptions());
         graphQLClientConfiguration
-                .setSslOptions(updatedTlsConfiguration.getSSLOptions()); // CLR
+                .setSslOptions(updatedTlsConfiguration.getSSLOptions());
     }
 }

--- a/extensions/smallrye-graphql-client/runtime/src/main/java/io/quarkus/smallrye/graphql/client/runtime/GraphQLClientTlsCleanupDestroyer.java
+++ b/extensions/smallrye-graphql-client/runtime/src/main/java/io/quarkus/smallrye/graphql/client/runtime/GraphQLClientTlsCleanupDestroyer.java
@@ -1,0 +1,26 @@
+package io.quarkus.smallrye.graphql.client.runtime;
+
+import java.util.Map;
+
+import jakarta.enterprise.context.spi.CreationalContext;
+
+import io.quarkus.arc.BeanDestroyer;
+
+public class GraphQLClientTlsCleanupDestroyer implements BeanDestroyer<Object> {
+
+    @Override
+    public void destroy(Object instance, CreationalContext<Object> creationalContext, Map<String, Object> params) {
+        SmallRyeGraphQLClientRecorder.TlsClientInfo info = SmallRyeGraphQLClientRecorder
+                .removeInstanceTlsInfo(instance);
+        if (info != null) {
+            SmallRyeGraphQLClientRecorder.removeReloadableHttpClient(info.tlsConfigName(), info.httpClient());
+        }
+        if (instance instanceof AutoCloseable closeable) {
+            try {
+                closeable.close();
+            } catch (Exception e) {
+                // ignore
+            }
+        }
+    }
+}

--- a/extensions/smallrye-graphql-client/runtime/src/main/java/io/quarkus/smallrye/graphql/client/runtime/SmallRyeGraphQLClientRecorder.java
+++ b/extensions/smallrye-graphql-client/runtime/src/main/java/io/quarkus/smallrye/graphql/client/runtime/SmallRyeGraphQLClientRecorder.java
@@ -1,14 +1,18 @@
 package io.quarkus.smallrye.graphql.client.runtime;
 
+import static io.quarkus.tls.runtime.config.TlsConfig.DEFAULT_NAME;
 import static io.smallrye.graphql.client.impl.GraphQLClientConfiguration.ProxyType.HTTP;
 import static io.smallrye.graphql.client.impl.GraphQLClientConfiguration.ProxyType.SOCKS4;
 import static io.smallrye.graphql.client.impl.GraphQLClientConfiguration.ProxyType.SOCKS5;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -23,6 +27,7 @@ import io.quarkus.proxy.ProxyConfiguration;
 import io.quarkus.proxy.ProxyConfigurationRegistry;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.tls.TlsConfiguration;
@@ -34,10 +39,15 @@ import io.smallrye.graphql.client.typesafe.api.TypesafeGraphQLClientBuilder;
 import io.smallrye.graphql.client.vertx.VertxManager;
 import io.smallrye.graphql.client.vertx.typesafe.VertxTypesafeGraphQLClientBuilder;
 import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
 
 @Recorder
 public class SmallRyeGraphQLClientRecorder {
     private final Logger logger = Logger.getLogger(SmallRyeGraphQLClientRecorder.class);
+
+    private static final Map<String, List<HttpClient>> tlsConfigNameToVertxHttpClients = new ConcurrentHashMap<>();
+    private static final Map<Object, TlsClientInfo> typesafeInstanceToTlsInfo = Collections
+            .synchronizedMap(new IdentityHashMap<>());
 
     private final RuntimeValue<GraphQLClientsConfig> runtimeConfig;
 
@@ -49,11 +59,59 @@ public class SmallRyeGraphQLClientRecorder {
         return new Function<>() {
             @Override
             public T apply(SyntheticCreationalContext<T> context) {
-                TypesafeGraphQLClientBuilder builder = TypesafeGraphQLClientBuilder.newBuilder();
+                VertxTypesafeGraphQLClientBuilder builder = (VertxTypesafeGraphQLClientBuilder) TypesafeGraphQLClientBuilder
+                        .newBuilder();
                 ClientModels clientModels = context.getInjectedReference(ClientModels.class);
-                return (((VertxTypesafeGraphQLClientBuilder) builder).clientModels(clientModels)).build(targetClassName);
+                builder.clientModels(clientModels);
+                T result = builder.build(targetClassName);
+
+                HttpClient httpClient = builder.getHttpClient();
+                if (httpClient != null) {
+                    String configKey = builder.getConfigKey();
+                    GraphQLClientsConfig config = Arc.container().instance(GraphQLClientsConfig.class).get();
+                    if (config != null && configKey != null) {
+                        GraphQLClientConfig clientConfig = config.clients().get(configKey);
+                        if (clientConfig != null) {
+                            String tlsConfigName = clientConfig.tlsConfigurationName().orElse(DEFAULT_NAME);
+                            registerReloadableHttpClient(tlsConfigName, httpClient);
+                            typesafeInstanceToTlsInfo.put(result,
+                                    new TlsClientInfo(tlsConfigName, httpClient));
+                        }
+                    }
+                }
+
+                return result;
             }
         };
+    }
+
+    public static void registerReloadableHttpClient(String tlsConfigName, HttpClient httpClient) {
+        tlsConfigNameToVertxHttpClients.computeIfAbsent(tlsConfigName, s -> new ArrayList<>(1)).add(httpClient);
+    }
+
+    public static void removeReloadableHttpClient(String tlsConfigName, HttpClient httpClient) {
+        if (tlsConfigName == null) {
+            return;
+        }
+        List<HttpClient> httpClients = tlsConfigNameToVertxHttpClients.get(tlsConfigName);
+        if (httpClients != null) {
+            httpClients.remove(httpClient);
+        }
+    }
+
+    public static TlsClientInfo removeInstanceTlsInfo(Object typesafeClientInstance) {
+        return typesafeInstanceToTlsInfo.remove(typesafeClientInstance);
+    }
+
+    public static List<HttpClient> clientsUsingTlsConfig(String tlsConfigName) {
+        return tlsConfigNameToVertxHttpClients.getOrDefault(tlsConfigName, Collections.emptyList());
+    }
+
+    public void cleanUp(ShutdownContext shutdown) {
+        shutdown.addShutdownTask(() -> {
+            tlsConfigNameToVertxHttpClients.clear();
+            typesafeInstanceToTlsInfo.clear();
+        });
     }
 
     public void setTypesafeApiClasses(List<String> apiClassNames) {
@@ -241,5 +299,8 @@ public class SmallRyeGraphQLClientRecorder {
             }
         }
         return Optional.empty();
+    }
+
+    record TlsClientInfo(String tlsConfigName, HttpClient httpClient) {
     }
 }


### PR DESCRIPTION
Allows dynamically reloading the TLS configuration for GraphQL clients' underlying HTTP client. Up until now, a "reload" only occurred by getting a new instance of the GraphQL client, so it had to have a shorter CDI scope than application. This way, reloads will happen immediately and also work for application-scoped clients.

- Closes: https://github.com/quarkusio/quarkus/issues/50874