### PR TITLE
OTel resource attributes for Kubernetes

### DIFF
--- a/docs/src/main/asciidoc/opentelemetry.adoc
+++ b/docs/src/main/asciidoc/opentelemetry.adoc
@@ -245,6 +245,84 @@ public class CustomConfiguration {
 }
 ----
 
+==== Kubernetes
+When running the application in Kubernetes, the https://opentelemetry.io/docs/specs/semconv/resource/k8s/[OpenTelemetry Kubernetes resource attributes] can be populated in a couple of ways.
+
+===== With the Quarkus Kubernetes extension
+
+When the `quarkus-kubernetes` extension is present, Quarkus automatically adds the following environment variables to the generated Kubernetes manifests:
+
+|===
+|Attribute name|Content example|Environment variable|Source
+
+|k8s.namespace.name
+|"my-namespace"
+|`QUARKUS_OTEL_K8S_RESOURCE_NAMESPACE`
+|Kubernetes Downward API: `metadata.namespace`. Falls back to reading the service account namespace file at `/var/run/secrets/kubernetes.io/serviceaccount/namespace`.
+
+|k8s.pod.name
+|"my-app-7d6f8b5c9-x2k4m"
+|`QUARKUS_OTEL_K8S_RESOURCE_POD_NAME`
+|Kubernetes Downward API: `metadata.name`.
+
+|k8s.pod.uid
+|"f4b5c6d7-1234-5678-9abc-def012345678"
+|`QUARKUS_OTEL_K8S_RESOURCE_POD_UID`
+|Kubernetes Downward API: `metadata.uid`.
+
+|k8s.node.name
+|"node-1"
+|`QUARKUS_OTEL_K8S_RESOURCE_NODE_NAME`
+|Kubernetes Downward API: `spec.nodeName`.
+
+|k8s.container.name
+|"my-app"
+|`QUARKUS_OTEL_K8S_RESOURCE_CONTAINER_NAME`
+|Set to the application name at build time.
+
+|k8s.deployment.name
+|"my-app"
+|`QUARKUS_OTEL_K8S_RESOURCE_DEPLOYMENT_NAME`
+|Set to `quarkus.kubernetes.name` (or the application name if not configured) at build time.
+|===
+
+The `k8s.cluster.name` attribute is not set automatically because the cluster name is not available through pod metadata.
+You can set it manually using `quarkus.otel.resource.attributes=k8s.cluster.name=my-cluster` or by setting the `QUARKUS_OTEL_K8S_RESOURCE_CLUSTER_NAME` environment variable.
+
+===== Without the Quarkus Kubernetes extension
+
+If the `quarkus-kubernetes` extension is *not* used, there's the need to manually set the environment variables defined in the previous section. The `quarkus-opentelemetry` extension will then be able to populate the Kubernetes resource attributes. This is a partial sample of a deployment manifest setting up the required env. vars.:
+
+[source,yaml]
+----
+spec:
+  containers:
+    - name: my-app
+      env:
+        - name: QUARKUS_OTEL_K8S_RESOURCE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: QUARKUS_OTEL_K8S_RESOURCE_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: QUARKUS_OTEL_K8S_RESOURCE_POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        - name: QUARKUS_OTEL_K8S_RESOURCE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: QUARKUS_OTEL_K8S_RESOURCE_CONTAINER_NAME
+          value: my-app
+        - name: QUARKUS_OTEL_K8S_RESOURCE_DEPLOYMENT_NAME
+          value: my-app
+        - name: QUARKUS_OTEL_K8S_RESOURCE_CLUSTER_NAME
+          value: production
+----
+
 === Semantic conventions
 
 OpenTelemetry provides a set of https://opentelemetry.io/docs/specs/semconv/http/http-spans/[semantic conventions] to standardize the data collected by the instrumentation.

--- a/extensions/opentelemetry/deployment/pom.xml
+++ b/extensions/opentelemetry/deployment/pom.xml
@@ -57,6 +57,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-server-spi-deployment</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-kubernetes-spi</artifactId>
+        </dependency>
 
         <!-- Test Dependencies -->
         <dependency>

--- a/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/OpenTelemetryProcessor.java
+++ b/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/OpenTelemetryProcessor.java
@@ -3,6 +3,12 @@ package io.quarkus.opentelemetry.deployment;
 import static io.quarkus.bootstrap.classloading.QuarkusClassLoader.isClassPresentAtRuntime;
 import static io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem.SPI_ROOT;
 import static io.quarkus.opentelemetry.runtime.OpenTelemetryRecorder.OPEN_TELEMETRY_DRIVER;
