### PR TITLE
Add building-docs skill for local documentation workflow  

### DIFF
--- a/.agents/skills/building-docs/SKILL.md
+++ b/.agents/skills/building-docs/SKILL.md
@@ -20,6 +20,28 @@ Run the full pipeline in one command:
 just docs-preview
 ```
 
+## How It Works
+
+The script uses local marker files to keep the preview workflow fast:
+
+* `docs/.docs-preview-root-build-last-run` — last successful root build.
+  Used to decide whether Step 1 can be skipped.
+* `docs/.docs-preview-root-build-head` — Git HEAD at last root build.
+  Detects branch switches, checkouts, and pulls.
+* `docs/.docs-preview-docs-build-last-run` — last successful docs rebuild.
+  Used to decide whether Step 2 can be skipped.
+* `docs/.docs-preview-last-run` — last preview run.
+  Used to detect recently changed files and open the right preview URL.
+* `docs/.docs-preview-times` — cached execution times for progress estimates.
+
+All marker files are gitignored. Delete them to force a full rebuild.
+
+**Caveat:** The script detects changes to docs sources and `pom.xml` files,
+but does not detect uncommitted changes outside `docs/` (e.g., new config
+properties, extension metadata, or generated-doc producers). If you modify
+code that affects generated documentation, force a root build manually:
+`QUARKUS_DOCS_PREVIEW_FULL=1 just docs-preview`
+
 ## Step 0 — Environment Setup
 
 Source `detect-env.sh` to set `$CONTAINER_CMD`, `$VOL_FLAG`,
@@ -102,8 +124,8 @@ fi
 
 The `--config` flag chain loads `_only_latest_guides_config.yml` (excludes
 old version directories) and `_config_dev.yml` (uses staging search
-cluster). These files are created by `sync-web-site.sh` inside
-`target/web-site/`.
+cluster). These files come from the `quarkusio.github.io` repository,
+cloned into `target/web-site/` by `sync-web-site.sh`.
 
 **Primary** — build from the upstream `jekyll-container/` Dockerfile
 (available after sync). This matches what `quarkusio.github.io` uses in

--- a/.agents/skills/building-docs/SKILL.md
+++ b/.agents/skills/building-docs/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: building-docs
+description: >
+  How to build, preview, and verify Quarkus documentation locally:
+  root Maven build, docs rebuild, Jekyll preview via Podman/Docker.
+---
+
+# Building Documentation
+
+## Supported Platforms
+
+This workflow is supported on Linux, macOS, and Windows through WSL2.
+Native Windows shells (PowerShell, CMD, Git Bash) are not supported.
+
+## Quick Start
+
+Run the full pipeline in one command:
+
+```bash
+just docs-preview
+```
+
+## Step 0 — Environment Setup
+
+Source `detect-env.sh` to set `$CONTAINER_CMD`, `$VOL_FLAG`,
+`$MVN_THREADS`, `$MAVEN_OPTS`, and `$BROWSER_CMD`:
+
+```bash
+. docs/detect-env.sh
+```
+
+The script computes Maven heap, thread count, container runtime,
+and browser automatically based on your machine.
+
+## Step 1 — Root Build (from repo root)
+
+Run **once**, then re-run roughly once a week, after pulling significant
+upstream changes, or when Step 2 fails.
+
+Use **`-DquicklyDocs`**, not **`-Dquickly`** (which sets `skipDocs=true`).
+The extra flags are not covered by the profile and are needed to skip
+integration-test modules, Gradle plugin build, and javadoc generation.
+
+```bash
+./mvnw $MVN_THREADS clean install -DquicklyDocs \
+  -Dno-test-modules -Dskip.gradle.build=true -Dmaven.javadoc.skip=true
+```
+
+Fallback (single-threaded) if the parallel build fails:
+
+```bash
+./mvnw clean install -DquicklyDocs \
+  -Dno-test-modules -Dskip.gradle.build=true -Dmaven.javadoc.skip=true
+```
+
+## Step 2 — Quick Docs Rebuild (from `docs/`)
+
+```bash
+cd docs
+../mvnw -ntp package -Dasciidoctor.fail-if=ERROR    # quick rebuild (~1 min)
+../mvnw -ntp clean package -Dasciidoctor.fail-if=ERROR  # if output looks stale
+```
+
+The `-Dasciidoctor.fail-if=ERROR` override lets the build succeed despite
+AsciiDoctor warnings (the default `WARN` level fails on cross-reference
+or attribute warnings that are harmless for local preview).
+
+## Step 3 — Sync (from `docs/`)
+
+First time: `./sync-web-site.sh`
+
+Subsequent iterations — fast re-sync (<1 second). This duplicates the
+rsync portion of `sync-web-site.sh` to skip its `rm -rf` + `git clone`
+(~4 min). If `sync-web-site.sh` gains a `--no-clone` flag, prefer that.
+
+```bash
+rsync -rt --delete \
+    --exclude='**/*.html' --exclude='**/index.adoc' \
+    --exclude='**/_attributes-local.adoc' --exclude='**/guides.md' \
+    --exclude='**/_templates' \
+    target/asciidoc/sources/ target/web-site/_versions/main/guides
+
+[ -d target/quarkus-generated-doc/ ] && rsync -rt --delete \
+    --exclude='**/*.html' --exclude='**/index.adoc' \
+    --exclude='**/_attributes.adoc' \
+    target/quarkus-generated-doc/ target/web-site/_generated-doc/main
+
+if [ -f target/indexByType.yaml ]; then
+    mkdir -p target/web-site/_data/versioned/main/index
+    { echo "# Generated file. Do not edit"; cat target/indexByType.yaml
+    } > target/web-site/_data/versioned/main/index/quarkus.yaml
+fi
+
+if [ -f target/relations.yaml ]; then
+    mkdir -p target/web-site/_data/versioned/main/index
+    { echo "# Generated file. Do not edit"; cat target/relations.yaml
+    } > target/web-site/_data/versioned/main/index/relations.yaml
+fi
+```
+
+## Step 4 — Serve (from `docs/target/web-site`)
+
+The `--config` flag chain loads `_only_latest_guides_config.yml` (excludes
+old version directories) and `_config_dev.yml` (uses staging search
+cluster). These files are created by `sync-web-site.sh` inside
+`target/web-site/`.
+
+**Primary** — build from the upstream `jekyll-container/` Dockerfile
+(available after sync). This matches what `quarkusio.github.io` uses in
+production and eliminates external image dependencies:
+
+```bash
+cd target/web-site
+$CONTAINER_CMD build -t quarkus-docs-jekyll:local jekyll-container/
+
+$CONTAINER_CMD run -d --name quarkus-docs-preview \
+  -p 127.0.0.1:4000:4000 -p 127.0.0.1:35729:35729 \
+  -v "$(pwd):/site${VOL_FLAG}" \
+  -v quarkus-jekyll-bundles:/usr/local/bundle \
+  quarkus-docs-jekyll:local \
+  bundle exec jekyll serve --host 0.0.0.0 \
+  --livereload --incremental \
+  --config _config.yml,_config_dev.yml,_only_latest_guides_config.yml
+```
+
+Stop: `$CONTAINER_CMD rm -f quarkus-docs-preview`
+
+**Fallback** — pre-built images (pinned by digest) if the local build
+is not available (e.g., first run before sync completes):
+
+```bash
+# Fallback 1: bretfisher/jekyll-serve
+$CONTAINER_CMD run -d --name quarkus-docs-preview \
+  -p 127.0.0.1:4000:4000 -p 127.0.0.1:35729:35729 \
+  -v "$(pwd):/site${VOL_FLAG}" \
+  -v quarkus-jekyll-bundles:/usr/local/bundle \
+  docker.io/bretfisher/jekyll-serve@sha256:db11b70736935b1a777b2ff2ae10f9ad191ee9fca6560eade1d5ad98b74e5f66 \
+  bundle exec jekyll serve --host 0.0.0.0 \
+  --livereload --incremental \
+  --config _config.yml,_config_dev.yml,_only_latest_guides_config.yml
+
+# Fallback 2: jekyll/jekyll (mount at /srv/jekyll)
+$CONTAINER_CMD run -d --name quarkus-docs-preview \
+  -p 127.0.0.1:4000:4000 -p 127.0.0.1:35729:35729 \
+  --volume="$(pwd):/srv/jekyll${VOL_FLAG}" \
+  -v quarkus-jekyll-bundles:/usr/local/bundle \
+  docker.io/jekyll/jekyll@sha256:bb45414c3fefa80a75c5001f30baf1dff48ae31dc961b8b51003b93b60675334 \
+  bundle exec jekyll serve --host 0.0.0.0 \
+  --livereload --incremental \
+  --config _config.yml,_config_dev.yml,_only_latest_guides_config.yml
+```
+
+## Step 5 — Verify
+
+The script auto-detects what you were working on and opens the right page:
+
+| Content type | How detected | Preview URL |
+|---|---|---|
+| 1 guide | Recently modified `.adoc` in `docs/src/main/asciidoc/` | `/version/main/guides/<name>.html` (direct) |
+| 2-4 guides | Multiple `.adoc` files modified | Opens a tab for each guide |
+| 5+ guides | Many files modified | `/version/main/guides/` (listing) |
+| Blog post | Recently modified `_posts/*.adoc`, no `user-story` tag | `/blog/<slug>/` (deep-link) |
+| User story | Recently modified `_posts/*.adoc`, has `user-story` tag | `/blog/<slug>/` (deep-link) |
+| No changes | No recent `.adoc` changes found | `/` (homepage) |
+
+## Iteration Loop
+
+```
+Edit .adoc → save → Step 2 (~1 min) → Step 3 re-sync (<1s) → browser auto-refreshes
+```
+
+Container stays running. Escalate to Step 1 when Step 2 fails or after
+significant upstream changes.
+
+## When to escalate to a root build
+
+| Symptom | Action |
+|---------|--------|
+| Quick rebuild succeeds but content looks stale | Try `../mvnw -ntp clean package -Dasciidoctor.fail-if=ERROR` in `docs/` |
+| `clean package` still broken or fails | Root build (Step 1) |
+| Pulled new upstream changes to `main` | Root build (Step 1) |
+| Root build is roughly a week old | Root build (Step 1) |
+| New config properties or extensions added | Root build (Step 1) |
+
+## Troubleshooting
+
+**`Failed to delete docs/.cache/formatter-maven-cache.properties`** —
+Rootless Podman UID mapping. Fix: `podman unshare rm -rf docs/.cache/`.
+With Docker: `rm -rf docs/.cache/`.
+
+**Volume mount errors on macOS/Ubuntu** — SELinux `:z` flag applied on
+a system without SELinux. Source `detect-env.sh` to set `$VOL_FLAG`
+correctly.
+
+**Container image pull fails** — The script first tries to build from the
+upstream `jekyll-container/` Dockerfile, then falls back to pre-built images
+pinned by digest. To force a rebuild of the local image:
+`$CONTAINER_CMD rmi quarkus-docs-jekyll:local`
+
+**Preview shows partial or stale content** — Jekyll's `--incremental`
+mode can sometimes miss dependency changes. Restart the container
+(`$CONTAINER_CMD rm -f quarkus-docs-preview`) and run `just docs-preview`
+again. If that doesn't help, delete `docs/target/web-site/.jekyll-cache`
+before re-running.
+
+**Force a full root build** — Set `QUARKUS_DOCS_PREVIEW_FULL=1` before
+running: `QUARKUS_DOCS_PREVIEW_FULL=1 just docs-preview`

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,8 @@ nb-configuration.xml
 
 CLAUDE.local.md
 docs/superpowers
+docs/.docs-preview-last-run
+docs/.docs-preview-root-build-last-run
+docs/.docs-preview-root-build-head
+docs/.docs-preview-times
+docs/.docs-preview.lock/

--- a/.gitignore
+++ b/.gitignore
@@ -40,8 +40,10 @@ nb-configuration.xml
 .mvn/.gradle-enterprise/
 .goose
 .claude
+.junie
 .bob
 **/.claude
