### PR TITLE
Bump postgresql-jdbc.version to 42.7.11

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -118,7 +118,7 @@
         <quartz.version>2.5.2</quartz.version>
         <h2.version>2.4.240</h2.version> <!-- When updating, needs to be matched in io.quarkus.hibernate.orm.runtime.config.DialectVersions
                                               and the dependency jts-core needs to be updated in extensions/jdbc/jdbc-h2/runtime/pom.xml -->
-        <postgresql-jdbc.version>42.7.10</postgresql-jdbc.version>
+        <postgresql-jdbc.version>42.7.11</postgresql-jdbc.version>
         <mariadb-jdbc.version>3.5.7</mariadb-jdbc.version>
         <mysql-jdbc.version>9.6.0</mysql-jdbc.version>
         <mssql-jdbc.version>13.2.1.jre11</mssql-jdbc.version>


### PR DESCRIPTION
Updated PostgreSQL JDBC version from 42.7.10 to 42.7.11 to fix [CVE-2026-42198](https://nvd.nist.gov/vuln/detail/CVE-2026-42198)


