### PR TITLE
Fix NPE in GraphQL source field resolvers when `CompletionStage` completes off the Vert.x event loop

### DIFF
--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/CompletionStageWithBlockingSourceTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/CompletionStageWithBlockingSourceTest.java
@@ -1,0 +1,177 @@
+package io.quarkus.smallrye.graphql.deployment;
+
+import static io.quarkus.smallrye.graphql.deployment.AbstractGraphQLTest.getPropertyAsString;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.graphql.Source;
+import org.hamcrest.CoreMatchers;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+
+/**
+ * Reproducer for https://github.com/quarkusio/quarkus/issues/44762
+ *
+ * When a {@code @Query} returns {@link CompletionStage} via
+ * {@link CompletableFuture#supplyAsync}, the future completes on
+ * {@code ForkJoinPool.commonPool} where {@code Vertx.currentContext()}
+ * is null. Blocking {@code @Source} field resolvers that run as
+ * downstream continuations then NPE in
+ * {@code BlockingHelper.runBlocking} because the Vert.x context is null.
+ */
+public class CompletionStageWithBlockingSourceTest extends AbstractGraphQLTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(PersonGraphQLApi.class, Person.class, Score.class)
+                    .addAsResource(new StringAsset(getPropertyAsString()), "application.properties")
+                    .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"));
+
+    @Test
+    public void testAsyncQueryWithBlockingSource() {
+        String request = getPayload("{\n" +
+                "  person(id: 0) {\n" +
+                "    name\n" +
+                "    score {\n" +
+                "      name\n" +
+                "      value\n" +
+                "    }\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given()
+                .when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(request)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .body(CoreMatchers.containsString("Alice"),
+                        CoreMatchers.containsString("math"),
+                        CoreMatchers.containsString("95"));
+    }
+
+    @Test
+    public void testAsyncQueryWithBlockingBatchSource() {
+        String request = getPayload("{\n" +
+                "  people {\n" +
+                "    name\n" +
+                "    score {\n" +
+                "      name\n" +
+                "      value\n" +
+                "    }\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given()
+                .when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(request)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .body(CoreMatchers.containsString("Alice"),
+                        CoreMatchers.containsString("Bob"),
+                        CoreMatchers.containsString("math"),
+                        CoreMatchers.containsString("95"),
+                        CoreMatchers.containsString("history"),
+                        CoreMatchers.containsString("88"));
+    }
+
+    @GraphQLApi
+    public static class PersonGraphQLApi {
+
+        @Query
+        public CompletionStage<Person> getPerson(long id) {
+            return supplyAsync(() -> Person.ALL.get((int) id));
+        }
+
+        @Query
+        public CompletionStage<List<Person>> getPeople() {
+            return supplyAsync(() -> new ArrayList<>(Person.ALL));
+        }
+
+        // Completes the future on a non-Vert.x thread (ForkJoinPool) with a
+        // delay so graphql-java attaches its continuations first — the source
+        // field resolvers then run where Vertx.currentContext() is null.
+        // The TCCL is propagated to avoid classloading issues in the test env.
+        private static <T> CompletionStage<T> supplyAsync(java.util.function.Supplier<T> supplier) {
+            ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+            return CompletableFuture.supplyAsync(() -> {
+                Thread.currentThread().setContextClassLoader(tccl);
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                return supplier.get();
+            });
+        }
+
+        public Score getScore(@Source Person person) {
+            return Score.forPerson(person.name);
+        }
+
+        public List<Score> getScore(@Source List<Person> people) {
+            List<Score> scores = new ArrayList<>();
+            for (Person person : people) {
+                scores.add(Score.forPerson(person.name));
+            }
+            return scores;
+        }
+    }
+
+    public static class Person {
+        static final List<Person> ALL = List.of(
+                new Person("Alice"),
+                new Person("Bob"));
+
+        public String name;
+
+        public Person() {
+        }
+
+        public Person(String name) {
+            this.name = name;
+        }
+    }
+
+    public static class Score {
+        public String name;
+        public int value;
+
+        public Score() {
+        }
+
+        public Score(String name, int value) {
+            this.name = name;
+            this.value = value;
+        }
+
+        static Score forPerson(String personName) {
+            return switch (personName) {
+                case "Alice" -> new Score("math", 95);
+                case "Bob" -> new Score("history", 88);
+                default -> new Score("unknown", 0);
+            };
+        }
+    }
+}

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/BlockingHelper.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/BlockingHelper.java
@@ -21,7 +21,7 @@ public final class BlockingHelper {
 
     public static boolean nonBlockingShouldExecuteBlocking(Operation operation, Context vc) {
         // Rule is that by default this should execute non-blocking except if marked as blocking
-        return operation.getExecute().equals(Execute.BLOCKING) && vc.isEventLoopContext();
+        return vc != null && operation.getExecute().equals(Execute.BLOCKING) && vc.isEventLoopContext();
     }
 
     public static boolean shouldUseVirtualThread(Operation operation, Context vc) {
@@ -42,9 +42,16 @@ public final class BlockingHelper {
                     result.fail(t);
                 }
             });
-        } else {
-            // use regular blocking execution
+        } else if (vc != null) {
             vc.executeBlocking(contextualCallable).onComplete(result);
+        } else {
+            // No Vert.x context (e.g. ForkJoinPool thread after CompletableFuture.supplyAsync) —
+            // already off the event loop, safe to execute directly
+            try {
+                result.complete(contextualCallable.call());
+            } catch (Throwable t) {
+                result.fail(t);
+            }
         }
     }
 }

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/QuarkusCompletionStageDataFetcher.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/QuarkusCompletionStageDataFetcher.java
@@ -23,7 +23,7 @@ public class QuarkusCompletionStageDataFetcher<K, T> extends AbstractAsyncDataFe
     @Override
     protected Uni<?> handleUserMethodCall(DataFetchingEnvironment dfe, Object[] transformedArguments) throws Exception {
         Context vc = Vertx.currentContext();
-        if (runBlocking(dfe) || !BlockingHelper.nonBlockingShouldExecuteBlocking(operation, vc)) {
+        if (vc == null || runBlocking(dfe) || !BlockingHelper.nonBlockingShouldExecuteBlocking(operation, vc)) {
             return handleUserMethodCallNonBlocking(transformedArguments);
         } else {
             return handleUserMethodCallBlocking(transformedArguments, vc);
@@ -33,7 +33,7 @@ public class QuarkusCompletionStageDataFetcher<K, T> extends AbstractAsyncDataFe
     @Override
     protected Uni<List<T>> handleUserBatchLoad(DataFetchingEnvironment dfe, Object[] arguments) throws Exception {
         Context vc = Vertx.currentContext();
-        if (runBlocking(dfe) || !BlockingHelper.nonBlockingShouldExecuteBlocking(operation, vc)) {
+        if (vc == null || runBlocking(dfe) || !BlockingHelper.nonBlockingShouldExecuteBlocking(operation, vc)) {
             return handleUserBatchLoadNonBlocking(arguments);
         } else {
             return handleUserBatchLoadBlocking(arguments, vc);

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/QuarkusDefaultDataFetcher.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/QuarkusDefaultDataFetcher.java
@@ -41,7 +41,7 @@ public class QuarkusDefaultDataFetcher<K, T> extends DefaultDataFetcher<K, T> {
         try {
             RequestContextHelper.reactivate(requestContext, dfe);
             Context vc = Vertx.currentContext();
-            if (runBlocking(dfe) || BlockingHelper.blockingShouldExecuteNonBlocking(operation, vc)) {
+            if (vc == null || runBlocking(dfe) || BlockingHelper.blockingShouldExecuteNonBlocking(operation, vc)) {
                 return super.invokeAndTransform(c, dfe, resultBuilder, transformedArguments);
             } else {
                 return invokeAndTransformBlocking(c, dfe, resultBuilder, transformedArguments, vc);
@@ -58,7 +58,7 @@ public class QuarkusDefaultDataFetcher<K, T> extends DefaultDataFetcher<K, T> {
         try {
             RequestContextHelper.reactivate(requestContext, dfe);
             Context vc = Vertx.currentContext();
-            if (runBlocking(dfe) || BlockingHelper.blockingShouldExecuteNonBlocking(operation, vc)) {
+            if (vc == null || runBlocking(dfe) || BlockingHelper.blockingShouldExecuteNonBlocking(operation, vc)) {
                 return super.invokeBatch(dfe, arguments);
             } else {
                 return invokeBatchBlocking(dfe, arguments, vc);

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/QuarkusUniDataFetcher.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/QuarkusUniDataFetcher.java
@@ -22,7 +22,7 @@ public class QuarkusUniDataFetcher<K, T> extends AbstractAsyncDataFetcher<K, T> 
     @Override
     protected Uni<?> handleUserMethodCall(DataFetchingEnvironment dfe, Object[] transformedArguments) throws Exception {
         Context vc = Vertx.currentContext();
-        if (runBlocking(dfe) || !BlockingHelper.nonBlockingShouldExecuteBlocking(operation, vc)) {
+        if (vc == null || runBlocking(dfe) || !BlockingHelper.nonBlockingShouldExecuteBlocking(operation, vc)) {
             return handleUserMethodCallNonBlocking(transformedArguments);
         } else {
             return handleUserMethodCallBlocking(transformedArguments, vc);
@@ -32,7 +32,7 @@ public class QuarkusUniDataFetcher<K, T> extends AbstractAsyncDataFetcher<K, T> 
     @Override
     protected Uni<List<T>> handleUserBatchLoad(DataFetchingEnvironment dfe, Object[] arguments) throws Exception {
         Context vc = Vertx.currentContext();
-        if (runBlocking(dfe) || !BlockingHelper.nonBlockingShouldExecuteBlocking(operation, vc)) {
+        if (vc == null || runBlocking(dfe) || !BlockingHelper.nonBlockingShouldExecuteBlocking(operation, vc)) {
             return handleUserBatchLoadNonBlocking(arguments);
         } else {
             return handleUserBatchLoadBlocking(arguments, vc);


### PR DESCRIPTION
When a `@Query` returns a `CompletionStage` via `CompletableFuture.supplyAsync()`, the future completes on `ForkJoinPool.commonPool` where `Vertx.currentContext()` is null. If that query has blocking `@Source` field resolvers, graphql-java chains them as continuations on the same ForkJoinPool thread. The data fetchers then pass the null Vert.x context to `BlockingHelper.runBlocking()`, which calls `vc.executeBlocking()` and throws a `NullPointerException`.

When there is no Vert.x context, we are already on a non-event-loop thread, so blocking execution is safe to perform directly without scheduling through Vert.x. This commit adds null guards to all data fetcher classes so they short-circuit to direct execution when the context is absent.

Fixes: #44762
