### PR TITLE
Tweak the picocli TestVersion test

### DIFF
--- a/integration-tests/picocli/src/test/java/io/quarkus/it/picocli/TestVersion.java
+++ b/integration-tests/picocli/src/test/java/io/quarkus/it/picocli/TestVersion.java
@@ -13,12 +13,12 @@ public class TestVersion {
     @RegisterExtension
     static final QuarkusProdModeTest config = createConfig("version-app", EntryWithVersionCommand.class,
             VersionProvider.class)
-            .overrideConfigKey("some.version", "1.1")
+            .overrideConfigKey("some.version", "1.99")
             .setCommandLineParameters("--version");
 
     @Test
     public void simpleTest() {
-        Assertions.assertThat(config.getStartupConsoleOutput()).containsOnlyOnce("1.1");
+        Assertions.assertThat(config.getStartupConsoleOutput()).containsOnlyOnce("1.99");
         Assertions.assertThat(config.getExitCode()).isZero();
     }
 


### PR DESCRIPTION
Sometimes Quarkus version contains the same version as it the picocli test search for. This causing to found duplicate entry e.g. Quarkus version is 3.33.1.1 and picocli settig the version to 1.1. This found duplicate entry in log and fail.

This was found in one of QE TS which executing Quarkus tests with the released version (mainly used for downstream). This is probably edge case which will happen 1 in tenths releases, but changing it to set and search for `1.99` version instead of `1.1` version should eliminate these cases to almost zero.

