### PR TITLE
Add trusted proxy check based on DN's subject for environment where IP based check is not possible

### DIFF
--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -637,6 +637,23 @@ quarkus.http.proxy.trusted-proxies=127.0.0.1 <1>
 ----
 <1> Configure trusted proxy with the IP address `127.0.0.1`. Request headers from any other address are going to be ignored.
 
+Alternatively, in mTLS environments where proxy IP addresses are not stable (e.g., Kubernetes), you can trust a proxy by its TLS client certificate Subject DN.
+The proxy is trusted when its certificate's Subject DN contains all components specified in any configured value.
+For example, `CN=my-proxy,O=MyOrg` matches a certificate with Subject DN `CN=my-proxy,O=MyOrg,C=US`.
+When no configured DN matches, forwarded headers are ignored and the original connection values are used:
+
+[source,properties]
+----
+quarkus.http.proxy.trusted-proxy-dns[0]=CN=my-proxy <1> <2> <3>
+quarkus.http.proxy.trusted-proxy-dns[1]=CN=envoy-client,O=MyOrg <4>
+----
+<1> DNs must be in RFC 2253 format.
+<2> This option cannot be combined with `quarkus.http.proxy.trusted-proxies`.
+<3> TLS client authentication must be enabled via `quarkus.http.ssl.client-auth` set to `request` or `required`.
+<4> Use indexed format to avoid multi-component DNs being split on commas.
+
+NOTE: Configure enough DN components to uniquely identify your proxy. Using only `CN=my-proxy` will match any certificate with that CN, regardless of issuing organization.
+
 Both configurations related to standard and non-standard headers can be combined, although the standard headers configuration will have precedence. However, combining them has security implications as clients can forge requests with a forwarded header that is not overwritten by the proxy. Therefore, proxies should strip unexpected `Forwarded` or `X-Forwarded-*` headers from the client.
 
 Supported forwarding address headers are:

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/AbstractTrustedProxyDnTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/AbstractTrustedProxyDnTest.java
@@ -1,0 +1,92 @@
+package io.quarkus.vertx.http.proxy;
+
+import static io.quarkus.vertx.http.proxy.AbstractTrustedProxyDnTest.PASSWORD;
+
+import java.io.File;
+import java.net.URL;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.vertx.http.ForwardedHandlerInitializer;
+import io.restassured.RestAssured;
+import io.restassured.response.ValidatableResponse;
+import io.restassured.specification.RequestSpecification;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.junit5.Certificate;
+import io.smallrye.certs.junit5.Certificates;
+
+@Certificates(certificates = @Certificate(name = AbstractTrustedProxyDnTest.CERT_NAME, password = PASSWORD, formats = {
+        Format.PKCS12 }, client = true), replaceIfExists = true, baseDir = "target/certs")
+abstract class AbstractTrustedProxyDnTest {
+
+    static final String CERT_NAME = "proxy-dn-test";
+    static final String PASSWORD = "secret";
+    static final String CERTS_DIR = "target/certs/";
+
+    @TestHTTPResource(value = "/trusted-proxy", tls = true)
+    URL tlsUrl;
+
+    static QuarkusExtensionTest createTest(String clientAuth, String... trustedProxyDns) {
+        final var sb = new StringBuilder("""
+                quarkus.tls.key-store.p12.path=%1$s-keystore.p12
+                quarkus.tls.key-store.p12.password=%2$s
+                quarkus.tls.trust-store.p12.path=%1$s-server-truststore.p12
+                quarkus.tls.trust-store.p12.password=%2$s
+                quarkus.http.ssl.client-auth=%3$s
+                quarkus.http.proxy.proxy-address-forwarding=true
+                quarkus.http.proxy.allow-forwarded=true
+                quarkus.http.proxy.allow-x-forwarded=true
+                quarkus.http.proxy.enable-forwarded-host=true
+                quarkus.http.proxy.enable-forwarded-prefix=true
+                quarkus.http.proxy.enable-trusted-proxy-header=true
+                """.formatted(CERTS_DIR + CERT_NAME, PASSWORD, clientAuth));
+        for (int i = 0; i < trustedProxyDns.length; i++) {
+            sb.append("quarkus.http.proxy.trusted-proxy-dns[").append(i).append("]=").append(trustedProxyDns[i])
+                    .append("\n");
+        }
+
+        return new QuarkusExtensionTest()
+                .withApplicationRoot(jar -> jar
+                        .addClasses(ForwardedHandlerInitializer.class)
+                        .addAsResource(new StringAsset(sb.toString()), "application.properties")
+                        .addAsResource(new File(CERTS_DIR + CERT_NAME + "-keystore.p12"), "server-keystore.p12")
+                        .addAsResource(new File(CERTS_DIR + CERT_NAME + "-server-truststore.p12"), "server-truststore.p12"));
+    }
+
+    final ValidatableResponse forwardedRequest() {
+        return mTlsRequest()
+                .header("Forwarded", "proto=https;for=backend:4444;host=somehost")
+                .get(tlsUrl)
+                .then()
+                .statusCode(200);
+    }
+
+    final ValidatableResponse xForwardedRequest() {
+        return mTlsRequest()
+                .header("X-Forwarded-Ssl", "on")
+                .header("X-Forwarded-For", "backend:4444")
+                .header("X-Forwarded-Host", "somehost")
+                .get(tlsUrl)
+                .then()
+                .statusCode(200);
+    }
+
+    static void assertTrusted(ValidatableResponse response) {
+        response.body(Matchers.equalTo("https|somehost|backend:4444|true"));
+    }
+
+    static void assertUntrusted(ValidatableResponse response) {
+        response
+                .body(Matchers.startsWith("https|localhost"))
+                .body(Matchers.endsWith("|false"));
+    }
+
+    static RequestSpecification mTlsRequest() {
+        return RestAssured.given()
+                .keyStore(CERTS_DIR + CERT_NAME + "-client-keystore.p12", PASSWORD)
+                .trustStore(CERTS_DIR + CERT_NAME + "-client-truststore.p12", PASSWORD);
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedProxyDnAndIpValidationFailureTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedProxyDnAndIpValidationFailureTest.java
@@ -1,0 +1,34 @@
+package io.quarkus.vertx.http.proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.vertx.http.ForwardedHandlerInitializer;
+
+class TrustedProxyDnAndIpValidationFailureTest {
+
+    private static final String configuration = """
+            quarkus.http.proxy.proxy-address-forwarding=true
+            quarkus.http.proxy.allow-forwarded=true
+            quarkus.http.proxy.trusted-proxies=localhost
+            quarkus.http.proxy.trusted-proxy-dns=CN=my-trusted-proxy
+            """;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar
+                    .addClasses(ForwardedHandlerInitializer.class)
+                    .addAsResource(new StringAsset(configuration), "application.properties"))
+            .assertException(t -> assertThat(t).hasMessageContaining("quarkus.http.proxy.trusted-proxies")
+                    .hasMessageContaining("quarkus.http.proxy.trusted-proxy-dns"));
+
+    @Test
+    void testStartupFails() {
+        fail("Application should not have started");
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedProxyDnNoClientAuthValidationFailureTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedProxyDnNoClientAuthValidationFailureTest.java
@@ -1,0 +1,33 @@
+package io.quarkus.vertx.http.proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.vertx.http.ForwardedHandlerInitializer;
+
+class TrustedProxyDnNoClientAuthValidationFailureTest {
+
+    private static final String configuration = """
+            quarkus.http.proxy.proxy-address-forwarding=true
+            quarkus.http.proxy.allow-forwarded=true
+            quarkus.http.proxy.trusted-proxy-dns=CN=my-trusted-proxy
+            """;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar
+                    .addClasses(ForwardedHandlerInitializer.class)
+                    .addAsResource(new StringAsset(configuration), "application.properties"))
+            .assertException(t -> assertThat(t).hasMessageContaining("quarkus.http.proxy.trusted-proxy-dns")
+                    .hasMessageContaining("quarkus.http.ssl.client-auth"));
+
+    @Test
+    void testStartupFails() {
+        fail("Application should not have started");
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedProxyDnNoForwardedHeadersValidationFailureTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedProxyDnNoForwardedHeadersValidationFailureTest.java
@@ -1,0 +1,36 @@
+package io.quarkus.vertx.http.proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.vertx.http.ForwardedHandlerInitializer;
+
+class TrustedProxyDnNoForwardedHeadersValidationFailureTest {
+
+    private static final String configuration = """
+            quarkus.http.ssl.client-auth=REQUEST
+            quarkus.http.proxy.proxy-address-forwarding=true
+            quarkus.http.proxy.allow-forwarded=false
+            quarkus.http.proxy.allow-x-forwarded=false
+            quarkus.http.proxy.trusted-proxy-dns[0]=CN=my-trusted-proxy
+            """;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar
+                    .addClasses(ForwardedHandlerInitializer.class)
+                    .addAsResource(new StringAsset(configuration), "application.properties"))
+            .assertException(t -> assertThat(t).hasMessageContaining("quarkus.http.proxy.trusted-proxy-dns")
+                    .hasMessageContaining("quarkus.http.proxy.allow-forwarded")
+                    .hasMessageContaining("quarkus.http.proxy.allow-x-forwarded"));
+
+    @Test
+    void testStartupFails() {
+        fail("Application should not have started");
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedProxyDnRequestFailureTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedProxyDnRequestFailureTest.java
@@ -1,0 +1,22 @@
+package io.quarkus.vertx.http.proxy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+class TrustedProxyDnRequestFailureTest extends AbstractTrustedProxyDnTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = createTest("REQUEST", "CN=my-trusted-proxy");
+
+    @Test
+    void testForwardedWithWrongDnIgnored() {
+        assertUntrusted(forwardedRequest());
+    }
+
+    @Test
+    void testXForwardedWithWrongDnIgnored() {
+        assertUntrusted(xForwardedRequest());
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedProxyDnRequestTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedProxyDnRequestTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.vertx.http.proxy;
+
+import java.net.URL;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.restassured.RestAssured;
+
+class TrustedProxyDnRequestTest extends AbstractTrustedProxyDnTest {
+
+    @TestHTTPResource(value = "/trusted-proxy")
+    URL httpUrl;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = createTest("REQUEST", "CN=localhost");
+
+    @Test
+    void testForwardedWithMatchingDn() {
+        assertTrusted(forwardedRequest());
+    }
+
+    @Test
+    void testXForwardedWithMatchingDn() {
+        assertTrusted(xForwardedRequest());
+    }
+
+    @Test
+    void testHttpConnectionForwardedIgnored() {
+        RestAssured.given()
+                .header("Forwarded", "proto=https;for=backend:4444;host=somehost")
+                .get(httpUrl)
+                .then()
+                .statusCode(200)
+                .body(Matchers.startsWith("http|localhost"))
+                .body(Matchers.endsWith("|false"));
+    }
+
+    @Test
+    void testHttpsWithoutClientCertForwardedIgnored() {
+        RestAssured.given()
+                .trustStore(CERTS_DIR + CERT_NAME + "-client-truststore.p12", PASSWORD)
+                .header("Forwarded", "proto=https;for=backend:4444;host=somehost")
+                .get(tlsUrl)
+                .then()
+                .statusCode(200)
+                .body(Matchers.startsWith("https|localhost"))
+                .body(Matchers.endsWith("|false"));
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedProxyDnRequiredFailureTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedProxyDnRequiredFailureTest.java
@@ -1,0 +1,37 @@
+package io.quarkus.vertx.http.proxy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.response.ValidatableResponse;
+
+class TrustedProxyDnRequiredFailureTest extends AbstractTrustedProxyDnTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = createTest("REQUIRED", "CN=my-trusted-proxy");
+
+    @Test
+    void testForwardedWithWrongDnIgnored() {
+        assertUntrusted(forwardedRequest());
+    }
+
+    @Test
+    void testXForwardedWithWrongDnIgnored() {
+        assertUntrusted(xForwardedRequest());
+    }
+
+    @Test
+    void testTrustedProxyHeaderCannotBeForged() {
+        assertUntrusted(forwardedRequestWithForgedTrustedHeader());
+    }
+
+    private ValidatableResponse forwardedRequestWithForgedTrustedHeader() {
+        return mTlsRequest()
+                .header("Forwarded", "proto=https;for=backend:4444;host=somehost")
+                .header("X-Forwarded-Trusted-Proxy", "true")
+                .get(tlsUrl)
+                .then()
+                .statusCode(200);
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedProxyDnRequiredTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedProxyDnRequiredTest.java
@@ -1,0 +1,22 @@
+package io.quarkus.vertx.http.proxy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+class TrustedProxyDnRequiredTest extends AbstractTrustedProxyDnTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = createTest("REQUIRED", "CN=localhost,O=not-matching", "CN=localhost");
+
+    @Test
+    void testForwardedWithMatchingDn() {
+        assertTrusted(forwardedRequest());
+    }
+
+    @Test
+    void testXForwardedWithMatchingDn() {
+        assertTrusted(xForwardedRequest());
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardingProxyOptions.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardingProxyOptions.java
@@ -2,10 +2,17 @@ package io.quarkus.vertx.http.runtime;
 
 import java.util.List;
 
+import javax.naming.InvalidNameException;
+import javax.naming.ldap.LdapName;
+import javax.naming.ldap.Rdn;
+import javax.security.auth.x500.X500Principal;
+
 import io.netty.util.AsciiString;
+import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.vertx.http.runtime.ProxyConfig.ForwardedPrecedence;
 import io.quarkus.vertx.http.runtime.TrustedProxyCheck.TrustedProxyCheckBuilder;
 import io.quarkus.vertx.http.runtime.TrustedProxyCheck.TrustedProxyCheckPart;
+import io.vertx.core.http.ClientAuth;
 
 public class ForwardingProxyOptions {
     public final boolean proxyAddressForwarding;
@@ -19,6 +26,7 @@ public class ForwardingProxyOptions {
     final ForwardedPrecedence forwardedPrecedence;
     public final TrustedProxyCheckBuilder trustedProxyCheckBuilder;
     final boolean enableTrustedProxyHeader;
+    public final List<List<Rdn>> trustedProxyDns;
 
     public ForwardingProxyOptions(final boolean proxyAddressForwarding,
             boolean allowForwarded,
@@ -30,7 +38,8 @@ public class ForwardingProxyOptions {
             boolean strictForwardedControl,
             ForwardedPrecedence forwardedPrecedence,
             AsciiString forwardedPrefixHeader,
-            TrustedProxyCheckBuilder trustedProxyCheckBuilder) {
+            TrustedProxyCheckBuilder trustedProxyCheckBuilder,
+            List<List<Rdn>> trustedProxyDns) {
         this.proxyAddressForwarding = proxyAddressForwarding;
         this.allowForwarded = allowForwarded;
         this.allowXForwarded = allowXForwarded;
@@ -42,9 +51,10 @@ public class ForwardingProxyOptions {
         this.forwardedPrecedence = forwardedPrecedence;
         this.trustedProxyCheckBuilder = trustedProxyCheckBuilder;
         this.enableTrustedProxyHeader = enableTrustedProxyHeader;
+        this.trustedProxyDns = trustedProxyDns;
     }
 
-    public static ForwardingProxyOptions from(ProxyConfig proxyConfig) {
+    public static ForwardingProxyOptions from(ProxyConfig proxyConfig, ClientAuth clientAuth) {
         final boolean proxyAddressForwarding = proxyConfig.proxyAddressForwarding();
         final boolean allowForwarded = proxyConfig.allowForwarded();
         final boolean allowXForwarded = proxyConfig.allowXForwarded().orElse(!allowForwarded);
@@ -58,11 +68,50 @@ public class ForwardingProxyOptions {
 
         final List<TrustedProxyCheckPart> parts = proxyConfig.trustedProxies()
                 .isPresent() ? List.copyOf(proxyConfig.trustedProxies().get()) : List.of();
+
+        final List<List<Rdn>> trustedProxyDns = collectAndValidateTrustedProxyDns(proxyConfig, clientAuth, parts,
+                allowXForwarded, allowForwarded);
+
         final var proxyCheckBuilder = (!allowXForwarded && !allowForwarded)
                 || parts.isEmpty() ? null : TrustedProxyCheckBuilder.builder(parts);
 
         return new ForwardingProxyOptions(proxyAddressForwarding, allowForwarded, allowXForwarded, enableForwardedHost,
                 enableTrustedProxyHeader, forwardedHostHeader, enableForwardedPrefix, strictForwardedControl,
-                forwardedPrecedence, forwardedPrefixHeader, proxyCheckBuilder);
+                forwardedPrecedence, forwardedPrefixHeader, proxyCheckBuilder, trustedProxyDns);
+    }
+
+    private static List<List<Rdn>> collectAndValidateTrustedProxyDns(ProxyConfig proxyConfig, ClientAuth clientAuth,
+            List<TrustedProxyCheckPart> parts, boolean allowXForwarded, boolean allowForwarded) {
+        final List<String> dnStrings = proxyConfig.trustedProxyDns().orElse(List.of());
+        if (dnStrings.isEmpty()) {
+            return null;
+        }
+
+        if (!parts.isEmpty()) {
+            throw new ConfigurationException(
+                    "'quarkus.http.proxy.trusted-proxies' and 'quarkus.http.proxy.trusted-proxy-dns' are mutually exclusive");
+        }
+
+        if (clientAuth == ClientAuth.NONE) {
+            throw new ConfigurationException(
+                    "'quarkus.http.proxy.trusted-proxy-dns' requires 'quarkus.http.ssl.client-auth' to be set "
+                            + "to 'request' or 'required'");
+        }
+
+        if (!allowXForwarded && !allowForwarded) {
+            throw new ConfigurationException(
+                    "'quarkus.http.proxy.trusted-proxy-dns' requires 'quarkus.http.proxy.allow-forwarded' "
+                            + "or 'quarkus.http.proxy.allow-x-forwarded' to be enabled");
+        }
+
+        return dnStrings.stream().map(dn -> {
+            try {
+                var x500PrincipalName = new X500Principal(dn).getName(); // force DN validation
+                return List.copyOf(new LdapName(x500PrincipalName).getRdns());
+            } catch (IllegalArgumentException | InvalidNameException e) {
+                throw new ConfigurationException("Invalid 'quarkus.http.proxy.trusted-proxy-dns' value '" + dn
+                        + "': not a valid RFC 2253 Distinguished Name", e);
+            }
+        }).toList();
     }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ProxyConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ProxyConfig.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigDocDefault;
+import io.quarkus.runtime.configuration.TrimmedStringConverter;
 import io.quarkus.vertx.http.runtime.TrustedProxyCheck.TrustedProxyCheckPart;
 import io.smallrye.config.WithConverter;
 import io.smallrye.config.WithDefault;
@@ -145,4 +146,19 @@ public interface ProxyConfig {
      */
     @ConfigDocDefault("All proxy addresses are trusted")
     Optional<List<@WithConverter(TrustedProxyCheckPartConverter.class) TrustedProxyCheckPart>> trustedProxies();
+
+    /**
+     * Configure the list of trusted proxy Distinguished Names (DNs).
+     * The proxy is trusted when its TLS client certificate's Subject DN contains all
+     * the components specified in any single configured value. For example, configuring
+     * {@code CN=my-proxy,O=MyOrg} matches a certificate with Subject DN {@code CN=my-proxy,O=MyOrg,C=US}.
+     * <p>
+     * DNs must be in RFC 2253 format.
+     * Use the indexed property format to avoid multi-component DN values being split on commas:
+     * {@code quarkus.http.proxy.trusted-proxy-dns[0]=CN=envoy-client,O=MyOrg}.
+     * <p>
+     * This option is mutually exclusive with {@link #trustedProxies()} and requires
+     * {@code quarkus.http.ssl.client-auth} to be set to {@code REQUEST} or {@code REQUIRED}.
+     */
+    Optional<List<@WithConverter(TrimmedStringConverter.class) String>> trustedProxyDns();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/TrustedProxyCheck.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/TrustedProxyCheck.java
@@ -1,17 +1,33 @@
 package io.quarkus.vertx.http.runtime;
 
 import java.net.InetAddress;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.BiPredicate;
 
+import javax.naming.InvalidNameException;
+import javax.naming.ldap.LdapName;
+import javax.naming.ldap.Rdn;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import javax.security.auth.x500.X500Principal;
+
+import org.jboss.logging.Logger;
+
+import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.net.SocketAddress;
 
 public interface TrustedProxyCheck {
+
+    Logger LOGGER = Logger.getLogger(TrustedProxyCheck.class.getName());
 
     static TrustedProxyCheck allowAll() {
         return new TrustedProxyCheck() {
@@ -38,6 +54,52 @@ public interface TrustedProxyCheck {
      * @return true if `Forwarded`, `X-Forwarded` or `X-Forwarded-*` headers were sent by trusted {@link SocketAddress}
      */
     boolean isProxyAllowed();
+
+    static TrustedProxyCheck createTrustedProxyDnCheck(HttpServerRequest event, List<List<Rdn>> trustedDns) {
+        final SSLSession sslSession = event.sslSession();
+        if (sslSession == null) {
+            LOGGER.debug("No SSL session, proxy DN check cannot be performed");
+            return denyAll();
+        }
+
+        final Certificate[] peerCertificates;
+        try {
+            peerCertificates = sslSession.getPeerCertificates();
+        } catch (SSLPeerUnverifiedException e) {
+            LOGGER.debug("Peer certificate not available, proxy DN check cannot be performed");
+            return denyAll();
+        }
+
+        if (peerCertificates == null || peerCertificates.length == 0
+                || !(peerCertificates[0] instanceof X509Certificate peerCert)) {
+            LOGGER.debug("No X509 peer certificate, proxy DN check cannot be performed");
+            return denyAll();
+        }
+
+        final X500Principal peerDn = peerCert.getSubjectX500Principal();
+        if (matchesAnyTrustedDn(peerDn, trustedDns)) {
+            LOGGER.debugf("Proxy DN '%s' matches trusted DN", peerDn);
+            return allowAll();
+        }
+
+        LOGGER.debugf("Proxy DN '%s' does not match any trusted DN", peerDn);
+        return denyAll();
+    }
+
+    static boolean matchesAnyTrustedDn(X500Principal peerDn, List<List<Rdn>> trustedDns) {
+        final Set<Rdn> peerRdns;
+        try {
+            peerRdns = new HashSet<>(new LdapName(peerDn.getName()).getRdns());
+        } catch (InvalidNameException e) {
+            return false;
+        }
+        for (List<Rdn> requiredRdns : trustedDns) {
+            if (peerRdns.containsAll(requiredRdns)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     final class TrustedProxyCheckBuilder {
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -12,6 +12,7 @@ import static io.quarkus.vertx.http.runtime.options.HttpServerOptionsUtils.RANDO
 import static io.quarkus.vertx.http.runtime.options.HttpServerOptionsUtils.RANDOM_PORT_MANAGEMENT;
 import static io.quarkus.vertx.http.runtime.options.HttpServerOptionsUtils.getInsecureRequestStrategy;
 import static io.quarkus.vertx.http.runtime.options.HttpServerTlsConfig.getHttpServerTlsConfigName;
+import static io.quarkus.vertx.http.runtime.options.HttpServerTlsConfig.getTlsClientAuth;
 
 import java.io.File;
 import java.io.IOException;
@@ -499,7 +500,8 @@ public class VertxHttpRecorder {
         }
 
         warnIfProxyAddressForwardingAllowedWithMultipleHeaders(httpConfig.proxy());
-        root = HttpServerCommonHandlers.applyProxy(httpConfig.proxy(), root, vertx);
+        root = HttpServerCommonHandlers.applyProxy(httpConfig.proxy(), root, vertx,
+                getTlsClientAuth(httpConfig, httpBuildTimeConfig, launchMode));
 
         boolean quarkusWrapperNeeded = false;
 
@@ -604,7 +606,8 @@ public class VertxHttpRecorder {
             applyCompression(managementBuildTimeConfig.enableCompression(), mr);
 
             Handler<HttpServerRequest> handler = HttpServerCommonHandlers.enforceDuplicatedContext(mr, mustResumeRequest);
-            handler = HttpServerCommonHandlers.applyProxy(managementConfig.getValue().proxy(), handler, vertx);
+            handler = HttpServerCommonHandlers.applyProxy(managementConfig.getValue().proxy(), handler, vertx,
+                    managementBuildTimeConfig.tlsClientAuth());
 
             int routesBeforeMiEvent = mr.getRoutes().size();
             event.select(ManagementInterface.class).fire(new ManagementInterfaceImpl(mr));

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerCommonHandlers.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerCommonHandlers.java
@@ -2,6 +2,7 @@ package io.quarkus.vertx.http.runtime.options;
 
 import static io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle.setCurrentContextSafe;
 import static io.quarkus.vertx.http.runtime.TrustedProxyCheck.allowAll;
+import static io.quarkus.vertx.http.runtime.TrustedProxyCheck.createTrustedProxyDnCheck;
 
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -27,6 +28,7 @@ import io.vertx.core.Context;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
+import io.vertx.core.http.ClientAuth;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.ext.web.Router;
@@ -91,26 +93,29 @@ public class HttpServerCommonHandlers {
     }
 
     public static Handler<HttpServerRequest> applyProxy(ProxyConfig proxyConfig, Handler<HttpServerRequest> root,
-            Supplier<Vertx> vertx) {
+            Supplier<Vertx> vertx, ClientAuth clientAuth) {
         if (proxyConfig.proxyAddressForwarding()) {
-            final ForwardingProxyOptions forwardingProxyOptions = ForwardingProxyOptions.from(proxyConfig);
+            final ForwardingProxyOptions forwardingProxyOptions = ForwardingProxyOptions.from(proxyConfig, clientAuth);
+
+            if (forwardingProxyOptions.trustedProxyDns != null && !forwardingProxyOptions.trustedProxyDns.isEmpty()) {
+                return new ProxyHttpServerRequestHandler(root, forwardingProxyOptions) {
+                    @Override
+                    protected TrustedProxyCheck getProxyCheck(HttpServerRequest event) {
+                        return createTrustedProxyDnCheck(event, forwardingProxyOptions.trustedProxyDns);
+                    }
+                };
+            }
+
             final TrustedProxyCheck.TrustedProxyCheckBuilder proxyCheckBuilder = forwardingProxyOptions.trustedProxyCheckBuilder;
             if (proxyCheckBuilder == null) {
                 // no proxy check => we do not restrict who can send `X-Forwarded` or `X-Forwarded-*` headers
-                final TrustedProxyCheck allowAllProxyCheck = allowAll();
-                return new Handler<>() {
+                return new ProxyHttpServerRequestHandler(root, forwardingProxyOptions) {
+
+                    private final TrustedProxyCheck trustedProxyCheck = allowAll();
+
                     @Override
-                    public void handle(HttpServerRequest event) {
-                        ForwardedServerRequestWrapper wrapper;
-                        try {
-                            wrapper = new ForwardedServerRequestWrapper(event, forwardingProxyOptions, allowAllProxyCheck);
-                            @SuppressWarnings("unused")
-                            var unused = wrapper.authority();
-                        } catch (IllegalArgumentException e) {
-                            event.response().setStatusCode(400).end();
-                            return;
-                        }
-                        root.handle(wrapper);
+                    protected TrustedProxyCheck getProxyCheck(HttpServerRequest event) {
+                        return trustedProxyCheck;
                     }
                 };
             } else {
@@ -208,6 +213,34 @@ public class HttpServerCommonHandlers {
                     }
                 }
             }
+        }
+    }
+
+    private static abstract class ProxyHttpServerRequestHandler implements Handler<HttpServerRequest> {
+
+        private final Handler<HttpServerRequest> root;
+        private final ForwardingProxyOptions forwardingProxyOptions;
+
+        protected ProxyHttpServerRequestHandler(Handler<HttpServerRequest> root,
+                ForwardingProxyOptions forwardingProxyOptions) {
+            this.root = root;
+            this.forwardingProxyOptions = forwardingProxyOptions;
+        }
+
+        protected abstract TrustedProxyCheck getProxyCheck(HttpServerRequest event);
+
+        @Override
+        public void handle(HttpServerRequest event) {
+            ForwardedServerRequestWrapper wrapper;
+            try {
+                wrapper = new ForwardedServerRequestWrapper(event, forwardingProxyOptions, getProxyCheck(event));
+                @SuppressWarnings("unused")
+                var unused = wrapper.authority();
+            } catch (IllegalArgumentException e) {
+                event.response().setStatusCode(400).end();
+                return;
+            }
+            root.handle(wrapper);
         }
     }
 }

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/ForwardedServerRequestWrapperTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/ForwardedServerRequestWrapperTest.java
@@ -44,7 +44,7 @@ class ForwardedServerRequestWrapperTest {
         when(mockRequest.authority()).thenReturn(HostAndPort.create("localhost", 8080));
 
         ForwardingProxyOptions options = new ForwardingProxyOptions(
-                false, false, false, false, false, null, false, false, null, null, null);
+                false, false, false, false, false, null, false, false, null, null, null, null);
 
         TrustedProxyCheck trustedProxyCheck = TrustedProxyCheck.allowAll();
         wrapper = new ForwardedServerRequestWrapper(mockRequest, options, trustedProxyCheck);

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/TrustedProxyCheckDnMatchingTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/TrustedProxyCheckDnMatchingTest.java
@@ -1,0 +1,88 @@
+package io.quarkus.vertx.http.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import javax.naming.InvalidNameException;
+import javax.naming.ldap.LdapName;
+import javax.naming.ldap.Rdn;
+import javax.security.auth.x500.X500Principal;
+
+import org.junit.jupiter.api.Test;
+
+class TrustedProxyCheckDnMatchingTest {
+
+    @Test
+    void cnOnlyMatchesCnOnly() {
+        assertThat(matches("CN=proxy", "CN=proxy")).isTrue();
+    }
+
+    @Test
+    void cnOnlyMatchesFullDn() {
+        assertThat(matches("CN=proxy,O=MyOrg,C=US", "CN=proxy")).isTrue();
+    }
+
+    @Test
+    void cnAndOrgMatchesFullDn() {
+        assertThat(matches("CN=proxy,O=MyOrg,C=US", "CN=proxy,O=MyOrg")).isTrue();
+    }
+
+    @Test
+    void fullDnMatchesFullDn() {
+        assertThat(matches("CN=proxy,O=MyOrg,C=US", "CN=proxy,O=MyOrg,C=US")).isTrue();
+    }
+
+    @Test
+    void wrongCnDoesNotMatch() {
+        assertThat(matches("CN=proxy,O=MyOrg", "CN=other")).isFalse();
+    }
+
+    @Test
+    void wrongOrgDoesNotMatch() {
+        assertThat(matches("CN=proxy,O=MyOrg", "CN=proxy,O=OtherOrg")).isFalse();
+    }
+
+    @Test
+    void extraRequiredComponentDoesNotMatch() {
+        assertThat(matches("CN=proxy", "CN=proxy,O=MyOrg")).isFalse();
+    }
+
+    @Test
+    void matchingIsCaseInsensitive() {
+        assertThat(matches("CN=Proxy,O=MyOrg", "cn=proxy")).isTrue();
+    }
+
+    @Test
+    void matchesRegardlessOfRdnOrder() {
+        assertThat(matches("CN=proxy,O=MyOrg,C=US", "O=MyOrg,C=US,CN=proxy")).isTrue();
+    }
+
+    @Test
+    void matchesSecondTrustedDn() {
+        assertThat(TrustedProxyCheck.matchesAnyTrustedDn(
+                new X500Principal("CN=proxy"),
+                List.of(toRdns("CN=other"), toRdns("CN=proxy")))).isTrue();
+    }
+
+    @Test
+    void matchesNoneTrustedDn() {
+        assertThat(TrustedProxyCheck.matchesAnyTrustedDn(
+                new X500Principal("CN=proxy"),
+                List.of(toRdns("CN=other"), toRdns("CN=another")))).isFalse();
+    }
+
+    private static boolean matches(String certDn, String requiredDn) {
+        return TrustedProxyCheck.matchesAnyTrustedDn(
+                new X500Principal(certDn),
+                List.of(toRdns(requiredDn)));
+    }
+
+    private static List<Rdn> toRdns(String dn) {
+        try {
+            return new LdapName(dn).getRdns();
+        } catch (InvalidNameException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+}


### PR DESCRIPTION
* In some environments IP-based check is not possible as proxy IPs are too volatile and you may not have or want DNS resolution (like resolving IP based from internal K8 DNS based on K8 service name wouldn't work for there can be multiple replications). If communication between proxy and Quarkus is using mTLS, we can increase trust that we are talking to the proxy with Subect DN check as this PR does. Please see discussion on https://github.com/keycloak/keycloak/issues/35858 for more infromation

---

* Closes: https://github.com/quarkusio/quarkus/issues/52889