### PR TITLE
Generate Kubernetes Ingress paths from Jakarta REST endpoints

### DIFF
--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -878,6 +878,55 @@ spec:
             pathType: Prefix
 ----
 
+==== Generating Ingress paths from Jakarta REST endpoints
+
+By default, the generated Ingress resource uses a single catch-all `Prefix` rule on `/`.
+You can opt in to per-endpoint rules based on the discovered Jakarta REST `@Path` annotations
+by setting `expose-jaxrs-paths` to `true`:
+
+[source,properties]
+----
+quarkus.kubernetes.ingress.expose=true
+quarkus.kubernetes.ingress.host=my-app.example.com
+quarkus.kubernetes.ingress.expose-jaxrs-paths=true
+----
+
+With this configuration, Quarkus scans the Jandex index for `@Path` annotations and generates one Ingress rule path per discovered endpoint:
+
+* Static paths (e.g. `/greeting`) use `pathType: Exact`.
+* Paths with template parameters (e.g. `/users/{id}`) use `pathType: Prefix` with the static prefix (`/users`).
+
+For example, if your application exposes `GET /greeting` and `GET /users/{id}`, the generated Ingress would look like:
+
+[source, yaml]
+----
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: my-app
+spec:
+  rules:
+    - host: my-app.example.com
+      http:
+        paths:
+          - backend:
+              service:
+                name: my-app
+                port:
+                  name: http
+            path: /greeting
+            pathType: Exact
+          - backend:
+              service:
+                name: my-app
+                port:
+                  name: http
+            path: /users
+            pathType: Prefix
+----
+
+NOTE: When explicit `quarkus.kubernetes.ingress.rules.*` entries are configured, they always take precedence and `expose-jaxrs-paths` has no effect.
+
 ==== Securing the Ingress resource
 
 To secure the incoming connections, Kubernetes allows enabling https://kubernetes.io/docs/concepts/services-networking/ingress/#tls[TLS] within the Ingress resource by specifying a Secret that contains a TLS private key and certificate. You can generate a secured Ingress resource by simply adding the "tls.secret-name" properties:

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ApplyJaxRsIngressRulesDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ApplyJaxRsIngressRulesDecorator.java
@@ -1,0 +1,87 @@
+package io.quarkus.kubernetes.deployment;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import io.dekorate.kubernetes.config.Port;
+import io.dekorate.kubernetes.decorator.AddIngressDecorator;
+import io.dekorate.kubernetes.decorator.AddIngressRuleDecorator;
+import io.dekorate.kubernetes.decorator.Decorator;
+import io.dekorate.kubernetes.decorator.NamedResourceDecorator;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.networking.v1.HTTPIngressPath;
+import io.fabric8.kubernetes.api.model.networking.v1.HTTPIngressPathBuilder;
+import io.fabric8.kubernetes.api.model.networking.v1.IngressSpecBuilder;
+
+public class ApplyJaxRsIngressRulesDecorator extends NamedResourceDecorator<IngressSpecBuilder> {
+
+    private final List<String> paths;
+    private final Optional<Port> defaultPort;
+    private final String host;
+
+    public ApplyJaxRsIngressRulesDecorator(String name, List<String> paths, Optional<Port> defaultPort, String host) {
+        super(name);
+        this.paths = paths;
+        this.defaultPort = defaultPort;
+        this.host = host;
+    }
+
+    @Override
+    public void andThenVisit(IngressSpecBuilder spec, ObjectMeta resourceMeta) {
+        if (spec.hasMatchingRule(r -> Objects.equals(host, r.getHost()))) {
+            spec.editMatchingRule(r -> Objects.equals(host, r.getHost()))
+                    .withNewHttp()
+                    .addAllToPaths(buildPaths())
+                    .endHttp()
+                    .endRule();
+        } else {
+            spec.addNewRule()
+                    .withHost(host)
+                    .withNewHttp()
+                    .addAllToPaths(buildPaths())
+                    .endHttp()
+                    .endRule();
+        }
+    }
+
+    private List<HTTPIngressPath> buildPaths() {
+        Map<String, HTTPIngressPath> deduped = new LinkedHashMap<>();
+        for (String path : paths) {
+            String finalPath = JaxRsPathCollector.hasPathTemplate(path)
+                    ? JaxRsPathCollector.staticPrefix(path)
+                    : path;
+            deduped.putIfAbsent(finalPath, buildPath(path));
+        }
+        return new ArrayList<>(deduped.values());
+    }
+
+    private HTTPIngressPath buildPath(String path) {
+        boolean hasTemplate = JaxRsPathCollector.hasPathTemplate(path);
+        String finalPath = hasTemplate ? JaxRsPathCollector.staticPrefix(path) : path;
+        String pathType = hasTemplate ? "Prefix" : "Exact";
+
+        String portName = defaultPort.map(Port::getName).orElse("http");
+
+        return new HTTPIngressPathBuilder()
+                .withPath(finalPath)
+                .withPathType(pathType)
+                .withNewBackend()
+                .withNewService()
+                .withName(name)
+                .withNewPort()
+                .withName(portName)
+                .endPort()
+                .endService()
+                .endBackend()
+                .build();
+    }
+
+    @Override
+    public Class<? extends Decorator>[] after() {
+        return new Class[] { AddIngressDecorator.class, AddIngressRuleDecorator.class };
+    }
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/IngressConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/IngressConfig.java
@@ -47,6 +47,15 @@ public interface IngressConfig {
      */
     Map<String, IngressRuleConfig> rules();
 
+    /**
+     * If true, Quarkus scans Jakarta REST {@code @Path} annotations and generates one Ingress rule path per
+     * discovered endpoint, using {@code Exact} for static paths and {@code Prefix} for paths with template
+     * parameters (e.g. {@code /users/{id}}).
+     * When explicit {@code quarkus.kubernetes.ingress.rules.*} are configured, this setting has no effect.
+     */
+    @WithDefault("false")
+    boolean exposeJaxrsPaths();
+
     interface IngressTlsConfig {
 
         /**

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/JaxRsPathCollector.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/JaxRsPathCollector.java
@@ -1,0 +1,143 @@
+package io.quarkus.kubernetes.deployment;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.MethodInfo;
+
+final class JaxRsPathCollector {
+
+    static final DotName PATH = DotName.createSimple("jakarta.ws.rs.Path");
+    static final DotName APPLICATION_PATH = DotName.createSimple("jakarta.ws.rs.ApplicationPath");
+
+    private JaxRsPathCollector() {
+    }
+
+    /**
+     * Collects all unique endpoint paths from the Jandex index, resolving them against the
+     * HTTP root path and any {@code @ApplicationPath}.
+     *
+     * @param index the combined Jandex index
+     * @param httpRootPath the value of {@code quarkus.http.root-path} (typically {@code /})
+     * @return deduplicated list of absolute endpoint paths
+     */
+    static List<String> collect(IndexView index, String httpRootPath) {
+        String applicationPath = resolveApplicationPath(index);
+        String basePath = appendPath(sanitize(httpRootPath), sanitize(applicationPath));
+
+        Set<String> paths = new LinkedHashSet<>();
+        Collection<AnnotationInstance> pathAnnotations = index.getAnnotations(PATH);
+
+        for (AnnotationInstance annotation : pathAnnotations) {
+            if (annotation.target().kind() != AnnotationTarget.Kind.METHOD) {
+                continue;
+            }
+            MethodInfo method = annotation.target().asMethod();
+            ClassInfo declaringClass = method.declaringClass();
+
+            String classPath = classPath(declaringClass);
+            if (classPath == null) {
+                continue;
+            }
+            String methodPath = annotation.value().asString();
+            String fullPath = appendPath(basePath, appendPath(sanitize(classPath), sanitize(methodPath)));
+            if (!fullPath.isBlank()) {
+                paths.add(fullPath);
+            }
+        }
+
+        for (AnnotationInstance annotation : pathAnnotations) {
+            if (annotation.target().kind() != AnnotationTarget.Kind.CLASS) {
+                continue;
+            }
+            ClassInfo clazz = annotation.target().asClass();
+            boolean hasMethodPaths = pathAnnotations.stream()
+                    .anyMatch(a -> a.target().kind() == AnnotationTarget.Kind.METHOD
+                            && a.target().asMethod().declaringClass().name().equals(clazz.name()));
+            if (!hasMethodPaths) {
+                String classPath = annotation.value().asString();
+                String fullPath = appendPath(basePath, sanitize(classPath));
+                if (!fullPath.isBlank()) {
+                    paths.add(fullPath);
+                }
+            }
+        }
+
+        return new ArrayList<>(paths);
+    }
+
+    private static String resolveApplicationPath(IndexView index) {
+        Collection<AnnotationInstance> appPaths = index.getAnnotations(APPLICATION_PATH);
+        if (appPaths.isEmpty()) {
+            return null;
+        }
+        AnnotationInstance first = appPaths.iterator().next();
+        return first.value() != null ? first.value().asString() : null;
+    }
+
+    private static String classPath(ClassInfo clazz) {
+        AnnotationInstance classPathAnnotation = clazz.declaredAnnotation(PATH);
+        if (classPathAnnotation == null) {
+            return null;
+        }
+        return classPathAnnotation.value() != null ? classPathAnnotation.value().asString() : null;
+    }
+
+    static String sanitize(String path) {
+        if (path == null || path.isBlank() || "/".equals(path)) {
+            return "";
+        }
+        path = path.trim();
+        if (!path.startsWith("/")) {
+            path = "/" + path;
+        }
+        if (path.endsWith("/")) {
+            path = path.substring(0, path.length() - 1);
+        }
+        return path;
+    }
+
+    static String appendPath(String prefix, String suffix) {
+        if (prefix == null || prefix.isBlank()) {
+            return suffix == null ? "" : suffix;
+        }
+        if (suffix == null || suffix.isBlank()) {
+            return prefix;
+        }
+        if (prefix.endsWith("/") && suffix.startsWith("/")) {
+            return prefix + suffix.substring(1);
+        }
+        if (!prefix.endsWith("/") && !suffix.startsWith("/")) {
+            return prefix + "/" + suffix;
+        }
+        return prefix + suffix;
+    }
+
+    /**
+     * Strips the path template portion from a path, returning the static prefix.
+     * For example, {@code /users/{id}/posts} becomes {@code /users}.
+     */
+    static String staticPrefix(String path) {
+        int idx = path.indexOf('{');
+        if (idx < 0) {
+            return path;
+        }
+        String prefix = path.substring(0, idx);
+        if (prefix.endsWith("/")) {
+            prefix = prefix.substring(0, prefix.length() - 1);
+        }
+        return prefix.isBlank() ? "/" : prefix;
+    }
+
+    static boolean hasPathTemplate(String path) {
+        return path.contains("{");
+    }
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/VanillaKubernetesProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/VanillaKubernetesProcessor.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import org.eclipse.microprofile.config.ConfigProvider;
+
 import io.dekorate.kubernetes.annotation.ServiceType;
 import io.dekorate.kubernetes.config.DeploymentStrategy;
 import io.dekorate.kubernetes.config.IngressBuilder;
@@ -23,6 +25,7 @@ import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.InitTaskBuildItem;
 import io.quarkus.deployment.metrics.MetricsCapabilityBuildItem;
 import io.quarkus.deployment.pkg.PackageConfig;
@@ -224,6 +227,36 @@ public class VanillaKubernetesProcessor extends BaseVanillaKubernetesProcessor {
                 }
             }
         }
+    }
+
+    @BuildStep
+    public void jaxrsIngressRules(
+            ApplicationInfoBuildItem applicationInfo,
+            CombinedIndexBuildItem combinedIndex,
+            List<KubernetesPortBuildItem> ports,
+            BuildProducer<DecoratorBuildItem> decorators) {
+        if (config.ingress() == null || !config.ingress().expose()) {
+            return;
+        }
+        if (!config.ingress().exposeJaxrsPaths()) {
+            return;
+        }
+        if (!config.ingress().rules().isEmpty()) {
+            return;
+        }
+
+        String httpRootPath = ConfigProvider.getConfig()
+                .getOptionalValue("quarkus.http.root-path", String.class)
+                .orElse("/");
+        List<String> paths = JaxRsPathCollector.collect(combinedIndex.getIndex(), httpRootPath);
+        if (paths.isEmpty()) {
+            return;
+        }
+
+        String name = ResourceNameUtil.getResourceName(config, applicationInfo);
+        String host = config.ingress().host().orElse(null);
+        decorators.produce(new DecoratorBuildItem(KUBERNETES,
+                new ApplyJaxRsIngressRulesDecorator(name, paths, optionalPort(ports), host)));
     }
 
     @BuildStep

