### PR TITLE
[4.0] Vert.x 5 migration just file module skips

### DIFF
--- a/integration-tests/virtual-threads/resteasy-reactive-virtual-threads/src/main/java/io/quarkus/virtual/rr/FilteredResource.java
+++ b/integration-tests/virtual-threads/resteasy-reactive-virtual-threads/src/main/java/io/quarkus/virtual/rr/FilteredResource.java
@@ -4,6 +4,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 
+import io.smallrye.common.vertx.ContextLocals;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -47,8 +48,8 @@ public class FilteredResource {
         assert requestContextActive.get();
 
         // DC
-        assert Vertx.currentContext().getLocal("filter").equals("test");
-        Vertx.currentContext().putLocal("test", "test test");
+        assert "test".equals(ContextLocals.get("filter", null));
+        ContextLocals.put("test", "test test");
 
         // MDC
         assert MDC.get("mdc").equals("test");

--- a/integration-tests/virtual-threads/resteasy-reactive-virtual-threads/src/main/java/io/quarkus/virtual/rr/Filters.java
+++ b/integration-tests/virtual-threads/resteasy-reactive-virtual-threads/src/main/java/io/quarkus/virtual/rr/Filters.java
@@ -1,5 +1,6 @@
 package io.quarkus.virtual.rr;
 
+import io.smallrye.common.vertx.ContextLocals;
 import jakarta.enterprise.inject.spi.CDI;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerResponseContext;
@@ -18,7 +19,7 @@ public class Filters {
             VirtualThreadsAssertions.assertWorkerOrEventLoopThread();
             MDC.put("mdc", "test");
             CDI.current().select(Counter.class).get().increment();
-            Vertx.currentContext().putLocal("filter", "test");
+            ContextLocals.put("filter", "test");
         }
     }
 
@@ -28,7 +29,7 @@ public class Filters {
             VirtualThreadsAssertions.assertEverything();
             // the request filter, the method, and here.
             assert CDI.current().select(Counter.class).get().increment() == 4;
-            assert Vertx.currentContext().getLocal("test").equals("test test");
+            assert "test test".equals(ContextLocals.get("test", null));
             assert MDC.get("mdc").equals("test test");
         }
     }

--- a/integration-tests/virtual-threads/virtual-threads-disabled/src/main/java/io/quarkus/virtual/disabled/FilteredResource.java
+++ b/integration-tests/virtual-threads/virtual-threads-disabled/src/main/java/io/quarkus/virtual/disabled/FilteredResource.java
@@ -1,5 +1,6 @@
 package io.quarkus.virtual.disabled;
 
+import io.smallrye.common.vertx.ContextLocals;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -26,8 +27,8 @@ public class FilteredResource {
         assert counter.increment() == 2;
 
         // DC
-        assert Vertx.currentContext().getLocal("filter").equals("test");
-        Vertx.currentContext().putLocal("test", "test test");
+        assert "test".equals(ContextLocals.get("filter", null));
+        ContextLocals.put("filter", "test test");
 
         // MDC
         assert MDC.get("mdc").equals("test");

--- a/integration-tests/virtual-threads/virtual-threads-disabled/src/main/java/io/quarkus/virtual/disabled/Filters.java
+++ b/integration-tests/virtual-threads/virtual-threads-disabled/src/main/java/io/quarkus/virtual/disabled/Filters.java
@@ -1,5 +1,6 @@
 package io.quarkus.virtual.disabled;
 
+import io.smallrye.common.vertx.ContextLocals;
 import jakarta.enterprise.inject.spi.CDI;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerResponseContext;
@@ -18,7 +19,7 @@ public class Filters {
             VirtualThreadsAssertions.assertWorkerOrEventLoopThread();
             MDC.put("mdc", "test");
             CDI.current().select(Counter.class).get().increment();
-            Vertx.currentContext().putLocal("filter", "test");
+            ContextLocals.put("filter", "test");
         }
     }
 
@@ -28,7 +29,7 @@ public class Filters {
             VirtualThreadsAssertions.assertWorkerOrEventLoopThread();
             // the request filter, the method, and here.
             assert CDI.current().select(Counter.class).get().increment() == 3;
-            assert Vertx.currentContext().getLocal("test").equals("test test");
+            assert "test test".equals(ContextLocals.get("test", null));
             assert MDC.get("mdc").equals("test test");
         }
     }

--- a/vertx.justfile
+++ b/vertx.justfile
@@ -1,45 +1,196 @@
 # Vertx 5 Migration justfile
 
