### PR TITLE
Allow to customize OIDC JavaScript redirect workaround response

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/JavaScriptRequestChecker.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/JavaScriptRequestChecker.java
@@ -1,5 +1,6 @@
 package io.quarkus.oidc;
 
+import io.quarkus.vertx.http.runtime.security.ChallengeData;
 import io.vertx.ext.web.RoutingContext;
 
 /**
@@ -22,4 +23,15 @@ public interface JavaScriptRequestChecker {
      * @return true if the current request was made by JavaScript
      */
     boolean isJavaScriptRequest(RoutingContext context);
+
+    /**
+     * Challenge data
+     *
+     * @param context {@link RoutingContext}
+     * @return ChallengeData, or null to use the default 499 response
+     */
+
+    default ChallengeData getChallenge(RoutingContext context) {
+        return new ChallengeData(499, "WWW-Authenticate", "OIDC");
+    }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -695,7 +695,15 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                         if (!shouldAutoRedirect(configContext, context)) {
                             // If the client (usually an SPA) wants to handle the redirect manually, then
                             // return status code 499 and WWW-Authenticate header with the 'OIDC' value.
-                            return Uni.createFrom().item(new ChallengeData(499, "WWW-Authenticate", "OIDC"));
+                            ChallengeData challenge = null;
+                            JavaScriptRequestChecker checker = resolver.getJavaScriptRequestChecker();
+                            if (checker != null) {
+                                challenge = checker.getChallenge(context);
+                            }
+                            if (challenge == null) {
+                                challenge = new ChallengeData(499, "WWW-Authenticate", "OIDC");
+                            }
+                            return Uni.createFrom().item(challenge);
                         }
 
                         StringBuilder codeFlowParams = new StringBuilder(168); // experimentally determined to be a good size for preventing resizing and not wasting space

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomJavaScriptRequestChecker.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomJavaScriptRequestChecker.java
@@ -3,6 +3,7 @@ package io.quarkus.it.keycloak;
 import jakarta.enterprise.context.ApplicationScoped;
 
 import io.quarkus.oidc.JavaScriptRequestChecker;
+import io.quarkus.vertx.http.runtime.security.ChallengeData;
 import io.vertx.ext.web.RoutingContext;
 
 @ApplicationScoped
@@ -10,7 +11,16 @@ public class CustomJavaScriptRequestChecker implements JavaScriptRequestChecker 
 
     @Override
     public boolean isJavaScriptRequest(RoutingContext context) {
-        return "true".equals(context.request().getHeader("HX-Request"));
+        return "true".equals(context.request().getHeader("HX-Request"))
+                || "true".equals(context.request().getHeader("HX-Problem-Request"));
+    }
+
+    @Override
+    public ChallengeData getChallenge(RoutingContext context) {
+        if ("true".equals(context.request().getHeader("HX-Problem-Request"))) {
+            return new ChallengeData(401, "WWW-Authenticate", "OIDC-SPA");
+        }
+        return null;
     }
 
 }

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -177,6 +177,22 @@ public class BearerTokenAuthorizationTest {
     }
 
     @Test
+    public void testJavaScriptRequestCustomResponse() throws IOException, InterruptedException {
+        try (final WebClient webClient = createWebClient()) {
+            try {
+                webClient.addRequestHeader("HX-Problem-Request", "true");
+                webClient.getPage("http://localhost:8081/tenant/tenant-web-app-javascript/api/user/webapp");
+                fail("401 status error is expected");
+            } catch (FailingHttpStatusCodeException ex) {
+                assertEquals(401, ex.getStatusCode());
+                assertEquals("OIDC-SPA", ex.getResponse().getResponseHeaderValue("WWW-Authenticate"));
+            }
+
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    @Test
     public void testResolveTenantIdentifierWebApp2() throws IOException {
         testTenantWebApp2("webapp2", "tenant-web-app2:alice");
     }


### PR DESCRIPTION
Quarkus OIDC lets SPA intercept authorization code flow redirects by capturing a 499 status, since Keycloak and some other providers would reject XHR auto-redirects to their authorization endpoints.

Users may want to follow a different response pattern as in
 
https://github.com/quarkiverse/quarkus-resteasy-problem/issues/601

This PR makes it possible for users to customize how `quarkus-oidc` responds in such cases