+**/.junie
 .quarkus
 
 CLAUDE.local.md
@@ -49,5 +51,6 @@ docs/superpowers
 docs/.docs-preview-last-run
 docs/.docs-preview-root-build-last-run
 docs/.docs-preview-root-build-head
+docs/.docs-preview-docs-build-last-run
 docs/.docs-preview-times
 docs/.docs-preview.lock/

--- a/.justfile
+++ b/.justfile
@@ -15,6 +15,10 @@ build-fast:
 build-docs:
     {{mvncmd}} -e -DskipTests -DskipITs -Dinvoker.skip -DskipExtensionValidation -Dskip.gradle.tests -Dtruststore.skip -Dno-test-modules -Dasciidoctor.fail-if=DEBUG clean install
 
+# build docs, sync to website, serve with Jekyll, and open browser
+docs-preview:
+    bash docs/docs-preview.sh
+
 # format code according to Quarkus coding conventions
 format:
     {{mvncmd}} process-sources -Denforcer.skip -Dprotoc.skip

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,3 +113,4 @@ Consult the relevant skill when you are about to do that type of work:
 | `building-and-testing` | Maven build commands, flags, incremental builds, and build rules                      |
 | `pull-requests` | PR title/description conventions, commit hygiene, labels, and contribution rules      |
 | `writing-extension-devui` | Writing a Dev UI for a Quarkus extension                                              |
+| `building-docs` | Building, previewing, or testing documentation changes locally                        |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,3 +23,5 @@ guidance before starting work:
   when building, testing, or understanding Maven flags and build commands.
 - **Pull requests** — Read `.agents/skills/pull-requests/SKILL.md`
   when preparing a pull request, writing commit messages, or choosing labels.
+- **Building docs** — Read `.agents/skills/building-docs/SKILL.md`
+  when building, previewing, or testing documentation changes locally.

--- a/docs/detect-env.sh
+++ b/docs/detect-env.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Detects the machine environment and sets variables for the docs
+# build pipeline. Source this script: . docs/detect-env.sh
+# Only MAVEN_OPTS is exported; other variables are set in the caller's
+# shell context when sourced.
+
+if command -v podman &>/dev/null; then CONTAINER_CMD="podman"
+elif command -v docker &>/dev/null; then CONTAINER_CMD="docker"
+else echo "ERROR: neither podman nor docker found" && return 1 2>/dev/null || exit 1; fi
+
+if command -v getenforce &>/dev/null && [ "$(getenforce 2>/dev/null)" != "Disabled" ]; then
+  VOL_FLAG=":z"
+else
+  VOL_FLAG=""
+fi
+
+if command -v nproc &>/dev/null; then
+  CORES=$(nproc)
+elif command -v sysctl &>/dev/null; then
+  CORES=$(sysctl -n hw.ncpu)
+else
+  CORES=4
+fi
+case "$CORES" in ''|*[!0-9]*) CORES=4 ;; esac
+
+if command -v free &>/dev/null; then
+  TOTAL_MEM_MB=$(free -m | awk '/^Mem:/{print $2}')
+elif command -v sysctl &>/dev/null; then
+  TOTAL_MEM_MB=$(sysctl -n hw.memsize | awk '{print int($1/1048576)}')
+else
+  TOTAL_MEM_MB=8192
+fi
+case "$TOTAL_MEM_MB" in ''|*[!0-9]*) TOTAL_MEM_MB=8192 ;; esac
+
+HEAP_MB=$((TOTAL_MEM_MB / 4))
+[ "$HEAP_MB" -lt 2048 ] && HEAP_MB=2048
+[ "$HEAP_MB" -gt 8192 ] && HEAP_MB=8192
+case "$MAVEN_OPTS" in
+  *-Xmx*) ;;
+  "") export MAVEN_OPTS="-Xmx${HEAP_MB}m" ;;
+  *)  export MAVEN_OPTS="$MAVEN_OPTS -Xmx${HEAP_MB}m" ;;
+esac
+
+AVAIL_FOR_THREADS=$((TOTAL_MEM_MB - HEAP_MB - 2048))
+[ "$AVAIL_FOR_THREADS" -lt 0 ] && AVAIL_FOR_THREADS=0
+MAX_THREADS_BY_RAM=$((AVAIL_FOR_THREADS / 750))
+MAX_THREADS_BY_CPU=$(awk -v cores="$CORES" 'BEGIN {printf "%d", cores * 0.8}')
+if [ "$MAX_THREADS_BY_RAM" -lt "$MAX_THREADS_BY_CPU" ] && [ "$MAX_THREADS_BY_RAM" -ge 1 ]; then
+  MVN_THREADS="-T $MAX_THREADS_BY_RAM"
+elif [ "$MAX_THREADS_BY_RAM" -lt 1 ]; then
+  MVN_THREADS=""
+else
+  MVN_THREADS="-T 0.8C"
+fi
+
+if command -v wslview &>/dev/null; then BROWSER_CMD="wslview"
+elif command -v xdg-open &>/dev/null; then BROWSER_CMD="xdg-open"
+elif command -v open &>/dev/null; then BROWSER_CMD="open"
+else BROWSER_CMD=""; fi
+
+echo "Container:  $CONTAINER_CMD"
+echo "SELinux:    ${VOL_FLAG:-none}"
+echo "Cores:      $CORES"
+echo "RAM:        $((TOTAL_MEM_MB / 1024))GB total → heap ${HEAP_MB}MB, threads: ${MVN_THREADS:-single-threaded}"
+echo "MAVEN_OPTS: $MAVEN_OPTS"
+echo "Browser:    ${BROWSER_CMD:-manual}"

--- a/docs/docs-preview.sh
+++ b/docs/docs-preview.sh
@@ -3,17 +3,19 @@ SCRIPTDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd) || exit 1
 cd "$SCRIPTDIR" || exit 1
 
 # Verify required commands before anything else
-for cmd in awk curl rsync find stat mktemp grep sed sort head tail cut basename date seq tee mv; do
+for cmd in awk curl rsync find stat mktemp grep sed sort head tail cut basename date seq tee mv git; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     echo "ERROR: required command not found: $cmd"
     exit 1
   fi
 done
 
+find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'quarkus-docs-build-*' -type d -mtime +7 -exec rm -rf {} + 2>/dev/null || true
 LOGDIR=$(mktemp -d "${TMPDIR:-/tmp}/quarkus-docs-build-XXXXXX") || exit 1
 
 # Primary: build from the upstream jekyll-container/ Dockerfile (in the website checkout).
 # Fallback: use pre-built images if the Dockerfile is not available (first run before sync).
