### PR TITLE
Qute: support literal values as the base of expressions

### DIFF
--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -304,6 +304,23 @@ You can learn more about virtual methods in the <<virtual_methods,following sect
 <1> no namespace, two parts - `item`, `getLabels(1)`, the second part is a virtual method with name `getLabels` and params `1`
 <2> infix notation that can be used for virtual methods with single parameter, translated to `name.or('John')`; no namespace, two parts - `name`, `or('John')`
 
+An expression can also use a <<literals,literal>> value as the base, followed by property accessors or virtual method invocations.
+
+.Literal Base Expression Examples
+[source]
+----
+{='foo'.toUpperCase} <1>
+{=1.intValue} <2>
+{#let name=('foo'.toUpperCase)}{name}{/let} <3>
+{name.replace('foo'.toUpperCase)} <4>
+----
+<1> string literal as the base followed by a property accessor; outputs `FOO`
+<2> integer literal as the base followed by a property accessor; outputs `1`
+<3> in a <<let_section,let>> section parameter, a literal base can be used directly inside parentheses
+<4> a literal base can also be used in nested expressions passed as parameters of virtual methods
+
+NOTE: In a top-level output expression, a literal base requires a special syntax prefix (such as `=`) configured via `ParserConfig`.
+
 [[literals]]
 ==== Supported Literals
 
@@ -1019,7 +1036,7 @@ This section allows you to define named local variables.
 {/let} <3>
 ----
 <1> The local variable is initialized with an expression that can also represent a <<literals,literal>>, i.e. `isActive=false` and `age=10`.
-<2> The infix notation is only supported if parentheses are used for grouping, e.g. `price=(order.price + 10)` is equivalent to `price=order.price.plus(10)`.
+<2> The infix notation is only supported if parentheses are used for grouping, e.g. `price=(order.price + 10)` is equivalent to `price=order.price.plus(10)`. A literal value can also be used as the first operand, e.g. `price=('$' + item.price)`.
 <3> Variables are not available outside the `let` section.
 
 The variables are not available outside the defining `let` section.

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/LiteralBaseTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/LiteralBaseTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.qute.deployment.typesafe;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.Template;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class LiteralBaseTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Movie.class)
+                    .addAsResource(new StringAsset(
+                            "{#let name=('foo' + 'bar') len='baz'.length price=(1 + 2)}"
+                                    + "{name}::{len}::{price}"
+                                    + "{/let}"),
+                            "templates/literalBase.html")
+                    .addAsResource(new StringAsset(
+                            "{@io.quarkus.qute.deployment.typesafe.Movie movie}"
+                                    + "{movie.findService('foo'.toUpperCase)}"),
+                            "templates/literalBaseParam.html"));
+
+    @Inject
+    Template literalBase;
+
+    @Inject
+    Template literalBaseParam;
+
+    @Test
+    public void testLetWithLiteralBase() {
+        assertEquals("foobar::3::3", literalBase.render());
+    }
+
+    @Test
+    public void testLiteralBaseAsParam() {
+        assertEquals("10", literalBaseParam.data("movie", new Movie()).render());
+    }
+
+}

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/EvaluatorImpl.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/EvaluatorImpl.java
@@ -81,6 +81,9 @@ class EvaluatorImpl implements Evaluator {
                 // Multiple namespace resolvers match
                 return resolveNamespace(context, resolutionContext, parts, matching, 0, expression);
             }
