### PR TITLE
Run quickstart tests only for impacted modules in CI

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -322,6 +322,7 @@ jobs:
     outputs:
       gib_args: ${{ steps.get-gib-config.outputs.gib_args }}
       gib_impacted: ${{ steps.get-gib-config.outputs.impacted_modules }}
+      gib_impacted_gav: ${{ steps.get-gib-config.outputs.impacted_modules_gav }}
     steps:
       - uses: runs-on/action@15385172809cc0346c6821b00c3c3dd2598785b4 # v2.1.0
       - name: Gradle Enterprise environment
@@ -400,6 +401,7 @@ jobs:
           PUSH_BRANCH: ${{ github.event_name == 'push' && github.ref_name }}
           GIB_DISABLED: ${{ needs.configure.outputs.maven-disable-gib }}
         run: |
+          GIB_IMPACTED_GAV='_all_'
           if [[ "$GIB_DISABLED" == "true" ]] || [[ "$PUSH_BRANCH" =~ ^main|[0-9]+\.[0-9]+$ ]] || [[ "$PULL_REQUEST_HEAD" =~ ^.*backport.*$ ]]; then
             GIB_ARGS=''
             GIB_IMPACTED='_all_'
@@ -432,6 +434,14 @@ jobs:
               GIB_ARGS=''
             fi
 
+            # Generate GAV-formatted impacted modules for quickstarts testing
+            if [[ "$GIB_IMPACTED" != '_all_' ]]; then
+              ./mvnw -q -T1C $COMMON_MAVEN_ARGS -Dscan=false -Dtcks -Dquickly-ci $GIB_ARGS -Dgib.logImpactedTo=gib-impacted-gav.log -Dgib.logImpactedFormat=gav validate
+              if [ -s gib-impacted-gav.log ]; then
+                GIB_IMPACTED_GAV=$(cat gib-impacted-gav.log)
+              fi
+            fi
+
             echo "GIB_ARGS: $GIB_ARGS"
           fi
 
@@ -441,6 +451,9 @@ jobs:
           # (see https://github.com/github/docs/issues/21529 and https://github.com/orgs/community/discussions/26288#discussioncomment-3876281)
           echo 'impacted_modules<<EOF' >> $GITHUB_OUTPUT
           echo "${GIB_IMPACTED}" >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+          echo 'impacted_modules_gav<<EOF' >> $GITHUB_OUTPUT
+          echo "${GIB_IMPACTED_GAV}" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
       - name: Print disk usage after build
         run: .github/ci-disk-usage.sh
@@ -1143,7 +1156,7 @@ jobs:
           retention-days: 7
 
   quickstarts-tests:
-    name: Quickstarts Compilation - JDK ${{matrix.java.name}}
+    name: Quickstarts - JDK ${{matrix.java.name}}
     runs-on: ${{ matrix.java.runs-on && fromJson(needs.configure.outputs.config).runners[format('{0}-{1}', matrix.java.os-name, 'large')].runsOn && format('{0}/tag={1}', fromJson(needs.configure.outputs.config).runners[format('{0}-{1}', matrix.java.os-name, 'large')].runsOn, matrix.java.tag) || matrix.java.os-name }}
     needs: [configure, build-jdk17, calculate-test-jobs]
     # Skip main in forks
@@ -1168,7 +1181,7 @@ jobs:
       - name: Gradle Enterprise environment
         run: |
           echo "GE_TAGS=jdk-${{matrix.java.name}}" >> "$GITHUB_ENV"
-          echo "GE_CUSTOM_VALUES=gh-job-name=Quickstarts Compilation - JDK ${{matrix.java.name}}" >> "$GITHUB_ENV"
+          echo "GE_CUSTOM_VALUES=gh-job-name=Quickstarts - JDK ${{matrix.java.name}}" >> "$GITHUB_ENV"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Restore Maven Repository
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -1194,7 +1207,7 @@ jobs:
         uses: gradle/develocity-actions/setup-maven@974e8dbcbda40db6828fc35f349c80a7c0e71529 # v2.1
         with:
           capture-strategy: ON_DEMAND
