### PR TITLE
Warn when pom properties drift from target stream defaults during update

### DIFF
--- a/docs/src/main/asciidoc/update-quarkus.adoc
+++ b/docs/src/main/asciidoc/update-quarkus.adoc
@@ -72,6 +72,13 @@ ifdef::devtools-wrapped[+]
 
 . Analyze the update command output for potential instructions and perform the suggested tasks if necessary.
 
+[NOTE]
+====
+For Maven projects, the update command warns if `compiler-plugin.version`, `surefire-plugin.version`, or `maven.compiler.release`
+are set in your `pom.xml` with values that differ from the target stream's defaults.
+These properties are not automatically updated — review the warnings and update them manually if needed.
+====
+
 . Use a diff tool to inspect all changes.
 
 . Review the {quarkus-migration-guide} for items that were not updated by the update command.

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandler.java
@@ -12,6 +12,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Scanner;
@@ -19,6 +20,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
 
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.devtools.commands.UpdateProject;
@@ -32,6 +34,8 @@ import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.project.JavaVersion;
 import io.quarkus.devtools.project.QuarkusProject;
 import io.quarkus.devtools.project.QuarkusProjectHelper;
+import io.quarkus.devtools.project.buildfile.MavenProjectBuildFile;
+import io.quarkus.devtools.project.extensions.ExtensionManager;
 import io.quarkus.devtools.project.state.ProjectState;
 import io.quarkus.devtools.project.update.ExtensionUpdateInfo;
 import io.quarkus.devtools.project.update.PlatformInfo;
@@ -66,6 +70,11 @@ public class UpdateProjectCommandHandler implements QuarkusCommandHandler {
         }
         final ApplicationModel appModel = invocation.getValue(UpdateProject.APP_MODEL);
         final ExtensionCatalog targetCatalog = invocation.getValue(UpdateProject.TARGET_CATALOG);
+        ExtensionManager extensionManager = invocation.getQuarkusProject().getExtensionManager();
+        if (extensionManager instanceof MavenProjectBuildFile maven) {
+            warnOnPomPropertyDrift(targetCatalog, maven::getRawPomProperty, invocation.getQuarkusProject().log());
+        }
+
         final ProjectState currentState = resolveProjectState(appModel,
                 invocation.getQuarkusProject().getExtensionsCatalog());
         final ArtifactCoords currentQuarkusPlatformBom = getProjectQuarkusPlatformBOM(currentState);
