### PR TITLE
Manage self-reference recursion in generated reflection-free Jackson serializers

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
@@ -307,7 +307,9 @@ public abstract class JacksonCodeGenerator {
 
     private MethodInfo getterMethodInfo(ClassInfo classInfo, FieldInfo fieldInfo) {
         MethodInfo namedAccessor = findMethod(classInfo, fieldInfo.name());
-        if (namedAccessor != null) {
+        if (namedAccessor != null
+                && (classInfo.isRecord() || namedAccessor.hasAnnotation(JsonProperty.class)
+                        || fieldInfo.hasAnnotation(JsonProperty.class))) {
             return namedAccessor;
         }
         String methodName = (fieldInfo.type().name().toString().equals("boolean") ? "is" : "get") + ucFirst(fieldInfo.name());

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
@@ -416,8 +416,9 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
             } else {
                 MethodDescriptor serializePojoMethod = MethodDescriptor.ofMethod(JacksonMapperUtil.class.getName(),
                         "serializePojo",
-                        void.class, Object.class, JsonGenerator.class, SerializerProvider.class);
-                bytecode.invokeStaticMethod(serializePojoMethod, arg, ctx.jsonGenerator, ctx.serializerProvider);
+                        void.class, Object.class, Object.class, JsonGenerator.class, SerializerProvider.class);
+                bytecode.invokeStaticMethod(serializePojoMethod, arg, ctx.valueHandle, ctx.jsonGenerator,
+                        ctx.serializerProvider);
             }
         }
     }

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/AbstractSimpleJsonTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/AbstractSimpleJsonTest.java
@@ -1279,4 +1279,15 @@ public abstract class AbstractSimpleJsonTest {
                 .body("item.type", CoreMatchers.is("type_a"))
                 .body("item.value", CoreMatchers.is("hello"));
     }
