### PR TITLE
Turn OIDC TokenVerificationResult to record

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BackChannelLogoutHandler.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BackChannelLogoutHandler.java
@@ -173,7 +173,7 @@ public final class BackChannelLogoutHandler implements Handler<RoutingContext> {
                                                 .verifyLogoutJwtToken(encodedLogoutToken);
 
                                         if (verifyLogoutTokenClaims(result)) {
-                                            String key = result.localVerificationResult
+                                            String key = result.localVerificationResult()
                                                     .getString(
                                                             tenantContext.oidcConfig().logout().backchannel().logoutTokenKey());
                                             BackChannelLogoutTokenCache tokens = resolver.getBackChannelLogoutTokens()
@@ -215,18 +215,18 @@ public final class BackChannelLogoutHandler implements Handler<RoutingContext> {
 
         private boolean verifyLogoutTokenClaims(TokenVerificationResult result) {
             // events
-            JsonObject events = result.localVerificationResult.getJsonObject(OidcConstants.BACK_CHANNEL_EVENTS_CLAIM);
+            JsonObject events = result.localVerificationResult().getJsonObject(OidcConstants.BACK_CHANNEL_EVENTS_CLAIM);
             if (events == null || events.getJsonObject(OidcConstants.BACK_CHANNEL_EVENT_NAME) == null) {
                 LOG.debug("Back channel logout token does not have a valid 'events' claim");
                 return false;
             }
-            if (!result.localVerificationResult
+            if (!result.localVerificationResult()
                     .containsKey(tenantContext.oidcConfig().logout().backchannel().logoutTokenKey())) {
                 LOG.debugf("Back channel logout token does not have %s",
                         tenantContext.oidcConfig().logout().backchannel().logoutTokenKey());
                 return false;
             }
-            if (result.localVerificationResult.containsKey(Claims.nonce.name())) {
+            if (result.localVerificationResult().containsKey(Claims.nonce.name())) {
                 LOG.debug("Back channel logout token must not contain 'nonce' claim");
                 return false;
             }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -564,19 +564,19 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
             }
 
             String idTokenIss = idTokenJson.getString(Claims.iss.name());
-            String logoutTokenIss = backChannelLogoutTokenResult.localVerificationResult.getString(Claims.iss.name());
+            String logoutTokenIss = backChannelLogoutTokenResult.localVerificationResult().getString(Claims.iss.name());
             if (logoutTokenIss != null && !logoutTokenIss.equals(idTokenIss)) {
                 LOG.debugf("Logout token issuer does not match the ID token issuer");
                 return false;
             }
             String idTokenSub = idTokenJson.getString(Claims.sub.name());
-            String logoutTokenSub = backChannelLogoutTokenResult.localVerificationResult.getString(Claims.sub.name());
+            String logoutTokenSub = backChannelLogoutTokenResult.localVerificationResult().getString(Claims.sub.name());
             if (logoutTokenSub != null && idTokenSub != null && !logoutTokenSub.equals(idTokenSub)) {
                 LOG.debugf("Logout token subject does not match the ID token subject");
                 return false;
             }
             String idTokenSid = idTokenJson.getString(OidcConstants.ID_TOKEN_SID_CLAIM);
-            String logoutTokenSid = backChannelLogoutTokenResult.localVerificationResult
+            String logoutTokenSid = backChannelLogoutTokenResult.localVerificationResult()
                     .getString(OidcConstants.BACK_CHANNEL_LOGOUT_SID_CLAIM);
             if (logoutTokenSid != null && idTokenSid != null && !logoutTokenSid.equals(idTokenSid)) {
                 LOG.debugf("Logout token session id does not match the ID token session id");

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -340,25 +340,25 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
     }
 
     private static String getTokenCertThumbprint(Map<String, Object> requestData, TokenVerificationResult t) {
-        JsonObject json = t.localVerificationResult != null ? t.localVerificationResult
-                : new JsonObject(t.introspectionResult.getIntrospectionString());
+        JsonObject json = t.localVerificationResult() != null ? t.localVerificationResult()
+                : new JsonObject(t.introspectionResult().getIntrospectionString());
         JsonObject cnf = json.getJsonObject(OidcConstants.CONFIRMATION_CLAIM);
         String thumbprint = cnf == null ? null : cnf.getString(OidcConstants.X509_SHA256_THUMBPRINT);
         if (thumbprint != null) {
-            requestData.put((t.introspectionResult == null ? OidcUtils.JWT_THUMBPRINT : OidcUtils.INTROSPECTION_THUMBPRINT),
+            requestData.put((t.introspectionResult() == null ? OidcUtils.JWT_THUMBPRINT : OidcUtils.INTROSPECTION_THUMBPRINT),
                     true);
         }
         return thumbprint;
     }
 
     private static String getDpopJwkThumbprint(Map<String, Object> requestData, TokenVerificationResult t) {
-        JsonObject json = t.localVerificationResult != null ? t.localVerificationResult
-                : new JsonObject(t.introspectionResult.getIntrospectionString());
+        JsonObject json = t.localVerificationResult() != null ? t.localVerificationResult()
+                : new JsonObject(t.introspectionResult().getIntrospectionString());
         JsonObject cnf = json.getJsonObject(OidcConstants.CONFIRMATION_CLAIM);
         String thumbprint = cnf == null ? null : cnf.getString(OidcConstants.DPOP_JWK_SHA256_THUMBPRINT);
         if (thumbprint != null) {
             requestData.put(
-                    (t.introspectionResult == null ? OidcUtils.DPOP_JWT_THUMBPRINT : OidcUtils.DPOP_INTROSPECTION_THUMBPRINT),
+                    (t.introspectionResult() == null ? OidcUtils.DPOP_JWT_THUMBPRINT : OidcUtils.DPOP_INTROSPECTION_THUMBPRINT),
                     true);
         }
         return thumbprint;
@@ -447,7 +447,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
         // an introspection request.
         final TokenCredential tokenCred = request.getToken();
 
-        JsonObject tokenJson = result.localVerificationResult;
+        JsonObject tokenJson = result.localVerificationResult();
         if (tokenJson == null) {
             // JSON token representation may be null not only if it is an opaque access token
             // but also if it is JWT and no JWK with a matching kid is available, asynchronous
@@ -470,7 +470,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                 JsonObject rolesJson = getRolesJson(requestData, resolvedContext, tokenCred, tokenJson,
                         userInfo);
                 SecurityIdentity securityIdentity = validateAndCreateIdentity(requestData, tokenCred,
-                        resolvedContext, tokenJson, rolesJson, userInfo, result.introspectionResult, request);
+                        resolvedContext, tokenJson, rolesJson, userInfo, result.introspectionResult(), request);
                 // If the primary token is a bearer access token then there's no point of checking if
                 // it should be refreshed as RT is only available for the code flow tokens
                 if (isIdToken(tokenCred)
@@ -495,7 +495,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
             OidcUtils.setSecurityIdentityUserInfo(builder, userInfo);
             OidcUtils.setSecurityIdentityConfigMetadata(builder, resolvedContext);
             final String userName;
-            if (result.introspectionResult == null) {
+            if (result.introspectionResult() == null) {
                 if (resolvedContext.oidcConfig().token().allowOpaqueTokenIntrospection() &&
                         resolvedContext.oidcConfig().token().verifyAccessTokenWithUserInfo().orElse(false)) {
                     if (resolvedContext.oidcConfig().token().principalClaim().isPresent() && userInfo != null) {
@@ -509,13 +509,13 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                     return Uni.createFrom().failure(new AuthenticationFailedException(tokenMap(tokenCred)));
                 }
             } else {
-                OidcUtils.setSecurityIdentityIntrospection(builder, result.introspectionResult);
-                String principalName = result.introspectionResult.getUsername();
+                OidcUtils.setSecurityIdentityIntrospection(builder, result.introspectionResult());
+                String principalName = result.introspectionResult().getUsername();
                 if (principalName == null) {
-                    principalName = result.introspectionResult.getSubject();
+                    principalName = result.introspectionResult().getSubject();
                 }
                 userName = principalName != null ? principalName : "";
-                OidcUtils.setIntrospectionScopes(builder, result.introspectionResult);
+                OidcUtils.setIntrospectionScopes(builder, result.introspectionResult());
             }
             builder.setPrincipal(new Principal() {
                 @Override
@@ -574,10 +574,10 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                 && requestData.get(REFRESH_TOKEN_GRANT_RESPONSE) != Boolean.TRUE
                 && requestData.get(NEW_AUTHENTICATION) != Boolean.TRUE) {
             Long expiry = null;
-            if (result.localVerificationResult != null) {
-                expiry = result.localVerificationResult.getLong(Claims.exp.name());
-            } else if (result.introspectionResult != null) {
-                expiry = result.introspectionResult.getLong(OidcConstants.INTROSPECTION_TOKEN_EXP);
+            if (result.localVerificationResult() != null) {
+                expiry = result.localVerificationResult().getLong(Claims.exp.name());
+            } else if (result.introspectionResult() != null) {
+                expiry = result.introspectionResult().getLong(OidcConstants.INTROSPECTION_TOKEN_EXP);
             }
             final long now = System.currentTimeMillis() / 1000;
             if (expiry == null && codeFlowAccessToken) {
@@ -607,7 +607,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
             } else if (tokenCred instanceof IdTokenCredential
                     && resolvedContext.oidcConfig().roles().source().get() == Source.accesstoken) {
                 rolesJson = ((TokenVerificationResult) requestData
-                        .get(OidcUtils.CODE_ACCESS_TOKEN_RESULT)).localVerificationResult;
+                        .get(OidcUtils.CODE_ACCESS_TOKEN_RESULT)).localVerificationResult();
                 if (rolesJson == null) {
                     // JSON token representation may be null not only if it is an opaque access token
                     // but also if it is JWT and no JWK with a matching kid is available, asynchronous
@@ -789,7 +789,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
             }
             return Uni.createFrom()
                     .item(validateAndCreateIdentity(Map.of(), request.getToken(), resolvedContext,
-                            result.localVerificationResult, result.localVerificationResult, null, null, request));
+                            result.localVerificationResult(), result.localVerificationResult(), null, null, request));
         } catch (Throwable t) {
             return Uni.createFrom().failure(t instanceof AuthenticationFailedException ? t
                     : new AuthenticationFailedException(t, tokenMap(request.getToken())));

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
@@ -191,7 +191,7 @@ public class OidcProvider implements Closeable {
         if (!enforceExpReq) {
             // Expiry check was skipped during the initial verification but if the logout token contains the exp claim
             // then it must be verified
-            final Long exp = result.localVerificationResult.getLong(Claims.exp.name());
+            final Long exp = result.localVerificationResult().getLong(Claims.exp.name());
             if (exp != null) {
                 final long secondsAfterExpiry = now() / 1000 - (exp + getLifespanGrace());
                 if (secondsAfterExpiry > 0) {
@@ -303,7 +303,7 @@ public class OidcProvider implements Closeable {
         }
         TokenVerificationResult result = new TokenVerificationResult(OidcCommonUtils.decodeJwtContent(token), null);
 
-        verifyTokenAge(result.localVerificationResult.getLong(Claims.iat.name()));
+        verifyTokenAge(result.localVerificationResult().getLong(Claims.iat.name()));
         return result;
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClientImpl.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClientImpl.java
@@ -183,14 +183,14 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
                                     return Uni.createFrom().item(
                                             new UserInfo(
                                                     oidcProvider.verifyJwtToken(response.data(), true, false,
-                                                            null).localVerificationResult
+                                                            null).localVerificationResult()
                                                             .encode()));
                                 } catch (Throwable t) {
                                     if (t.getCause() instanceof UnresolvableKeyException) {
                                         LOG.debug(
                                                 "No matching JWK key is found, refreshing and repeating the signed UserInfo verification");
                                         return oidcProvider.refreshJwksAndVerifyJwtToken(response.data(), true, false, null)
-                                                .onItem().transform(v -> new UserInfo(v.localVerificationResult.encode()));
+                                                .onItem().transform(v -> new UserInfo(v.localVerificationResult().encode()));
                                     } else {
                                         LOG.debugf("Signed UserInfo verification has failed: %s", t.getMessage());
                                         return Uni.createFrom().failure(t);
@@ -200,7 +200,7 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
                                 return oidcProvider
                                         .getKeyResolverAndVerifyJwtToken(new TokenCredential(response.data(), "userinfo"), true,
                                                 false, null, true)
-                                        .onItem().transform(v -> new UserInfo(v.localVerificationResult.encode()));
+                                        .onItem().transform(v -> new UserInfo(v.localVerificationResult().encode()));
                             }
                         } else {
                             return Uni.createFrom().item(new UserInfo(response.data()));

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTokenCredentialProducer.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTokenCredentialProducer.java
@@ -111,7 +111,7 @@ public class OidcTokenCredentialProducer {
         if (codeFlowAccessTokenResult == null) {
             return tokenIntrospectionFromIdentityAttribute();
         } else {
-            return tokenIntrospectionInstance(codeFlowAccessTokenResult.introspectionResult);
+            return tokenIntrospectionInstance(codeFlowAccessTokenResult.introspectionResult());
         }
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -378,7 +378,7 @@ public final class OidcUtils {
         if (codeFlowAccessTokenResult != null) {
             builder.addAttribute(CODE_ACCESS_TOKEN_RESULT, codeFlowAccessTokenResult);
             if (Roles.Source.accesstoken == config.roles().source().orElse(null)) {
-                setIntrospectionScopes(builder, codeFlowAccessTokenResult.introspectionResult);
+                setIntrospectionScopes(builder, codeFlowAccessTokenResult.introspectionResult());
                 if (codeTokens != null && codeTokens.getAccessTokenScope() != null) {
                     builder.addPermissionsAsString(new HashSet<>(Arrays.asList(codeTokens.getAccessTokenScope().split(" "))));
                 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/StepUpAuthenticationPolicy.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/StepUpAuthenticationPolicy.java
@@ -34,8 +34,8 @@ record StepUpAuthenticationPolicy(String[] expectedAcrValues, Long maxAge) imple
 
     @Override
     public void accept(TokenVerificationResult t) {
-        JsonObject json = t.localVerificationResult != null ? t.localVerificationResult
-                : new JsonObject(t.introspectionResult.getIntrospectionString());
+        JsonObject json = t.localVerificationResult() != null ? t.localVerificationResult()
+                : new JsonObject(t.introspectionResult().getIntrospectionString());
         verifyAcr(json);
         if (maxAge != null) {
             verifyMaxAge(json);

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TokenVerificationResult.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TokenVerificationResult.java
@@ -3,12 +3,5 @@ package io.quarkus.oidc.runtime;
 import io.quarkus.oidc.TokenIntrospection;
 import io.vertx.core.json.JsonObject;
 
-public class TokenVerificationResult {
-    JsonObject localVerificationResult;
-    TokenIntrospection introspectionResult;
-
-    public TokenVerificationResult(JsonObject localVerificationResult, TokenIntrospection introspectionResult) {
-        this.localVerificationResult = localVerificationResult;
-        this.introspectionResult = introspectionResult;
-    }
+public record TokenVerificationResult(JsonObject localVerificationResult, TokenIntrospection introspectionResult) {
 }

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcProviderTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcProviderTest.java
@@ -63,7 +63,7 @@ public class OidcProviderTest {
 
         }, null)) {
             TokenVerificationResult result = provider.verifyJwtToken(newToken, false, false, null);
-            assertEquals("http://keycloak/realm", result.localVerificationResult.getString("iss"));
+            assertEquals("http://keycloak/realm", result.localVerificationResult().getString("iss"));
         }
     }
 
@@ -78,7 +78,7 @@ public class OidcProviderTest {
 
         try (OidcProvider provider = new OidcProvider(null, new OidcTenantConfig(), jwkSet)) {
             TokenVerificationResult result = provider.verifyJwtToken(token, false, false, null);
-            assertEquals("http://keycloak/realm", result.localVerificationResult.getString("iss"));
+            assertEquals("http://keycloak/realm", result.localVerificationResult().getString("iss"));
         }
     }
 
@@ -114,7 +114,7 @@ public class OidcProviderTest {
 
         try (OidcProvider provider = new OidcProvider(null, config, jwkSet)) {
             TokenVerificationResult result = provider.verifyJwtToken(token, false, false, null);
-            assertEquals("http://keycloak/realm", result.localVerificationResult.getString("iss"));
+            assertEquals("http://keycloak/realm", result.localVerificationResult().getString("iss"));
         }
     }
 
@@ -163,7 +163,7 @@ public class OidcProviderTest {
 
         try (OidcProvider provider = new OidcProvider(null, oidcConfig, jwkSet)) {
             TokenVerificationResult result = provider.verifyJwtToken(tokenWithSub, false, true, null);
-            assertEquals("subject", result.localVerificationResult.getString(Claims.sub.name()));
+            assertEquals("subject", result.localVerificationResult().getString(Claims.sub.name()));
         }
 
         final String tokenWithoutSub = Jwt.claims().jws().keyId("k1").sign(rsaJsonWebKey.getPrivateKey());
@@ -190,7 +190,7 @@ public class OidcProviderTest {
 
         try (OidcProvider provider = new OidcProvider(null, oidcConfig, jwkSet)) {
             TokenVerificationResult result = provider.verifyJwtToken(tokenWithNonce, false, false, "123456");
-            assertEquals("123456", result.localVerificationResult.getString(Claims.nonce.name()));
+            assertEquals("123456", result.localVerificationResult().getString(Claims.nonce.name()));
         }
 
         final String tokenWithoutNonce = Jwt.claims().jws().keyId("k1").sign(rsaJsonWebKey.getPrivateKey());
@@ -227,7 +227,7 @@ public class OidcProviderTest {
 
         try (OidcProvider provider = new OidcProvider(null, oidcConfig, jwkSet)) {
             TokenVerificationResult result = provider.verifyJwtToken(token, false, false, null);
-            assertNull(result.localVerificationResult.getString(Claims.iat.name()));
+            assertNull(result.localVerificationResult().getString(Claims.iat.name()));
         }
 
         OidcTenantConfig oidcConfigRequireAge = new OidcTenantConfig();
@@ -257,8 +257,8 @@ public class OidcProviderTest {
         // no validators
         try (OidcProvider provider = new OidcProvider(null, oidcConfig, jwkSet, null, null)) {
             TokenVerificationResult result = provider.verifyJwtToken(token, false, false, null);
-            assertEquals("claimValue1", result.localVerificationResult.getString("claim1"));
-            assertEquals("claimValue2", result.localVerificationResult.getString("claim2"));
+            assertEquals("claimValue1", result.localVerificationResult().getString("claim1"));
+            assertEquals("claimValue2", result.localVerificationResult().getString("claim2"));
         }
 
         // one validator


### PR DESCRIPTION
Token verification results may need to be accessed outside of the quarkus-oidc package