### PR TITLE
Add AI skill for quarkus-opentelemetry

### DIFF
--- a/extensions/opentelemetry/deployment/src/main/resources/META-INF/quarkus-skill.md
+++ b/extensions/opentelemetry/deployment/src/main/resources/META-INF/quarkus-skill.md
@@ -1,0 +1,133 @@
+### Automatic Instrumentation
+
+- REST endpoints, REST clients, gRPC, and reactive messaging are traced automatically — no code changes needed.
+- The service name defaults to `quarkus.application.name`. Override with `quarkus.otel.service.name` if needed.
+- OTLP exporter sends to `http://localhost:4317` by default. Change with `quarkus.otel.exporter.otlp.endpoint`.
+
+### @WithSpan and @SpanAttribute
+
+No extra dependency needed — `@WithSpan` and `@SpanAttribute` are on the classpath when you add `quarkus-opentelemetry`.
+
+```java
+import io.opentelemetry.instrumentation.annotations.WithSpan;
+import io.opentelemetry.instrumentation.annotations.SpanAttribute;
+
+@WithSpan("validate-order")
+public void validate(@SpanAttribute("order.item") String item) {
+    // creates a span named "validate-order" with attribute "order.item"
+}
+```
+
+- Default span name is `ClassName.methodName` — override with `@WithSpan("custom-name")`.
+- Set span kind: `@WithSpan(kind = SpanKind.CLIENT)`. Default is `INTERNAL`.
+- Methods must be on CDI beans — `@WithSpan` on plain classes is ignored.
+
+### Manual Span Creation
+
+Inject `Tracer` to create spans programmatically:
+
+```java
+@Inject Tracer tracer;
+
+public void process() {
+    Span span = tracer.spanBuilder("process-step")
+        .setAttribute("step.id", stepId)
+        .setParent(Context.current().with(Span.current()))
+        .startSpan();
+    try (Scope scope = span.makeCurrent()) {
+        // work here — child spans will link to this parent
+    } catch (Exception e) {
+        span.setStatus(StatusCode.ERROR);
+        span.recordException(e);
+        throw e;
+    } finally {
+        span.end();
+    }
+}
+```
+
+### Available CDI Injections
+
+- `io.opentelemetry.api.OpenTelemetry` — the SDK entry point
+- `io.opentelemetry.api.trace.Tracer` — for creating spans
+- `io.opentelemetry.api.trace.Span` — the current active span
+- `io.opentelemetry.api.baggage.Baggage` — for cross-service context propagation
+
+### Span Events and Attributes
+
+```java
+Span.current().addEvent("cache-miss");
+Span.current().setAttribute("order.total", 42.0);
+Span.current().recordException(exception);
+Span.current().setStatus(StatusCode.ERROR, "validation failed");
+```
+
+### Baggage Propagation
+
+```java
+Baggage baggage = Baggage.current().toBuilder().put("correlation.id", value).build();
+try (Scope scope = Context.current().with(baggage).makeCurrent()) {
+    // REST Client calls here automatically propagate baggage
+}
+// In downstream service: Baggage.current().getEntryValue("correlation.id")
+```
+
+### Metrics
+
+Metrics are disabled by default. Enable with `quarkus.otel.metrics.enabled=true`.
+Inject `Meter` to create counters and histograms:
+
+```java
+@Inject Meter meter;
+LongCounter counter = meter.counterBuilder("requests.count").build();
+counter.add(1, Attributes.of(AttributeKey.stringKey("endpoint"), "/api/foo"));
+```
+
+### Testing
+
+Use the SPI-based `ConfigurableSpanExporterProvider` pattern to capture spans in tests:
+
+1. Create a `TestSpanExporter` CDI bean implementing `SpanExporter`:
+   ```java
+   @Unremovable
+   @ApplicationScoped
+   public class TestSpanExporter implements SpanExporter {
+       private final List<SpanData> spans = new CopyOnWriteArrayList<>();
+       public List<SpanData> getFinishedSpans() { return spans; }
+       public void reset() { spans.clear(); }
+       @Override public CompletableResultCode export(Collection<SpanData> spans) {
+           this.spans.addAll(spans); return CompletableResultCode.ofSuccess();
+       }
+       @Override public CompletableResultCode flush() { return CompletableResultCode.ofSuccess(); }
+       @Override public CompletableResultCode shutdown() { spans.clear(); return CompletableResultCode.ofSuccess(); }
+   }
+   ```
+2. Create a `TestSpanExporterProvider` implementing `ConfigurableSpanExporterProvider`:
+   ```java
+   public class TestSpanExporterProvider implements ConfigurableSpanExporterProvider {
+       @Override public SpanExporter createExporter(ConfigProperties config) {
+           return CDI.current().select(TestSpanExporter.class).get();
+       }
+       @Override public String getName() { return "test-span-exporter"; }
+   }
+   ```
+3. Register via SPI: create `META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider` containing the provider class name.
+4. Set `quarkus.otel.traces.exporter=test-span-exporter` and `quarkus.otel.bsp.schedule.delay=50ms` in test `application.properties`.
+5. Inject `TestSpanExporter`, call the endpoint, then use Awaitility to wait for spans (they arrive asynchronously).
+
+### Dev Services
+
+Add `quarkus-observability-devservices-lgtm` for a Grafana+Tempo+Loki+Prometheus stack in dev mode. This is a separate extension — not included by default.
+
+### Customization
+
+- Produce a `Resource` CDI bean to add custom attributes to all spans (e.g., environment, version).
+- Implement `SpanProcessor` as a CDI bean to modify spans at start/end (e.g., adding global attributes).
+
+### Common Pitfalls
+
+- `@WithSpan` only works on CDI bean methods — plain class methods are not intercepted.
+- Spans arrive asynchronously to the exporter — use `Awaitility` or polling, not immediate assertions.
+- Always call `span.end()` in a `finally` block — unclosed spans leak resources.
+- `Span.current()` returns a no-op span if no trace context is active (e.g., outside a request).
+- `io.opentelemetry.semconv.ResourceAttributes` is NOT available — use `AttributeKey.stringKey()` instead.


