### PR TITLE
Add AI skill for quarkus-websockets-next

### DIFF
--- a/extensions/websockets-next/deployment/src/main/resources/META-INF/quarkus-skill.md
+++ b/extensions/websockets-next/deployment/src/main/resources/META-INF/quarkus-skill.md
@@ -1,0 +1,106 @@
+
+### Server Endpoints
+
+- Annotate a class with `@WebSocket(path = "/chat/{room}")` — it becomes a CDI bean (default `@Singleton`).
+- Use callback annotations: `@OnOpen`, `@OnTextMessage`, `@OnBinaryMessage`, `@OnClose`, `@OnError`.
+- Inject `WebSocketConnection` to access `pathParam("room")`, `id()`, `broadcast()`, `getOpenConnections()`.
+- Return a value from a callback to send it to the client; use `broadcast = true` on `@OnTextMessage` or `@OnOpen` to broadcast the return value to all connected clients instead.
+- Use `@WebSocket(endpointId = "my-id")` to assign a stable endpoint ID for use with `OpenConnections`.
+
+### Broadcasting
+
+- `@OnTextMessage(broadcast = true)` — return value is sent to ALL open connections.
+- `connection.broadcast().sendTextAndAwait(msg)` — programmatic broadcast from any callback.
+- `connection.broadcast().filter(c -> !c.id().equals(excludeId)).sendTextAndAwait(msg)` — broadcast with filter.
+- Cross-endpoint broadcasting — inject `OpenConnections` and iterate:
+  ```java
+  @Inject OpenConnections connections;
+  for (var conn : connections.findByEndpointId("notifications")) {
+      conn.sendTextAndAwait(message);
+  }
+  ```
+
+### @OnClose Behavior
+
+- `@OnClose` methods must return `void` or `Uni<Void>` — they cannot return a message.
+- The closing connection is already closed when `@OnClose` fires — you cannot send to it.
+- Broadcasting from `@OnClose` WORKS — it sends to all OTHER open connections.
+
+### Serialization
+
+- Objects are auto-serialized to/from JSON. `String`, `JsonObject`, `JsonArray`, `Buffer`, `byte[]` are sent as-is.
+- For custom serialization, implement `TextMessageCodec<T>` as a CDI bean:
+  ```java
+  @Singleton
+  public class MyCodec implements TextMessageCodec<MyType> {
+      @Override
+      public boolean supports(Type type) { return type.equals(MyType.class); }
+      @Override
+      public String encode(MyType value) { return JsonObject.mapFrom(value).encode(); }
+      @Override
+      public MyType decode(Type type, String value) { return new JsonObject(value).mapTo(MyType.class); }
+  }
+  ```
+- Note: `supports()` and `decode()` take `java.lang.reflect.Type`, not `Class<?>`.
+
+### Streams
+
+- Accept `Multi<X>` as a parameter in `@OnTextMessage` for streaming input.
+- Return `Multi<X>` from `@OnOpen` to establish a persistent server-push stream for the connection's lifetime.
+- Return `Multi<X>` from `@OnTextMessage` for bidirectional streaming — each incoming message produces a stream of responses.
+- When returning `void` with a `Multi` parameter, you MUST subscribe to the `Multi` manually.
+
+### HTTP Upgrade Checks
+
+- Implement `HttpUpgradeCheck` as a CDI bean to validate upgrade requests:
+  ```java
+  @Singleton
+  public class TokenCheck implements HttpUpgradeCheck {
+      @Override
+      public Uni<CheckResult> perform(HttpUpgradeContext context) {
+          String token = context.httpRequest().getParam("token");
+          if (token == null) {
+              return CheckResult.rejectUpgrade(403);
+          }
+          return CheckResult.permitUpgrade();
+      }
+  }
+  ```
+- `perform()` returns `Uni<CheckResult>` — use `CheckResult.permitUpgrade()` or `CheckResult.rejectUpgrade(statusCode)`.
+- Access query params via `context.httpRequest().getParam("name")`, headers via `context.httpRequest().headers()`.
+- Use `appliesTo(String endpointId)` to scope the check to specific endpoints.
+- Beans must be `@ApplicationScoped`, `@Singleton`, or `@Dependent` — NOT `@RequestScoped`.
+
+### Testing
+
+- Use Vert.x `WebSocketClient` directly — this is what the extension's own tests use:
+  ```java
+  @Inject Vertx vertx;
+  @TestHTTPResource("chat/myroom") URI chatUri;
+
+  WebSocketClient client = vertx.createWebSocketClient();
+  CountDownLatch messageLatch = new CountDownLatch(1);
+  List<String> received = new CopyOnWriteArrayList<>();
+
+  client.connect(chatUri.getPort(), chatUri.getHost(), chatUri.getPath())
+      .onComplete(r -> {
+          WebSocket ws = r.result();
+          ws.textMessageHandler(msg -> {
+              received.add(msg);
+              messageLatch.countDown();
+          });
+          ws.writeTextMessage("hello");
+      });
+  assertTrue(messageLatch.await(5, TimeUnit.SECONDS));
+  ```
+- Use `CountDownLatch` for synchronization — WebSocket messages are async.
+- `BasicWebSocketConnector` is for programmatic client connections in application code; for tests, prefer the raw Vert.x client above.
+- Messages are received as raw `String` on the client side — parse JSON manually with `new JsonObject(msg)`.
+- Close clients in a `finally` block: `client.close().toCompletionStage().toCompletableFuture().get()`.
+
+### Common Pitfalls
+
+- `@OnClose` cannot return a message — use `connection.broadcast().sendTextAndAwait()` instead.
+- `WebSocketConnection` is session-scoped; do NOT inject it in `@ApplicationScoped` beans outside endpoint classes — it won't resolve to the correct connection.
+- `broadcast()` includes the sender connection — use `.filter()` to exclude it if needed.
+- Blocking methods (returning `void`) run on a worker thread by default; use `@NonBlocking` for event loop execution.

