### PR TITLE
Bump Agroal to 3.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -13,7 +13,7 @@
     <name>Quarkus - BOM</name>
     <packaging>pom</packaging>
 
-        <properties>
+    <properties>
         <angus-activation.version>2.0.3</angus-activation.version>
         <angus-mail.version>2.0.5</angus-mail.version> <!-- keep in sync with angus-activation (mail depends on activation) -->
         <bouncycastle.version>1.84</bouncycastle.version>
@@ -97,7 +97,7 @@
              hibernate-search.version, antlr.version, bytebuddy.version -->
         <narayana.version>7.3.3.Final</narayana.version>
         <narayana-lra.version>1.1.0.Final</narayana-lra.version>
-        <agroal.version>3.0.1</agroal.version>
+        <agroal.version>3.1</agroal.version>
         <jboss-transaction-spi.version>8.0.0.Final</jboss-transaction-spi.version>
         <elasticsearch-opensource-components.version>9.3.2</elasticsearch-opensource-components.version>
         <rxjava.version>2.2.21</rxjava.version>

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcRuntimeConfig.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcRuntimeConfig.java
@@ -175,7 +175,7 @@ public interface DataSourceJdbcRuntimeConfig {
      */
     @ConfigDocDefault("By default, multiple acquisition is allowed without any restriction.")
     @WithDefault("lenient")
-    MultipleAcquisition multipleAcquisition();
+    AgroalConnectionPoolConfiguration.MultipleAcquisitionAction multipleAcquisition();
 
     /**
      * Other unspecified properties to be passed to the JDBC driver when creating new connections.
@@ -200,33 +200,4 @@ public interface DataSourceJdbcRuntimeConfig {
      * connection is closed.
      */
     Optional<Duration> readTimeout();
-
-    enum MultipleAcquisition {
-
-        /**
-         * Allow a thread to acquire multiple connections from the pool without any restriction.
-         * This is the default.
-         */
-        LENIENT(AgroalConnectionPoolConfiguration.MultipleAcquisitionAction.OFF),
-
-        /**
-         * Log a warning when a thread that already holds a connection tries to acquire another one.
-         */
-        WARN(AgroalConnectionPoolConfiguration.MultipleAcquisitionAction.WARN),
-
-        /**
-         * Throw an exception when a thread that already holds a connection tries to acquire another one.
-         */
-        STRICT(AgroalConnectionPoolConfiguration.MultipleAcquisitionAction.STRICT);
-
-        private final AgroalConnectionPoolConfiguration.MultipleAcquisitionAction action;
-
-        MultipleAcquisition(AgroalConnectionPoolConfiguration.MultipleAcquisitionAction action) {
-            this.action = action;
-        }
-
-        public AgroalConnectionPoolConfiguration.MultipleAcquisitionAction toAgroalAction() {
-            return action;
-        }
-    }
 }

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcRuntimeConfig.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcRuntimeConfig.java
@@ -200,4 +200,14 @@ public interface DataSourceJdbcRuntimeConfig {
      * connection is closed.
      */
     Optional<Duration> readTimeout();
+
+    /**
+     * Sets the maximum duration a connection will wait for the database to reply to any one request,
+     * using the standard JDBC 4.1 {@link java.sql.Connection#setNetworkTimeout} API.
+     * <p>
+     * Unlike {@code readTimeout}, which operates at the socket/driver level for individual read operations,
+     * this timeout is managed by the JDBC {@link java.sql.Connection} object and applies to any pending
+     * database request on the connection, making it the more portable option.
+     */
+    Optional<Duration> networkTimeout();
 }

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
@@ -1,6 +1,5 @@
 package io.quarkus.agroal.runtime;
 
-import java.sql.Connection;
 import java.sql.Driver;
 import java.time.Duration;
 import java.util.Collection;
@@ -8,7 +7,6 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
-import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 
 import jakarta.enterprise.inject.Any;
