### PR TITLE
Add AI skill for quarkus-quartz

### DIFF
--- a/extensions/quartz/deployment/src/main/resources/META-INF/quarkus-skill.md
+++ b/extensions/quartz/deployment/src/main/resources/META-INF/quarkus-skill.md
@@ -1,0 +1,102 @@
+
+### When to Use
+
+Use `quartz` instead of `scheduler` when you need: JDBC-backed persistent jobs, clustering, the direct Quartz API for programmatic job management, or misfire handling. For simple in-memory scheduling, `quarkus-scheduler` alone is sufficient.
+
+### Scheduled Methods
+
+```java
+@ApplicationScoped
+public class Jobs {
+    @Scheduled(every = "10s", identity = "my-job")
+    void everyTenSeconds() { /* runs every 10 seconds */ }
+
+    @Scheduled(cron = "0 0 8 * * ?", identity = "morning-report")
+    void dailyAt8am() { /* Quartz cron format (6 fields, includes seconds) */ }
+}
+```
+
+- Methods must be on CDI beans, return `void` or `Uni<Void>`, and take no arguments (or `ScheduledExecution`).
+- The `identity` is used for pause/resume operations and must be unique.
+- Quartz cron uses **6 fields** (seconds minutes hours day-of-month month day-of-week), not the standard 5-field Unix cron.
+
+### Two Scheduler APIs
+
+1. **`io.quarkus.scheduler.Scheduler`** — Quarkus abstraction for controlling scheduled jobs:
+   ```java
+   @Inject Scheduler scheduler;
+   scheduler.pause("my-job");
+   scheduler.resume("my-job");
+   boolean running = scheduler.isRunning();
+   ```
+
+2. **`org.quartz.Scheduler`** — Direct Quartz API for programmatic job creation:
+   ```java
+   @Inject org.quartz.Scheduler quartz;
+
+   JobDetail job = JobBuilder.newJob(MyJob.class)
+       .withIdentity("dynamic-job", "my-group")
+       .usingJobData("param", "value")
+       .build();
+   Trigger trigger = TriggerBuilder.newTrigger()
+       .withIdentity("dynamic-trigger", "my-group")
+       .withSchedule(SimpleScheduleBuilder.simpleSchedule()
+           .withIntervalInSeconds(5).repeatForever())
+       .build();
+   quartz.scheduleJob(job, trigger);
+   ```
+
+Use the Quarkus `Scheduler` for pause/resume and status. Use the Quartz `Scheduler` for creating/deleting jobs at runtime.
+
+### Programmatic Jobs (Quartz API)
+
+Implement `org.quartz.Job`:
+
+```java
+public class MyJob implements Job {
+    @Inject SomeService service;  // CDI injection works
+
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        String param = context.getJobDetail().getJobDataMap().getString("param");
+        service.process(param);
+    }
+}
+```
+
+- CDI injection works in `Job` classes automatically.
+- Use `@DisallowConcurrentExecution` to prevent overlapping executions.
+- Access job data via `context.getJobDetail().getJobDataMap()`.
+
+### Concurrent Execution
+
+- By default, `@Scheduled` methods CAN run concurrently with themselves.
+- Use `@Scheduled(concurrentExecution = SKIP)` to prevent concurrent runs.
+- For Quartz `Job` classes, use `@DisallowConcurrentExecution`.
+
+### JDBC Job Store (Persistent Jobs)
+
+```properties
+quarkus.quartz.store-type=jdbc-cmt
+quarkus.quartz.clustered=true
+```
+
+Requires a datasource. Quartz tables are created automatically if `quarkus.quartz.store-type=jdbc-cmt` is set. Jobs survive application restarts.
+
+### Testing
+
+- `@Scheduled` methods run during tests by default.
+- Disable scheduling in tests if not needed: `quarkus.scheduler.enabled=false`.
+- For timing-based tests, use `Awaitility`:
+  ```java
+  await().atMost(Duration.ofSeconds(5)).until(() -> counter.get() > 0);
+  ```
+- After pausing a job, wait and verify the counter doesn't change.
+
+### Common Pitfalls
+
+- Quartz cron uses **6 fields** (with seconds) — `"0 */5 * * * ?"` not `"*/5 * * * *"`.
+- `@Scheduled` methods must be on CDI beans — plain classes are ignored.
+- Do NOT use `@Scheduled` on private methods.
+- The Quarkus `Scheduler` and Quartz `Scheduler` are different types — inject the right one for your use case.
+- "No scheduled business methods found" log message at startup is normal if code hasn't compiled yet in dev mode.

