### PR TITLE
Strip matrix parameters from request paths during HTTP security polic…

### DIFF
--- a/docs/src/main/asciidoc/security-authorize-web-endpoints-reference.adoc
+++ b/docs/src/main/asciidoc/security-authorize-web-endpoints-reference.adoc
@@ -13,11 +13,6 @@ include::_attributes.adoc[]
 Quarkus incorporates a pluggable web security layer.
 When security is active, the system performs a permission check on all HTTP requests to determine if they should proceed.
 
-[NOTE]
-====
-If you use Jakarta RESTful Web Services, consider using `quarkus.security.jaxrs.deny-unannotated-endpoints` or `quarkus.security.jaxrs.default-roles-allowed` to set default security requirements instead of HTTP path-level matching because annotations can override these properties on an individual endpoint.
-====
-
 Authorization is based on user roles that the security provider provides.
 To customize these roles, a `SecurityIdentityAugmentor` can be created, see
 xref:security-customization.adoc#security-identity-customization[Security Identity Customization].
@@ -25,11 +20,29 @@ xref:security-customization.adoc#security-identity-customization[Security Identi
 [[authorization-using-configuration]]
 == Authorization using configuration
 
+[NOTE]
+====
+If you work with Jakarta RESTful Web Services (JAX-RS) and need to set default security requirements, consider using <<standard-security-annotations>> and `quarkus.security.jaxrs.deny-unannotated-endpoints` or `quarkus.security.jaxrs.default-roles-allowed` properties instead of the HTTP security policy path-level matching because the security annotations can override these properties on an individual JAX-RS resource or method level.
+====
+
 Permissions are defined in the Quarkus configuration by permission sets, each specifying a policy for access control.
 
 [NOTE]
 ====
 When a security policy's `paths` property contains the most specific path that matches the current request path, it takes precedence over other security policies with matching paths and is said to win.
+====
+
+[NOTE]
+====
+Configured HTTP security policy must not contain a semicolon ';' character in its `paths` property.
+Use <<custom-http-security-policy>> when a security policy decision depends on a presence of certain matrix parameters in the request path.
+====
+
+[IMPORTANT]
+====
+Be careful with creating complex, possibly overlapping HTTP security policy path expressions.
+Make sure your HTTP policy configuration is thoroughly tested.
+If you work with Jakarta RESTful Web Services (JAX-RS) and need to create complex security policies, consider using <<standard-security-annotations>> instead.
 ====
 
 .{project-name} policies summary

--- a/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerAuthorizer.java
+++ b/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerAuthorizer.java
@@ -29,6 +29,7 @@ import io.quarkus.security.runtime.QuarkusSecurityIdentity;
 import io.quarkus.security.spi.runtime.BlockingSecurityExecutor;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
 import io.quarkus.vertx.http.runtime.security.HttpSecurityPolicy;
+import io.quarkus.vertx.http.runtime.security.HttpSecurityUtils;
 import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
 
