### PR TITLE
fix(logging-json): add mdc.flat-fields option and promote OTel trace fields to ECS root paths

### DIFF
--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -482,6 +482,23 @@ The possible values are:
 
 * *default*: Generates structured logs based on the `key,values` present in the log record.
 Mapped Diagnostic Context (MDC) and Nested Diagnostic Context (NDC) data are included under the `mdc` and `ndc` fields.
++
+Set `quarkus.log.console.json.mdc.flat-fields=true` to write MDC entries as root-level JSON fields instead of nesting them under `mdc`.
+This is useful when a log aggregator (such as OpenSearch or Elasticsearch) needs MDC fields to be queryable as top-level document fields.
++
+.Example: nested MDC (default, `flat-fields=false`)
+[source,json]
+----
+{"timestamp":"...","message":"Handling request","mdc":{"requestId":"abc123","userId":"42"}}
+----
++
+.Example: flat MDC (`flat-fields=true`)
+[source,json]
+----
+{"timestamp":"...","message":"Handling request","requestId":"abc123","userId":"42"}
+----
++
+The option is available for all handler types: `quarkus.log.console.json.mdc.flat-fields`, `quarkus.log.file.json.mdc.flat-fields`, `quarkus.log.syslog.json.mdc.flat-fields`, `quarkus.log.socket.json.mdc.flat-fields`, and named handlers such as `quarkus.log.handler.console.<name>.json.mdc.flat-fields`.
 * *ecs*: Uses the link:https://www.elastic.co/docs/reference/ecs/ecs-field-reference[Elastic Common Schema (ECS)] format.
 This format modifies some default field names and adds other fields to align with ECS.
 +

--- a/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/ConsoleJsonFormatterFlatMdcTest.java
+++ b/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/ConsoleJsonFormatterFlatMdcTest.java
@@ -1,0 +1,92 @@
+package io.quarkus.logging.json;
+
+import static io.quarkus.logging.json.ConsoleJsonFormatterDefaultConfigTest.getJsonFormatter;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.logging.Level;
+
+import org.jboss.logmanager.ExtLogRecord;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkus.logging.json.runtime.JsonFormatter;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class ConsoleJsonFormatterFlatMdcTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar.addClasses(ConsoleJsonFormatterDefaultConfigTest.class))
+            .withConfigurationResource("application-console-json-formatter-flat-mdc.properties");
+
+    @Test
+    public void flatMdcEnabledConfigTest() {
+        JsonFormatter jsonFormatter = getJsonFormatter();
+        assertThat(jsonFormatter.isFlatMdc()).isTrue();
+    }
+
+    @Test
+    public void flatMdcFieldsAtRootLevelTest() throws Exception {
+        JsonFormatter jsonFormatter = getJsonFormatter();
+
+        ExtLogRecord record = new ExtLogRecord(Level.INFO, "flat MDC test", ConsoleJsonFormatterFlatMdcTest.class.getName());
+        record.putMdc("requestId", "abc123");
+        record.putMdc("userId", "42");
+
+        String line = jsonFormatter.format(record);
+        JsonNode node = new ObjectMapper().readTree(line);
+
+        // MDC wrapper object must not be present
+        assertThat(node.has("mdc")).isFalse();
+
+        // Each MDC entry must be a root-level field
+        assertThat(node.has("requestId")).isTrue();
+        assertThat(node.get("requestId").asText()).isEqualTo("abc123");
+        assertThat(node.has("userId")).isTrue();
+        assertThat(node.get("userId").asText()).isEqualTo("42");
+
+        // Standard fields are still present
+        assertThat(node.has("message")).isTrue();
+        assertThat(node.get("message").asText()).isEqualTo("flat MDC test");
+    }
+
+    @Test
+    public void flatMdcEmptyMdcProducesNoExtraFieldsTest() throws Exception {
+        // Create the formatter directly so this test is self-contained.
+        JsonFormatter formatter = new JsonFormatter();
+        formatter.setFlatMdc(true);
+
+        // An ExtLogRecord with no putMdc() calls; the MDC map comes from the
+        // thread-local MDC which is empty in this test context.
+        ExtLogRecord record = new ExtLogRecord(Level.INFO, "no MDC",
+                ConsoleJsonFormatterFlatMdcTest.class.getName());
+
+        String line = formatter.format(record);
+        JsonNode node = new ObjectMapper().readTree(line);
+
+        // With flat-mdc=true and an empty MDC map, neither the "mdc" wrapper
+        // nor any flat MDC fields should appear.
+        assertThat(node.has("mdc")).isFalse();
+        assertThat(node.get("message").asText()).isEqualTo("no MDC");
+    }
+
+    @Test
+    public void defaultBehaviorKeepsMdcNestedTest() throws Exception {
+        // Regression: a formatter without flat-mdc enabled must still produce nested MDC.
+        JsonFormatter formatter = new JsonFormatter();
+        assertThat(formatter.isFlatMdc()).isFalse();
+
+        ExtLogRecord record = new ExtLogRecord(Level.INFO, "nested MDC test",
+                ConsoleJsonFormatterFlatMdcTest.class.getName());
+        record.putMdc("traceId", "xyz789");
+
+        String line = formatter.format(record);
+        JsonNode node = new ObjectMapper().readTree(line);
+
+        assertThat(node.has("mdc")).isTrue();
+        assertThat(node.get("mdc").get("traceId").asText()).isEqualTo("xyz789");
+    }
+}

--- a/extensions/logging-json/deployment/src/test/resources/application-console-json-formatter-flat-mdc.properties
+++ b/extensions/logging-json/deployment/src/test/resources/application-console-json-formatter-flat-mdc.properties
@@ -1,5 +1,5 @@
 quarkus.log.level=INFO
 quarkus.log.console.enabled=true