+CONTAINER_NAME="quarkus-docs-preview"
 JEKYLL_LOCAL_IMAGE="quarkus-docs-jekyll:local"
 JEKYLL_IMAGE_FALLBACK="docker.io/bretfisher/jekyll-serve@sha256:db11b70736935b1a777b2ff2ae10f9ad191ee9fca6560eade1d5ad98b74e5f66"
 JEKYLL_IMAGE_FALLBACK2="docker.io/jekyll/jekyll@sha256:bb45414c3fefa80a75c5001f30baf1dff48ae31dc961b8b51003b93b60675334"
@@ -21,6 +23,7 @@ JEKYLL_IMAGE_FALLBACK2="docker.io/jekyll/jekyll@sha256:bb45414c3fefa80a75c5001f3
 PREVIEW_REF="$SCRIPTDIR/docs/.docs-preview-last-run"
 ROOT_BUILD_REF="$SCRIPTDIR/docs/.docs-preview-root-build-last-run"
 ROOT_BUILD_HEAD_REF="$SCRIPTDIR/docs/.docs-preview-root-build-head"
+DOCS_BUILD_REF="$SCRIPTDIR/docs/.docs-preview-docs-build-last-run"
 TIMES_CACHE="$SCRIPTDIR/docs/.docs-preview-times"
 LOCK_DIR="$SCRIPTDIR/docs/.docs-preview.lock"
 
@@ -30,9 +33,15 @@ ACTIVE_PID=""
 
 # Prevent concurrent runs
 if ! mkdir "$LOCK_DIR" 2>/dev/null; then
