### PR TITLE
Deprecate LateBoundSpanProcessor

### DIFF
--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/tracing/LateBoundSpanProcessor.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/tracing/LateBoundSpanProcessor.java
@@ -12,7 +12,10 @@ import io.opentelemetry.sdk.trace.SpanProcessor;
  * Class to facilitate a delay in when the worker thread inside {@link SpanProcessor}
  * is started, enabling Quarkus to instantiate a {@link io.opentelemetry.api.trace.TracerProvider}
  * during static initialization and set a {@link SpanProcessor} delegate during runtime initialization.
+ *
+ * Deprecated for removal. Check: https://github.com/quarkusio/quarkus/pull/52752
  */
+@Deprecated(forRemoval = true)
 public class LateBoundSpanProcessor implements SpanProcessor {
     private static final Logger log = Logger.getLogger(LateBoundSpanProcessor.class);
 

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/tracing/RemoveableLateBoundSpanProcessor.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/tracing/RemoveableLateBoundSpanProcessor.java
@@ -5,7 +5,10 @@ import io.quarkus.opentelemetry.runtime.AutoConfiguredOpenTelemetrySdkBuilderCus
 /**
  * The only point in having this class is to allow {@link TracerProviderCustomizer}
  * to easily ignore the configured {@link LateBoundSpanProcessor}.
+ *
+ * Deprecated for removal. Check: https://github.com/quarkusio/quarkus/pull/52752
  */
+@Deprecated(forRemoval = true)
 public final class RemoveableLateBoundSpanProcessor extends LateBoundSpanProcessor {
 
     public static final RemoveableLateBoundSpanProcessor INSTANCE = new RemoveableLateBoundSpanProcessor();


### PR DESCRIPTION
`LateBoundSpanProcessor` and `RemoveableLateBoundSpanProcessor` have been deprecated and marked for removal. 
If you rely on the behavior of those classes, please checkout the new code and prepare accordingly: https://github.com/quarkusio/quarkus/pull/52752