### PR TITLE
[4.0] Migrate a few more extensions to Vert.x 5

### DIFF
--- a/extensions/amazon-lambda-http/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
+++ b/extensions/amazon-lambda-http/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
@@ -1,7 +1,5 @@
 package io.quarkus.amazon.lambda.http.deployment;
 
-import static io.vertx.core.file.impl.FileResolverImpl.CACHE_DIR_BASE_PROP_NAME;
-
 import org.jboss.jandex.DotName;
 import org.jboss.logging.Logger;
 
@@ -30,6 +28,7 @@ import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
 import io.quarkus.resteasy.reactive.server.spi.ContextTypeBuildItem;
 import io.quarkus.vertx.http.deployment.RequireVirtualHttpBuildItem;
+import io.vertx.core.impl.SysProps;
 
 public class AmazonLambdaHttpProcessor {
     private static final Logger log = Logger.getLogger(AmazonLambdaHttpProcessor.class);
@@ -95,7 +94,7 @@ public class AmazonLambdaHttpProcessor {
      */
     @BuildStep
     void setTempDir(BuildProducer<SystemPropertyBuildItem> systemProperty) {
-        systemProperty.produce(new SystemPropertyBuildItem(CACHE_DIR_BASE_PROP_NAME, "/tmp/quarkus"));
+        systemProperty.produce(new SystemPropertyBuildItem(SysProps.FILE_CACHE_DIR.get(), "/tmp/quarkus"));
     }
 
     @BuildStep

--- a/extensions/amazon-lambda-http/http-event-server/src/main/java/io/quarkus/amazon/lambda/runtime/MockHttpEventServer.java
+++ b/extensions/amazon-lambda-http/http-event-server/src/main/java/io/quarkus/amazon/lambda/runtime/MockHttpEventServer.java
@@ -50,7 +50,7 @@ public class MockHttpEventServer extends MockEventServer {
             traceId = UUID.randomUUID().toString();
         }
         ctx.put(AmazonLambdaApi.LAMBDA_TRACE_HEADER_KEY, traceId);
-        Buffer body = ctx.getBody();
+        Buffer body = ctx.body().buffer();
 
         APIGatewayV2HTTPEvent event = new APIGatewayV2HTTPEvent();
         event.setRequestContext(new APIGatewayV2HTTPEvent.RequestContext());

--- a/extensions/amazon-lambda/event-server/src/main/java/io/quarkus/amazon/lambda/runtime/MockBodyHandler.java
+++ b/extensions/amazon-lambda/event-server/src/main/java/io/quarkus/amazon/lambda/runtime/MockBodyHandler.java
@@ -3,15 +3,16 @@ package io.quarkus.amazon.lambda.runtime;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.jboss.logging.Logger;
+
 import io.netty.handler.codec.DecoderException;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerRequest;
-import io.vertx.core.impl.logging.Logger;
-import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
+import io.vertx.ext.web.impl.RequestBodyImpl;
 import io.vertx.ext.web.impl.RoutingContextInternal;
 
 /**
@@ -20,7 +21,7 @@ import io.vertx.ext.web.impl.RoutingContextInternal;
  */
 public class MockBodyHandler implements BodyHandler {
 
-    private static final Logger LOG = LoggerFactory.getLogger(io.vertx.ext.web.handler.impl.BodyHandlerImpl.class);
+    private static final org.jboss.logging.Logger LOG = Logger.getLogger(io.vertx.ext.web.handler.impl.BodyHandlerImpl.class);
 
     private long bodyLimit = DEFAULT_BODY_LIMIT;
     private String uploadsDir;
@@ -189,7 +190,8 @@ public class MockBodyHandler implements BodyHandler {
             if (mergeFormAttributes && req.isExpectMultipart()) {
                 req.params().addAll(req.formAttributes());
             }
-            context.setBody(body);
+            // Vert.x 5 remove the possibility to pass a synthetic body.
+            ((RequestBodyImpl) context.body()).setBuffer(body);
             // release body as it may take lots of memory
             body = null;
 

--- a/extensions/amazon-lambda/event-server/src/main/java/io/quarkus/amazon/lambda/runtime/MockEventServer.java
+++ b/extensions/amazon-lambda/event-server/src/main/java/io/quarkus/amazon/lambda/runtime/MockEventServer.java
@@ -205,7 +205,7 @@ public class MockEventServer implements Closeable {
     }
 
     protected Buffer processEventBody(RoutingContext request) {
-        return request.getBody();
+        return request.body().buffer();
     }
 
     public void handleResponse(RoutingContext ctx) {
@@ -217,7 +217,7 @@ public class MockEventServer implements Closeable {
             return;
         }
         log.debugf("Sending response %s", requestId);
-        Buffer buffer = ctx.getBody();
+        Buffer buffer = ctx.body().buffer();
         processResponse(ctx, pending, buffer);
         ctx.response().setStatusCode(204);
         ctx.end();
@@ -266,7 +266,7 @@ public class MockEventServer implements Closeable {
             return;
         }
         log.debugf("Sending response %s", requestId);
-        Buffer buffer = ctx.getBody();
+        Buffer buffer = ctx.body().buffer();
         processError(ctx, pending, buffer);
         ctx.response().setStatusCode(204);
         ctx.end();

--- a/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/TransactionalInterceptorBase.java
+++ b/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/TransactionalInterceptorBase.java
@@ -14,6 +14,7 @@ import io.quarkus.arc.runtime.InterceptorBindings;
 import io.quarkus.reactive.transaction.runtime.pool.TransactionalContextPool;
 import io.quarkus.transaction.annotations.Rollback;
 import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle;
+import io.smallrye.common.vertx.ContextLocals;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
@@ -71,9 +72,10 @@ public abstract class TransactionalInterceptorBase {
     }
 
     protected <T> Uni<T> defineReactiveTransactionalChain(Transactional annotation, Method method, Supplier<Uni<T>> work) {
+        // We are running on the retrieved context, however, the method also switch the safety flag.
         Context context = vertxContext();
 
-        if (context.getLocal(TRANSACTIONAL_METHOD_KEY) == null) {
+        if (ContextLocals.get(TRANSACTIONAL_METHOD_KEY).isEmpty()) {
             // This is the parent method, responsible for commit, rollback or cancellation of the transaction
 
             /*
@@ -82,24 +84,16 @@ public abstract class TransactionalInterceptorBase {
              * Subsequent nested methods will avoid tx management
              */
             LOG.tracef("Setting this method as transactional: %s", method);
-            context.putLocal(TRANSACTIONAL_METHOD_KEY, true);
+            ContextLocals.put(TRANSACTIONAL_METHOD_KEY, true);
 
             return work.get()
-                    .onFailure().call(exception -> {
-                        return rollbackOrCommitBasedOnException(context, annotation, exception);
-                    })
-                    .onCancellation().call(() -> {
-                        return rollbackOnCancel();
-                    })
+                    .onFailure().call(exception -> rollbackOrCommitBasedOnException(context, annotation, exception))
+                    .onCancellation().call(this::rollbackOnCancel)
                     .call(() -> { // Good path - commit
                         LOG.tracef("Calling commit from method %s", method);
                         return invokeBeforeCommitAndCommit(context);
                     })
-                    .eventually(() -> {
-                        return reactiveResource.afterCommit(context);
-                    }).eventually(() -> {
-                        return closeConnection();
-                    });
+                    .eventually(() -> reactiveResource.afterCommit(context)).eventually(this::closeConnection);
         } else {
             // Nested methods should just propagate the reactive chain without transaction handling
             return work.get();
@@ -268,22 +262,23 @@ public abstract class TransactionalInterceptorBase {
     }
 
     protected void validateLegacyPanacheAnnotations() {
-        Context context = vertxContext();
-        if (context.getLocal(SESSION_ON_DEMAND_KEY) != null) {
+        // We are running on the retrieved context, however, the method also switch the safety flag.
+        Context ignored = vertxContext();
+        if (ContextLocals.get(SESSION_ON_DEMAND_KEY).isPresent()) {
             throw new UnsupportedOperationException(
                     "Calling a method annotated with @Transactional from a method annotated with @WithSessionOnDemand is not supported. "
                             + "Use either @Transactional or @WithSessionOnDemand/@WithSession/@WithTransaction, "
                             + "but not both, throughout your whole application.");
         }
 
-        if (context.getLocal(WITH_TRANSACTION_METHOD_KEY) != null) {
+        if (ContextLocals.get(WITH_TRANSACTION_METHOD_KEY).isPresent()) {
             throw new UnsupportedOperationException(
                     "Calling a method annotated with @Transactional from a method annotated with @WithTransaction is not supported. "
                             + "Use either @Transactional or @WithSessionOnDemand/@WithSession/@WithTransaction, "
                             + "but not both, throughout your whole application.");
         }
 
-        if (context.getLocal(REACTIVE_TRANSACTIONAL_METHOD_KEY) != null) {
+        if (ContextLocals.get(REACTIVE_TRANSACTIONAL_METHOD_KEY).isPresent()) {
             throw new UnsupportedOperationException(
                     "Calling a method annotated with @Transactional from a method annotated with @ReactiveTransactional is not supported. "
                             + "Use either @Transactional or @WithSessionOnDemand/@WithSession/@WithTransaction, "

--- a/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/pool/TransactionalContextConnection.java
+++ b/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/pool/TransactionalContextConnection.java
@@ -2,8 +2,6 @@ package io.quarkus.reactive.transaction.runtime.pool;
 
 import org.jboss.logging.Logger;
 
-import io.vertx.codegen.annotations.Fluent;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.sqlclient.PrepareOptions;
@@ -30,21 +28,9 @@ public class TransactionalContextConnection implements SqlConnection {
         this.connection = connection;
     }
 
-    @Fluent
-    @Override
-    public SqlConnection prepare(String sql, Handler<AsyncResult<PreparedStatement>> handler) {
-        return connection.prepare(sql, handler);
-    }
-
     @Override
     public Future<PreparedStatement> prepare(String sql) {
         return connection.prepare(sql);
-    }
-
-    @Fluent
-    @Override
-    public SqlConnection prepare(String sql, PrepareOptions options, Handler<AsyncResult<PreparedStatement>> handler) {
-        return connection.prepare(sql, options, handler);
     }
 
     @Override
@@ -52,21 +38,14 @@ public class TransactionalContextConnection implements SqlConnection {
         return connection.prepare(sql, options);
     }
 
-    @Fluent
     @Override
     public SqlConnection exceptionHandler(Handler<Throwable> handler) {
         return connection.exceptionHandler(handler);
     }
 
-    @Fluent
     @Override
     public SqlConnection closeHandler(Handler<Void> handler) {
         return connection.closeHandler(handler);
-    }
-
-    @Override
-    public void begin(Handler<AsyncResult<Transaction>> handler) {
-        connection.begin(handler);
     }
 
     @Override
@@ -82,12 +61,6 @@ public class TransactionalContextConnection implements SqlConnection {
     @Override
     public boolean isSSL() {
         return connection.isSSL();
-    }
-
-    @Override
-    public void close(Handler<AsyncResult<Void>> handler) {
-        LOG.tracef("Calling no-op close on TransactionalContextConnection it will close after the closing of session");
-        handler.handle(Future.succeededFuture());
     }
 
     @Override

--- a/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/pool/TransactionalContextPool.java
+++ b/extensions/reactive-transactions/runtime/src/main/java/io/quarkus/reactive/transaction/runtime/pool/TransactionalContextPool.java
@@ -2,16 +2,13 @@ package io.quarkus.reactive.transaction.runtime.pool;
 
 import static io.quarkus.reactive.transaction.runtime.TransactionalInterceptorBase.TRANSACTIONAL_METHOD_KEY;
 
-import java.util.function.Function;
-
 import org.jboss.logging.Logger;
 
-import io.vertx.core.AsyncResult;
+import io.smallrye.common.vertx.ContextLocals;
+import io.smallrye.common.vertx.VertxContext;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import io.vertx.core.impl.ContextInternal;
 import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PrepareOptions;
 import io.vertx.sqlclient.PreparedQuery;
@@ -37,18 +34,6 @@ public class TransactionalContextPool implements Pool {
     }
 
     @Override
-    public void getConnection(Handler<AsyncResult<SqlConnection>> handler) {
-        if (!shouldOpenTransaction()) {
-            delegate.getConnection(handler);
-        } else {
-            getOrCreateConnectionHolder()
-                    .getConnection()
-                    .map(conn -> (SqlConnection) conn)
-                    .onComplete(handler);
-        }
-    }
-
-    @Override
     public Future<SqlConnection> getConnection() {
         if (!shouldOpenTransaction()) {
             return delegate.getConnection();
@@ -64,11 +49,10 @@ public class TransactionalContextPool implements Pool {
      * The holder ensures only one connection is created even with concurrent access.
      */
     private ConnectionHolder getOrCreateConnectionHolder() {
-        Context context = Vertx.currentContext();
-        ConnectionHolder holder = context.getLocal(CURRENT_CONNECTION_KEY);
+        ConnectionHolder holder = ContextLocals.get(CURRENT_CONNECTION_KEY, null);
         if (holder == null) {
             holder = new ConnectionHolder(delegate);
-            context.putLocal(CURRENT_CONNECTION_KEY, holder);
+            ContextLocals.put(CURRENT_CONNECTION_KEY, holder);
         }
         return holder;
     }
@@ -78,7 +62,7 @@ public class TransactionalContextPool implements Pool {
         if (context == null) {
             return null;
         }
-        ConnectionHolder holder = context.getLocal(CURRENT_CONNECTION_KEY);
+        ConnectionHolder holder = ContextLocals.get(CURRENT_CONNECTION_KEY, null);
         if (holder == null) {
             return null;
         }
@@ -96,7 +80,7 @@ public class TransactionalContextPool implements Pool {
         if (context == null) {
             return null;
         }
-        ConnectionHolder holder = context.getLocal(CURRENT_CONNECTION_KEY);
+        ConnectionHolder holder = ContextLocals.get(CURRENT_CONNECTION_KEY, null);
         if (holder == null) {
             return null;
         }
@@ -106,7 +90,7 @@ public class TransactionalContextPool implements Pool {
                     SqlConnection delegateConnection = wrappedConnection.getDelegate();
                     return delegateConnection.close();
                 })
-                .andThen(ar -> context.removeLocal(CURRENT_CONNECTION_KEY));
+                .andThen(ar -> ContextLocals.remove(CURRENT_CONNECTION_KEY));
     }
 
     private boolean shouldOpenTransaction() {
@@ -115,8 +99,8 @@ public class TransactionalContextPool implements Pool {
 
         // Vert.x context during DB Validation in startup is null
         // When using reactive in a @Transactional method, the context is surely duplicated
-        if (context != null && ((ContextInternal) context).isDuplicate()) {
-            Object createTransaction = context.getLocal(TRANSACTIONAL_METHOD_KEY);
+        if (VertxContext.isOnDuplicatedContext()) {
+            Object createTransaction = ContextLocals.get(TRANSACTIONAL_METHOD_KEY, null);
             return createTransaction != null && (boolean) createTransaction;
         } else {
             LOG.tracef("Vert.x context is either null or non duplicated, won't create a new transaction");
@@ -132,25 +116,6 @@ public class TransactionalContextPool implements Pool {
     @Override
     public PreparedQuery<RowSet<Row>> preparedQuery(String sql) {
         return delegate.preparedQuery(sql);
-    }
-
-    @Override
-    public void close(Handler<AsyncResult<Void>> handler) {
-        delegate.close(handler);
-    }
-
-    @Override
-    @Deprecated
-    public Pool connectHandler(Handler<SqlConnection> handler) {
-        // Deprecated, and not needed by Reactive, and no idea how it affects auto-transactions.
-        throw new UnsupportedOperationException("This operation is not supported");
-    }
-
-    @Override
-    @Deprecated
-    public Pool connectionProvider(Function<Context, Future<SqlConnection>> provider) {
-        // Deprecated, and not needed by Reactive, and no idea how it affects auto-transactions.
-        throw new UnsupportedOperationException("This operation is not supported");
     }
 
     @Override

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ContextualEmitterImpl.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/ContextualEmitterImpl.java
@@ -8,6 +8,7 @@ import java.util.function.Function;
 import org.eclipse.microprofile.reactive.messaging.Message;
 
 import io.smallrye.common.annotation.CheckReturnValue;
+import io.smallrye.common.vertx.VertxContext;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.operators.uni.UniOnItemTransformToUni;
@@ -21,7 +22,7 @@ import io.smallrye.reactive.messaging.providers.locals.ContextAwareMessage;
 import io.smallrye.reactive.messaging.providers.locals.LocalContextMetadata;
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
-import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.internal.ContextInternal;
 
 public class ContextualEmitterImpl<T> extends AbstractEmitter<T> implements ContextualEmitter<T> {
 
@@ -107,7 +108,7 @@ public class ContextualEmitterImpl<T> extends AbstractEmitter<T> implements Cont
             // create new context and copy local data from previous context
             ContextInternal internal = (ContextInternal) context;
             ContextInternal newCtx = internal.duplicate();
-            newCtx.localContextData().putAll(internal.localContextData());
+            VertxContext.localContextData(newCtx).putAll(VertxContext.localContextData(internal));
             return msg.addMetadata(new LocalContextMetadata(newCtx));
         }
     }

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/QuarkusWorkerPoolRegistry.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/QuarkusWorkerPoolRegistry.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -30,9 +31,8 @@ import io.smallrye.reactive.messaging.annotations.Blocking;
 import io.smallrye.reactive.messaging.providers.connectors.ExecutionHolder;
 import io.smallrye.reactive.messaging.providers.connectors.WorkerPoolRegistry;
 import io.smallrye.reactive.messaging.providers.helpers.Validation;
-import io.vertx.core.impl.ConcurrentHashSet;
-import io.vertx.core.impl.ContextInternal;
-import io.vertx.core.impl.WorkerExecutorInternal;
+import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.internal.WorkerExecutorInternal;
 import io.vertx.mutiny.core.Context;
 import io.vertx.mutiny.core.Vertx;
 import io.vertx.mutiny.core.WorkerExecutor;
@@ -56,7 +56,7 @@ public class QuarkusWorkerPoolRegistry extends WorkerPoolRegistry {
     private volatile boolean closed = false;
 
     private static Set<String> initVirtualThreadWorkers() {
-        Set<String> set = new ConcurrentHashSet<>();
+        Set<String> set = new CopyOnWriteArraySet<>();
         set.add(DEFAULT_VIRTUAL_THREAD_WORKER);
         return set;
     }
@@ -79,7 +79,7 @@ public class QuarkusWorkerPoolRegistry extends WorkerPoolRegistry {
                 WorkerExecutor executor = entry.getValue();
                 // Get the underlying Vert.x WorkerPool and shutdown its executor
                 try {
-                    ((WorkerExecutorInternal) executor.getDelegate()).getPool().executor().shutdown();
+                    ((WorkerExecutorInternal) executor.getDelegate()).pool().executor().shutdown();
                 } catch (Exception e) {
                     log.warnf(e, "Failed to shutdown worker pool %s", entry.getKey());
                 }
@@ -94,7 +94,7 @@ public class QuarkusWorkerPoolRegistry extends WorkerPoolRegistry {
                 terminated = true;
                 for (Map.Entry<String, WorkerExecutor> entry : workerExecutors.entrySet()) {
                     WorkerExecutor workerExecutor = entry.getValue();
-                    ExecutorService innerExecutor = ((WorkerExecutorInternal) workerExecutor.getDelegate()).getPool()
+                    ExecutorService innerExecutor = ((WorkerExecutorInternal) workerExecutor.getDelegate()).pool()
                             .executor();
                     WorkerPoolConfig poolConfig = workerConfig.get(entry.getKey());
                     long timeout = poolConfig != null ? poolConfig.shutdownTimeout().toNanos()
@@ -121,7 +121,7 @@ public class QuarkusWorkerPoolRegistry extends WorkerPoolRegistry {
                         for (Map.Entry<String, WorkerExecutor> remaining : workerExecutors.entrySet()) {
                             try {
                                 WorkerExecutor exec = remaining.getValue();
-                                ExecutorService execService = ((WorkerExecutorInternal) exec.getDelegate()).getPool()
+                                ExecutorService execService = ((WorkerExecutorInternal) exec.getDelegate()).pool()
                                         .executor();
                                 execService.shutdownNow();
                                 exec.closeAndAwait();
@@ -148,9 +148,9 @@ public class QuarkusWorkerPoolRegistry extends WorkerPoolRegistry {
         Objects.requireNonNull(uni, "Action to execute not provided");
         if (workerName == null) {
             if (msgContext != null) {
-                return msgContext.executeBlocking(uni, ordered);
+                return msgContext.executeBlocking(() -> uni.await().indefinitely(), ordered);
             }
-            return executionHolder.vertx().executeBlocking(uni, ordered);
+            return executionHolder.vertx().executeBlocking(() -> uni.await().indefinitely(), ordered);
         } else if (virtualThreadWorkers.contains(workerName)) {
             return runOnVirtualThread(msgContext, uni);
         } else {
@@ -161,18 +161,16 @@ public class QuarkusWorkerPoolRegistry extends WorkerPoolRegistry {
     private <T> Uni<T> runOnWorkerThread(Context msgContext, Uni<T> uni, String workerName, boolean ordered) {
         WorkerExecutor worker = getWorker(workerName);
         if (msgContext != null) {
-            return worker.executeBlocking(uniOnMessageContext(uni, msgContext), ordered)
-                    .onItemOrFailure().transformToUni((item, failure) -> {
-                        return Uni.createFrom().emitter(emitter -> {
-                            if (failure != null) {
-                                msgContext.runOnContext(() -> emitter.fail(failure));
-                            } else {
-                                msgContext.runOnContext(() -> emitter.complete(item));
-                            }
-                        });
-                    });
+            return worker.executeBlocking(() -> uniOnMessageContext(uni, msgContext).await().indefinitely(), ordered)
+                    .onItemOrFailure().transformToUni((item, failure) -> Uni.createFrom().emitter(emitter -> {
+                        if (failure != null) {
+                            msgContext.runOnContext(() -> emitter.fail(failure));
+                        } else {
+                            msgContext.runOnContext(() -> emitter.complete(item));
+                        }
+                    }));
         }
-        return worker.executeBlocking(uni, ordered);
+        return worker.executeBlocking(() -> uni.await().indefinitely(), ordered);
     }
 
     private static <T> Uni<T> uniOnMessageContext(Uni<T> uni, Context msgContext) {
@@ -222,8 +220,7 @@ public class QuarkusWorkerPoolRegistry extends WorkerPoolRegistry {
 
         @Override
         public void run() {
-            if (context instanceof ContextInternal) {
-                ContextInternal contextInternal = (ContextInternal) context;
+            if (context instanceof ContextInternal contextInternal) {
                 final var previousContext = contextInternal.beginDispatch();
                 try {
                     task.run();


### PR DESCRIPTION
Migrate to Vert.x 5 the following extensions:

- AWS Lambda and AWS Lambda HTTP
- Reactive Transaction
- Reactive Messaging (main extension, unable to run the tests without a migration of SmallRye Reactive Messaging to Vert.x 5)

Related to #51959 