+        } else if (expression.getLiteralValue() != null) {
+            // Literal with chaining parts - use the literal value as the base for subsequent parts
+            return resolveReference(false, expression.getLiteral(), expression.getParts(), resolutionContext, expression, 1);
         } else {
             return resolveReference(true, resolutionContext.getData(), expression.getParts(), resolutionContext, expression,
                     0);

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Expression.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Expression.java
@@ -10,6 +10,9 @@ import io.quarkus.qute.TemplateNode.Origin;
 /**
  * Represents a value expression. It could be a literal such as {@code 'foo'}. It could have a namespace such as {@code data}
  * for {@code data:name}. It could have several parts such as {@code item} and {@code name} for {@code item.name}.
+ * <p>
+ * A literal expression may also have additional parts that chain on the literal value, such as property accessors and virtual
+ * methods. For example, {@code 'foo'.length} or {@code 1l.intValue}.
  *
  * @see Evaluator
  */
@@ -27,24 +30,35 @@ public interface Expression {
     }
 
     /**
+     * For a non-literal expression, each part represents either a property accessor or a virtual method invocation.
+     * A literal expression always has at least one part with type info. It may also have additional parts that represent
+     * property accessors or virtual methods chained on the literal value.
      *
      * @return the list of parts, is never {@code null}
      */
     List<Part> getParts();
 
     /**
+     * A simple literal expression has exactly one part with type info and no chaining parts.
+     * An expression with a literal base and additional chaining parts (e.g. {@code 'foo'.length}) is not considered a literal.
      *
-     * @return true if it represents a literal
+     * @return true if it represents a simple literal without chaining parts
+     * @see #getParts()
+     * @see #getLiteralValue()
      */
     boolean isLiteral();
 
     /**
+     * The literal value may be non-null even if {@link #isLiteral()} returns false, for expressions with a literal base
+     * and additional chaining parts.
      *
      * @return the literal value, or null
      */
     CompletableFuture<Object> getLiteralValue();
 
     /**
+     * The literal value may be non-null even if {@link #isLiteral()} returns false, for expressions with a literal base
+     * and additional chaining parts.
      *
      * @return the literal value, or null
      */

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ExpressionImpl.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ExpressionImpl.java
@@ -77,7 +77,7 @@ final class ExpressionImpl implements Expression {
 
     @Override
     public boolean isLiteral() {
-        return literal != null;
+        return literal != null && parts.size() <= 1;
     }
 
     public CompletableFuture<Object> getLiteralValue() {

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/LiteralSupport.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/LiteralSupport.java
@@ -94,7 +94,16 @@ class LiteralSupport {
             return false;
         }
         char firstChar = value.charAt(0);
-        return isStringLiteralSeparator(firstChar) && value.charAt(value.length() - 1) == firstChar;
+        if (!isStringLiteralSeparator(firstChar) || value.charAt(value.length() - 1) != firstChar) {
+            return false;
+        }
+        // Make sure there are no unescaped separator chars between the outer delimiters
+        for (int i = 1; i < value.length() - 1; i++) {
+            if (value.charAt(i) == firstChar) {
+                return false;
+            }
+        }
+        return true;
     }
 
 }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Parser.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Parser.java
@@ -1049,8 +1049,24 @@ class Parser implements ParserHelper, ParserDelegate, WithOrigin, ErrorInitializ
                     .add(last.substring(0, last.length() - 2)).add("or(null)").build();
         }
 
+        // Check if the first part is a literal value with chaining virtual method parts
+        Object literalValue = Results.NotFound.EMPTY;
         List<Part> parts = new ArrayList<>(strParts.size());
         Part first = null;
+
+        if (strParts.size() > 1) {
+            Object firstPartLiteral = LiteralSupport.getLiteralValue(strParts.get(0));
+            if (!Results.isNotFound(firstPartLiteral)) {
+                literalValue = firstPartLiteral;
+                String literalTypeInfo = firstPartLiteral != null
+                        ? Expressions.typeInfoFrom(firstPartLiteral.getClass().getName())
+                        : null;
+                first = new ExpressionImpl.PartImpl(strParts.get(0), literalTypeInfo);
+                parts.add(first);
+                strParts = strParts.subList(1, strParts.size());
+            }
+        }
+
         Iterator<String> strPartsIterator = strParts.iterator();
         while (strPartsIterator.hasNext()) {
             Part part = createPart(idGenerator, namespace, first, strPartsIterator, scope, origin, value);
@@ -1059,7 +1075,7 @@ class Parser implements ParserHelper, ParserDelegate, WithOrigin, ErrorInitializ
             }
             parts.add(part);
         }
