### PR TITLE
Add AI skill for quarkus-flyway

### DIFF
--- a/extensions/flyway/deployment/src/main/resources/META-INF/quarkus-skill.md
+++ b/extensions/flyway/deployment/src/main/resources/META-INF/quarkus-skill.md
@@ -1,0 +1,142 @@
+
+## Key Patterns
+
+### Migration file location and naming
+
+Place SQL migrations in `src/main/resources/db/migration/`. Naming convention uses **double underscores**:
+
+```
+V1.0.0__Create_tables.sql       # versioned (runs once, in order)
+V1.0.1__Add_column.sql
+R__Create_views.sql              # repeatable (re-runs when content changes)
+```
+
+Repeatable migrations (`R__`) run after all versioned migrations and re-execute whenever their checksum changes. Use them for views, stored procedures, and functions.
+
+### Essential configuration
+
+```properties
+# Required — migrations don't run automatically without this
+quarkus.flyway.migrate-at-start=true
+
+# Flyway owns the schema — disable Hibernate schema management
+quarkus.hibernate-orm.schema-management.strategy=none
+
+# Dev mode — clean and recreate schema on each restart (NEVER in prod)
+%dev.quarkus.flyway.clean-at-start=true
+%test.quarkus.flyway.clean-at-start=true
+```
+
+Quarkus Dev Services (from the JDBC extension) auto-starts a database container in dev/test mode — no JDBC URL needed.
+
+### Multiple datasources
+
+Configure named datasources with separate migration directories:
+
+```properties
+quarkus.datasource.audit.db-kind=postgresql
+quarkus.flyway.audit.migrate-at-start=true
+quarkus.flyway.audit.locations=db/audit
+```
+
+Place migrations in `src/main/resources/db/audit/`. Inject named Flyway beans:
+
+```java
+@Inject
+@FlywayDataSource("audit")
+Flyway auditFlyway;
+```
+
+### Integration with Hibernate ORM Panache
+
+When using Flyway to manage schema AND Panache for entities, the ID generation strategy must match:
+
+**SERIAL/BIGSERIAL columns — use IDENTITY strategy:**
+```sql
+-- V1.0.0__Create_task_table.sql
+CREATE TABLE task (id BIGSERIAL PRIMARY KEY, title VARCHAR(255));
+```
+```java
+@Entity
+public class Task extends PanacheEntityBase {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public Long id;
+    public String title;
+}
+```
+
+**Explicit sequence — use PanacheEntity (sequence-based ID generation):**
+```sql
+CREATE SEQUENCE task_seq START WITH 1 INCREMENT BY 50;
+CREATE TABLE task (id BIGINT PRIMARY KEY, title VARCHAR(255));
+```
+```java
+@Entity
+public class Task extends PanacheEntity {
+    public String title;
+}
+```
+
+### Programmatic access
+
+Inject the `Flyway` bean to query migration status:
+
+```java
+@Inject
+Flyway flyway;
+
+public MigrationInfo[] getMigrationInfo() {
+    return flyway.info().all();
+}
+```
+
+### Callbacks
+
+Implement `org.flywaydb.core.api.callback.Callback` and register via configuration. Callback classes must have a no-arg constructor and must not be abstract:
+
+```properties
+quarkus.flyway.callbacks=com.example.MigrationCallback
+```
+
+```java
+public class MigrationCallback implements Callback {
+    private static final Logger LOG = Logger.getLogger(MigrationCallback.class);
+    public boolean supports(Event event, Context context) {
+        return event == Event.AFTER_EACH_MIGRATE;
+    }
+    public boolean canHandleInTransaction(Event event, Context context) { return true; }
+    public void handle(Event event, Context context) {
+        LOG.infof("Migrated: %s", context.getMigrationInfo().getDescription());
+    }
+    public String getCallbackName() { return "MigrationCallback"; }
+}
+```
+
+## Common Pitfalls
+
+- **`PanacheEntity` + `BIGSERIAL` = broken.** `PanacheEntity` expects a sequence named `{table}_seq`. `BIGSERIAL` creates `{table}_id_seq`. Use `PanacheEntityBase` with `GenerationType.IDENTITY` instead.
+- **`migrate-at-start` defaults to `false`.** Migrations won't run until you set `quarkus.flyway.migrate-at-start=true`.
+- **`clean-at-start` is destructive.** Only use with `%dev` or `%test` profile prefix. Set `quarkus.flyway.clean-disabled=true` in production as a safety net.
+- **Double underscore in filenames.** `V1__Name.sql` not `V1_Name.sql`. Single underscore causes Flyway to ignore the file silently.
+
+## Testing
+
+Flyway migrations run automatically in `@QuarkusTest` when Dev Services provides the database:
+
+```java
+@QuarkusTest
+class MigrationTest {
+
+    @Test
+    void testSeedDataExists() {
+        given()
+            .when().get("/tasks")
+            .then()
+            .statusCode(200)
+            .body("size()", greaterThanOrEqualTo(3));
+    }
+}
+```
+
+Use `%test.quarkus.flyway.clean-at-start=true` for test isolation — each test run starts with a fresh schema plus seed migrations.


### PR DESCRIPTION
This adds an AI skill file for the Flyway extension, enabling AI coding assistants to guide developers through Flyway-specific patterns when building Quarkus applications.

The skill was developed using an automated skill factory process that:

1. **Tested without a skill** — A Sonnet-level agent attempted to build a Flyway app from scratch (basic scenario: REST API with versioned/seed migrations, Panache integration, Dev Services). Key friction points discovered:
   - `migrate-at-start` defaults to `false` — migrations silently don't run
   - `PanacheEntity` vs `PanacheEntityBase` ID strategy mismatch with `BIGSERIAL` columns
   - Double underscore naming requirement not obvious (single underscore silently ignored)
   - `hibernate-orm.database.generation` conflicts with Flyway-managed schema

2. **Verified all claims** — Every factual assertion was checked against the Quarkus source code. Notable corrections:
   - `quarkus.hibernate-orm.database.generation` is deprecated since 3.22 — skill uses the replacement `quarkus.hibernate-orm.schema-management.strategy`
   - Callbacks require explicit configuration via `quarkus.flyway.callbacks` (not CDI auto-discovery)
   - `clean-disabled` defaults to `false` (not `true` in prod as initially stated)
   - Dev Services are provided by the JDBC extension, not by Flyway itself

3. **Validated with an advanced scenario** — A fresh Sonnet agent used the skill to build a complex app (multiple datasources, repeatable migrations, programmatic Flyway access, callbacks, clean-at-start configuration). Result: **good** rating.

### What the skill covers

- Migration file naming conventions and locations
- Essential configuration (`migrate-at-start`, `clean-at-start` with profile guards, `schema-management.strategy`)
- Multiple datasource support (`@FlywayDataSource` qualifier, separate migration directories)
- Hibernate ORM Panache integration (ID strategy matching)
- Programmatic Flyway access
- Callback implementation with explicit registration
- Common pitfalls (4 specific traps with explanations)
- Testing patterns with Dev Services

Closes #53986