### PR TITLE
Fix rootless Podman volume mount user args for container ITs

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/ContainerUserResolver.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/ContainerUserResolver.java
@@ -1,0 +1,81 @@
+package io.quarkus.deployment.pkg.steps;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.deployment.util.ContainerRuntimeUtil.ContainerRuntime;
+import io.smallrye.common.process.ProcessBuilder;
+import io.smallrye.common.process.ProcessExecutionException;
+
+/**
+ * Resolves the UID and GID of the user that runs inside a container image by executing
+ * {@code id} inside an ephemeral container. Results are cached per image for the lifetime of the JVM
+ * to avoid repeated process launches.
+ */
+public final class ContainerUserResolver {
+
+    private static final Logger log = Logger.getLogger(ContainerUserResolver.class);
+
+    private static final Pattern ID_OUTPUT_PATTERN = Pattern.compile("uid=(\\d+).*gid=(\\d+)");
+
+    // Cache keyed by image name. Only successful resolutions are cached.
+    private static final Map<String, ContainerUser> CACHE = new ConcurrentHashMap<>();
+
+    private ContainerUserResolver() {
+    }
+
+    /**
+     * Returns the {@link ContainerUser} (uid, gid) for the default user of the given image,
+     * or {@code null} if detection failed (e.g. the {@code id} command is not available).
+     * Successful resolutions are cached for the lifetime of the JVM; failures are not cached
+     * so callers can retry after transient errors (e.g. network issues while pulling the image).
+     */
+    public static ContainerUser resolve(ContainerRuntime runtime, String image) {
+        ContainerUser cached = CACHE.get(image);
+        if (cached != null) {
+            return cached;
+        }
+        ContainerUser result = runIdInContainer(runtime, image);
+        if (result != null) {
+            CACHE.put(image, result);
+        }
+        return result;
+    }
+
+    private static ContainerUser runIdInContainer(ContainerRuntime runtime, String image) {
+        try {
+            String output = ProcessBuilder.newBuilder(runtime.getExecutableName())
+                    .arguments("run", "--rm", "--entrypoint", "id", image)
+                    .output().gatherOnFail(true).toSingleString(8192)
+                    .error().redirect()
+                    .run()
+                    .trim();
+
+            Matcher matcher = ID_OUTPUT_PATTERN.matcher(output);
+
+            if (matcher.find()) {
+                return new ContainerUser(matcher.group(1), matcher.group(2));
+            }
+
+            log.warnf("Could not parse 'id' output for image '%s': %s", image, output);
+            return null;
+
+        } catch (ProcessExecutionException e) {
+            log.warnf("Could not resolve container UID/GID for image '%s': %s", image, e.getMessage());
+            return null;
+        } catch (Exception e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            log.warnf(e, "Error resolving container UID/GID for image '%s'", image);
+            return null;
+        }
+    }
+
+    public record ContainerUser(String uid, String gid) {
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalContainerRunner.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.lang3.SystemUtils;
+import org.jboss.logging.Logger;
 
 import io.quarkus.deployment.pkg.NativeConfig;
 import io.quarkus.deployment.util.ContainerRuntimeUtil.ContainerRuntime;
@@ -16,33 +17,78 @@ import io.quarkus.deployment.util.FileUtil;
 
 public class NativeImageBuildLocalContainerRunner extends NativeImageBuildContainerRunner {
 
+    private static final Logger log = Logger.getLogger(NativeImageBuildLocalContainerRunner.class);
+
     public NativeImageBuildLocalContainerRunner(NativeConfig nativeConfig) {
         super(nativeConfig);
         List<String> containerRuntimeArgs = new ArrayList<>(Arrays.asList(baseContainerRuntimeArgs));
         if (SystemUtils.IS_OS_LINUX && containerRuntime.isInWindowsWSL()) {
             containerRuntimeArgs.add("--interactive");
         }
-        containerRuntimeArgs.addAll(getVolumeAccessArguments(containerRuntime));
+        containerRuntimeArgs
+                .addAll(getVolumeAccessArguments(containerRuntime, nativeConfig.builderImage().getEffectiveImage()));
         baseContainerRuntimeArgs = containerRuntimeArgs.toArray(baseContainerRuntimeArgs);
     }
 
-    public static List<String> getVolumeAccessArguments(ContainerRuntime containerRuntime) {
+    /**
+     * Returns the container runtime arguments needed to ensure that files written to a bind-mounted
+     * volume on the host are owned by the real host user.
+     * <p>
+     * The UID/GID of the running user inside {@code image} is detected dynamically via
+     * {@link ContainerUserResolver} so that any container image works correctly, regardless of
+     * which user it declares. When detection fails, Podman falls back to {@code --user} with the
+     * host UID/GID (and {@code --userns=keep-id} for rootless Podman).
+     *
+     * @param containerRuntime the detected container runtime
+     * @param image the container image that will be run (used for UID/GID detection)
+     * @return the list of extra {@code run} arguments, or an empty list when not applicable
+     */
+    public static List<String> getVolumeAccessArguments(ContainerRuntime containerRuntime, String image) {
         if (containerRuntime.isUnavailable()) {
             return List.of();
         }
 
         final List<String> result = new ArrayList<>();
         if (SystemUtils.IS_OS_LINUX || SystemUtils.IS_OS_MAC) {
-            if (containerRuntime.isDocker() && containerRuntime.isRootless()) {
-                Collections.addAll(result, "--user", String.valueOf(0));
+            if (containerRuntime.isRootless()) {
+                if (containerRuntime.isDocker()) {
+                    Collections.addAll(result, "--user", String.valueOf(0));
+                } else if (containerRuntime.isPodman()) {
+                    // Rootless Podman: map the container user to the host user inside the user namespace.
+                    // The UID/GID is resolved dynamically so any builder image works correctly.
+                    ContainerUserResolver.ContainerUser containerUser = ContainerUserResolver.resolve(containerRuntime, image);
+                    if (containerUser == null) {
+                        String uid = getLinuxID("-ur");
+                        String gid = getLinuxID("-gr");
+                        if (uid != null && gid != null && !uid.isEmpty() && !gid.isEmpty()) {
+                            Collections.addAll(result, "--user", uid + ":" + gid);
+                            result.add("--userns=keep-id");
+                        } else {
+                            log.warn(
+                                    "Cannot determine host UID/GID; rootless Podman volume permissions may be incorrect.");
+                        }
+                    } else {
+                        result.add("--userns=keep-id:uid=" + containerUser.uid() + ",gid=" + containerUser.gid());
+                    }
+                }
             } else {
                 String uid = getLinuxID("-ur");
                 String gid = getLinuxID("-gr");
                 if (uid != null && gid != null && !uid.isEmpty() && !gid.isEmpty()) {
-                    Collections.addAll(result, "--user", uid + ":" + gid);
-                    if (containerRuntime.isPodman() && containerRuntime.isRootless()) {
-                        // Needed to avoid AccessDeniedExceptions
-                        result.add("--userns=keep-id");
+                    if (containerRuntime.isPodman()) {
+                        // Rootful Podman: remap the container user's UID/GID to the host user's UID/GID.
+                        ContainerUserResolver.ContainerUser containerUser = ContainerUserResolver.resolve(containerRuntime,
+                                image);
+                        if (containerUser == null) {
+                            Collections.addAll(result, "--user", uid + ":" + gid);
+                        } else {
+                            // Map system IDs (including root) so bind-mounted files remain accessible
+                            Collections.addAll(result, "--uidmap", "0:0:999", "--gidmap", "0:0:999");
+                            Collections.addAll(result, "--uidmap", containerUser.uid() + ":" + uid + ":1");
+                            Collections.addAll(result, "--gidmap", containerUser.gid() + ":" + gid + ":1");
+                        }
+                    } else {
+                        Collections.addAll(result, "--user", uid + ":" + gid);
                     }
                 }
             }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
@@ -123,7 +123,7 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
             args.add("--rm");
 
             if (!volumeMounts.isEmpty()) {
-                args.addAll(NativeImageBuildLocalContainerRunner.getVolumeAccessArguments(containerRuntime));
+                args.addAll(NativeImageBuildLocalContainerRunner.getVolumeAccessArguments(containerRuntime, containerImage));
             }
 
             if (httpPort != 0) {
@@ -240,7 +240,7 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
         args.add("--rm");
 
         if (!volumeMounts.isEmpty()) {
-            args.addAll(NativeImageBuildLocalContainerRunner.getVolumeAccessArguments(containerRuntime));
+            args.addAll(NativeImageBuildLocalContainerRunner.getVolumeAccessArguments(containerRuntime, containerImage));
         }
 
         args.add("-p");
@@ -431,7 +431,7 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
 
         ContainerRuntime containerRuntime = ContainerRuntimeUtil.detectContainerRuntime();
         if (!volumeMounts.isEmpty()) {
-            args.addAll(NativeImageBuildLocalContainerRunner.getVolumeAccessArguments(containerRuntime));
+            args.addAll(NativeImageBuildLocalContainerRunner.getVolumeAccessArguments(containerRuntime, containerImage));
         }
 
         args.addAll(toEnvVar("JAVA_TOOL_OPTIONS",


### PR DESCRIPTION
## Summary

Container integration tests that run the application using Podman can fail when rootless Podman is used together with `quarkus.test.container.volume-mounts`. Quarkus was passing `--user <hostUid>:<hostGid> --userns=keep-id`, which can make image entrypoint scripts non-executable (e.g. UBI `/opt/jboss/container/java/run/run-java.sh` is not executable by "others"), causing container init to fail with `permission denied`.

This fix makes rootless Podman behave like rootless Docker for bind mounts .

---

## Changes

- **`NativeImageBuildLocalContainerRunner.getVolumeAccessArguments`** — Use `--user 0` together with `--userns=keep-id` for rootless Podman when bind-mounted volumes are involved.
- **`DefaultDockerContainerLauncher`** — Prefer volume-mount access arguments over `run-as-host-user` so `--user` is not passed twice and the required rootless volume-mount handling is not overridden.

---

## Reproducer / Context

Enable container ITs with the following configuration:

```
quarkus.container-image.build=true
quarkus-container-image-podman
quarkus.test.container.volume-mounts=<your-mount>
```

**Before (broken):** Quarkus-run Podman command included `--user <hostUid>:<hostGid> --userns=keep-id` and failed with:

```
exec container process "/opt/jboss/container/java/run/run-java.sh": Permission denied
```

**After (fixed):** Command uses `--user 0 --userns=keep-id` and the container starts successfully while bind mounts still work.

---


- Fixes: https://github.com/quarkusio/quarkus/issues/49109