--- a/extensions/quartz/deployment/src/main/resources/META-INF/quarkus-skill.md
+++ b/extensions/quartz/deployment/src/main/resources/META-INF/quarkus-skill.md
@@ -18,9 +18,9 @@ public class Jobs {
 
 - Methods must be on CDI beans, return `void` or `Uni<Void>`, and take no arguments (or `ScheduledExecution`).
 - The `identity` is used for pause/resume operations and must be unique.
-- Quartz cron uses **6 fields** (seconds minutes hours day-of-month month day-of-week), not the standard 5-field Unix cron.
+- Quartz cron uses **6 fields** by default (seconds minutes hours day-of-month month day-of-week). This is configurable via `quarkus.scheduler.cron-type` — see the [scheduler reference](https://quarkus.io/guides/scheduler-reference#quarkus-scheduler_quarkus-scheduler-cron-type).
 
-### Two Scheduler APIs
+### Scheduler APIs
 
 1. **`io.quarkus.scheduler.Scheduler`** — Quarkus abstraction for controlling scheduled jobs:
    ```java
@@ -30,23 +30,21 @@ public class Jobs {
    boolean running = scheduler.isRunning();
    ```
 
-2. **`org.quartz.Scheduler`** — Direct Quartz API for programmatic job creation:
+2. **`io.quarkus.quartz.QuartzScheduler`** — Quarkus-native way to access Quartz features, including programmatic job creation and direct access to the underlying Quartz `Scheduler`:
    ```java
-   @Inject org.quartz.Scheduler quartz;
+   @Inject QuartzScheduler quartzScheduler;
 
-   JobDetail job = JobBuilder.newJob(MyJob.class)
-       .withIdentity("dynamic-job", "my-group")
-       .usingJobData("param", "value")
-       .build();
-   Trigger trigger = TriggerBuilder.newTrigger()
-       .withIdentity("dynamic-trigger", "my-group")
-       .withSchedule(SimpleScheduleBuilder.simpleSchedule()
-           .withIntervalInSeconds(5).repeatForever())
-       .build();
-   quartz.scheduleJob(job, trigger);
+   // Programmatic job via Quarkus API
+   quartzScheduler.newJob("dynamic-job")
+       .setInterval("10s")
+       .setTask(execution -> { /* ... */ })
+       .schedule();
+
+   // Or access the underlying org.quartz.Scheduler directly
+   org.quartz.Scheduler quartz = quartzScheduler.getScheduler();
    ```
 
-Use the Quarkus `Scheduler` for pause/resume and status. Use the Quartz `Scheduler` for creating/deleting jobs at runtime.
+Use the Quarkus `Scheduler` for pause/resume and status. Use `QuartzScheduler` for programmatic job management and Quartz-specific features.
 
 ### Programmatic Jobs (Quartz API)
 
@@ -71,7 +69,8 @@ public class MyJob implements Job {
 ### Concurrent Execution
 
 - By default, `@Scheduled` methods CAN run concurrently with themselves.
-- Use `@Scheduled(concurrentExecution = SKIP)` to prevent concurrent runs.
+- Use `@Nonconcurrent` on a `@Scheduled` method to prevent overlapping executions.
+- Alternatively, use `@Scheduled(concurrentExecution = SKIP)`.
 - For Quartz `Job` classes, use `@DisallowConcurrentExecution`.
 
 ### JDBC Job Store (Persistent Jobs)
@@ -81,7 +80,7 @@ quarkus.quartz.store-type=jdbc-cmt
 quarkus.quartz.clustered=true
 ```
 
-Requires a datasource. Quartz tables are created automatically if `quarkus.quartz.store-type=jdbc-cmt` is set. Jobs survive application restarts.
+Requires a datasource. Quartz tables must be created manually via SQL migration (Flyway or Liquibase) — see the [Quarkus Quartz guide](https://quarkus.io/guides/quartz#creating-quartz-tables) for the required table definitions. Jobs survive application restarts.
 
 ### Testing
 
@@ -93,10 +92,24 @@ Requires a datasource. Quartz tables are created automatically if `quarkus.quart
   ```
 - After pausing a job, wait and verify the counter doesn't change.
 
+### Misfire Handling
+
+Misfires occur when a job's trigger time passes without the job executing (e.g., the application was down). Configure misfire policies on `@Scheduled`:
+
+```java
+@Scheduled(cron = "0 0 8 * * ?", identity = "daily-report",
+    misfirePolicy = MisfirePolicy.FIRE_NOW)
+void dailyReport() { /* ... */ }
+```
+
+- `SMART_POLICY` (default) — Quartz picks a sensible policy based on the trigger type.
+- `FIRE_NOW` — execute immediately on recovery.
+- `IGNORE_MISFIRE_POLICY` — fire all missed triggers.
+- `DO_NOTHING` — skip misfired triggers and wait for the next scheduled time.
+
 ### Common Pitfalls
 
-- Quartz cron uses **6 fields** (with seconds) — `"0 */5 * * * ?"` not `"*/5 * * * *"`.
+- Quartz cron uses **6 fields** by default (with seconds) — `"0 */5 * * * ?"` not `"*/5 * * * *"`.
 - `@Scheduled` methods must be on CDI beans — plain classes are ignored.
 - Do NOT use `@Scheduled` on private methods.
 - The Quarkus `Scheduler` and Quartz `Scheduler` are different types — inject the right one for your use case.
-- "No scheduled business methods found" log message at startup is normal if code hasn't compiled yet in dev mode.

--- a/extensions/quartz/deployment/src/main/resources/META-INF/quarkus-skill.md
+++ b/extensions/quartz/deployment/src/main/resources/META-INF/quarkus-skill.md
@@ -1,4 +1,3 @@
-
 ### When to Use
 
 Use `quartz` instead of `scheduler` when you need: JDBC-backed persistent jobs, clustering, the direct Quartz API for programmatic job management, or misfire handling. For simple in-memory scheduling, `quarkus-scheduler` alone is sufficient.
@@ -16,7 +15,7 @@ public class Jobs {
 }
 ```
 
-- Methods must be on CDI beans, return `void` or `Uni<Void>`, and take no arguments (or `ScheduledExecution`).
+- Methods must return `void`, `Uni<Void>`, or `CompletionStage<Void>`, and take no arguments (or `ScheduledExecution`).
 - The `identity` is used for pause/resume operations and must be unique.
 - Quartz cron uses **6 fields** by default (seconds minutes hours day-of-month month day-of-week). This is configurable via `quarkus.scheduler.cron-type` — see the [scheduler reference](https://quarkus.io/guides/scheduler-reference#quarkus-scheduler_quarkus-scheduler-cron-type).
 
@@ -69,8 +68,8 @@ public class MyJob implements Job {
 ### Concurrent Execution
 
 - By default, `@Scheduled` methods CAN run concurrently with themselves.
-- Use `@Nonconcurrent` on a `@Scheduled` method to prevent overlapping executions.
-- Alternatively, use `@Scheduled(concurrentExecution = SKIP)`.
+- Use `@Nonconcurrent` on a `@Scheduled` method to prevent overlapping executions. Note: unlike `SKIP`, the `SkippedExecution` event is never fired when Quartz skips execution.
+- Alternatively, use `@Scheduled(concurrentExecution = SKIP)` — this fires a `SkippedExecution` event when an execution is skipped.
 - For Quartz `Job` classes, use `@DisallowConcurrentExecution`.
 
 ### JDBC Job Store (Persistent Jobs)
@@ -94,22 +93,29 @@ Requires a datasource. Quartz tables must be created manually via SQL migration 
 
 ### Misfire Handling
 
-Misfires occur when a job's trigger time passes without the job executing (e.g., the application was down). Configure misfire policies on `@Scheduled`:
+Misfires occur when a job's trigger time passes without the job executing (e.g., the application was down). Configure misfire policies in `application.properties`:
 
-```java
-@Scheduled(cron = "0 0 8 * * ?", identity = "daily-report",
-    misfirePolicy = MisfirePolicy.FIRE_NOW)
-void dailyReport() { /* ... */ }
+```properties
+# Per-job misfire policy (keyed by the job's identity)
+quarkus.quartz.misfire-policy."daily-report"=fire-now
+
+# Global defaults for all triggers of a given type
+quarkus.quartz.cron-trigger.misfire-policy=smart-policy
+quarkus.quartz.simple-trigger.misfire-policy=smart-policy
 ```
 
-- `SMART_POLICY` (default) — Quartz picks a sensible policy based on the trigger type.
-- `FIRE_NOW` — execute immediately on recovery.
-- `IGNORE_MISFIRE_POLICY` — fire all missed triggers.
-- `DO_NOTHING` — skip misfired triggers and wait for the next scheduled time.
+Available policies (common):
+- `smart-policy` (default) — Quartz picks a sensible policy based on the trigger type.
+- `fire-now` — execute immediately on recovery.
+- `ignore-misfire-policy` — fire all missed triggers.
+- `cron-trigger-do-nothing` — skip misfired cron triggers and wait for the next scheduled time.
+
+Additional simple-trigger-specific policies: `simple-trigger-reschedule-now-with-existing-repeat-count`, `simple-trigger-reschedule-now-with-remaining-repeat-count`, `simple-trigger-reschedule-next-with-existing-count`, `simple-trigger-reschedule-next-with-remaining-count`.
 
 ### Common Pitfalls
 
 - Quartz cron uses **6 fields** by default (with seconds) — `"0 */5 * * * ?"` not `"*/5 * * * *"`.
-- `@Scheduled` methods must be on CDI beans — plain classes are ignored.
+- `@Scheduled` methods must be on CDI beans — a class that has no scope and declares at least one non-static method annotated with `@Scheduled` is automatically annotated with `@Singleton`.
 - Do NOT use `@Scheduled` on private methods.
 - The Quarkus `Scheduler` and Quartz `Scheduler` are different types — inject the right one for your use case.
+- If using only programmatic jobs (no `@Scheduled` methods), set `quarkus.scheduler.start-mode=forced` — otherwise the scheduler won't start.


### PR DESCRIPTION
This adds an AI skill file (`quarkus-skill.md`) for the `quarkus-quartz` extension, helping AI coding assistants guide developers through Quartz job scheduling.

## Process

1. **Tester** built a scheduler service with @Scheduled, pause/resume, and programmatic jobs — rated SOME FRICTION
2. **Skill creation** based on tester findings
3. **Validator** built an advanced system with direct Quartz API, job data, misfire policies, @DisallowConcurrentExecution — 7/7 tests passing, rated EXCELLENT

## What the skill teaches

- When to use `quartz` vs `scheduler`
- `@Scheduled` with interval and cron expressions (6-field Quartz cron format)
- Two scheduler APIs: Quarkus `Scheduler` (pause/resume) vs Quartz `Scheduler` (programmatic jobs)
- Direct Quartz API: `JobBuilder`, `TriggerBuilder`, `JobDataMap`
- Programmatic `Job` implementation with CDI injection
- Concurrent execution control (`SKIP` and `@DisallowConcurrentExecution`)
- JDBC job store for persistence and clustering
- Testing with Awaitility for timing-based assertions

## Validation result

- **Rating**: Excellent
- **Tests**: 7/7 passing
- **No incorrect content** found

Closes https://github.com/quarkusio/quarkus/issues/54048