### PR TITLE
Support @JsonUnwrapped and @JsonSubTypes annotations in generated reflection-free Jackson serializers

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
@@ -33,6 +33,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
@@ -52,6 +56,21 @@ import io.quarkus.resteasy.reactive.jackson.SecureField;
 public abstract class JacksonCodeGenerator {
 
     private static final Logger log = Logger.getLogger(JacksonCodeGenerator.class);
+
+    private static final Set<String> SUPPORTED_JACKSON_ANNOTATIONS = Set.of(
+            JsonAlias.class.getName(),
+            JsonAnySetter.class.getName(),
+            JsonCreator.class.getName(),
+            JsonIgnore.class.getName(),
+            JsonIgnoreProperties.class.getName(),
+            JsonNaming.class.getName(),
+            JsonProperty.class.getName(),
+            JsonSubTypes.class.getName(),
+            JsonTypeInfo.class.getName(),
+            JsonTypeName.class.getName(),
+            JsonUnwrapped.class.getName(),
+            JsonValue.class.getName(),
+            JsonView.class.getName());
 
     protected final BuildProducer<GeneratedClassBuildItem> generatedClassBuildItemBuildProducer;
     protected final IndexView jandexIndex;
@@ -486,16 +505,9 @@ public abstract class JacksonCodeGenerator {
             return annotations.get(JsonIgnore.class.getName()) != null;
         }
 
-        private static final Set<String> SUPPORTED_JACKSON_ANNOTATIONS = Set.of(
-                JsonProperty.class.getName(),
-                JsonIgnore.class.getName(),
-                JsonIgnoreProperties.class.getName(),
-                JsonAnySetter.class.getName(),
-                JsonCreator.class.getName(),
-                JsonAlias.class.getName(),
-                JsonNaming.class.getName(),
-                JsonValue.class.getName(),
-                JsonView.class.getName());
+        boolean isUnwrapped() {
+            return annotations.get(JsonUnwrapped.class.getName()) != null;
+        }
 
         static boolean isUnknownAnnotation(String ann) {
             if (ann.startsWith("com.fasterxml.jackson.")) {

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
@@ -29,7 +29,6 @@ import com.fasterxml.jackson.databind.SerializationConfig;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.fasterxml.jackson.databind.type.SimpleType;
 
 import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
@@ -42,6 +41,7 @@ import io.quarkus.gizmo.FieldDescriptor;
 import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.resteasy.reactive.jackson.runtime.mappers.GeneratedSerializer;
 import io.quarkus.resteasy.reactive.jackson.runtime.mappers.JacksonMapperUtil;
 
 /**
@@ -59,6 +59,7 @@ import io.quarkus.resteasy.reactive.jackson.runtime.mappers.JacksonMapperUtil;
  *     private int age;
  *
  *     &#64;SecureField(rolesAllowed = "admin")
+ *     &#64;JsonUnwrapped
  *     private Address address;
  *
  *     &#64;JsonView(Private.class)
@@ -81,7 +82,7 @@ import io.quarkus.resteasy.reactive.jackson.runtime.mappers.JacksonMapperUtil;
  * it generates the following {@code StdSerializer} implementation
  *
  * <pre>{@code
- * public class Person$quarkusjacksonserializer extends StdSerializer {
+ * public class Person$quarkusjacksonserializer extends GeneratedSerializer {
  *     static final String[] address_ROLES_ALLOWED = new String[] { "admin" };
  *     static final Class[] id_VIEW_CLASSES = new Class[] { Private.class };
  *
@@ -89,7 +90,7 @@ import io.quarkus.resteasy.reactive.jackson.runtime.mappers.JacksonMapperUtil;
  *         super(Person.class);
  *     }
  *
- *     public void serialize(Object object, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+ *     public void serializeContent(Object object, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
  *             throws IOException {
  *         Person person = (Person) object;
  *         SerializationInclude serializationInclude = SerializationInclude.decode(object, serializerProvider);
@@ -100,9 +101,7 @@ import io.quarkus.resteasy.reactive.jackson.runtime.mappers.JacksonMapperUtil;
  *         if (JacksonMapperUtil.includeSecureField(serializerProvider, address_ROLES_ALLOWED)) {
  *             Address address = person.getAddress();
  *             if (serializationInclude.shouldSerialize(address)) {
- *                 JacksonMapperUtil.writeFieldName(jsonGenerator, propertyNamingStrategy, "address",
- *                         SerializedStrings$quarkusjacksonserializer.address);
- *                 JacksonMapperUtil.serializePojo(address, jsonGenerator, serializerProvider);
+ *                 JacksonMapperUtil.serializeUnwrapped(address, jsonGenerator, serializerProvider);
  *             }
  *         }
  *
@@ -160,7 +159,7 @@ import io.quarkus.resteasy.reactive.jackson.runtime.mappers.JacksonMapperUtil;
  * at each serialization.
  *
  * Note that in this case also the {@code Address} class has to be serialized in the same way, and then this factory triggers
- * the generation of a second StdSerializer also for it. More in general if during the generation of a serializer for a
+ * the generation of a second StdSerializer also for it. More in general, if during the generation of a serializer for a
  * given class it discovers a non-primitive field of another type for which a serializer hasn't been generated yet, this
  * factory enqueues a code generation also for that type. The same is valid for both arrays of that type, like
  * {@code Address[]}, and collections, like {@code List&lt;Address&gt}.
@@ -168,8 +167,7 @@ import io.quarkus.resteasy.reactive.jackson.runtime.mappers.JacksonMapperUtil;
 public class JacksonSerializerFactory extends JacksonCodeGenerator {
 
     private static final String CLASS_NAME_SUFFIX = "$quarkusjacksonserializer";
-    private static final String SUPER_CLASS_NAME = StdSerializer.class.getName();
-    private static final String JSON_GEN_CLASS_NAME = JsonGenerator.class.getName();
+    private static final String SUPER_CLASS_NAME = GeneratedSerializer.class.getName();
     private static final String SER_STRINGS_CLASS_NAME = "SerializedStrings$quarkusjacksonserializer";
 
     private final Map<String, Set<String>> generatedFields = new HashMap<>();
@@ -225,47 +223,45 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
 
     @Override
     protected boolean createSerializationMethod(ClassInfo classInfo, ClassCreator classCreator, String beanClassName) {
-        MethodCreator bytecode = classCreator.getMethodCreator("serialize", "void", "java.lang.Object", JSON_GEN_CLASS_NAME,
-                "com.fasterxml.jackson.databind.SerializerProvider")
-                .setModifiers(ACC_PUBLIC)
-                .addException(IOException.class);
-
-        boolean valid = serializeObject(classInfo, classCreator, beanClassName, bytecode);
-        bytecode.returnVoid();
-        return valid;
-    }
-
-    private boolean serializeObject(ClassInfo classInfo, ClassCreator classCreator, String beanClassName,
-            MethodCreator bytecode) {
-
         var jsonValueFieldSpecs = jsonValueFieldSpecs(classInfo);
         if (jsonValueFieldSpecs == null) {
             return false;
         }
 
-        SerializationContext ctx = new SerializationContext(bytecode, beanClassName);
+        boolean isJsonValue = jsonValueFieldSpecs.isPresent();
 
-        if (jsonValueFieldSpecs.isPresent()) {
-            serializeJsonValue(ctx, bytecode, jsonValueFieldSpecs.get());
-            return true;
+        // Generate serializeContent() — writes field content without object boundaries
+        MethodCreator contentMethod = classCreator.getMethodCreator("serializeContent", void.class,
+                Object.class, JsonGenerator.class, SerializerProvider.class)
+                .setModifiers(ACC_PUBLIC)
+                .addException(IOException.class);
+
+        if (isJsonValue) {
+            SerializationContext ctx = new SerializationContext(contentMethod, beanClassName);
+            serializeJsonValue(ctx, contentMethod, jsonValueFieldSpecs.get());
+        } else {
+            Set<String> serializedFields = new HashSet<>();
+            SerializationContext ctx = new SerializationContext(contentMethod, beanClassName);
+            serializeObjectData(classInfo, classCreator, contentMethod, ctx, serializedFields);
+            if (serializedFields.isEmpty()) {
+                throwExceptionForEmptyBean(beanClassName, contentMethod, contentMethod.getMethodParam(1));
+            }
+            classCreator.getMethodCreator("<clinit>", void.class).setModifiers(ACC_STATIC).returnVoid();
         }
+        contentMethod.returnVoid();
 
-        // jsonGenerator.writeStartObject();
-        MethodDescriptor writeStartObject = MethodDescriptor.ofMethod(JSON_GEN_CLASS_NAME, "writeStartObject", "void");
-        bytecode.invokeVirtualMethod(writeStartObject, ctx.jsonGenerator);
-
-        Set<String> serializedFields = new HashSet<>();
-        serializeObjectData(classInfo, classCreator, bytecode, ctx, serializedFields);
-
-        // jsonGenerator.writeEndObject();
-        MethodDescriptor writeEndObject = MethodDescriptor.ofMethod(JSON_GEN_CLASS_NAME, "writeEndObject", "void");
-        bytecode.invokeVirtualMethod(writeEndObject, ctx.jsonGenerator);
-
-        if (serializedFields.isEmpty()) {
-            throwExceptionForEmptyBean(beanClassName, bytecode, ctx.jsonGenerator);
+        if (isJsonValue) {
+            // @JsonValue: override serialize() to skip object boundaries
+            MethodCreator serialize = classCreator.getMethodCreator("serialize", void.class,
+                    Object.class, JsonGenerator.class, SerializerProvider.class)
+                    .setModifiers(ACC_PUBLIC)
+                    .addException(IOException.class);
+            MethodDescriptor serializeContentMd = MethodDescriptor.ofMethod(classCreator.getClassName(),
+                    "serializeContent", void.class, Object.class, JsonGenerator.class, SerializerProvider.class);
+            serialize.invokeVirtualMethod(serializeContentMd, serialize.getThis(),
+                    serialize.getMethodParam(0), serialize.getMethodParam(1), serialize.getMethodParam(2));
+            serialize.returnVoid();
         }
-
-        classCreator.getMethodCreator("<clinit>", void.class).setModifiers(ACC_STATIC).returnVoid();
 
         return true;
     }
@@ -289,7 +285,7 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
             return jsonValueMethodFieldSpecs.isPresent() ? null : jsonValueFieldFieldSpecs;
         }
         //  If none valid reflection-free JsonValue annotated target has been found,but
-        //  a non-public element annotated is present,just use standard Jackson
+        //  a non-public element annotated is present, just use standard Jackson
         //  serializer
         if (jsonValueMethodFieldSpecs.isEmpty() && jsonValueAnnotationFound) {
             return null;
@@ -365,14 +361,21 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
     }
 
     private void writeField(ClassInfo classInfo, FieldSpecs fieldSpecs, BytecodeCreator bytecode, SerializationContext ctx) {
-        String pkgName = classInfo.name().packagePrefixName().toString();
-        generatedFields.computeIfAbsent(pkgName, pkg -> new HashSet<>()).add(fieldSpecs.jsonName);
-
         ResultHandle arg = fieldSpecs.toValueReaderHandle(bytecode, ctx.valueHandle);
         bytecode = checkInclude(bytecode, ctx, arg);
 
-        String typeName = fieldSpecs.fieldType.name().toString();
-        writeFieldValue(fieldSpecs, bytecode, ctx, typeName, arg, pkgName);
+        if (fieldSpecs.isUnwrapped()) {
+            String typeName = fieldSpecs.fieldType.name().toString();
+            registerTypeToBeGenerated(fieldSpecs.fieldType, typeName);
+            MethodDescriptor serializeUnwrapped = MethodDescriptor.ofMethod(JacksonMapperUtil.class.getName(),
+                    "serializeUnwrapped", void.class, Object.class, JsonGenerator.class, SerializerProvider.class);
+            bytecode.invokeStaticMethod(serializeUnwrapped, arg, ctx.jsonGenerator, ctx.serializerProvider);
+        } else {
+            String pkgName = classInfo.name().packagePrefixName().toString();
+            generatedFields.computeIfAbsent(pkgName, pkg -> new HashSet<>()).add(fieldSpecs.jsonName);
+            String typeName = fieldSpecs.fieldType.name().toString();
+            writeFieldValue(fieldSpecs, bytecode, ctx, typeName, arg, pkgName);
+        }
     }
 
     private void writeFieldValue(FieldSpecs fieldSpecs, BytecodeCreator bytecode, SerializationContext ctx, String typeName,
@@ -388,7 +391,7 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
                 writeFieldName(fieldSpecs, primitiveBytecode, ctx, pkgName);
             }
 
-            MethodDescriptor primitiveWriter = MethodDescriptor.ofMethod(JSON_GEN_CLASS_NAME, primitiveMethodName, "void",
+            MethodDescriptor primitiveWriter = MethodDescriptor.ofMethod(JsonGenerator.class, primitiveMethodName, void.class,
                     fieldSpecs.writtenType());
             primitiveBytecode.invokeVirtualMethod(primitiveWriter, ctx.jsonGenerator, arg);
 
@@ -434,7 +437,7 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
                         SerializedString.class.getName()));
 
         if (fieldSpecs.hasExplicitJsonName) {
-            MethodDescriptor writeFieldName = MethodDescriptor.ofMethod(JSON_GEN_CLASS_NAME, "writeFieldName", void.class,
+            MethodDescriptor writeFieldName = MethodDescriptor.ofMethod(JsonGenerator.class, "writeFieldName", void.class,
                     SerializableString.class);
             bytecode.invokeVirtualMethod(writeFieldName, ctx.jsonGenerator, serStringHandle);
         } else {

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonWithReflectionFreeSerializersTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonWithReflectionFreeSerializersTest.java
@@ -1,6 +1,9 @@
 package io.quarkus.resteasy.reactive.jackson.deployment.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.function.Supplier;
+import java.util.logging.Level;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -41,15 +44,8 @@ public class SimpleJsonWithReflectionFreeSerializersTest extends AbstractSimpleJ
                                     "quarkus.rest.jackson.optimization.enable-reflection-free-serializers=true\n"),
                                     "application.properties");
                 }
-            });
-
-    // The following assertions have been commented out because at the moment it is discovering classes with unknown
-    // Jackson annotations, for which it cannot generate a serializer and then the log messages are no longer empty.
-    // We plan to add support for those outstanding annotations, but before the focus is to check that the mechanism
-    // falling back to standard reflection-based Jackson serializers works as expected.
-
-    //            .setLogRecordPredicate(record -> record.getLevel().equals(Level.INFO)
-    //                    && record.getLoggerName().equals(
-    //                            "io.quarkus.resteasy.reactive.jackson.deployment.processor.JacksonCodeGenerator"))
-    //            .assertLogRecords(records -> assertThat(records).isEmpty());
+            }).setLogRecordPredicate(record -> record.getLevel().equals(Level.INFO)
+                    && record.getLoggerName().equals(
+                            "io.quarkus.resteasy.reactive.jackson.deployment.processor.JacksonCodeGenerator"))
+            .assertLogRecords(records -> assertThat(records).isEmpty());
 }

--- a/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/mappers/GeneratedSerializer.java
+++ b/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/mappers/GeneratedSerializer.java
@@ -1,0 +1,44 @@
+package io.quarkus.resteasy.reactive.jackson.runtime.mappers;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.type.WritableTypeId;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.fasterxml.jackson.databind.util.NameTransformer;
+
+public abstract class GeneratedSerializer extends StdSerializer<Object> {
+
+    protected GeneratedSerializer(Class<?> cls) {
+        super(cls, false);
+    }
+
+    public abstract void serializeContent(Object value, JsonGenerator gen,
+            SerializerProvider prov) throws IOException;
+
+    @Override
+    public void serialize(Object value, JsonGenerator gen,
+            SerializerProvider prov) throws IOException {
+        gen.writeStartObject();
+        serializeContent(value, gen, prov);
+        gen.writeEndObject();
+    }
+
+    @Override
+    public void serializeWithType(Object value, JsonGenerator gen,
+            SerializerProvider prov, TypeSerializer typeSer) throws IOException {
+        WritableTypeId typeIdDef = typeSer.writeTypePrefix(gen,
+                typeSer.typeId(value, JsonToken.START_OBJECT));
+        serializeContent(value, gen, prov);
+        typeSer.writeTypeSuffix(gen, typeIdDef);
+    }
+
+    @Override
+    public JsonSerializer<Object> unwrappingSerializer(NameTransformer transformer) {
+        return new UnwrappingSerializer(this);
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/mappers/JacksonMapperUtil.java
+++ b/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/mappers/JacksonMapperUtil.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.util.NameTransformer;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
@@ -192,6 +193,20 @@ public class JacksonMapperUtil {
                 .constructCollectionType((Class<? extends Collection>) collectionClass, elementClass);
         JsonSerializer<Object> serializer = serializerProvider.findValueSerializer(collectionType);
         serializer.serialize(value, generator, serializerProvider);
+    }
+
+    public static void serializeUnwrapped(Object value, JsonGenerator generator,
+            SerializerProvider serializerProvider) throws IOException {
+        if (value == null) {
+            return;
+        }
+        JsonSerializer<Object> serializer = serializerProvider.findValueSerializer(value.getClass());
+        if (serializer instanceof GeneratedSerializer gs) {
+            gs.serializeContent(value, generator, serializerProvider);
+        } else {
+            serializer.unwrappingSerializer(NameTransformer.NOP)
+                    .serialize(value, generator, serializerProvider);
+        }
     }
 
     public enum SerializationInclude {

--- a/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/mappers/UnwrappingSerializer.java
+++ b/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/mappers/UnwrappingSerializer.java
@@ -1,0 +1,27 @@
+package io.quarkus.resteasy.reactive.jackson.runtime.mappers;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+public class UnwrappingSerializer extends StdSerializer<Object> {
+
+    private final GeneratedSerializer delegate;
+
+    public UnwrappingSerializer(GeneratedSerializer delegate) {
+        super(Object.class);
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void serialize(Object value, JsonGenerator gen, SerializerProvider prov) throws IOException {
+        delegate.serializeContent(value, gen, prov);
+    }
+
+    @Override
+    public boolean isUnwrappingSerializer() {
+        return true;
+    }
+}


### PR DESCRIPTION
The serializers generation for both the mentioned annotations couldn't work because the generated `serialize() `always wrote `writeStartObject() + fields + writeEndObject()` and there's no way to write just the fields without the object boundaries.

This fix extracts field-writing into a `serializeContent()` method, then compose it differently for each use case:                                                                                                                  
                                                                                                                                                                                                                                    
  1. serialize() = writeStartObject + serializeContent + writeEndObject (same as before)                                                                                                                                             
  2. serializeWithType() = writeTypePrefix + serializeContent + writeTypeSuffix (no double {)
  3. unwrappingSerializer() = returns a wrapper that calls only serializeContent (no boundaries at all)

The logic to invoke these different strategies is mostly contained in the new `GeneratedSerializer` abstract class, that now acts as an intermediate abstraction between the Jackson's StdSerializer and the actual generated serializer.

This is related with the problem described here https://github.com/quarkusio/quarkus/issues/53765 and a follow up of the work done in https://github.com/quarkusio/quarkus/pull/53829

The former pull request made sure that in presence of those unsupported annotations the serialization could correctly fallback to the default Jackson's reflection-based mechanism, while this pull request properly support them with the generated reflection-free ones.