-  echo "Another docs preview run is already active."
-  echo "If this is stale, remove: $LOCK_DIR"
-  exit 1
+  LOCK_PID=$(cat "$LOCK_DIR/pid" 2>/dev/null)
+  if [ -n "$LOCK_PID" ] && kill -0 "$LOCK_PID" 2>/dev/null; then
+    echo "Another docs preview run is already active (PID $LOCK_PID)."
+    echo "If this is stale, remove: $LOCK_DIR"
+    exit 1
+  fi
+  echo "Removing stale lock (PID ${LOCK_PID:-unknown} no longer running)."
+  rm -rf "$LOCK_DIR"
+  mkdir "$LOCK_DIR" || exit 1
 fi
 
 cleanup_on_exit() {
@@ -43,12 +52,15 @@ cleanup_on_interrupt() {
   echo "Interrupted."
   if [ -n "$ACTIVE_PID" ] && kill -0 "$ACTIVE_PID" 2>/dev/null; then
     kill "$ACTIVE_PID" 2>/dev/null || true
+    wait "$ACTIVE_PID" 2>/dev/null || true
   fi
   rm -rf "$LOCK_DIR"
   exit 130
 }
 trap cleanup_on_exit EXIT
 trap cleanup_on_interrupt INT TERM
+
+echo $$ > "$LOCK_DIR/pid"
 
 # --- Progress display helpers ---
 
@@ -160,7 +172,7 @@ root_build_needed() {
 # --- Container reuse ---
 
 container_running() {
-  [ "$($CONTAINER_CMD inspect -f '{{.State.Running}}' quarkus-docs-preview 2>/dev/null)" = "true" ]
+  [ "$($CONTAINER_CMD inspect -f '{{.State.Running}}' "$CONTAINER_NAME" 2>/dev/null)" = "true" ]
 }
 
 preview_ready() {
@@ -221,9 +233,20 @@ port_in_use() {
 
 if [ "$PREVIEW_ALREADY_RUNNING" != "true" ]; then
   if port_in_use 4000 || port_in_use 35729; then
-    echo "Port 4000 or 35729 is already in use."
-    echo "If a previous preview is running: $CONTAINER_CMD rm -f quarkus-docs-preview"
-    exit 1
+    if container_running; then
+      echo "  Stale preview container detected. Removing..."
+      $CONTAINER_CMD rm -f "$CONTAINER_NAME" 2>/dev/null || true
+      sleep 1
+      if port_in_use 4000 || port_in_use 35729; then
+        echo "Port 4000 or 35729 is still in use after removing stale container."
+        echo "Free the port and try again."
+        exit 1
+      fi
+    else
+      echo "Port 4000 or 35729 is already in use by another process."
+      echo "Free the port and try again."
+      exit 1
+    fi
   fi
 fi
 
@@ -273,13 +296,34 @@ fi
 # --- Step 2: Docs Rebuild ---
 
 echo ""
-echo "=== Step 2: Docs rebuild (~${EST_DOCS}s estimated) ==="
-cd docs || exit 1
-STEP2_START=$(date +%s)
-run_with_progress "Docs rebuild" "$EST_DOCS" "$LOGDIR/step2.log" \
-  ../mvnw -ntp package -Dasciidoctor.fail-if=ERROR
-RC=$?
-STEP2_TIME=$(( $(date +%s) - STEP2_START ))
+docs_rebuild_needed() {
+  [ "$RUN_ROOT_BUILD" = "true" ] && return 0
+  [ ! -f "$DOCS_BUILD_REF" ] && return 0
+  [ ! -d "$SCRIPTDIR/docs/target/asciidoc/sources" ] && return 0
+  if [ "$SCRIPTDIR/docs/pom.xml" -nt "$DOCS_BUILD_REF" ]; then
+    return 0
+  fi
+  if find "$SCRIPTDIR/docs/src/main/asciidoc" \
+      -type f -newer "$DOCS_BUILD_REF" -print 2>/dev/null | grep -q .; then
+    return 0
+  fi
+  return 1
+}
+
+if docs_rebuild_needed; then
+  echo "=== Step 2: Docs rebuild (~${EST_DOCS}s estimated) ==="
+  cd docs || exit 1
+  STEP2_START=$(date +%s)
+  run_with_progress "Docs rebuild" "$EST_DOCS" "$LOGDIR/step2.log" \
+    ../mvnw -ntp package -Dasciidoctor.fail-if=ERROR
+  RC=$?
+  STEP2_TIME=$(( $(date +%s) - STEP2_START ))
+else
+  echo "=== Step 2: Docs rebuild (skipped — no source changes) ==="
+  cd docs || exit 1
+  RC=0
+  STEP2_TIME=0
+fi
 
 # If docs rebuild fails and we skipped root build, retry with root build
 if [ $RC -ne 0 ] && [ "$RUN_ROOT_BUILD" != "true" ]; then
@@ -289,7 +333,7 @@ if [ $RC -ne 0 ] && [ "$RUN_ROOT_BUILD" != "true" ]; then
   STEP1_START=$(date +%s)
   # shellcheck disable=SC2086
   run_with_progress "Root build (recovery)" "$EST_ROOT" "$LOGDIR/step1-recovery.log" \
-    $MVNCMD install -DquicklyDocs \
+    $MVNCMD clean install -DquicklyDocs \
     -Dno-test-modules -Dskip.gradle.build=true -Dmaven.javadoc.skip=true
   RC=$?
   if [ $RC -ne 0 ]; then
@@ -311,7 +355,10 @@ if [ $RC -ne 0 ]; then
   echo "  Docs rebuild failed. Check $LOGDIR/step2.log"
   exit 1
 fi
-save_step_time "docs" "$STEP2_TIME" || true
+if [ "$STEP2_TIME" -gt 0 ]; then
+  save_step_time "docs" "$STEP2_TIME" || true
+  touch "$DOCS_BUILD_REF" 2>/dev/null || true
+fi
 
 # --- Step 3: Sync ---
 
@@ -345,8 +392,7 @@ run_fast_sync() {
 
 run_full_sync() {
   local log="$1"
-  ./sync-web-site.sh 2>&1 | tee "$log"
-  [ "${PIPESTATUS[0]}" -eq 0 ]
+  ./sync-web-site.sh > "$log" 2>&1
 }
 
 SYNC_TYPE="full"
@@ -409,13 +455,13 @@ if [ "$PREVIEW_ALREADY_RUNNING" = "true" ]; then
 fi
 
 if [ "$PREVIEW_ALREADY_RUNNING" != "true" ]; then
-  $CONTAINER_CMD rm -f quarkus-docs-preview 2>/dev/null || true
+  $CONTAINER_CMD rm -f "$CONTAINER_NAME" 2>/dev/null || true
   cd target/web-site || exit 1
   STEP4_START=$(date +%s)
 
   start_jekyll() {
     local image="$1" mount="$2" run_log="$3"
-    if ! $CONTAINER_CMD run -d --name quarkus-docs-preview \
+    if ! $CONTAINER_CMD run -d --name "$CONTAINER_NAME" \
       -p 127.0.0.1:4000:4000 -p 127.0.0.1:35729:35729 \
       -v "$(pwd):${mount}${VOL_FLAG}" \
       -v quarkus-jekyll-bundles:/usr/local/bundle \
@@ -426,11 +472,15 @@ if [ "$PREVIEW_ALREADY_RUNNING" != "true" ]; then
       > "$run_log" 2>&1; then
       return 1
     fi
-    sleep 3
-    if [ "$($CONTAINER_CMD inspect -f '{{.State.Running}}' quarkus-docs-preview 2>/dev/null)" != "true" ]; then
-      $CONTAINER_CMD logs quarkus-docs-preview >> "$run_log" 2>&1
-      return 1
-    fi
+    local _i
+    for _i in $(seq 1 10); do
+      if [ "$($CONTAINER_CMD inspect -f '{{.State.Running}}' "$CONTAINER_NAME" 2>/dev/null)" = "true" ]; then
+        return 0
+      fi
+      sleep 1
+    done
+    $CONTAINER_CMD logs "$CONTAINER_NAME" >> "$run_log" 2>&1
+    return 1
   }
 
   # Primary: build from the upstream jekyll-container/ Dockerfile
@@ -445,7 +495,7 @@ if [ "$PREVIEW_ALREADY_RUNNING" != "true" ]; then
         STARTED=true
       else
         echo "  Local image failed to start. Trying fallback..."
-        $CONTAINER_CMD rm -f quarkus-docs-preview >/dev/null 2>&1 || true
+        $CONTAINER_CMD rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
       fi
     fi
   fi
@@ -455,13 +505,13 @@ if [ "$PREVIEW_ALREADY_RUNNING" != "true" ]; then
     PULL_OK=true
     if ! $CONTAINER_CMD image inspect "$JEKYLL_IMAGE_FALLBACK" > /dev/null 2>&1; then
       echo "  Pulling fallback Jekyll image (first time only)..."
-      $CONTAINER_CMD pull "$JEKYLL_IMAGE_FALLBACK" > /dev/null 2>&1 || PULL_OK=false
+      $CONTAINER_CMD pull "$JEKYLL_IMAGE_FALLBACK" > "$LOGDIR/step4-fallback-pull.log" 2>&1 || PULL_OK=false
     fi
     if [ "$PULL_OK" = "true" ]; then
       if start_jekyll "$JEKYLL_IMAGE_FALLBACK" "/site" "$LOGDIR/step4-fallback.log"; then
         STARTED=true
       else
-        $CONTAINER_CMD rm -f quarkus-docs-preview >/dev/null 2>&1 || true
+        $CONTAINER_CMD rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
       fi
     fi
   fi
@@ -471,29 +521,29 @@ if [ "$PREVIEW_ALREADY_RUNNING" != "true" ]; then
     PULL_OK2=true
     if ! $CONTAINER_CMD image inspect "$JEKYLL_IMAGE_FALLBACK2" > /dev/null 2>&1; then
       echo "  Pulling second fallback image..."
-      $CONTAINER_CMD pull "$JEKYLL_IMAGE_FALLBACK2" > /dev/null 2>&1 || PULL_OK2=false
+      $CONTAINER_CMD pull "$JEKYLL_IMAGE_FALLBACK2" > "$LOGDIR/step4-fallback2-pull.log" 2>&1 || PULL_OK2=false
     fi
     if [ "$PULL_OK2" = "true" ]; then
       if start_jekyll "$JEKYLL_IMAGE_FALLBACK2" "/srv/jekyll" "$LOGDIR/step4-fallback2.log"; then
         STARTED=true
       else
-        $CONTAINER_CMD rm -f quarkus-docs-preview >/dev/null 2>&1 || true
+        $CONTAINER_CMD rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
       fi
     fi
   fi
 
   if [ "$STARTED" != "true" ]; then
     echo "  All images failed. Check $LOGDIR/step4*.log"
-    $CONTAINER_CMD rm -f quarkus-docs-preview >/dev/null 2>&1 || true
+    $CONTAINER_CMD rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
     exit 1
   fi
 
   echo "  Waiting for Jekyll to generate the site..."
   for i in $(seq 1 150); do
-    if [ "$($CONTAINER_CMD inspect -f '{{.State.Running}}' quarkus-docs-preview 2>/dev/null)" != "true" ]; then
+    if [ "$($CONTAINER_CMD inspect -f '{{.State.Running}}' "$CONTAINER_NAME" 2>/dev/null)" != "true" ]; then
       echo "  Container exited during startup."
-      $CONTAINER_CMD logs quarkus-docs-preview 2>&1 | tail -50 | tee "$LOGDIR/step4-crash.log"
-      $CONTAINER_CMD rm -f quarkus-docs-preview >/dev/null 2>&1 || true
+      $CONTAINER_CMD logs "$CONTAINER_NAME" 2>&1 | tail -50 | tee "$LOGDIR/step4-crash.log"
+      $CONTAINER_CMD rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
       exit 1
     fi
     if [ "$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:4000 2>/dev/null)" = "200" ]; then
@@ -504,8 +554,8 @@ if [ "$PREVIEW_ALREADY_RUNNING" != "true" ]; then
     fi
     if [ "$i" -eq 150 ]; then
       echo "  Timeout after 300s."
-      $CONTAINER_CMD logs quarkus-docs-preview 2>&1 | tail -50 | tee "$LOGDIR/step4-timeout.log"
-      $CONTAINER_CMD rm -f quarkus-docs-preview >/dev/null 2>&1 || true
+      $CONTAINER_CMD logs "$CONTAINER_NAME" 2>&1 | tail -50 | tee "$LOGDIR/step4-timeout.log"
+      $CONTAINER_CMD rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
       exit 1
     fi
     local_elapsed=$(( $(date +%s) - STEP4_START ))
@@ -532,11 +582,9 @@ echo "==============================="
 echo ""
 
 file_mtime_path() {
-  if stat -c '%Y %n' "$1" >/dev/null 2>&1; then
-    stat -c '%Y %n' "$1"
-  else
-    stat -f '%m %N' "$1"
-  fi
+  local result
+  result=$(stat -c '%Y %n' "$1" 2>/dev/null) || result=$(stat -f '%m %N' "$1")
+  echo "$result"
 }
 
 newest_adoc_after() {
@@ -552,7 +600,7 @@ all_adoc_after() {
   local dir="$1" ref="$2"
   [ -d "$dir" ] || return 0
   [ -f "$ref" ] || return 0
-  find "$dir" -name '*.adoc' -newer "$ref" -print 2>/dev/null
+  find "$dir" -maxdepth 1 -name '*.adoc' -newer "$ref" -print 2>/dev/null
 }
 
 PREVIEW_URLS=()
@@ -608,6 +656,6 @@ else
 fi
 echo ""
 echo "Preview is ready."
-echo "Container: quarkus-docs-preview"
-echo "Stop:      $CONTAINER_CMD rm -f quarkus-docs-preview"
+echo "Container: $CONTAINER_NAME"
+echo "Stop:      $CONTAINER_CMD rm -f $CONTAINER_NAME"
 echo "Logs:      $LOGDIR"

--- a/docs/docs-preview.sh
+++ b/docs/docs-preview.sh
@@ -1,0 +1,613 @@
+#!/bin/bash
+SCRIPTDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd) || exit 1
+cd "$SCRIPTDIR" || exit 1
+
+# Verify required commands before anything else
+for cmd in awk curl rsync find stat mktemp grep sed sort head tail cut basename date seq tee mv; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "ERROR: required command not found: $cmd"
+    exit 1
+  fi
+done
+
+LOGDIR=$(mktemp -d "${TMPDIR:-/tmp}/quarkus-docs-build-XXXXXX") || exit 1
+
+# Primary: build from the upstream jekyll-container/ Dockerfile (in the website checkout).
+# Fallback: use pre-built images if the Dockerfile is not available (first run before sync).
+JEKYLL_LOCAL_IMAGE="quarkus-docs-jekyll:local"
+JEKYLL_IMAGE_FALLBACK="docker.io/bretfisher/jekyll-serve@sha256:db11b70736935b1a777b2ff2ae10f9ad191ee9fca6560eade1d5ad98b74e5f66"
+JEKYLL_IMAGE_FALLBACK2="docker.io/jekyll/jekyll@sha256:bb45414c3fefa80a75c5001f30baf1dff48ae31dc961b8b51003b93b60675334"
+
+PREVIEW_REF="$SCRIPTDIR/docs/.docs-preview-last-run"
+ROOT_BUILD_REF="$SCRIPTDIR/docs/.docs-preview-root-build-last-run"
+ROOT_BUILD_HEAD_REF="$SCRIPTDIR/docs/.docs-preview-root-build-head"
+TIMES_CACHE="$SCRIPTDIR/docs/.docs-preview-times"
+LOCK_DIR="$SCRIPTDIR/docs/.docs-preview.lock"
+
+# --- Interrupt handling ---
+
+ACTIVE_PID=""
+
+# Prevent concurrent runs
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  echo "Another docs preview run is already active."
+  echo "If this is stale, remove: $LOCK_DIR"
+  exit 1
+fi
+
+cleanup_on_exit() {
+  rm -rf "$LOCK_DIR"
+}
+cleanup_on_interrupt() {
+  echo ""
+  echo "Interrupted."
+  if [ -n "$ACTIVE_PID" ] && kill -0 "$ACTIVE_PID" 2>/dev/null; then
+    kill "$ACTIVE_PID" 2>/dev/null || true
+  fi
+  rm -rf "$LOCK_DIR"
+  exit 130
+}
+trap cleanup_on_exit EXIT
+trap cleanup_on_interrupt INT TERM
+
+# --- Progress display helpers ---
+
+estimate_step() {
+  local step="$1"
+  if [ -f "$TIMES_CACHE" ]; then
+    local cached
+    cached=$(grep "^${step}=" "$TIMES_CACHE" 2>/dev/null | cut -d= -f2)
+    if [ -n "$cached" ] && [ "$cached" -gt 0 ] 2>/dev/null; then
+      echo "$cached"
+      return
+    fi
+  fi
+  case "$step" in
+    root)      awk -v c="$CORES" 'BEGIN {t=int(100+(22-c)*22.2); if(t<60)t=60; printf "%d",t}' ;;
+    docs)      awk -v c="$CORES" 'BEGIN {t=int(75+(22-c)*1.7);  if(t<30)t=30; printf "%d",t}' ;;
+    sync_full) echo 200 ;;
+    sync_fast) echo 1 ;;
+    jekyll)    awk -v c="$CORES" 'BEGIN {t=int(100+(22-c)*4.1);  if(t<60)t=60; printf "%d",t}' ;;
+    *)         echo 120 ;;
+  esac
+}
+
+save_step_time() {
+  local step="$1" seconds="$2" tmp
+  case "$seconds" in ''|*[!0-9]*) return 0 ;; esac
+  tmp=$(mktemp "${TMPDIR:-/tmp}/docs-preview-times-XXXXXX") || return 1
+  if [ -f "$TIMES_CACHE" ]; then
+    awk -F= -v key="$step" -v val="$seconds" \
+      'BEGIN{u=0} $1==key{print key"="val;u=1;next} {print} END{if(!u)print key"="val}' \
+      "$TIMES_CACHE" > "$tmp" || { rm -f "$tmp"; return 1; }
+  else
+    echo "${step}=${seconds}" > "$tmp" || { rm -f "$tmp"; return 1; }
+  fi
+  mv "$tmp" "$TIMES_CACHE" || { rm -f "$tmp"; return 1; }
+}
+
+run_with_progress() {
+  local label="$1" est="$2" log="$3"
+  shift 3
+  case "$est" in ''|*[!0-9]*) est=120 ;; esac
+  [ "$est" -lt 1 ] && est=120
+
+  "$@" > "$log" 2>&1 &
+  ACTIVE_PID=$!
+  local pid=$ACTIVE_PID
+  local start
+  start=$(date +%s)
+
+  while kill -0 "$pid" 2>/dev/null; do
+    local elapsed=$(( $(date +%s) - start ))
+    local pct=$(( elapsed * 100 / est ))
+    [ "$pct" -gt 99 ] && pct=99
+    if [ -t 1 ]; then
+      printf '\r  %s [%3d%%] %ds / ~%ds ' "$label" "$pct" "$elapsed" "$est"
+    else
+      printf '  %s: %ds / ~%ds\n' "$label" "$elapsed" "$est"
+    fi
+    sleep 2
+  done
+
+  wait "$pid"
+  local rc=$?
+  ACTIVE_PID=""
+  local elapsed=$(( $(date +%s) - start ))
+
+  if [ $rc -eq 0 ]; then
+    if [ -t 1 ]; then
+      printf '\r  %s ✓ %ds                          \n' "$label" "$elapsed"
+    else
+      printf '  %s: completed in %ds\n' "$label" "$elapsed"
+    fi
+  else
+    if [ -t 1 ]; then
+      printf '\r  %s ✗ %ds (failed)                  \n' "$label" "$elapsed"
+    else
+      printf '  %s: failed after %ds\n' "$label" "$elapsed"
+    fi
+    echo "  Last log lines:"
+    tail -15 "$log" | sed 's/^/    /'
+  fi
+  return $rc
+}
+
+# --- Root build decision ---
+
+root_build_needed() {
+  [ "${QUARKUS_DOCS_PREVIEW_FULL:-}" = "1" ] && return 0
+  [ ! -f "$ROOT_BUILD_REF" ] && return 0
+  if [ -n "$(find "$ROOT_BUILD_REF" -mtime +7 -print 2>/dev/null)" ]; then
+    return 0
+  fi
+  if find "$SCRIPTDIR" \
+      -path "$SCRIPTDIR/.git" -prune -o \
+      -path "$SCRIPTDIR/docs/target" -prune -o \
+      -name 'pom.xml' -newer "$ROOT_BUILD_REF" -print 2>/dev/null | grep -q .; then
+    return 0
+  fi
+  # Detect git pull, checkout, or branch switch since last root build
+  if command -v git >/dev/null 2>&1 && git -C "$SCRIPTDIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    local current_head saved_head
+    current_head=$(git -C "$SCRIPTDIR" rev-parse HEAD 2>/dev/null || true)
+    saved_head=$(cat "$ROOT_BUILD_HEAD_REF" 2>/dev/null || true)
+    [ -n "$current_head" ] && [ "$current_head" != "$saved_head" ] && return 0
+  fi
+  return 1
+}
+
+# --- Container reuse ---
+
+container_running() {
+  [ "$($CONTAINER_CMD inspect -f '{{.State.Running}}' quarkus-docs-preview 2>/dev/null)" = "true" ]
+}
+
+preview_ready() {
+  [ "$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:4000 2>/dev/null)" = "200" ]
+}
+
+# --- Step 0: Environment ---
+
+ENVSCRIPT="docs/detect-env.sh"
+echo "=== Environment ==="
+# shellcheck source=detect-env.sh
+. "$ENVSCRIPT" || exit 1
+
+MVNCMD="${QMVNCMD:-./mvnw -ntp $MVN_THREADS}"
+MVNCMD_ST="${QMVNCMD:-./mvnw -ntp}"
+
+RUN_ROOT_BUILD=false
+if root_build_needed; then
+  RUN_ROOT_BUILD=true
+fi
+
+EST_ROOT=$(estimate_step root)
+EST_DOCS=$(estimate_step docs)
+EST_JEKYLL=$(estimate_step jekyll)
+
+PREVIEW_ALREADY_RUNNING=false
+if container_running && preview_ready; then
+  PREVIEW_ALREADY_RUNNING=true
+fi
+
+echo ""
+if [ "$RUN_ROOT_BUILD" = "true" ]; then
+  EST_SYNC=$(estimate_step sync_full)
+  EST_TOTAL=$((EST_ROOT + EST_DOCS + EST_SYNC + EST_JEKYLL))
+  echo "Full root build needed."
+  echo "Estimated time: ~$((EST_TOTAL / 60)) minutes on this machine."
+  echo "After this completes, later docs updates take about 1 minute."
+else
+  echo "Root build output is ready."
+  echo "Running the quick docs rebuild path."
+  echo "Expected time: about 1 minute."
+fi
+echo "Logs: $LOGDIR"
+echo ""
+
+# Pre-flight: port check (skip if reusing container)
+port_in_use() {
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -nP -iTCP:"$1" -sTCP:LISTEN >/dev/null 2>&1
+    return $?
+  fi
+  if command -v nc >/dev/null 2>&1; then
+    nc -z 127.0.0.1 "$1" 2>/dev/null
+    return $?
+  fi
+  curl --max-time 1 -s -o /dev/null "http://127.0.0.1:$1" 2>/dev/null
+}
+
+if [ "$PREVIEW_ALREADY_RUNNING" != "true" ]; then
+  if port_in_use 4000 || port_in_use 35729; then
+    echo "Port 4000 or 35729 is already in use."
+    echo "If a previous preview is running: $CONTAINER_CMD rm -f quarkus-docs-preview"
+    exit 1
+  fi
+fi
+
+START_TOTAL=$(date +%s)
+
+# Non-fatal cache cleanup
+if [ "$CONTAINER_CMD" = "podman" ]; then
+  podman unshare rm -rf docs/.cache/ 2>/dev/null || rm -rf docs/.cache/ 2>/dev/null || true
+else
+  rm -rf docs/.cache/ 2>/dev/null || true
+fi
+
+# --- Step 1: Root Build ---
+
+if [ "$RUN_ROOT_BUILD" = "true" ]; then
+  echo "=== Step 1: Root build (~${EST_ROOT}s estimated) ==="
+  STEP1_START=$(date +%s)
+  # shellcheck disable=SC2086
+  run_with_progress "Root build" "$EST_ROOT" "$LOGDIR/step1-parallel.log" \
+    $MVNCMD clean install -DquicklyDocs \
+    -Dno-test-modules -Dskip.gradle.build=true -Dmaven.javadoc.skip=true
+  RC=$?
+  STEP1_TIME=$(( $(date +%s) - STEP1_START ))
+
+  if [ $RC -ne 0 ] && [ -n "$MVN_THREADS" ]; then
+    echo "  Parallel build failed. Retrying single-threaded..."
+    STEP1_START=$(date +%s)
+    # shellcheck disable=SC2086
+    run_with_progress "Root build (single-threaded)" "$((EST_ROOT * 2))" "$LOGDIR/step1-fallback.log" \
+      $MVNCMD_ST clean install -DquicklyDocs \
+      -Dno-test-modules -Dskip.gradle.build=true -Dmaven.javadoc.skip=true
+    RC=$?
+    STEP1_TIME=$(( $(date +%s) - STEP1_START ))
+  fi
+
+  if [ $RC -ne 0 ]; then
+    echo "  Root build failed. Check $LOGDIR/step1*.log"
+    exit 1
+  fi
+  save_step_time "root" "$STEP1_TIME" || true
+  touch "$ROOT_BUILD_REF" || exit 1
+  git -C "$SCRIPTDIR" rev-parse HEAD > "$ROOT_BUILD_HEAD_REF" 2>/dev/null || true
+else
+  echo "=== Step 1: Root build (skipped — output is fresh) ==="
+fi
+
+# --- Step 2: Docs Rebuild ---
+
+echo ""
+echo "=== Step 2: Docs rebuild (~${EST_DOCS}s estimated) ==="
+cd docs || exit 1
+STEP2_START=$(date +%s)
+run_with_progress "Docs rebuild" "$EST_DOCS" "$LOGDIR/step2.log" \
+  ../mvnw -ntp package -Dasciidoctor.fail-if=ERROR
+RC=$?
+STEP2_TIME=$(( $(date +%s) - STEP2_START ))
+
+# If docs rebuild fails and we skipped root build, retry with root build
+if [ $RC -ne 0 ] && [ "$RUN_ROOT_BUILD" != "true" ]; then
+  echo "  Docs rebuild failed after skipping root build."
+  echo "  Refreshing root build output, then retrying..."
+  cd "$SCRIPTDIR" || exit 1
+  STEP1_START=$(date +%s)
+  # shellcheck disable=SC2086
+  run_with_progress "Root build (recovery)" "$EST_ROOT" "$LOGDIR/step1-recovery.log" \
+    $MVNCMD install -DquicklyDocs \
+    -Dno-test-modules -Dskip.gradle.build=true -Dmaven.javadoc.skip=true
+  RC=$?
+  if [ $RC -ne 0 ]; then
+    echo "  Root build failed. Check $LOGDIR/step1-recovery.log"
+    exit 1
+  fi
+  touch "$ROOT_BUILD_REF" || exit 1
+  git -C "$SCRIPTDIR" rev-parse HEAD > "$ROOT_BUILD_HEAD_REF" 2>/dev/null || true
+  save_step_time "root" "$(( $(date +%s) - STEP1_START ))" || true
+  cd docs || exit 1
+  STEP2_START=$(date +%s)
+  run_with_progress "Docs rebuild (retry)" "$EST_DOCS" "$LOGDIR/step2.log" \
+    ../mvnw -ntp package -Dasciidoctor.fail-if=ERROR
+  RC=$?
+  STEP2_TIME=$(( $(date +%s) - STEP2_START ))
+fi
+
+if [ $RC -ne 0 ]; then
+  echo "  Docs rebuild failed. Check $LOGDIR/step2.log"
+  exit 1
+fi
+save_step_time "docs" "$STEP2_TIME" || true
+
+# --- Step 3: Sync ---
+
+echo ""
+echo "=== Step 3: Sync ==="
+STEP3_START=$(date +%s)
+
+run_fast_sync() {
+  rsync -rt --delete \
+      --exclude='**/*.html' --exclude='**/index.adoc' \
+      --exclude='**/_attributes-local.adoc' --exclude='**/guides.md' \
+      --exclude='**/_templates' \
+      target/asciidoc/sources/ target/web-site/_versions/main/guides || return 1
+  if [ -d target/quarkus-generated-doc/ ]; then
+    rsync -rt --delete \
+        --exclude='**/*.html' --exclude='**/index.adoc' \
+        --exclude='**/_attributes.adoc' \
+        target/quarkus-generated-doc/ target/web-site/_generated-doc/main || return 1
+  fi
+  if [ -f target/indexByType.yaml ]; then
+    mkdir -p target/web-site/_data/versioned/main/index || return 1
+    { echo "# Generated file. Do not edit"; cat target/indexByType.yaml
+    } > target/web-site/_data/versioned/main/index/quarkus.yaml || return 1
+  fi
+  if [ -f target/relations.yaml ]; then
+    mkdir -p target/web-site/_data/versioned/main/index || return 1
+    { echo "# Generated file. Do not edit"; cat target/relations.yaml
+    } > target/web-site/_data/versioned/main/index/relations.yaml || return 1
+  fi
+}
+
+run_full_sync() {
+  local log="$1"
+  ./sync-web-site.sh 2>&1 | tee "$log"
+  [ "${PIPESTATUS[0]}" -eq 0 ]
+}
+
+SYNC_TYPE="full"
+if [ -d target/web-site/_versions ]; then
+  SYNC_OK=true
+  [ ! -d target/web-site/_versions/main/guides ] && SYNC_OK=false
+  [ ! -f target/web-site/_config.yml ] && SYNC_OK=false
+  [ ! -f target/web-site/_only_latest_guides_config.yml ] && SYNC_OK=false
+
+  if [ "$SYNC_OK" = "true" ]; then
+    SYNC_TYPE="fast"
+    echo "  Running fast re-sync..."
+    if ! run_fast_sync > "$LOGDIR/step3-fast-sync.log" 2>&1; then
+      echo "  Fast sync failed. Falling back to full sync..."
+      SYNC_TYPE="full"
+      rm -rf target/web-site || exit 1
+      if ! run_full_sync "$LOGDIR/step3.log"; then
+        echo "  Sync failed. Check $LOGDIR/step3.log"
+        exit 1
+      fi
+    else
+      printf '  Sync ✓ fast\n'
+    fi
+  else
+    echo "  Website layout changed. Full sync..."
+    rm -rf target/web-site || exit 1
+    if ! run_full_sync "$LOGDIR/step3.log"; then
+      echo "  Sync failed. Check $LOGDIR/step3.log"
+      exit 1
+    fi
+  fi
+else
+  echo "  First run — cloning quarkusio.github.io..."
+  if ! run_full_sync "$LOGDIR/step3.log"; then
+    echo "  Sync failed. Check $LOGDIR/step3.log"
+    exit 1
+  fi
+fi
+STEP3_TIME=$(( $(date +%s) - STEP3_START ))
+if [ "$SYNC_TYPE" = "fast" ]; then
+  save_step_time "sync_fast" "$STEP3_TIME" || true
+else
+  save_step_time "sync_full" "$STEP3_TIME" || true
+  # Full sync recreated the mount directory — container must restart
+  PREVIEW_ALREADY_RUNNING=false
+fi
+
+# --- Step 4: Serve ---
+
+echo ""
+echo "=== Step 4: Preview server ==="
+
+if [ "$PREVIEW_ALREADY_RUNNING" = "true" ]; then
+  if container_running && preview_ready; then
+    echo "  Preview server is already running. Reusing it."
+  else
+    echo "  Previously running preview server is no longer ready. Restarting."
+    PREVIEW_ALREADY_RUNNING=false
+  fi
+fi
+
+if [ "$PREVIEW_ALREADY_RUNNING" != "true" ]; then
+  $CONTAINER_CMD rm -f quarkus-docs-preview 2>/dev/null || true
+  cd target/web-site || exit 1
+  STEP4_START=$(date +%s)
+
+  start_jekyll() {
+    local image="$1" mount="$2" run_log="$3"
+    if ! $CONTAINER_CMD run -d --name quarkus-docs-preview \
+      -p 127.0.0.1:4000:4000 -p 127.0.0.1:35729:35729 \
+      -v "$(pwd):${mount}${VOL_FLAG}" \
+      -v quarkus-jekyll-bundles:/usr/local/bundle \
+      "$image" \
+      bundle exec jekyll serve --host 0.0.0.0 \
+      --livereload --incremental \
+      --config _config.yml,_config_dev.yml,_only_latest_guides_config.yml \
+      > "$run_log" 2>&1; then
+      return 1
+    fi
+    sleep 3
+    if [ "$($CONTAINER_CMD inspect -f '{{.State.Running}}' quarkus-docs-preview 2>/dev/null)" != "true" ]; then
+      $CONTAINER_CMD logs quarkus-docs-preview >> "$run_log" 2>&1
+      return 1
+    fi
+  }
+
+  # Primary: build from the upstream jekyll-container/ Dockerfile
+  STARTED=false
+  if [ -d "jekyll-container" ] && [ -f "jekyll-container/Dockerfile" ]; then
+    echo "  Checking Jekyll image (build cache)..."
+    if ! $CONTAINER_CMD build -t "$JEKYLL_LOCAL_IMAGE" jekyll-container/ > "$LOGDIR/step4-build.log" 2>&1; then
+      echo "  Image build failed. Falling back to pre-built image..."
+    fi
+    if $CONTAINER_CMD image inspect "$JEKYLL_LOCAL_IMAGE" > /dev/null 2>&1; then
+      if start_jekyll "$JEKYLL_LOCAL_IMAGE" "/site" "$LOGDIR/step4-primary.log"; then
+        STARTED=true
+      else
+        echo "  Local image failed to start. Trying fallback..."
+        $CONTAINER_CMD rm -f quarkus-docs-preview >/dev/null 2>&1 || true
+      fi
+    fi
+  fi
+
+  # Fallback 1: bretfisher/jekyll-serve (pinned by digest)
+  if [ "$STARTED" != "true" ]; then
+    PULL_OK=true
+    if ! $CONTAINER_CMD image inspect "$JEKYLL_IMAGE_FALLBACK" > /dev/null 2>&1; then
+      echo "  Pulling fallback Jekyll image (first time only)..."
+      $CONTAINER_CMD pull "$JEKYLL_IMAGE_FALLBACK" > /dev/null 2>&1 || PULL_OK=false
+    fi
+    if [ "$PULL_OK" = "true" ]; then
+      if start_jekyll "$JEKYLL_IMAGE_FALLBACK" "/site" "$LOGDIR/step4-fallback.log"; then
+        STARTED=true
+      else
+        $CONTAINER_CMD rm -f quarkus-docs-preview >/dev/null 2>&1 || true
+      fi
+    fi
+  fi
+
+  # Fallback 2: jekyll/jekyll (pinned by digest)
+  if [ "$STARTED" != "true" ]; then
+    PULL_OK2=true
+    if ! $CONTAINER_CMD image inspect "$JEKYLL_IMAGE_FALLBACK2" > /dev/null 2>&1; then
+      echo "  Pulling second fallback image..."
+      $CONTAINER_CMD pull "$JEKYLL_IMAGE_FALLBACK2" > /dev/null 2>&1 || PULL_OK2=false
+    fi
+    if [ "$PULL_OK2" = "true" ]; then
+      if start_jekyll "$JEKYLL_IMAGE_FALLBACK2" "/srv/jekyll" "$LOGDIR/step4-fallback2.log"; then
+        STARTED=true
+      else
+        $CONTAINER_CMD rm -f quarkus-docs-preview >/dev/null 2>&1 || true
+      fi
+    fi
+  fi
+
+  if [ "$STARTED" != "true" ]; then
+    echo "  All images failed. Check $LOGDIR/step4*.log"
+    $CONTAINER_CMD rm -f quarkus-docs-preview >/dev/null 2>&1 || true
+    exit 1
+  fi
+
+  echo "  Waiting for Jekyll to generate the site..."
+  for i in $(seq 1 150); do
+    if [ "$($CONTAINER_CMD inspect -f '{{.State.Running}}' quarkus-docs-preview 2>/dev/null)" != "true" ]; then
+      echo "  Container exited during startup."
+      $CONTAINER_CMD logs quarkus-docs-preview 2>&1 | tail -50 | tee "$LOGDIR/step4-crash.log"
+      $CONTAINER_CMD rm -f quarkus-docs-preview >/dev/null 2>&1 || true
+      exit 1
+    fi
+    if [ "$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:4000 2>/dev/null)" = "200" ]; then
+      STEP4_TIME=$(( $(date +%s) - STEP4_START ))
+      printf '  Preview server ✓ %ds\n' "$STEP4_TIME"
+      save_step_time "jekyll" "$STEP4_TIME" || true
+      break
+    fi
+    if [ "$i" -eq 150 ]; then
+      echo "  Timeout after 300s."
+      $CONTAINER_CMD logs quarkus-docs-preview 2>&1 | tail -50 | tee "$LOGDIR/step4-timeout.log"
+      $CONTAINER_CMD rm -f quarkus-docs-preview >/dev/null 2>&1 || true
+      exit 1
+    fi
+    local_elapsed=$(( $(date +%s) - STEP4_START ))
+    local_pct=$(( local_elapsed * 100 / (EST_JEKYLL > 0 ? EST_JEKYLL : 120) ))
+    [ "$local_pct" -gt 99 ] && local_pct=99
+    if [ -t 1 ]; then
+      printf '\r  Jekyll [%3d%%] %ds / ~%ds ' "$local_pct" "$local_elapsed" "$EST_JEKYLL"
+    else
+      printf '  Jekyll: %ds / ~%ds\n' "$local_elapsed" "$EST_JEKYLL"
+    fi
+    sleep 2
+  done
+fi
+
+# --- Step 5: Detect and open ---
+
+echo ""
+END_TOTAL=$(date +%s)
+TOTAL_TIME=$((END_TOTAL - START_TOTAL))
+
+echo "==============================="
+echo "Done in ${TOTAL_TIME}s"
+echo "==============================="
+echo ""
+
+file_mtime_path() {
+  if stat -c '%Y %n' "$1" >/dev/null 2>&1; then
+    stat -c '%Y %n' "$1"
+  else
+    stat -f '%m %N' "$1"
+  fi
+}
+
+newest_adoc_after() {
+  local dir="$1" ref="$2"
+  [ -d "$dir" ] || return 0
+  [ -f "$ref" ] || return 0
+  find "$dir" -name '*.adoc' -newer "$ref" -print 2>/dev/null |
+    while IFS= read -r f; do file_mtime_path "$f"; done |
+    sort -rn | head -1 | cut -d' ' -f2-
+}
+
+all_adoc_after() {
+  local dir="$1" ref="$2"
+  [ -d "$dir" ] || return 0
+  [ -f "$ref" ] || return 0
+  find "$dir" -name '*.adoc' -newer "$ref" -print 2>/dev/null
+}
+
+PREVIEW_URLS=()
+RECENT_POST=""
+
+if [ -f "$PREVIEW_REF" ]; then
+  RECENT_POST=$(newest_adoc_after "$SCRIPTDIR/docs/target/web-site/_posts" "$PREVIEW_REF")
+  GUIDE_COUNT=$(all_adoc_after "$SCRIPTDIR/docs/src/main/asciidoc" "$PREVIEW_REF" | awk 'END { print NR }')
+fi
+
+if [ -n "$RECENT_POST" ]; then
+  SLUG=$(basename "$RECENT_POST" .adoc | sed 's/^[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}-//')
+  PREVIEW_URLS=("http://127.0.0.1:4000/blog/${SLUG}/")
+  if awk '/^---$/{c++; next} c==1' "$RECENT_POST" | grep -q 'user-story'; then
+    echo "Detected: user story ($(basename "$RECENT_POST"))"
+  else
+    echo "Detected: blog post ($(basename "$RECENT_POST"))"
+  fi
+elif [ "${GUIDE_COUNT:-0}" -eq 1 ]; then
+  GUIDE_FILE=$(all_adoc_after "$SCRIPTDIR/docs/src/main/asciidoc" "$PREVIEW_REF" | head -1)
+  GUIDE_SLUG=$(basename "$GUIDE_FILE" .adoc)
+  PREVIEW_URLS=("http://127.0.0.1:4000/version/main/guides/${GUIDE_SLUG}.html")
+  echo "Detected: guide ($GUIDE_SLUG.adoc)"
+elif [ "${GUIDE_COUNT:-0}" -ge 2 ] && [ "${GUIDE_COUNT:-0}" -le 4 ]; then
+  echo "Detected: $GUIDE_COUNT guides modified"
+  while IFS= read -r gf; do
+    GS=$(basename "$gf" .adoc)
+    PREVIEW_URLS+=("http://127.0.0.1:4000/version/main/guides/${GS}.html")
+    echo "  - $GS.adoc"
+  done < <(all_adoc_after "$SCRIPTDIR/docs/src/main/asciidoc" "$PREVIEW_REF")
+elif [ "${GUIDE_COUNT:-0}" -ge 5 ]; then
+  PREVIEW_URLS=("http://127.0.0.1:4000/version/main/guides/")
+  echo "Detected: $GUIDE_COUNT guides modified. Opening listing."
+else
+  PREVIEW_URLS=("http://127.0.0.1:4000")
+  echo "No recent changes detected. Opening homepage."
+fi
+
+touch "$PREVIEW_REF" || exit 1
+
+echo ""
+if [ -n "$BROWSER_CMD" ]; then
+  for url in "${PREVIEW_URLS[@]}"; do
+    echo "Opening: $url"
+    "$BROWSER_CMD" "$url" 2>/dev/null
+    sleep 1
+  done
+else
+  echo "Open in your browser:"
+  for url in "${PREVIEW_URLS[@]}"; do
+    echo "  $url"
+  done
+fi
+echo ""
+echo "Preview is ready."
+echo "Container: quarkus-docs-preview"
+echo "Stop:      $CONTAINER_CMD rm -f quarkus-docs-preview"
+echo "Logs:      $LOGDIR"

