### PR TITLE
Add test for dev services config isolation

### DIFF
--- a/integration-tests/devservices/dependent-extension/deployment/src/main/java/io/quarkus/tests/dependentextension/deployment/DependentDevServicesProcessor.java
+++ b/integration-tests/devservices/dependent-extension/deployment/src/main/java/io/quarkus/tests/dependentextension/deployment/DependentDevServicesProcessor.java
@@ -1,6 +1,7 @@
 package io.quarkus.tests.dependentextension.deployment;
 
 import static io.quarkus.tests.dependentextension.Constants.QUARKUS_DEPENDENT_EXTENSION_BASE_URL;
+import static io.quarkus.tests.dependentextension.Constants.QUARKUS_DEPENDENT_EXTENSION_CONFIG_CONTAMINATED;
 import static io.quarkus.tests.dependentextension.Constants.QUARKUS_DEPENDENT_EXTENSION_SEES_DEPENDENCY;
 import static io.quarkus.tests.dependentextension.Constants.QUARKUS_OPTIONAL_DEPENDENT_EXTENSION_BASE_URL;
 import static io.quarkus.tests.dependentextension.Constants.QUARKUS_OPTIONAL_DEPENDENT_EXTENSION_SEES_DEPENDENCY;
@@ -12,6 +13,7 @@ import java.util.Map;
 
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.DevServicesAdditionalConfigBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.dev.devservices.DevServicesConfig;
@@ -23,6 +25,18 @@ public class DependentDevServicesProcessor {
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(FEATURE);
+    }
+
+    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = DevServicesConfig.Enabled.class)
+    DevServicesAdditionalConfigBuildItem detectConfigContamination() {
+        return new DevServicesAdditionalConfigBuildItem(devServicesConfig -> {
+            boolean hasDependentKey = devServicesConfig.containsKey(QUARKUS_DEPENDENT_EXTENSION_BASE_URL);
+            boolean hasSimpleKey = devServicesConfig.containsKey("acme.simpleextension.base-url");
+            if (hasDependentKey && hasSimpleKey) {
+                return Map.of(QUARKUS_DEPENDENT_EXTENSION_CONFIG_CONTAMINATED, "true");
+            }
+            return Map.of();
+        });
     }
 
     @BuildStep(onlyIfNot = IsNormal.class, onlyIf = DevServicesConfig.Enabled.class)

--- a/integration-tests/devservices/dependent-extension/runtime/src/main/java/io/quarkus/tests/dependentextension/Constants.java
+++ b/integration-tests/devservices/dependent-extension/runtime/src/main/java/io/quarkus/tests/dependentextension/Constants.java
@@ -10,4 +10,6 @@ public class Constants {
     public static final String QUARKUS_OPTIONAL_DEPENDENT_EXTENSION_SEES_DEPENDENCY = "acme.dependentextension.optional.dependency.available";
     public static final String QUARKUS_UNSATISFIED_OPTIONAL_DEPENDENT_EXTENSION_SEES_DEPENDENCY = "acme.dependentextension.unsat.optional.dependency.available";
 
+    public static final String QUARKUS_DEPENDENT_EXTENSION_CONFIG_CONTAMINATED = "acme.dependentextension.config-contaminated";
+
 }

--- a/integration-tests/devservices/tests/src/test/java/io/quarkus/devservices/test/DevServicesTest.java
+++ b/integration-tests/devservices/tests/src/test/java/io/quarkus/devservices/test/DevServicesTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.devservices.test;
 
 import static io.quarkus.tests.dependentextension.Constants.QUARKUS_DEPENDENT_EXTENSION_BASE_URL;
+import static io.quarkus.tests.dependentextension.Constants.QUARKUS_DEPENDENT_EXTENSION_CONFIG_CONTAMINATED;
 import static io.quarkus.tests.dependentextension.Constants.QUARKUS_DEPENDENT_EXTENSION_SEES_DEPENDENCY;
 import static io.quarkus.tests.dependentextension.Constants.QUARKUS_OPTIONAL_DEPENDENT_EXTENSION_BASE_URL;
 import static io.quarkus.tests.dependentextension.Constants.QUARKUS_OPTIONAL_DEPENDENT_EXTENSION_SEES_DEPENDENCY;
@@ -56,6 +57,9 @@ public class DevServicesTest {
 
     @ConfigProperty(name = SIMPLE_EXTENSION_CLASSLOADER_ON_SERVICE_START, defaultValue = UNSET)
     String classloaderOnServiceStart;
+
+    @ConfigProperty(name = QUARKUS_DEPENDENT_EXTENSION_CONFIG_CONTAMINATED, defaultValue = "false")
+    String dependentExtensionConfigContaminated;
 
     @Test
     public void testTheLazyDevServicesConfigIsAvailable() {
@@ -113,6 +117,11 @@ public class DevServicesTest {
     public void testOptionalDependentServiceWithUnsatisfiedDependencyIsStarted() {
         assertIsSet(unsatisfiedOptionalDependentExtensionBaseUrl);
         assertFalse(unsatisfiedOptionalDependentExtensionSeesDependencyService);
+    }
+
+    @Test
+    public void testDevServiceConfigIsNotContaminatedByOtherDevServices() {
+        assertEquals("false", dependentExtensionConfigContaminated);
     }
 
     @Test


### PR DESCRIPTION
I know @gsmet said that he sees failures in his epic-PR-batch without #53794, but I thought it would be good to have an explicit test for this case. It can tag along with existing projects, so it should be cheap to run. 

Claude has confirmed that the test fails without the fix, and passes with it.

The test uses a `DevServicesAdditionalConfigBuildItem` in the dependent-extension test processor to detect when a dev service's config map contains keys from other dev services.