+
+    @Test
+    void sensor_metadata_shouldDeserialize() {
+        given()
+                .when()
+                .get("/simple/sensor-metadata")
+                .then()
+                .statusCode(200)
+                .body("metadata.CPU.description", CoreMatchers.is("CPU Power"))
+                .body("documentation", CoreMatchers.is("macOS powermetrics derived information"));
+    }
 }

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SensorMetadata.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SensorMetadata.java
@@ -1,0 +1,220 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * The metadata associated with a power-consumption recording sensor. This allows to make sense of the data sent by the power
+ * server by providing information about each component (e.g. CPU) recorded by the sensor during each periodical measure.
+ */
+public class SensorMetadata {
+    @JsonProperty("metadata")
+    private final Map<String, ComponentMetadata> components;
+    @JsonProperty("documentation")
+    private final String documentation;
+
+    /**
+     * Initializes sensor metadata information
+     *
+     * @param components a map describing the metadata for each component
+     * @param documentation a text providing any relevant information associated with the described sensor
+     * @throws IllegalArgumentException if indices specified in {@code totalComponents} do not represent power measures
+     *         expressible in Watts or are not a valid index
+     */
+    public SensorMetadata(List<ComponentMetadata> components, String documentation) {
+        Objects.requireNonNull(components, "Must provide components");
+        if (components.isEmpty()) {
+            throw new IllegalArgumentException("Must provide at least one component");
+        }
+
+        final var cardinality = components.size();
+        this.components = new LinkedHashMap<>(cardinality);
+        this.documentation = documentation;
+        final var indices = new BitSet(cardinality);
+        components.stream().sorted(Comparator.comparingInt(ComponentMetadata::index)).forEach(component -> {
+            // check that index is valid
+            final var index = component.index;
+            // record index as known
+            indices.set(index);
+            this.components.put(component.name, component);
+        });
+    }
+
+    @JsonCreator
+    SensorMetadata(@JsonProperty("metadata") Map<String, ComponentMetadata> components,
+            @JsonProperty("documentation") String documentation) {
+        this.components = components;
+        this.documentation = documentation;
+    }
+
+    public static Builder withNewComponent(String name, String description, boolean isAttributed,
+            String unitSymbol) {
+        return new Builder().withNewComponent(name, description, isAttributed, unitSymbol);
+    }
+
+    public static Builder withNewComponent(String name, String description, boolean isAttributed,
+            SensorUnit unit) {
+        return new Builder().withNewComponent(name, description, isAttributed, unit);
+    }
+
+    public static Builder from(SensorMetadata sensorMetadata) {
+        final var builder = new Builder();
+        sensorMetadata.components.values().stream().sorted(Comparator.comparing(ComponentMetadata::index))
+                .forEach(component -> builder.withNewComponent(component.name, component.description, component.isAttributed,
+                        component.unit));
+        return builder;
+    }
+
+    @Override
+    public String toString() {
+        final var sb = new StringBuilder();
+        components.values().stream().sorted(Comparator.comparing(ComponentMetadata::index))
+                .forEach(cm -> sb.append("- ").append(cm).append("\n"));
+        return "components:\n"
+                + sb
+                + (documentation != null ? "documentation: " + documentation : "");
+    }
+
+    /**
+     * Determines whether a component with the specified name is known for this sensor
+     *
+     * @param component the name of the component
+     * @return {@code true} if a component with the specified name exists for the associated sensor, {@code false} otherwise
+     */
+    public boolean exists(String component) {
+        return components.containsKey(component);
+    }
+
+    /**
+     * Retrieves the {@link ComponentMetadata} associated with the specified component name if it exists
+     *
+     * @param component the name of the component which metadata is to be retrieved
+     * @return the {@link ComponentMetadata} associated with the specified name
+     * @throws IllegalArgumentException if no component with the specified name is known for the associated sensor
+     */
+    public ComponentMetadata metadataFor(String component) throws IllegalArgumentException {
+        final var componentMetadata = components.get(component);
+        if (componentMetadata == null) {
+            throw new IllegalArgumentException("Unknown component: " + component);
+        }
+        return componentMetadata;
+    }
+
+    /**
+     * Retrieves the number of known components for the associated sensor
+     *
+     * @return the cardinality of known components
+     */
+    public int componentCardinality() {
+        return components.size();
+    }
+
+    /**
+     * Retrieves the known {@link ComponentMetadata} for the associated sensor as an unmodifiable Map keyed by the components'
+     * name
+     *
+     * @return an unmodifiable Map of the known {@link ComponentMetadata}
+     */
+    public Map<String, ComponentMetadata> components() {
+        return components;
+    }
+
+    /**
+     * Retrieves the documentation, if any, associated with this SensorMetadata
+     *
+     * @return the documentation relevant for the associated sensor
+     */
+    public String documentation() {
+        return documentation;
+    }
+
+    /**
+     * Retrieves the metadata associated with the specified component index if it exists.
+     *
+     * @param componentIndex the index of the component we want to retrieve the metadata for
+     * @return the {@link ComponentMetadata} associated with the specified index if it exists
+     * @throws IllegalArgumentException if no component is associated with the specified index
+     */
+    public ComponentMetadata metadataFor(int componentIndex) {
+        return components.values().stream()
+                .filter(cm -> componentIndex == cm.index)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("No component was found for index " + componentIndex));
+    }
+
+    @SuppressWarnings("unused")
+    public static class Builder {
+        private final List<ComponentMetadata> components = new ArrayList<>();
+        private int currentIndex = 0;
+        private String documentation;
+
+        public Builder withNewComponent(String name, String description, boolean isAttributed, String unitSymbol) {
+            components
+                    .add(new ComponentMetadata(name, currentIndex++, description, isAttributed, unitSymbol));
+            return this;
+        }
+
+        public Builder withNewComponent(String name, String description, boolean isAttributed, SensorUnit unit) {
+            components.add(new ComponentMetadata(name, currentIndex++, description, isAttributed, unit));
+            return this;
+        }
+
+        public Builder withDocumentation(String documentation) {
+            this.documentation = documentation;
+            return this;
+        }
+
+        public SensorMetadata build() {
+            return new SensorMetadata(components, documentation);
+        }
+
+        public Builder withNewComponent(ComponentMetadata metadata) {
+            if (-1 == metadata.index) {
+                metadata = new ComponentMetadata(metadata.name, currentIndex++, metadata.description,
+                        metadata.isAttributed, metadata.unit);
+            }
+            components.add(metadata);
+            return this;
+        }
+    }
+
+    public record ComponentMetadata(String name, int index, String description, boolean isAttributed, SensorUnit unit) {
+
+        public ComponentMetadata {
+            if (name == null) {
+                throw new IllegalArgumentException("Component name cannot be null");
+            }
+            if (unit == null) {
+                throw new IllegalArgumentException("Component unit cannot be null");
+            }
+        }
+
+        /**
+         * Creates a ComponentMetadata that will be automatically assigned an index whenever added to a {@link SensorMetadata},
+         * based on the contextual order of how other components have been added.
+         */
+        public ComponentMetadata(String name, String description, boolean isAttributed, SensorUnit unit) {
+            this(name, -1, description, isAttributed, unit);
+        }
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        public ComponentMetadata(@JsonProperty("name") String name, @JsonProperty("index") int index,
+                @JsonProperty("description") String description,
+                @JsonProperty("isAttributed") boolean isAttributed, @JsonProperty("unit") String unitSymbol) {
+            this(name, index, description, isAttributed, SensorUnit.of(unitSymbol));
+        }
+
+        @JsonProperty("unit")
+        public String unitAsSymbol() {
+            return unit.symbol();
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SensorUnit.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SensorUnit.java
@@ -1,0 +1,132 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class SensorUnit {
+
+    /**
+     * Note that for simplicity's sake, we're not supporting deca prefix since it would make the prefix identification logic
+     * more complex and it's not a very used prefix. Might revisit as needed.
+     */
+    private final static Map<String, Double> prefixesToFactors = Map.of(
+            "n", 1e-9,
+            "µ", 1e-6,
+            "m", 1e-3,
+            "c", 1e-2,
+            "d", 1e-1,
+            "h", 100.0,
+            "k", 1e3,
+            "M", 1e6,
+            "G", 1e9);
+    private final static Map<String, SensorUnit> baseUnits = new HashMap<>();
+    public static final SensorUnit W = baseUnitFor("W");
+    public static final SensorUnit J = baseUnitFor("J");
+    public static final SensorUnit decimalPercentage = baseUnitFor("decimal percentage");
+    private final static Map<String, SensorUnit> knownUnits = new HashMap<>();
+    public static final SensorUnit mW = SensorUnit.of("mW");
+    public static final SensorUnit µJ = SensorUnit.of("µJ");
+    private final String symbol;
+    private final SensorUnit base;
+    private final double factor;
+
+    public SensorUnit(String symbol, SensorUnit base, double factor) {
+        this.symbol = Objects.requireNonNull(symbol).trim();
+        this.base = base != null ? base : this;
+        this.factor = factor < 0 ? 1 : factor;
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static SensorUnit of(String symbol) {
+        symbol = Objects.requireNonNull(symbol, "Unit symbol cannot be null").trim();
+        if (symbol.isBlank()) {
+            throw new IllegalArgumentException("Unit symbol cannot be blank");
+        }
+
+        var unit = baseUnits.get(symbol);
+        if (unit != null) {
+            return unit;
+        }
+
+        unit = knownUnits.get(symbol);
+        if (unit != null) {
+            return unit;
+        }
+
+        if (symbol.length() == 1) {
+            // assume base unit
+            return baseUnitFor(symbol);
+        }
+
+        final var prefix = symbol.substring(0, 1);
+        final var base = symbol.substring(1);
+        var baseUnit = baseUnits.get(base);
+        if (baseUnit == null) {
+            baseUnit = baseUnitFor(base);
+        }
+        final var factor = prefixesToFactors.get(prefix);
+        if (factor == null) {
+            throw new IllegalArgumentException(
+                    "Unknown unit prefix '" + prefix + "', known prefixes: " + prefixesToFactors.entrySet().stream()
+                            .sorted(Comparator.comparingDouble(Map.Entry::getValue)).map(Map.Entry::getKey).toList());
+        }
+
+        unit = new SensorUnit(symbol, baseUnit, factor);
+        knownUnits.put(symbol, unit);
+        return unit;
+    }
+
+    private static SensorUnit baseUnitFor(String symbol) {
+        return baseUnits.computeIfAbsent(symbol, s -> new SensorUnit(symbol, null, 1.0));
+    }
+
+    public boolean isCommensurableWith(SensorUnit other) {
+        return other != null && base.equals(other.base);
+    }
+
+    public double conversionFactorTo(SensorUnit other) {
+        if (other.isCommensurableWith(this)) {
+            return factor / other.factor;
+        } else {
+            throw new IllegalArgumentException("Cannot convert " + this + " to " + other);
+        }
+    }
+
+    @JsonProperty("symbol")
+    public String symbol() {
+        return symbol;
+    }
+
+    public SensorUnit base() {
+        return base;
+    }
+
+    public double factor() {
+        return factor;
+    }
+
+    @Override
+    public String toString() {
+        return symbol;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        SensorUnit that = (SensorUnit) o;
+        return Objects.equals(symbol, that.symbol);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(symbol);
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
@@ -742,4 +742,13 @@ public class SimpleJsonResource extends SuperClass<Person> {
     public PolymorphicItemResponse polymorphicItemSer() {
         return new PolymorphicItemResponse(new PolymorphicItem.TypeA("hello"));
     }
+
+    @GET
+    @Path("/sensor-metadata")
+    public SensorMetadata sensorMetadata() {
+        return new SensorMetadata(
+                List.of(
+                        new SensorMetadata.ComponentMetadata("CPU", 0, "CPU Power", true, SensorUnit.mW)),
+                "macOS powermetrics derived information");
+    }
 }

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
@@ -33,7 +33,8 @@ public class SimpleJsonTest extends AbstractSimpleJsonTest {
                                     JsonAliasRecord.class, AnnotationNamingRequest.class, Pair.class, Score.class,
                                     ProductPrice.class, DefaultValueHolder.class, OptionalHolder.class, AnySetterRequest.class,
                                     UnwrappedResult.class, UnwrappedResultsResponse.class, Detail.class, ErrorInfo.class,
-                                    PolymorphicItemResponse.class, PolymorphicItem.class)
+                                    PolymorphicItemResponse.class, PolymorphicItem.class,
+                                    SensorMetadata.class, SensorMetadata.ComponentMetadata.class, SensorUnit.class)
                             .addAsResource(new StringAsset("admin-expression=admin\n" +
                                     "user-expression=user\n" +
                                     "birth-date-roles=alice,bob\n" +

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonWithReflectionFreeSerializersTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonWithReflectionFreeSerializersTest.java
@@ -36,7 +36,8 @@ public class SimpleJsonWithReflectionFreeSerializersTest extends AbstractSimpleJ
                                     JsonAliasRecord.class, AnnotationNamingRequest.class, Pair.class, Score.class,
                                     ProductPrice.class, DefaultValueHolder.class, OptionalHolder.class, AnySetterRequest.class,
                                     UnwrappedResult.class, UnwrappedResultsResponse.class, Detail.class, ErrorInfo.class,
-                                    PolymorphicItemResponse.class, PolymorphicItem.class)
+                                    PolymorphicItemResponse.class, PolymorphicItem.class,
+                                    SensorMetadata.class, SensorMetadata.ComponentMetadata.class, SensorUnit.class)
                             .addAsResource(new StringAsset("admin-expression=admin\n" +
                                     "user-expression=user\n" +
                                     "birth-date-roles=alice,bob\n" +

--- a/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/mappers/JacksonMapperUtil.java
+++ b/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/mappers/JacksonMapperUtil.java
@@ -14,9 +14,11 @@ import com.fasterxml.jackson.core.SerializableString;
 import com.fasterxml.jackson.databind.BeanProperty;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.util.NameTransformer;
 
@@ -170,8 +172,16 @@ public class JacksonMapperUtil {
 
     public static void serializePojo(Object value, JsonGenerator generator, SerializerProvider serializerProvider)
             throws IOException {
+        serializePojo(value, null, generator, serializerProvider);
+    }
+
+    public static void serializePojo(Object value, Object bean, JsonGenerator generator,
+            SerializerProvider serializerProvider) throws IOException {
         if (value == null || value instanceof Map) {
             generator.writePOJO(value);
+            return;
+        }
+        if (value == bean && handleSelfReference(bean, generator, serializerProvider)) {
             return;
         }
         JsonSerializer<Object> serializer = serializerProvider.findTypedValueSerializer(value.getClass(), true, null);
@@ -180,6 +190,19 @@ public class JacksonMapperUtil {
         } else {
             generator.writePOJO(value);
         }
+    }
+
+    private static boolean handleSelfReference(Object bean, JsonGenerator generator,
+            SerializerProvider serializerProvider) throws IOException {
+        if (!serializerProvider.isEnabled(SerializationFeature.FAIL_ON_SELF_REFERENCES)) {
+            return false;
+        }
+        if (serializerProvider.isEnabled(SerializationFeature.WRITE_SELF_REFERENCES_AS_NULL)) {
+            generator.writeNull();
+            return true;
+        }
+        throw JsonMappingException.from(generator,
+                "Direct self-reference leading to cycle (through reference chain: " + bean.getClass().getName() + ")");
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
This fix mimic exactly the Jackson behavior when using its standard reflection based serializers. In particular Jackson detects direct self-references performs a simple identity check `(value == bean)`. If `FAIL_ON_SELF_REFERENCES` is enabled (the default), it throws `JsonMappingException`.

Indirect cycles (A → B → A → B...) are not detected at all. Jackson has no call-stack or object-graph tracking during serialization. The result is a `StackOverflowError`, or in Jackson 2.15.2+, a nesting depth limit violation (`StreamWriteConstraints.maxNestingDepth`, default 1000) which throws a cleaner exception before the stack actually overflows.
                                                                                                                                                                                                                                    
To handle indirect cycles, Jackson requires explicit annotations:                                                                                                                                                                 
  - `@JsonIdentityInfo` -> serializes the first occurrence fully, subsequent occurrences as an ID reference
  - `@JsonManagedReference` / `@JsonBackReference` -> one side serializes normally, the other is omitted                                                                                                                                 
  - `@JsonIgnore` -> breaks the cycle by excluding the field entirely

This pull request also provides a second alignment with Jackson behavior: in fact the property discovery mechanism now only uses bare-name accessor methods (e.g. base() for field base) when the class is a record, or when either the method or field has `@JsonProperty`. For regular classes without these annotations, only standard getXxx()/isXxx() getters are recognized, matching Jackson's default behavior. In the provided test case, this prevents `SensorUnit.base` and `SensorUnit.factor` from being serialized, which was the root cause of the infinite recursion.

- Fixes: #53848
