### PR TITLE
Undeprecate REST Client connect timeout config

### DIFF
--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
@@ -141,7 +141,6 @@ public interface RestClientsConfig {
      * <p>
      * Can be overwritten by client-specific settings.
      */
-    @Deprecated
     @WithDefault("15000")
     Long connectTimeout();
 


### PR DESCRIPTION
This was deprecated by mistake in  #51911

- Closes: #54012