-        return new ExpressionImpl(idGenerator.get(), namespace, ImmutableList.copyOf(parts), Results.NotFound.EMPTY, origin);
+        return new ExpressionImpl(idGenerator.get(), namespace, ImmutableList.copyOf(parts), literalValue, origin);
     }
 
     private static Part createPart(Supplier<Integer> idGenerator, String namespace, Part first,

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ValueResolvers.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ValueResolvers.java
@@ -515,6 +515,25 @@ public final class ValueResolvers {
         }
 
         @Override
+        public boolean appliesTo(EvalContext context) {
+            if (super.appliesTo(context)) {
+                return true;
+            }
+            Object base = context.getBase();
+            return base instanceof CharSequence && context.getParams().size() == 1
+                    && appliesToName(context.getName());
+        }
+
+        @Override
+        public CompletionStage<Object> resolve(EvalContext context) {
+            if (context.getBase() instanceof CharSequence) {
+                return context.evaluate(context.getParams().get(0))
+                        .thenApply(param -> context.getBase().toString() + (param != null ? param.toString() : ""));
+            }
+            return super.resolve(context);
+        }
+
+        @Override
         protected Object compute(Long op1, Long op2) {
             return op1 + op2;
         }

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/ExpressionTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/ExpressionTest.java
@@ -32,6 +32,28 @@ public class ExpressionTest {
                 .parse("{>bar}{bar}")
                 .data("bar", "foo")
                 .render());
+        // Literal base with chaining parts
+        assertEquals("foobar", Engine.builder()
+                .addDefaults()
+                .addValueResolver(new ReflectionValueResolver())
+                .configureParser((id, variant) -> new ParserConfig('='))
+                .build()
+                .parse("{='foo'.concat('bar')}")
+                .render());
+        assertEquals("3", Engine.builder()
+                .addDefaults()
+                .addValueResolver(new ReflectionValueResolver())
+                .configureParser((id, variant) -> new ParserConfig('='))
+                .build()
+                .parse("{='bar'.length}")
+                .render());
+        assertEquals("1", Engine.builder()
+                .addDefaults()
+                .addValueResolver(new ReflectionValueResolver())
+                .configureParser((id, variant) -> new ParserConfig('='))
+                .build()
+                .parse("{=1.intValue}")
+                .render());
         assertThrows(IllegalArgumentException.class, () -> new ParserConfig('#'));
         assertThrows(IllegalArgumentException.class, () -> new ParserConfig('@'));
         assertThrows(IllegalArgumentException.class, () -> new ParserConfig('/'));

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/LiteralSupportTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/LiteralSupportTest.java
@@ -1,7 +1,9 @@
 package io.quarkus.qute;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -52,6 +54,18 @@ public class LiteralSupportTest {
     public void testNonLiteral() {
         assertEquals(Results.NotFound.EMPTY, LiteralSupport.getLiteralValue("'foo'.ping()"));
         assertEquals(Results.NotFound.EMPTY, LiteralSupport.getLiteralValue("foo.bar"));
+    }
+
+    @Test
+    public void testIsStringLiteral() {
+        assertTrue(LiteralSupport.isStringLiteral("'foo'"));
+        assertTrue(LiteralSupport.isStringLiteral("\"foo\""));
+        assertTrue(LiteralSupport.isStringLiteral("'café'"));
+        assertTrue(LiteralSupport.isStringLiteral("'🎉'"));
+        assertFalse(LiteralSupport.isStringLiteral("bar"));
+        assertFalse(LiteralSupport.isStringLiteral("'bar' + 'baz'"));
+        assertFalse(LiteralSupport.isStringLiteral("'bar' 🎉 'baz'"));
+        assertFalse(LiteralSupport.isStringLiteral("\"bar\" + \"baz\""));
     }
 
 }

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/SetSectionTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/SetSectionTest.java
@@ -75,6 +75,28 @@ public class SetSectionTest {
     }
 
     @Test
+    public void testCompositeParamsWithLiteralBase() {
+        // https://github.com/quarkusio/quarkus/issues/53959
+        Engine engine = Engine.builder().addDefaults().addValueResolver(new ReflectionValueResolver()).build();
+        // String literals with single and double quotes
+        assertEquals("barbaz",
+                engine.parse("{#let foo=('bar' + 'baz')}{foo}{/let}").render());
+        assertEquals("barbaz",
+                engine.parse("{#let foo=(\"bar\" + \"baz\")}{foo}{/let}").render());
+        assertEquals("barbaz",
+                engine.parse("{#let foo = ('bar' + 'baz')}{foo}{/let}").render());
+        // Integer literal as base
+        assertEquals("3",
+                engine.parse("{#let foo=(1 + 2)}{foo}{/let}").render());
+        // Chained infix on string literal
+        assertEquals("hello world",
+                engine.parse("{#let foo=('hello' + ' ' + 'world')}{foo}{/let}").render());
+        // Property accessor on string literal
+        assertEquals("3",
+                engine.parse("{#let foo='bar'.length}{foo}{/let}").render());
+    }
+
+    @Test
     public void testOptionalEndTag() {
         Engine engine = Engine.builder().addDefaults().build();
         assertEquals("true",


### PR DESCRIPTION
- fixes #53959
- expressions can now use a literal value (string, integer, etc.) as the base for property accessors and virtual method invocations, e.g. 'foo'.toUpperCase
- in a top-level output expression, a literal base requires a special syntax prefix (such as `=`)