@@ -86,15 +95,18 @@ public class UpdateProjectCommandHandler implements QuarkusCommandHandler {
         final ProjectExtensionsUpdateInfo extensionsUpdateInfo = ProjectUpdateInfos.resolveExtensionsUpdateInfo(
                 currentState,
                 recommendedState);
-        boolean shouldUpdate = logUpdates(invocation.getQuarkusProject(), currentState, recommendedState, platformUpdateInfo,
+        boolean shouldUpdate = logUpdates(invocation.getQuarkusProject(), currentState, recommendedState,
+                platformUpdateInfo,
                 extensionsUpdateInfo,
                 invocation.log());
         Boolean rewrite = invocation.getValue(UpdateProject.REWRITE, null);
         boolean rewriteDryRun = invocation.getValue(UpdateProject.REWRITE_DRY_RUN, false);
+
         if (shouldUpdate) {
             final QuarkusProject quarkusProject = invocation.getQuarkusProject();
             final BuildTool buildTool = quarkusProject.getExtensionManager().getBuildTool();
-            // TODO targetCatalog shouldn't be used here, since it might not be the recommended one according to the calculated recommended state
+            // TODO targetCatalog shouldn't be used here, since it might not be the
+            // recommended one according to the calculated recommended state
             String kotlinVersion = getMetadata(targetCatalog, "project", "properties", "kotlin-version");
             final Optional<Integer> updateJavaVersion = resolveUpdateJavaVersion(extensionsUpdateInfo, projectJavaVersion);
             QuarkusUpdates.ProjectUpdateRequest request = new QuarkusUpdates.ProjectUpdateRequest(
@@ -201,7 +213,7 @@ public class UpdateProjectCommandHandler implements QuarkusCommandHandler {
         try (Scanner scanner = new Scanner(new FilterInputStream(System.in) {
             @Override
             public void close() throws IOException {
-                //don't close System.in!
+                // don't close System.in!
             }
         })) {
             return scanner.nextLine();
@@ -235,7 +247,8 @@ public class UpdateProjectCommandHandler implements QuarkusCommandHandler {
         return null;
     }
 
-    private static QuarkusCommandOutcome<Void> ensureQuarkusBomVersionIsNotNull(ArtifactCoords bomCoords, MessageWriter log) {
+    private static QuarkusCommandOutcome<Void> ensureQuarkusBomVersionIsNotNull(ArtifactCoords bomCoords,
+            MessageWriter log) {
         if (bomCoords == null) {
             String error = "The project state is missing the Quarkus platform BOM";
             log.error(error);
@@ -392,7 +405,7 @@ public class UpdateProjectCommandHandler implements QuarkusCommandHandler {
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    private <T> T getMetadata(ExtensionCatalog catalog, String... path) {
+    private static <T> T getMetadata(ExtensionCatalog catalog, String... path) {
         Object currentValue = catalog.getMetadata();
         for (String pathElement : path) {
             if (!(currentValue instanceof Map)) {
@@ -405,4 +418,24 @@ public class UpdateProjectCommandHandler implements QuarkusCommandHandler {
         return (T) currentValue;
     }
 
+    static void warnOnPomPropertyDrift(ExtensionCatalog target, Function<String, String> localProperty,
+            MessageWriter log) {
+        checkDrift("compiler-plugin.version", "compiler-plugin-version", localProperty, target, log);
+        checkDrift("surefire-plugin.version", "surefire-plugin-version", localProperty, target, log);
+        checkDrift("maven.compiler.release", "recommended-java-version", localProperty, target, log);
+    }
+
+    private static void checkDrift(String pomPropName, String catalogKey,
+            Function<String, String> localProperty, ExtensionCatalog target, MessageWriter log) {
+        String localValue = localProperty.apply(pomPropName);
+        if (localValue == null)
+            return;
+        String expected = getMetadata(target, "project", "properties", catalogKey);
+        if (expected == null)
+            return;
+        if (!Objects.equals(localValue, expected)) {
+            log.warn("Project property '%s' is '%s' but the target stream recommends '%s'."
+                    + " Consider updating it in your pom.xml.", pomPropName, localValue, expected);
+        }
+    }
 }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/MavenProjectBuildFile.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/MavenProjectBuildFile.java
@@ -275,7 +275,7 @@ public class MavenProjectBuildFile extends BuildFile {
         if (!managed) {
             d.setVersion(coords.getVersion());
         }
-        // When classifier is empty, you get  <classifier></classifier> in the pom.xml
+        // When classifier is empty, you get <classifier></classifier> in the pom.xml
         if (coords.getClassifier() != null && !coords.getClassifier().isEmpty()) {
             d.setClassifier(coords.getClassifier());
         }
@@ -372,6 +372,10 @@ public class MavenProjectBuildFile extends BuildFile {
     @Override
     protected String getProperty(String propertyName) {
         return projectProps.getProperty(propertyName);
+    }
+
+    public String getRawPomProperty(String name) {
+        return projectProps == null ? null : projectProps.getProperty(name);
     }
 
     @Override

--- a/independent-projects/tools/devtools-common/src/test/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandlerTest.java
+++ b/independent-projects/tools/devtools-common/src/test/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandlerTest.java
@@ -1,0 +1,79 @@
+package io.quarkus.devtools.commands.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.devtools.messagewriter.MessageWriter;
+import io.quarkus.registry.catalog.ExtensionCatalog;
+
+class UpdateProjectCommandHandlerTest {
+
+    final ExtensionCatalog catalog = ExtensionCatalog.builder().setMetadata(Map.of("project", Map.of("properties", Map.of(
+            "compiler-plugin-version", "3.14.0",
+            "recommended-java-version", "21",
+            "surefire-plugin-version", "4.5.3")))).build();
+
+    @Test
+    void shouldWarnWhenLocalValuesDiffer() {
+        List<String> warnings = new ArrayList<>();
+        Map<String, String> localProps = Map.of("compiler-plugin.version", "3.15.0", "maven.compiler.release", "17");
+        MessageWriter log = recordingWriter(warnings);
+        UpdateProjectCommandHandler.warnOnPomPropertyDrift(catalog, localProps::get, log);
+        assertThat(warnings).hasSize(2);
+    }
+
+    @Test
+    void shouldNotWarnWhenValuesMatch() {
+        List<String> warnings = new ArrayList<>();
+        Map<String, String> localProps = Map.of("compiler-plugin.version", "3.14.0");
+        MessageWriter log = recordingWriter(warnings);
+        UpdateProjectCommandHandler.warnOnPomPropertyDrift(catalog, localProps::get, log);
+        assertThat(warnings).hasSize(0);
+    }
+
+    @Test
+    void shouldNotWarnWhenValuesNotSetLocally() {
+        List<String> warnings = new ArrayList<>();
+        Map<String, String> localProps = Map.of();
+        MessageWriter log = recordingWriter(warnings);
+        UpdateProjectCommandHandler.warnOnPomPropertyDrift(catalog, localProps::get, log);
+        assertThat(warnings).hasSize(0);
+    }
+
+    @Test
+    void shouldNotWarnWhenCatalogHasNoEntry() {
+        List<String> warnings = new ArrayList<>();
+        ExtensionCatalog emptyCatalog = ExtensionCatalog.builder().build();
+        Map<String, String> localProps = Map.of("compiler-plugin.version", "3.14.0");
+        MessageWriter log = recordingWriter(warnings);
+        UpdateProjectCommandHandler.warnOnPomPropertyDrift(emptyCatalog, localProps::get, log);
+        assertThat(warnings).hasSize(0);
+    }
+
+    private MessageWriter recordingWriter(List<String> warnings) {
+        return new MessageWriter() {
+            public void warn(String msg) {
+                warnings.add(msg);
+            }
+
+            public void info(String msg) {
+            }
+
+            public void error(String msg) {
+            }
+
+            public void debug(String msg) {
+            }
+
+            public boolean isDebugEnabled() {
+                return false;
+            }
+        };
+    }
+
+}


### PR DESCRIPTION


<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
and the AI/LLM usage policy at https://github.com/quarkusio/quarkus/blob/main/AI_POLICY.md
-->

When running `quarkus update` , properties like `compiler-plugin.version`, `surefire-plugin.version`, and `maven.compiler.release` could silently remain at old values even after updating the platform BOM. This adds a warning when those properties are set locally in the pom and differ from what the target stream recommends.

This check is Maven only since these properties don't exist in Gradle builds. The properties that aren't set locally are skipped.

Closes #53671
<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