-modules := """
-    independent-projects/resteasy-reactive
-    bom/application
-    core
-    extensions/devui
-    extensions/arc
-    extensions/virtual-threads
-    extensions/smallrye-context-propagation
-    extensions/mutiny
-    extensions/netty
-    extensions/vertx
-    extensions/vertx-http
-    extensions/tls-registry
-    extensions/mailer
-    extensions/reactive-datasource
-    extensions/reactive-db2-client
-    extensions/reactive-mssql-client
-    extensions/reactive-mysql-client
-    extensions/reactive-oracle-client
-    extensions/reactive-pg-client
-    extensions/redis-client
-    extensions/grpc
-    extensions/vertx-graphql
-    extensions/stork
-    integration-tests/grpc-stork-response-time
-    integration-tests/grpc-stork-simple
-    integration-tests/rest-client-reactive-stork
-    integration-tests/smallrye-stork-consul-registration
-    integration-tests/smallrye-stork-consul-registration-health-check
-    integration-tests/smallrye-stork-consul-registration-prod-mode
+# Modules to skip (broken during migration) - artifact IDs
+skip_modules := """
+    quarkus-bom-quarkus-platform-descriptor
+    quarkus-documentation
+    quarkus-hibernate-orm-panache-common-deployment
+    quarkus-hibernate-orm-panache-deployment
+    quarkus-hibernate-orm-panache-kotlin-deployment
+    quarkus-hibernate-orm-rest-data-panache-deployment
+    quarkus-hibernate-panache-next
+    quarkus-hibernate-panache-next-deployment
+    quarkus-hibernate-reactive
+    quarkus-hibernate-reactive-deployment
+    quarkus-hibernate-reactive-panache
+    quarkus-hibernate-reactive-panache-common
+    quarkus-hibernate-reactive-panache-common-deployment
+    quarkus-hibernate-reactive-panache-deployment
+    quarkus-hibernate-reactive-panache-kotlin
+    quarkus-hibernate-reactive-panache-kotlin-deployment
+    quarkus-hibernate-reactive-rest-data-panache
+    quarkus-hibernate-reactive-rest-data-panache-deployment
+    quarkus-hibernate-search-orm-elasticsearch-deployment
+    quarkus-hibernate-search-orm-outbox-polling-deployment
+    quarkus-integration-test-cache
+    quarkus-integration-test-devmode
+    quarkus-integration-test-gradle-plugin
+    quarkus-integration-test-grpc-hibernate
+    quarkus-integration-test-grpc-hibernate-reactive
+    quarkus-integration-test-grpc-interceptors
+    quarkus-integration-test-grpc-streaming
+    quarkus-integration-test-hibernate-orm-compatibility-5.6-mariadb
+    quarkus-integration-test-hibernate-orm-compatibility-5.6-postgresql
+    quarkus-integration-test-hibernate-orm-data
+    quarkus-integration-test-hibernate-orm-envers
+    quarkus-integration-test-hibernate-orm-graphql-panache
+    quarkus-integration-test-hibernate-orm-jpamodelgen
+    quarkus-integration-test-hibernate-orm-panache
+    quarkus-integration-test-hibernate-orm-panache-data
+    quarkus-integration-test-hibernate-orm-panache-kotlin
+    quarkus-integration-test-hibernate-orm-rest-data-panache
+    quarkus-integration-test-hibernate-orm-spatial
+    quarkus-integration-test-hibernate-orm-tenancy-connection-resolver
+    quarkus-integration-test-hibernate-orm-tenancy-connection-resolver-legacy-qualifiers
+    quarkus-integration-test-hibernate-orm-tenancy-datasource
+    quarkus-integration-test-hibernate-orm-tenancy-discriminator
+    quarkus-integration-test-hibernate-orm-tenancy-schema
+    quarkus-integration-test-hibernate-orm-tenancy-schema-mariadb
+    quarkus-integration-test-hibernate-orm-vector
+    quarkus-integration-test-hibernate-reactive-db2
+    quarkus-integration-test-hibernate-reactive-mariadb
+    quarkus-integration-test-hibernate-reactive-mssql
+    quarkus-integration-test-hibernate-reactive-mysql
+    quarkus-integration-test-hibernate-reactive-mysql-agroal-flyway
+    quarkus-integration-test-hibernate-reactive-oracle
+    quarkus-integration-test-hibernate-reactive-orm-compatibility
+    quarkus-integration-test-hibernate-reactive-panache
+    quarkus-integration-test-hibernate-reactive-panache-kotlin
+    quarkus-integration-test-hibernate-reactive-postgresql
+    quarkus-integration-test-hibernate-search-orm-elasticsearch
+    quarkus-integration-test-hibernate-search-orm-elasticsearch-outbox-polling
+    quarkus-integration-test-hibernate-search-orm-elasticsearch-tenancy
+    quarkus-integration-test-hibernate-search-orm-opensearch
+    quarkus-integration-test-hibernate-validator
+    quarkus-integration-test-infinispan-cache-jpa
+    quarkus-integration-test-jfr-opentelemetry
+    quarkus-integration-test-jpa
+    quarkus-integration-test-jpa-db2
+    quarkus-integration-test-jpa-h2
+    quarkus-integration-test-jpa-h2-embedded
+    quarkus-integration-test-jpa-mapping-xml-legacy-app
+    quarkus-integration-test-jpa-mapping-xml-modern-app
+    quarkus-integration-test-jpa-mariadb
+    quarkus-integration-test-jpa-mssql
+    quarkus-integration-test-jpa-mysql
+    quarkus-integration-test-jpa-oracle
+    quarkus-integration-test-jpa-postgresql
+    quarkus-integration-test-jpa-postgresql-withxml
+    quarkus-integration-test-jpa-without-entity
+    quarkus-integration-test-jpa-xml-legacy-library-a
+    quarkus-integration-test-jpa-xml-legacy-library-b
+    quarkus-integration-test-jpa-xml-modern-library-a
+    quarkus-integration-test-jpa-xml-modern-library-b
+    quarkus-integration-test-kafka
+    quarkus-integration-test-kafka-devservices
+    quarkus-integration-test-kafka-sasl
+    quarkus-integration-test-kafka-snappy
+    quarkus-integration-test-kafka-ssl
+    quarkus-integration-test-kafka-streams
+    quarkus-integration-test-keycloak-authorization
+    quarkus-integration-test-kubernetes-service-binding-jdbc
+    quarkus-integration-test-kubernetes-service-binding-reactive
+    quarkus-integration-test-liquibase-mongodb
+    quarkus-integration-test-logging-json
+    quarkus-integration-test-logging-panache
+    quarkus-integration-test-logging-panache-kotlin
+    quarkus-integration-test-main
+    quarkus-integration-test-management-interface
+    quarkus-integration-test-management-interface-auth
+    quarkus-integration-test-maven
+    quarkus-integration-test-micrometer-opentelemetry
+    quarkus-integration-test-micrometer-prometheus
+    quarkus-integration-test-micrometer-security
+    quarkus-integration-test-mongodb-client
+    quarkus-integration-test-mongodb-devservices
+    quarkus-integration-test-mongodb-panache
+    quarkus-integration-test-mongodb-panache-kotlin
+    quarkus-integration-test-mongodb-rest-data-panache
+    quarkus-integration-test-observability-lgtm
+    quarkus-integration-test-observability-lgtm-fixedports
+    quarkus-integration-test-observability-lgtm-prometheus
+    quarkus-integration-test-oidc-code-flow
+    quarkus-integration-test-opentelemetry
+    quarkus-integration-test-opentelemetry-exporter-logging
+    quarkus-integration-test-opentelemetry-grpc
+    quarkus-integration-test-opentelemetry-grpc-only
+    quarkus-integration-test-opentelemetry-jdbc-instrumentation
+    quarkus-integration-test-opentelemetry-minimal
+    quarkus-integration-test-opentelemetry-mongodb-client-instrumentation
+    quarkus-integration-test-opentelemetry-quartz
+    quarkus-integration-test-opentelemetry-quickstart
+    quarkus-integration-test-opentelemetry-reactive
+    quarkus-integration-test-opentelemetry-reactive-messaging
+    quarkus-integration-test-opentelemetry-redis-instrumentation
+    quarkus-integration-test-opentelemetry-scheduler
+    quarkus-integration-test-opentelemetry-spi
+    quarkus-integration-test-opentelemetry-vertx
+    quarkus-integration-test-opentelemetry-vertx-exporter
+    quarkus-integration-test-quartz
+    quarkus-integration-test-quartz-deferred-datasource
+    quarkus-integration-test-qute
+    quarkus-integration-test-reactive-messaging-context-propagation
+    quarkus-integration-test-reactive-messaging-hibernate-orm
+    quarkus-integration-test-reactive-messaging-kafka
+    quarkus-integration-test-reactive-oracle-client
+    quarkus-integration-test-rest-client
+    quarkus-integration-test-rest-client-reactive
+    quarkus-integration-test-resteasy-mutiny
+    quarkus-integration-test-resteasy-reactive-kotlin-prod-mode
+    quarkus-integration-test-resteasy-reactive-kotlin-standard
+    quarkus-integration-test-security-webauthn
+    quarkus-integration-test-smallrye-context-propagation
+    quarkus-integration-test-smallrye-graphql
+    quarkus-integration-test-smallrye-jwt-oidc-webapp
+    quarkus-integration-test-spring-data-jpa
+    quarkus-integration-test-spring-data-rest
+    quarkus-integration-test-spring-web
+    quarkus-integration-test-virtual-threads-disabled
+    quarkus-integration-test-virtual-threads-micrometer
+    quarkus-integration-test-virtual-threads-quartz
+    quarkus-integration-test-virtual-threads-reseteasy-reactive
+    quarkus-integration-test-virtual-threads-scheduler
+    quarkus-liquibase-mongodb-deployment
+    quarkus-micrometer
+    quarkus-micrometer-deployment
+    quarkus-micrometer-opentelemetry
+    quarkus-micrometer-opentelemetry-deployment
+    quarkus-micrometer-registry-prometheus
+    quarkus-micrometer-registry-prometheus-deployment
+    quarkus-mongodb-client-deployment
+    quarkus-mongodb-panache
+    quarkus-mongodb-panache-common
+    quarkus-mongodb-panache-common-deployment
+    quarkus-mongodb-panache-deployment
+    quarkus-mongodb-panache-kotlin
+    quarkus-mongodb-panache-kotlin-deployment
+    quarkus-mongodb-rest-data-panache
+    quarkus-mongodb-rest-data-panache-deployment
+    quarkus-oidc-db-token-state-manager-deployment
+    quarkus-scheduler
+    quarkus-scheduler-deployment
+    quarkus-security-jpa-deployment
+    quarkus-security-jpa-reactive
+    quarkus-security-jpa-reactive-deployment
+    quarkus-spring-data-jpa-deployment
+    quarkus-spring-data-rest-deployment
+    quarkus-spring-scheduled-deployment
+    quarkus-test-hibernate-reactive-panache
+    quarkus-quartz
+    quarkus-quartz-deployment
+    reactive-messaging-hibernate-reactive
     """
 
-# Build the comma-separated list of directories containing a pom.xml
-# This resolves sub-modules automatically
-list := shell("for dir in $1; do find \"$dir\" -name pom.xml -exec dirname {} \\;; done | paste -sd, -", modules)
+# Build the comma-separated exclusion list with !: prefix
+exclude_list := shell("echo $1 | tr -s ' \\n' '\\n' | sed '/^$/d' | sed 's/^/!:/' | paste -sd, -", skip_modules)
 
 quickly:
-    @echo "Building modules: {{list}}"
-    mvn -T4 -pl {{list}} -am clean install -Dquickly
+    @echo "Building with exclusions..."
+    mvn -T4 -pl {{exclude_list}} clean install -Dquickly
 
 test:
-    @echo "Testing modules: {{list}}"
-    mvn -pl {{list}} -am clean verify -Dtest-containers -Dstart-containers
+    @echo "Testing with exclusions..."
+    mvn -pl {{exclude_list}} clean verify -Dtest-containers -Dstart-containers
+
+dependents artifact:
+    mvn validate -pl :{{artifact}} -amd 2>&1 | sed -n 's/^\[INFO\] --- .*@ \(.*\) ---.*/\1/p' | sort -u

--- a/vertx.justfile
+++ b/vertx.justfile
@@ -145,10 +145,8 @@ skip_modules := """
     quarkus-integration-test-spring-data-jpa
     quarkus-integration-test-spring-data-rest
     quarkus-integration-test-spring-web
-    quarkus-integration-test-virtual-threads-disabled
     quarkus-integration-test-virtual-threads-micrometer
     quarkus-integration-test-virtual-threads-quartz
-    quarkus-integration-test-virtual-threads-reseteasy-reactive
     quarkus-integration-test-virtual-threads-scheduler
     quarkus-liquibase-mongodb-deployment
     quarkus-micrometer


### PR DESCRIPTION
Update `vertx.justfile` to have a list of modules to skip