### PR TITLE
Set network timeout on connection validation queries

### DIFF
--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
@@ -1,5 +1,6 @@
 package io.quarkus.agroal.runtime;
 
+import java.sql.Connection;
 import java.sql.Driver;
 import java.time.Duration;
 import java.util.Collection;
@@ -7,6 +8,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
+import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 
 import jakarta.enterprise.inject.Any;
@@ -353,8 +355,11 @@ public class DataSources {
         }
         if (dataSourceJdbcRuntimeConfig.validationQuerySql().isPresent()) {
             String validationQuery = dataSourceJdbcRuntimeConfig.validationQuerySql().get();
-            int timeout = (int) dataSourceJdbcRuntimeConfig.validationQueryTimeout().orElse(Duration.ZERO).toSeconds();
-            poolConfiguration.connectionValidator(ConnectionValidator.sqlValidator(validationQuery, timeout));
+            Duration timeout = dataSourceJdbcRuntimeConfig.validationQueryTimeout().orElse(Duration.ZERO);
+            // Network timeout must exceed query timeout so the JDBC driver can handle the query timeout gracefully
+            // before the network layer forcibly closes the connection
+            poolConfiguration.connectionValidator(sqlValidator(validationQuery, timeout,
+                    timeout.isZero() ? null : timeout.plusSeconds(5L)));
         }
         poolConfiguration.validateOnBorrow(dataSourceJdbcRuntimeConfig.validateOnBorrow());
         poolConfiguration.reapTimeout(dataSourceJdbcRuntimeConfig.idleRemovalInterval());
@@ -371,6 +376,47 @@ public class DataSources {
         poolConfiguration.enhancedLeakReport(dataSourceJdbcRuntimeConfig.extendedLeakReport());
         poolConfiguration.flushOnClose(dataSourceJdbcRuntimeConfig.flushOnClose());
         poolConfiguration.recoveryEnable(dataSourceJdbcRuntimeConfig.enableRecovery());
+    }
+
+    /**
+     * A validator that uses the provided SQL statement for validation with a query timeout and a configurable network timeout.
+     * If the timeout period expires before the operation completes, the connection is invalidated.
+     * A timeout of zero means no timeout.
+     * The network timeout should be greater than the query timeout to allow the query timeout to cancel the statement
+     * cleanly before the network timeout forces the socket closed.
+     */
+    static ConnectionValidator sqlValidator(String sql, Duration queryTimeout, Duration networkTimeout) {
+        return new ConnectionValidator() {
+            @Override
+            public boolean isValid(Connection connection) {
+                Executor executor = Runnable::run;
+                int originalNetworkTimeout = 0;
+                if (networkTimeout != null) {
+                    try {
+                        originalNetworkTimeout = connection.getNetworkTimeout();
+                        connection.setNetworkTimeout(executor, (int) networkTimeout.toMillis());
+                    } catch (Exception e) {
+                        log.debug("Driver does not support network timeout", e);
+                    }
+                }
+                try (var statement = connection.createStatement()) {
+                    statement.setQueryTimeout((int) queryTimeout.toSeconds());
+                    statement.execute(sql);
+                    return true;
+                } catch (Exception e) {
+                    log.debugv(e, "Failed to execute validation query: {0}", sql);
+                    return false;
+                } finally {
+                    if (networkTimeout != null) {
+                        try {
+                            connection.setNetworkTimeout(executor, originalNetworkTimeout);
+                        } catch (Exception ignore) {
+                            // already logged above
+                        }
+                    }
+                }
+            }
+        };
     }
 
     /**


### PR DESCRIPTION
The existing validation relied solely on Statement.setQueryTimeout(), which sends a cooperative cancellation signal to the server. If the connection is stuck at the network level, that signal never reaches the server and validation hangs indefinitely.

Add `Connection.setNetworkTimeout()` as a hard backstop at the socket level so validation always returns within the configured timeout.

- Fixes #49976