--- a/extensions/websockets-next/deployment/src/main/resources/META-INF/quarkus-skill.md
+++ b/extensions/websockets-next/deployment/src/main/resources/META-INF/quarkus-skill.md
@@ -1,9 +1,10 @@
 
 ### Server Endpoints
 
-- Annotate a class with `@WebSocket(path = "/chat/{room}")` — it becomes a CDI bean (default `@Singleton`).
+- Annotate a class with `@WebSocket(path = "/my-endpoint/{param}")` — it becomes a CDI bean (default `@Singleton`).
 - Use callback annotations: `@OnOpen`, `@OnTextMessage`, `@OnBinaryMessage`, `@OnClose`, `@OnError`.
-- Inject `WebSocketConnection` to access `pathParam("room")`, `id()`, `broadcast()`, `getOpenConnections()`.
+- Callback method parameters: annotate with `@io.quarkus.websockets.next.PathParam` to receive path parameters, or accept `WebSocketConnection` or `HandshakeRequest` directly. See the [method parameters reference](https://quarkus.io/guides/websockets-next-reference#method-parameters).
+- Inject `WebSocketConnection` to access `pathParam("param")`, `id()`, `broadcast()`, `getOpenConnections()`.
 - Return a value from a callback to send it to the client; use `broadcast = true` on `@OnTextMessage` or `@OnOpen` to broadcast the return value to all connected clients instead.
 - Use `@WebSocket(endpointId = "my-id")` to assign a stable endpoint ID for use with `OpenConnections`.
 
@@ -73,30 +74,30 @@
 
 ### Testing
 
-- Use Vert.x `WebSocketClient` directly — this is what the extension's own tests use:
+- Use `BasicWebSocketConnector` or `WebSocketConnector` for test clients — they are the standard API and handle context propagation:
   ```java
-  @Inject Vertx vertx;
-  @TestHTTPResource("chat/myroom") URI chatUri;
+  @Inject BasicWebSocketConnector connector;
 
-  WebSocketClient client = vertx.createWebSocketClient();
-  CountDownLatch messageLatch = new CountDownLatch(1);
-  List<String> received = new CopyOnWriteArrayList<>();
+  @Test
+  void testEndpoint() throws Exception {
+      CountDownLatch messageLatch = new CountDownLatch(1);
+      List<String> received = new CopyOnWriteArrayList<>();
 
-  client.connect(chatUri.getPort(), chatUri.getHost(), chatUri.getPath())
-      .onComplete(r -> {
-          WebSocket ws = r.result();
-          ws.textMessageHandler(msg -> {
+      var connection = connector
+          .baseUri(uri)
+          .path("/my-endpoint/myParam")
+          .onTextMessage((c, msg) -> {
               received.add(msg);
               messageLatch.countDown();
-          });
-          ws.writeTextMessage("hello");
-      });
-  assertTrue(messageLatch.await(5, TimeUnit.SECONDS));
+          })
+          .connectAndAwait();
+      connection.sendTextAndAwait("hello");
+      assertTrue(messageLatch.await(5, TimeUnit.SECONDS));
+      connection.closeAndAwait();
+  }
   ```
 - Use `CountDownLatch` for synchronization — WebSocket messages are async.
-- `BasicWebSocketConnector` is for programmatic client connections in application code; for tests, prefer the raw Vert.x client above.
 - Messages are received as raw `String` on the client side — parse JSON manually with `new JsonObject(msg)`.
-- Close clients in a `finally` block: `client.close().toCompletionStage().toCompletableFuture().get()`.
 
 ### Common Pitfalls
 


### PR DESCRIPTION
This adds an AI skill file (`quarkus-skill.md`) for the `quarkus-websockets-next` extension, helping AI coding assistants guide developers through WebSocket development patterns.

## Process

The skill was created using the [extension skills methodology](https://github.com/quarkusio/quarkus-agent-mcp/blob/main/docs/creating-extension-skills.md):

1. **Tester agent** (Sonnet) attempted to build a chat room application without any skill guidance
2. **Verification** of all tester claims against the extension source code
3. **Skill creation** based on verified findings
4. **Validation agent** (Sonnet) built an advanced notification system with the skill installed — 9/9 tests passing

## What the tester struggled with

- **Testing patterns**: Used `BasicWebSocketConnector` instead of the canonical Vert.x `WebSocketClient` approach. No testing examples in docs or quickstart to reference.
- **`@OnClose` broadcasting**: Assumed `connection.broadcast()` doesn't work in `@OnClose` — it does, but only for other open connections. Test timing issues masked the correct behavior.
- **JSON handling in tests**: Expected a `codec()` method on `WebSocketClientConnection` — client-side messages are raw strings, requiring manual JSON parsing.

## What the skill teaches

- Server endpoint setup with `@WebSocket`, callback annotations, and `WebSocketConnection` injection
- Broadcasting patterns: annotation-based (`broadcast = true`), programmatic, filtered, and cross-endpoint via `OpenConnections`
- `@OnClose` behavior: cannot return messages, but broadcasting to other connections works
- Custom `TextMessageCodec<T>` with correct `Type`-based method signatures
- `HttpUpgradeCheck` with complete example showing `Uni<CheckResult>` return type and query param access
- `Multi<T>` streaming: server-push from `@OnOpen`, bidirectional from `@OnTextMessage`
- Testing with Vert.x `WebSocketClient`, `CountDownLatch` synchronization, and JSON parsing

## Key verification results

- Tester claim "@OnClose broadcast doesn't work" was **incorrect** — verified in `WebSocketConnectionImpl.java:246` that `broadcast()` filters by `isOpen()`, correctly excluding the closing connection
- Tester claim "no codec() on client connection" was **verified** — `BasicWebSocketConnector` and `WebSocketClientConnection` have no codec method
- Validator flagged `TextMessageCodec` type signatures — **verified** that `supports()` and `decode()` use `java.lang.reflect.Type`, not `Class<?>`; skill was updated

## Validation result

- **Rating**: Good (updated from needs-work after incorporating validator feedback)
- **Tests**: 9/9 passing on advanced scenario
- **Scenario tested**: Multi-endpoint notification system with streaming, custom codecs, HTTP upgrade checks, and cross-endpoint broadcasting
- **No Dev Services required**

Closes https://github.com/quarkusio/quarkus/issues/53997