### PR TITLE
Fix live reload failure with TYPE_USE annotations

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/ClassComparisonUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/ClassComparisonUtil.java
@@ -1,8 +1,6 @@
 package io.quarkus.deployment.dev;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -17,7 +15,6 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
-import org.jboss.jandex.TypeTarget;
 
 public class ClassComparisonUtil {
     private static final Set<DotName> IGNORED_ANNOTATIONS = Set.of(
@@ -95,10 +92,20 @@ public class ClassComparisonUtil {
                 if (!paramEqual) {
                     continue;
                 }
-                if (!compareMethodAnnotations(i.annotations(), method.annotations())) {
-                    continue;
-                }
+                // The two methods match;
+                // this implies they have the same return type and parameter types,
+                // which implies those have the same annotations (`type().equals(...)` considers annotations).
                 om = i;
+                // We still need to check method annotations and parameter annotations are equivalent.
+                if (!compareAnnotations(method.declaredAnnotations(), om.declaredAnnotations())) {
+                    return false;
+                }
+                for (int j = 0; j < method.parametersCount(); ++j) {
+                    if (!compareAnnotations(method.parameters().get(j).declaredAnnotations(),
+                            om.parameters().get(j).declaredAnnotations())) {
+                        return false;
+                    }
+                }
             }
             //no further checks needed, we fully matched in the loop
             if (om == null) {
@@ -108,7 +115,7 @@ public class ClassComparisonUtil {
         return true;
     }
 
-    static boolean compareAnnotations(Collection<AnnotationInstance> a, Collection<AnnotationInstance> b) {
+    private static boolean compareAnnotations(Collection<AnnotationInstance> a, Collection<AnnotationInstance> b) {
         if (a.size() != b.size()) {
             return false;
         }
@@ -125,66 +132,6 @@ public class ClassComparisonUtil {
             }
         }
         return true;
-    }
-
-    static boolean compareMethodAnnotations(Collection<AnnotationInstance> a, Collection<AnnotationInstance> b) {
-        if (a.size() != b.size()) {
-            return false;
-        }
-        List<AnnotationInstance> method1 = new ArrayList<>();
-        Map<Integer, List<AnnotationInstance>> params1 = new HashMap<>();
-        Map<Integer, List<AnnotationInstance>> paramTypes1 = new HashMap<>();
-        methodMap(a, method1, params1, paramTypes1);
-        List<AnnotationInstance> method2 = new ArrayList<>();
-        Map<Integer, List<AnnotationInstance>> params2 = new HashMap<>();
-        Map<Integer, List<AnnotationInstance>> paramTypes2 = new HashMap<>();
-        methodMap(b, method2, params2, paramTypes2);
-        if (!compareAnnotations(method1, method2)) {
-            return false;
-        }
-        if (!params1.keySet().equals(params2.keySet())) {
-            return false;
-        }
-        for (Map.Entry<Integer, List<AnnotationInstance>> entry : params1.entrySet()) {
-            List<AnnotationInstance> other = params2.get(entry.getKey());
-            if (!compareAnnotations(other, entry.getValue())) {
-                return false;
-            }
-        }
-        for (Map.Entry<Integer, List<AnnotationInstance>> entry : paramTypes1.entrySet()) {
-            List<AnnotationInstance> other = paramTypes2.get(entry.getKey());
-            if (!compareAnnotations(other, entry.getValue())) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private static void methodMap(Collection<AnnotationInstance> b, List<AnnotationInstance> method2,
-            Map<Integer, List<AnnotationInstance>> params2, Map<Integer, List<AnnotationInstance>> paramTypes2) {
-        for (AnnotationInstance i : b) {
-            int index;
-            switch (i.target().kind()) {
-                case METHOD:
-                    method2.add(i);
-                    break;
-                case METHOD_PARAMETER:
-                    index = i.target().asMethodParameter().position();
-                    params2.computeIfAbsent(index, k -> new ArrayList<>()).add(i);
-                    break;
-                case TYPE:
-                    TypeTarget.Usage usage = i.target().asType().usage();
-                    if (usage == TypeTarget.Usage.METHOD_PARAMETER) {
-                        index = i.target().asType().asMethodParameterType().position();
-                        paramTypes2.computeIfAbsent(index, k -> new ArrayList<>()).add(i);
-                    } else {
-                        throw new IllegalArgumentException("Unsupported type annotation usage: " + usage);
-                    }
-                    break;
-                default:
-                    throw new IllegalArgumentException("Unsupported annotation target kind: " + i.target().kind());
-            }
-        }
     }
 
     private static boolean compareAnnotation(AnnotationInstance a, AnnotationInstance b) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/ClassComparisonUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/ClassComparisonUtil.java
@@ -53,7 +53,10 @@ public class ClassComparisonUtil {
             if (!of.type().equals(field.type())) {
                 return false;
             }
-            if (!compareAnnotations(of.annotations(), field.annotations())) {
+            // Use declaredAnnotations() to only compare FIELD annotations, not TYPE annotations.
+            // TYPE annotations are already compared via the type().equals() check above,
+            // since Jandex Type objects include annotation positioning information.
+            if (!compareAnnotations(of.declaredAnnotations(), field.declaredAnnotations())) {
                 return false;
             }
         }

--- a/core/deployment/src/test/java/io/quarkus/deployment/dev/ClassComparisonUtilTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/dev/ClassComparisonUtilTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
-import java.lang.annotation.Annotation;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -12,93 +11,86 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.List;
 
-import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.Index;
-import org.jboss.jandex.MethodParameterInfo;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class ClassComparisonUtilTest {
 
     @Nested
-    class CompareMethodAnnotations {
+    class CompareMethodParameterAnnotations {
 
         @Test
-        public void annotationsEqual() {
-            AnnotationInstance instance1 = methodParameterAnnotation(AnnotationForTest1.class);
-            AnnotationInstance instance2 = methodParameterAnnotation(AnnotationForTest1.class);
-
-            List<AnnotationInstance> instances1 = List.of(instance1);
-            List<AnnotationInstance> instances2 = List.of(instance2);
-
-            assertTrue(ClassComparisonUtil.compareMethodAnnotations(instances1, instances2));
+        public void annotationsEqual() throws IOException {
+            assertTrue(isSameStructure(ClassWithParameterAnnotation1.class, ClassWithParameterAnnotation1.class));
+            assertTrue(isSameStructure(ClassWithParameterAnnotation2.class, ClassWithParameterAnnotation2.class));
         }
 
         @Test
-        public void annotationsNotEqual() {
-            AnnotationInstance instance1 = methodParameterAnnotation(AnnotationForTest1.class);
-            AnnotationInstance instance2 = methodParameterAnnotation(AnnotationForTest2.class);
-
-            List<AnnotationInstance> instances1 = List.of(instance1);
-            List<AnnotationInstance> instances2 = List.of(instance2);
-
-            assertFalse(ClassComparisonUtil.compareMethodAnnotations(instances1, instances2));
+        public void annotationsNotEqual() throws IOException {
+            assertFalse(isSameStructure(ClassWithParameterAnnotation1.class, ClassWithParameterAnnotation2.class));
         }
 
         @Test
-        public void compareMethodAnnotationsSizeDiffer() {
-            AnnotationInstance instance = methodParameterAnnotation(AnnotationForTest1.class);
-
-            List<AnnotationInstance> instances = List.of(instance);
-
-            assertFalse(ClassComparisonUtil.compareMethodAnnotations(instances, List.of()));
-            assertFalse(ClassComparisonUtil.compareMethodAnnotations(List.of(), instances));
+        public void compareMethodAnnotationsSizeDiffer() throws IOException {
+            assertFalse(isSameStructure(ClassWithNoParameterAnnotation.class, ClassWithParameterAnnotation1.class));
         }
 
         @Test
-        public void multipleAnnotationsAtSamePosition() {
-            List<AnnotationInstance> instances1 = List.of(
-                    methodParameterAnnotation(AnnotationForTest1.class),
-                    methodParameterAnnotation(AnnotationForTest2.class));
-            List<AnnotationInstance> instances2 = List.of(
-                    methodParameterAnnotation(AnnotationForTest2.class),
-                    methodParameterAnnotation(AnnotationForTest1.class));
-
-            assertTrue(ClassComparisonUtil.compareMethodAnnotations(instances1, instances2));
+        public void multipleAnnotationsAtSamePosition() throws IOException {
+            assertTrue(isSameStructure(ClassWithParameterAnnotationMultipleSamePosition.class,
+                    ClassWithParameterAnnotationMultipleSamePositionInverted.class));
         }
 
         @Test
-        public void multipleAnnotations() {
-            List<AnnotationInstance> instances1 = List.of(
-                    methodParameterAnnotation(AnnotationForTest1.class, 1),
-                    methodParameterAnnotation(AnnotationForTest2.class, 2));
-
-            List<AnnotationInstance> instances2 = List.of(
-                    methodParameterAnnotation(AnnotationForTest1.class, 2),
-                    methodParameterAnnotation(AnnotationForTest2.class, 1));
-
-            assertFalse(ClassComparisonUtil.compareMethodAnnotations(instances1, instances2));
+        public void multipleAnnotations() throws IOException {
+            assertFalse(isSameStructure(ClassWithParameterAnnotationOnTwoParams.class,
+                    ClassWithParameterAnnotationOnTwoParamsInverted.class));
         }
 
-        private static AnnotationInstance methodParameterAnnotation(
-                Class<? extends Annotation> annotation) {
-            return methodParameterAnnotation(annotation, 1);
+        static class ClassWithNoParameterAnnotation {
+            public void process(String param1) {
+            }
         }
 
-        private static AnnotationInstance methodParameterAnnotation(
-                Class<? extends Annotation> annotation, int position) {
-            MethodParameterInfo target = MethodParameterInfo.create(null, (short) position);
-            return AnnotationInstance.builder(annotation).buildWithTarget(target);
+        static class ClassWithParameterAnnotation1 {
+            public void process(@AnnotationForTest1 String param1) {
+            }
         }
 
-        @Target({ ElementType.PARAMETER, ElementType.TYPE_USE })
+        static class ClassWithParameterAnnotation2 {
+            public void process(@AnnotationForTest2 String param1) {
+            }
+        }
+
+        static class ClassWithParameterAnnotationMultipleSamePosition {
+            public void process(@AnnotationForTest1 @AnnotationForTest2 String param1) {
+            }
+        }
+
+        static class ClassWithParameterAnnotationMultipleSamePositionInverted {
+            public void process(@AnnotationForTest2 @AnnotationForTest1 String param1) {
+            }
+        }
+
+        static class ClassWithParameterAnnotationOnTwoParams {
+            public void process(@AnnotationForTest1 String param1, @AnnotationForTest2 String param2) {
+            }
+        }
+
+        static class ClassWithParameterAnnotationOnTwoParamsInverted {
+            public void process(@AnnotationForTest2 String param1, @AnnotationForTest1 String param2) {
+            }
+        }
+
+        @Target({ ElementType.PARAMETER })
         @Retention(RetentionPolicy.RUNTIME)
         @Documented
         private @interface AnnotationForTest1 {
         }
 
-        @Target({ ElementType.PARAMETER, ElementType.TYPE_USE })
+        @Target({ ElementType.PARAMETER })
         @Retention(RetentionPolicy.RUNTIME)
         @Documented
         private @interface AnnotationForTest2 {

--- a/core/deployment/src/test/java/io/quarkus/deployment/dev/ClassComparisonUtilTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/dev/ClassComparisonUtilTest.java
@@ -1,5 +1,9 @@
 package io.quarkus.deployment.dev;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -9,8 +13,9 @@ import java.lang.annotation.Target;
 import java.util.List;
 
 import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.Index;
 import org.jboss.jandex.MethodParameterInfo;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -27,7 +32,7 @@ class ClassComparisonUtilTest {
             List<AnnotationInstance> instances1 = List.of(instance1);
             List<AnnotationInstance> instances2 = List.of(instance2);
 
-            Assertions.assertTrue(ClassComparisonUtil.compareMethodAnnotations(instances1, instances2));
+            assertTrue(ClassComparisonUtil.compareMethodAnnotations(instances1, instances2));
         }
 
         @Test
@@ -38,7 +43,7 @@ class ClassComparisonUtilTest {
             List<AnnotationInstance> instances1 = List.of(instance1);
             List<AnnotationInstance> instances2 = List.of(instance2);
 
-            Assertions.assertFalse(ClassComparisonUtil.compareMethodAnnotations(instances1, instances2));
+            assertFalse(ClassComparisonUtil.compareMethodAnnotations(instances1, instances2));
         }
 
         @Test
@@ -47,8 +52,8 @@ class ClassComparisonUtilTest {
 
             List<AnnotationInstance> instances = List.of(instance);
 
-            Assertions.assertFalse(ClassComparisonUtil.compareMethodAnnotations(instances, List.of()));
-            Assertions.assertFalse(ClassComparisonUtil.compareMethodAnnotations(List.of(), instances));
+            assertFalse(ClassComparisonUtil.compareMethodAnnotations(instances, List.of()));
+            assertFalse(ClassComparisonUtil.compareMethodAnnotations(List.of(), instances));
         }
 
         @Test
@@ -60,7 +65,7 @@ class ClassComparisonUtilTest {
                     methodParameterAnnotation(AnnotationForTest2.class),
                     methodParameterAnnotation(AnnotationForTest1.class));
 
-            Assertions.assertTrue(ClassComparisonUtil.compareMethodAnnotations(instances1, instances2));
+            assertTrue(ClassComparisonUtil.compareMethodAnnotations(instances1, instances2));
         }
 
         @Test
@@ -73,7 +78,7 @@ class ClassComparisonUtilTest {
                     methodParameterAnnotation(AnnotationForTest1.class, 2),
                     methodParameterAnnotation(AnnotationForTest2.class, 1));
 
-            Assertions.assertFalse(ClassComparisonUtil.compareMethodAnnotations(instances1, instances2));
+            assertFalse(ClassComparisonUtil.compareMethodAnnotations(instances1, instances2));
         }
 
         private static AnnotationInstance methodParameterAnnotation(
@@ -98,6 +103,177 @@ class ClassComparisonUtilTest {
         @Documented
         private @interface AnnotationForTest2 {
         }
+    }
+
+    @Nested
+    class CompareAnnotationsWithTypeUse {
+
+        /**
+         * Check that our approach to calling isSameStructure() on two different classes does make sense
+         * -- i.e. that the method doesn't care about the class name, which would make all other tests meaningless.
+         */
+        @Test
+        public void sanity() throws IOException {
+            assertTrue(isSameStructure(EntityWithTypeUseAnnotation.class, EntityWithTypeUseAnnotation2.class));
+        }
+
+        @Test
+        public void repeatableAnnotationsWithContainer() throws IOException {
+            // When using @Repeatable, e.g., @NotNull @NotNull, javac generates a container annotation
+            // @NotNull.List containing the repeated annotations
+            assertFalse(isSameStructure(EntityWithTypeUseAnnotation.class, EntityWithTypeUseAnnotationRepeated.class));
+        }
+
+        /**
+         * Test for https://github.com/quarkusio/quarkus/issues/53971
+         * When an annotation has both FIELD and TYPE_USE targets, javac generates both
+         * a field annotation and a type annotation in the bytecode. Using field.annotations()
+         * would return both and cause duplicate keys when building a map by annotation name.
+         * The fix uses field.declaredAnnotations() which only returns FIELD annotations.
+         */
+        @Test
+        public void fieldAndTypeUseAnnotationsFromRealBytecode() throws IOException {
+            // Compare the class to itself - this should not throw any exceptions
+            assertTrue(isSameStructure(EntityWithTypeUseAnnotation.class, EntityWithTypeUseAnnotation.class));
+        }
+
+        @Test
+        public void typeUseAnnotationPositionChangeFieldList() throws IOException {
+            // Test that we detect when a TYPE_USE annotation moves position on a field
+            // e.g., from @Ann List<String> to List<@Ann String>
+            //
+            // This works because the field type comparison (type().equals()) includes
+            // annotation positioning information. The Type objects are:
+            // - @Ann List<String> vs List<@Ann String>
+            // These are structurally different types, so isSameStructure() correctly
+            // detects the change via the type comparison before even checking annotations.
+            assertFalse(isSameStructure(EntityWithFieldTypeAnnotationOnType.class,
+                    EntityWithFieldTypeAnnotationOnTypeArgument.class));
+        }
+
+        @Test
+        public void typeUseAnnotationPositionChangeFieldMap() throws IOException {
+            // Test Map<@Ann String, String> vs Map<String, @Ann String> on a field
+            // The annotation moves from key to value type - should be detected as different.
+            //
+            // Again, the type comparison handles this because the Type objects include
+            // annotation positioning: Map<@Ann String, String> vs Map<String, @Ann String>
+            // are structurally different types.
+            assertFalse(isSameStructure(EntityWithMapKeyAnnotation.class, EntityWithMapValueAnnotation.class));
+        }
+
+        @Test
+        public void typeUseAnnotationPositionChangeMethodReturnType() throws IOException {
+            // Test that we detect when a TYPE_USE annotation moves position on a method return type
+            // e.g., from @Ann List<String> to List<@Ann String>
+            assertFalse(isSameStructure(EntityWithMethodReturnTypeAnnotationOnType.class,
+                    EntityWithMethodReturnTypeAnnotationOnTypeArgument.class));
+        }
+
+        @Test
+        public void typeUseAnnotationPositionChangeMethodParameter() throws IOException {
+            // Test that we detect when a TYPE_USE annotation moves position on a method parameter
+            // e.g., from @Ann List<String> to List<@Ann String>
+            assertFalse(isSameStructure(EntityWithMethodParameterTypeAnnotationOnType.class,
+                    EntityWithMethodParameterTypeAnnotationOnTypeArgument.class));
+        }
+
+        @Test
+        public void typeUseAnnotationRemoved() throws IOException {
+            // Test that we detect when a TYPE_USE annotation is removed from a field type
+            // e.g., from @Ann List<String> to List<String>
+            assertFalse(isSameStructure(EntityWithFieldTypeAnnotationOnType.class, EntityWithoutTypeAnnotation.class));
+        }
+
+        @java.lang.annotation.Repeatable(NotNullAnnotation.List.class)
+        @Target({ ElementType.FIELD, ElementType.TYPE_USE })
+        @Retention(RetentionPolicy.RUNTIME)
+        @Documented
+        private @interface NotNullAnnotation {
+            @Target({ ElementType.FIELD, ElementType.TYPE_USE })
+            @Retention(RetentionPolicy.RUNTIME)
+            @Documented
+            @interface List {
+                NotNullAnnotation[] value();
+            }
+        }
+
+        @Target({ ElementType.FIELD, ElementType.TYPE_USE })
+        @Retention(RetentionPolicy.RUNTIME)
+        @Documented
+        private @interface NotBlankAnnotation {
+        }
+
+        @Target({ ElementType.TYPE_USE })
+        @Retention(RetentionPolicy.RUNTIME)
+        @Documented
+        private @interface TypeOnlyAnnotation {
+        }
+
+        static class EntityWithTypeUseAnnotation {
+            @NotNullAnnotation
+            public String name;
+        }
+
+        static class EntityWithTypeUseAnnotation2 {
+            @NotNullAnnotation
+            public String name;
+        }
+
+        static class EntityWithTypeUseAnnotationRepeated {
+            @NotNullAnnotation
+            @NotNullAnnotation
+            public String name;
+        }
+
+        static class EntityWithFieldTypeAnnotationOnType {
+            @TypeOnlyAnnotation
+            public List<String> items;
+        }
+
+        static class EntityWithFieldTypeAnnotationOnTypeArgument {
+            public List<@TypeOnlyAnnotation String> items;
+        }
+
+        static class EntityWithMapKeyAnnotation {
+            public java.util.Map<@TypeOnlyAnnotation String, String> data;
+        }
+
+        static class EntityWithMapValueAnnotation {
+            public java.util.Map<String, @TypeOnlyAnnotation String> data;
+        }
+
+        static class EntityWithMethodReturnTypeAnnotationOnType {
+            public @TypeOnlyAnnotation List<String> getItems() {
+                return null;
+            }
+        }
+
+        static class EntityWithMethodReturnTypeAnnotationOnTypeArgument {
+            public List<@TypeOnlyAnnotation String> getItems() {
+                return null;
+            }
+        }
+
+        static class EntityWithMethodParameterTypeAnnotationOnType {
+            public void process(@TypeOnlyAnnotation List<String> items) {
+            }
+        }
+
+        static class EntityWithMethodParameterTypeAnnotationOnTypeArgument {
+            public void process(List<@TypeOnlyAnnotation String> items) {
+            }
+        }
+
+        static class EntityWithoutTypeAnnotation {
+            public List<String> items;
+        }
+    }
+
+    private static boolean isSameStructure(Class<?> clazz1, Class<?> clazz2) throws IOException {
+        ClassInfo classInfo1 = Index.singleClass(clazz1);
+        ClassInfo classInfo2 = Index.singleClass(clazz2);
+        return ClassComparisonUtil.isSameStructure(classInfo1, classInfo2);
     }
 
 }


### PR DESCRIPTION
* Fixes #53971
* Supersedes #53984

I tracked down the problem to the fact that `@NotNull` can be applied to both fields and types, meaning when it's applied to a field in the source code, it's registered twice in the bytecode: once for the field, once for the type.

And apparently, the way we're retrieving annotations in `ClassComparisonUtil`, we're retrieving both field and type annotations, mixed. Hence why we're ending up in this situation.

See also the comment below:

> I think I'm finally there. The fix for #53971 is down to just using `declaredAnnotations()`, so that we only compare annotations on the field, not on type use.
> 
> That obviously removes the problem of putting annotations in a map, but more importantly: that doesn't prevent us from detecting type use annotation changes, because... we use `field.type().equals(otherField.type())`, and _that_ apparently includes type use annotations -- and I mean type use annotations, not type annotations. I know, I was surprised too.
> 
> Going from there, I added a couple commits that simplify method comparison, because then we do not need to check type annotations on method return type / parameter type (we already check types), just method annotations and parameter annotations.