-          job-name: "Quickstarts Compilation - JDK ${{matrix.java.name}}"
+          job-name: "Quickstarts - JDK ${{matrix.java.name}}"
           add-pr-comment: false
           add-job-summary: false
           develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
@@ -1218,13 +1231,30 @@ jobs:
         id: get-quarkus-version
         run: |
           echo "quarkus-version=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_OUTPUT
-      - name: Compile Quickstarts
+      - name: Clone Quickstarts
+        env:
+          QUICKSTARTS_BRANCH: ${{ steps.get-quickstarts-branch.outputs.result }}
+          QUICKSTARTS_REPO: https://github.com/quarkusio/quarkus-quickstarts.git
+        run: |
+          echo "Cloning repository: ${QUICKSTARTS_REPO} (branch: ${QUICKSTARTS_BRANCH})"
+          git clone --depth=1 -b "${QUICKSTARTS_BRANCH}" "${QUICKSTARTS_REPO}"
+      - name: Test Impacted Quickstarts
+        working-directory: quarkus-quickstarts
         env:
           CAPTURE_BUILD_SCAN: true
+          GIB_IMPACTED_GAV: ${{ needs.build-jdk17.outputs.gib_impacted_gav }}
         run: |
-          git clone --depth=1 -b ${{ steps.get-quickstarts-branch.outputs.result }} https://github.com/quarkusio/quarkus-quickstarts.git && cd quarkus-quickstarts
+          echo "=== GIB_IMPACTED_GAV ==="
+          echo "$GIB_IMPACTED_GAV"
+          echo "========================"
           QUARKUS_VERSION_ARGS="-Dquarkus.platform.version=${{ steps.get-quarkus-version.outputs.quarkus-version }}"
-          export LANG=en_US && ./mvnw -e -B -fae --global-settings ../.github/mvn-settings.xml --settings .github/mvn-settings.xml clean verify -DskipTests -Dquarkus.platform.group-id=io.quarkus $QUARKUS_VERSION_ARGS
+          if [ "$GIB_IMPACTED_GAV" == '_all_' ]; then
+            export LANG=en_US && ./mvnw -e -B -fae --global-settings ../.github/mvn-settings.xml --settings .github/mvn-settings.xml verify -Dquarkus.platform.group-id=io.quarkus $QUARKUS_VERSION_ARGS
+          else
+            echo "$GIB_IMPACTED_GAV" > gib-dependencies.log
+            export LANG=en_US && ./mvnw -e -B -fae --global-settings ../.github/mvn-settings.xml --settings .github/mvn-settings.xml verify -Dquarkus.platform.group-id=io.quarkus $QUARKUS_VERSION_ARGS \
+              -Dincremental -Dgib.loadImpactedDependenciesFrom=gib-dependencies.log
+          fi
       - name: Prepare build reports archive
         if: always()
         run: |
@@ -1236,7 +1266,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
-          name: "build-reports-${{ github.run_attempt }}-Quickstarts Compilation - JDK ${{matrix.java.name}}"
+          name: "build-reports-${{ github.run_attempt }}-Quickstarts - JDK ${{matrix.java.name}}"
           path: |
             build-reports.zip
           retention-days: 7


### PR DESCRIPTION
Quarkus CI verifies that the framework itself works, but it has a blind spot — it doesn't verify that changes to Quarkus modules actually break real-world applications. 
The quickstarts repo is the closest thing to "real user code" that the project maintains. Right now, QE discovers regressions after merge, creating a costly feedback loop: QE files a bug, a developer has to context-switch back, the fix takes another PR cycle, and in the meantime the broken code may have shipped in a snapshot or even a release. 

However, running the full Quickstarts will take a long time CI-wise, so this PR will add GAV-formatted impacted module output from GIB and use it to selectively run quickstart tests, avoiding a full test run when only a subset of extensions changed.

- Requires https://github.com/quarkusio/quarkus-quickstarts/pull/1639
- Fixes https://redhat.atlassian.net/browse/QQE-2349