### PR TITLE
Replace `@Dependant` with `@ApplicationScoped` in Panache repositories

### DIFF
--- a/extensions/panache/hibernate-panache-next/deployment/src/main/java/io/quarkus/hibernate/panache/deployment/PanacheHibernateResourceProcessor.java
+++ b/extensions/panache/hibernate-panache-next/deployment/src/main/java/io/quarkus/hibernate/panache/deployment/PanacheHibernateResourceProcessor.java
@@ -15,21 +15,25 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
 
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 
 import org.hibernate.Session;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.AnnotationTransformation;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type.Kind;
 
+import io.quarkus.arc.deployment.AnnotationsTransformerBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.arc.deployment.ValidationPhaseBuildItem;
 import io.quarkus.arc.deployment.staticmethods.InterceptedStaticMethodsTransformersRegisteredBuildItem;
+import io.quarkus.arc.processor.BuiltinScope;
 import io.quarkus.builder.BuildException;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
@@ -43,6 +47,7 @@ import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.util.JandexUtil;
+import io.quarkus.hibernate.orm.deployment.HibernateOrmProcessor;
 import io.quarkus.hibernate.orm.deployment.JpaModelPersistenceUnitMappingBuildItem;
 import io.quarkus.hibernate.orm.deployment.PersistenceUnitDescriptorBuildItem;
 import io.quarkus.hibernate.orm.deployment.spi.AdditionalJpaModelBuildItem;
@@ -87,6 +92,13 @@ public final class PanacheHibernateResourceProcessor {
             .createSimple(PanacheStatelessReactiveEntity.class.getName());
     static final DotName DOTNAME_PANACHE_ENTITY_MARKER = DotName.createSimple(PanacheEntityMarker.class.getName());
 
+    private static final Set<String> ALL_REPOSITORY_METHOD_ANNOTATIONS;
+    static {
+        Set<String> set = new HashSet<>(PANACHE_REPOSITORY_ANNOTATIONS);
+        HibernateOrmProcessor.HIBERNATE_REPOSITORY_ANNOTATIONS.stream().map(Class::getName).forEach(set::add);
+        ALL_REPOSITORY_METHOD_ANNOTATIONS = Set.copyOf(set);
+    }
+
     private static final DotName DOTNAME_SESSION = DotName.createSimple(Session.class.getName());
 
     private static final DotName DOTNAME_ID = DotName.createSimple(Id.class.getName());
@@ -114,6 +126,37 @@ public final class PanacheHibernateResourceProcessor {
     UnremovableBeanBuildItem ensureBeanLookupAvailable() {
         // FIXME: look for mutiny sessions too?
         return new UnremovableBeanBuildItem(new UnremovableBeanBuildItem.BeanTypeExclusion(DOTNAME_SESSION));
+    }
+
+    @BuildStep
+    void makePanache2ReposApplicationScopedAndUnremovable(
+            CombinedIndexBuildItem index,
+            BuildProducer<AnnotationsTransformerBuildItem> annotationsTransformer,
+            BuildProducer<UnremovableBeanBuildItem> unremovableBeanBuildItems) {
+        Set<DotName> repositoryImpls = new HashSet<>();
+        collectEntityInnerInterfaces(index.getIndex(),
+                (memberClass, implementingBean) -> {
+                    if (!implementingBean.isInterface() && !implementingBean.isAbstract()) {
+                        repositoryImpls.add(implementingBean.name());
+                    }
+                });
+        for (ClassInfo classInfo : index.getIndex().getAllKnownImplementations(DOTNAME_PANACHE_REPOSITORY_SWITCHER)) {
+            if (!classInfo.isInterface() && !classInfo.isAbstract()) {
+                repositoryImpls.add(classInfo.name());
+            }
+        }
+
+        if (repositoryImpls.isEmpty()) {
+            return;
+        }
+
+        unremovableBeanBuildItems.produce(UnremovableBeanBuildItem.beanTypes(repositoryImpls));
+        annotationsTransformer.produce(new AnnotationsTransformerBuildItem(AnnotationTransformation.forClasses()
+                .whenClass(c -> repositoryImpls.contains(c.name()))
+                .transform(c -> {
+                    c.remove(a -> a.name().equals(BuiltinScope.DEPENDENT.getName()));
+                    c.add(ApplicationScoped.class);
+                })));
     }
 
     @BuildStep
@@ -205,27 +248,6 @@ public final class PanacheHibernateResourceProcessor {
             }
         }
         recorder.setRepositoryClassesToEntityClasses(repositoryClassesToEntityClasses);
-    }
-
-    @BuildStep
-    void makePanache2ReposUnremovable(
-            CombinedIndexBuildItem index,
-            BuildProducer<UnremovableBeanBuildItem> unremovableBeanBuildItems) throws ClassNotFoundException {
-        Set<DotName> unremovable = new HashSet<>();
-        // Find Panache 2 repos, by listing every entity, to find query interfaces with no supertype
-        collectEntityInnerInterfaces(index.getIndex(),
-                (memberClass, implementingBean) -> unremovable.add(implementingBean.name()));
-        // Now, some entities that do not explicitly add stateless/managed query repos will get some generated, so
-        // either we figure out who they are, or we blanket add them all
-        index.getIndex().getKnownClasses();
-        for (ClassInfo classInfo : index.getIndex().getAllKnownImplementations(DOTNAME_PANACHE_REPOSITORY_SWITCHER)) {
-            // Only keep concrete classes
-            if (classInfo.isInterface() || classInfo.isAbstract()) {
-                continue;
-            }
-            unremovable.add(classInfo.name());
-        }
-        unremovableBeanBuildItems.produce(UnremovableBeanBuildItem.beanTypes(unremovable));
     }
 
     @BuildStep