@@ -61,7 +62,8 @@ public class KeycloakPolicyEnforcerAuthorizer implements HttpSecurityPolicy {
                                     return blockingExecutor.executeBlocking(new Supplier<PathConfig>() {
                                         @Override
                                         public PathConfig get() {
-                                            return policyEnforcer.getPathMatcher().matches(routingContext.normalizedPath());
+                                            return policyEnforcer.getPathMatcher().matches(HttpSecurityUtils
+                                                    .pathWithoutMatrixParams(routingContext.normalizedPath()));
                                         }
                                     }).flatMap(new Function<PathConfig, Uni<? extends CheckResult>>() {
                                         @Override

--- a/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/VertxHttpFacade.java
+++ b/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/VertxHttpFacade.java
@@ -10,6 +10,7 @@ import org.keycloak.adapters.authorization.spi.HttpResponse;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.quarkus.vertx.http.runtime.VertxInputStream;
+import io.quarkus.vertx.http.runtime.security.HttpSecurityUtils;
 import io.vertx.core.http.Cookie;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
@@ -119,7 +120,7 @@ public class VertxHttpFacade implements HttpRequest, HttpResponse {
 
             @Override
             public String getRelativePath() {
-                return routingContext.normalizedPath();
+                return HttpSecurityUtils.pathWithoutMatrixParams(routingContext.normalizedPath());
             }
 
             @Override

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/StaticTenantResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/StaticTenantResolver.java
@@ -20,6 +20,7 @@ import org.jboss.logging.Logger;
 import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.TenantResolver;
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
+import io.quarkus.vertx.http.runtime.security.HttpSecurityUtils;
 import io.quarkus.vertx.http.runtime.security.ImmutablePathMatcher;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.json.JsonArray;
@@ -125,12 +126,13 @@ final class StaticTenantResolver {
 
         @Override
         public String resolve(RoutingContext context) {
-            String[] pathSegments = context.request().path().split(PATH_SEPARATOR);
-            for (String segment : pathSegments) {
-                if (tenantConfigBean.getStaticTenant(segment) != null) {
+            String[] pathSegments = HttpSecurityUtils.pathWithoutMatrixParams(context.normalizedPath())
+                    .split(PATH_SEPARATOR);
+            for (String canonicalSegment : pathSegments) {
+                if (tenantConfigBean.getStaticTenant(canonicalSegment) != null) {
                     LOG.debugf(
-                            "Tenant id '%s' is selected on the '%s' request path", segment, context.normalizedPath());
-                    return segment;
+                            "Tenant id '%s' is selected on the '%s' request path", canonicalSegment, context.normalizedPath());
+                    return canonicalSegment;
                 }
             }
             return null;
@@ -157,10 +159,11 @@ final class StaticTenantResolver {
 
         @Override
         public String resolve(RoutingContext context) {
-            String tenantId = staticTenantPaths.match(context.normalizedPath()).getValue();
+            String canonicalPath = HttpSecurityUtils.pathWithoutMatrixParams(context.normalizedPath());
+            String tenantId = staticTenantPaths.match(canonicalPath).getValue();
             if (tenantId != null) {
                 LOG.debugf(
-                        "Tenant id '%s' is selected on the '%s' request path", tenantId, context.normalizedPath());
+                        "Tenant id '%s' is selected on the '%s' request path", tenantId, canonicalPath);
                 return tenantId;
             }
             return null;

--- a/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/security/JakartaRestAuthenticationWithMatrixTest.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/security/JakartaRestAuthenticationWithMatrixTest.java
@@ -1,0 +1,156 @@
+package io.quarkus.resteasy.test.security;
+
+import static org.apache.commons.codec.binary.Base64.encodeBase64URLSafeString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URL;
+import java.time.Duration;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.mutiny.core.Vertx;
+import io.vertx.mutiny.core.http.HttpClientRequest;
+
+public class JakartaRestAuthenticationWithMatrixTest {
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(20);
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(TestIdentityProvider.class, TestIdentityController.class, ApiResource.class,
+                            ApiWithMatrixResource.class, ApiWithEncodedSemicolonResource.class));
+
+    @BeforeAll
+    public static void setup() {
+        TestIdentityController.resetRoles()
+                .add("admin", "admin", "admin")
+                .add("test", "test", "test");
+    }
+
+    @TestHTTPResource
+    URL url;
+
+    @Inject
+    Vertx vertx;
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/api", "/api/service",
+            "/api;", "/api;/service;",
+            "/api;a", "/api;/service;a",
+            "/api-with-percent-encoded%3Ba"
+    })
+    public void testNotAuthenticated(String path) {
+        assureAuthenticationFailure(path);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/api", "/api/service",
+            "/api;", "/api;/service;",
+            "/api;a", "/api;/service;a",
+            "/api-with-percent-encoded%3Ba"
+    })
+    public void testAuthenticated(String path) {
+        assureAuthenticationSuccess(path);
+    }
+
+    @Test
+    public void testMatrixInPathAnnotation() {
+        assurePath("/api-with-matrix;a", 404);
+    }
+
+    @Test
+    public void testMatrixInsteadOfPercentEncodedNotFound() {
+        assureNotFound("/api-with-percent-encoded;a");
+    }
+
+    @Path("/api")
+    @Authenticated
+    public static class ApiResource {
+
+        @GET
+        public String api() {
+            return "api";
+        }
+
+        @GET
+        @Path("/service")
+        public String service() {
+            return "service";
+        }
+    }
+
+    @Path("/api-with-matrix;a")
+    public static class ApiWithMatrixResource {
+
+        @GET
+        public String apiWithMatrix() {
+            throw new RuntimeException();
+        }
+    }
+
+    @Path("/api-with-percent-encoded%3Ba")
+    @Authenticated
+    public static class ApiWithEncodedSemicolonResource {
+
+        @GET
+        public String apiWithEncodedSemicolon() {
+            return "hello";
+        }
+    }
+
+    private void assureAuthenticationFailure(String path) {
+        assurePath(path, 401);
+    }
+
+    private void assureAuthenticationSuccess(String path) {
+        assurePath(path, 200);
+    }
+
+    private void assureNotFound(String path) {
+        assurePath(path, 404);
+    }
+
+    private void assurePath(String path, int expectedStatusCode) {
+        var httpClient = vertx.createHttpClient();
+        try {
+            httpClient
+                    .request(HttpMethod.GET, url.getPort(), url.getHost(), path)
+                    .map(r -> {
+                        if (expectedStatusCode == 200) {
+                            r.putHeader("Authorization",
+                                    "Basic " + encodeBase64URLSafeString("admin:admin".getBytes()));
+                        }
+                        return r;
+                    })
+                    .flatMap(HttpClientRequest::send)
+                    .invoke(r -> assertEquals(expectedStatusCode, r.statusCode(), path))
+                    .flatMap(r -> {
+                        return Uni.createFrom().nullItem();
+                    })
+                    .await()
+                    .atMost(REQUEST_TIMEOUT);
+        } finally {
+            httpClient
+                    .close()
+                    .await()
+                    .atMost(REQUEST_TIMEOUT);
+        }
+    }
+}

--- a/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/security/JakartaRestResourceHttpPermissionTest.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/security/JakartaRestResourceHttpPermissionTest.java
@@ -22,6 +22,7 @@ import io.quarkus.security.test.utils.TestIdentityController;
 import io.quarkus.security.test.utils.TestIdentityProvider;
 import io.quarkus.test.QuarkusExtensionTest;
 import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.vertx.http.runtime.security.HttpSecurityUtils;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.mutiny.core.Vertx;
@@ -82,8 +83,34 @@ public class JakartaRestResourceHttpPermissionTest {
     }
 
     @ParameterizedTest
+    @ValueSource(strings = {
+            // path without wildcard, with leading slashes in both policy and @Path
+            "/api;/foo;/", "/api;/foo;",
+            "/api;a/foo;a/", "/api;a/foo;a",
+            // path with wildcard, without leading slashes in both policy and @Path
+            "/api;/bar;", "/api;/bar;/irish;",
+            "/api;a/bar;/", "/api;a/bar;a", "/api;a/bar;a/",
+            "/api;a/bar;a/irish;", "/api;a/bar;a/irish;a",
+            // combination of permit and authenticated policies, paths are resolved to /api/baz/fum/ and auth required
+            "/api;/baz;/fum;/",
+            "/api;a/baz;a/fum;a/"
+    })
+    public void testEmptyPathSegmentsWithMatrix(String path) {
+        assurePath(path, 401);
+        assurePathAuthenticated(path, getLastNonEmptySegmentContent(path));
+    }
+
+    @ParameterizedTest
     @ValueSource(strings = { "/", "///", "/?stuff", "" })
     public void testRootPath(String path) {
+        assurePath(path, 401);
+        assurePathAuthenticated(path);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "/;", "/;?stuff",
+            "/;a", "/;a?stuff" })
+    public void testRootPathWithMatrix(String path) {
         assurePath(path, 401);
         assurePathAuthenticated(path);
     }
@@ -96,10 +123,44 @@ public class JakartaRestResourceHttpPermissionTest {
     }
 
     @ParameterizedTest
+    @ValueSource(strings = { "/one;/", "/three;?stuff",
+            "/one;a/", "/three;a?stuff" })
+    public void testNotSecuredPathsWithMatrix(String path) {
+        // negative testing - all paths are public unless auth policy is applied
+        assurePath(path, 200);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "/one;/;", "/one;a/;a" })
+    public void testNotSecuredNotFoundWithMatrix(String path) {
+        // Classic can't route these paths but they are not secured either
+        assurePath(path, 404);
+    }
+
+    @ParameterizedTest
     @ValueSource(strings = { "/api/foo///", "////api/foo", "/api//foo", "/api/bar///irish", "/api/bar///irish/",
             "/api//baz/fum//",
             "/api///foo", "////api/bar", "/api///bar", "/api//bar" })
     public void testSecuredNotFound(String path) {
+        assurePath(path, 401);
+        assurePathAuthenticated(path, 404);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/api;/foo;///", "////api;/foo;", "/api;//foo;", "/api;/foo;///.", "/api;/foo;/./",
+            "/api;/foo;/;", "/api;///foo;",
+            "/api;/bar;///irish;", "/api;/bar;///irish;/", "/api;/bar;///irish;/.", "/../api;/bar;///irish;/.",
+            "/api;/bar;/;", "/api;//bar;", "////api;/bar;", "/api;///bar;",
+            "/api;//baz;/fum;//", "/api;//baz;/fum;//;", "/api;//baz;/fum;/.", "/api;/baz;/fum;/;",
+            "/api;a/foo;a///", "/api;a/foo;a///;a", "////api;a/foo;a", "/api;a//foo;a",
+            "/api;a/foo;a///.", "/api;a/foo;a/./", "/api;a/foo;a/;a",
+            "/api;a///foo;a",
+            "/api;a/bar;a///irish;a", "/api;a/bar;a///irish;a/", "/api;a/bar;a///irish;a/.", "/../api;a/bar;a///irish;a/.",
+            "/api;a/bar;a/;a", "/api;a//bar;a", "////api;a/bar;a", "/api;a///bar;a",
+            "/api;a//baz;a/fum;a//", "/api;a//baz;a/fum;a//;a", "/api;a//baz;a/fum;a/.", "/api;a/baz;a/fum;a/;a",
+            "///;", "///;a" })
+    public void testSecuredNotFoundWithMatrix(String path) {
         assurePath(path, 401);
         assurePathAuthenticated(path, 404);
     }
@@ -113,7 +174,19 @@ public class JakartaRestResourceHttpPermissionTest {
         assurePath("/jax-rs", 200, "admin", true, "admin:admin");
     }
 
+    @Test
+    public void testJaxRsRolesHttpSecurityPolicyWithMatrix() {
+        assurePath("/jax-rs;", 401);
+        assurePath("/jax-rs;a", 401);
+        assurePath("///jax-rs;///", 401);
+        assurePath("///jax-rs;a///", 401);
+
+        assurePath("/jax-rs;", 200, "admin", true, "admin:admin");
+        assurePath("/jax-rs;a", 200, "admin", true, "admin:admin");
+    }
+
     private static String getLastNonEmptySegmentContent(String path) {
+        path = HttpSecurityUtils.pathWithoutMatrixParams(path);
         while (path.endsWith("/") || path.endsWith(".")) {
             path = path.substring(0, path.length() - 1);
         }
@@ -239,7 +312,8 @@ public class JakartaRestResourceHttpPermissionTest {
                     .request(HttpMethod.GET, url.getPort(), url.getHost(), path)
                     .map(r -> {
                         if (auth) {
-                            r.putHeader("Authorization", "Basic " + encodeBase64URLSafeString(credentials.getBytes()));
+                            r.putHeader("Authorization",
+                                    "Basic " + encodeBase64URLSafeString(credentials.getBytes()));
                         }
                         return r;
                     })

--- a/extensions/resteasy-reactive/rest-csrf/runtime/src/main/java/io/quarkus/csrf/reactive/runtime/CsrfRequestResponseReactiveFilter.java
+++ b/extensions/resteasy-reactive/rest-csrf/runtime/src/main/java/io/quarkus/csrf/reactive/runtime/CsrfRequestResponseReactiveFilter.java
@@ -16,6 +16,7 @@ import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
 import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveContainerRequestContext;
 
 import io.quarkus.runtime.LaunchMode;
+import io.quarkus.vertx.http.runtime.security.HttpSecurityUtils;
 import io.vertx.core.http.Cookie;
 import io.vertx.core.http.impl.CookieImpl;
 import io.vertx.ext.web.RoutingContext;
@@ -274,7 +275,7 @@ public class CsrfRequestResponseReactiveFilter {
 
     private static boolean isCsrfTokenRequired(RoutingContext routing, RestCsrfConfig config) {
         return config.createTokenPath()
-                .map(value -> value.contains(routing.normalizedPath())).orElse(true);
+                .map(value -> value.contains(HttpSecurityUtils.pathWithoutMatrixParams(routing.normalizedPath()))).orElse(true);
     }
 
     private static void createCookie(String cookieTokenValue, RoutingContext routing, RestCsrfConfig config) {

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/JakartaRestAuthenticationWithMatrixTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/JakartaRestAuthenticationWithMatrixTest.java
@@ -1,0 +1,154 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URL;
+import java.time.Duration;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.client.WebClient;
+
+public class JakartaRestAuthenticationWithMatrixTest {
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(20);
+
+    private static WebClient client;
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(TestIdentityProvider.class, TestIdentityController.class, ApiResource.class,
+                            ApiWithMatrixResource.class, ApiWithEncodedSemicolonResource.class));
+
+    @BeforeAll
+    public static void setup() {
+        TestIdentityController.resetRoles()
+                .add("admin", "admin", "admin")
+                .add("test", "test", "test");
+    }
+
+    @AfterAll
+    public static void cleanup() {
+        if (client != null) {
+            client.close();
+        }
+    }
+
+    @Inject
+    Vertx vertx;
+
+    @TestHTTPResource
+    URL url;
+
+    private WebClient getClient() {
+        if (client == null) {
+            client = WebClient.create(vertx);
+        }
+        return client;
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/api", "/api/service",
+            "/api;", "/api;/service;",
+            "/api;a", "/api;/service;a",
+            "/api-with-percent-encoded%3Ba"
+    })
+    public void testNotAuthenticated(String path) {
+        assureAuthenticationFailure(path);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/api", "/api/service",
+            "/api;", "/api;/service;",
+            "/api;a", "/api;/service;a",
+            "/api-with-percent-encoded%3Ba"
+    })
+    public void testAuthenticated(String path) {
+        assureAuthenticationSuccess(path);
+    }
+
+    @Test
+    public void testMatrixInPathAnnotationNotFound() {
+        assureNotFound("/api-with-matrix;a");
+    }
+
+    @Test
+    public void testMatrixInsteadOfPercentEncodedNotFound() {
+        assureNotFound("/api-with-percent-encoded;a");
+    }
+
+    @Path("/api")
+    @Authenticated
+    public static class ApiResource {
+
+        @GET
+        public String api() {
+            return "api";
+        }
+
+        @GET
+        @Path("/service")
+        public String service() {
+            return "service";
+        }
+    }
+
+    @Path("/api-with-matrix;a")
+    public static class ApiWithMatrixResource {
+
+        @GET
+        public String apiWithMatrix() {
+            throw new RuntimeException();
+        }
+    }
+
+    @Path("/api-with-percent-encoded%3Ba")
+    @Authenticated
+    public static class ApiWithEncodedSemicolonResource {
+
+        @GET
+        public String apiWithEncodedSemicolon() {
+            return "hello";
+        }
+    }
+
+    private void assureAuthenticationFailure(String path) {
+        assurePath(path, 401);
+    }
+
+    private void assureAuthenticationSuccess(String path) {
+        assurePath(path, 200);
+    }
+
+    private void assureNotFound(String path) {
+        assurePath(path, 404);
+    }
+
+    private void assurePath(String path, int expectedStatusCode) {
+        var req = getClient().get(url.getPort(), url.getHost(), path);
+        if (expectedStatusCode == 200) {
+            req.basicAuthentication("admin", "admin");
+        }
+        var result = req.send();
+        await().atMost(REQUEST_TIMEOUT).until(result::isComplete);
+        assertEquals(expectedStatusCode, result.result().statusCode(), path);
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/JakartaRestResourceHttpPermissionTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/JakartaRestResourceHttpPermissionTest.java
@@ -24,6 +24,7 @@ import io.quarkus.security.test.utils.TestIdentityController;
 import io.quarkus.security.test.utils.TestIdentityProvider;
 import io.quarkus.test.QuarkusExtensionTest;
 import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.vertx.http.runtime.security.HttpSecurityUtils;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.client.WebClient;
 
@@ -100,6 +101,29 @@ public class JakartaRestResourceHttpPermissionTest {
     }
 
     @ParameterizedTest
+    @ValueSource(strings = {
+            // path without wildcard, with leading slashes in both policy and @Path
+            "////api;/foo;", "/api;/foo;", "/api;//foo;", "/api;//foo;", "/api;///foo;", "/api;/foo;/;", "/api;/foo;///",
+            "/api;/foo;///.", "/api;/foo;/./",
+            "////api;a/foo;a", "/api;a/foo;a", "/api;a//foo;a", "/api;a//foo;a", "/api;a///foo;a", "/api;a/foo;a/;a",
+            "/api;a/foo;a///",
+            "/api;a/foo;a///.", "/api;a/foo;a/./",
+            // path with wildcard, without leading slashes in both policy and @Path
+            "////api;/bar;", "/api;///bar;", "/api;//bar;", "/api;/bar;", "/api;/bar;/;", "/api;/bar;/irish;",
+            "/api;/bar;///irish;", "/api;/bar;///irish;/.", "/../api;/bar;///irish;/.",
+            "////api;a/bar;a", "/api;a///bar;a", "/api;a//bar;a", "/api;a/bar;a", "/api;a/bar;a/;a", "/api;a/bar;a/irish;a",
+            "/api;a/bar;a///irish;a", "/api;a/bar;a///irish;a/.", "/../api;a/bar;a///irish;a/.",
+            // combination of permit and authenticated policies, paths are resolved to /api/baz/fum/ and auth required
+            "/api;/baz;/fum;/;", "/api;//baz;/fum;//;", "/api;//baz;/fum;/.",
+            "/api;a/baz;a/fum;a/;a", "/api;a//baz;a/fum;a//;a", "/api;a//baz;a/fum;a/."
+    })
+    public void testEmptyPathSegmentsWithMatrix(String path) {
+        assurePath(path, 401);
+
+        assurePathAuthenticated(path, getLastNonEmptySegmentContent(path));
+    }
+
+    @ParameterizedTest
     @ValueSource(strings = { "/", "///", "/?stuff", "/#stuff/", "" })
     public void testRootPath(String path) {
         assurePath(path, 401);
@@ -107,8 +131,24 @@ public class JakartaRestResourceHttpPermissionTest {
     }
 
     @ParameterizedTest
+    @ValueSource(strings = { "/;", "///;", "/;?stuff", "/#stuff;/;",
+            "/;a", "///;a", "/;a?stuff", "/#stuff;a/;a" })
+    public void testRootPathWithMatrix(String path) {
+        assurePath(path, 401);
+        assurePathAuthenticated(path);
+    }
+
+    @ParameterizedTest
     @ValueSource(strings = { "/one/", "///two", "/three?stuff", "/four#stuff", "/.////five" })
     public void testNotSecuredPaths(String path) {
+        // negative testing - all paths are public unless auth policy is applied
+        assurePathAuthenticated(path);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "/one;/;", "///two;", "/three;?stuff", "/four#stuff;", "/.////five;",
+            "/one;a/;a", "///two;a", "/three;a?stuff", "/four#stuff;a", "/.////five;a" })
+    public void testNotSecuredPathsWithMatrix(String path) {
         // negative testing - all paths are public unless auth policy is applied
         assurePathAuthenticated(path);
     }
@@ -122,7 +162,20 @@ public class JakartaRestResourceHttpPermissionTest {
         assurePath("/jax-rs", 200, "admin", true, "admin");
     }
 
+    @Test
+    public void testJaxRsRolesHttpSecurityPolicyWithMatrix() {
+        // insufficient role, expected admin
+        assurePath("/jax-rs;", 401);
+        assurePath("/jax-rs;a", 401);
+        assurePath("///jax-rs;///;", 401);
+        assurePath("///jax-rs;a///;a", 401);
+
+        assurePath("/jax-rs;", 200, "admin", true, "admin");
+        assurePath("/jax-rs;a", 200, "admin", true, "admin");
+    }
+
     private static String getLastNonEmptySegmentContent(String path) {
+        path = HttpSecurityUtils.pathWithoutMatrixParams(path);
         while (path.endsWith("/") || path.endsWith(".")) {
             path = path.substring(0, path.length() - 1);
         }

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/ServletHttpSecurityPolicy.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/ServletHttpSecurityPolicy.java
@@ -6,6 +6,7 @@ import jakarta.inject.Singleton;
 
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.vertx.http.runtime.security.HttpSecurityPolicy;
+import io.quarkus.vertx.http.runtime.security.HttpSecurityUtils;
 import io.smallrye.mutiny.Uni;
 import io.undertow.servlet.api.Deployment;
 import io.undertow.servlet.api.SecurityInfo;
@@ -25,7 +26,7 @@ public class ServletHttpSecurityPolicy implements HttpSecurityPolicy {
     public Uni<CheckResult> checkPermission(RoutingContext request, Uni<SecurityIdentity> identity,
             AuthorizationRequestContext requestContext) {
 
-        String requestPath = request.normalizedPath();
+        String requestPath = HttpSecurityUtils.pathWithoutMatrixParams(request.normalizedPath());
         if (!requestPath.startsWith(contextPath)) {
             //anything outside the context path we don't have anything to do with
             return CheckResult.permit();

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/ConfigBasedPathMatchingHttpSecurityPolicyTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/ConfigBasedPathMatchingHttpSecurityPolicyTest.java
@@ -28,6 +28,8 @@ public class ConfigBasedPathMatchingHttpSecurityPolicyTest extends PathMatchingH
             quarkus.http.auth.permission.inner-wildcard6.paths=/api/*/sadly/*/dont-know
             quarkus.http.auth.permission.inner-wildcard6.policy=deny
             quarkus.http.auth.permission.baz.paths=/api/baz
+            quarkus.http.auth.permission.baz-percent-enc.policy=authenticated
+            quarkus.http.auth.permission.baz-percent-enc.paths=/api/baz%3Bv=1.1
             quarkus.http.auth.permission.baz.policy=authenticated
             quarkus.http.auth.permission.static-resource.paths=/static-file.html
             quarkus.http.auth.permission.static-resource.policy=authenticated

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FluentApiPathMatchingHttpSecurityPolicyTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FluentApiPathMatchingHttpSecurityPolicyTest.java
@@ -27,6 +27,8 @@ public class FluentApiPathMatchingHttpSecurityPolicyTest extends PathMatchingHtt
 
             httpSecurity.path("/api/fubar/baz*").authenticated();
 
+            httpSecurity.path("/api/baz%3Bv=1.1").authenticated();
+
             httpSecurity.path("/q/*").authenticated();
 
             httpSecurity.path("/secured/*").shared().authorization()

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/HttpPolicyConfigurationWithSemicolonTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/HttpPolicyConfigurationWithSemicolonTestCase.java
@@ -1,0 +1,45 @@
+package io.quarkus.vertx.http.security;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class HttpPolicyConfigurationWithSemicolonTestCase {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset(
+                            "quarkus.http.auth.permission.matrix.paths=/a;\n"
+                                    + "quarkus.http.auth.permission.matrix.policy=authenticated"),
+                            "application.properties"))
+            .assertException(t -> {
+                Throwable e = t;
+                ConfigurationException te = null;
+                while (e != null) {
+                    if (e instanceof ConfigurationException) {
+                        te = (ConfigurationException) e;
+                        break;
+                    }
+                    e = e.getCause();
+                }
+                assertNotNull(te);
+                assertTrue(
+                        te.getMessage()
+                                .contains("HttpSecurityPolicy '/a;' path contains a semicolon ';' character."),
+                        te.getMessage());
+            });
+
+    @Test
+    public void test() {
+        Assertions.fail();
+    }
+
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/ManagementInterfaceBasicAuthTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/ManagementInterfaceBasicAuthTest.java
@@ -39,7 +39,7 @@ public class ManagementInterfaceBasicAuthTest {
                             quarkus.management.enabled=true
                             quarkus.management.auth.enabled=true
                             quarkus.management.auth.policy.r1.roles-allowed=admin
-                            quarkus.management.auth.permission.roles1.paths=/admin
+                            quarkus.management.auth.permission.roles1.paths=/q/metrics
                             quarkus.management.auth.permission.roles1.policy=r1
                             """), "application.properties");
         }
@@ -70,12 +70,49 @@ public class ManagementInterfaceBasicAuthTest {
     }
 
     @Test
-    public void testBasicAuthFailure() {
+    public void testBasicAuthFailureWithoutPassword() {
+        RestAssured
+                .given()
+                .redirects().follow(false)
+                .get(metrics)
+                .then()
+                .assertThat()
+                .statusCode(401);
+
+    }
+
+    @Test
+    public void testBasicAuthFailureWithoutPasswordWithMatrix() {
+        RestAssured
+                .given()
+                .redirects().follow(false)
+                .get(metrics.toString() + ";a=a1")
+                .then()
+                .assertThat()
+                .statusCode(404); // instead of 401
+
+    }
+
+    @Test
+    public void testBasicAuthFailureWrongPassword() {
         RestAssured
                 .given()
                 .auth().preemptive().basic("admin", "wrongpassword")
                 .redirects().follow(false)
                 .get(metrics)
+                .then()
+                .assertThat()
+                .statusCode(401);
+
+    }
+
+    @Test
+    public void testBasicAuthFailureWrongPasswordWithMatrix() {
+        RestAssured
+                .given()
+                .auth().preemptive().basic("admin", "wrongpassword")
+                .redirects().follow(false)
+                .get(metrics + ";a=a1")
                 .then()
                 .assertThat()
                 .statusCode(401);

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/PathMatchingHttpSecurityPolicyTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/PathMatchingHttpSecurityPolicyTest.java
@@ -106,6 +106,37 @@ public abstract class PathMatchingHttpSecurityPolicyTest {
         assurePath("/api/now/sally/i/dont-know", 200);
     }
 
+    @Test
+    public void testInnerWildcardPathWithMatrix() {
+        assurePath("/api;/any-value;/bar;", 401);
+        assurePath("/api;param/any-value;param/bar;param", 401);
+        assurePath("/api;/any-value;/bar;", 401);
+        assurePath("/api;param/any-value;param/bar;param", 401);
+        assurePath("/api;/next;/any-value;/prev;", 401);
+        assurePath("/api;param/next;param/any-value;param/prev;param", 401);
+        assurePath("/api;/one;/two;/three;/four;", 401);
+        assurePath("/api;param/one;param/two;param/three;param/four;param", 401);
+        assurePath("/api;////any-value;//////bar;", 401);
+        assurePath("/api;param////any-value;param//////bar;param", 401);
+        assurePath("/api;/next;///////any-value;////prev;", 401);
+        assurePath("/api;param/next;param///////any-value;param////prev;param", 401);
+        assurePath("////api;//one;/two;//three;////four;?door=wood", 401);
+        assurePath("////api;param//one;param/two;param//three;param////four;param?door=wood", 401);
+        assurePath("/api;/one;/three;/four;/five;", 401);
+        assurePath("/api;param/one;param/three;param/four;param/five;param", 401);
+        assurePath("/api;/one;/3;/4;/five;", 401);
+        assurePath("/api;param/one;param/3;param/4;param/five;param", 401);
+        assurePath("////api;/one;///3;/4;/five;", 401);
+        assurePath("////api;param/one;param///3;param/4;param/five;param", 401);
+        assurePath("/api;/now;/sadly;/i;/dont-know;", 401);
+        assurePath("/api;param/now;param/sadly;param/i;param/dont-know;param", 401);
+        assurePath("/api;/now;/sadly;///i;/dont-know;", 401);
+        assurePath("/api;param/now;param/sadly;param///i;param/dont-know;param", 401);
+        assurePath("/api/one/three/jamaica/five", 200);
+        assurePath("/api/one/three/jamaica/football", 200);
+        assurePath("/api/now/sally/i/dont-know", 200);
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {
             // path policy without wildcard
@@ -128,11 +159,57 @@ public abstract class PathMatchingHttpSecurityPolicyTest {
 
     @ParameterizedTest
     @ValueSource(strings = {
+            // path policy without wildcard
+            "/api;/foo;//bar;", "/api;/foo;///bar;", "/api;/foo;////bar;", "/api;/foo;/////bar;", "//api;/foo;/bar;",
+            "///api;/foo;/bar;",
+            "////api;/foo;/bar;", "//api;//foo;//bar;", "//api;/foo;//bar;",
+            "/api;param/foo;param//bar;param", "/api;param/foo;param///bar;param", "/api;param/foo;param////bar;param",
+            "/api;param/foo;param/////bar;param", "//api;param/foo;param/bar;param", "///api;param/foo;param/bar;param",
+            "////api;param/foo;param/bar;param", "//api;param//foo;param//bar;param", "//api;param/foo;param//bar;param",
+            // path policy with wildcard
+            "/api;/fubar;/baz;", "/api;/fubar;/baz;/;", "/api;/fubar;/baz;//;", "/api;/fubar;/baz;/.", "/api;/fubar;/baz;////.",
+            "/api;/fubar;/baz;/bar;",
+            "/api;param/fubar;param/baz;param", "/api;param/fubar;param/baz;param/", "/api;param/fubar;param/baz;param//",
+            "/api;param/fubar;param/baz;param/.", "/api;param/fubar;param/baz;param////.",
+            "/api;param/fubar;param/baz;param/bar;param",
+            // routes defined for exact paths
+            "/api;/baz;", "//api;/baz;", "///api;////baz;", "/api;//baz;",
+            "/api;param/baz;param", "//api;param/baz;param", "///api;param////baz;param", "/api;param//baz;param",
+            // zero length path
+            "/;?one=two",
+            "/;param?one=two",
+            // empty segments only are match with path policy for '/'
+            "/;", "///;", "////;", "/////;",
+            "/;param", "///;param", "////;param", "/////;param"
+    })
+    public void testEmptyPathSegmentsWithMatrix(String path) {
+        assurePath(path, 401);
+        assurePathAuthenticated(path);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
             "/api/foo/./bar", "/../api/foo///bar", "/api/./foo/.///bar", "/api/foo/./////bar", "/api/fubar/baz/.",
             "/..///api/foo/bar", "////../../api/foo/bar", "/./api//foo//bar", "//api/foo/./bar",
             "/.", "/..", "/./", "/..//", "/.///", "/..////", "/./////"
     })
     public void testDotPathSegments(String path) {
+        assurePath(path, 401);
+        assurePathAuthenticated(path);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/api;/foo;/./bar;", "/../api;/foo;///bar;", "/api;/./foo;/.///bar;", "/api;/foo;/./////bar;",
+            "/api;/fubar;/baz;/.",
+            "/api;param/foo;param/./bar;param", "/../api;param/foo;param///bar;param", "/api;param/./foo;param/.///bar;param",
+            "/api;param/foo;param/./////bar;param", "/api;param/fubar;param/baz;param/.",
+            "/..///api;/foo;/bar;", "////../../api;/foo;/bar;", "/./api;//foo;//bar;", "//api;/foo;/./bar;",
+            "/..///api;param/foo;param/bar;param", "////../../api;param/foo;param/bar;param",
+            "/./api;param//foo;param//bar;param",
+            "//api;param/foo;param/./bar;param"
+    })
+    public void testDotPathSegmentsWithMatrix(String path) {
         assurePath(path, 401);
         assurePathAuthenticated(path);
     }
@@ -146,10 +223,87 @@ public abstract class PathMatchingHttpSecurityPolicyTest {
         assurePathAuthenticated(path);
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/static-file.html;", "//static-file.html;", "///static-file.html;",
+            "/static-file.html;param", "//static-file.html;param", "///static-file.html;param"
+    })
+    public void testStaticResourceWithParam(String path) {
+        assurePath(path, 401);
+        assurePathAuthenticated(path);
+    }
+
+    @Test
+    public void testExactPathWithMatrixParams() {
+        // /api/baz policy = authenticated; matrix params must not bypass it
+        assurePath("/api/baz;v=1.1", 401);
+        assurePath("/api/baz;", 401);
+        assurePath("/api/baz;a=1;b=2", 401);
+        assurePathAuthenticated("/api/baz;v=1.1");
+        assurePathAuthenticated("/api/baz;");
+
+        // /api/foo/bar policy = authenticated; matrix on intermediate and last segments
+        assurePath("/api/foo;x=1/bar", 401);
+        assurePath("/api/foo/bar;y=2", 401);
+        assurePath("/api/foo;x=1/bar;y=2", 401);
+        assurePathAuthenticated("/api/foo;x=1/bar");
+        assurePathAuthenticated("/api/foo/bar;y=2");
+        assurePathAuthenticated("/api/foo;x=1/bar;y=2");
+    }
+
+    @Test
+    public void testEncodedSemicolon() {
+        // /api/baz policy = authenticated; matrix params must not bypass it
+        assurePath("/api/baz;v=1.1", 401);
+        assurePathAuthenticated("/api/baz;v=1.1");
+        // %3B is not matrix parameter therefore requires a dedicated policy
+        assurePath("/api/baz%3Bv=1.1", 401);
+        assurePathAuthenticated("/api/baz%3Bv=1.1");
+    }
+
+    @Test
+    public void testWildcardSuffixPathWithMatrixParams() {
+        // /api/fubar/baz* policy = authenticated
+
+        assurePath("/api/fubar/baz;v=1", 401);
+        assurePath("/api/fubar;x=1/baz", 401);
+        assurePath("/api/fubar/baz/extra;v=1", 401);
+        assurePathAuthenticated("/api/fubar/baz;v=1");
+        assurePathAuthenticated("/api/fubar;x=1/baz");
+    }
+
+    @Test
+    public void testStaticResourceWithMatrixParams() {
+        // /static-file.html policy = authenticated
+        assurePath("/static-file.html;v=1", 401);
+        assurePathAuthenticated("/static-file.html;v=1");
+    }
+
+    @Test
+    public void testRootPathWithMatrixParams() {
+        // / policy = authenticated
+        assurePath("/;v=1", 401);
+        assurePath("/;", 401);
+        assurePathAuthenticated("/;v=1");
+    }
+
+    @Test
+    public void testPermittedPathWithMatrixParams() {
+        // /api* policy = permit; must still be permitted with matrix params
+        assurePath("/api/something;v=1", 200);
+        assurePath("/api;v=1/something", 200);
+    }
+
+    @Test
+    public void testMatrixParamsWithMultipleSlashes() {
+        assurePath("//api;x=1//baz;y=2", 401);
+        assurePath("///api;x=1/foo;y=2/bar;z=3", 401);
+        assurePathAuthenticated("//api;x=1//baz;y=2");
+        assurePathAuthenticated("///api;x=1/foo;y=2/bar;z=3");
+    }
+
     @Test
     public void testMiscellaneousPaths() {
-        // /api/baz with segment indicating version shouldn't match /api/baz path policy
-        assurePath("/api/baz;v=1.1", 200);
         // /api/baz/ is different resource than secured /api/baz, but we secure both when there is not more specific exact path pattern
         assurePath("/api/baz/", 401);
     }
@@ -221,10 +375,6 @@ public abstract class PathMatchingHttpSecurityPolicyTest {
 
     private void assurePathAuthenticated(String path) {
         assurePath(path, 200, null, "test", null);
-    }
-
-    private void assurePathAuthenticated(String path, String body) {
-        assurePath(path, 200, body, "test", null);
     }
 
     private void assurePath(String path, int expectedStatusCode, String body, String auth, String header) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/AbstractPathMatchingHttpSecurityPolicy.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/AbstractPathMatchingHttpSecurityPolicy.java
@@ -185,6 +185,12 @@ public class AbstractPathMatchingHttpSecurityPolicy {
         }
 
         for (String path : httpPermission.getPaths()) {
+            if (path.indexOf(';') != -1) {
+                throw new ConfigurationException("""
+                        HttpSecurityPolicy '%s' path contains a semicolon ';' character.
+                        Custom HttpSecurityPolicy bean must be used to check matrix parameters.
+                        """.formatted(path));
+            }
             HttpMatcher m = new HttpMatcher(httpPermission.getAuthMechanisms(), httpPermission.getMethods(), policy);
             List<HttpMatcher> perms = new ArrayList<>();
             perms.add(m);
@@ -203,7 +209,8 @@ public class AbstractPathMatchingHttpSecurityPolicy {
 
     private static List<HttpMatcher> findHttpMatchers(RoutingContext context,
             ImmutablePathMatcher<List<HttpMatcher>> pathMatcher) {
-        PathMatch<List<HttpMatcher>> toCheck = pathMatcher.match(context.normalizedPath());
+        String normalizedPath = context.normalizedPath();
+        PathMatch<List<HttpMatcher>> toCheck = pathMatcher.match(HttpSecurityUtils.pathWithoutMatrixParams(normalizedPath));
         if (toCheck.getValue() == null || toCheck.getValue().isEmpty()) {
             return List.of();
         }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityUtils.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityUtils.java
@@ -28,6 +28,43 @@ public final class HttpSecurityUtils {
     }
 
     /**
+     * Removes matrix parameters from the path.
+     * <p>
+     * The path may contain one or more path segments separated by a forward slash `/`.
+     * Each path segment may contain matrix parameters that are separated from the path value
+     * by a semicolon ';' character.
+     * <p>
+     * When the current path segment contains a semicolon ';', it has all its data
+     * removed starting from this semicolon character.
+     * <p>
+     * For example, passing both `/a;/b;` and `/a;a1=1;a2=2/b;b1=1;b2=2` paths to this function
+     * produces the `/a/b` path.
+     * <p>
+     *
+     * @param path the path that may contain matrix parameters.
+     * @return the path without the matrix parameters.
+     */
+    public static String pathWithoutMatrixParams(String path) {
+        if (path.indexOf(';') == -1) {
+            return path;
+        }
+        StringBuilder sb = new StringBuilder(path.length());
+        boolean inMatrix = false;
+        for (int i = 0; i < path.length(); i++) {
+            char c = path.charAt(i);
+            if (c == ';') {
+                inMatrix = true;
+            } else if (c == '/') {
+                inMatrix = false;
+                sb.append(c);
+            } else if (!inMatrix) {
+                sb.append(c);
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
      * Provides all the {@link SecurityIdentity} created by the inclusive authentication.
      *
      * @return null if {@link RoutingContext} is not available or {@link #getSecurityIdentities(RoutingContext)}

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/security/AbstractPathMatchingHttpSecurityPolicyTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/security/AbstractPathMatchingHttpSecurityPolicyTest.java
@@ -1,0 +1,97 @@
+package io.quarkus.vertx.http.runtime.security;
+
+import static io.quarkus.vertx.http.runtime.security.HttpSecurityUtils.pathWithoutMatrixParams;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class AbstractPathMatchingHttpSecurityPolicyTest {
+
+    @Test
+    public void testSinglePathSegmentWithoutMatrixParams() {
+
+        assertEquals("/a", pathWithoutMatrixParams("/a"));
+        assertEquals("/a/", pathWithoutMatrixParams("/a/"));
+        assertEquals("/", pathWithoutMatrixParams("/"));
+        assertEquals("a", pathWithoutMatrixParams("a"));
+        assertEquals("", pathWithoutMatrixParams(""));
+    }
+
+    @Test
+    public void testSinglePathSegmentWithSemicolon() {
+
+        assertEquals("/a", pathWithoutMatrixParams("/a;"));
+        assertEquals("/a/", pathWithoutMatrixParams("/a/;"));
+        assertEquals("/", pathWithoutMatrixParams("/;"));
+        assertEquals("a", pathWithoutMatrixParams("a;"));
+        assertEquals("", pathWithoutMatrixParams(";"));
+    }
+
+    @Test
+    public void testSinglePathSegmentWithMatrixParams() {
+
+        assertEquals("/a", pathWithoutMatrixParams("/a;a1=2"));
+        assertEquals("/a/", pathWithoutMatrixParams("/a/;a1=2"));
+        assertEquals("/", pathWithoutMatrixParams("/;a1=2"));
+        assertEquals("a", pathWithoutMatrixParams("a;a1=2"));
+
+        assertEquals("/a", pathWithoutMatrixParams("/a;a1=2;"));
+        assertEquals("/a/", pathWithoutMatrixParams("/a/;a1=2;"));
+        assertEquals("/", pathWithoutMatrixParams("/;a1=2;"));
+        assertEquals("a", pathWithoutMatrixParams("a;a1=2;"));
+
+    }
+
+    @Test
+    public void testTwoPathSegmentsWithoutMatrixParams() {
+
+        assertEquals("/a/b", pathWithoutMatrixParams("/a/b"));
+        assertEquals("/a/b/", pathWithoutMatrixParams("/a/b/"));
+    }
+
+    @Test
+    public void testTwoPathSegmentsWithSemicolon() {
+        assertEquals("/a/b", pathWithoutMatrixParams("/a;/b;"));
+        assertEquals("/a/b/", pathWithoutMatrixParams("/a;/b;/;"));
+        assertEquals("/a/b", pathWithoutMatrixParams("/a/b;"));
+        assertEquals("/a/b", pathWithoutMatrixParams("/a;/b"));
+        assertEquals("/a/b/", pathWithoutMatrixParams("/a/b/;"));
+    }
+
+    @Test
+    public void testTwoPathSegmentsWithMatrixParams() {
+        assertEquals("/a/b", pathWithoutMatrixParams("/a;k=v/b;k=v"));
+        assertEquals("/a/b", pathWithoutMatrixParams("/a;k=v/b"));
+        assertEquals("/a/b", pathWithoutMatrixParams("/a/b;k=v"));
+        assertEquals("/a/b/", pathWithoutMatrixParams("/a;k=v/b;k=v/"));
+    }
+
+    @Test
+    public void testThreePathSegmentsWithMatrixParams() {
+        assertEquals("/a/b/c", pathWithoutMatrixParams("/a;1/b;2/c;3"));
+        assertEquals("/a/b/c", pathWithoutMatrixParams("/a/b;m/c"));
+        assertEquals("/a/b/c/", pathWithoutMatrixParams("/a;1/b;2/c;3/"));
+    }
+
+    @Test
+    public void testTrailingSlashPreservedWithMatrixParams() {
+        assertEquals("/a/b/", pathWithoutMatrixParams("/a;m/b;m/"));
+        assertEquals("/api/baz/", pathWithoutMatrixParams("/api;x/baz;y/"));
+        assertEquals("/a/", pathWithoutMatrixParams("/a;m/"));
+    }
+
+    @Test
+    public void testMultipleConsecutiveSlashesWithMatrixParams() {
+        assertEquals("//a//b", pathWithoutMatrixParams("//a;m//b;m"));
+        assertEquals("///a/b", pathWithoutMatrixParams("///a;m/b;m"));
+        assertEquals("////api/baz", pathWithoutMatrixParams("////api;x/baz;y"));
+    }
+
+    @Test
+    public void testMatrixParamWithSpecialValues() {
+        assertEquals("/a/b", pathWithoutMatrixParams("/a;k=v=w/b"));
+        assertEquals("/a/b", pathWithoutMatrixParams("/a;k=v;k2=v2/b"));
+        assertEquals("/a/b", pathWithoutMatrixParams("/a;k=v;k2=v2/b;k3=v3;k4=v4"));
+    }
+
+}

--- a/integration-tests/elytron-undertow/src/test/java/io/quarkus/it/undertow/elytron/WebXmlPermissionsTestCase.java
+++ b/integration-tests/elytron-undertow/src/test/java/io/quarkus/it/undertow/elytron/WebXmlPermissionsTestCase.java
@@ -44,6 +44,11 @@ class WebXmlPermissionsTestCase extends HttpsSetup {
                 .get("/foo/bar/../openapi")
                 .then()
                 .statusCode(401);
+        given()
+                .when()
+                .get("/foo/bar/../openapi/;a")
+                .then()
+                .statusCode(401);
     }
 
     @Test

--- a/integration-tests/keycloak-authorization/src/test/java/io/quarkus/it/keycloak/AbstractPolicyEnforcerTest.java
+++ b/integration-tests/keycloak-authorization/src/test/java/io/quarkus/it/keycloak/AbstractPolicyEnforcerTest.java
@@ -65,16 +65,41 @@ public abstract class AbstractPolicyEnforcerTest {
     }
 
     @Test
-    public void testUserHasSuperUserRoleWebTenant() throws Exception {
-        testWebAppTenantAllowed("alice");
-        testWebAppTenantForbidden("admin");
-        testWebAppTenantForbidden("jdoe");
+    public void testUserHasAdminRoleServiceTenantWithMatrix() {
+        assureGetPath("/api-permission-tenant;", 403, getAccessToken("alice"), null);
+        assureGetPath("//api-permission-tenant;", 403, getAccessToken("alice"), null);
+        assureGetPath("/api-permission-tenant;a", 403, getAccessToken("alice"), null);
+        assureGetPath("//api-permission-tenant;a", 403, getAccessToken("alice"), null);
+
+        assureGetPath("/api-permission-tenant;", 403, getAccessToken("jdoe"), null);
+        assureGetPath("//api-permission-tenant;", 403, getAccessToken("jdoe"), null);
+        assureGetPath("/api-permission-tenant;a", 403, getAccessToken("jdoe"), null);
+        assureGetPath("//api-permission-tenant;a", 403, getAccessToken("jdoe"), null);
+
+        assureGetPath("/api-permission-tenant;", 200, getAccessToken("admin"), "Permission Resource Tenant");
+        assureGetPath("//api-permission-tenant;", 200, getAccessToken("admin"), "Permission Resource Tenant");
+        assureGetPath("/api-permission-tenant;a", 200, getAccessToken("admin"), "Permission Resource Tenant");
+        assureGetPath("//api-permission-tenant;a", 200, getAccessToken("admin"), "Permission Resource Tenant");
     }
 
-    private void testWebAppTenantAllowed(String user) throws Exception {
+    @Test
+    public void testUserHasSuperUserRoleWebTenant() throws Exception {
+        testWebAppTenantAllowed("alice", "/api-permission-webapp");
+        testWebAppTenantForbidden("admin", "/api-permission-webapp");
+        testWebAppTenantForbidden("jdoe", "/api-permission-webapp");
+    }
+
+    @Test
+    public void testUserHasSuperUserRoleWebTenantWithMatrix() throws Exception {
+        testWebAppTenantAllowed("alice", "/api-permission-webapp;a=b");
+        testWebAppTenantForbidden("admin", "/api-permission-webapp;a=b");
+        testWebAppTenantForbidden("jdoe", "/api-permission-webapp;a=b");
+    }
+
+    private void testWebAppTenantAllowed(String user, String path) throws Exception {
         Awaitility.await().atMost(REQUEST_TIMEOUT).untilAsserted(() -> assertTokenStateCount(0));
         try (final org.htmlunit.WebClient webClient = createWebClient()) {
-            HtmlPage page = webClient.getPage("http://localhost:8081/api-permission-webapp");
+            HtmlPage page = webClient.getPage("http://localhost:8081" + path);
 
             assertEquals("Sign in to quarkus", page.getTitleText());
 
@@ -96,9 +121,9 @@ public abstract class AbstractPolicyEnforcerTest {
         }
     }
 
-    private void testWebAppTenantForbidden(String user) throws Exception {
+    private void testWebAppTenantForbidden(String user, String path) throws Exception {
         try (final org.htmlunit.WebClient webClient = createWebClient()) {
-            HtmlPage page = webClient.getPage("http://localhost:8081/api-permission-webapp");
+            HtmlPage page = webClient.getPage("http://localhost:8081" + path);
 
             assertEquals("Sign in to quarkus", page.getTitleText());
 
@@ -153,10 +178,53 @@ public abstract class AbstractPolicyEnforcerTest {
     }
 
     @Test
+    public void testUserHasRoleConfidentialWithMatrix() {
+        assureGetPath("/api;/permission;", 403, getAccessToken("alice"), null);
+        assureGetPath("//api;/permission;", 403, getAccessToken("alice"), null);
+
+        assureGetPath("/api;a/permission;a", 403, getAccessToken("alice"), null);
+        assureGetPath("//api;a/permission;a", 403, getAccessToken("alice"), null);
+
+        assureGetPath("/api;/permission;", 200, getAccessToken("jdoe"), "Permission Resource");
+        assureGetPath("//api;/permission;", 200, getAccessToken("jdoe"), "Permission Resource");
+
+        assureGetPath("/api;a/permission;a", 200, getAccessToken("jdoe"), "Permission Resource");
+        assureGetPath("//api;a/permission;a", 200, getAccessToken("jdoe"), "Permission Resource");
+
+        assureGetPath("/api;/permission;/scope;?scope=write", 403, getAccessToken("jdoe"), null);
+        assureGetPath("//api;/permission;/scope;?scope=write", 403, getAccessToken("jdoe"), null);
+
+        assureGetPath("/api;a/permission;a/scope;a?scope=write", 403, getAccessToken("jdoe"), null);
+        assureGetPath("//api;a/permission;a/scope;a?scope=write", 403, getAccessToken("jdoe"), null);
+
+        assureGetPath("/api;/permission;/annotation;/scope-write;", 403, getAccessToken("jdoe"), null);
+        assureGetPath("//api;/permission;/annotation;/scope-write;", 403, getAccessToken("jdoe"), null);
+
+        assureGetPath("/api;a/permission;a/annotation;a/scope-write;a", 403, getAccessToken("jdoe"), null);
+        assureGetPath("//api;a/permission;a/annotation;a/scope-write;a", 403, getAccessToken("jdoe"), null);
+
+        assureGetPath("/api;/permission;/scope;?scope=read", 200, getAccessToken("jdoe"), "read");
+        assureGetPath("//api;/permission;/scope;?scope=read", 200, getAccessToken("jdoe"), "read");
+
+        assureGetPath("/api;a/permission;a/scope;a?scope=read", 200, getAccessToken("jdoe"), "read");
+        assureGetPath("//api;a/permission;a/scope;a?scope=read", 200, getAccessToken("jdoe"), "read");
+
+        assureGetPath("/api;/permission;", 403, getAccessToken("admin"), null);
+        assureGetPath("//api;/permission;", 403, getAccessToken("admin"), null);
+
+        assureGetPath("/api;a/permission;a", 403, getAccessToken("admin"), null);
+        assureGetPath("//api;a/permission;a", 403, getAccessToken("admin"), null);
+
+        assureGetPath("/api;/permission;/entitlements;", 200, getAccessToken("admin"), null);
+        assureGetPath("//api;/permission;/entitlements;", 200, getAccessToken("admin"), null);
+
+        assureGetPath("/api;a/permission;a/entitlements;a", 200, getAccessToken("admin"), null);
+        assureGetPath("//api;a/permission;a/entitlements;a", 200, getAccessToken("admin"), null);
+    }
+
+    @Test
     public void testRequestParameterAsClaim() {
         assureGetPath("/api/permission/claim-protected?grant=true", 200, getAccessToken("alice"),
-                "Claim Protected Resource");
-        assureGetPath("//api/permission/claim-protected?grant=true", 200, getAccessToken("alice"),
                 "Claim Protected Resource");
 
         assureGetPath("/api/permission/claim-protected?grant=false", 403, getAccessToken("alice"), null);
@@ -164,6 +232,27 @@ public abstract class AbstractPolicyEnforcerTest {
 
         assureGetPath("/api/permission/claim-protected", 403, getAccessToken("alice"), null);
         assureGetPath("//api/permission/claim-protected", 403, getAccessToken("alice"), null);
+    }
+
+    @Test
+    public void testRequestParameterAsClaimWithMatrix() {
+        assureGetPath("/api;/permission;/claim-protected;?grant=true", 200, getAccessToken("alice"),
+                "Claim Protected Resource");
+
+        assureGetPath("/api;/permission;/claim-protected;?grant=false", 403, getAccessToken("alice"), null);
+        assureGetPath("//api;/permission;/claim-protected;?grant=false", 403, getAccessToken("alice"), null);
+
+        assureGetPath("/api;/permission;/claim-protected;", 403, getAccessToken("alice"), null);
+        assureGetPath("//api;/permission;/claim-protected;", 403, getAccessToken("alice"), null);
+
+        assureGetPath("/api;a/permission;a/claim-protected;a?grant=true", 200, getAccessToken("alice"),
+                "Claim Protected Resource");
+
+        assureGetPath("/api;a/permission;a/claim-protected;a?grant=false", 403, getAccessToken("alice"), null);
+        assureGetPath("//api;a/permission;a/claim-protected;a?grant=false", 403, getAccessToken("alice"), null);
+
+        assureGetPath("/api;a/permission;a/claim-protected;a", 403, getAccessToken("alice"), null);
+        assureGetPath("//api;a/permission;a/claim-protected;a", 403, getAccessToken("alice"), null);
     }
 
     @Test
@@ -176,8 +265,31 @@ public abstract class AbstractPolicyEnforcerTest {
     }
 
     @Test
+    public void testHttpResponseFromExternalServiceAsClaimWithMatrix() {
+        assureGetPath("/api;/permission;/http-response-claim-protected;", 200, getAccessToken("alice"), null);
+        assureGetPath("//api;/permission;/http-response-claim-protected;", 200, getAccessToken("alice"), null);
+
+        assureGetPath("/api;/permission;/http-response-claim-protected;", 403, getAccessToken("jdoe"), null);
+        assureGetPath("//api;/permission;/http-response-claim-protected;", 403, getAccessToken("jdoe"), null);
+
+        assureGetPath("/api;a/permission;a/http-response-claim-protected;a", 200, getAccessToken("alice"), null);
+        assureGetPath("//api;a/permission;a/http-response-claim-protected;a", 200, getAccessToken("alice"), null);
+
+        assureGetPath("/api;a/permission;a/http-response-claim-protected;a", 403, getAccessToken("jdoe"), null);
+        assureGetPath("//api;a/permission;a/http-response-claim-protected;a", 403, getAccessToken("jdoe"), null);
+    }
+
+    @Test
     public void testBodyClaim() {
         assurePostPath("/api/permission/body-claim", "{\"from-body\": \"grant\"}", 200, getAccessToken("alice"),
+                "Body Claim Protected Resource");
+    }
+
+    @Test
+    public void testBodyClaimWithMatrix() {
+        assurePostPath("/api;/permission;/body-claim;", "{\"from-body\": \"grant\"}", 200, getAccessToken("alice"),
+                "Body Claim Protected Resource");
+        assurePostPath("/api;a/permission;a/body-claim;a", "{\"from-body\": \"grant\"}", 200, getAccessToken("alice"),
                 "Body Claim Protected Resource");
     }
 
@@ -193,14 +305,38 @@ public abstract class AbstractPolicyEnforcerTest {
     }
 
     @Test
+    public void testPublicResourceWithEnforcingPolicyWithMatrix() {
+        assureGetPath("/api;/public-enforcing;", 401, null, null);
+        assureGetPath("//api;/public-enforcing;", 401, null, null);
+        assureGetPath("/api;a/public-enforcing;a", 401, null, null);
+        assureGetPath("//api;a/public-enforcing;a", 401, null, null);
+    }
+
+    @Test
     public void testPublicResourceWithEnforcingPolicyAndToken() {
         assureGetPath("/api/public-enforcing", 403, getAccessToken("alice"), null);
         assureGetPath("//api/public-enforcing", 403, getAccessToken("alice"), null);
     }
 
     @Test
+    public void testPublicResourceWithEnforcingPolicyAndTokenWithMatrix() {
+        assureGetPath("/api;/public-enforcing;", 403, getAccessToken("alice"), null);
+        assureGetPath("//api;/public-enforcing;", 403, getAccessToken("alice"), null);
+        assureGetPath("/api;a/public-enforcing;a", 403, getAccessToken("alice"), null);
+        assureGetPath("//api;a/public-enforcing;a", 403, getAccessToken("alice"), null);
+    }
+
+    @Test
     public void testPublicResourceWithDisabledPolicyAndToken() {
         assureGetPath("/api/public-token", 204, getAccessToken("alice"), null);
+    }
+
+    @Test
+    public void testPublicResourceWithDisabledPolicyAndTokenWithMatrix() {
+        assureGetPath("/api;/public-token;", 204, getAccessToken("alice"), null);
+        assureGetPath("//api;/public-token;", 204, getAccessToken("alice"), null);
+        assureGetPath("/api;a/public-token;a", 204, getAccessToken("alice"), null);
+        assureGetPath("//api;a/public-token;a", 204, getAccessToken("alice"), null);
     }
 
     @Test
@@ -213,6 +349,27 @@ public abstract class AbstractPolicyEnforcerTest {
 
         assureGetPath("/", 404, null, null);
         assureGetPath("//", 400, null, null);
+    }
+
+    @Test
+    public void testPathConfigurationPrecedenceWhenPathCacheNotDefinedWithMatrix() {
+        assureGetPath("/api2;/resource;", 401, null, null);
+        assureGetPath("//api2;/resource;", 401, null, null);
+
+        assureGetPath("/hello;", 404, null, null);
+        assureGetPath("//hello;", 404, null, null);
+
+        assureGetPath("/;", 404, null, null);
+        assureGetPath("//;", 404, null, null);
+
+        assureGetPath("/api2;a/resource;a", 401, null, null);
+        assureGetPath("//api2;a/resource;a", 401, null, null);
+
+        assureGetPath("/hello;a", 404, null, null);
+        assureGetPath("//hello;a", 404, null, null);
+
+        assureGetPath("/;a", 404, null, null);
+        assureGetPath("//;a", 404, null, null);
     }
 
     @Test
@@ -236,6 +393,49 @@ public abstract class AbstractPolicyEnforcerTest {
 
         assureGetPath("/api/permission/scopes/annotation-way-denied", 403, getAccessToken("jdoe"), null);
         assureGetPath("//api/permission/scopes/annotation-way-denied", 403, getAccessToken("jdoe"), null);
+    }
+
+    @Test
+    public void testPermissionScopesWithMatrix() {
+        // 'jdoe' has scope 'read' and 'read' is required
+        assureGetPath("/api;/permission;/scopes;/standard-way;", 200, getAccessToken("jdoe"), "read");
+        assureGetPath("//api;/permission;/scopes;/standard-way;", 200, getAccessToken("jdoe"), "read");
+
+        // 'jdoe' has scope 'read' while 'write' is required
+        assureGetPath("/api;/permission;/scopes;/standard-way-denied;", 403, getAccessToken("jdoe"), null);
+        assureGetPath("//api;/permission;/scopes;/standard-way-denied;", 403, getAccessToken("jdoe"), null);
+
+        assureGetPath("/api;/permission;/scopes;/programmatic-way;", 200, getAccessToken("jdoe"), "read");
+        assureGetPath("//api;/permission;/scopes;/programmatic-way;", 200, getAccessToken("jdoe"), "read");
+
+        assureGetPath("/api;/permission;/scopes;/programmatic-way-denied;", 403, getAccessToken("jdoe"), null);
+        assureGetPath("//api;/permission;/scopes;/programmatic-way-denied;", 403, getAccessToken("jdoe"), null);
+
+        assureGetPath("/api;/permission;/scopes;/annotation-way;", 200, getAccessToken("jdoe"), "read");
+        assureGetPath("//api;/permission;/scopes;/annotation-way;", 200, getAccessToken("jdoe"), "read");
+
+        assureGetPath("/api;/permission;/scopes;/annotation-way-denied;", 403, getAccessToken("jdoe"), null);
+        assureGetPath("//api;/permission;/scopes;/annotation-way-denied;", 403, getAccessToken("jdoe"), null);
+
+        // 'jdoe' has scope 'read' and 'read' is required
+        assureGetPath("/api;a/permission;a/scopes;a/standard-way;a", 200, getAccessToken("jdoe"), "read");
+        assureGetPath("//api;a/permission;a/scopes;a/standard-way;a", 200, getAccessToken("jdoe"), "read");
+
+        // 'jdoe' has scope 'read' while 'write' is required
+        assureGetPath("/api;a/permission;a/scopes;a/standard-way-denied;a", 403, getAccessToken("jdoe"), null);
+        assureGetPath("//api;a/permission;a/scopes;a/standard-way-denied;a", 403, getAccessToken("jdoe"), null);
+
+        assureGetPath("/api;a/permission;a/scopes;a/programmatic-way;a", 200, getAccessToken("jdoe"), "read");
+        assureGetPath("//api;a/permission;a/scopes;a/programmatic-way;a", 200, getAccessToken("jdoe"), "read");
+
+        assureGetPath("/api;a/permission;a/scopes;a/programmatic-way-denied;a", 403, getAccessToken("jdoe"), null);
+        assureGetPath("//api;a/permission;a/scopes;a/programmatic-way-denied;a", 403, getAccessToken("jdoe"), null);
+
+        assureGetPath("/api;a/permission;a/scopes;a/annotation-way;a", 200, getAccessToken("jdoe"), "read");
+        assureGetPath("//api;a/permission;a/scopes;a/annotation-way;a", 200, getAccessToken("jdoe"), "read");
+
+        assureGetPath("/api;a/permission;a/scopes;a/annotation-way-denied;a", 403, getAccessToken("jdoe"), null);
+        assureGetPath("//api;a/permission;a/scopes;a/annotation-way-denied;a", 403, getAccessToken("jdoe"), null);
     }
 
     protected String getAccessToken(String userName) {

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -220,7 +220,7 @@ quarkus.oidc.tenant-split-tokens.application-type=web-app
 quarkus.oidc.tenant-split-tokens.authentication.cookie-same-site=strict
 quarkus.oidc.tenant-split-tokens.authentication.scopes=phone
 
-quarkus.http.auth.permission.roles1.paths=/index.html,/index.html;/checktterer
+quarkus.http.auth.permission.roles1.paths=/index.html,/index.html/checktterer
 quarkus.http.auth.permission.roles1.policy=authenticated
 
 quarkus.http.auth.permission.logout.paths=/tenant-logout

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -1369,8 +1369,8 @@ public class CodeFlowTest {
     @Test
     public void testInvalidPath() throws IOException {
         try (final WebClient webClient = createWebClient()) {
-            HtmlPage page = webClient.getPage("http://localhost:8081/index.html;/checktterer");
-            assertEquals("/index.html;/checktterer", getStateCookieSavedPath(webClient, null));
+            HtmlPage page = webClient.getPage("http://localhost:8081/index.html/checktterer");
+            assertEquals("/index.html/checktterer", getStateCookieSavedPath(webClient, null));
 
             assertEquals("Sign in to quarkus", page.getTitleText());
 
@@ -1381,6 +1381,7 @@ public class CodeFlowTest {
 
             try {
                 page = loginForm.getButtonByName("login").click();
+                fail("404 is expected");
             } catch (FailingHttpStatusCodeException ex) {
                 assertEquals(404, ex.getStatusCode());
             }

--- a/integration-tests/rest-csrf/src/test/java/io/quarkus/it/csrf/CsrfReactiveTest.java
+++ b/integration-tests/rest-csrf/src/test/java/io/quarkus/it/csrf/CsrfReactiveTest.java
@@ -269,6 +269,10 @@ public class CsrfReactiveTest {
                         csrfToken, "verified:true:tokenHeaderIsSet=true");
                 assurePostFormPath(vertxWebClient, "//service/csrfTokenWithHeader", 200, csrfCookie,
                         csrfToken, "verified:true:tokenHeaderIsSet=true");
+                assurePostFormPath(vertxWebClient, "//service;/csrfTokenWithHeader;", 200, csrfCookie,
+                        csrfToken, "verified:true:tokenHeaderIsSet=true");
+                assurePostFormPath(vertxWebClient, "//service;a/csrfTokenWithHeader;a", 200, csrfCookie,
+                        csrfToken, "verified:true:tokenHeaderIsSet=true");
 
                 webClient.getCookieManager().clearCookies();
             }
@@ -296,6 +300,10 @@ public class CsrfReactiveTest {
                         csrfToken, "verified:true:tokenHeaderIsSet=true");
                 assurePostJsonPath(vertxWebClient, "//service/csrfTokenWithHeader", 200, csrfCookie,
                         csrfToken, "verified:true:tokenHeaderIsSet=true");
+                assurePostJsonPath(vertxWebClient, "//service;/csrfTokenWithHeader;", 200, csrfCookie,
+                        csrfToken, "verified:true:tokenHeaderIsSet=true");
+                assurePostJsonPath(vertxWebClient, "//service;a/csrfTokenWithHeader;a", 200, csrfCookie,
+                        csrfToken, "verified:true:tokenHeaderIsSet=true");
 
                 webClient.getCookieManager().clearCookies();
             }
@@ -321,6 +329,10 @@ public class CsrfReactiveTest {
                 assurePostFormPath(vertxWebClient, "/service/csrfTokenWithHeader", 400, csrfCookie,
                         csrfCookie.getValue(), null);
                 assurePostFormPath(vertxWebClient, "//service/csrfTokenWithHeader", 400, csrfCookie,
+                        csrfCookie.getValue(), null);
+                assurePostFormPath(vertxWebClient, "//service;/csrfTokenWithHeader;", 400, csrfCookie,
+                        csrfCookie.getValue(), null);
+                assurePostFormPath(vertxWebClient, "//service;a/csrfTokenWithHeader;a", 400, csrfCookie,
                         csrfCookie.getValue(), null);
                 webClient.getCookieManager().clearCookies();
             }
@@ -367,6 +379,32 @@ public class CsrfReactiveTest {
             assertNotNull(webClient.getCookieManager().getCookie("csrftoken"));
 
             // Can't check that it matches the cookie because it's signed
+            assertNotNull(htmlPage.getContent());
+
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    @Test
+    public void testGetWithCsrfTokenWithMatrix() throws Exception {
+        try (final WebClient webClient = createWebClient()) {
+
+            assertNull(webClient.getCookieManager().getCookie("csrftoken"));
+
+            // matrix params must not prevent CSRF token generation on createTokenPath
+            TextPage htmlPage = webClient.getPage("http://localhost:8081/service/token;a");
+
+            assertNotNull(webClient.getCookieManager().getCookie("csrftoken"));
+            assertNotNull(htmlPage.getContent());
+
+            webClient.getCookieManager().clearCookies();
+
+            // empty matrix param
+            assertNull(webClient.getCookieManager().getCookie("csrftoken"));
+
+            htmlPage = webClient.getPage("http://localhost:8081/service/token;");
+
+            assertNotNull(webClient.getCookieManager().getCookie("csrftoken"));
             assertNotNull(htmlPage.getContent());
 
             webClient.getCookieManager().clearCookies();


### PR DESCRIPTION
…y matching

Matrix parameters (semicolon-delimited values in URL path segments, e.g. /api;v=1/resource) could bypass HTTP security policy path matching. This commit strips matrix parameters before matching across all security-relevant paths: HTTP policy matcher, Keycloak policy enforcer, OIDC tenant resolver, CSRF filter, and Undertow servlet policy.

Additionally, the build now fails if an HTTP security policy path contains a literal semicolon character.