--- a/docs/sync-web-site.sh
+++ b/docs/sync-web-site.sh
@@ -30,17 +30,18 @@ if [ $# -ge 2 ]; then
   TARGET_DIR=$2
 fi
 
-if [ -z $TARGET_DIR ]; then
+if [ -z "$TARGET_DIR" ]; then
   TARGET_DIR=target/web-site
-  rm -rf ${TARGET_DIR}
+  rm -rf "$TARGET_DIR"
   GIT_OPTIONS=""
   if [[ "$QUARKUS_WEB_SITE_PUSH" != "true" ]]; then
     GIT_OPTIONS="--depth=1"
-  fi
-  if [ -n "${RELEASE_GITHUB_TOKEN}" ]; then
-    git clone --single-branch $GIT_OPTIONS https://github.com/quarkusio/quarkusio.github.io.git ${TARGET_DIR}
+    # Read-only clone: always use HTTPS (works without SSH keys)
+    git clone --single-branch $GIT_OPTIONS https://github.com/quarkusio/quarkusio.github.io.git "$TARGET_DIR" || exit 1
+  elif [ -n "${RELEASE_GITHUB_TOKEN}" ]; then
+    git clone --single-branch $GIT_OPTIONS https://github.com/quarkusio/quarkusio.github.io.git "$TARGET_DIR" || exit 1
   else
-    git clone --single-branch $GIT_OPTIONS git@github.com:quarkusio/quarkusio.github.io.git ${TARGET_DIR}
+    git clone --single-branch $GIT_OPTIONS git@github.com:quarkusio/quarkusio.github.io.git "$TARGET_DIR" || exit 1
   fi
 fi
 


### PR DESCRIPTION
## Summary

This PR adds a new agent skill at `.agents/skills/building-docs/SKILL.md`.
The skill documents the local workflow for building, previewing, and iterating on Quarkus documentation.
Run a simple command to start the workflow.
After a full build, the preview opens automatically in your default browser in about four minutes.
After later content changes, `mvn package` usually updates the preview in a few seconds.
The scripts detect the required steps and run them automatically.
The workflow is designed to return results as quickly as possible.

The content is based on direct testing in a local environment.

The workflow and recommendations were validated on a 22-core machine with 62 GB of RAM.
The script includes an environment detection step that reads the CPU core count, available RAM, the container runtime (such as `Podman` or `Docker`), SELinux state, and the default browser.
It uses this information to automatically calculate the Maven heap size, thread count, and container volume flags.

On machines with limited RAM, such as an 8 GB system with 16 cores, the script limits parallelism to reduce the risk of out-of-memory failures.
On higher-end systems, the script increases parallelism to improve throughput.
This removes the need for manual tuning.

## Same skill, two AI assistants
<img width="2597" height="450" alt="image" src="https://github.com/user-attachments/assets/baca91cf-4cc4-462e-907c-04e05debdbf8" />


## What the skill documents

* The `-DquicklyDocs` profile as a simplified way to run documentation builds.
* A faster re-sync workflow after the initial `sync-web-site.sh` clone.
* The use of `--incremental` and `--livereload` for faster Jekyll preview cycles.
* The `bundle exec` prefix to avoid the `jekyll-sass-converter` gem conflict in `bretfisher/jekyll-serve`.
* A rootless Podman UID issue that can break cleanup in `docs/.cache/`.
* Context-aware browser targeting that deep-links to the specific guide, blog post, or user story being edited.
* Automatic container image fallback if the primary image is unavailable or crashes on startup.                                                                                                                 
* A persistent preview marker that survives mvn clean and tracks what was changed between runs.  

## One-command entry point

This PR also adds a `just docs-preview` recipe that runs the full preview pipeline with a single command.
The pipeline includes environment detection, the root build, the documentation rebuild, the sync step, starting the Jekyll server, and opening the browser.
The underlying script is located at ~~`.agents/skills/building-docs/run.sh~~ docs/docs-preview.sh`.

## Context-aware preview                                     
                                                                                                                                                                                                                    
The script automatically detects what content you were working on and opens the browser directly on the right page:

<img width="2268" height="439" alt="image" src="https://github.com/user-attachments/assets/0dfa6822-26e6-4c4f-ab24-d13a6f53f384" />

Detection uses a persistent marker (docs/.docs-preview-last-run) from the previous successful preview run. On the first run, no marker exists, so the script opens the homepage. On subsequent runs, it finds files   
newer than the marker and deep-links to the specific page you're working on - no manual navigation needed.

## Security

* Container ports are bound only to `127.0.0.1`, which prevents LAN exposure on shared networks.
* Shell variables are passed to `awk` with the `-v` flag to reduce the injection surface.
* The container image is pinned by @sha256: digest ~~to docker.io/bretfisher/jekyll-serve:stable-20250315-2119a31~~, not by a mutable tag. A fallback image (jekyll/jekyll) is also pinned by digest and used automatically if the primary image is unavailable.  

## Observed improvements

* The `-DquicklyDocs` profile replaces several manual Maven flags intended for documentation work.
* In testing, the root build time dropped from about `3:30` to about `1:48`.
* After the initial `sync-web-site.sh` clone, subsequent iterations can skip the clone step and re-sync only changed `.adoc` files.
* This reduces the sync step from about `4` minutes to less than `1` second.
* Jekyll warm starts with `--incremental --livereload` completed in about `7` seconds, compared to about `80` seconds for a cold start.

## Measured results

<img width="705" height="455" alt="image" src="https://github.com/user-attachments/assets/e6a3768f-c88a-4151-9177-e2d041a742a2" />

## Questions for review

1. Is `-DquicklyDocs` the intended option for the root documentation build workflow?
   It skips tests, integration tests, enforcer checks, and validation, while keeping `skipDocs=false`.
   It worked well in testing, but I want to confirm that this is the supported approach.

2. Can `sync-web-site.sh` skip the re-clone when `target/web-site/` already exists.
   At the moment, each run performs `rm -rf target/web-site` followed by `git clone`.
   A `--no-clone` flag, or automatic detection of an existing checkout, would remove the main bottleneck in the iterative workflow.

3. Does the Quarkus site work correctly with Jekyll `--livereload`.
   It worked correctly in testing, but I want to confirm that there are no known issues with the site JavaScript or WebSocket handling.

4. Does the bundle cache volume described in `sync-web-site.sh` still work reliably with the current Gemfile and `jekyll ~> 4.4.1`.
   The script suggests caching gems with `docker volume create quarkus-jekyll-bundles`.
   If this still works, it can further reduce container startup time.


## The current progress:
<img width="2124" height="751" alt="image" src="https://github.com/user-attachments/assets/c0d2fb9f-f60a-445b-bb84-59967d184828" />

##  Supported platforms                                       
                     
This workflow is supported on Linux, macOS, and Windows through WSL2. Native Windows shells (PowerShell, CMD, Git Bash) are not supported.


## Where does this help?
It provides a solution until https://github.com/quarkusio/quarkus/discussions/53541 is implemented.

It helps mostly writers or anyone who wants to see the final shape of documents after significant changes or updates.

The final results are demonstrated in the live preview in your default browser.

## Possible follow-up work

These follow-up improvements are out of scope for this PR.

I collected them from reviews by ChatGPT, GitHub Copilot, Bob Shell, and our own observations.
None of them are blockers.
The script is production-ready in its current form.

### UX improvements

* Add a `--help` flag and argument parsing.
Implement `show_help()`, parse `-h` and `--help`, and support `-f` and `--full`, which map to `QUARKUS_DOCS_PREVIEW_FULL=1`.
The script currently accepts no arguments.

* Add a `docs-preview-full` `just` recipe.
A simple one-line recipe such as `QUARKUS_DOCS_PREVIEW_FULL=1 bash docs/docs-preview.sh` would remove the need to set the environment variable manually.

* Show which process is using the port on conflict.
When port `4000` or `35729` is already in use, run `lsof -nP -iTCP:4000 -sTCP:LISTEN` to show the process that owns the port.

* Wait for the guide URL after fast sync and container reuse.
When Jekyll is already running and a new guide is added through fast sync, the HTML file might not exist yet.
A short `curl` polling loop, with a maximum wait of about `15` seconds and no hard failure, would avoid a brief `404` in the browser.

* Print periodic status during the Jekyll wait loop.
For example, every `30` iterations, print a hint such as `Still waiting... Check logs: $CONTAINER_CMD logs quarkus-docs-preview`.

### Robustness

* Write a PID file in the lock directory.
Store `$$` in `$LOCK_DIR/pid` so that a later run can check whether the locking process is still alive.
This would make stale lock cleanup easier.

* Add a Bash version check.
The script uses arrays, `PIPESTATUS`, and `BASH_SOURCE`, which require Bash `3.2` or later.
A guard at the top would provide a clear error instead of a cryptic failure when the script is run in a non-Bash shell.

* Add `-type f` to the `find` commands.
The `newest_adoc_after()` and `all_adoc_after()` functions do not currently exclude symlinks.
This is not a real problem today because there are no `.adoc` symlinks, but it is a reasonable defensive improvement.

* Validate the output of `detect-env.sh`.
Add a final check that `$CONTAINER_CMD` and `$MAVEN_OPTS` are set before the script continues.

### Cleanup

* Remove the unused `JEKYLL_LOCAL_BUILD_DIR` variable.
It is defined at line `17` but is not referenced at runtime.
Step `4` checks `jekyll-container/` relative to the current working directory after `cd target/web-site`.
Either use the variable, for example with `if [ -d "$SCRIPTDIR/$JEKYLL_LOCAL_BUILD_DIR" ]`, or remove it.
At the moment, it only acts as a comment.

* Reduce duplication if `sync-web-site.sh` gains fast re-sync support.
The current fast re-sync path duplicates the `rsync` logic from `sync-web-site.sh` to avoid its `rm -rf` and `git clone` behavior, which takes about `4` minutes.
If upstream adds a `--no-clone` or `--fast` option, we can remove that duplication.

### Security hardening

* Test container capability dropping.
Evaluate `--cap-drop=ALL` and `--security-opt=no-new-privileges` with all three image paths, which are the local build, `bretfisher`, and `jekyll/jekyll`, on both Docker and Podman.
Do not add `--read-only` without explicit writable `tmpfs` mounts for Jekyll output and the bundle cache.

* Pin the upstream Dockerfile base image.
The `jekyll-container/Dockerfile` currently uses `ruby:3.3-slim-bookworm`, which is a mutable tag.
Pinning it by digest would improve supply chain security, but that change belongs upstream in `quarkusio.github.io`, not in this PR.

### Documentation

* Document disk space requirements.
The website clone is about `500 MB`, and the full build output, including `target/`, can grow to several gigabytes.

* Add developer documentation for the script itself.
This can include an architecture overview, guidance for adding new features, and debugging tips.
This is low priority because the script is already well commented and largely self-documenting.

### Testing

* Add integration tests.
Useful smoke tests include `bash -n`, lock detection, `detect-env.sh` output validation, and `--help` output verification.
This is low priority because the script has already been tested manually on Fedora systems with `22` cores and `62 GB` of RAM and on Linux systems with `8` cores and `31 GB` of RAM.

### Performance

* Evaluate parallel `rsync` in fast sync.
The two `rsync` operations could run concurrently.
Fast sync already completes in less than `1` second, so the real gain would be small, about `0.3` seconds.

* Consider a shallow clone for the website repository.
Using `--depth=1` in `sync-web-site.sh` would reduce the initial clone time by about `100` seconds.
This requires an upstream change.

### Immediate candidates for future work

* Add a `--no-clone` or re-sync option to `sync-web-site.sh` for iterative use.
* Investigate whether AsciiDoctor incremental processing can reduce the time spent in `mvn package` under `docs/`.
