### PR TITLE
Add a way for test dependencies to influence surefire

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeMojo.java
@@ -2,7 +2,10 @@ package io.quarkus.maven;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
 import java.util.function.Consumer;
@@ -21,6 +24,7 @@ import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.util.BootstrapUtils;
 import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.paths.PathCollection;
 import io.quarkus.paths.PathList;
 import io.quarkus.runtime.LaunchMode;
@@ -108,6 +112,9 @@ public class GenerateCodeMojo extends QuarkusBootstrapMojo {
             // the resolver and re-resolving it as part of the test bootstrap
             if (test && curatedApplication != null) {
                 var appModel = curatedApplication.getApplicationModel();
+
+                injectTestJvmArgsFromDependencies(appModel.getRuntimeDependencies());
+
                 closeApplication(LaunchMode.TEST);
                 if (isSerializeTestModel()) {
                     final int workspaceId = getWorkspaceId();
@@ -153,5 +160,80 @@ public class GenerateCodeMojo extends QuarkusBootstrapMojo {
 
     private Path generatedSourcesDir(boolean test) {
         return test ? buildDir().toPath().resolve("generated-test-sources") : buildDir().toPath().resolve("generated-sources");
+    }
+
+    private static final String QUARKUS_TEST_JVM_CONFIG = "META-INF/quarkus-test-jvm-config.properties";
+    private static final String XX_PREFIX = "xx.";
+    private static final String STD_PREFIX = "std.";
+
+    private void injectTestJvmArgsFromDependencies(Collection<ResolvedDependency> dependencies) {
+        List<String> args = collectTestJvmArgs(dependencies);
+        if (args.isEmpty()) {
+            return;
+        }
+        Properties properties = mavenProject().getProperties();
+        String argLine = properties.getProperty("argLine", "");
+        StringBuilder sb = new StringBuilder(argLine);
+        for (String arg : args) {
+            if (!argLine.contains(arg)) {
+                sb.append(" ").append(arg);
+            }
+        }
+        String newArgLine = sb.toString().trim();
+        if (!newArgLine.equals(argLine)) {
+            properties.setProperty("argLine", newArgLine);
+            if (getLog().isDebugEnabled()) {
+                getLog().debug("Injected test JVM args from dependencies: " + args);
+            }
+        }
+    }
+
+    private List<String> collectTestJvmArgs(Collection<ResolvedDependency> dependencies) {
+        List<String> args = new ArrayList<>();
+        for (ResolvedDependency dep : dependencies) {
+            dep.getContentTree().accept(QUARKUS_TEST_JVM_CONFIG, visit -> {
+                if (visit == null) {
+                    return;
+                }
+                try (var is = Files.newInputStream(visit.getPath())) {
+                    Properties jvmConfig = new Properties();
+                    jvmConfig.load(is);
+                    if (getLog().isDebugEnabled()) {
+                        getLog().debug("Found " + QUARKUS_TEST_JVM_CONFIG + " in "
+                                + dep.getGroupId() + ":" + dep.getArtifactId());
+                    }
+                    args.addAll(parseJvmConfigProperties(jvmConfig));
+                } catch (IOException e) {
+                    getLog().debug("Failed to read " + QUARKUS_TEST_JVM_CONFIG + " from "
+                            + dep.getGroupId() + ":" + dep.getArtifactId() + ": " + e.getMessage());
+                }
+            });
+        }
+        return args;
+    }
+
+    private static List<String> parseJvmConfigProperties(Properties jvmConfig) {
+        List<String> args = new ArrayList<>();
+        for (String name : jvmConfig.stringPropertyNames()) {
+            String value = jvmConfig.getProperty(name).trim();
+            if (name.startsWith(XX_PREFIX)) {
+                String optionName = name.substring(XX_PREFIX.length());
+                if ("true".equalsIgnoreCase(value)) {
+                    args.add("-XX:+" + optionName);
+                } else if ("false".equalsIgnoreCase(value)) {
+                    args.add("-XX:-" + optionName);
+                } else if (!value.isEmpty()) {
+                    args.add("-XX:" + optionName + "=" + value);
+                }
+            } else if (name.startsWith(STD_PREFIX)) {
+                String optionName = name.substring(STD_PREFIX.length());
+                if (value.isEmpty()) {
+                    args.add("--" + optionName);
+                } else {
+                    args.add("--" + optionName + "=" + value);
+                }
+            }
+        }
+        return args;
     }
 }

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/BuildIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/BuildIT.java
@@ -46,6 +46,21 @@ class BuildIT extends MojoTestBase {
     }
 
     @Test
+    void testMockitoNoDynamicAgentWarning()
+            throws MavenInvocationException, InterruptedException, IOException {
+        testDir = initProject("projects/mockito-non-public-inner-class",
+                "projects/mockito-non-public-inner-class-no-warning");
+        running = new RunningInvoker(testDir, false);
+        MavenProcessInvocationResult result = running.execute(
+                List.of("clean", "verify", "-Dquarkus.analytics.disabled=true"),
+                Map.of());
+        assertThat(result.getProcess().waitFor()).isZero();
+
+        String log = running.log();
+        assertThat(log).doesNotContain("A Java agent has been loaded dynamically");
+    }
+
+    @Test
     void testCustomTestSourceSets()
             throws MavenInvocationException, InterruptedException {
         testDir = initProject("projects/test-source-sets");

--- a/test-framework/junit-mockito/src/main/resources/META-INF/quarkus-test-jvm-config.properties
+++ b/test-framework/junit-mockito/src/main/resources/META-INF/quarkus-test-jvm-config.properties
@@ -1,0 +1,1 @@
+xx.EnableDynamicAgentLoading=true


### PR DESCRIPTION
Unfortunately we can't use build items because
bootstrap runs before the build system is
used.
Furthermore, we can't use extension configuration
similar to what is done in dev mode, because
quarkus-junit-mockito is not an actual extension,
it's just a test dependency

- Closes: #53481