### PR TITLE
[4.0] Migration of the AWS Lambda and AWS Lambda and Vert.x ITs

### DIFF
--- a/extensions/amazon-lambda-rest/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
+++ b/extensions/amazon-lambda-rest/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
@@ -1,7 +1,5 @@
 package io.quarkus.amazon.lambda.http.deployment;
 
-import static io.vertx.core.file.impl.FileResolverImpl.CACHE_DIR_BASE_PROP_NAME;
-
 import org.jboss.jandex.DotName;
 
 import io.quarkus.amazon.lambda.deployment.LambdaUtil;
@@ -34,6 +32,7 @@ import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
 import io.quarkus.resteasy.reactive.server.spi.ContextTypeBuildItem;
 import io.quarkus.vertx.http.deployment.RequireVirtualHttpBuildItem;
+import io.vertx.core.impl.SysProps;
 
 public class AmazonLambdaHttpProcessor {
     private static final DotName AWS_PROXY_REQUEST_CONTEXT = DotName.createSimple(AwsProxyRequestContext.class);
@@ -97,7 +96,7 @@ public class AmazonLambdaHttpProcessor {
      */
     @BuildStep(onlyIf = IsProduction.class)
     void setTempDir(BuildProducer<SystemPropertyBuildItem> systemProperty) {
-        systemProperty.produce(new SystemPropertyBuildItem(CACHE_DIR_BASE_PROP_NAME, "/tmp/quarkus"));
+        systemProperty.produce(new SystemPropertyBuildItem(SysProps.FILE_CACHE_DIR.get(), "/tmp/quarkus"));
     }
 
     @BuildStep

--- a/extensions/amazon-lambda-rest/rest-event-server/src/main/java/io/quarkus/amazon/lambda/runtime/MockRestEventServer.java
+++ b/extensions/amazon-lambda-rest/rest-event-server/src/main/java/io/quarkus/amazon/lambda/runtime/MockRestEventServer.java
@@ -56,7 +56,7 @@ public class MockRestEventServer extends MockEventServer {
             traceId = UUID.randomUUID().toString();
         }
         ctx.put(AmazonLambdaApi.LAMBDA_TRACE_HEADER_KEY, traceId);
-        Buffer body = ctx.getBody();
+        Buffer body = ctx.body().buffer();
 
         AwsProxyRequest event = new AwsProxyRequest();
         event.setRequestContext(new AwsProxyRequestContext());

--- a/extensions/funqy/funqy-http/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/http/VertxRequestHandler.java
+++ b/extensions/funqy/funqy-http/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/http/VertxRequestHandler.java
@@ -26,6 +26,7 @@ import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.core.internal.buffer.BufferInternal;
 import io.vertx.ext.web.RoutingContext;
 
 public class VertxRequestHandler implements Handler<RoutingContext> {
@@ -98,10 +99,10 @@ public class VertxRequestHandler implements Handler<RoutingContext> {
                 dispatch(routingContext, invoker, finalInput);
             });
         } else if (routingContext.request().method() == HttpMethod.POST) {
-            var buff = routingContext.getBody();
+            var buff = routingContext.body().buffer();
             Object input = null;
             if (buff != null && buff.length() > 0) {
-                ByteBufInputStream in = new ByteBufInputStream(buff.getByteBuf());
+                ByteBufInputStream in = new ByteBufInputStream(((BufferInternal) buff).getByteBuf());
                 ObjectReader reader = (ObjectReader) invoker.getBindingContext().get(ObjectReader.class.getName());
                 try {
                     input = reader.readValue((InputStream) in);

--- a/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/VertxRequestHandler.java
+++ b/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/VertxRequestHandler.java
@@ -54,6 +54,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.internal.buffer.BufferInternal;
 import io.vertx.ext.web.RoutingContext;
 
 public class VertxRequestHandler implements Handler<RoutingContext> {
@@ -491,7 +492,7 @@ public class VertxRequestHandler implements Handler<RoutingContext> {
                                 + "' does not accept input");
                     }
                 } else if (buff != null && buff.length() > 0) {
-                    ByteBufInputStream in = new ByteBufInputStream(buff.getByteBuf());
+                    ByteBufInputStream in = new ByteBufInputStream(((BufferInternal) buff).getByteBuf());
                     ObjectReader reader = (ObjectReader) invoker.getBindingContext().get(DATA_OBJECT_READER);
                     try {
                         input = reader.readValue((InputStream) in);

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -1576,7 +1576,10 @@ public class VertxHttpRecorder {
                 .childHandler(new ChannelInitializer<VirtualChannel>() {
                     @Override
                     public void initChannel(VirtualChannel ch) throws Exception {
-                        ContextInternal rootContext = vertx.createEventLoopContext();
+                        // We are already on a Netty Event loop, just ask Vert.x to create a context from it.
+                        // This is the root context used by the HTTP connection (read and write MUST be done from
+                        // THAT event loop).
+                        ContextInternal rootContext = vertx.getOrCreateContext();
                         VertxHandler<Http1xServerConnection> handler = VertxHandler.create(chctx -> {
 
                             Http1xServerConnection conn = new Http1xServerConnection(

--- a/integration-tests/amazon-lambda-http/src/main/java/io/quarkus/it/amazon/lambda/GreetingVertx.java
+++ b/integration-tests/amazon-lambda-http/src/main/java/io/quarkus/it/amazon/lambda/GreetingVertx.java
@@ -16,7 +16,7 @@ public class GreetingVertx {
 
     @Route(path = "/vertx/hello", methods = POST)
     void helloPost(RoutingContext context) {
-        String name = context.getBodyAsString();
+        String name = context.body().asString();
         context.response().headers().set("Content-Type", "text/plain");
         context.response().setStatusCode(200).end("hello " + name);
     }

--- a/integration-tests/amazon-lambda-rest-reactive-routes/src/main/java/io/quarkus/it/amazon/lambda/rest/reactive/routes/GreetingVertx.java
+++ b/integration-tests/amazon-lambda-rest-reactive-routes/src/main/java/io/quarkus/it/amazon/lambda/rest/reactive/routes/GreetingVertx.java
@@ -16,7 +16,7 @@ public class GreetingVertx {
 
     @Route(path = "/vertx/hello", methods = POST)
     void helloPost(RoutingContext context) {
-        String name = context.getBodyAsString();
+        String name = context.body().asString();
         context.response().headers().set("Content-Type", "text/plain");
         context.response().setStatusCode(200).end("hello " + name);
     }
@@ -29,7 +29,7 @@ public class GreetingVertx {
 
     @Route(path = "/vertx/rx/hello", methods = POST)
     void rxHelloPost(RoutingContext context) {
-        String name = context.getBodyAsString();
+        String name = context.body().asString();
         context.response().headers().set("Content-Type", "text/plain");
         context.response().setStatusCode(200).end("hello " + name);
     }

--- a/integration-tests/vertx-http-compressors/app/src/test/java/io/quarkus/compressors/it/Testflow.java
+++ b/integration-tests/vertx-http-compressors/app/src/test/java/io/quarkus/compressors/it/Testflow.java
@@ -81,7 +81,7 @@ public class Testflow {
                     .putHeader(HttpHeaders.ACCEPT_ENCODING.toString(), acceptEncoding)
                     .putHeader(HttpHeaders.ACCEPT.toString(), "*/*")
                     .putHeader(HttpHeaders.USER_AGENT.toString(), "Tester")
-                    .send(ar -> {
+                    .send().onComplete(ar -> {
                         if (ar.succeeded()) {
                             future.complete(ar.result());
                         } else {
@@ -136,7 +136,7 @@ public class Testflow {
                     .putHeader(HttpHeaders.CONTENT_ENCODING.toString(), contentEncoding)
                     .putHeader(HttpHeaders.ACCEPT.toString(), "*/*")
                     .putHeader(HttpHeaders.USER_AGENT.toString(), "Tester")
-                    .sendBuffer(compress(contentEncoding, TEXT), ar -> {
+                    .sendBuffer(compress(contentEncoding, TEXT)).onComplete(ar -> {
                         if (ar.succeeded()) {
                             future.complete(ar.result());
                         } else {

--- a/integration-tests/vertx-http/src/main/java/io/quarkus/it/vertx/BeanRegisteringRoute.java
+++ b/integration-tests/vertx-http/src/main/java/io/quarkus/it/vertx/BeanRegisteringRoute.java
@@ -3,8 +3,6 @@ package io.quarkus.it.vertx;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.web.Router;
 
@@ -18,12 +16,8 @@ public class BeanRegisteringRoute {
 
         //ping only works on HTTP/2
         router.get("/ping").handler(rc -> {
-            rc.request().connection().ping(Buffer.buffer(PING_DATA), new Handler<AsyncResult<Buffer>>() {
-                @Override
-                public void handle(AsyncResult<Buffer> event) {
-                    rc.response().end(event.result());
-                }
-            });
+            rc.request().connection().ping(Buffer.buffer(PING_DATA))
+                    .onComplete(event -> rc.response().end(event.result()));
         });
     }
 }

--- a/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/Http2TestCase.java
+++ b/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/Http2TestCase.java
@@ -13,8 +13,6 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpVersion;
@@ -58,9 +56,9 @@ public class Http2TestCase {
                     .setUseAlpn(true)
                     .setProtocolVersion(HttpVersion.HTTP_2)
                     .setSsl(true)
-                    .setKeyStoreOptions(
+                    .setKeyCertOptions(
                             new JksOptions().setPath("src/test/resources/" + keystoreName).setPassword("password"))
-                    .setTrustStoreOptions(
+                    .setTrustOptions(
                             new JksOptions().setPath("src/test/resources/client-truststore.jks").setPassword("password"));
 
             WebClient client = WebClient.create(vertx, options);
@@ -93,7 +91,7 @@ public class Http2TestCase {
         client
                 .get(port, "localhost", "/ping")
                 .virtualHost("server")
-                .send(ar -> {
+                .send().onComplete(ar -> {
                     if (ar.succeeded()) {
                         // Obtain response
                         HttpResponse<Buffer> response = ar.result();
@@ -111,12 +109,8 @@ public class Http2TestCase {
         public void register(@Observes Router router) {
             //ping only works on HTTP/2
             router.get("/ping").handler(rc -> {
-                rc.request().connection().ping(Buffer.buffer(PING_DATA), new Handler<AsyncResult<Buffer>>() {
-                    @Override
-                    public void handle(AsyncResult<Buffer> event) {
-                        rc.response().end(event.result());
-                    }
-                });
+                rc.request().connection().ping(Buffer.buffer(PING_DATA))
+                        .onComplete(event -> rc.response().end(event.result()));
             });
         }
 

--- a/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/TlsProtocolVersionDefaultTestCase.java
+++ b/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/TlsProtocolVersionDefaultTestCase.java
@@ -30,9 +30,9 @@ public class TlsProtocolVersionDefaultTestCase {
     void testWithWebClientRequestingMultipleTlsVersions() {
         // The Web client is requesting TLS 1.2 or 1.3, the server is exposing 1.3 - all good
         WebClient client = WebClient.create(vertx, new WebClientOptions().setSsl(true)
-                .setKeyStoreOptions(
+                .setKeyCertOptions(
                         new JksOptions().setPath("src/test/resources/client-keystore-1.jks").setPassword("password"))
-                .setTrustStoreOptions(
+                .setTrustOptions(
                         new JksOptions().setPath("src/test/resources/client-truststore.jks").setPassword("password"))
                 .setVerifyHost(false));
         var resp = client.getAbs(url).sendAndAwait();
@@ -44,9 +44,9 @@ public class TlsProtocolVersionDefaultTestCase {
         // The Web client is requesting TLS 1.3, the server is exposing 1.3 - all good
         WebClient client = WebClient.create(vertx, new WebClientOptions().setSsl(true)
                 .setEnabledSecureTransportProtocols(Set.of("TLSv1.3"))
-                .setKeyStoreOptions(
+                .setKeyCertOptions(
                         new JksOptions().setPath("src/test/resources/client-keystore-1.jks").setPassword("password"))
-                .setTrustStoreOptions(
+                .setTrustOptions(
                         new JksOptions().setPath("src/test/resources/client-truststore.jks").setPassword("password"))
                 .setVerifyHost(false));
         var resp = client.getAbs(url).sendAndAwait();
@@ -58,13 +58,13 @@ public class TlsProtocolVersionDefaultTestCase {
         // The Web client is requesting TLS 1.2, the server is exposing 1.3 - KO
         WebClient client = WebClient.create(vertx, new WebClientOptions().setSsl(true)
                 .setEnabledSecureTransportProtocols(Set.of("TLSv1.2"))
-                .setKeyStoreOptions(
+                .setKeyCertOptions(
                         new JksOptions().setPath("src/test/resources/client-keystore-1.jks").setPassword("password"))
-                .setTrustStoreOptions(
+                .setTrustOptions(
                         new JksOptions().setPath("src/test/resources/client-truststore.jks").setPassword("password"))
                 .setVerifyHost(false));
         Throwable exception = Assertions.assertThrows(CompletionException.class, () -> client.getAbs(url).sendAndAwait());
-        Assertions.assertTrue(exception.getCause() instanceof SSLHandshakeException);
+        Assertions.assertInstanceOf(SSLHandshakeException.class, exception.getCause());
     }
 
     @Test
@@ -72,12 +72,12 @@ public class TlsProtocolVersionDefaultTestCase {
         // The Web client is requesting TLS 1.1, the server is exposing 1.2 and 1.3 - KO
         WebClient client = WebClient.create(vertx, new WebClientOptions().setSsl(true)
                 .setEnabledSecureTransportProtocols(Set.of("TLSv1.1"))
-                .setKeyStoreOptions(
+                .setKeyCertOptions(
                         new JksOptions().setPath("src/test/resources/client-keystore-1.jks").setPassword("password"))
-                .setTrustStoreOptions(
+                .setTrustOptions(
                         new JksOptions().setPath("src/test/resources/client-truststore.jks").setPassword("password"))
                 .setVerifyHost(false));
         Throwable exception = Assertions.assertThrows(CompletionException.class, () -> client.getAbs(url).sendAndAwait());
-        Assertions.assertTrue(exception.getCause() instanceof SSLHandshakeException);
+        Assertions.assertInstanceOf(SSLHandshakeException.class, exception.getCause());
     }
 }

--- a/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/TlsProtocolVersionSelectionTestCase.java
+++ b/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/TlsProtocolVersionSelectionTestCase.java
@@ -32,9 +32,9 @@ public class TlsProtocolVersionSelectionTestCase {
     void testWithWebClientRequestingMultipleTlsVersions() {
         // The Web client is requesting TLS 1.2 or 1.3, the server is exposing 1.3 - all good
         WebClient client = WebClient.create(vertx, new WebClientOptions().setSsl(true)
-                .setKeyStoreOptions(
+                .setKeyCertOptions(
                         new JksOptions().setPath("src/test/resources/client-keystore-1.jks").setPassword("password"))
-                .setTrustStoreOptions(
+                .setTrustOptions(
                         new JksOptions().setPath("src/test/resources/client-truststore.jks").setPassword("password"))
                 .setVerifyHost(false));
         var resp = client.getAbs(url).sendAndAwait();
@@ -46,9 +46,9 @@ public class TlsProtocolVersionSelectionTestCase {
         // The Web client is requesting TLS 1.3, the server is exposing 1.3 - all good
         WebClient client = WebClient.create(vertx, new WebClientOptions().setSsl(true)
                 .setEnabledSecureTransportProtocols(Set.of("TLSv1.3"))
-                .setKeyStoreOptions(
+                .setKeyCertOptions(
                         new JksOptions().setPath("src/test/resources/client-keystore-1.jks").setPassword("password"))
-                .setTrustStoreOptions(
+                .setTrustOptions(
                         new JksOptions().setPath("src/test/resources/client-truststore.jks").setPassword("password"))
                 .setVerifyHost(false));
         var resp = client.getAbs(url).sendAndAwait();
@@ -60,9 +60,9 @@ public class TlsProtocolVersionSelectionTestCase {
         // The Web client is requesting TLS 1.2, the server is exposing 1.3 - KO
         WebClient client = WebClient.create(vertx, new WebClientOptions().setSsl(true)
                 .setEnabledSecureTransportProtocols(Set.of("TLSv1.2"))
-                .setKeyStoreOptions(
+                .setKeyCertOptions(
                         new JksOptions().setPath("src/test/resources/client-keystore-1.jks").setPassword("password"))
-                .setTrustStoreOptions(
+                .setTrustOptions(
                         new JksOptions().setPath("src/test/resources/client-truststore.jks").setPassword("password"))
                 .setVerifyHost(false));
         Throwable exception = Assertions.assertThrows(CompletionException.class, () -> client.getAbs(url).sendAndAwait());
@@ -74,9 +74,9 @@ public class TlsProtocolVersionSelectionTestCase {
         // The Web client is requesting TLS 1.1, the server is exposing 1.3 - KO
         WebClient client = WebClient.create(vertx, new WebClientOptions().setSsl(true)
                 .setEnabledSecureTransportProtocols(Set.of("TLSv1.1"))
-                .setKeyStoreOptions(
+                .setKeyCertOptions(
                         new JksOptions().setPath("src/test/resources/client-keystore-1.jks").setPassword("password"))
-                .setTrustStoreOptions(
+                .setTrustOptions(
                         new JksOptions().setPath("src/test/resources/client-truststore.jks").setPassword("password"))
                 .setVerifyHost(false));
         Throwable exception = Assertions.assertThrows(CompletionException.class, () -> client.getAbs(url).sendAndAwait());

--- a/integration-tests/vertx-kotlin/src/main/kotlin/io/quarkus/it/vertx/kotlin/MessageConsumers.kt
+++ b/integration-tests/vertx-kotlin/src/main/kotlin/io/quarkus/it/vertx/kotlin/MessageConsumers.kt
@@ -1,6 +1,7 @@
 package io.quarkus.it.vertx.kotlin
 
 import io.quarkus.vertx.ConsumeEvent
+import io.vertx.core.MultiMap
 import jakarta.inject.Singleton
 import java.util.concurrent.CountDownLatch
 
@@ -36,13 +37,7 @@ class MessageConsumers {
     }
 
     @ConsumeEvent("headers-payload")
-    fun headersPayload(headers: io.vertx.core.MultiMap, msg: String) {
-        message = "${headers["header"]} - $msg"
-        latch.countDown()
-    }
-
-    @ConsumeEvent("mutiny-headers-payload")
-    fun mutinyHeadersPayload(headers: io.vertx.mutiny.core.MultiMap, msg: String) {
+    fun headersPayload(headers: MultiMap, msg: String) {
         message = "${headers["header"]} - $msg"
         latch.countDown()
     }

--- a/integration-tests/vertx-kotlin/src/main/kotlin/io/quarkus/it/vertx/kotlin/SuspendMessageConsumers.kt
+++ b/integration-tests/vertx-kotlin/src/main/kotlin/io/quarkus/it/vertx/kotlin/SuspendMessageConsumers.kt
@@ -1,6 +1,7 @@
 package io.quarkus.it.vertx.kotlin
 
 import io.quarkus.vertx.ConsumeEvent
+import io.vertx.core.MultiMap
 import jakarta.inject.Singleton
 import java.util.concurrent.CountDownLatch
 import kotlinx.coroutines.delay
@@ -40,14 +41,7 @@ class SuspendMessageConsumers {
     }
 
     @ConsumeEvent("suspend-headers-payload")
-    suspend fun headersPayload(headers: io.vertx.core.MultiMap, msg: String) {
-        delay(100)
-        message = "${headers["header"]} - $msg"
-        latch.countDown()
-    }
-
-    @ConsumeEvent("suspend-mutiny-headers-payload")
-    suspend fun mutinyHeadersPayload(headers: io.vertx.mutiny.core.MultiMap, msg: String) {
+    suspend fun headersPayload(headers: MultiMap, msg: String) {
         delay(100)
         message = "${headers["header"]} - $msg"
         latch.countDown()

--- a/integration-tests/vertx-kotlin/src/test/kotlin/io/quarkus/it/vertx/kotlin/KotlinConsumeEventTest.kt
+++ b/integration-tests/vertx-kotlin/src/test/kotlin/io/quarkus/it/vertx/kotlin/KotlinConsumeEventTest.kt
@@ -50,13 +50,4 @@ class KotlinConsumeEventTest {
         MessageConsumers.latch.await(2, TimeUnit.SECONDS)
         assertEquals("test header - payload", MessageConsumers.message)
     }
-
-    @Test
-    fun mutinyHeadersPayload() {
-        val options = DeliveryOptions().addHeader("header", "test mutiny header")
-        bus.send("mutiny-headers-payload", "payload", options)
-
-        MessageConsumers.latch.await(2, TimeUnit.SECONDS)
-        assertEquals("test mutiny header - payload", MessageConsumers.message)
-    }
 }

--- a/integration-tests/vertx-kotlin/src/test/kotlin/io/quarkus/it/vertx/kotlin/KotlinSuspendConsumeEventTest.kt
+++ b/integration-tests/vertx-kotlin/src/test/kotlin/io/quarkus/it/vertx/kotlin/KotlinSuspendConsumeEventTest.kt
@@ -50,13 +50,4 @@ class KotlinSuspendConsumeEventTest {
         SuspendMessageConsumers.latch.await(2, TimeUnit.SECONDS)
         assertEquals("test header - payload", SuspendMessageConsumers.message)
     }
-
-    @Test
-    fun mutinyHeadersPayload() {
-        val options = DeliveryOptions().addHeader("header", "test mutiny header")
-        bus.send("suspend-mutiny-headers-payload", "payload", options)
-
-        SuspendMessageConsumers.latch.await(2, TimeUnit.SECONDS)
-        assertEquals("test mutiny header - payload", SuspendMessageConsumers.message)
-    }
 }

--- a/integration-tests/vertx/src/main/java/io/quarkus/it/vertx/verticles/BareVerticle.java
+++ b/integration-tests/vertx/src/main/java/io/quarkus/it/vertx/verticles/BareVerticle.java
@@ -10,6 +10,6 @@ public class BareVerticle extends AbstractVerticle {
         String address = config().getString("id");
         vertx.eventBus().consumer(address)
                 .handler(message -> message.reply("OK-" + address))
-                .completionHandler(done);
+                .completion().onComplete(done);
     }
 }

--- a/integration-tests/vertx/src/main/java/io/quarkus/it/vertx/verticles/MdcVerticle.java
+++ b/integration-tests/vertx/src/main/java/io/quarkus/it/vertx/verticles/MdcVerticle.java
@@ -11,7 +11,7 @@ public class MdcVerticle extends AbstractVerticle {
     private static final Logger LOGGER = Logger.getLogger(MdcVerticle.class);
 
     @Override
-    public void start(Promise<Void> done) {
+    public void start(Promise<Void> promise) {
         String address = config().getString("id");
         vertx.eventBus().<String> consumer(address)
                 .handler(message -> {
@@ -25,6 +25,6 @@ public class MdcVerticle extends AbstractVerticle {
                         }).onComplete(bar -> message.reply("OK-" + MDC.get(MDC_KEY)));
                     });
                 })
-                .completionHandler(done);
+                .completion().onComplete(promise);
     }
 }

--- a/integration-tests/vertx/src/main/java/io/quarkus/it/vertx/verticles/MutinyAsyncVerticle.java
+++ b/integration-tests/vertx/src/main/java/io/quarkus/it/vertx/verticles/MutinyAsyncVerticle.java
@@ -10,7 +10,7 @@ public class MutinyAsyncVerticle extends AbstractVerticle {
         String address = config().getString("id");
         return vertx.eventBus().consumer(address)
                 .handler(message -> message.reply("OK-" + address))
-                .completionHandler();
+                .completion();
     }
 
 }


### PR DESCRIPTION
- Fix event loop affinity in the virtual server support
- Migrate the Funqy extension to Vertx 5
- Migrate the AWS Lambda HTTP integration tests to vert.x 5 API
- Migrate AWS Lambda Reactive Routes tests to Vert.x 5 API
- Migrate AWS Lambda REST extension to Vert.x 5
- Migrate Vert.x integration tests to Vert.x 5 API