--- a/integration-tests/kubernetes/quarkus-standard-way/src/main/java/io/quarkus/it/kubernetes/UserResource.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/main/java/io/quarkus/it/kubernetes/UserResource.java
@@ -1,0 +1,39 @@
+package io.quarkus.it.kubernetes;
+
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/users")
+public class UserResource {
+
+    @GET
+    @Path("{id}")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getUser(@PathParam("id") String id) {
+        return id;
+    }
+
+    @PUT
+    @Path("{id}")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String updateUser(@PathParam("id") String id) {
+        return id;
+    }
+
+    @DELETE
+    @Path("{id}")
+    public void deleteUser(@PathParam("id") String id) {
+    }
+
+    @GET
+    @Path("{id}/orders")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getUserOrders(@PathParam("id") String id) {
+        return id;
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithJaxRsIngressStrategyTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithJaxRsIngressStrategyTest.java
@@ -1,0 +1,76 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1.IngressRule;
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+/**
+ * Verifies that {@code quarkus.kubernetes.ingress.expose-jaxrs-paths=true} generates per-endpoint Ingress rules:
+ * static paths use {@code Exact} and paths with template parameters use {@code Prefix}.
+ */
+public class KubernetesWithJaxRsIngressStrategyTest {
+
+    private static final String APP_NAME = "kubernetes-with-jaxrs-ingress-strategy";
+    private static final String HOST = "my-app.example.com";
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot((jar) -> jar.addClasses(GreetingResource.class, UserResource.class))
+            .setApplicationName(APP_NAME)
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .withConfigurationResource(APP_NAME + ".properties")
+            .setLogFileName("k8s.log")
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-kubernetes", Version.getVersion())));
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        final Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        assertThat(kubernetesDir)
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.json"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.yml"));
+
+        List<HasMetadata> list = DeserializationUtil.deserializeAsList(kubernetesDir.resolve("kubernetes.yml"));
+
+        assertThat(list).filteredOn(i -> "Ingress".equals(i.getKind())).singleElement()
+                .isInstanceOfSatisfying(Ingress.class, ingress -> {
+                    assertThat(ingress.getMetadata().getName()).isEqualTo(APP_NAME);
+
+                    List<IngressRule> rules = ingress.getSpec().getRules();
+                    assertThat(rules).hasSize(1);
+
+                    IngressRule rule = rules.get(0);
+                    assertThat(rule.getHost()).isEqualTo(HOST);
+                    assertThat(rule.getHttp()).isNotNull();
+                    assertThat(rule.getHttp().getPaths()).hasSize(2);
+
+                    assertThat(rule.getHttp().getPaths()).anySatisfy(path -> {
+                        assertThat(path.getPath()).isEqualTo("/greeting");
+                        assertThat(path.getPathType()).isEqualTo("Exact");
+                        assertThat(path.getBackend().getService().getName()).isEqualTo(APP_NAME);
+                    });
+
+                    assertThat(rule.getHttp().getPaths()).anySatisfy(path -> {
+                        assertThat(path.getPath()).isEqualTo("/users");
+                        assertThat(path.getPathType()).isEqualTo("Prefix");
+                        assertThat(path.getBackend().getService().getName()).isEqualTo(APP_NAME);
+                    });
+                });
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-jaxrs-ingress-strategy.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-jaxrs-ingress-strategy.properties
@@ -1,0 +1,3 @@
+quarkus.kubernetes.ingress.expose=true
+quarkus.kubernetes.ingress.host=my-app.example.com
+quarkus.kubernetes.ingress.expose-jaxrs-paths=true


### PR DESCRIPTION
When `quarkus.kubernetes.ingress.expose=true`, the generated Ingress currently always uses a single catch-all `/` Prefix rule. This makes it impossible for the Ingress controller to reject traffic to unmapped paths before it reaches the application.

This PR adds an opt-in boolean property `quarkus.kubernetes.ingress.expose-jaxrs-paths`. When enabled, Quarkus scans the Jandex index for `@Path` annotations at build time and generates one Ingress rule path per discovered endpoint:
static paths use `pathType: Exact`, paths with template parameters (e.g. `/users/{id}`) use `pathType: Prefix` with their static prefix (`/users`).

Explicit `quarkus.kubernetes.ingress.rules.*` entries always take precedence: `expose-jaxrs-paths` has no effect when rules are configured manually.

For example, an app with `GET /greeting`, `GET /users/{id}`, and `GET /products/{id}` produces:

```yaml
spec:
  rules:
    - host: my-app.example.com
      http:
        paths:
          - path: /products
            pathType: Prefix
            backend: ...
          - path: /users
            pathType: Prefix
            backend: ...
          - path: /greeting
            pathType: Exact
            backend: ...
```

The implementation lives entirely in the Kubernetes module, using the same Jandex scan pattern as SmallRye OpenAPI. It works with any JAX-RS implementation present in the app; if no `@Path` annotations are found, the build step skips silently.

---

- Fixes: #45696