+import static io.quarkus.opentelemetry.runtime.resource.KubernetesResourceProvider.CONTAINER_NAME_ENV;
+import static io.quarkus.opentelemetry.runtime.resource.KubernetesResourceProvider.DEPLOYMENT_NAME_ENV;
+import static io.quarkus.opentelemetry.runtime.resource.KubernetesResourceProvider.NAMESPACE_ENV;
+import static io.quarkus.opentelemetry.runtime.resource.KubernetesResourceProvider.NODE_NAME_ENV;
+import static io.quarkus.opentelemetry.runtime.resource.KubernetesResourceProvider.POD_NAME_ENV;
+import static io.quarkus.opentelemetry.runtime.resource.KubernetesResourceProvider.POD_UID_ENV;
 import static java.util.stream.Collectors.toList;
 
 import java.io.IOException;
@@ -37,6 +43,7 @@ import io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporter
 import io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSamplerProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
+import io.opentelemetry.sdk.resources.Resource;
 import io.quarkus.agroal.spi.JdbcDataSourceBuildItem;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.AnnotationsTransformerBuildItem;
@@ -65,6 +72,8 @@ import io.quarkus.deployment.builditem.nativeimage.ReflectiveMethodBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.util.ServiceUtil;
+import io.quarkus.kubernetes.spi.KubernetesEnvBuildItem;
+import io.quarkus.kubernetes.spi.KubernetesResourceMetadataBuildItem;
 import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.opentelemetry.OpenTelemetryDestroyer;
 import io.quarkus.opentelemetry.deployment.metric.MetricsEnabled;
@@ -132,6 +141,39 @@ public class OpenTelemetryProcessor {
                 .scope(Singleton.class)
                 .setRuntimeInit()
                 .done();
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    SyntheticBeanBuildItem kubernetesResource(OpenTelemetryRecorder recorder) {
+        return SyntheticBeanBuildItem.configure(Resource.class)
+                .types(Resource.class)
+                .supplier(recorder.kubernetesResource())
+                .scope(Singleton.class)
+                .setRuntimeInit()
+                .done();
+    }
+
+    @BuildStep
+    void kubernetesEnvVars(
+            List<KubernetesResourceMetadataBuildItem> resourceMetadata,
+            ApplicationInfoBuildItem appInfo,
+            BuildProducer<KubernetesEnvBuildItem> envProducer) {
+        if (resourceMetadata.isEmpty()) {
+            return;
+        }
+        // Downward API fieldRef-based env vars
+        envProducer.produce(KubernetesEnvBuildItem.createFromField(NAMESPACE_ENV, "metadata.namespace", null));
+        envProducer.produce(KubernetesEnvBuildItem.createFromField(POD_NAME_ENV, "metadata.name", null));
+        envProducer.produce(KubernetesEnvBuildItem.createFromField(POD_UID_ENV, "metadata.uid", null));
+        envProducer.produce(KubernetesEnvBuildItem.createFromField(NODE_NAME_ENV, "spec.nodeName", null));
+        // Static env vars — values resolved from K8s extension metadata and application info
+        envProducer.produce(KubernetesEnvBuildItem.createSimpleVar(CONTAINER_NAME_ENV, appInfo.getName(), null));
+        String deploymentName = resourceMetadata.stream()
+                .findFirst()
+                .map(KubernetesResourceMetadataBuildItem::getName)
+                .orElse(appInfo.getName());
+        envProducer.produce(KubernetesEnvBuildItem.createSimpleVar(DEPLOYMENT_NAME_ENV, deploymentName, null));
     }
 
     @BuildStep

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/OpenTelemetryRecorder.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/OpenTelemetryRecorder.java
@@ -26,6 +26,7 @@ import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.sdk.resources.Resource;
 import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.opentelemetry.runtime.config.runtime.OTelRuntimeConfig;
+import io.quarkus.opentelemetry.runtime.resource.KubernetesResourceProvider;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.runtime.annotations.RuntimeInit;
@@ -62,6 +63,16 @@ public class OpenTelemetryRecorder {
                                         WEBENGINE_VERSION, quarkusVersion)))
                         .getAttributes());
                 return result;
+            }
+        };
+    }
+
+    @RuntimeInit
+    public Supplier<Resource> kubernetesResource() {
+        return new Supplier<>() {
+            @Override
+            public Resource get() {
+                return KubernetesResourceProvider.createResource();
             }
         };
     }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/OTelRuntimeConfig.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/OTelRuntimeConfig.java
