### PR TITLE
Rename SPIFFE enum value to SPIFFE_JWT

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
@@ -237,13 +237,13 @@ Quarkus loads a new token from the filesystem and reloads it when the token expi
 .Example: Using a SPIFFE JWT-SVID token to authenticate a client
 
 link:https://spiffe.io[SPIFFE] (Secure Production Identity Framework for Everyone) JWT-SVID tokens can be used as client assertions for client authentication.
-When the JWT source is set to `spiffe`, the `client_assertion_type` parameter is set to `urn:ietf:params:oauth:client-assertion-type:jwt-spiffe` and the token's `sub` claim must contain a valid SPIFFE ID starting with `spiffe://`.
+When the JWT source is set to `spiffe-jwt`, the `client_assertion_type` parameter is set to `urn:ietf:params:oauth:client-assertion-type:jwt-spiffe` and the token's `sub` claim must contain a valid SPIFFE ID starting with `spiffe://`.
 
 [source,properties]
 ----
 quarkus.oidc.auth-server-url=http://localhost:8180/realms/quarkus/
 quarkus.oidc.client-id=quarkus-app
-quarkus.oidc.credentials.jwt.source=spiffe <1>
+quarkus.oidc.credentials.jwt.source=spiffe-jwt <1>
 quarkus.oidc.credentials.jwt.token-path=/var/run/secrets/tokens <2>
 ----
 <1> Use a SPIFFE JWT-SVID token to authenticate the OIDC provider client.

--- a/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
@@ -1110,7 +1110,7 @@ Enable it as follows:
 ----
 quarkus.oidc-client.auth-server-url=${auth-server-url}
 quarkus.oidc-client.client-id=quarkus-app
-quarkus.oidc-client.credentials.jwt.source=spiffe
+quarkus.oidc-client.credentials.jwt.source=spiffe-jwt
 ----
 
 Quarkus can load the SPIFFE JWT-SVID token from the file system.

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/KubernetesServiceClientAssertionProvider.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/KubernetesServiceClientAssertionProvider.java
@@ -36,7 +36,7 @@ final class KubernetesServiceClientAssertionProvider implements ClientAssertionP
         if (source == Source.BEARER) {
             this.clientAssertionType = OidcConstants.JWT_BEARER_CLIENT_ASSERTION_TYPE;
             this.tokenType = "JWT bearer";
-        } else if (source == Source.SPIFFE) {
+        } else if (source == Source.SPIFFE_JWT) {
             this.clientAssertionType = OidcConstants.SPIFFE_SVID_CLIENT_ASSERTION_TYPE;
             this.tokenType = "SPIFFE JWT-SVID";
         } else {

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcClientCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcClientCommonConfig.java
@@ -380,7 +380,7 @@ public abstract class OidcClientCommonConfig extends OidcCommonConfig
                 // This option is only supported by the OIDC client extension.
                 BEARER,
                 // SPIFFE SVID token is used as a client assertion
-                SPIFFE
+                SPIFFE_JWT
             }
 
             /**

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -924,7 +924,7 @@ public class OidcCommonUtils {
             if (clientAssertionProvider.getClientAssertion() == null) {
                 throw exceptionCreator
                         .apply("Cannot find a valid "
-                                + (jwtConfig.source() == Source.SPIFFE ? "SPIFFE SVID" : "JWT bearer")
+                                + (jwtConfig.source() == Source.SPIFFE_JWT ? "SPIFFE JWT-SVID" : "JWT bearer")
                                 + " token at path: " + jwtConfig.tokenPath().get());
             }
             return clientAssertionProvider;
@@ -935,7 +935,7 @@ public class OidcCommonUtils {
     public static Object getClientAssertionTokenType(Source source) {
         return switch (source) {
             case BEARER, CLIENT -> "JWT bearer";
-            case SPIFFE -> "SPIFFE SVID";
+            case SPIFFE_JWT -> "SPIFFE JWT-SVID";
         };
     }
 

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/config/OidcClientCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/config/OidcClientCommonConfig.java
@@ -145,7 +145,7 @@ public interface OidcClientCommonConfig extends OidcCommonConfig {
                 /**
                  * SPIFFE SVID token is used as a client assertion: urn:ietf:params:oauth:client-assertion-type:jwt-spiffe
                  */
