### PR TITLE
OIDC extensions: reload provider WebClient TLS certificates when they are rotated

### DIFF
--- a/extensions/oidc-client-registration/runtime/src/main/java/io/quarkus/oidc/client/registration/runtime/OidcClientRegistrationImpl.java
+++ b/extensions/oidc-client-registration/runtime/src/main/java/io/quarkus/oidc/client/registration/runtime/OidcClientRegistrationImpl.java
@@ -25,6 +25,7 @@ import io.quarkus.oidc.common.OidcRequestFilter;
 import io.quarkus.oidc.common.OidcResponseFilter;
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.quarkus.oidc.common.runtime.OidcConstants;
+import io.quarkus.oidc.common.runtime.OidcWebClient;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.groups.UniOnItem;
@@ -34,7 +35,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.mutiny.core.buffer.Buffer;
 import io.vertx.mutiny.ext.web.client.HttpRequest;
 import io.vertx.mutiny.ext.web.client.HttpResponse;
-import io.vertx.mutiny.ext.web.client.WebClient;
 
 public class OidcClientRegistrationImpl implements OidcClientRegistration {
     private static final Logger LOG = Logger.getLogger(OidcClientRegistrationImpl.class);
@@ -42,7 +42,7 @@ public class OidcClientRegistrationImpl implements OidcClientRegistration {
     private static final String AUTHORIZATION_HEADER = String.valueOf(HttpHeaders.AUTHORIZATION);
     private static final String DEFAULT_ID = "Default";
 
-    private final WebClient client;
+    private final OidcWebClient client;
     private final long connectionDelayInMillisecs;
     private final String registrationUri;
     private final OidcClientRegistrationConfig oidcConfig;
@@ -51,7 +51,7 @@ public class OidcClientRegistrationImpl implements OidcClientRegistration {
     private final RegisteredClient registeredClient;
     private volatile boolean closed;
 
-    public OidcClientRegistrationImpl(WebClient client, long connectionDelayInMillisecs,
+    public OidcClientRegistrationImpl(OidcWebClient client, long connectionDelayInMillisecs,
             String registrationUri,
             OidcClientRegistrationConfig oidcConfig, RegisteredClient registeredClient,
             Map<Type, List<OidcRequestFilter>> oidcRequestFilters,
@@ -136,7 +136,7 @@ public class OidcClientRegistrationImpl implements OidcClientRegistration {
         return requestFilters.isEmpty() && responseFilters.isEmpty() ? null : new OidcRequestContextProperties();
     }
 
-    static Uni<RegisteredClient> registerClient(WebClient client,
+    static Uni<RegisteredClient> registerClient(OidcWebClient client,
             String registrationUri,
             OidcClientRegistrationConfig oidcConfig,
             Map<Type, List<OidcRequestFilter>> requestFilters,
@@ -150,7 +150,7 @@ public class OidcClientRegistrationImpl implements OidcClientRegistration {
     }
 
     static UniOnItem<HttpResponse<Buffer>> postRequest(OidcRequestContextProperties requestProps,
-            WebClient client, String registrationUri,
+            OidcWebClient client, String registrationUri,
             OidcClientRegistrationConfig oidcConfig,
             Map<Type, List<OidcRequestFilter>> filters, String clientRegJson) {
         HttpRequest<Buffer> request = client.postAbs(registrationUri);
@@ -180,7 +180,7 @@ public class OidcClientRegistrationImpl implements OidcClientRegistration {
     }
 
     static private Uni<RegisteredClient> newRegisteredClient(HttpResponse<Buffer> resp,
-            WebClient client, OidcClientRegistrationConfig oidcConfig,
+            OidcWebClient client, OidcClientRegistrationConfig oidcConfig,
             Map<Type, List<OidcRequestFilter>> requestFilters,
             Map<Type, List<OidcResponseFilter>> responseFilters,
             OidcRequestContextProperties requestProps) {

--- a/extensions/oidc-client-registration/runtime/src/main/java/io/quarkus/oidc/client/registration/runtime/OidcClientRegistrationRecorder.java
+++ b/extensions/oidc-client-registration/runtime/src/main/java/io/quarkus/oidc/client/registration/runtime/OidcClientRegistrationRecorder.java
@@ -24,6 +24,7 @@ import io.quarkus.oidc.common.OidcRequestFilter;
 import io.quarkus.oidc.common.OidcResponseFilter;
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.quarkus.oidc.common.runtime.OidcTlsSupport;
+import io.quarkus.oidc.common.runtime.OidcWebClient;
 import io.quarkus.proxy.ProxyConfigurationRegistry;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
@@ -32,8 +33,6 @@ import io.quarkus.tls.TlsConfigurationRegistry;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Vertx;
-import io.vertx.ext.web.client.WebClientOptions;
-import io.vertx.mutiny.ext.web.client.WebClient;
 
 @Recorder
 public class OidcClientRegistrationRecorder {
@@ -129,17 +128,13 @@ public class OidcClientRegistrationRecorder {
             return Uni.createFrom().failure(new RuntimeException(message));
         }
 
-        WebClientOptions options = new WebClientOptions();
-        options.setFollowRedirects(oidcConfig.followRedirects());
-        OidcCommonUtils.setHttpClientOptions(oidcConfig, options,
-                tlsSupport.forConfig(oidcConfig.tls().tlsConfigurationName()), proxyConfigurationRegistrySupplier.get());
-
         final io.vertx.mutiny.core.Vertx vertx = new io.vertx.mutiny.core.Vertx(vertxSupplier.get());
-        WebClient client = WebClient.create(vertx, options);
+        OidcWebClient client = OidcWebClient.create(oidcConfig, tlsSupport, vertx, proxyConfigurationRegistrySupplier.get(),
+                "OIDC client registration `" + oidcConfig.id().orElse(DEFAULT_ID) + "`");
 
         Map<OidcEndpoint.Type, List<OidcRequestFilter>> oidcRequestFilters = OidcCommonUtils.getOidcRequestFilters();
         Map<OidcEndpoint.Type, List<OidcResponseFilter>> oidcResponseFilters = OidcCommonUtils.getOidcResponseFilters();
-        Uni<OidcConfigurationMetadata> clientRegConfigUni = null;
+        final Uni<OidcConfigurationMetadata> clientRegConfigUni;
         if (OidcCommonUtils.isAbsoluteUrl(oidcConfig.registrationPath())) {
             clientRegConfigUni = Uni.createFrom().item(
                     new OidcConfigurationMetadata(oidcConfig.registrationPath().get()));
@@ -151,8 +146,7 @@ public class OidcClientRegistrationRecorder {
                                 OidcCommonUtils.getOidcEndpointUrl(authServerUriString, oidcConfig.registrationPath())));
             } else {
                 clientRegConfigUni = discoverRegistrationUri(client, oidcRequestFilters, oidcResponseFilters,
-                        authServerUriString.toString(), vertx,
-                        oidcConfig);
+                        authServerUriString, vertx, oidcConfig);
             }
         }
         return clientRegConfigUni.onItemOrFailure()
@@ -161,10 +155,12 @@ public class OidcClientRegistrationRecorder {
                     @Override
                     public Uni<OidcClientRegistration> apply(OidcConfigurationMetadata metadata, Throwable t) {
                         if (t != null) {
+                            client.close();
                             throw toOidcClientRegException(getEndpointUrl(oidcConfig), t);
                         }
 
                         if (metadata.clientRegistrationUri == null) {
+                            client.close();
                             throw new ConfigurationException(
                                     "OpenId Connect Provider client registration endpoint URL is not configured and can not be discovered");
                         }
@@ -233,7 +229,7 @@ public class OidcClientRegistrationRecorder {
         return oidcConfig.authServerUrl().isPresent() ? oidcConfig.authServerUrl().get() : oidcConfig.registrationPath().get();
     }
 
-    private static Uni<OidcConfigurationMetadata> discoverRegistrationUri(WebClient client,
+    private static Uni<OidcConfigurationMetadata> discoverRegistrationUri(OidcWebClient client,
             Map<OidcEndpoint.Type, List<OidcRequestFilter>> oidcRequestFilters,
             Map<OidcEndpoint.Type, List<OidcResponseFilter>> oidcResponseFilters,
             String authServerUrl, io.vertx.mutiny.core.Vertx vertx, OidcClientRegistrationConfig oidcConfig) {

--- a/extensions/oidc-client-registration/runtime/src/main/java/io/quarkus/oidc/client/registration/runtime/RegisteredClientImpl.java
+++ b/extensions/oidc-client-registration/runtime/src/main/java/io/quarkus/oidc/client/registration/runtime/RegisteredClientImpl.java
@@ -24,13 +24,13 @@ import io.quarkus.oidc.common.OidcRequestFilter;
 import io.quarkus.oidc.common.OidcResponseFilter;
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.quarkus.oidc.common.runtime.OidcConstants;
+import io.quarkus.oidc.common.runtime.OidcWebClient;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.groups.UniOnItem;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.mutiny.core.buffer.Buffer;
 import io.vertx.mutiny.ext.web.client.HttpRequest;
 import io.vertx.mutiny.ext.web.client.HttpResponse;
-import io.vertx.mutiny.ext.web.client.WebClient;
 
 public class RegisteredClientImpl implements RegisteredClient {
     private static final Logger LOG = Logger.getLogger(RegisteredClientImpl.class);
@@ -42,7 +42,7 @@ public class RegisteredClientImpl implements RegisteredClient {
             OidcConstants.CLIENT_METADATA_ID_ISSUED_AT);
     private static final OidcRequestContextProperties DEFAULT_REQUEST_PROPS = new OidcRequestContextProperties();
 
-    private final WebClient client;
+    private final OidcWebClient client;
     private final OidcClientRegistrationConfig oidcConfig;
     private final String registrationClientUri;
     private final String registrationToken;
@@ -51,7 +51,7 @@ public class RegisteredClientImpl implements RegisteredClient {
     private final Map<OidcEndpoint.Type, List<OidcResponseFilter>> responseFilters;
     private volatile boolean closed;
 
-    public RegisteredClientImpl(WebClient client, OidcClientRegistrationConfig oidcConfig,
+    public RegisteredClientImpl(OidcWebClient client, OidcClientRegistrationConfig oidcConfig,
             Map<Type, List<OidcRequestFilter>> oidcRequestFilters,
             Map<Type, List<OidcResponseFilter>> oidcResponseFilters,
             ClientMetadata registeredMetadata, String registrationClientUri, String registrationToken) {

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/DeferredOidcClient.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/DeferredOidcClient.java
@@ -8,6 +8,7 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.oidc.client.OidcClient;
 import io.quarkus.oidc.client.Tokens;
+import io.quarkus.oidc.common.runtime.OidcWebClient;
 import io.smallrye.mutiny.Uni;
 
 /**
@@ -20,12 +21,14 @@ final class DeferredOidcClient implements OidcClient {
     private static final Logger LOG = Logger.getLogger(DeferredOidcClient.class);
     private final Uni<OidcClient> deferredOidcClient;
     private final String oidcClientId;
+    private final OidcWebClient webClient;
     private volatile OidcClient resolvedOidcClient;
 
-    DeferredOidcClient(Uni<OidcClient> deferredOidcClient, String oidcClientId) {
+    DeferredOidcClient(Uni<OidcClient> deferredOidcClient, String oidcClientId, OidcWebClient webClient) {
         this.deferredOidcClient = deferredOidcClient;
         this.resolvedOidcClient = null;
         this.oidcClientId = oidcClientId;
+        this.webClient = webClient;
     }
 
     @Override
@@ -62,6 +65,8 @@ final class DeferredOidcClient implements OidcClient {
     public void close() throws IOException {
         if (resolvedOidcClient != null) {
             resolvedOidcClient.close();
+        } else {
+            webClient.close();
         }
     }
 

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
@@ -26,6 +26,7 @@ import io.quarkus.oidc.common.OidcResponseFilter;
 import io.quarkus.oidc.common.runtime.ClientAssertionProvider;
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.quarkus.oidc.common.runtime.OidcConstants;
+import io.quarkus.oidc.common.runtime.OidcWebClient;
 import io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials.Jwt.Source;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.groups.UniOnItem;
@@ -37,7 +38,6 @@ import io.vertx.mutiny.core.MultiMap;
 import io.vertx.mutiny.core.buffer.Buffer;
 import io.vertx.mutiny.ext.web.client.HttpRequest;
 import io.vertx.mutiny.ext.web.client.HttpResponse;
-import io.vertx.mutiny.ext.web.client.WebClient;
 
 public class OidcClientImpl implements OidcClient {
 
@@ -62,7 +62,7 @@ public class OidcClientImpl implements OidcClient {
     private static final String DEFAULT_OIDC_CLIENT_ID = "Default";
     private static final String AUTHORIZATION_HEADER = String.valueOf(HttpHeaders.AUTHORIZATION);
 
-    private final WebClient client;
+    private final OidcWebClient client;
     private final String tokenRequestUri;
     private final String tokenRevokeUri;
     private final MultiMap tokenGrantParams;
@@ -78,7 +78,7 @@ public class OidcClientImpl implements OidcClient {
     private volatile String clientSecret;
     private volatile String clientSecretBasicAuthScheme;
 
-    private OidcClientImpl(WebClient client, String tokenRequestUri, String tokenRevokeUri, String grantType,
+    private OidcClientImpl(OidcWebClient client, String tokenRequestUri, String tokenRevokeUri, String grantType,
             MultiMap tokenGrantParams, MultiMap commonRefreshGrantParams, OidcClientConfig oidcClientConfig,
             Map<OidcEndpoint.Type, List<OidcRequestFilter>> requestFilters,
             Map<OidcEndpoint.Type, List<OidcResponseFilter>> responseFilters, Vertx vertx,
@@ -467,7 +467,7 @@ public class OidcClientImpl implements OidcClient {
         return oidcConfig;
     }
 
-    WebClient getWebClient() {
+    OidcWebClient getWebClient() {
         return client;
     }
 
@@ -475,7 +475,7 @@ public class OidcClientImpl implements OidcClient {
         return op == Operation.REFRESH;
     }
 
-    static Uni<OidcClient> of(WebClient client, String tokenRequestUri, String tokenRevokeUri, String grantType,
+    static Uni<OidcClient> of(OidcWebClient client, String tokenRequestUri, String tokenRevokeUri, String grantType,
             MultiMap tokenGrantParams, MultiMap commonRefreshGrantParams, OidcClientConfig oidcClientConfig,
             Map<OidcEndpoint.Type, List<OidcRequestFilter>> requestFilters,
             Map<OidcEndpoint.Type, List<OidcResponseFilter>> responseFilters, Vertx vertx) {

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
@@ -25,14 +25,13 @@ import io.quarkus.oidc.common.OidcResponseFilter;
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.quarkus.oidc.common.runtime.OidcTlsSupport;
+import io.quarkus.oidc.common.runtime.OidcWebClient;
 import io.quarkus.proxy.ProxyConfigurationRegistry;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Vertx;
-import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.mutiny.core.MultiMap;
-import io.vertx.mutiny.ext.web.client.WebClient;
 
 @Recorder
 public class OidcClientRecorder {
@@ -104,13 +103,9 @@ public class OidcClientRecorder {
             return Uni.createFrom().item(new DisabledOidcClient(message));
         }
 
-        WebClientOptions options = new WebClientOptions();
-        options.setFollowRedirects(oidcConfig.followRedirects());
-        OidcCommonUtils.setHttpClientOptions(oidcConfig, options, tlsSupport.forConfig(oidcConfig.tls()),
-                proxyConfigurationRegistry);
-
         var mutinyVertx = new io.vertx.mutiny.core.Vertx(vertx);
-        WebClient client = WebClient.create(mutinyVertx, options);
+        OidcWebClient client = OidcWebClient.create(oidcConfig, tlsSupport, mutinyVertx, proxyConfigurationRegistry,
+                "OIDC client `" + oidcClientId + "`");
 
         Map<OidcEndpoint.Type, List<OidcRequestFilter>> oidcRequestFilters = OidcCommonUtils.getOidcRequestFilters();
         Map<OidcEndpoint.Type, List<OidcResponseFilter>> oidcResponseFilters = OidcCommonUtils.getOidcResponseFilters();
@@ -144,7 +139,7 @@ public class OidcClientRecorder {
                             .onFailure().transform(t -> toOidcClientException(getEndpointUrl(oidcConfig), t))
                             .flatMap(m -> createOidcClientUniFromMetadata(m, oidcConfig, client, oidcRequestFilters,
                                     oidcResponseFilters, vertx));
-                    return Uni.createFrom().item(new DeferredOidcClient(deferredClient, oidcClientId));
+                    return Uni.createFrom().item(new DeferredOidcClient(deferredClient, oidcClientId, client));
                 }
                 return createOidcClientUniFromMetadata(metadata, oidcConfig, client, oidcRequestFilters, oidcResponseFilters,
                         vertx);
@@ -153,9 +148,11 @@ public class OidcClientRecorder {
     }
 
     private static Uni<OidcClient> createOidcClientUniFromMetadata(OidcConfigurationMetadata metadata,
-            OidcClientConfig oidcConfig, WebClient client, Map<OidcEndpoint.Type, List<OidcRequestFilter>> oidcRequestFilters,
+            OidcClientConfig oidcConfig, OidcWebClient client,
+            Map<OidcEndpoint.Type, List<OidcRequestFilter>> oidcRequestFilters,
             Map<OidcEndpoint.Type, List<OidcResponseFilter>> oidcResponseFilters, Vertx vertx) {
         if (metadata.tokenRequestUri == null) {
+            client.close();
             throw new ConfigurationException(
                     "OpenId Connect Provider token endpoint URL is not configured and can not be discovered");
         }
@@ -178,6 +175,7 @@ public class OidcClientRecorder {
                         final String userName = grantOptions.get(OidcConstants.PASSWORD_GRANT_USERNAME);
                         final String userPassword = grantOptions.get(OidcConstants.PASSWORD_GRANT_PASSWORD);
                         if (userName == null || userPassword == null) {
+                            client.close();
                             throw new ConfigurationException(
                                     "Username and password must be set when a password grant is used",
                                     Set.of("quarkus.oidc-client.grant.type",
@@ -225,7 +223,7 @@ public class OidcClientRecorder {
         }
     }
 
-    private static Uni<OidcConfigurationMetadata> discoverTokenUris(WebClient client,
+    private static Uni<OidcConfigurationMetadata> discoverTokenUris(OidcWebClient client,
             Map<OidcEndpoint.Type, List<OidcRequestFilter>> oidcRequestFilters,
             Map<OidcEndpoint.Type, List<OidcResponseFilter>> oidcResponseFilters,
             String authServerUrl, OidcClientConfig oidcConfig, io.vertx.mutiny.core.Vertx vertx) {

--- a/extensions/oidc-common/deployment/src/main/java/io/quarkus/oidc/common/deployment/DummyForJavadoc.java
+++ b/extensions/oidc-common/deployment/src/main/java/io/quarkus/oidc/common/deployment/DummyForJavadoc.java
@@ -1,8 +1,0 @@
-package io.quarkus.oidc.common.deployment;
-
-/**
- * Quick workaround to have at least one public class and generate a Javadoc jar.
- */
-public class DummyForJavadoc {
-
-}

--- a/extensions/oidc-common/deployment/src/main/java/io/quarkus/oidc/common/deployment/OidcCommonProcessor.java
+++ b/extensions/oidc-common/deployment/src/main/java/io/quarkus/oidc/common/deployment/OidcCommonProcessor.java
@@ -1,0 +1,14 @@
+package io.quarkus.oidc.common.deployment;
+
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.oidc.common.runtime.CertificateUpdateEventListener;
+
+public class OidcCommonProcessor {
+
+    @BuildStep
+    AdditionalBeanBuildItem registerCertificateUpdateEventListener() {
+        return AdditionalBeanBuildItem.unremovableOf(CertificateUpdateEventListener.class);
+    }
+
+}

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/CertificateUpdateEventListener.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/CertificateUpdateEventListener.java
@@ -1,0 +1,61 @@
+package io.quarkus.oidc.common.runtime;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.tls.CertificateUpdatedEvent;
+import io.vertx.mutiny.ext.web.client.WebClient;
+
+@ApplicationScoped
+public class CertificateUpdateEventListener {
+
+    private record WebClientRegistration(String tlsConfigName, WebClient webClient, String clientUser) {
+    }
+
+    private static final Logger LOG = Logger.getLogger(CertificateUpdateEventListener.class);
+
+    private final List<WebClientRegistration> webClientRegistrations;
+
+    CertificateUpdateEventListener() {
+        this.webClientRegistrations = new CopyOnWriteArrayList<>();
+    }
+
+    void onCertificateUpdate(@Observes CertificateUpdatedEvent event) throws InterruptedException {
+        if (!webClientRegistrations.isEmpty()) {
+            var registrationsToUpdate = webClientRegistrations.stream().filter(r -> r.tlsConfigName.equals(event.name()))
+                    .toList();
+            if (!registrationsToUpdate.isEmpty()) {
+                CountDownLatch latch = new CountDownLatch(registrationsToUpdate.size());
+                for (var registration : registrationsToUpdate) {
+                    registration.webClient.updateSSLOptions(event.tlsConfiguration().getSSLOptions())
+                            .subscribe().with(
+                                    ignored -> {
+                                        LOG.infof("The TLS configuration `%s` used by the WebClient of the %s has been updated",
+                                                event.name(), registration.clientUser);
+                                        latch.countDown();
+                                    },
+                                    throwable -> {
+                                        LOG.warnf(throwable,
+                                                "Failed to update TLS configuration `%s` for the WebClient of the %s",
+                                                event.name(), registration.clientUser);
+                                        latch.countDown();
+                                    });
+                }
+
+                latch.await();
+            }
+        }
+    }
+
+    Runnable registerWebClient(String tlsConfigName, WebClient webClient, String clientUser) {
+        var registration = new WebClientRegistration(tlsConfigName, webClient, clientUser);
+        webClientRegistrations.add(registration);
+        return () -> webClientRegistrations.remove(registration);
+    }
+}

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -74,7 +74,6 @@ import io.vertx.mutiny.core.Vertx;
 import io.vertx.mutiny.core.buffer.Buffer;
 import io.vertx.mutiny.ext.web.client.HttpRequest;
 import io.vertx.mutiny.ext.web.client.HttpResponse;
-import io.vertx.mutiny.ext.web.client.WebClient;
 
 public class OidcCommonUtils {
     public static final Duration CONNECTION_BACKOFF_DURATION = Duration.ofSeconds(2);
@@ -575,7 +574,7 @@ public class OidcCommonUtils {
         return true;
     }
 
-    public static Uni<JsonObject> discoverMetadata(WebClient client,
+    public static Uni<JsonObject> discoverMetadata(OidcWebClient client,
             Map<OidcEndpoint.Type, List<OidcRequestFilter>> requestFilters,
             OidcRequestContextProperties contextProperties, Map<OidcEndpoint.Type, List<OidcResponseFilter>> responseFilters,
             String discoveryUrl,
@@ -604,7 +603,7 @@ public class OidcCommonUtils {
 
     }
 
-    public static Uni<JsonObject> doDiscoverMetadata(WebClient client,
+    public static Uni<JsonObject> doDiscoverMetadata(OidcWebClient client,
             Map<OidcEndpoint.Type, List<OidcRequestFilter>> requestFilters,
             OidcRequestContextProperties requestProps, Map<OidcEndpoint.Type, List<OidcResponseFilter>> responseFilters,
             String discoveryUrl,

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcTlsSupport.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcTlsSupport.java
@@ -91,6 +91,10 @@ public interface OidcTlsSupport {
             return null;
         }
 
+        public boolean useTlsRegistryAndMtls() {
+            return useTlsRegistry() && tlsConfig.getKeyStoreOptions() != null;
+        }
+
         public String getTlsConfigName() {
             return tlsConfigName;
         }

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcWebClient.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcWebClient.java
@@ -1,0 +1,72 @@
+package io.quarkus.oidc.common.runtime;
+
+import java.io.Closeable;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.oidc.common.runtime.config.OidcCommonConfig;
+import io.quarkus.proxy.ProxyConfigurationRegistry;
+import io.vertx.ext.web.client.WebClientOptions;
+import io.vertx.mutiny.core.Vertx;
+import io.vertx.mutiny.core.buffer.Buffer;
+import io.vertx.mutiny.ext.web.client.HttpRequest;
+import io.vertx.mutiny.ext.web.client.WebClient;
+
+public final class OidcWebClient implements Closeable {
+
+    private final WebClient webClient;
+    private final Runnable onClose;
+
+    private OidcWebClient(WebClient webClient, Runnable onClose) {
+        this.webClient = webClient;
+        this.onClose = onClose;
+    }
+
+    public HttpRequest<Buffer> getAbs(String absoluteURI) {
+        return webClient.getAbs(absoluteURI);
+    }
+
+    public HttpRequest<Buffer> postAbs(String absoluteURI) {
+        return webClient.postAbs(absoluteURI);
+    }
+
+    public HttpRequest<Buffer> headAbs(String absoluteURI) {
+        return webClient.headAbs(absoluteURI);
+    }
+
+    public HttpRequest<Buffer> putAbs(String absoluteURI) {
+        return webClient.putAbs(absoluteURI);
+    }
+
+    public HttpRequest<Buffer> deleteAbs(String absoluteURI) {
+        return webClient.deleteAbs(absoluteURI);
+    }
+
+    @Override
+    public void close() {
+        if (onClose != null) {
+            onClose.run();
+        }
+        webClient.close();
+    }
+
+    public static OidcWebClient create(OidcCommonConfig oidcConfig, OidcTlsSupport tlsSupport, Vertx vertx,
+            ProxyConfigurationRegistry proxyConfigurationRegistry, String clientUser) {
+        var tlsConfigSupport = tlsSupport.forConfig(oidcConfig.tls());
+        var webClient = createWebClient(oidcConfig, tlsConfigSupport, vertx, proxyConfigurationRegistry);
+        final Runnable onClose;
+        if (tlsConfigSupport.useTlsRegistryAndMtls()) {
+            onClose = Arc.requireContainer().select(CertificateUpdateEventListener.class).get()
+                    .registerWebClient(tlsConfigSupport.getTlsConfigName(), webClient, clientUser);
+        } else {
+            onClose = null;
+        }
+        return new OidcWebClient(webClient, onClose);
+    }
+
+    private static WebClient createWebClient(OidcCommonConfig oidcConfig, OidcTlsSupport.TlsConfigSupport tlsConfigSupport,
+            Vertx vertx, ProxyConfigurationRegistry proxyConfigurationRegistry) {
+        WebClientOptions options = new WebClientOptions().setFollowRedirects(oidcConfig.followRedirects());
+        OidcCommonUtils.setHttpClientOptions(oidcConfig, options, tlsConfigSupport, proxyConfigurationRegistry);
+        return WebClient.create(vertx, options);
+    }
+}

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/OidcTlsCertificateReloadTest.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/OidcTlsCertificateReloadTest.java
@@ -1,0 +1,124 @@
+package io.quarkus.oidc.test;
+
+import static org.awaitility.Awaitility.await;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.Authenticated;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+import io.restassured.response.ValidatableResponse;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.junit5.Certificate;
+import io.smallrye.certs.junit5.Certificates;
+
+@Certificates(baseDir = "target/certs", certificates = {
+        @Certificate(name = "oidc-reload-A", password = "password", formats = Format.PKCS12),
+        @Certificate(name = "oidc-reload-B", password = "password", formats = Format.PKCS12),
+})
+class OidcTlsCertificateReloadTest {
+
+    private static final File temp = new File("target/test-certificates-" + UUID.randomUUID());
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar.addClasses(ProtectedEndpoint.class, MockIntrospectionEndpoint.class))
+            .withConfiguration("""
+                    quarkus.keycloak.devservices.enabled=false
+                    quarkus.http.auth.proactive=false
+                    """)
+            .withRuntimeConfiguration("""
+                    quarkus.tls.key-store.p12.path=target/certs/oidc-reload-A-keystore.p12
+                    quarkus.tls.key-store.p12.password=password
+                    # configure keystore as reload is only intended for scenarios with keystore as well
+                    quarkus.tls.oidc-provider.key-store.p12.path=target/certs/oidc-reload-A-keystore.p12
+                    quarkus.tls.oidc-provider.key-store.p12.password=password
+                    quarkus.tls.oidc-provider.trust-store.p12.path=%1$s/truststore.p12
+                    quarkus.tls.oidc-provider.trust-store.p12.password=password
+                    quarkus.tls.oidc-provider.reload-period=1s
+                    quarkus.oidc.auth-server-url=https://localhost:8444
+                    quarkus.oidc.discovery-enabled=false
+                    quarkus.oidc.introspection-path=/introspect
+                    quarkus.oidc.client-id=test-client
+                    quarkus.oidc.credentials.secret=test-secret
+                    quarkus.oidc.tls.tls-configuration-name=oidc-provider
+                    quarkus.http.idle-timeout=1s
+                    loc=%1$s
+                    """.formatted(temp.getAbsolutePath()))
+            .setBeforeAllCustomizer(() -> {
+                try {
+                    Files.createDirectories(temp.toPath());
+                    Files.copy(new File("target/certs/oidc-reload-A-truststore.p12").toPath(),
+                            new File(temp, "truststore.p12").toPath());
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            })
+            .setAfterAllCustomizer(() -> {
+                try {
+                    Files.deleteIfExists(new File(temp, "truststore.p12").toPath());
+                    Files.deleteIfExists(temp.toPath());
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+    @ConfigProperty(name = "loc")
+    File certs; // we need to inject location as the test currently uses different classloader
+
+    @Test
+    void certReloadUpdatesOidcWebClientSslOptions() throws IOException {
+        callProtectedEndpoint().statusCode(200);
+
+        Files.copy(new File("target/certs/oidc-reload-B-truststore.p12").toPath(),
+                new File(certs, "truststore.p12").toPath(), StandardCopyOption.REPLACE_EXISTING);
+
+        await().atMost(15, TimeUnit.SECONDS)
+                .pollInterval(1, TimeUnit.SECONDS)
+                .untilAsserted(() -> callProtectedEndpoint().statusCode(401));
+    }
+
+    private static ValidatableResponse callProtectedEndpoint() {
+        return RestAssured.given()
+                .auth().oauth2("any-token")
+                .get("/protected")
+                .then();
+    }
+
+    @Path("/protected")
+    @Authenticated
+    public static class ProtectedEndpoint {
+
+        @GET
+        public String get() {
+            return "OK";
+        }
+    }
+
+    @Path("/introspect")
+    public static class MockIntrospectionEndpoint {
+
+        @POST
+        @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+        @Produces(MediaType.APPLICATION_JSON)
+        public String introspect() {
+            return "{\"active\":true,\"sub\":\"test-user\",\"username\":\"test-user\"}";
+        }
+    }
+}

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
@@ -301,7 +301,7 @@ public class DefaultTenantConfigResolver {
                         Uni<TenantConfigContext> dynamicContextUni = null;
                         if (Boolean.valueOf(context.get(REPLACE_TENANT_CONFIG_CONTEXT))) {
                             // replace the context and reconnect
-                            dynamicContextUni = tenantConfigBean.replaceDynamicTenantContext(tenantConfig);
+                            dynamicContextUni = tenantConfigBean.replaceDynamicTenantContext(tenantConfig, context.vertx());
                         } else {
                             // update the context without reconnect
                             dynamicContextUni = tenantConfigBean.updateDynamicTenantContext(tenantConfig);

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClientImpl.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClientImpl.java
@@ -30,6 +30,7 @@ import io.quarkus.oidc.common.runtime.ClientAssertionProvider;
 import io.quarkus.oidc.common.runtime.OidcClientRedirectException;
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.quarkus.oidc.common.runtime.OidcConstants;
+import io.quarkus.oidc.common.runtime.OidcWebClient;
 import io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig;
 import io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials.Secret.Method;
 import io.quarkus.security.credential.TokenCredential;
@@ -42,7 +43,6 @@ import io.vertx.mutiny.core.MultiMap;
 import io.vertx.mutiny.core.buffer.Buffer;
 import io.vertx.mutiny.ext.web.client.HttpRequest;
 import io.vertx.mutiny.ext.web.client.HttpResponse;
-import io.vertx.mutiny.ext.web.client.WebClient;
 
 public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
 
@@ -72,7 +72,7 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
     private static final String APPLICATION_X_WWW_FORM_URLENCODED = HttpHeaders.APPLICATION_X_WWW_FORM_URLENCODED.toString();
     private static final String APPLICATION_JSON = "application/json";
 
-    private final WebClient client;
+    private final OidcWebClient client;
     private final Vertx vertx;
     private final OidcConfigurationMetadata metadata;
     private final OidcTenantConfig oidcConfig;
@@ -90,7 +90,7 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
 
     private OidcProvider oidcProvider;
 
-    private OidcProviderClientImpl(WebClient client, Vertx vertx, OidcConfigurationMetadata metadata,
+    private OidcProviderClientImpl(OidcWebClient client, Vertx vertx, OidcConfigurationMetadata metadata,
             OidcTenantConfig oidcConfig, ClientCredentials clientCredentials,
             Map<OidcEndpoint.Type, List<OidcRequestFilter>> requestFilters,
             Map<OidcEndpoint.Type, List<OidcResponseFilter>> responseFilters) {
@@ -636,7 +636,7 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
         return vertx;
     }
 
-    public WebClient getWebClient() {
+    public OidcWebClient getWebClient() {
         return client;
     }
 
@@ -647,7 +647,7 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
         return op == TokenOperation.INTROSPECT;
     }
 
-    static Uni<OidcProviderClientImpl> of(WebClient client, Vertx vertx, OidcConfigurationMetadata metadata,
+    static Uni<OidcProviderClientImpl> of(OidcWebClient client, Vertx vertx, OidcConfigurationMetadata metadata,
             OidcTenantConfig oidcConfig,
             Map<OidcEndpoint.Type, List<OidcRequestFilter>> requestFilters,
             Map<OidcEndpoint.Type, List<OidcResponseFilter>> responseFilters) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigBean.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigBean.java
@@ -20,6 +20,7 @@ import io.vertx.core.Vertx;
 public final class TenantConfigBean {
 
     private static final Logger LOG = Logger.getLogger(TenantConfigBean.class);
+    private static final int DELAY_5_SECONDS = 5000;
 
     private final Map<String, TenantConfigContext> staticTenantsConfig;
     private final Map<String, TenantConfigContext> dynamicTenantsConfig;
@@ -75,10 +76,14 @@ public final class TenantConfigBean {
         }
     }
 
-    Uni<TenantConfigContext> replaceDynamicTenantContext(OidcTenantConfig oidcConfig) {
+    Uni<TenantConfigContext> replaceDynamicTenantContext(OidcTenantConfig oidcConfig, Vertx vertx) {
         var tenantId = oidcConfig.tenantId().orElseThrow();
         LOG.debugf("Replacing the resolved tenant %s configuration with a new configuration", tenantId);
-        dynamicTenantsConfig.remove(tenantId);
+        var previousContext = dynamicTenantsConfig.remove(tenantId);
+        if (previousContext != null && previousContext.provider() != null) {
+            // even though we are replacing the context, it could be that other HTTP request is currently using it
+            vertx.setTimer(DELAY_5_SECONDS, ignored -> previousContext.provider().close());
+        }
         return createDynamicTenantContext(oidcConfig);
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantContextFactory.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantContextFactory.java
@@ -29,6 +29,7 @@ import io.quarkus.oidc.common.OidcRequestFilter;
 import io.quarkus.oidc.common.OidcResponseFilter;
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.quarkus.oidc.common.runtime.OidcTlsSupport;
+import io.quarkus.oidc.common.runtime.OidcWebClient;
 import io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig;
 import io.quarkus.proxy.ProxyConfigurationRegistry;
 import io.quarkus.runtime.LaunchMode;
@@ -39,8 +40,6 @@ import io.smallrye.mutiny.TimeoutException;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.client.WebClientOptions;
-import io.vertx.mutiny.ext.web.client.WebClient;
 
 final class TenantContextFactory {
 
@@ -453,17 +452,14 @@ final class TenantContextFactory {
 
         String authServerUriString = OidcCommonUtils.getAuthServerUrl(oidcConfig);
 
-        WebClientOptions options = new WebClientOptions();
-        options.setFollowRedirects(oidcConfig.followRedirects());
-        OidcCommonUtils.setHttpClientOptions(oidcConfig, options, tlsSupport.forConfig(oidcConfig.tls()),
-                proxyConfigurationRegistry);
         var mutinyVertx = new io.vertx.mutiny.core.Vertx(vertx);
-        WebClient client = WebClient.create(mutinyVertx, options);
+        OidcWebClient client = OidcWebClient.create(oidcConfig, tlsSupport, mutinyVertx, proxyConfigurationRegistry,
+                "OIDC tenant `" + oidcConfig.tenantId().get() + "`");
 
         Map<OidcEndpoint.Type, List<OidcRequestFilter>> oidcRequestFilters = OidcUtils.getOidcRequestFilters(oidcConfig);
         Map<OidcEndpoint.Type, List<OidcResponseFilter>> oidcResponseFilters = OidcUtils.getOidcResponseFilters(oidcConfig);
 
-        Uni<OidcConfigurationMetadata> metadataUni = null;
+        final Uni<OidcConfigurationMetadata> metadataUni;
         if (!oidcConfig.discoveryEnabled().orElse(true)) {
             metadataUni = Uni.createFrom().item(createLocalMetadata(oidcConfig, authServerUriString));
         } else {
@@ -522,6 +518,7 @@ final class TenantContextFactory {
                         }
                         if (OidcUtils.isParEnabled(oidcConfig.authentication(), metadata)) {
                             if (metadata.getPushedAuthorizationRequestUri() == null) {
+                                client.close();
                                 String exceptionMessage = ("OIDC tenant '%s' has enabled the pushed authorization requests, but "
                                         + "the OpenID Provider PAR endpoint is not configured. Use '%s' if the discovery is disabled.")
                                         .formatted(tenantId,
@@ -539,6 +536,7 @@ final class TenantContextFactory {
                             boolean clientSecretQueryAuthentication = oidcConfig.credentials().clientSecret().method()
                                     .orElse(null) == OidcClientCommonConfig.Credentials.Secret.Method.QUERY;
                             if (clientSecretQueryAuthentication) {
+                                client.close();
                                 String exceptionMessage = ("OIDC tenant '%s' has enabled the pushed authorization requests, "
                                         + "and uses the client authentication method 'query'. Please set different"
                                         + " client authentication method").formatted(tenantId);


### PR DESCRIPTION
* when TLS certificates are rotated, we need to update WebClient of OIDC (provider) client
* prerequisite for the https://github.com/quarkusio/quarkus/issues/53816
* since the WebClient is closed on app shutdown or when dynamic tenant provider is closed, we don't need dedicated observer that cleans certificate reload registrations on Quarkus shutdown (live reload)