@@ -121,4 +121,5 @@ public interface OTelRuntimeConfig {
     @WithName("mp.compatibility")
     @WithDefault("false")
     boolean mpCompatibility();
+
 }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/resource/KubernetesResourceProvider.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/resource/KubernetesResourceProvider.java
@@ -1,0 +1,86 @@
+package io.quarkus.opentelemetry.runtime.resource;
+
+import static io.opentelemetry.semconv.incubating.K8sIncubatingAttributes.K8S_CLUSTER_NAME;
+import static io.opentelemetry.semconv.incubating.K8sIncubatingAttributes.K8S_CONTAINER_NAME;
+import static io.opentelemetry.semconv.incubating.K8sIncubatingAttributes.K8S_DEPLOYMENT_NAME;
+import static io.opentelemetry.semconv.incubating.K8sIncubatingAttributes.K8S_NAMESPACE_NAME;
+import static io.opentelemetry.semconv.incubating.K8sIncubatingAttributes.K8S_NODE_NAME;
+import static io.opentelemetry.semconv.incubating.K8sIncubatingAttributes.K8S_POD_NAME;
+import static io.opentelemetry.semconv.incubating.K8sIncubatingAttributes.K8S_POD_UID;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.jboss.logging.Logger;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.sdk.resources.Resource;
+
+public class KubernetesResourceProvider {
+
+    private static final Logger log = Logger.getLogger(KubernetesResourceProvider.class);
+
+    public static final String NAMESPACE_ENV = "QUARKUS_OTEL_K8S_RESOURCE_NAMESPACE";
+    public static final String POD_NAME_ENV = "QUARKUS_OTEL_K8S_RESOURCE_POD_NAME";
+    public static final String POD_UID_ENV = "QUARKUS_OTEL_K8S_RESOURCE_POD_UID";
+    public static final String NODE_NAME_ENV = "QUARKUS_OTEL_K8S_RESOURCE_NODE_NAME";
+    public static final String CONTAINER_NAME_ENV = "QUARKUS_OTEL_K8S_RESOURCE_CONTAINER_NAME";
+    public static final String DEPLOYMENT_NAME_ENV = "QUARKUS_OTEL_K8S_RESOURCE_DEPLOYMENT_NAME";
+    public static final String CLUSTER_NAME_ENV = "QUARKUS_OTEL_K8S_RESOURCE_CLUSTER_NAME";
+
+    private static final String NAMESPACE_FILE = "/var/run/secrets/kubernetes.io/serviceaccount/namespace";
+
+    private KubernetesResourceProvider() {
+    }
+
+    public static Resource createResource() {
+        AttributesBuilder builder = Attributes.builder();
+
+        // Namespace: from env var or filesystem fallback
+        String namespace = getEnv(NAMESPACE_ENV);
+        if (namespace == null) {
+            namespace = readNamespaceFromFile(NAMESPACE_FILE);
+        }
+        if (namespace != null) {
+            builder.put(K8S_NAMESPACE_NAME, namespace);
+        }
+
+        addIfSet(builder, K8S_POD_NAME, getEnv(POD_NAME_ENV));
+        addIfSet(builder, K8S_POD_UID, getEnv(POD_UID_ENV));
+        addIfSet(builder, K8S_NODE_NAME, getEnv(NODE_NAME_ENV));
+        addIfSet(builder, K8S_CONTAINER_NAME, getEnv(CONTAINER_NAME_ENV));
+        addIfSet(builder, K8S_DEPLOYMENT_NAME, getEnv(DEPLOYMENT_NAME_ENV));
+        addIfSet(builder, K8S_CLUSTER_NAME, getEnv(CLUSTER_NAME_ENV));
+
+        return Resource.create(builder.build());
+    }
+
+    private static String getEnv(String name) {
+        String value = System.getenv(name);
+        if (value != null && !value.isEmpty()) {
+            return value;
+        }
+        return null;
+    }
+
+    private static void addIfSet(AttributesBuilder builder,
+            AttributeKey<String> key, String value) {
+        if (value != null) {
+            builder.put(key, value);
+        }
+    }
+
+    private static String readNamespaceFromFile(String path) {
+        try {
+            Path namespacePath = Path.of(path);
+            if (Files.exists(namespacePath) && Files.isReadable(namespacePath)) {
+                return Files.readString(namespacePath).trim();
+            }
+        } catch (Exception e) {
+            log.debug("Failed to read Kubernetes namespace from file: " + path, e);
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
I will not use the Kubernetes API call because resources are created at startup and calling an external API at this point takes too long. 

We are reading env vars at startup wich makes this quite dificult to test. 

- Closes: https://github.com/quarkusio/quarkus/issues/37008