### PR TITLE
Add AI skill for quarkus-mongodb-client

### DIFF
--- a/extensions/mongodb-client/deployment/src/main/resources/META-INF/quarkus-skill.md
+++ b/extensions/mongodb-client/deployment/src/main/resources/META-INF/quarkus-skill.md
@@ -1,0 +1,114 @@
+
+### Injecting the Client
+
+```java
+@Inject MongoClient mongoClient;          // blocking
+@Inject ReactiveMongoClient reactiveClient; // reactive (Mutiny-based)
+```
+
+Choose **blocking** `MongoClient` for simple CRUD with `@Blocking` REST endpoints. Choose **reactive** `ReactiveMongoClient` when returning `Uni<T>` or `Multi<T>`.
+
+### Getting a Database and Collection
+
+```java
+MongoDatabase db = mongoClient.getDatabase("mydb");
+MongoCollection<Document> collection = db.getCollection("books");
+```
+
+Set the database name in config: `quarkus.mongodb.database=mydb`. Dev Services provides the connection string automatically but does NOT set the database name — you must configure it.
+
+### CRUD Operations
+
+```java
+// Insert
+Document doc = new Document("title", "Quarkus in Action").append("author", "Someone");
+collection.insertOne(doc);
+
+// Find all
+List<Document> all = collection.find().into(new ArrayList<>());
+
+// Find by ID
+Document found = collection.find(Filters.eq("_id", new ObjectId(id))).first();
+
+// Find with filter
+List<Document> results = collection.find(Filters.eq("author", "Someone")).into(new ArrayList<>());
+
+// Delete
+collection.deleteOne(Filters.eq("_id", new ObjectId(id)));
+
+// Update
+collection.updateOne(Filters.eq("_id", new ObjectId(id)),
+    Updates.set("title", "New Title"));
+```
+
+### ObjectId Handling
+
+MongoDB's `ObjectId` does not serialize cleanly to JSON — it becomes an object, not a string. In DTOs/records, use `String` for the ID field and convert:
+
+```java
+// Document → DTO
+String id = doc.getObjectId("_id").toHexString();
+
+// DTO → filter
+Filters.eq("_id", new ObjectId(stringId));
+```
+
+### POJO Codec (Typed Collections)
+
+Quarkus auto-initializes the POJO codec — no manual `CodecRegistry` setup needed. Just request a typed collection:
+
+```java
+MongoCollection<Product> products = db.getCollection("products", Product.class);
+products.insertOne(new Product("Widget", 9.99));
+Product p = products.find(Filters.eq("name", "Widget")).first();
+```
+
+This works for both blocking and reactive clients. POJO classes need a no-arg constructor and public getters/setters (or be records with `@BsonCreator`).
+
+### Reactive Client
+
+```java
+@Inject ReactiveMongoClient reactiveClient;
+
+public Uni<List<Document>> listAll() {
+    return reactiveClient.getDatabase("mydb")
+        .getCollection("books")
+        .find().collect().asList();
+}
+```
+
+### Aggregation
+
+```java
+collection.aggregate(List.of(
+    Aggregates.match(Filters.eq("category", "electronics")),
+    Aggregates.group("$category", Accumulators.avg("avgPrice", "$price"))
+)).into(new ArrayList<>());
+```
+
+### Dev Services
+
+MongoDB Dev Service starts automatically in dev and test mode using a `mongo:7.0` container. The connection string is auto-configured. Set `quarkus.mongodb.database` in `application.properties` — this is NOT auto-configured by Dev Services.
+
+### Multiple Named Clients
+
+```properties
+quarkus.mongodb.clients.inventory.connection-string=mongodb://...
+quarkus.mongodb.clients.inventory.database=inventory
+```
+
+```java
+@Inject @MongoClientName("inventory") MongoClient inventoryClient;
+```
+
+### Testing
+
+- Dev Services provides a real MongoDB in tests — no mocking needed.
+- For test isolation, clear collections in `@BeforeEach` or use unique collection names.
+
+### Common Pitfalls
+
+- `quarkus.mongodb.database` must be set explicitly — Dev Services only provides the connection string.
+- `ObjectId` does not serialize to JSON as a string — use `toHexString()` in your DTOs.
+- `find().into(new ArrayList<>())` collects results; `find().first()` returns a single document or null.
+- The blocking `MongoClient` must not be used on the event loop thread — use `@Blocking` on REST endpoints or use `ReactiveMongoClient` instead.


### PR DESCRIPTION
This adds an AI skill file (`quarkus-skill.md`) for the `quarkus-mongodb-client` extension, helping AI coding assistants guide developers using the MongoDB client API directly (without Panache).

## Process

1. **Tester agent** (Sonnet) built a book catalog with raw MongoClient — rated SIGNIFICANT FRICTION
2. **Verification** of all claims against source code
3. **Skill creation** based on verified findings
4. **Validation agent** (Sonnet) built a multi-collection app with POJO codec, reactive client, and aggregation — 20/20 tests passing, rated EXCELLENT

## What the tester struggled with

- **Docs focused on Panache**: Searches consistently returned Panache results rather than raw MongoClient patterns. The tester had to rely on prior MongoDB Java driver knowledge.
- **ObjectId serialization**: MongoDB's ObjectId serializes as an object in JSON, not a string. Caused a `ProxyMap` cast error that took significant debugging time.
- **Database name not auto-configured**: Dev Services provides the connection string but NOT the database name — not obvious and caused confusion.

## What the skill teaches

- Blocking `MongoClient` vs reactive `ReactiveMongoClient` selection guidance
- Database/collection access and `quarkus.mongodb.database` requirement
- Complete CRUD examples with `Document` API
- ObjectId handling pattern (use `String` in DTOs, convert with `toHexString()`)
- POJO codec: Quarkus auto-initializes it — no manual codec registry needed
- Reactive client patterns with Mutiny types
- Aggregation pipeline examples
- Multiple named clients with `@MongoClientName`
- Dev Services and testing guidance

## Key verification results

- All tester claims verified correctly
- Validator found that the initial POJO codec example was misleading (showed manual setup when Quarkus auto-initializes) — fixed to show the simpler pattern

## Validation result

- **Rating**: Excellent (9/10)
- **Tests**: 20/20 passing on advanced scenario
- **Scenario tested**: Multi-collection POJO codec, reactive client, aggregation with $lookup/$group/$avg
- **Dev Services**: MongoDB started automatically, worked flawlessly

Closes https://github.com/quarkusio/quarkus/issues/54021