### PR TITLE
Fix Liquibase native resolution when included changelogs use logicalFilePath

### DIFF
--- a/extensions/liquibase/liquibase-common/src/main/java/io/quarkus/liquibase/common/LiquibaseChangeLogResourceDiscovery.java
+++ b/extensions/liquibase/liquibase-common/src/main/java/io/quarkus/liquibase/common/LiquibaseChangeLogResourceDiscovery.java
@@ -1,0 +1,126 @@
+package io.quarkus.liquibase.common;
+
+import java.nio.file.Paths;
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import liquibase.change.Change;
+import liquibase.change.core.CreateProcedureChange;
+import liquibase.change.core.CreateViewChange;
+import liquibase.change.core.LoadDataChange;
+import liquibase.change.core.SQLFileChange;
+import liquibase.changelog.ChangeSet;
+import liquibase.changelog.DatabaseChangeLog;
+
+/**
+ * Collects classpath resource paths and logical↔physical aliases for Liquibase changelogs.
+ * <p>
+ * When {@code logicalFilePath} is set, {@link DatabaseChangeLog#getFilePath()} returns the logical
+ * path while the file on the classpath keeps its physical path. Native image registration must
+ * account for both.
+ */
+public final class LiquibaseChangeLogResourceDiscovery {
+
+    private LiquibaseChangeLogResourceDiscovery() {
+    }
+
+    /**
+     * @param logical normalized logical path (as Liquibase resolves it for resource lookup)
+     * @param physical normalized physical classpath path of the same changelog file
+     */
+    public record LogicalPhysicalAlias(String logical, String physical) {
+    }
+
+    public record ScanResult(Set<String> resourcePaths, Set<LogicalPhysicalAlias> logicalPhysicalAliases) {
+    }
+
+    public static ScanResult scan(DatabaseChangeLog changelog) {
+        LinkedHashSet<String> resources = new LinkedHashSet<>();
+        LinkedHashSet<LogicalPhysicalAlias> aliases = new LinkedHashSet<>();
+        for (ChangeSet changeSet : changelog.getChangeSets()) {
+            addChangeSetResources(changeSet, resources, aliases);
+            changeSet.getChanges().stream()
+                    .map(change -> extractChangeFile(change, changeSet.getFilePath()))
+                    .forEach(path -> path.ifPresent(p -> resources.add(DatabaseChangeLog.normalizePath(p))));
+
+            DatabaseChangeLog parent = changeSet.getChangeLog();
+            while (parent != null) {
+                addDatabaseChangeLog(parent, resources, aliases);
+                parent = parent.getParentChangeLog();
+            }
+        }
+        addDatabaseChangeLog(changelog, resources, aliases);
+        return new ScanResult(resources, aliases);
+    }
+
+    private static void addChangeSetResources(ChangeSet changeSet, Set<String> resources,
+            Set<LogicalPhysicalAlias> aliases) {
+        String changeSetFile = normalizeNullable(changeSet.getFilePath());
+        DatabaseChangeLog owningLog = changeSet.getChangeLog();
+        String physical = owningLog != null ? normalizeNullable(owningLog.getPhysicalFilePath()) : null;
+        if (changeSetFile != null) {
+            resources.add(changeSetFile);
+        }
+        if (physical != null) {
+            resources.add(physical);
+        }
+        maybeAddAlias(aliases, changeSetFile, physical);
+    }
+
+    private static void addDatabaseChangeLog(DatabaseChangeLog log, Set<String> resources,
+            Set<LogicalPhysicalAlias> aliases) {
+        if (log == null) {
+            return;
+        }
+        String physical = normalizeNullable(log.getPhysicalFilePath());
+        String logical = normalizeNullable(log.getFilePath());
+        if (physical != null) {
+            resources.add(physical);
+        }
+        if (logical != null) {
+            resources.add(logical);
+        }
+        maybeAddAlias(aliases, logical, physical);
+    }
+
+    private static void maybeAddAlias(Set<LogicalPhysicalAlias> aliases, String logical, String physical) {
+        if (logical != null && physical != null && !logical.equals(physical)) {
+            aliases.add(new LogicalPhysicalAlias(logical, physical));
+        }
+    }
+
+    private static String normalizeNullable(String path) {
+        if (path == null) {
+            return null;
+        }
+        return DatabaseChangeLog.normalizePath(path);
+    }
+
+    private static Optional<String> extractChangeFile(Change change, String changeSetFilePath) {
+        String path = null;
+        Boolean relative = null;
+        if (change instanceof LoadDataChange loadDataChange) {
+            path = loadDataChange.getFile();
+            relative = loadDataChange.isRelativeToChangelogFile();
+        } else if (change instanceof SQLFileChange sqlFileChange) {
+            path = sqlFileChange.getPath();
+            relative = sqlFileChange.isRelativeToChangelogFile();
+        } else if (change instanceof CreateProcedureChange createProcedureChange) {
+            path = createProcedureChange.getPath();
+            relative = createProcedureChange.isRelativeToChangelogFile();
+        } else if (change instanceof CreateViewChange createViewChange) {
+            path = createViewChange.getPath();
+            relative = createViewChange.getRelativeToChangelogFile();
+        }
+
+        if (path == null) {
+            return Optional.empty();
+        }
+        if (relative == null || !relative || changeSetFilePath == null) {
+            return Optional.of(path);
+        }
+
+        return Optional.of(Paths.get(changeSetFilePath).resolveSibling(path).toString().replace('\\', '/'));
+    }
+}