@@ -358,7 +356,7 @@ public class DataSources {
             Duration timeout = dataSourceJdbcRuntimeConfig.validationQueryTimeout().orElse(Duration.ZERO);
             // Network timeout must exceed query timeout so the JDBC driver can handle the query timeout gracefully
             // before the network layer forcibly closes the connection
-            poolConfiguration.connectionValidator(sqlValidator(validationQuery, timeout,
+            poolConfiguration.connectionValidator(ConnectionValidator.sqlValidator(validationQuery, timeout,
                     timeout.isZero() ? null : timeout.plusSeconds(5L)));
         }
         poolConfiguration.validateOnBorrow(dataSourceJdbcRuntimeConfig.validateOnBorrow());
@@ -372,51 +370,10 @@ public class DataSources {
         if (dataSourceJdbcRuntimeConfig.transactionRequirement().isPresent()) {
             poolConfiguration.transactionRequirement(dataSourceJdbcRuntimeConfig.transactionRequirement().get());
         }
-        poolConfiguration.multipleAcquisition(dataSourceJdbcRuntimeConfig.multipleAcquisition().toAgroalAction());
+        poolConfiguration.multipleAcquisition(dataSourceJdbcRuntimeConfig.multipleAcquisition());
         poolConfiguration.enhancedLeakReport(dataSourceJdbcRuntimeConfig.extendedLeakReport());
         poolConfiguration.flushOnClose(dataSourceJdbcRuntimeConfig.flushOnClose());
         poolConfiguration.recoveryEnable(dataSourceJdbcRuntimeConfig.enableRecovery());
-    }
-
-    /**
-     * A validator that uses the provided SQL statement for validation with a query timeout and a configurable network timeout.
-     * If the timeout period expires before the operation completes, the connection is invalidated.
-     * A timeout of zero means no timeout.
-     * The network timeout should be greater than the query timeout to allow the query timeout to cancel the statement
-     * cleanly before the network timeout forces the socket closed.
-     */
-    static ConnectionValidator sqlValidator(String sql, Duration queryTimeout, Duration networkTimeout) {
-        return new ConnectionValidator() {
-            @Override
-            public boolean isValid(Connection connection) {
-                Executor executor = Runnable::run;
-                int originalNetworkTimeout = 0;
-                if (networkTimeout != null) {
-                    try {
-                        originalNetworkTimeout = connection.getNetworkTimeout();
-                        connection.setNetworkTimeout(executor, (int) networkTimeout.toMillis());
-                    } catch (Exception e) {
-                        log.debug("Driver does not support network timeout", e);
-                    }
-                }
-                try (var statement = connection.createStatement()) {
-                    statement.setQueryTimeout((int) queryTimeout.toSeconds());
-                    statement.execute(sql);
-                    return true;
-                } catch (Exception e) {
-                    log.debugv(e, "Failed to execute validation query: {0}", sql);
-                    return false;
-                } finally {
-                    if (networkTimeout != null) {
-                        try {
-                            connection.setNetworkTimeout(executor, originalNetworkTimeout);
-                        } catch (Exception ignore) {
-                            // already logged above
-                        }
-                    }
-                }
-            }
-        };
     }
 
     /**

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
@@ -317,6 +317,12 @@ public class DataSources {
                     .credential(new AgroalVaultCredentialsProviderPassword(name, credentialsProvider));
         }
 
+        // Set the network timeout configuration if available
+        if (dataSourceJdbcRuntimeConfig.networkTimeout().isPresent()) {
+            Duration networkTimeout = dataSourceJdbcRuntimeConfig.networkTimeout().get();
+            connectionFactoryConfiguration.networkTimeout(networkTimeout);
+        }
+
         // Additional JDBC properties from build time config
         for (Map.Entry<String, String> entry : buildTimeJdbcProperties.entrySet()) {
             connectionFactoryConfiguration.jdbcProperty(entry.getKey(), entry.getValue());


### PR DESCRIPTION
- The custom sqlValidator method is now provided by Agroal's ConnectionValidator, so the local copy can be removed.
- The AgroalConnectionPoolConfiguration.MultipleAcquisitionAction now has the LENIENT option
- Introduced a `networkTimeout()` configuration too