-                SPIFFE
+                SPIFFE_JWT
             }
 
             /**

--- a/extensions/oidc-common/runtime/src/test/java/io/quarkus/oidc/common/runtime/KubernetesServiceClientAssertionProviderTest.java
+++ b/extensions/oidc-common/runtime/src/test/java/io/quarkus/oidc/common/runtime/KubernetesServiceClientAssertionProviderTest.java
@@ -69,7 +69,8 @@ public class KubernetesServiceClientAssertionProviderTest {
         Path svidTokenPath = Path.of("target").resolve("spiffe-svid-token.json");
         String svidToken = createSpiffeSvidToken();
         storeNewJwtBearerToken(svidTokenPath, svidToken);
-        try (var clientAssertionProvider = new KubernetesServiceClientAssertionProvider(vertx, svidTokenPath, Source.SPIFFE)) {
+        try (var clientAssertionProvider = new KubernetesServiceClientAssertionProvider(vertx, svidTokenPath,
+                Source.SPIFFE_JWT)) {
             assertEquals(svidToken, clientAssertionProvider.getClientAssertion());
             assertEquals(OidcConstants.SPIFFE_SVID_CLIENT_ASSERTION_TYPE, clientAssertionProvider.getClientAssertionType());
 
@@ -89,7 +90,8 @@ public class KubernetesServiceClientAssertionProviderTest {
         Path svidTokenPath = Path.of("target").resolve("invalid-spiffe-svid-token.json");
         String token = createJwtBearerToken();
         storeNewJwtBearerToken(svidTokenPath, token);
-        try (var clientAssertionProvider = new KubernetesServiceClientAssertionProvider(vertx, svidTokenPath, Source.SPIFFE)) {
+        try (var clientAssertionProvider = new KubernetesServiceClientAssertionProvider(vertx, svidTokenPath,
+                Source.SPIFFE_JWT)) {
             assertNull(clientAssertionProvider.getClientAssertion());
         } finally {
             vertx.close().toCompletionStage().toCompletableFuture().join();

--- a/integration-tests/oidc-client-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-client-wiremock/src/main/resources/application.properties
@@ -37,7 +37,7 @@ quarkus.oidc-client.spiffe.auth-server-url=${keycloak.url}
 quarkus.oidc-client.spiffe.discovery-enabled=false
 quarkus.oidc-client.spiffe.token-path=/tokens-spiffe
 quarkus.oidc-client.spiffe.client-id=quarkus-app
-quarkus.oidc-client.spiffe.credentials.jwt.source=spiffe
+quarkus.oidc-client.spiffe.credentials.jwt.source=spiffe-jwt
 quarkus.oidc-client.spiffe.credentials.jwt.token-path=${spiffe-token-path:}
 
 quarkus.oidc-client.jwtbearer-grant.auth-server-url=${keycloak.url}

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -392,6 +392,6 @@ quarkus.oidc.code-flow-spiffe-auth.user-info-path=protocol/openid-connect/userin
 quarkus.oidc.code-flow-spiffe-auth.authentication.id-token-required=false
 quarkus.oidc.code-flow-spiffe-auth.authentication.verify-access-token=false
 quarkus.oidc.code-flow-spiffe-auth.client-id=quarkus-web-app
-quarkus.oidc.code-flow-spiffe-auth.credentials.jwt.source=spiffe
+quarkus.oidc.code-flow-spiffe-auth.credentials.jwt.source=spiffe-jwt
 quarkus.oidc.code-flow-spiffe-auth.credentials.jwt.token-path=${code-flow-spiffe-token-path:}
 quarkus.oidc.code-flow-spiffe-auth.application-type=web-app


### PR DESCRIPTION
This PR renames a `SPIFFE` enum value to `SPIFFE_JWT` in anticipation of  #53894 that will bring `SPIFFE_WIT`.

`SPIFFE_JWT_SVID` would be too long for users to type IMHO, so a `SPIFFE_JWT` shortcut should do