### PR TITLE
Fix continuous testing in Quarkus DEV mode when `@QuarkusTest` is used on meta-annotation

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
@@ -14,7 +14,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Deque;
@@ -606,8 +605,15 @@ public class JunitTestRunner {
             }
         }
         Set<String> quarkusTestClasses = new HashSet<>();
-        for (var a : Arrays.asList(QUARKUS_TEST, QUARKUS_MAIN_TEST)) {
+        List<DotName> quarkusTestAnnotation = new ArrayList<>(collectQuarkusTestAnnotations(index, QUARKUS_TEST));
+        quarkusTestAnnotation.add(QUARKUS_MAIN_TEST);
+        for (var a : quarkusTestAnnotation) {
             for (AnnotationInstance i : index.getAnnotations(a)) {
+
+                if (i.target().asClass().isAnnotation()) {
+                    // ignore annotation on annotation
+                    continue;
+                }
 
                 DotName name = i.target()
                         .asClass()
@@ -641,16 +647,21 @@ public class JunitTestRunner {
         // Most logic in the JUnitRunner counts main tests as quarkus tests, so do a (mildly irritating) special pass to get the ones which are strictly @QuarkusTest
 
         Set<String> quarkusTestClassesForFacadeClassLoader = new HashSet<>();
-        for (AnnotationInstance i : index.getAnnotations(QUARKUS_TEST)) {
-            DotName name = i.target()
-                    .asClass()
-                    .name();
-            quarkusTestClassesForFacadeClassLoader.add(name.toString());
-            for (ClassInfo clazz : index.getAllKnownSubclasses(name)) {
-                if (!integrationTestClasses.contains(clazz.name()
-                        .toString())) {
-                    quarkusTestClassesForFacadeClassLoader.add(clazz.name()
-                            .toString());
+        for (var a : collectQuarkusTestAnnotations(index, QUARKUS_TEST)) {
+            for (AnnotationInstance i : index.getAnnotations(a)) {
+                if (i.target().asClass().isAnnotation()) {
+                    continue;
+                }
+                DotName name = i.target()
+                        .asClass()
+                        .name();
+                quarkusTestClassesForFacadeClassLoader.add(name.toString());
+                for (ClassInfo clazz : index.getAllKnownSubclasses(name)) {
+                    if (!integrationTestClasses.contains(clazz.name()
+                            .toString())) {
+                        quarkusTestClassesForFacadeClassLoader.add(clazz.name()
+                                .toString());
+                    }
                 }
             }
         }
@@ -1370,4 +1381,13 @@ public class JunitTestRunner {
         }
     }
 
+    private static List<DotName> collectQuarkusTestAnnotations(Index index, DotName testAnnotationName) {
+        return Stream.concat(Stream.of(testAnnotationName),
+                index.getAnnotations(testAnnotationName).stream()
+                        .filter(ai -> ai.target().kind() == AnnotationTarget.Kind.CLASS
+                                && ai.target().asClass().isAnnotation())
+                        .map(ai -> ai.target().asClass().name())
+                        .flatMap(name -> collectQuarkusTestAnnotations(index, name).stream()))
+                .toList();
+    }
 }


### PR DESCRIPTION
* I have no idea how to create automated test for this considering it only reproduces the issue with continuous testing, so I tested it manually in `integration-tests/smallrye-jwt-token-propagation/src/test/java/io/quarkus/it/keycloak/` running `quarkus dev` and then `r`:

```Java
package io.quarkus.it.keycloak;

import java.lang.annotation.ElementType;
import java.lang.annotation.Retention;
import java.lang.annotation.RetentionPolicy;
import java.lang.annotation.Target;

import io.quarkus.test.junit.QuarkusTest;
import io.quarkus.test.security.TestSecurity;

@QuarkusTest
@TestSecurity(user = "authenticated-user")
@Target(ElementType.TYPE)
@Retention(RetentionPolicy.RUNTIME)
public @interface QuarkusTestSecurity {
}

package io.quarkus.it.keycloak;

import org.junit.jupiter.api.Assertions;
import org.junit.jupiter.api.Test;

import io.quarkus.test.common.http.TestHTTPEndpoint;
import io.restassured.RestAssured;

@QuarkusTestSecurity
@TestHTTPEndpoint(ProtectedJwtResource.class)
public class QuarkusTestSecurityMetaAnnotationTest {

    @Test
    public void testTestSecurityAnnotationNoAugmentors_authenticatedUser() {
        TestSecurityIdentityAugmentor.resetInvoked();
        // user is authenticated, but doesn't have required role granted by the augmentor
        // and no augmentors are applied
        RestAssured.get("test-security-with-augmentors").then().statusCode(403);
        Assertions.assertFalse(TestSecurityIdentityAugmentor.isInvoked());
    }

}
```

- Closes: https://github.com/quarkusio/quarkus/issues/53867