@@ -358,10 +380,13 @@ public final class PanacheHibernateResourceProcessor {
                 continue;
             }
             ClassInfo entityClass = target.asClass();
-            // find its member interfaces
+            // find its member interfaces that are Panache repository types
             for (DotName memberClassName : entityClass.memberClasses()) {
                 ClassInfo memberClass = index.getClassByName(memberClassName);
                 if (!memberClass.isInterface()) {
+                    continue;
+                }
+                if (!isPanacheRepositoryInterface(memberClass, index)) {
                     continue;
                 }
                 for (ClassInfo implementingBean : index.getAllKnownImplementations(memberClassName)) {
@@ -369,5 +394,19 @@ public final class PanacheHibernateResourceProcessor {
                 }
             }
         }
+    }
+
+    private static boolean isPanacheRepositoryInterface(ClassInfo interfaceClass, IndexView index) {
+        if (index.getAllKnownSubinterfaces(DOTNAME_PANACHE_REPOSITORY_SWITCHER).contains(interfaceClass)) {
+            return true;
+        }
+        for (MethodInfo method : interfaceClass.methods()) {
+            for (AnnotationInstance annotation : method.annotations()) {
+                if (ALL_REPOSITORY_METHOD_ANNOTATIONS.contains(annotation.name().toString())) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }

--- a/extensions/panache/hibernate-panache-next/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/FirstTest.java
+++ b/extensions/panache/hibernate-panache-next/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/FirstTest.java
@@ -1,11 +1,13 @@
 package io.quarkus.hibernate.panache.deployment.test;
 
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.transaction.Transactional;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkus.arc.Arc;
 import io.quarkus.test.QuarkusExtensionTest;
 
 public class FirstTest {
@@ -14,7 +16,8 @@ public class FirstTest {
     static QuarkusExtensionTest runner = new QuarkusExtensionTest()
             .withApplicationRoot((jar) -> jar
                     .addAsResource("application-test.properties", "application.properties")
-                    .addClasses(MyEntity.class, MyEntity_.class, MyEntity_.ManagedBlockingQueries_.class));
+                    .addClasses(MyEntity.class, MyEntity_.class, MyEntity_.ManagedBlockingQueries_.class,
+                            MyEntity_.FindOnlyRepo_.class));
 
     @Transactional
     void createOne() {
@@ -132,6 +135,18 @@ public class FirstTest {
         Assertions.assertEquals(1, MyEntity_.managedBlockingQueries().findFoos("fu").size());
         Assertions.assertEquals(1, MyEntity_.managedBlockingQueries().findFoosHQL("fu").size());
         Assertions.assertEquals(1, MyEntity_.managedBlockingQueries().findFoosFind("fu").size());
+    }
+
+    @Test
+    void testRepositoryScopeIsApplicationScoped() {
+        Assertions.assertEquals(ApplicationScoped.class,
+                Arc.container().select(MyEntity.ManagedBlockingQueries.class).getHandle().getBean().getScope());
+    }
+
+    @Test
+    void testFindOnlyRepoScopeIsApplicationScoped() {
+        Assertions.assertEquals(ApplicationScoped.class,
+                Arc.container().select(MyEntity.FindOnlyRepo.class).getHandle().getBean().getScope());
     }
 
     @Test

--- a/extensions/panache/hibernate-panache-next/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/MyEntity.java
+++ b/extensions/panache/hibernate-panache-next/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/MyEntity.java
@@ -26,4 +26,9 @@ public class MyEntity extends PanacheEntity {
         @Find
         List<MyEntity> findFoosFind(String foo);
     }
+
+    interface FindOnlyRepo {
+        @Find
+        List<MyEntity> findByFoo(String foo);
+    }
 }

--- a/extensions/panache/hibernate-panache-next/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/ReactiveTest.java
+++ b/extensions/panache/hibernate-panache-next/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/ReactiveTest.java
@@ -1,9 +1,12 @@
 package io.quarkus.hibernate.panache.deployment.test;
 
+import jakarta.enterprise.context.ApplicationScoped;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkus.arc.Arc;
 import io.quarkus.hibernate.reactive.panache.common.WithTransaction;
 import io.quarkus.test.QuarkusExtensionTest;
 import io.quarkus.test.vertx.RunOnVertxContext;
@@ -172,6 +175,12 @@ public class ReactiveTest {
                     Assertions.assertEquals(1, list.size());
                 })
                 .replaceWithVoid();
+    }
+
+    @Test
+    void testRepositoryScopeIsApplicationScoped() {
+        Assertions.assertEquals(ApplicationScoped.class,
+                Arc.container().select(MyReactiveEntity.ManagedReactiveQueries.class).getHandle().getBean().getScope());
     }
 
     @RunOnVertxContext

--- a/integration-tests/hibernate-panache-next/pom.xml
+++ b/integration-tests/hibernate-panache-next/pom.xml
@@ -41,7 +41,7 @@
         <!-- test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit</artifactId>
+            <artifactId>quarkus-junit-mockito</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integration-tests/hibernate-panache-next/src/main/java/io/quarkus/it/panache/next/PersonService.java
+++ b/integration-tests/hibernate-panache-next/src/main/java/io/quarkus/it/panache/next/PersonService.java
@@ -1,0 +1,19 @@
+package io.quarkus.it.panache.next;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class PersonService {
+
+    @Inject
+    Person.Repository personRepository;
+
+    public Person findById(Long id) {
+        return personRepository.findById(id);
+    }
+
+    public long count() {
+        return personRepository.count();
+    }
+}

--- a/integration-tests/hibernate-panache-next/src/test/java/io/quarkus/it/panache/next/PanacheNextInjectMockTest.java
+++ b/integration-tests/hibernate-panache-next/src/test/java/io/quarkus/it/panache/next/PanacheNextInjectMockTest.java
@@ -1,0 +1,43 @@
+package io.quarkus.it.panache.next;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class PanacheNextInjectMockTest {
+
+    @Inject
+    PersonService personService;
+
+    @InjectMock
+    Person.Repository personRepository;
+
+    @Test
+    void testMockFindById() {
+        Person testPerson = new Person();
+        testPerson.id = 999L;
+        testPerson.name = "Mock Person";
+        testPerson.age = 42;
+        Mockito.when(personRepository.findById(1L)).thenReturn(testPerson);
+
+        Person result = personService.findById(1L);
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(999L, result.id);
+        Assertions.assertEquals("Mock Person", result.name);
+    }
+
+    @Test
+    void testMockCount() {
+        Mockito.when(personRepository.count()).thenReturn(23L);
+        Assertions.assertEquals(23L, personService.count());
+
+        Mockito.when(personRepository.count()).thenReturn(42L);
+        Assertions.assertEquals(42L, personService.count());
+    }
+}


### PR DESCRIPTION
This is done in order to support mocking of repositories

- Fixes: #53873

P.S. This is based on an idea first expressed by @Ladicek in the issue discussion