### PR TITLE
Remove useless codegen annotations and bump smallrye-mutiny-vertx

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -13,7 +13,7 @@
     <name>Quarkus - BOM</name>
     <packaging>pom</packaging>
 
-    <properties>
+        <properties>
         <angus-activation.version>2.0.3</angus-activation.version>
         <angus-mail.version>2.0.5</angus-mail.version> <!-- keep in sync with angus-activation (mail depends on activation) -->
         <bouncycastle.version>1.84</bouncycastle.version>
@@ -55,7 +55,7 @@
         <smallrye-context-propagation.version>2.3.0</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.3</smallrye-reactive-types-converter.version>
-        <smallrye-mutiny-vertx-binding.version>3.22.1</smallrye-mutiny-vertx-binding.version>
+        <smallrye-mutiny-vertx-binding.version>3.22.2</smallrye-mutiny-vertx-binding.version>
         <smallrye-reactive-messaging.version>4.34.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>2.7.9</smallrye-stork.version>
         <jakarta.activation.version>2.1.4</jakarta.activation.version>

--- a/extensions/micrometer/runtime/pom.xml
+++ b/extensions/micrometer/runtime/pom.xml
@@ -21,6 +21,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-codegen</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
         </dependency>

--- a/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/VertxUtilTest.java
+++ b/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/VertxUtilTest.java
@@ -10,7 +10,6 @@ import javax.security.cert.X509Certificate;
 import org.junit.jupiter.api.Test;
 
 import io.netty.handler.codec.DecoderResult;
-import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
@@ -110,7 +109,7 @@ class VertxUtilTest {
             }
 
             @Override
-            public @Nullable String scheme() {
+            public String scheme() {
                 return "";
             }
 
@@ -120,27 +119,27 @@ class VertxUtilTest {
             }
 
             @Override
-            public @Nullable String path() {
+            public String path() {
                 return "";
             }
 
             @Override
-            public @Nullable String query() {
+            public String query() {
                 return "";
             }
 
             @Override
-            public @Nullable HostAndPort authority() {
+            public HostAndPort authority() {
                 return null;
             }
 
             @Override
-            public @Nullable HostAndPort authority(boolean b) {
+            public HostAndPort authority(boolean b) {
                 return null;
             }
 
             @Override
-            public @Nullable String host() {
+            public String host() {
                 return "";
             }
 
@@ -212,7 +211,7 @@ class VertxUtilTest {
             }
 
             @Override
-            public HttpServerRequest uploadHandler(@Nullable Handler<HttpServerFileUpload> uploadHandler) {
+            public HttpServerRequest uploadHandler(Handler<HttpServerFileUpload> uploadHandler) {
                 return null;
             }
 
@@ -222,7 +221,7 @@ class VertxUtilTest {
             }
 
             @Override
-            public @Nullable String getFormAttribute(String attributeName) {
+            public String getFormAttribute(String attributeName) {
                 return "";
             }
 
@@ -257,12 +256,12 @@ class VertxUtilTest {
             }
 
             @Override
-            public @Nullable Cookie getCookie(String name) {
+            public Cookie getCookie(String name) {
                 return null;
             }
 
             @Override
-            public @Nullable Cookie getCookie(String name, String domain, String path) {
+            public Cookie getCookie(String name, String domain, String path) {
                 return null;
             }
 

--- a/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/pool/TransactionalContextConnection.java
+++ b/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/pool/TransactionalContextConnection.java
@@ -2,7 +2,6 @@ package io.quarkus.reactive.transaction.runtime.pool;
 
 import org.jboss.logging.Logger;
 
-import io.vertx.codegen.annotations.Fluent;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -30,7 +29,6 @@ public class TransactionalContextConnection implements SqlConnection {
         this.connection = connection;
     }
 
-    @Fluent
     @Override
     public SqlConnection prepare(String sql, Handler<AsyncResult<PreparedStatement>> handler) {
         return connection.prepare(sql, handler);
@@ -41,7 +39,6 @@ public class TransactionalContextConnection implements SqlConnection {
         return connection.prepare(sql);
     }
 
-    @Fluent
     @Override
     public SqlConnection prepare(String sql, PrepareOptions options, Handler<AsyncResult<PreparedStatement>> handler) {
         return connection.prepare(sql, options, handler);
@@ -52,13 +49,11 @@ public class TransactionalContextConnection implements SqlConnection {
         return connection.prepare(sql, options);
     }
 
-    @Fluent
     @Override
     public SqlConnection exceptionHandler(Handler<Throwable> handler) {
         return connection.exceptionHandler(handler);
     }
 
-    @Fluent
     @Override
     public SqlConnection closeHandler(Handler<Void> handler) {
         return connection.closeHandler(handler);

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/ObservableRedis.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/ObservableRedis.java
@@ -2,7 +2,6 @@ package io.quarkus.redis.runtime.client;
 
 import java.util.List;
 
-import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -47,7 +46,7 @@ public class ObservableRedis implements Redis {
     }
 
     @Override
-    public Redis send(Request command, Handler<AsyncResult<@Nullable Response>> onSend) {
+    public Redis send(Request command, Handler<AsyncResult<Response>> onSend) {
         long begin = System.nanoTime();
         redis.send(command, ar -> {
             report(System.nanoTime() - begin, ar.succeeded());
@@ -57,7 +56,7 @@ public class ObservableRedis implements Redis {
     }
 
     @Override
-    public Redis batch(List<Request> commands, Handler<AsyncResult<List<@Nullable Response>>> onSend) {
+    public Redis batch(List<Request> commands, Handler<AsyncResult<List<Response>>> onSend) {
         long begin = System.nanoTime();
         redis.batch(commands, ar -> {
             report(System.nanoTime() - begin, ar.succeeded());
@@ -106,7 +105,7 @@ public class ObservableRedis implements Redis {
         }
 
         @Override
-        public RedisConnection handler(@Nullable Handler<Response> handler) {
+        public RedisConnection handler(Handler<Response> handler) {
             delegate.handler(handler);
             return this;
         }
@@ -130,7 +129,7 @@ public class ObservableRedis implements Redis {
         }
 
         @Override
-        public RedisConnection endHandler(@Nullable Handler<Void> endHandler) {
+        public RedisConnection endHandler(Handler<Void> endHandler) {
             delegate.endHandler(endHandler);
             return this;
         }

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -56,7 +56,7 @@
         <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>
 
         <mutiny.version>3.2.0</mutiny.version>
-        <smallrye-mutiny-vertx-core.version>3.22.1</smallrye-mutiny-vertx-core.version>
+        <smallrye-mutiny-vertx-core.version>3.22.2</smallrye-mutiny-vertx-core.version>
         <smallrye-common.version>2.17.0</smallrye-common.version>
         <vertx.version>4.5.26</vertx.version>
         <rest-assured.version>6.0.0</rest-assured.version>


### PR DESCRIPTION
Removed useless codegen annotations in Quarkus sources and bumped smallrye-vertx-mutiny to make dependency optional. See [Smallrye-mutiny-vertx PR](https://github.com/smallrye/smallrye-mutiny-vertx-bindings/pull/1316).