-quarkus.log.console.level=ALL
+quarkus.log.console.level=WARNING
 quarkus.log.console.json.enabled=true
 quarkus.log.console.json.mdc.flat-fields=true

--- a/extensions/logging-json/deployment/src/test/resources/application-console-json-formatter-flat-mdc.properties
+++ b/extensions/logging-json/deployment/src/test/resources/application-console-json-formatter-flat-mdc.properties
@@ -1,0 +1,5 @@
+quarkus.log.level=INFO
+quarkus.log.console.enabled=true
+quarkus.log.console.level=ALL
+quarkus.log.console.json.enabled=true
+quarkus.log.console.json.mdc.flat-fields=true

--- a/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/JsonFormatter.java
+++ b/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/JsonFormatter.java
@@ -30,6 +30,7 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
     private Map<String, AdditionalField> additionalFields;
     private LogFormat logFormat = LogFormat.DEFAULT;
     private String tracePrefix = "";
+    private boolean flatMdc = false;
     private List<JsonProvider> discoveredProviders = Collections.emptyList();
     private volatile List<JsonProvider> jsonProviders;
 
@@ -126,10 +127,18 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
         this.tracePrefix = tracePrefix;
     }
 
+    public boolean isFlatMdc() {
+        return flatMdc;
+    }
+
+    public void setFlatMdc(boolean flatMdc) {
+        this.flatMdc = flatMdc;
+    }
+
     @Override
     protected Generator createGenerator(final Writer writer) {
         Generator superGenerator = super.createGenerator(writer);
-        return new FormatterJsonGenerator(superGenerator, this.excludedKeys);
+        return new FormatterJsonGenerator(superGenerator, this.excludedKeys, this.flatMdc);
     }
 
     @Override
@@ -290,10 +299,12 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
 
         private final Generator delegate;
         private final Set<String> excludedKeys;
+        private final boolean flatMdc;
 
-        private FormatterJsonGenerator(final Generator delegate, final Set<String> excludedKeys) {
+        private FormatterJsonGenerator(final Generator delegate, final Set<String> excludedKeys, final boolean flatMdc) {
             this.delegate = delegate;
             this.excludedKeys = excludedKeys;
+            this.flatMdc = flatMdc;
         }
 
         @Override
@@ -321,7 +332,16 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
         @Override
         public Generator add(final String key, final Map<String, ?> value) throws Exception {
             if (!excludedKeys.contains(key)) {
-                delegate.add(key, value);
+                if (flatMdc && value != null && !value.isEmpty()) {
+                    for (Map.Entry<String, ?> entry : value.entrySet()) {
+                        Object v = entry.getValue();
+                        if (v != null) {
+                            delegate.add(entry.getKey(), v.toString());
+                        }
+                    }
+                } else if (!flatMdc) {
+                    delegate.add(key, value);
+                }
             }
             return this;
         }

--- a/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/JsonLogConfig.java
+++ b/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/JsonLogConfig.java
@@ -202,6 +202,17 @@ public interface JsonLogConfig extends LogRuntimeConfig {
         @WithDefault("default")
         LogFormat logFormat();
 
+        /**
+         * When true, MDC entries are written as root-level JSON fields instead of being grouped under a
+         * nested {@code "mdc"} object.
+         * <p>
+         * This is useful when log aggregators (such as OpenSearch or Elasticsearch) expect MDC fields to
+         * be queryable as top-level document fields rather than nested properties.
+         */
+        @WithDefault("false")
+        @WithName("mdc.flat-fields")
+        boolean mdcFlatFields();
+
         enum LogFormat {
             DEFAULT,
             ECS,

--- a/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/LoggingJsonRecorder.java
+++ b/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/LoggingJsonRecorder.java
@@ -139,6 +139,7 @@ public class LoggingJsonRecorder {
         if (JsonConfig.LogFormat.GCP == config.logFormat()) {
             formatter.setTracePrefix("projects/" + applicationConfig.getValue().name().orElse("") + "/traces/");
         }
+        formatter.setFlatMdc(config.mdcFlatFields());
         formatter.setExcludedKeys(overridableJsonConfig.excludedKeys());
         formatter.setAdditionalFields(overridableJsonConfig.additionalFields());
         formatter.setDiscoveredProviders(providers);


### PR DESCRIPTION
## Summary

Two related improvements to the JSON logging formatter:

**1. General MDC flattening (`mdc.flat-fields`)**

Adds `quarkus.log.console.json.mdc.flat-fields=true` to write all MDC entries as root-level JSON fields instead of nesting them under the `mdc` object. Useful for log pipelines that expect flat documents (e.g. OpenSearch/Elasticsearch index mappings without nested field support).

Fixes #37465.

**2. ECS trace field promotion**

When `quarkus.log.console.json.log-format=ecs` is set, promotes OTel MDC keys `traceId` and `spanId` to their ECS-compliant root paths (`trace.id`, `span.id`). Previously these appeared nested under `mdc.traceId` / `mdc.spanId`, breaking log-trace correlation in Elastic/OpenSearch dashboards without collector-side remapping workarounds (Fluent Bit/Logstash).

MDC key names sourced from `OpenTelemetryUtil.java` constants. `sampled` and `parentId` have no ECS root equivalents and are intentionally excluded. No `transactionId` exists in the Quarkus OTel MDC bridge.

Relates to #45585.

## Changes

- `JsonLogConfig.java` — new `mdc.flat-fields` config key
- `JsonFormatter.java` — `flatMdc` flag + `promotedMdcKeys` injection; ECS branch in `after()`
- `LoggingJsonRecorder.java` — wires `flatMdc` and ECS promoted keys from config
- `logging.adoc` — documents the new config option
- `ConsoleJsonFormatterFlatMdcTest` + properties file — test coverage