### PR DESCRIPTION
This adds an AI skill file (`quarkus-skill.md`) for the `quarkus-opentelemetry` extension, helping AI coding assistants guide developers through OpenTelemetry tracing, metrics, and testing patterns.

## Process

The skill was created using the [extension skills methodology](https://github.com/quarkusio/quarkus-agent-mcp/blob/main/docs/creating-extension-skills.md):

1. **Tester agent** (Sonnet) built an order processing service with custom tracing — no skill guidance
2. **Verification** of all claims against the extension source code
3. **Skill creation** based on verified findings
4. **Validation agent** (Sonnet) built an advanced distributed tracing system with the skill — 7/7 tests passing

## What the tester struggled with

- **`@WithSpan`/`@SpanAttribute` discovery**: Believed these annotations required a separate dependency. In reality, `opentelemetry-instrumentation-annotations` is a transitive dependency of `quarkus-opentelemetry` — no extra POM entry needed.
- **Testing with InMemorySpanExporter**: Could not figure out how to verify spans in tests. The SPI-based `ConfigurableSpanExporterProvider` pattern (used by the extension's own tests) is non-obvious but critical.
- **Manual `Tracer` injection**: Worked but was not confident in the approach without documentation.

## What the skill teaches

- Auto-instrumentation scope (REST, REST Client, gRPC, reactive messaging)
- `@WithSpan` and `@SpanAttribute` annotations with imports and CDI requirements
- Manual span creation with proper error handling and `Scope` management
- Available CDI injections: `OpenTelemetry`, `Tracer`, `Span`, `Baggage`
- Span events, attributes, exception recording, and status codes
- Baggage propagation with context management
- Metrics API (counters, histograms) with enablement config
- Complete testing pattern using `TestSpanExporter` + `ConfigurableSpanExporterProvider` SPI
- Customization: `Resource` and `SpanProcessor` CDI beans
- Dev Services: separate `quarkus-observability-devservices-lgtm` extension

## Key verification results

- Tester claim "annotations not in BOM" was **incorrect** — `opentelemetry-instrumentation-annotations` is both in the BOM and a transitive dep of the runtime module
- Tester claim "InMemorySpanExporter broken" was **incorrect** — the SPI pattern works, but the setup is complex; skill now documents it fully
- Tester claim "No Dev Services" was **partially incorrect** — separate `quarkus-observability-devservices-lgtm` extension exists

## Validation result

- **Rating**: Good
- **Tests**: 7/7 passing on advanced scenario
- **Scenario tested**: Distributed tracing with context propagation, REST Client integration, baggage, custom metrics, SpanProcessor, and Resource customization
- **No incorrect content** found in the skill by the validator

Closes https://github.com/quarkusio/quarkus/issues/54000