### PR TITLE
Make it possible to reuse OIDC token verification code for some SD-JWT tokens

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
@@ -184,6 +184,14 @@ public class OidcProvider implements Closeable {
                 asymmetricKeyResolver, true, oidcConfig.token().issuedAtRequired());
     }
 
+    public TokenVerificationResult verifyJwtToken(String token, boolean enforceAudienceVerification, boolean subjectRequired,
+            String nonce, boolean enforceExpReq)
+            throws InvalidJwtException {
+        return verifyJwtTokenInternal(customizeJwtToken(token), enforceAudienceVerification, subjectRequired, nonce,
+                (requiredAlgorithmConstraints != null ? requiredAlgorithmConstraints : ASYMMETRIC_ALGORITHM_CONSTRAINTS),
+                asymmetricKeyResolver, enforceExpReq, oidcConfig.token().issuedAtRequired());
+    }
+
     public TokenVerificationResult verifyLogoutJwtToken(String token) throws InvalidJwtException {
         final boolean enforceExpReq = !oidcConfig.token().age().isPresent();
         TokenVerificationResult result = verifyJwtTokenInternal(token, true, false, null, ASYMMETRIC_ALGORITHM_CONSTRAINTS,


### PR DESCRIPTION
This PR is only adding one more call option for the OIDC provider to facilitate reusing token verification code for verifying SD-JWT credential and/or key binding token signatures, as some of these tokens do not have an expiry claim - but the application has a token age property configured instead - that is enforced in this code