### PR TITLE
Add AI generated tests covering all Jackson annotations

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/AbstractGeneratedAnnotationTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/AbstractGeneratedAnnotationTest.java
@@ -1,0 +1,534 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import io.restassured.RestAssured;
+
+public abstract class AbstractGeneratedAnnotationTest {
+
+    // --- @JsonProperty + @JsonIgnore ---
+
+    @Test
+    public void testPropertyIgnoreSerialization() {
+        RestAssured.get("/generated/property-ignore")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("display_name", Matchers.is("Alice"))
+                .body("years_old", Matchers.is(25))
+                .body(not(containsString("secret")))
+                .body(not(containsString("hidden-value")));
+    }
+
+    @Test
+    public void testPropertyIgnoreRoundTrip() {
+        given()
+                .contentType("application/json")
+                .body("{\"display_name\":\"Bob\",\"years_old\":30}")
+                .when()
+                .post("/generated/property-ignore")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("display_name", Matchers.is("Bob"))
+                .body("years_old", Matchers.is(30))
+                .body(not(containsString("secret")));
+    }
+
+    @Test
+    public void testPropertyIgnoreList() {
+        given()
+                .contentType("application/json")
+                .body("[{\"display_name\":\"A\",\"years_old\":1},{\"display_name\":\"B\",\"years_old\":2}]")
+                .when()
+                .post("/generated/property-ignore-list")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("[0].display_name", Matchers.is("A"))
+                .body("[0].years_old", Matchers.is(1))
+                .body("[1].display_name", Matchers.is("B"))
+                .body("[1].years_old", Matchers.is(2))
+                .body(not(containsString("secret")));
+    }
+
+    // --- @JsonNaming + @JsonProperty + @JsonIgnore ---
+
+    @Test
+    public void testNamingWithOverrideSerialization() {
+        RestAssured.get("/generated/naming-override")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("first_name", Matchers.is("John"))
+                .body("last_name", Matchers.is("Doe"))
+                .body("email", Matchers.is("john@example.com"))
+                .body(not(containsString("internalId")))
+                .body(not(containsString("internal_id")))
+                .body(not(containsString("INT-001")));
+    }
+
+    @Test
+    public void testNamingWithOverrideRoundTrip() {
+        given()
+                .contentType("application/json")
+                .body("{\"first_name\":\"Jane\",\"last_name\":\"Roe\",\"email\":\"jane@test.com\"}")
+                .when()
+                .post("/generated/naming-override")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("first_name", Matchers.is("Jane"))
+                .body("last_name", Matchers.is("Roe"))
+                .body("email", Matchers.is("jane@test.com"))
+                .body(not(containsString("internalId")))
+                .body(not(containsString("internal_id")));
+    }
+
+    // --- @JsonCreator + @JsonAlias + @JsonProperty ---
+
+    @Test
+    public void testCreatorAliasWithPrimaryNames() {
+        given()
+                .contentType("application/json")
+                .body("{\"name\":\"Alice\",\"code\":\"A1\"}")
+                .when()
+                .post("/generated/creator-alias")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("name", Matchers.is("Alice"))
+                .body("code", Matchers.is("A1"));
+    }
+
+    @Test
+    public void testCreatorAliasWithAliasNames() {
+        given()
+                .contentType("application/json")
+                .body("{\"fullName\":\"Bob\",\"identifier\":\"B2\"}")
+                .when()
+                .post("/generated/creator-alias")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("name", Matchers.is("Bob"))
+                .body("code", Matchers.is("B2"));
+    }
+
+    @Test
+    public void testCreatorAliasWithSecondAlias() {
+        given()
+                .contentType("application/json")
+                .body("{\"display_name\":\"Charlie\",\"code\":\"C3\"}")
+                .when()
+                .post("/generated/creator-alias")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("name", Matchers.is("Charlie"))
+                .body("code", Matchers.is("C3"));
+    }
+
+    // --- @JsonView + @JsonIgnore ---
+
+    @Test
+    public void testViewIgnoreWithoutView() {
+        RestAssured.get("/generated/view-ignore")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("publicField", Matchers.is("visible"))
+                .body("privateField", Matchers.is(42))
+                .body(not(containsString("ignoredField")))
+                .body(not(containsString("ignored-value")));
+    }
+
+    @Test
+    public void testViewIgnorePublicView() {
+        RestAssured.get("/generated/view-ignore-public")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("publicField", Matchers.is("visible"))
+                .body(not(containsString("privateField")))
+                .body(not(containsString("ignoredField")));
+    }
+
+    @Test
+    public void testViewIgnorePrivateView() {
+        RestAssured.get("/generated/view-ignore-private")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("publicField", Matchers.is("visible"))
+                .body("privateField", Matchers.is(42))
+                .body(not(containsString("ignoredField")));
+    }
+
+    // --- @JsonUnwrapped + @JsonProperty + @JsonIgnore ---
+
+    @Test
+    public void testUnwrappedWithRenameSerialization() {
+        RestAssured.get("/generated/unwrapped-rename")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("label", Matchers.is("test"))
+                .body("city", Matchers.is("NYC"))
+                .body("zip_code", Matchers.is("10001"))
+                .body(not(containsString("hidden")))
+                .body(not(containsString("secret")))
+                .body(not(containsString("address")));
+    }
+
+    // --- @JsonAnySetter + @JsonIgnoreProperties + @JsonProperty ---
+
+    @Test
+    public void testAnySetterIgnoreProperties() {
+        given()
+                .contentType("application/json")
+                .body("{\"id\":\"123\",\"name\":\"test\",\"extra1\":\"val1\",\"removed\":\"gone\",\"deleted\":\"gone\"}")
+                .when()
+                .post("/generated/any-setter-ignore-props")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("id", Matchers.is("123"))
+                .body("name", Matchers.is("test"))
+                .body("extras_size", Matchers.is(1));
+    }
+
+    @Test
+    public void testAnySetterIgnorePropertiesOnlyExtras() {
+        given()
+                .contentType("application/json")
+                .body("{\"id\":\"456\",\"name\":\"test2\",\"extra1\":\"a\",\"extra2\":\"b\",\"extra3\":\"c\"}")
+                .when()
+                .post("/generated/any-setter-ignore-props")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("id", Matchers.is("456"))
+                .body("name", Matchers.is("test2"))
+                .body("extras_size", Matchers.is(3));
+    }
+
+    // --- @JsonTypeInfo + @JsonSubTypes + @JsonTypeName + @JsonProperty ---
+
+    @Test
+    public void testPolymorphicTextSerialization() {
+        RestAssured.get("/generated/polymorphic-text")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("kind", Matchers.is("text"))
+                .body("text_value", Matchers.is("hello"))
+                .body("format", Matchers.is("plain"));
+    }
+
+    @Test
+    public void testPolymorphicNumberSerialization() {
+        RestAssured.get("/generated/polymorphic-number")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("kind", Matchers.is("number"))
+                .body("num_value", Matchers.is(42));
+    }
+
+    @Test
+    public void testPolymorphicListSerialization() {
+        RestAssured.get("/generated/polymorphic-list")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("[0].kind", Matchers.is("text"))
+                .body("[0].text_value", Matchers.is("first"))
+                .body("[0].format", Matchers.is("html"))
+                .body("[1].kind", Matchers.is("number"))
+                .body("[1].num_value", Matchers.is(99));
+    }
+
+    // --- @JsonProperty + @JsonAlias + @JsonIgnoreProperties ---
+
+    @Test
+    public void testMultiAnnotationRecordWithPrimaryNames() {
+        given()
+                .contentType("application/json")
+                .body("{\"title\":\"My Title\",\"summary\":\"A summary\",\"is_active\":true}")
+                .when()
+                .post("/generated/multi-annotation-record")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("title", Matchers.is("My Title"))
+                .body("summary", Matchers.is("A summary"))
+                .body("is_active", Matchers.is(true));
+    }
+
+    @Test
+    public void testMultiAnnotationRecordWithAlias() {
+        given()
+                .contentType("application/json")
+                .body("{\"title\":\"Title\",\"desc\":\"A description\",\"is_active\":false}")
+                .when()
+                .post("/generated/multi-annotation-record")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("title", Matchers.is("Title"))
+                .body("summary", Matchers.is("A description"))
+                .body("is_active", Matchers.is(false));
+    }
+
+    @Test
+    public void testMultiAnnotationRecordWithDescriptionAlias() {
+        given()
+                .contentType("application/json")
+                .body("{\"title\":\"T\",\"description\":\"Full desc\",\"is_active\":true}")
+                .when()
+                .post("/generated/multi-annotation-record")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("title", Matchers.is("T"))
+                .body("summary", Matchers.is("Full desc"))
+                .body("is_active", Matchers.is(true));
+    }
+
+    @Test
+    public void testMultiAnnotationRecordIgnoresUnknown() {
+        given()
+                .contentType("application/json")
+                .body("{\"title\":\"T\",\"summary\":\"S\",\"is_active\":true,\"unknown_field\":\"ignored\"}")
+                .when()
+                .post("/generated/multi-annotation-record")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("title", Matchers.is("T"))
+                .body("summary", Matchers.is("S"))
+                .body("is_active", Matchers.is(true));
+    }
+
+    // --- @JsonCreator + @JsonIgnore + @JsonProperty ---
+
+    @Test
+    public void testCreatorIgnoreRoundTrip() {
+        given()
+                .contentType("application/json")
+                .body("{\"name\":\"test\",\"value\":42}")
+                .when()
+                .post("/generated/creator-ignore")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("name", Matchers.is("test"))
+                .body("value", Matchers.is(42))
+                .body(not(containsString("computed")))
+                .body(not(containsString("test:42")));
+    }
+
+    // --- @JsonValue + @JsonCreator ---
+
+    @Test
+    public void testValueCreatorSerialization() {
+        RestAssured.get("/generated/value-creator")
+                .then()
+                .statusCode(200)
+                .body(Matchers.equalTo("\"hello world\""));
+    }
+
+    // --- @JsonNaming + @JsonAlias ---
+
+    @Test
+    public void testNamingAliasSerialization() {
+        RestAssured.get("/generated/naming-alias")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("first_name", Matchers.is("John"))
+                .body("last_name", Matchers.is("Doe"));
+    }
+
+    @Test
+    public void testNamingAliasWithNamingStrategyKeys() {
+        given()
+                .contentType("application/json")
+                .body("{\"first_name\":\"Jane\",\"last_name\":\"Roe\"}")
+                .when()
+                .post("/generated/naming-alias")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("first_name", Matchers.is("Jane"))
+                .body("last_name", Matchers.is("Roe"));
+    }
+
+    @Test
+    public void testNamingAliasWithSurnameAlias() {
+        given()
+                .contentType("application/json")
+                .body("{\"first_name\":\"Jane\",\"surname\":\"Roe\"}")
+                .when()
+                .post("/generated/naming-alias")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("first_name", Matchers.is("Jane"))
+                .body("last_name", Matchers.is("Roe"));
+    }
+
+    @Test
+    public void testNamingAliasWithFamilyNameAlias() {
+        given()
+                .contentType("application/json")
+                .body("{\"first_name\":\"Jane\",\"familyName\":\"Roe\"}")
+                .when()
+                .post("/generated/naming-alias")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("first_name", Matchers.is("Jane"))
+                .body("last_name", Matchers.is("Roe"));
+    }
+
+    // --- @JsonProperty + @JsonView ---
+
+    @Test
+    public void testPropertyViewWithoutView() {
+        RestAssured.get("/generated/property-view")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("display_name", Matchers.is("Alice"))
+                .body("secret_code", Matchers.is("SECRET"))
+                .body("category", Matchers.is("A"));
+    }
+
+    @Test
+    public void testPropertyViewPublic() {
+        RestAssured.get("/generated/property-view-public")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("display_name", Matchers.is("Alice"))
+                .body("category", Matchers.is("A"))
+                .body(not(containsString("secret_code")))
+                .body(not(containsString("SECRET")));
+    }
+
+    @Test
+    public void testPropertyViewPrivate() {
+        RestAssured.get("/generated/property-view-private")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("display_name", Matchers.is("Alice"))
+                .body("secret_code", Matchers.is("SECRET"))
+                .body("category", Matchers.is("A"));
+    }
+
+    // --- @JsonNaming + @JsonView + @JsonProperty ---
+
+    @Test
+    public void testNamingViewWithoutView() {
+        RestAssured.get("/generated/naming-view")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("first_name", Matchers.is("Jane"))
+                .body("last_name", Matchers.is("Smith"))
+                .body("e_mail", Matchers.is("jane@example.com"));
+    }
+
+    @Test
+    public void testNamingViewPublic() {
+        RestAssured.get("/generated/naming-view-public")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("first_name", Matchers.is("Jane"))
+                .body("e_mail", Matchers.is("jane@example.com"))
+                .body(not(containsString("last_name")))
+                .body(not(containsString("Smith")));
+    }
+
+    @Test
+    public void testNamingViewPrivate() {
+        RestAssured.get("/generated/naming-view-private")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("first_name", Matchers.is("Jane"))
+                .body("last_name", Matchers.is("Smith"))
+                .body("e_mail", Matchers.is("jane@example.com"));
+    }
+
+    // --- @JsonIgnoreProperties + @JsonProperty ---
+
+    @Test
+    public void testIgnorePropertiesCreatorRecordRoundTrip() {
+        given()
+                .contentType("application/json")
+                .body("{\"name\":\"item\",\"value\":10,\"temp\":\"ignored\",\"debug\":\"ignored\"}")
+                .when()
+                .post("/generated/ignore-props-creator")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("name", Matchers.is("item"))
+                .body("value", Matchers.is(10))
+                .body(not(containsString("temp")))
+                .body(not(containsString("debug")));
+    }
+
+    @Test
+    public void testIgnorePropertiesCreatorRecordRejectsUnknown() {
+        given()
+                .contentType("application/json")
+                .body("{\"name\":\"item\",\"value\":10,\"truly_unknown\":\"fail\"}")
+                .when()
+                .post("/generated/ignore-props-creator")
+                .then()
+                .statusCode(400);
+    }
+
+    // --- @JsonIgnore + @JsonAnySetter + @JsonProperty ---
+
+    @Test
+    public void testIgnoreAnySetterWithExtras() {
+        given()
+                .contentType("application/json")
+                .body("{\"name\":\"test\",\"extra1\":\"a\",\"extra2\":\"b\"}")
+                .when()
+                .post("/generated/ignore-any-setter")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("name", CoreMatchers.is("test"))
+                .body("others_size", CoreMatchers.is(2));
+    }
+
+    @Test
+    public void testIgnoreAnySetterHiddenFieldCapturedByAnySetter() {
+        // @JsonIgnore makes the property unknown to regular deserialization,
+        // so @JsonAnySetter captures it along with other unknown keys
+        given()
+                .contentType("application/json")
+                .body("{\"name\":\"test\",\"hidden\":\"secret\",\"extra1\":\"a\"}")
+                .when()
+                .post("/generated/ignore-any-setter")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("name", CoreMatchers.is("test"))
+                .body("others_size", CoreMatchers.is(2));
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/AbstractUnsupportedAnnotationTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/AbstractUnsupportedAnnotationTest.java
@@ -1,0 +1,212 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import io.restassured.RestAssured;
+
+public abstract class AbstractUnsupportedAnnotationTest {
+
+    // --- @JsonAnyGetter ---
+
+    @Test
+    public void testAnyGetterSerialization() {
+        // @JsonAnyGetter serializes map entries as flat top-level properties
+        RestAssured.get("/unsupported/any-getter")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("name", Matchers.is("test"))
+                .body("color", Matchers.is("red"))
+                .body("size", Matchers.is("large"))
+                .body(not(containsString("properties")));
+    }
+
+    @Test
+    public void testAnyGetterDeserialization() {
+        // Flat properties are captured by @JsonAnySetter
+        given()
+                .contentType("application/json")
+                .body("{\"name\":\"hello\",\"key1\":\"val1\",\"key2\":\"val2\"}")
+                .when()
+                .post("/unsupported/any-getter")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("name", CoreMatchers.is("hello"))
+                .body("props_size", CoreMatchers.is(2));
+    }
+
+    // --- @JsonAutoDetect ---
+
+    @Test
+    public void testAutoDetectFieldVisibility() {
+        // With fieldVisibility=ANY and getterVisibility=NONE, fields are serialized directly
+        RestAssured.get("/unsupported/auto-detect")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("visibleField", Matchers.is("hello"))
+                .body("count", Matchers.is(42));
+    }
+
+    // --- @JsonManagedReference + @JsonBackReference ---
+
+    @Test
+    public void testManagedBackReferenceSerialization() {
+        // Parent serializes child, but child does NOT serialize back-reference to parent
+        RestAssured.get("/unsupported/managed-reference")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("parentName", Matchers.is("parent"))
+                .body("child.childName", Matchers.is("child"))
+                .body("child", not(hasKey("parent")));
+    }
+
+    // --- @JsonFormat ---
+
+    @Test
+    public void testFormatEnumAsNumberSerialization() {
+        // @JsonFormat(shape=NUMBER) serializes enum as ordinal
+        RestAssured.get("/unsupported/format")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("name", Matchers.is("shape-test"))
+                .body("shape", Matchers.is(1));
+    }
+
+    @Test
+    public void testFormatEnumAsNumberDeserialization() {
+        given()
+                .contentType("application/json")
+                .body("{\"name\":\"round-trip\",\"shape\":2}")
+                .when()
+                .post("/unsupported/format")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("name", Matchers.is("round-trip"))
+                .body("shape", Matchers.is(2));
+    }
+
+    // --- @JsonGetter + @JsonSetter ---
+
+    @Test
+    public void testGetterSetterSerialization() {
+        // @JsonGetter("label") renames the output property
+        RestAssured.get("/unsupported/getter-setter")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("label", Matchers.is("test"))
+                .body("count", Matchers.is(5))
+                .body(not(containsString("\"name\"")));
+    }
+
+    @Test
+    public void testGetterSetterDeserialization() {
+        // @JsonSetter("label") accepts the renamed input
+        given()
+                .contentType("application/json")
+                .body("{\"label\":\"hello\",\"count\":10}")
+                .when()
+                .post("/unsupported/getter-setter")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("label", Matchers.is("hello"))
+                .body("count", Matchers.is(10));
+    }
+
+    // --- @JsonIgnoreType ---
+
+    @Test
+    public void testIgnoreTypeSerialization() {
+        // Field of @JsonIgnoreType type is excluded from serialization
+        RestAssured.get("/unsupported/ignore-type")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("name", Matchers.is("visible"))
+                .body(not(containsString("metadata")))
+                .body(not(containsString("secret-data")));
+    }
+
+    // --- @JsonInclude ---
+
+    @Test
+    public void testIncludeAllFieldsPresent() {
+        // When all fields are set, all appear in output
+        RestAssured.get("/unsupported/include-all-set")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("name", Matchers.is("test"))
+                .body("nullableField", Matchers.is("present"))
+                .body("emptyField", Matchers.is("not-empty"));
+    }
+
+    @Test
+    public void testIncludeNullAndEmptyExcluded() {
+        // @JsonInclude(NON_NULL) excludes null fields,
+        // @JsonInclude(NON_EMPTY) excludes empty strings
+        RestAssured.get("/unsupported/include-nulls")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("name", Matchers.is("test"))
+                .body(not(containsString("nullableField")))
+                .body(not(containsString("emptyField")));
+    }
+
+    // --- @JsonPropertyOrder ---
+
+    @Test
+    public void testPropertyOrderSerialization() {
+        // @JsonPropertyOrder({"zebra","alpha","middle"}) controls output key ordering
+        String body = RestAssured.get("/unsupported/property-order")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("alpha", Matchers.is("a"))
+                .body("middle", Matchers.is("m"))
+                .body("zebra", Matchers.is("z"))
+                .extract()
+                .asString();
+
+        int zebraPos = body.indexOf("\"zebra\"");
+        int alphaPos = body.indexOf("\"alpha\"");
+        int middlePos = body.indexOf("\"middle\"");
+        assertTrue(zebraPos < alphaPos, "zebra should appear before alpha");
+        assertTrue(alphaPos < middlePos, "alpha should appear before middle");
+    }
+
+    // --- @JsonRawValue ---
+
+    @Test
+    public void testRawValueSerialization() {
+        // @JsonRawValue outputs the string as raw JSON (not escaped)
+        String body = RestAssured.get("/unsupported/raw-value")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("name", Matchers.is("test"))
+                .body("rawJson.nested", Matchers.is("value"))
+                .body("rawJson.count", Matchers.is(1))
+                .extract()
+                .asString();
+
+        // Verify the raw JSON is embedded directly, not escaped as a string
+        assertTrue(body.contains("\"nested\":\"value\""),
+                "Raw JSON should be embedded directly, not escaped");
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/AnyGetterBean.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/AnyGetterBean.java
@@ -1,0 +1,32 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+
+public class AnyGetterBean {
+
+    private String name;
+
+    private Map<String, String> properties = new HashMap<>();
+
+    @JsonAnyGetter
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    @JsonAnySetter
+    public void addProperty(String key, String value) {
+        properties.put(key, value);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/AnySetterIgnorePropertiesBean.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/AnySetterIgnorePropertiesBean.java
@@ -1,0 +1,44 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties({ "removed", "deleted" })
+public class AnySetterIgnorePropertiesBean {
+
+    @JsonProperty("id")
+    private String identifier;
+
+    private String name;
+
+    private Map<String, Object> extras = new HashMap<>();
+
+    @JsonAnySetter
+    public void addExtra(String key, Object value) {
+        extras.put(key, value);
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Map<String, Object> getExtras() {
+        return extras;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/AutoDetectBean.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/AutoDetectBean.java
@@ -1,0 +1,18 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE)
+public class AutoDetectBean {
+
+    private String visibleField;
+    private int count;
+
+    public AutoDetectBean() {
+    }
+
+    public AutoDetectBean(String visibleField, int count) {
+        this.visibleField = visibleField;
+        this.count = count;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/CreatorAliasBean.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/CreatorAliasBean.java
@@ -1,0 +1,27 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CreatorAliasBean {
+
+    private final String name;
+    private final String code;
+
+    @JsonCreator
+    public CreatorAliasBean(
+            @JsonProperty("name") @JsonAlias({ "fullName", "display_name" }) String name,
+            @JsonProperty("code") @JsonAlias("identifier") String code) {
+        this.name = name;
+        this.code = code;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getCode() {
+        return code;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/CreatorIgnoreBean.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/CreatorIgnoreBean.java
@@ -1,0 +1,35 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CreatorIgnoreBean {
+
+    private final String name;
+    private final int value;
+
+    @JsonIgnore
+    private final String computed;
+
+    @JsonCreator
+    public CreatorIgnoreBean(
+            @JsonProperty("name") String name,
+            @JsonProperty("value") int value) {
+        this.name = name;
+        this.value = value;
+        this.computed = name + ":" + value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public String getComputed() {
+        return computed;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/FormatBean.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/FormatBean.java
@@ -1,0 +1,27 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+public class FormatBean {
+
+    private String name;
+
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+    private FormatShape shape;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public FormatShape getShape() {
+        return shape;
+    }
+
+    public void setShape(FormatShape shape) {
+        this.shape = shape;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/FormatShape.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/FormatShape.java
@@ -1,0 +1,7 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+public enum FormatShape {
+    CIRCLE,
+    SQUARE,
+    TRIANGLE
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationResource.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationResource.java
@@ -1,0 +1,279 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import java.util.List;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+
+import com.fasterxml.jackson.annotation.JsonView;
+
+import io.smallrye.common.annotation.NonBlocking;
+
+@Path("/generated")
+@NonBlocking
+public class GeneratedAnnotationResource {
+
+    @ServerExceptionMapper
+    public Response handleParseException(WebApplicationException e) {
+        var cause = e.getCause() == null ? e : e.getCause();
+        return Response.status(Response.Status.BAD_REQUEST).entity(cause.getMessage()).build();
+    }
+
+    // --- PropertyIgnoreBean: @JsonProperty + @JsonIgnore ---
+
+    @GET
+    @Path("/property-ignore")
+    public PropertyIgnoreBean getPropertyIgnore() {
+        PropertyIgnoreBean bean = new PropertyIgnoreBean();
+        bean.setName("Alice");
+        bean.setSecret("hidden-value");
+        bean.setAge(25);
+        return bean;
+    }
+
+    @POST
+    @Path("/property-ignore")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public PropertyIgnoreBean echoPropertyIgnore(PropertyIgnoreBean bean) {
+        return bean;
+    }
+
+    // --- NamingWithOverrideBean: @JsonNaming + @JsonProperty + @JsonIgnore ---
+
+    @GET
+    @Path("/naming-override")
+    public NamingWithOverrideBean getNamingOverride() {
+        NamingWithOverrideBean bean = new NamingWithOverrideBean();
+        bean.setFirstName("John");
+        bean.setLastName("Doe");
+        bean.setEmailAddress("john@example.com");
+        bean.setInternalId("INT-001");
+        return bean;
+    }
+
+    @POST
+    @Path("/naming-override")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public NamingWithOverrideBean echoNamingOverride(NamingWithOverrideBean bean) {
+        return bean;
+    }
+
+    // --- CreatorAliasBean: @JsonCreator + @JsonAlias + @JsonProperty ---
+
+    @POST
+    @Path("/creator-alias")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public CreatorAliasBean echoCreatorAlias(CreatorAliasBean bean) {
+        return bean;
+    }
+
+    // --- ViewIgnoreBean: @JsonView + @JsonIgnore ---
+
+    @GET
+    @Path("/view-ignore")
+    public ViewIgnoreBean getViewIgnore() {
+        return createViewIgnoreBean();
+    }
+
+    @JsonView(GeneratedViews.Public.class)
+    @GET
+    @Path("/view-ignore-public")
+    public ViewIgnoreBean getViewIgnorePublic() {
+        return createViewIgnoreBean();
+    }
+
+    @JsonView(GeneratedViews.Private.class)
+    @GET
+    @Path("/view-ignore-private")
+    public ViewIgnoreBean getViewIgnorePrivate() {
+        return createViewIgnoreBean();
+    }
+
+    private static ViewIgnoreBean createViewIgnoreBean() {
+        ViewIgnoreBean bean = new ViewIgnoreBean();
+        bean.setPublicField("visible");
+        bean.setPrivateField(42);
+        bean.setIgnoredField("ignored-value");
+        return bean;
+    }
+
+    // --- UnwrappedWithRenameBean: @JsonUnwrapped + @JsonProperty + @JsonIgnore ---
+
+    @GET
+    @Path("/unwrapped-rename")
+    public UnwrappedWithRenameBean getUnwrappedRename() {
+        UnwrappedWithRenameBean bean = new UnwrappedWithRenameBean();
+        bean.setName("test");
+        bean.setHidden("secret");
+        UnwrappedWithRenameBean.InnerAddress address = new UnwrappedWithRenameBean.InnerAddress();
+        address.setCity("NYC");
+        address.setZipCode("10001");
+        bean.setAddress(address);
+        return bean;
+    }
+
+    // --- AnySetterIgnorePropertiesBean: @JsonAnySetter + @JsonIgnoreProperties + @JsonProperty ---
+
+    @POST
+    @Path("/any-setter-ignore-props")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public String echoAnySetterIgnoreProperties(AnySetterIgnorePropertiesBean bean) {
+        return "{\"id\":\"" + bean.getIdentifier()
+                + "\",\"name\":\"" + bean.getName()
+                + "\",\"extras_size\":" + bean.getExtras().size() + "}";
+    }
+
+    // --- PolymorphicWithPropertyBase: @JsonTypeInfo + @JsonSubTypes + @JsonTypeName + @JsonProperty ---
+
+    @GET
+    @Path("/polymorphic-text")
+    public PolymorphicWithPropertyBase getPolymorphicText() {
+        return new PolymorphicWithPropertyBase.TextItem("hello", "plain");
+    }
+
+    @GET
+    @Path("/polymorphic-number")
+    public PolymorphicWithPropertyBase getPolymorphicNumber() {
+        return new PolymorphicWithPropertyBase.NumberItem(42);
+    }
+
+    // --- MultiAnnotationRecord: @JsonProperty + @JsonAlias + @JsonIgnoreProperties ---
+
+    @POST
+    @Path("/multi-annotation-record")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public MultiAnnotationRecord echoMultiAnnotationRecord(MultiAnnotationRecord record) {
+        return record;
+    }
+
+    // --- CreatorIgnoreBean: @JsonCreator + @JsonIgnore + @JsonProperty ---
+
+    @POST
+    @Path("/creator-ignore")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public CreatorIgnoreBean echoCreatorIgnore(CreatorIgnoreBean bean) {
+        return bean;
+    }
+
+    // --- ValueCreatorWrapper: @JsonValue + @JsonCreator ---
+
+    @GET
+    @Path("/value-creator")
+    @Produces(MediaType.APPLICATION_JSON)
+    public ValueCreatorWrapper getValueCreator() {
+        return new ValueCreatorWrapper("hello world");
+    }
+
+    // --- NamingAliasRecord: @JsonNaming + @JsonAlias ---
+
+    @GET
+    @Path("/naming-alias")
+    public NamingAliasRecord getNamingAlias() {
+        return new NamingAliasRecord("John", "Doe");
+    }
+
+    @POST
+    @Path("/naming-alias")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public NamingAliasRecord echoNamingAlias(NamingAliasRecord record) {
+        return record;
+    }
+
+    // --- PropertyViewRecord: @JsonProperty + @JsonView ---
+
+    @GET
+    @Path("/property-view")
+    public PropertyViewRecord getPropertyView() {
+        return new PropertyViewRecord("Alice", "SECRET", "A");
+    }
+
+    @JsonView(GeneratedViews.Public.class)
+    @GET
+    @Path("/property-view-public")
+    public PropertyViewRecord getPropertyViewPublic() {
+        return new PropertyViewRecord("Alice", "SECRET", "A");
+    }
+
+    @JsonView(GeneratedViews.Private.class)
+    @GET
+    @Path("/property-view-private")
+    public PropertyViewRecord getPropertyViewPrivate() {
+        return new PropertyViewRecord("Alice", "SECRET", "A");
+    }
+
+    // --- NamingViewBean: @JsonNaming + @JsonView + @JsonProperty ---
+
+    @GET
+    @Path("/naming-view")
+    public NamingViewBean getNamingView() {
+        return createNamingViewBean();
+    }
+
+    @JsonView(GeneratedViews.Public.class)
+    @GET
+    @Path("/naming-view-public")
+    public NamingViewBean getNamingViewPublic() {
+        return createNamingViewBean();
+    }
+
+    @JsonView(GeneratedViews.Private.class)
+    @GET
+    @Path("/naming-view-private")
+    public NamingViewBean getNamingViewPrivate() {
+        return createNamingViewBean();
+    }
+
+    private static NamingViewBean createNamingViewBean() {
+        NamingViewBean bean = new NamingViewBean();
+        bean.setFirstName("Jane");
+        bean.setLastName("Smith");
+        bean.setEmail("jane@example.com");
+        return bean;
+    }
+
+    // --- IgnorePropertiesCreatorRecord: @JsonIgnoreProperties + @JsonProperty ---
+
+    @POST
+    @Path("/ignore-props-creator")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public IgnorePropertiesCreatorRecord echoIgnorePropsCreator(IgnorePropertiesCreatorRecord record) {
+        return record;
+    }
+
+    // --- IgnoreAnySetterBean: @JsonIgnore + @JsonAnySetter + @JsonProperty ---
+
+    @POST
+    @Path("/ignore-any-setter")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public String echoIgnoreAnySetter(IgnoreAnySetterBean bean) {
+        return "{\"name\":\"" + bean.getName()
+                + "\",\"others_size\":" + bean.getOthers().size() + "}";
+    }
+
+    // --- Lists/collections of annotated types ---
+
+    @POST
+    @Path("/property-ignore-list")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public List<PropertyIgnoreBean> echoPropertyIgnoreList(List<PropertyIgnoreBean> list) {
+        return list;
+    }
+
+    @GET
+    @Path("/polymorphic-list")
+    public List<PolymorphicWithPropertyBase> getPolymorphicList() {
+        return List.of(
+                new PolymorphicWithPropertyBase.TextItem("first", "html"),
+                new PolymorphicWithPropertyBase.NumberItem(99));
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import java.util.function.Supplier;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class GeneratedAnnotationTest extends AbstractGeneratedAnnotationTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(GeneratedAnnotationResource.class,
+                                    GeneratedViews.class,
+                                    PropertyIgnoreBean.class,
+                                    NamingWithOverrideBean.class,
+                                    CreatorAliasBean.class,
+                                    ViewIgnoreBean.class,
+                                    UnwrappedWithRenameBean.class,
+                                    UnwrappedWithRenameBean.InnerAddress.class,
+                                    AnySetterIgnorePropertiesBean.class,
+                                    PolymorphicWithPropertyBase.class,
+                                    PolymorphicWithPropertyBase.TextItem.class,
+                                    PolymorphicWithPropertyBase.NumberItem.class,
+                                    MultiAnnotationRecord.class,
+                                    CreatorIgnoreBean.class,
+                                    ValueCreatorWrapper.class,
+                                    NamingAliasRecord.class,
+                                    PropertyViewRecord.class,
+                                    NamingViewBean.class,
+                                    IgnorePropertiesCreatorRecord.class,
+                                    IgnoreAnySetterBean.class)
+                            .addAsResource(new StringAsset(
+                                    "quarkus.jackson.fail-on-unknown-properties=true\n" +
+                                            "quarkus.rest.jackson.optimization.enable-reflection-free-serializers=false\n"),
+                                    "application.properties");
+                }
+            });
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationWithReflectionFreeSerializersTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationWithReflectionFreeSerializersTest.java
@@ -1,0 +1,52 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.function.Supplier;
+import java.util.logging.Level;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class GeneratedAnnotationWithReflectionFreeSerializersTest extends AbstractGeneratedAnnotationTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(GeneratedAnnotationResource.class,
+                                    GeneratedViews.class,
+                                    PropertyIgnoreBean.class,
+                                    NamingWithOverrideBean.class,
+                                    CreatorAliasBean.class,
+                                    ViewIgnoreBean.class,
+                                    UnwrappedWithRenameBean.class,
+                                    UnwrappedWithRenameBean.InnerAddress.class,
+                                    AnySetterIgnorePropertiesBean.class,
+                                    PolymorphicWithPropertyBase.class,
+                                    PolymorphicWithPropertyBase.TextItem.class,
+                                    PolymorphicWithPropertyBase.NumberItem.class,
+                                    MultiAnnotationRecord.class,
+                                    CreatorIgnoreBean.class,
+                                    ValueCreatorWrapper.class,
+                                    NamingAliasRecord.class,
+                                    PropertyViewRecord.class,
+                                    NamingViewBean.class,
+                                    IgnorePropertiesCreatorRecord.class,
+                                    IgnoreAnySetterBean.class)
+                            .addAsResource(new StringAsset(
+                                    "quarkus.jackson.fail-on-unknown-properties=true\n" +
+                                            "quarkus.rest.jackson.optimization.enable-reflection-free-serializers=true\n"),
+                                    "application.properties");
+                }
+            }).setLogRecordPredicate(record -> record.getLevel().equals(Level.INFO)
+                    && record.getLoggerName().equals(
+                            "io.quarkus.resteasy.reactive.jackson.deployment.processor.JacksonCodeGenerator"))
+            .assertLogRecords(records -> assertThat(records).isEmpty());
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedViews.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedViews.java
@@ -1,0 +1,10 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+public class GeneratedViews {
+
+    public static class Public {
+    }
+
+    public static class Private extends Public {
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GetterSetterBean.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GetterSetterBean.java
@@ -1,0 +1,28 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonSetter;
+
+public class GetterSetterBean {
+
+    private String name;
+    private int count;
+
+    @JsonGetter("label")
+    public String getName() {
+        return name;
+    }
+
+    @JsonSetter("label")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public void setCount(int count) {
+        this.count = count;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/IgnoreAnySetterBean.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/IgnoreAnySetterBean.java
@@ -1,0 +1,44 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class IgnoreAnySetterBean {
+
+    @JsonProperty("name")
+    private String name;
+
+    @JsonIgnore
+    private String hidden;
+
+    private Map<String, String> others = new HashMap<>();
+
+    @JsonAnySetter
+    public void addOther(String key, String value) {
+        others.put(key, value);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getHidden() {
+        return hidden;
+    }
+
+    public void setHidden(String hidden) {
+        this.hidden = hidden;
+    }
+
+    public Map<String, String> getOthers() {
+        return others;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/IgnorePropertiesCreatorRecord.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/IgnorePropertiesCreatorRecord.java
@@ -1,0 +1,10 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties({ "temp", "debug" })
+public record IgnorePropertiesCreatorRecord(
+        @JsonProperty("name") String name,
+        @JsonProperty("value") int value) {
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/IgnoreTypeBean.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/IgnoreTypeBean.java
@@ -1,0 +1,26 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonPropertyOrder({ "name", "metadata" })
+public class IgnoreTypeBean {
+
+    private String name;
+    private IgnoredType metadata;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public IgnoredType getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(IgnoredType metadata) {
+        this.metadata = metadata;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/IgnoredType.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/IgnoredType.java
@@ -1,0 +1,24 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreType;
+
+@JsonIgnoreType
+public class IgnoredType {
+
+    private String secret;
+
+    public IgnoredType() {
+    }
+
+    public IgnoredType(String secret) {
+        this.secret = secret;
+    }
+
+    public String getSecret() {
+        return secret;
+    }
+
+    public void setSecret(String secret) {
+        this.secret = secret;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/IncludeBean.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/IncludeBean.java
@@ -1,0 +1,37 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class IncludeBean {
+
+    private String name;
+    private String nullableField;
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private String emptyField;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getNullableField() {
+        return nullableField;
+    }
+
+    public void setNullableField(String nullableField) {
+        this.nullableField = nullableField;
+    }
+
+    public String getEmptyField() {
+        return emptyField;
+    }
+
+    public void setEmptyField(String emptyField) {
+        this.emptyField = emptyField;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/ManagedReferenceChild.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/ManagedReferenceChild.java
@@ -1,0 +1,27 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+
+public class ManagedReferenceChild {
+
+    private String childName;
+
+    @JsonBackReference
+    private ManagedReferenceParent parent;
+
+    public String getChildName() {
+        return childName;
+    }
+
+    public void setChildName(String childName) {
+        this.childName = childName;
+    }
+
+    public ManagedReferenceParent getParent() {
+        return parent;
+    }
+
+    public void setParent(ManagedReferenceParent parent) {
+        this.parent = parent;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/ManagedReferenceParent.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/ManagedReferenceParent.java
@@ -1,0 +1,27 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+
+public class ManagedReferenceParent {
+
+    private String parentName;
+
+    @JsonManagedReference
+    private ManagedReferenceChild child;
+
+    public String getParentName() {
+        return parentName;
+    }
+
+    public void setParentName(String parentName) {
+        this.parentName = parentName;
+    }
+
+    public ManagedReferenceChild getChild() {
+        return child;
+    }
+
+    public void setChild(ManagedReferenceChild child) {
+        this.child = child;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/MultiAnnotationRecord.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/MultiAnnotationRecord.java
@@ -1,0 +1,13 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record MultiAnnotationRecord(
+        @JsonProperty("title") String name,
+        @JsonAlias( {
+                "desc", "description" }) String summary,
+        @JsonProperty("is_active") boolean active){
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/NamingAliasRecord.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/NamingAliasRecord.java
@@ -1,0 +1,12 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record NamingAliasRecord(
+        String firstName,
+        @JsonAlias( {
+                "surname", "familyName" }) String lastName){
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/NamingViewBean.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/NamingViewBean.java
@@ -1,0 +1,43 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class NamingViewBean {
+
+    @JsonView(GeneratedViews.Public.class)
+    private String firstName;
+
+    @JsonView(GeneratedViews.Private.class)
+    private String lastName;
+
+    @JsonProperty("e_mail")
+    private String email;
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/NamingWithOverrideBean.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/NamingWithOverrideBean.java
@@ -1,0 +1,52 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class NamingWithOverrideBean {
+
+    private String firstName;
+
+    private String lastName;
+
+    @JsonProperty("email")
+    private String emailAddress;
+
+    @JsonIgnore
+    private String internalId;
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getEmailAddress() {
+        return emailAddress;
+    }
+
+    public void setEmailAddress(String emailAddress) {
+        this.emailAddress = emailAddress;
+    }
+
+    public String getInternalId() {
+        return internalId;
+    }
+
+    public void setInternalId(String internalId) {
+        this.internalId = internalId;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/PolymorphicWithPropertyBase.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/PolymorphicWithPropertyBase.java
@@ -1,0 +1,25 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = PolymorphicWithPropertyBase.TextItem.class),
+        @JsonSubTypes.Type(value = PolymorphicWithPropertyBase.NumberItem.class)
+})
+public sealed interface PolymorphicWithPropertyBase {
+
+    @JsonTypeName("text")
+    record TextItem(
+            @JsonProperty("text_value") String value,
+            @JsonProperty("format") String format) implements PolymorphicWithPropertyBase {
+    }
+
+    @JsonTypeName("number")
+    record NumberItem(
+            @JsonProperty("num_value") int value) implements PolymorphicWithPropertyBase {
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/PropertyIgnoreBean.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/PropertyIgnoreBean.java
@@ -1,0 +1,40 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class PropertyIgnoreBean {
+
+    @JsonProperty("display_name")
+    private String name;
+
+    @JsonIgnore
+    private String secret;
+
+    @JsonProperty("years_old")
+    private int age;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSecret() {
+        return secret;
+    }
+
+    public void setSecret(String secret) {
+        this.secret = secret;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/PropertyOrderBean.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/PropertyOrderBean.java
@@ -1,0 +1,35 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonPropertyOrder({ "zebra", "alpha", "middle" })
+public class PropertyOrderBean {
+
+    private String alpha;
+    private String middle;
+    private String zebra;
+
+    public String getAlpha() {
+        return alpha;
+    }
+
+    public void setAlpha(String alpha) {
+        this.alpha = alpha;
+    }
+
+    public String getMiddle() {
+        return middle;
+    }
+
+    public void setMiddle(String middle) {
+        this.middle = middle;
+    }
+
+    public String getZebra() {
+        return zebra;
+    }
+
+    public void setZebra(String zebra) {
+        this.zebra = zebra;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/PropertyViewRecord.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/PropertyViewRecord.java
@@ -1,0 +1,10 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonView;
+
+public record PropertyViewRecord(
+        @JsonView(GeneratedViews.Public.class) @JsonProperty("display_name") String name,
+        @JsonView(GeneratedViews.Private.class) @JsonProperty("secret_code") String code,
+        @JsonProperty("category") String category) {
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/RawValueBean.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/RawValueBean.java
@@ -1,0 +1,27 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import com.fasterxml.jackson.annotation.JsonRawValue;
+
+public class RawValueBean {
+
+    private String name;
+
+    @JsonRawValue
+    private String rawJson;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getRawJson() {
+        return rawJson;
+    }
+
+    public void setRawJson(String rawJson) {
+        this.rawJson = rawJson;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/UnsupportedAnnotationResource.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/UnsupportedAnnotationResource.java
@@ -1,0 +1,160 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+
+import io.smallrye.common.annotation.NonBlocking;
+
+@Path("/unsupported")
+@NonBlocking
+public class UnsupportedAnnotationResource {
+
+    @ServerExceptionMapper
+    public Response handleParseException(WebApplicationException e) {
+        var cause = e.getCause() == null ? e : e.getCause();
+        return Response.status(Response.Status.BAD_REQUEST).entity(cause.getMessage()).build();
+    }
+
+    // --- @JsonAnyGetter + @JsonAnySetter ---
+
+    @GET
+    @Path("/any-getter")
+    public AnyGetterBean getAnyGetter() {
+        AnyGetterBean bean = new AnyGetterBean();
+        bean.setName("test");
+        bean.addProperty("color", "red");
+        bean.addProperty("size", "large");
+        return bean;
+    }
+
+    @POST
+    @Path("/any-getter")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public String echoAnyGetter(AnyGetterBean bean) {
+        return "{\"name\":\"" + bean.getName()
+                + "\",\"props_size\":" + bean.getProperties().size() + "}";
+    }
+
+    // --- @JsonAutoDetect ---
+
+    @GET
+    @Path("/auto-detect")
+    public AutoDetectBean getAutoDetect() {
+        return new AutoDetectBean("hello", 42);
+    }
+
+    // --- @JsonManagedReference + @JsonBackReference ---
+
+    @GET
+    @Path("/managed-reference")
+    public ManagedReferenceParent getManagedReference() {
+        ManagedReferenceParent parent = new ManagedReferenceParent();
+        parent.setParentName("parent");
+        ManagedReferenceChild child = new ManagedReferenceChild();
+        child.setChildName("child");
+        child.setParent(parent);
+        parent.setChild(child);
+        return parent;
+    }
+
+    // --- @JsonFormat ---
+
+    @GET
+    @Path("/format")
+    public FormatBean getFormat() {
+        FormatBean bean = new FormatBean();
+        bean.setName("shape-test");
+        bean.setShape(FormatShape.SQUARE);
+        return bean;
+    }
+
+    @POST
+    @Path("/format")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public FormatBean echoFormat(FormatBean bean) {
+        return bean;
+    }
+
+    // --- @JsonGetter + @JsonSetter ---
+
+    @GET
+    @Path("/getter-setter")
+    public GetterSetterBean getGetterSetter() {
+        GetterSetterBean bean = new GetterSetterBean();
+        bean.setName("test");
+        bean.setCount(5);
+        return bean;
+    }
+
+    @POST
+    @Path("/getter-setter")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public GetterSetterBean echoGetterSetter(GetterSetterBean bean) {
+        return bean;
+    }
+
+    // --- @JsonIgnoreType ---
+
+    @GET
+    @Path("/ignore-type")
+    public IgnoreTypeBean getIgnoreType() {
+        IgnoreTypeBean bean = new IgnoreTypeBean();
+        bean.setName("visible");
+        bean.setMetadata(new IgnoredType("secret-data"));
+        return bean;
+    }
+
+    // --- @JsonInclude ---
+
+    @GET
+    @Path("/include-all-set")
+    public IncludeBean getIncludeAllSet() {
+        IncludeBean bean = new IncludeBean();
+        bean.setName("test");
+        bean.setNullableField("present");
+        bean.setEmptyField("not-empty");
+        return bean;
+    }
+
+    @GET
+    @Path("/include-nulls")
+    public IncludeBean getIncludeNulls() {
+        IncludeBean bean = new IncludeBean();
+        bean.setName("test");
+        bean.setNullableField(null);
+        bean.setEmptyField("");
+        return bean;
+    }
+
+    // --- @JsonPropertyOrder ---
+
+    @GET
+    @Path("/property-order")
+    public PropertyOrderBean getPropertyOrder() {
+        PropertyOrderBean bean = new PropertyOrderBean();
+        bean.setAlpha("a");
+        bean.setMiddle("m");
+        bean.setZebra("z");
+        return bean;
+    }
+
+    // --- @JsonRawValue ---
+
+    @GET
+    @Path("/raw-value")
+    public RawValueBean getRawValue() {
+        RawValueBean bean = new RawValueBean();
+        bean.setName("test");
+        bean.setRawJson("{\"nested\":\"value\",\"count\":1}");
+        return bean;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/UnsupportedAnnotationTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/UnsupportedAnnotationTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import java.util.function.Supplier;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class UnsupportedAnnotationTest extends AbstractUnsupportedAnnotationTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(UnsupportedAnnotationResource.class,
+                                    AnyGetterBean.class,
+                                    AutoDetectBean.class,
+                                    ManagedReferenceParent.class,
+                                    ManagedReferenceChild.class,
+                                    FormatShape.class,
+                                    FormatBean.class,
+                                    GetterSetterBean.class,
+                                    IgnoredType.class,
+                                    IgnoreTypeBean.class,
+                                    IncludeBean.class,
+                                    PropertyOrderBean.class,
+                                    RawValueBean.class)
+                            .addAsResource(new StringAsset(
+                                    "quarkus.rest.jackson.optimization.enable-reflection-free-serializers=false\n"),
+                                    "application.properties");
+                }
+            });
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/UnsupportedAnnotationWithReflectionFreeSerializersTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/UnsupportedAnnotationWithReflectionFreeSerializersTest.java
@@ -1,0 +1,44 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.function.Supplier;
+import java.util.logging.Level;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class UnsupportedAnnotationWithReflectionFreeSerializersTest extends AbstractUnsupportedAnnotationTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(UnsupportedAnnotationResource.class,
+                                    AnyGetterBean.class,
+                                    AutoDetectBean.class,
+                                    ManagedReferenceParent.class,
+                                    ManagedReferenceChild.class,
+                                    FormatShape.class,
+                                    FormatBean.class,
+                                    GetterSetterBean.class,
+                                    IgnoredType.class,
+                                    IgnoreTypeBean.class,
+                                    IncludeBean.class,
+                                    PropertyOrderBean.class,
+                                    RawValueBean.class)
+                            .addAsResource(new StringAsset(
+                                    "quarkus.rest.jackson.optimization.enable-reflection-free-serializers=true\n"),
+                                    "application.properties");
+                }
+            }).setLogRecordPredicate(record -> record.getLevel().equals(Level.INFO)
+                    && record.getLoggerName().equals(
+                            "io.quarkus.resteasy.reactive.jackson.deployment.processor.JacksonCodeGenerator"))
+            .assertLogRecords(records -> assertThat(records).isNotEmpty());
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/UnwrappedWithRenameBean.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/UnwrappedWithRenameBean.java
@@ -1,0 +1,65 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+
+public class UnwrappedWithRenameBean {
+
+    @JsonProperty("label")
+    private String name;
+
+    @JsonUnwrapped
+    private InnerAddress address;
+
+    @JsonIgnore
+    private String hidden;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public InnerAddress getAddress() {
+        return address;
+    }
+
+    public void setAddress(InnerAddress address) {
+        this.address = address;
+    }
+
+    public String getHidden() {
+        return hidden;
+    }
+
+    public void setHidden(String hidden) {
+        this.hidden = hidden;
+    }
+
+    public static class InnerAddress {
+
+        private String city;
+
+        @JsonProperty("zip_code")
+        private String zipCode;
+
+        public String getCity() {
+            return city;
+        }
+
+        public void setCity(String city) {
+            this.city = city;
+        }
+
+        public String getZipCode() {
+            return zipCode;
+        }
+
+        public void setZipCode(String zipCode) {
+            this.zipCode = zipCode;
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/ValueCreatorWrapper.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/ValueCreatorWrapper.java
@@ -1,0 +1,19 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public class ValueCreatorWrapper {
+
+    private final String data;
+
+    @JsonCreator
+    public ValueCreatorWrapper(String data) {
+        this.data = data;
+    }
+
+    @JsonValue
+    public String getData() {
+        return data;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/ViewIgnoreBean.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/ViewIgnoreBean.java
@@ -1,0 +1,40 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonView;
+
+public class ViewIgnoreBean {
+
+    @JsonView(GeneratedViews.Public.class)
+    private String publicField;
+
+    @JsonView(GeneratedViews.Private.class)
+    private int privateField;
+
+    @JsonIgnore
+    private String ignoredField;
+
+    public String getPublicField() {
+        return publicField;
+    }
+
+    public void setPublicField(String publicField) {
+        this.publicField = publicField;
+    }
+
+    public int getPrivateField() {
+        return privateField;
+    }
+
+    public void setPrivateField(int privateField) {
+        this.privateField = privateField;
+    }
+
+    public String getIgnoredField() {
+        return ignoredField;
+    }
+
+    public void setIgnoredField(String ignoredField) {
+        this.ignoredField = ignoredField;
+    }
+}


### PR DESCRIPTION
This covers both supported and unsupported Jackson annotations in the generated reflection-free serializers. Not supported annotations correctly fallback to standard reflection-based Jackson serialization mechanism. Once this will be merged I will try to add support in the generated serializers for as many annotations as possible in the generated serializers with subsequent pull requests.

