### PR TITLE
Add AI skill for quarkus-redis-client

### DIFF
--- a/extensions/redis-client/deployment/src/main/resources/META-INF/quarkus-skill.md
+++ b/extensions/redis-client/deployment/src/main/resources/META-INF/quarkus-skill.md
@@ -1,0 +1,123 @@
+
+### Injecting the Data Source
+
+```java
+@Inject RedisDataSource redis;          // blocking (imperative)
+@Inject ReactiveRedisDataSource reactive; // reactive (Mutiny-based)
+```
+
+### Command Groups
+
+Access Redis commands through typed groups on `RedisDataSource`:
+
+```java
+HashCommands<String, String, String> hash = redis.hash(String.class);
+ValueCommands<String, String> values = redis.value(String.class);
+KeyCommands<String> keys = redis.key();
+SortedSetCommands<String, String> sortedSets = redis.sortedSet(String.class);
+ListCommands<String, String> lists = redis.list(String.class);
+SetCommands<String, String> sets = redis.set(String.class);
+```
+
+The type parameter is the value type. Key type defaults to `String`. For non-string keys, use the full form: `redis.hash(UUID.class, String.class, Person.class)`.
+
+### Hash Operations
+
+```java
+// Set fields
+hash.hset("user:1", "name", "Alice");
+hash.hset("user:1", Map.of("name", "Alice", "role", "admin"));
+
+// Get fields
+String name = hash.hget("user:1", "name");
+Map<String, String> all = hash.hgetall("user:1");
+
+// Delete fields
+hash.hdel("user:1", "role");
+```
+
+### Value (String) Operations
+
+```java
+ValueCommands<String, String> values = redis.value(String.class);
+values.set("greeting", "hello");
+String v = values.get("greeting");
+
+// Counters
+ValueCommands<String, Long> counters = redis.value(Long.class);
+counters.incr("counter");           // increment by 1
+counters.incrby("counter", 5);      // increment by N
+Long count = counters.get("counter"); // may be null if key doesn't exist
+```
+
+### Key Operations
+
+```java
+KeyCommands<String> keys = redis.key();
+keys.expire("session:abc", Duration.ofMinutes(30));  // set TTL
+keys.del("session:abc");                              // delete
+boolean exists = keys.exists("session:abc");
+List<String> matching = keys.keys("session:*");       // find by pattern
+```
+
+### Sorted Set Operations (Leaderboards)
+
+```java
+SortedSetCommands<String, String> zset = redis.sortedSet(String.class);
+zset.zadd("leaderboard", 100.0, "player1");           // zadd(key, score, member)
+zset.zadd("leaderboard", 250.0, "player2");
+List<String> top = zset.zrange("leaderboard", 0, 9);  // ascending
+// Descending (for leaderboards): use ZRangeArgs
+List<ScoredValue<String>> topWithScores = zset.zrangeWithScores("leaderboard", 0, 9, new ZRangeArgs().rev());
+OptionalDouble score = zset.zscore("leaderboard", "player1");  // returns OptionalDouble
+OptionalLong rank = zset.zrevrank("leaderboard", "player1");   // returns OptionalLong, 0-based
+```
+
+Note: `zadd` takes **score first, then member**. `zscore`/`zrank`/`zrevrank` return `Optional` types.
+
+### List Operations
+
+```java
+ListCommands<String, String> list = redis.list(String.class);
+list.lpush("activity", "event1", "event2");     // push to head
+List<String> recent = list.lrange("activity", 0, 19);  // get range
+list.ltrim("activity", 0, 99);                  // keep only last 100
+```
+
+### Pub/Sub
+
+```java
+PubSubCommands<String> pubsub = redis.pubsub(String.class);
+pubsub.publish("channel", "message");
+
+// Subscribe (returns a subscriber that can be cancelled)
+PubSubCommands.RedisSubscriber subscriber = pubsub.subscribe("channel", message -> {
+    System.out.println("Received: " + message);
+});
+// Later: subscriber.unsubscribe();
+```
+
+### Reactive API
+
+All command groups have reactive equivalents returning `Uni<T>` or `Multi<T>`:
+
+```java
+ReactiveHashCommands<String, String, String> hash = reactive.hash(String.class);
+Uni<Map<String, String>> data = hash.hgetall("user:1");
+```
+
+### Dev Services
+
+Redis Dev Service starts automatically in dev and test mode — no configuration needed.
+
+### Testing
+
+- Dev Services provides a real Redis in tests — no mocking needed.
+- Clear keys in `@BeforeEach` for test isolation: `redis.flushall()`.
+
+### Common Pitfalls
+
+- `value.get()` returns `null` for non-existent keys — handle null when using counters.
+- Command group instances are lightweight — create them per method call or cache in constructor.
+- Use `key().keys("pattern*")` sparingly in production — it scans all keys. Use `SCAN` for large datasets.
+- The blocking `RedisDataSource` must not be used on the event loop — use `@Blocking` on REST endpoints or use `ReactiveRedisDataSource`.


### PR DESCRIPTION
This adds an AI skill file (`quarkus-skill.md`) for the `quarkus-redis-client` extension, helping AI coding assistants guide developers through Redis data structure operations.

## Process

1. **Tester agent** (Sonnet) built a session store with hashes, counters, and TTL — rated SOME FRICTION
2. **Verification** of all claims against source code
3. **Skill creation** based on verified findings
4. **Validation agent** (Sonnet) built a gaming leaderboard with sorted sets, lists, pub/sub, and reactive API — 21/21 tests passing

## What the tester struggled with

- **API discovery**: The typed command group pattern (`redis.hash(String.class)`, `redis.key()`, etc.) was not obvious without docs
- **TTL management**: Finding the right method for setting expiration (`keys.expire(key, Duration)`) required guessing
- **Docs focused on Panache**: Search results often returned unrelated results

## What the skill teaches

- `RedisDataSource` (blocking) vs `ReactiveRedisDataSource` (Mutiny) injection
- Typed command groups: hash, value, key, sorted set, list, set, pub/sub
- Hash operations (hset, hget, hgetall, hdel)
- Value/counter operations (set, get, incr, incrby)
- Key operations (expire, del, exists, keys)
- Sorted set operations with correct `zadd(key, score, member)` parameter order, `OptionalDouble`/`OptionalLong` returns, and `ZRangeArgs` for reverse ranges
- List operations (lpush, lrange, ltrim)
- Pub/Sub publish and subscribe patterns
- Dev Services and testing guidance

## Key verification results

- Initial skill had wrong `zadd` parameter order (`zadd(key, member, score)` vs correct `zadd(key, score, member)`) — fixed after validator caught it
- `zscore` returns `OptionalDouble`, `zrank`/`zrevrank` return `OptionalLong` — not `Double`/`Long` — fixed
- `zrevrangeWithScores` doesn't exist — must use `zrangeWithScores(key, start, stop, new ZRangeArgs().rev())` — fixed

## Validation result

- **Rating**: Good (updated from needs-work after fixing sorted set API)
- **Tests**: 21/21 passing on advanced scenario
- **Scenario tested**: Gaming leaderboard with sorted sets, player profiles with hashes, activity feed with lists, pub/sub notifications, reactive API
- **Dev Services**: Redis started automatically in ~370ms

Closes https://github.com/quarkusio/quarkus/issues/54023