### PR TITLE
Allow WebDependencyJarBuildItem to carry import mappings directly

### DIFF
--- a/extensions/vertx-http/deployment-spi/src/main/java/io/quarkus/vertx/http/deployment/spi/WebDependencyJarBuildItem.java
+++ b/extensions/vertx-http/deployment-spi/src/main/java/io/quarkus/vertx/http/deployment/spi/WebDependencyJarBuildItem.java
@@ -1,6 +1,7 @@
 package io.quarkus.vertx.http.deployment.spi;
 
 import java.nio.file.Path;
+import java.util.Map;
 
 import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.maven.dependency.ArtifactKey;
@@ -12,15 +13,25 @@ import io.quarkus.maven.dependency.ArtifactKey;
  * UI framework extensions (web-dependency-locator, web-bundler, etc.)
  * consume these to discover web dependencies without classpath scanning
  * or group-ID matching.
+ * <p>
+ * Extensions that generate their import mappings at build time can pass them
+ * directly via {@link #WebDependencyJarBuildItem(ArtifactKey, Path, Map)},
+ * avoiding the need for a static {@code META-INF/importmap.json} in the JAR.
  */
 public final class WebDependencyJarBuildItem extends MultiBuildItem {
 
     private final ArtifactKey artifactKey;
     private final Path jarPath;
+    private final Map<String, String> importMappings;
 
     public WebDependencyJarBuildItem(ArtifactKey artifactKey, Path jarPath) {
+        this(artifactKey, jarPath, Map.of());
+    }
+
+    public WebDependencyJarBuildItem(ArtifactKey artifactKey, Path jarPath, Map<String, String> importMappings) {
         this.artifactKey = artifactKey;
         this.jarPath = jarPath;
+        this.importMappings = importMappings;
     }
 
     public ArtifactKey getArtifactKey() {
@@ -29,5 +40,13 @@ public final class WebDependencyJarBuildItem extends MultiBuildItem {
 
     public Path getJarPath() {
         return jarPath;
+    }
+
+    /**
+     * Returns the import mappings provided at build time, or an empty map
+     * if the import map should be read from the JAR's {@code META-INF/importmap.json}.
+     */
+    public Map<String, String> getImportMappings() {
+        return importMappings;
     }
 }

--- a/extensions/web-dependency-locator/deployment/src/main/java/io/quarkus/webdependency/locator/deployment/WebDependencyLocatorProcessor.java
+++ b/extensions/web-dependency-locator/deployment/src/main/java/io/quarkus/webdependency/locator/deployment/WebDependencyLocatorProcessor.java
@@ -167,15 +167,20 @@ public class WebDependencyLocatorProcessor {
         LibInfo mvnpmNameLibInfo = getLibInfo(curateOutcome, MVNPM_PREFIX, MVNPM_NAME);
 
         // Merge extension-declared web dependency JARs into mvnpm discovery
+        Map<String, String> directImportMappings = new HashMap<>();
         if (!webDependencyJars.isEmpty()) {
             if (mvnpmNameLibInfo == null) {
                 mvnpmNameLibInfo = new LibInfo(new HashMap<>(), new HashSet<>());
             }
             for (WebDependencyJarBuildItem webDep : webDependencyJars) {
-                try {
-                    mvnpmNameLibInfo.jars.add(webDep.getJarPath().toUri().toURL());
-                } catch (MalformedURLException ex) {
-                    throw new RuntimeException(ex);
+                if (!webDep.getImportMappings().isEmpty()) {
+                    directImportMappings.putAll(webDep.getImportMappings());
+                } else {
+                    try {
+                        mvnpmNameLibInfo.jars.add(webDep.getJarPath().toUri().toURL());
+                    } catch (MalformedURLException ex) {
+                        throw new RuntimeException(ex);
+                    }
                 }
             }
         }
@@ -195,6 +200,9 @@ public class WebDependencyLocatorProcessor {
                 }
                 // Also create a importmap endpoint
                 Aggregator aggregator = new Aggregator(mvnpmNameLibInfo.jars);
+                if (!directImportMappings.isEmpty()) {
+                    aggregator.addMappings(directImportMappings);
+                }
                 Map<String, String> importMappings = config.importMappings();
                 if (!importMappings.containsKey(config.appRoot() + SLASH)) {
                     // Add default for app/


### PR DESCRIPTION
Extensions that generate their web asset import mappings at build time (e.g. [quarkus-json-rpc](https://github.com/quarkiverse/quarkus-json-rpc)) currently need a static `META-INF/importmap.json` in their runtime JAR for discovery by web-dependency-locator and web-bundler. This is awkward when the mappings are already known at build time and the extension generates its JS resources dynamically.

This adds an optional `Map<String, String> importMappings` parameter to `WebDependencyJarBuildItem`. When provided, the web-dependency-locator merges these mappings directly into the aggregated import map instead of scanning the JAR for `importmap.json`. The existing constructor and behavior are unchanged for extensions that ship a static importmap in their JAR.

Builds on #53555.