### PR TITLE
Add .cachebro to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ nb-configuration.xml
 
 CLAUDE.local.md
 docs/superpowers
+.cachebro


### PR DESCRIPTION
The `.cachebro/` directory is generated by the CacheBro tool and should not be tracked in version control.