### PR TITLE
Cleanup stacktraces of REST client tests

### DIFF
--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/ClientMultipleBodyParamLogMessageTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/ClientMultipleBodyParamLogMessageTest.java
@@ -17,7 +17,10 @@ class ClientMultipleBodyParamLogMessageTest {
     @RegisterExtension
     static final QuarkusExtensionTest TEST = new QuarkusExtensionTest()
             .withApplicationRoot((jar) -> jar
-                    .addClass(Client.class));
+                    .addClass(Client.class))
+            .overrideConfigKey(
+                    "quarkus.log.category.\"org.jboss.resteasy.reactive.common.processor.EndpointIndexer\".level",
+                    "OFF");
 
     @Test
     void basicTest() {

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/error/BlockingExceptionMapperTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/error/BlockingExceptionMapperTest.java
@@ -49,10 +49,11 @@ public class BlockingExceptionMapperTest {
                             ClientResource.class,
                             Resource.class)
                     .addAsResource(
-                            new StringAsset(setUrlForClass(ClientUsingNotBlockingExceptionMapper.class) + "\n"
-                                    + setUrlForClass(ClientUsingBlockingExceptionMapper.class) + "\n"
-                                    + setUrlForClass(ClientUsingBlockingExceptionMapperWithAnnotation.class) + "\n"
-                                    + setUrlForClass(ClientUsingBothExceptionMappers.class) + "\n"),
+                            new StringAsset(setUrlForClass(ClientUsingNotBlockingExceptionMapper.class)
+                                    + setUrlForClass(ClientUsingBlockingExceptionMapper.class)
+                                    + setUrlForClass(ClientUsingBlockingExceptionMapperWithAnnotation.class)
+                                    + setUrlForClass(ClientUsingBothExceptionMappers.class)
+                                    + "quarkus.log.category.\"io.quarkus.vertx.http.runtime.QuarkusErrorHandler\".level=OFF\n"),
                             "application.properties"));
 
     public static final String ERROR_MESSAGE = "The entity was not found";

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/lock/prevention/RestClientReactiveBlockingTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/lock/prevention/RestClientReactiveBlockingTest.java
@@ -16,7 +16,8 @@ public class RestClientReactiveBlockingTest {
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withApplicationRoot((jar) -> jar
                     .addPackage(TestClient.class.getPackage())
-                    .addAsResource(new StringAsset(setUrlForClass(TestClient.class)),
+                    .addAsResource(new StringAsset(setUrlForClass(TestClient.class)
+                            + "quarkus.log.category.\"io.quarkus.vertx.http.runtime.QuarkusErrorHandler\".level=OFF\n"),
                             "application.properties"));
 
     @Timeout(5) // it should end immediately, not after rest client timeout

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/multipart/MultiByteFileTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/multipart/MultiByteFileTest.java
@@ -37,6 +37,7 @@ import io.quarkus.test.common.http.TestHTTPResource;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.subscription.MultiEmitter;
 import io.vertx.core.Vertx;
+import io.vertx.core.VertxException;
 
 public class MultiByteFileTest {
     public static final int BYTES_SENT = 5_000_000; // 5 megs
@@ -137,7 +138,7 @@ public class MultiByteFileTest {
                 () -> {
                     long iteration = i.getAndIncrement();
                     if (iteration > BYTES_SENT / 2) {
-                        throw new RuntimeException("forced");
+                        throw VertxException.noStackTrace("forced");
                     }
                     return (byte) ((iteration + 1) % 123);
                 }).atMost(BYTES_SENT);

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/multipart/MultipartResponseTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/multipart/MultipartResponseTest.java
@@ -41,6 +41,7 @@ import io.quarkus.rest.client.reactive.TestJacksonBasicMessageBodyWriter;
 import io.quarkus.test.QuarkusExtensionTest;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.smallrye.mutiny.Uni;
+import io.vertx.core.VertxException;
 
 public class MultipartResponseTest {
 
@@ -320,7 +321,7 @@ public class MultipartResponseTest {
         @Produces(MediaType.MULTIPART_FORM_DATA)
         @Path("/error")
         public MultipartData throwError() {
-            throw new RuntimeException("forced error");
+            throw VertxException.noStackTrace("forced error");
         }
 
         private static File createTempFileToDownload() throws IOException {

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/resources/stork-application.properties
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/resources/stork-application.properties
@@ -3,3 +3,5 @@ quarkus.stork.hello-service.service-discovery.address-list=${quarkus.http.host}:
 quarkus.stork.hello-service.load-balancer.type=least-response-time
 
 hello2/mp-rest/url=stork://hello-service/hello
+
+quarkus.log.category."org.jboss.resteasy.reactive.client.impl.StorkClientRequestFilter".level=OFF


### PR DESCRIPTION
This is done in order to make it easier to identify real issues that might be buried
in the test logs
