### PR TITLE
Apply client request customizer to redirect requests

### DIFF
--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/RestClientRedirectPrometheusTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/RestClientRedirectPrometheusTest.java
@@ -1,0 +1,99 @@
+package io.quarkus.micrometer.deployment.binder;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.equalTo;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.quarkus.micrometer.test.Util;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class RestClientRedirectPrometheusTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .setFlatClassPath(true)
+            .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
+            .overrideConfigKey("quarkus.micrometer.binder.http-client.enabled", "true")
+            .overrideConfigKey("quarkus.micrometer.binder.http-server.enabled", "true")
+            .overrideConfigKey("quarkus.micrometer.binder.vertx.enabled", "true")
+            .overrideConfigKey("quarkus.micrometer.export.prometheus.enabled", "true")
+            .overrideConfigKey("quarkus.micrometer.registry-enabled-default", "false")
+            .overrideConfigKey("quarkus.redis.devservices.enabled", "false")
+            .overrideConfigKey("quarkus.rest-client.redirect-client.url", "${test.url}")
+            .overrideConfigKey("quarkus.rest-client.redirect-client.follow-redirects", "true")
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Util.class, RedirectResource.class, RedirectResource.RedirectClient.class));
+
+    @Inject
+    MeterRegistry registry;
+
+    @Test
+    public void redirectShouldNotRegisterConflictingClientMeters() throws InterruptedException {
+        when()
+                .get("/exercise")
+                .then()
+                .statusCode(200)
+                .body(equalTo("Hello World!"));
+
+        Util.waitForMeters(registry.find("http.client.requests").timers(), 1);
+        Assertions.assertEquals(1, registry.find("http.client.requests").timers().size(),
+                Util.foundClientRequests(registry, "Expected a single REST client timer after following a redirect."));
+    }
+
+    @Path("/")
+    @Singleton
+    public static class RedirectResource {
+
+        @RegisterRestClient(configKey = "redirect-client")
+        public interface RedirectClient {
+
+            @GET
+            @Path("/redirect")
+            @Produces(MediaType.TEXT_PLAIN)
+            Response getThroughRedirect();
+        }
+
+        @Inject
+        @RestClient
+        RedirectClient redirectClient;
+
+        @GET
+        @Path("/redirect")
+        public Response redirect() {
+            return Response.status(302)
+                    .header("Location", "/target")
+                    .build();
+        }
+
+        @GET
+        @Path("/target")
+        @Produces(MediaType.TEXT_PLAIN)
+        public String target() {
+            return "Hello World!";
+        }
+
+        @GET
+        @Path("/exercise")
+        @Produces(MediaType.TEXT_PLAIN)
+        public String exercise() {
+            try (Response response = redirectClient.getThroughRedirect()) {
+                return response.readEntity(String.class);
+            }
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSendRequestHandler.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSendRequestHandler.java
@@ -116,11 +116,7 @@ public class ClientSendRequestHandler implements ClientRestHandler {
                     return;
                 }
 
-                for (int i = 0; i < clientRequestCustomizers.size(); i++) {
-                    clientRequestCustomizers.get(i).accept(httpClientRequest);
-                }
-
-                requestContext.setHttpClientRequest(httpClientRequest);
+                customizeRequest(httpClientRequest, requestContext);
 
                 // adapt headers to HTTP/2 depending on the underlying HTTP connection
                 ClientSendRequestHandler.this.adaptRequest(httpClientRequest);
@@ -254,6 +250,71 @@ public class ClientSendRequestHandler implements ClientRestHandler {
                     reportFinish(event, requestContext);
                 }
             }
+        });
+    }
+
+    private void customizeRequest(HttpClientRequest httpClientRequest, RestClientRequestContext requestContext) {
+        installRedirectRequestCustomizer(httpClientRequest, requestContext);
+        for (int i = 0; i < clientRequestCustomizers.size(); i++) {
+            clientRequestCustomizers.get(i).accept(httpClientRequest);
+        }
+
+        requestContext.setHttpClientRequest(httpClientRequest);
+    }
+
+    /*
+     * If the request leads to a new request because of redirect then this method will install the original request's
+     * customizers to the new redirect request.
+     */
+    private void installRedirectRequestCustomizer(HttpClientRequest httpClientRequest,
+            RestClientRequestContext requestContext) {
+        if (!followRedirects || clientRequestCustomizers.isEmpty()) {
+            return;
+        }
+        httpClientRequest.redirectHandler(response -> {
+            /*
+             * The docs for `redirectHandler()` make no statement about whether the returned result is nullable.
+             * We'll guard against null here and assume there's no redirect taking place.
+             */
+            Function<HttpClientResponse, Future<RequestOptions>> redirectHandler = requestContext.getHttpClient()
+                    // For Vert.x 5 we'll have to cast the `HttpClient` to `HttpClientInternal` in order to access
+                    // this method
+                    .redirectHandler();
+            if (redirectHandler == null) {
+                return Future.succeededFuture(null);
+            }
+
+            /*
+             * @see HttpClient#redirectHandler(Function)
+             * According to the docs the `redirectHandler` function returns null if there is no redirect taking place.
+             *
+             * But it doesn't return `HttpClientRequest`, it returns a `Future<RequestOptions>`.
+             * Vert.x 3 exposed redirect handling in terms of HttpClientRequest, while Vert.x 4
+             * changed the client-level redirect handler to Future<RequestOptions>. The current
+             * docs still describe the old null semantics, so they are likely stale.
+             *
+             * In practice, we defensively accept both interpretations of "no redirect":
+             * - the handler returns a null Future<RequestOptions>
+             * - the handler returns a Future completing with null RequestOptions
+             */
+            Future<RequestOptions> redirectOptions = redirectHandler.apply(response);
+            if (redirectOptions == null) {
+                return Future.succeededFuture(null);
+            }
+            return redirectOptions.compose(options -> {
+                if (options == null) {
+                    return Future.succeededFuture(null);
+                }
+                /*
+                 * If there is a redirect taking place install the original request's customizers to the redirect
+                 * request.
+                 */
+                return requestContext.getHttpClient().request(options)
+                        .map(nextRequest -> {
+                            customizeRequest(nextRequest, requestContext);
+                            return nextRequest;
+                        });
+            });
         });
     }
 


### PR DESCRIPTION
This PR attempts to solve the issue described here https://github.com/quarkusio/quarkus/issues/53914

I'm not sure that the solution here is the best possible one for the issue. I wouldn't be surprised if maintainers could find a better fix.

That being said, the test in the PR does have value as it captures the described issue.

The change made here ensures that the client request customizer is also applied to any subsequent request that is a result of a redirect.

* Fixes #53914