--- a/extensions/liquibase/liquibase-common/src/main/java/io/quarkus/liquibase/common/LiquibaseClasspathResources.java
+++ b/extensions/liquibase/liquibase-common/src/main/java/io/quarkus/liquibase/common/LiquibaseClasspathResources.java
@@ -1,0 +1,41 @@
+package io.quarkus.liquibase.common;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+
+import liquibase.changelog.DatabaseChangeLog;
+
+public final class LiquibaseClasspathResources {
+
+    private LiquibaseClasspathResources() {
+    }
+
+    /**
+     * Reads a classpath resource using the same path normalization Liquibase uses for changelog paths.
+     *
+     * @return the resource bytes, or {@code null} if not found
+     */
+    public static byte[] readAllBytesOrNull(ClassLoader classLoader, String resourcePath) {
+        String normalized = DatabaseChangeLog.normalizePath(resourcePath);
+        byte[] fromNormalized = readStream(classLoader, normalized);
+        if (fromNormalized != null) {
+            return fromNormalized;
+        }
+        if (normalized.startsWith("/")) {
+            return readStream(classLoader, normalized.substring(1));
+        }
+        return null;
+    }
+
+    private static byte[] readStream(ClassLoader classLoader, String path) {
+        try (InputStream in = classLoader.getResourceAsStream(path)) {
+            if (in == null) {
+                return null;
+            }
+            return in.readAllBytes();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/extensions/liquibase/liquibase-common/src/main/java/io/quarkus/liquibase/common/runtime/LiquibaseLogicalPathMappings.java
+++ b/extensions/liquibase/liquibase-common/src/main/java/io/quarkus/liquibase/common/runtime/LiquibaseLogicalPathMappings.java
@@ -1,0 +1,60 @@
+package io.quarkus.liquibase.common.runtime;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Build-time generated logical→physical classpath paths for Liquibase changelogs (native image).
+ */
+public final class LiquibaseLogicalPathMappings {
+
+    /**
+     * JDBC / Agroal Liquibase extension mappings (all named datasources merged).
+     */
+    public static final String JDBC_MAPPING_RESOURCE = "META-INF/quarkus/quarkus-liquibase-logical-path-mappings.properties";
+
+    /**
+     * MongoDB Liquibase extension mappings (all clients merged).
+     */
+    public static final String MONGODB_MAPPING_RESOURCE = "META-INF/quarkus/quarkus-liquibase-mongodb-logical-path-mappings.properties";
+
+    private LiquibaseLogicalPathMappings() {
+    }
+
+    public static Map<String, String> load(ClassLoader classLoader, String resourcePath) {
+        try (InputStream in = classLoader.getResourceAsStream(resourcePath)) {
+            if (in == null) {
+                return Collections.emptyMap();
+            }
+            LinkedHashMap<String, String> map = new LinkedHashMap<>();
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    line = line.strip();
+                    if (line.isEmpty() || line.startsWith("#")) {
+                        continue;
+                    }
+                    int eq = line.indexOf('=');
+                    if (eq <= 0) {
+                        continue;
+                    }
+                    String logical = line.substring(0, eq).strip();
+                    String physical = line.substring(eq + 1).strip();
+                    if (!logical.isEmpty() && !physical.isEmpty()) {
+                        map.put(logical, physical);
+                    }
+                }
+            }
+            return Collections.unmodifiableMap(map);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/extensions/liquibase/liquibase-common/src/main/java/io/quarkus/liquibase/common/runtime/LogicalPathMappingResourceAccessor.java
+++ b/extensions/liquibase/liquibase-common/src/main/java/io/quarkus/liquibase/common/runtime/LogicalPathMappingResourceAccessor.java
@@ -1,0 +1,62 @@
+package io.quarkus.liquibase.common.runtime;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import liquibase.changelog.DatabaseChangeLog;
+import liquibase.resource.ResourceAccessor;
+
+/**
+ * Delegates to another {@link ResourceAccessor}, remapping Liquibase {@code logicalFilePath} keys to
+ * physical classpath resource paths when present in the mapping table (native image only).
+ */
+public final class LogicalPathMappingResourceAccessor implements ResourceAccessor {
+
+    private final Map<String, String> logicalToPhysical;
+    private final ResourceAccessor delegate;
+
+    public LogicalPathMappingResourceAccessor(Map<String, String> logicalToPhysical, ResourceAccessor delegate) {
+        this.logicalToPhysical = logicalToPhysical == null ? Map.of() : logicalToPhysical;
+        this.delegate = delegate;
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public List search(String path, boolean recursive) throws IOException {
+        return delegate.search(remap(path), recursive);
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public List getAll(String path) throws IOException {
+        return delegate.getAll(remap(path));
+    }
+
+    private String remap(String path) {
+        if (path == null || logicalToPhysical.isEmpty()) {
+            return path;
+        }
+        String normalized = DatabaseChangeLog.normalizePath(path);
+        String physical = logicalToPhysical.get(normalized);
+        return physical != null ? physical : path;
+    }
+
+    @Override
+    public List<String> describeLocations() {
+        if (logicalToPhysical.isEmpty()) {
+            return delegate.describeLocations();
+        }
+        List<String> locations = new ArrayList<>(1 + delegate.describeLocations().size());
+        locations.add("Liquibase logicalFilePath mappings (" + logicalToPhysical.size() + " entries)");
+        locations.addAll(delegate.describeLocations());
+        return Collections.unmodifiableList(locations);
+    }
+
+    @Override
+    public void close() throws Exception {
+        delegate.close();
+    }
+}

--- a/extensions/liquibase/liquibase-mongodb/deployment/src/main/java/io/quarkus/liquibase/mongodb/deployment/LiquibaseMongodbProcessor.java
+++ b/extensions/liquibase/liquibase-mongodb/deployment/src/main/java/io/quarkus/liquibase/mongodb/deployment/LiquibaseMongodbProcessor.java
@@ -1,16 +1,15 @@
 package io.quarkus.liquibase.mongodb.deployment;
 
 import java.io.IOException;
-import java.nio.file.Paths;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Default;
@@ -32,6 +31,7 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
 import io.quarkus.deployment.builditem.InitTaskBuildItem;
 import io.quarkus.deployment.builditem.InitTaskCompletedBuildItem;
@@ -44,6 +44,9 @@ import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.deployment.util.ServiceUtil;
+import io.quarkus.liquibase.common.LiquibaseChangeLogResourceDiscovery;
+import io.quarkus.liquibase.common.LiquibaseChangeLogResourceDiscovery.LogicalPhysicalAlias;
+import io.quarkus.liquibase.common.runtime.LiquibaseLogicalPathMappings;
 import io.quarkus.liquibase.mongodb.LiquibaseMongodbFactory;
 import io.quarkus.liquibase.mongodb.runtime.LiquibaseMongodbBuildTimeClientConfig;
 import io.quarkus.liquibase.mongodb.runtime.LiquibaseMongodbBuildTimeConfig;
@@ -53,16 +56,9 @@ import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.mongodb.runtime.MongoConfig;
 import io.quarkus.paths.PathFilter;
-import liquibase.change.Change;
 import liquibase.change.DatabaseChangeProperty;
-import liquibase.change.core.CreateProcedureChange;
-import liquibase.change.core.CreateViewChange;
-import liquibase.change.core.LoadDataChange;
-import liquibase.change.core.SQLFileChange;
 import liquibase.changelog.ChangeLogParameters;
-import liquibase.changelog.ChangeSet;
 import liquibase.changelog.DatabaseChangeLog;
-import liquibase.exception.LiquibaseException;
 import liquibase.parser.ChangeLogParser;
 import liquibase.parser.ChangeLogParserFactory;
 import liquibase.plugin.AbstractPluginFactory;
@@ -214,6 +210,60 @@ class LiquibaseMongodbProcessor {
         resourceBundle.produce(new NativeImageResourceBundleBuildItem("liquibase/i18n/liquibase-mongo"));
     }
 
+    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    void liquibaseNativeLogicalPathMappings(
+            LiquibaseMongodbBuildTimeConfig liquibaseBuildConfig,
+            BuildProducer<GeneratedResourceBuildItem> generatedResources,
+            BuildProducer<NativeImageResourceBuildItem> nativeImageResources) {
+
+        ChangeLogParameters changeLogParameters = new ChangeLogParameters();
+        ChangeLogParserFactory changeLogParserFactory = ChangeLogParserFactory.getInstance();
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+
+        LinkedHashSet<LogicalPhysicalAlias> allAliases = new LinkedHashSet<>();
+        try (var classLoaderResourceAccessor = new ClassLoaderResourceAccessor(classLoader)) {
+            for (LiquibaseMongodbBuildTimeClientConfig buildConfig : liquibaseBuildConfig.clientConfigs().values()) {
+                String changeLog = buildConfig.changeLog();
+                ChangeLogParser parser = changeLogParserFactory.getParser(changeLog, classLoaderResourceAccessor);
+                DatabaseChangeLog root = parser.parse(changeLog, changeLogParameters, classLoaderResourceAccessor);
+                if (root != null) {
+                    allAliases.addAll(LiquibaseChangeLogResourceDiscovery.scan(root).logicalPhysicalAliases());
+                }
+            }
+        } catch (Exception ex) {
+            throw new IllegalStateException(
+                    "Error while loading the liquibase changelogs: %s".formatted(ex.getMessage()), ex);
+        }
+
+        byte[] mappingBytes = mergeLogicalPathMappingProperties(allAliases);
+        if (mappingBytes != null) {
+            generatedResources.produce(
+                    new GeneratedResourceBuildItem(LiquibaseLogicalPathMappings.MONGODB_MAPPING_RESOURCE, mappingBytes));
+            nativeImageResources
+                    .produce(new NativeImageResourceBuildItem(LiquibaseLogicalPathMappings.MONGODB_MAPPING_RESOURCE));
+        }
+    }
+
+    private byte[] mergeLogicalPathMappingProperties(LinkedHashSet<LogicalPhysicalAlias> aliases) {
+        if (aliases.isEmpty()) {
+            return null;
+        }
+        TreeMap<String, String> sorted = new TreeMap<>();
+        for (LogicalPhysicalAlias alias : aliases) {
+            String previous = sorted.put(alias.logical(), alias.physical());
+            if (previous != null && !previous.equals(alias.physical())) {
+                LOGGER.warnf("Conflicting Liquibase logical path mapping for %s: %s vs %s", alias.logical(), previous,
+                        alias.physical());
+            }
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append("# Generated by Quarkus -- logicalFilePath to classpath resource path (MongoDB Liquibase)\n");
+        for (var entry : sorted.entrySet()) {
+            sb.append(entry.getKey()).append('=').append(entry.getValue()).append('\n');
+        }
+        return sb.toString().getBytes(StandardCharsets.UTF_8);
+    }
+
     private void addService(BuildProducer<ServiceProviderBuildItem> services,
             BuildProducer<ReflectiveClassBuildItem> reflective, String serviceClassName,
             boolean shouldRegisterFieldForReflection, String... excludedImpls) {
@@ -305,11 +355,13 @@ class LiquibaseMongodbProcessor {
 
             Set<String> resources = new LinkedHashSet<>();
             for (LiquibaseMongodbBuildTimeClientConfig buildConfig : liquibaseBuildConfig.clientConfigs().values()) {
-                resources.addAll(findAllChangeLogFiles(
-                        buildConfig.changeLog(),
-                        changeLogParserFactory,
-                        classLoaderResourceAccessor,
-                        changeLogParameters));
+                ChangeLogParser parser = changeLogParserFactory.getParser(buildConfig.changeLog(),
+                        classLoaderResourceAccessor);
+                DatabaseChangeLog changelog = parser.parse(buildConfig.changeLog(), changeLogParameters,
+                        classLoaderResourceAccessor);
+                if (changelog != null) {
+                    resources.addAll(LiquibaseChangeLogResourceDiscovery.scan(changelog).resourcePaths());
+                }
             }
             LOGGER.debugf("Liquibase changeLogs: %s", resources);
 
@@ -322,70 +374,4 @@ class LiquibaseMongodbProcessor {
         }
     }
 
-    /**
-     * Finds all resource files for the given change log file
-     */
-    private Set<String> findAllChangeLogFiles(String file, ChangeLogParserFactory changeLogParserFactory,
-            ClassLoaderResourceAccessor classLoaderResourceAccessor,
-            ChangeLogParameters changeLogParameters) {
-        try {
-            ChangeLogParser parser = changeLogParserFactory.getParser(file, classLoaderResourceAccessor);
-            DatabaseChangeLog changelog = parser.parse(file, changeLogParameters, classLoaderResourceAccessor);
-
-            if (changelog != null) {
-                Set<String> result = new LinkedHashSet<>();
-                // get all changeSet files
-                for (ChangeSet changeSet : changelog.getChangeSets()) {
-                    result.add(changeSet.getFilePath());
-
-                    changeSet.getChanges().stream()
-                            .map(change -> extractChangeFile(change, changeSet.getFilePath()))
-                            .forEach(changeFile -> changeFile.ifPresent(result::add));
-
-                    // get all parents of the changeSet
-                    DatabaseChangeLog parent = changeSet.getChangeLog();
-                    while (parent != null) {
-                        result.add(parent.getFilePath());
-                        parent = parent.getParentChangeLog();
-                    }
-                }
-                result.add(changelog.getFilePath());
-                return result;
-            }
-        } catch (LiquibaseException ex) {
-            throw new IllegalStateException(ex);
-        }
-        return Collections.emptySet();
-    }
-
-    private Optional<String> extractChangeFile(Change change, String changeSetFilePath) {
-        String path = null;
-        Boolean relative = null;
-        if (change instanceof LoadDataChange loadDataChange) {
-            path = loadDataChange.getFile();
-            relative = loadDataChange.isRelativeToChangelogFile();
-        } else if (change instanceof SQLFileChange sqlFileChange) {
-            path = sqlFileChange.getPath();
-            relative = sqlFileChange.isRelativeToChangelogFile();
-        } else if (change instanceof CreateProcedureChange createProcedureChange) {
-            path = createProcedureChange.getPath();
-            relative = createProcedureChange.isRelativeToChangelogFile();
-        } else if (change instanceof CreateViewChange createViewChange) {
-            path = createViewChange.getPath();
-            relative = createViewChange.getRelativeToChangelogFile();
-        }
-
-        // unrelated change or change does not reference a file (e.g. inline view)
-        if (path == null) {
-            return Optional.empty();
-        }
-        // absolute file path or changeSet has no file path
-        if (relative == null || !relative || changeSetFilePath == null) {
-            return Optional.of(path);
-        }
-
-        // relative file path needs to be resolved against changeSetFilePath
-        // notes: ClassLoaderResourceAccessor does not provide a suitable method and CLRA.getFinalPath() is not visible
-        return Optional.of(Paths.get(changeSetFilePath).resolveSibling(path).toString().replace('\\', '/'));
-    }
 }

--- a/extensions/liquibase/liquibase-mongodb/runtime/src/main/java/io/quarkus/liquibase/mongodb/LiquibaseMongodbFactory.java
+++ b/extensions/liquibase/liquibase-mongodb/runtime/src/main/java/io/quarkus/liquibase/mongodb/LiquibaseMongodbFactory.java
@@ -10,6 +10,8 @@ import java.util.regex.Pattern;
 import com.mongodb.client.MongoClient;
 
 import io.quarkus.arc.Arc;
+import io.quarkus.liquibase.common.runtime.LiquibaseLogicalPathMappings;
+import io.quarkus.liquibase.common.runtime.LogicalPathMappingResourceAccessor;
 import io.quarkus.liquibase.common.runtime.NativeImageResourceAccessor;
 import io.quarkus.liquibase.mongodb.runtime.LiquibaseMongodbBuildTimeClientConfig;
 import io.quarkus.liquibase.mongodb.runtime.LiquibaseMongodbClientConfig;
@@ -80,7 +82,13 @@ public class LiquibaseMongodbFactory {
     }
 
     private ResourceAccessor nativeImageResourceAccessor(CompositeResourceAccessor rootAccessor) {
-        return rootAccessor.addResourceAccessor(new NativeImageResourceAccessor());
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        var nativeAccessor = new NativeImageResourceAccessor();
+        var mapping = LiquibaseLogicalPathMappings.load(cl, LiquibaseLogicalPathMappings.MONGODB_MAPPING_RESOURCE);
+        if (mapping.isEmpty()) {
+            return rootAccessor.addResourceAccessor(nativeAccessor);
+        }
+        return rootAccessor.addResourceAccessor(new LogicalPathMappingResourceAccessor(mapping, nativeAccessor));
     }
 
     private String parseChangeLog(String changeLog) {

--- a/extensions/liquibase/liquibase/deployment/src/main/java/io/quarkus/liquibase/deployment/LiquibaseProcessor.java
+++ b/extensions/liquibase/liquibase/deployment/src/main/java/io/quarkus/liquibase/deployment/LiquibaseProcessor.java
@@ -2,6 +2,7 @@ package io.quarkus.liquibase.deployment;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -12,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
@@ -44,6 +46,7 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
 import io.quarkus.deployment.builditem.InitTaskBuildItem;
 import io.quarkus.deployment.builditem.InitTaskCompletedBuildItem;
@@ -58,6 +61,9 @@ import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.deployment.util.ServiceUtil;
 import io.quarkus.liquibase.LiquibaseDataSource;
 import io.quarkus.liquibase.LiquibaseFactory;
+import io.quarkus.liquibase.common.LiquibaseChangeLogResourceDiscovery;
+import io.quarkus.liquibase.common.LiquibaseChangeLogResourceDiscovery.LogicalPhysicalAlias;
+import io.quarkus.liquibase.common.runtime.LiquibaseLogicalPathMappings;
 import io.quarkus.liquibase.runtime.LiquibaseBuildTimeConfig;
 import io.quarkus.liquibase.runtime.LiquibaseDataSourceBuildTimeConfig;
 import io.quarkus.liquibase.runtime.LiquibaseFactoryProducer;
@@ -66,17 +72,10 @@ import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.paths.PathFilter;
 import io.quarkus.runtime.util.StringUtil;
-import liquibase.change.Change;
 import liquibase.change.DatabaseChangeProperty;
-import liquibase.change.core.CreateProcedureChange;
-import liquibase.change.core.CreateViewChange;
-import liquibase.change.core.LoadDataChange;
-import liquibase.change.core.SQLFileChange;
 import liquibase.changelog.ChangeLogParameters;
-import liquibase.changelog.ChangeSet;
 import liquibase.changelog.DatabaseChangeLog;
 import liquibase.datatype.DataTypeInfo;
-import liquibase.exception.LiquibaseException;
 import liquibase.parser.ChangeLogParser;
 import liquibase.parser.ChangeLogParserFactory;
 import liquibase.plugin.AbstractPluginFactory;
@@ -244,6 +243,78 @@ class LiquibaseProcessor {
         resourceBundle.produce(new NativeImageResourceBundleBuildItem("liquibase/i18n/liquibase-core"));
     }
 
+    /**
+     * Writes a small logical→physical classpath mapping for Liquibase {@code logicalFilePath} entries so native
+     * image can resolve changelog paths without duplicating file contents.
+     */
+    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    void liquibaseNativeLogicalPathMappings(
+            LiquibaseBuildTimeConfig liquibaseBuildConfig,
+            List<JdbcDataSourceBuildItem> jdbcDataSourceBuildItems,
+            BuildProducer<GeneratedResourceBuildItem> generatedResources,
+            BuildProducer<NativeImageResourceBuildItem> nativeImageResources) {
+
+        Collection<String> dataSourceNames = jdbcDataSourceBuildItems.stream()
+                .map(JdbcDataSourceBuildItem::getName)
+                .collect(Collectors.toSet());
+
+        if (dataSourceNames.isEmpty()) {
+            return;
+        }
+
+        List<LiquibaseDataSourceBuildTimeConfig> liquibaseDataSources = new ArrayList<>();
+        for (String dataSourceName : dataSourceNames) {
+            liquibaseDataSources.add(liquibaseBuildConfig.datasources().get(dataSourceName));
+        }
+
+        ChangeLogParameters changeLogParameters = new ChangeLogParameters();
+        ChangeLogParserFactory changeLogParserFactory = ChangeLogParserFactory.getInstance();
+
+        LinkedHashSet<LogicalPhysicalAlias> allAliases = new LinkedHashSet<>();
+        for (LiquibaseDataSourceBuildTimeConfig liquibaseDataSourceConfig : liquibaseDataSources) {
+            Optional<List<String>> oSearchPaths = liquibaseDataSourceConfig.searchPath();
+            String changeLog = liquibaseDataSourceConfig.changeLog();
+            String parsedChangeLog = parseChangeLog(oSearchPaths, changeLog);
+
+            try (ResourceAccessor resourceAccessor = resolveResourceAccessor(oSearchPaths, changeLog)) {
+                ChangeLogParser parser = changeLogParserFactory.getParser(parsedChangeLog, resourceAccessor);
+                DatabaseChangeLog root = parser.parse(parsedChangeLog, changeLogParameters, resourceAccessor);
+                if (root != null) {
+                    allAliases.addAll(LiquibaseChangeLogResourceDiscovery.scan(root).logicalPhysicalAliases());
+                }
+            } catch (Exception ex) {
+                throw new IllegalStateException(ex);
+            }
+        }
+
+        byte[] mappingBytes = mergeLogicalPathMappingProperties(allAliases);
+        if (mappingBytes != null) {
+            generatedResources.produce(
+                    new GeneratedResourceBuildItem(LiquibaseLogicalPathMappings.JDBC_MAPPING_RESOURCE, mappingBytes));
+            nativeImageResources.produce(new NativeImageResourceBuildItem(LiquibaseLogicalPathMappings.JDBC_MAPPING_RESOURCE));
+        }
+    }
+
+    private byte[] mergeLogicalPathMappingProperties(LinkedHashSet<LogicalPhysicalAlias> aliases) {
+        if (aliases.isEmpty()) {
+            return null;
+        }
+        TreeMap<String, String> sorted = new TreeMap<>();
+        for (LogicalPhysicalAlias alias : aliases) {
+            String previous = sorted.put(alias.logical(), alias.physical());
+            if (previous != null && !previous.equals(alias.physical())) {
+                LOGGER.warnf("Conflicting Liquibase logical path mapping for %s: %s vs %s", alias.logical(), previous,
+                        alias.physical());
+            }
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append("# Generated by Quarkus -- logicalFilePath to classpath resource path\n");
+        for (var entry : sorted.entrySet()) {
+            sb.append(entry.getKey()).append('=').append(entry.getValue()).append('\n');
+        }
+        return sb.toString().getBytes(StandardCharsets.UTF_8);
+    }
+
     private void consumeService(String serviceClassName, BiConsumer<String, Collection<String>> consumer) {
         try {
             String service = ServiceProviderBuildItem.SPI_ROOT + serviceClassName;
@@ -362,8 +433,11 @@ class LiquibaseProcessor {
             String parsedChangeLog = parseChangeLog(oSearchPaths, changeLog);
 
             try (ResourceAccessor resourceAccessor = resolveResourceAccessor(oSearchPaths, changeLog)) {
-                resources.addAll(findAllChangeLogFiles(parsedChangeLog, changeLogParserFactory,
-                        resourceAccessor, changeLogParameters));
+                ChangeLogParser parser = changeLogParserFactory.getParser(parsedChangeLog, resourceAccessor);
+                DatabaseChangeLog changelog = parser.parse(parsedChangeLog, changeLogParameters, resourceAccessor);
+                if (changelog != null) {
+                    resources.addAll(LiquibaseChangeLogResourceDiscovery.scan(changelog).resourcePaths());
+                }
             } catch (Exception ex) {
                 throw new IllegalStateException(ex);
             }
@@ -415,69 +489,4 @@ class LiquibaseProcessor {
         return changeLog;
     }
 
-    /**
-     * Finds all resource files for the given change log file
-     */
-    private Set<String> findAllChangeLogFiles(String file, ChangeLogParserFactory changeLogParserFactory,
-            ResourceAccessor resourceAccessor, ChangeLogParameters changeLogParameters) {
-        try {
-            ChangeLogParser parser = changeLogParserFactory.getParser(file, resourceAccessor);
-            DatabaseChangeLog changelog = parser.parse(file, changeLogParameters, resourceAccessor);
-
-            if (changelog != null) {
-                Set<String> result = new LinkedHashSet<>();
-                // get all changeSet files
-                for (ChangeSet changeSet : changelog.getChangeSets()) {
-                    result.add(changeSet.getFilePath());
-
-                    changeSet.getChanges().stream()
-                            .map(change -> extractChangeFile(change, changeSet.getFilePath()))
-                            .forEach(changeFile -> changeFile.ifPresent(result::add));
-
-                    // get all parents of the changeSet
-                    DatabaseChangeLog parent = changeSet.getChangeLog();
-                    while (parent != null) {
-                        result.add(parent.getFilePath());
-                        parent = parent.getParentChangeLog();
-                    }
-                }
-                result.add(changelog.getFilePath());
-                return result;
-            }
-        } catch (LiquibaseException ex) {
-            throw new IllegalStateException(ex);
-        }
-        return Collections.emptySet();
-    }
-
-    private Optional<String> extractChangeFile(Change change, String changeSetFilePath) {
-        String path = null;
-        Boolean relative = null;
-        if (change instanceof LoadDataChange loadDataChange) {
-            path = loadDataChange.getFile();
-            relative = loadDataChange.isRelativeToChangelogFile();
-        } else if (change instanceof SQLFileChange sqlFileChange) {
-            path = sqlFileChange.getPath();
-            relative = sqlFileChange.isRelativeToChangelogFile();
-        } else if (change instanceof CreateProcedureChange createProcedureChange) {
-            path = createProcedureChange.getPath();
-            relative = createProcedureChange.isRelativeToChangelogFile();
-        } else if (change instanceof CreateViewChange createViewChange) {
-            path = createViewChange.getPath();
-            relative = createViewChange.getRelativeToChangelogFile();
-        }
-
-        // unrelated change or change does not reference a file (e.g. inline view)
-        if (path == null) {
-            return Optional.empty();
-        }
-        // absolute file path or changeSet has no file path
-        if (relative == null || !relative || changeSetFilePath == null) {
-            return Optional.of(path);
-        }
-
-        // relative file path needs to be resolved against changeSetFilePath
-        // notes: ClassLoaderResourceAccessor does not provide a suitable method and CLRA.getFinalPath() is not visible
-        return Optional.of(Paths.get(changeSetFilePath).resolveSibling(path).toString().replace('\\', '/'));
-    }
 }

--- a/extensions/liquibase/liquibase/deployment/src/test/java/io/quarkus/liquibase/test/LiquibaseChangeLogResourceDiscoveryTest.java
+++ b/extensions/liquibase/liquibase/deployment/src/test/java/io/quarkus/liquibase/test/LiquibaseChangeLogResourceDiscoveryTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.liquibase.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.liquibase.common.LiquibaseChangeLogResourceDiscovery;
+import io.quarkus.liquibase.common.LiquibaseChangeLogResourceDiscovery.LogicalPhysicalAlias;
+import io.quarkus.liquibase.common.LiquibaseClasspathResources;
+import liquibase.changelog.ChangeLogParameters;
+import liquibase.changelog.DatabaseChangeLog;
+import liquibase.parser.ChangeLogParser;
+import liquibase.parser.ChangeLogParserFactory;
+import liquibase.resource.ClassLoaderResourceAccessor;
+
+class LiquibaseChangeLogResourceDiscoveryTest {
+
+    @Test
+    void logicalFilePathProducesAliasForNativeEmbedding() throws Exception {
+        try (ClassLoaderResourceAccessor accessor = new ClassLoaderResourceAccessor(
+                Thread.currentThread().getContextClassLoader())) {
+
+            ChangeLogParserFactory factory = ChangeLogParserFactory.getInstance();
+            ChangeLogParser parser = factory.getParser("discovery/logical-path-root.xml", accessor);
+            DatabaseChangeLog changelog = parser.parse("discovery/logical-path-root.xml", new ChangeLogParameters(),
+                    accessor);
+
+            LiquibaseChangeLogResourceDiscovery.ScanResult scan = LiquibaseChangeLogResourceDiscovery.scan(changelog);
+
+            assertThat(scan.logicalPhysicalAliases())
+                    .extracting(LogicalPhysicalAlias::logical)
+                    .contains("db/changelog/db.changelog-1.0.0.xml");
+
+            LogicalPhysicalAlias alias = scan.logicalPhysicalAliases().stream()
+                    .filter(a -> "db/changelog/db.changelog-1.0.0.xml".equals(a.logical()))
+                    .findFirst()
+                    .orElseThrow();
+
+            assertThat(alias.physical()).isEqualTo("discovery/included-with-logical.xml");
+
+            assertThat(scan.resourcePaths()).contains(alias.logical(), alias.physical());
+
+            assertThat(LiquibaseClasspathResources.readAllBytesOrNull(
+                    Thread.currentThread().getContextClassLoader(), alias.physical()))
+                    .isNotNull();
+        }
+    }
+}

--- a/extensions/liquibase/liquibase/deployment/src/test/resources/discovery/included-with-logical.xml
+++ b/extensions/liquibase/liquibase/deployment/src/test/resources/discovery/included-with-logical.xml
@@ -1,0 +1,13 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        logicalFilePath="db/changelog/db.changelog-1.0.0.xml"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="1" author="quarkus-test">
+        <createTable tableName="discovery_logical_path">
+            <column name="id" type="int"/>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/extensions/liquibase/liquibase/deployment/src/test/resources/discovery/logical-path-root.xml
+++ b/extensions/liquibase/liquibase/deployment/src/test/resources/discovery/logical-path-root.xml
@@ -1,0 +1,8 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <include relativeToChangelogFile="true" file="included-with-logical.xml"/>
+</databaseChangeLog>

--- a/extensions/liquibase/liquibase/runtime/src/main/java/io/quarkus/liquibase/LiquibaseFactory.java
+++ b/extensions/liquibase/liquibase/runtime/src/main/java/io/quarkus/liquibase/LiquibaseFactory.java
@@ -10,6 +10,8 @@ import java.util.Map;
 import javax.sql.DataSource;
 
 import io.agroal.api.AgroalDataSource;
+import io.quarkus.liquibase.common.runtime.LiquibaseLogicalPathMappings;
+import io.quarkus.liquibase.common.runtime.LogicalPathMappingResourceAccessor;
 import io.quarkus.liquibase.common.runtime.NativeImageResourceAccessor;
 import io.quarkus.liquibase.runtime.LiquibaseConfig;
 import io.quarkus.runtime.ImageMode;
@@ -73,7 +75,13 @@ public class LiquibaseFactory {
     }
 
     private ResourceAccessor nativeImageResourceAccessor(CompositeResourceAccessor rootAccessor) {
-        return rootAccessor.addResourceAccessor(new NativeImageResourceAccessor());
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        var nativeAccessor = new NativeImageResourceAccessor();
+        var mapping = LiquibaseLogicalPathMappings.load(cl, LiquibaseLogicalPathMappings.JDBC_MAPPING_RESOURCE);
+        if (mapping.isEmpty()) {
+            return rootAccessor.addResourceAccessor(nativeAccessor);
+        }
+        return rootAccessor.addResourceAccessor(new LogicalPathMappingResourceAccessor(mapping, nativeAccessor));
     }
 
     private String parseChangeLog(String changeLog) {

--- a/extensions/liquibase/pom.xml
+++ b/extensions/liquibase/pom.xml
@@ -14,9 +14,10 @@
     <packaging>pom</packaging>
 
     <modules>
+        <!-- Build first: liquibase + liquibase-mongodb depend on this artifact. -->
+        <module>liquibase-common</module>
         <module>liquibase</module>
         <module>liquibase-mongodb</module>
-        <module>liquibase-common</module>
     </modules>
 
 </project>

--- a/integration-tests/liquibase/src/main/resources/db/xml/test/test.xml
+++ b/integration-tests/liquibase/src/main/resources/db/xml/test/test.xml
@@ -2,6 +2,7 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   logicalFilePath="db/changelog/db.changelog-1.0.0.xml"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
     <changeSet author="dev (generated)" id="test-1">

--- a/integration-tests/liquibase/src/test/java/io/quarkus/it/liquibase/LiquibaseLogicalFilePathNativeIT.java
+++ b/integration-tests/liquibase/src/test/java/io/quarkus/it/liquibase/LiquibaseLogicalFilePathNativeIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.liquibase;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class LiquibaseLogicalFilePathNativeIT extends LiquibaseLogicalFilePathTest {
+}

--- a/integration-tests/liquibase/src/test/java/io/quarkus/it/liquibase/LiquibaseLogicalFilePathTest.java
+++ b/integration-tests/liquibase/src/test/java/io/quarkus/it/liquibase/LiquibaseLogicalFilePathTest.java
@@ -1,0 +1,22 @@
+package io.quarkus.it.liquibase;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * JVM coverage for changelogs included with {@code relativeToChangelogFile="true"} where the included
+ * file sets {@code logicalFilePath} (see {@code db/xml/test/test.xml}). Native coverage is
+ * {@link LiquibaseLogicalFilePathNativeIT}.
+ */
+@QuarkusTest
+@DisplayName("Liquibase logicalFilePath on included changelogs")
+public class LiquibaseLogicalFilePathTest {
+
+    @Test
+    @DisplayName("Resolves included changelog and runs migrations when logicalFilePath differs from physical path")
+    void includedChangeLogWithLogicalFilePathMigratesSuccessfully() {
+        LiquibaseFunctionalityTest.doTestLiquibaseQuarkusFunctionality();
+    }
+}


### PR DESCRIPTION
Liquibase resolves included changelogs using the `logicalFilePath` when it is set, but in native mode only classpath resource paths embedded in the image are visible. We only registered the physical resource paths, so Liquibase looked up the logical path (for example `db/changelog/db.changelog-1.0.0.xml`) and failed with `ChangeLogParseException` even though the same project worked on the JVM.

At native image build time we now record logical vs physical paths while parsing changelogs, copy the physical file bytes under the logical paths in the application output, and reuse the same discovery logic for JDBC and MongoDB Liquibase extensions.

- Fixes: #53982