### PR TITLE
Fix ClassComparisonUtil to handle repeated annotations

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/ClassComparisonUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/ClassComparisonUtil.java
@@ -109,16 +109,28 @@ public class ClassComparisonUtil {
         if (a.size() != b.size()) {
             return false;
         }
-        Map<DotName, AnnotationInstance> lookup = b.stream()
-                .collect(Collectors.toMap(AnnotationInstance::name, Function.identity()));
+        // Use List to handle repeated annotations (e.g., multiple @NotNull)
+        Map<DotName, List<AnnotationInstance>> lookup = b.stream()
+                .collect(Collectors.groupingBy(AnnotationInstance::name));
 
-        for (AnnotationInstance i1 : a) {
-            AnnotationInstance i2 = lookup.get(i1.name());
-            if (i2 == null) {
+        Map<DotName, List<AnnotationInstance>> aGrouped = a.stream()
+                .collect(Collectors.groupingBy(AnnotationInstance::name));
+
+        if (!aGrouped.keySet().equals(lookup.keySet())) {
+            return false;
+        }
+
+        for (Map.Entry<DotName, List<AnnotationInstance>> entry : aGrouped.entrySet()) {
+            List<AnnotationInstance> aList = entry.getValue();
+            List<AnnotationInstance> bList = lookup.get(entry.getKey());
+            if (aList.size() != bList.size()) {
                 return false;
             }
-            if (!compareAnnotation(i1, i2)) {
-                return false;
+            // For repeated annotations, compare them pairwise
+            for (int i = 0; i < aList.size(); i++) {
+                if (!compareAnnotation(aList.get(i), bList.get(i))) {
+                    return false;
+                }
             }
         }
         return true;

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/dev/livereload/HibernateInstrumentationLiveReloadTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/dev/livereload/HibernateInstrumentationLiveReloadTest.java
@@ -1,0 +1,45 @@
+package io.quarkus.hibernate.orm.dev.livereload;
+
+import static org.hamcrest.Matchers.is;
+
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.TestTags;
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+
+/**
+ * Test for https://github.com/quarkusio/quarkus/issues/53971
+ * Verifies that live reload doesn't fail when entities have validation annotations.
+ * The bug was that ClassComparisonUtil used Collectors.toMap() which threw an
+ * exception when annotations were repeated, causing live reload to fail.
+ */
+@Tag(TestTags.DEVMODE)
+public class HibernateInstrumentationLiveReloadTest {
+
+    @RegisterExtension
+    final static QuarkusDevModeTest TEST = new QuarkusDevModeTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(ProductEntity.class, ProductResource.class));
+
+    @Test
+    public void testLiveReloadWithValidationAnnotations() {
+        RestAssured.when().get("/product/test").then().body(is("Product[name=test]"));
+
+        // Change field visibility from public to private - this is the original issue scenario
+        TEST.modifySourceFile(ProductEntity.class, new Function<String, String>() {
+            @Override
+            public String apply(String s) {
+                return s.replace("public String name;", "private String name;");
+            }
+        });
+
+        // Should complete without exception - the bug would cause IllegalStateException
+        // when compareAnnotations() tried to use toMap() with repeated annotations
+        RestAssured.when().get("/product/changed").then().body(is("Product[name=changed]"));
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/dev/livereload/ProductEntity.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/dev/livereload/ProductEntity.java
@@ -1,0 +1,44 @@
+package io.quarkus.hibernate.orm.dev.livereload;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+
+@Entity
+public class ProductEntity {
+
+    @Id
+    private Long id;
+
+    @NotNull
+    public String name;
+
+    public ProductEntity() {
+    }
+
+    public ProductEntity(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "Product[name=" + name + "]";
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/dev/livereload/ProductResource.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/dev/livereload/ProductResource.java
@@ -1,0 +1,21 @@
+package io.quarkus.hibernate.orm.dev.livereload;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/product")
+@ApplicationScoped
+public class ProductResource {
+
+    @GET
+    @Path("/{name}")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String get(@PathParam("name") String name) {
+        ProductEntity product = new ProductEntity(1L, name);
+        return product.toString();
+    }
+}


### PR DESCRIPTION
Fixes #53971

This fixes the superficial issue, which is: annotations can be repeated, so `clazz.declaredAnnotations()` can end up returning two annotation instances for the same `DotName`.

I think there is another, deeper problem, because:

1. I would have expected a repeated annotation to use the "repeatable container" in the Jandex index. But maybe that's not how it works -- hopefully @Ladicek knows?
2. I'm not sure why `@jakarta.validation.NotNull` gets repeated in the index in this particular scenario. There may be something wrong with indexing or -- more likely -- bytecode enhancement leading to the annotation being duplicated.

That being said, since this fixes the immediate issue, and since repeated annotations are *in principle* something that could happen in other cases, I'm tempted to merge the fix anyway?

WDYT?