### PR TITLE
Add AI skill for quarkus-infinispan-client

### DIFF
--- a/extensions/infinispan-client/deployment/src/main/resources/META-INF/quarkus-skill.md
+++ b/extensions/infinispan-client/deployment/src/main/resources/META-INF/quarkus-skill.md
@@ -1,0 +1,118 @@
+
+### Setup
+
+Add `quarkus-infinispan-client`. Dev Services auto-starts an Infinispan container — no manual config needed in dev/test.
+
+### Protobuf Serialization
+
+All cached types must be annotated for Protobuf serialization:
+
+```java
+import org.infinispan.protostream.annotations.Proto;
+
+@Proto
+public record Product(String id, String name, double price, String category) {}
+```
+
+Register a schema:
+
+```java
+import org.infinispan.protostream.GeneratedSchema;
+import org.infinispan.protostream.annotations.ProtoSchema;
+
+@ProtoSchema(includeClasses = { Product.class }, schemaPackageName = "com.example")
+public interface ProductSchema extends GeneratedSchema {}
+```
+
+- `@Proto` on records/classes — generates Protobuf mappings at build time.
+- `@ProtoSchema` on an interface extending `GeneratedSchema` — registers all types.
+- `schemaPackageName` should match your Java package.
+
+### Injecting a Remote Cache
+
+```java
+import io.quarkus.infinispan.client.Remote;
+import org.infinispan.client.hotrod.RemoteCache;
+
+@Inject
+@Remote("products")
+RemoteCache<String, Product> cache;
+```
+
+- `@Remote("cache-name")` is from `io.quarkus.infinispan.client` — NOT from the Infinispan library.
+- The cache is auto-created on first access if it doesn't exist.
+
+### CRUD Operations
+
+```java
+cache.put(id, product);                     // create/update
+Product p = cache.get(id);                  // read (null if not found)
+cache.remove(id);                           // delete
+Map<String, Product> all = cache.getAll(cache.keySet()); // list all (small caches only)
+cache.put(id, product, 30, TimeUnit.MINUTES); // put with TTL
+```
+
+### Programmatic Cache Access
+
+```java
+@Inject RemoteCacheManager cacheManager;
+
+RemoteCache<String, Product> cache = cacheManager.getCache("products");
+```
+
+### Ickle Queries
+
+For queries and listeners, use `RemoteCacheManager.getCache()` instead of `@Remote` injection (CDI proxy breaks `Search.getQueryFactory()`):
+
+```java
+@Inject RemoteCacheManager cacheManager;
+
+public List<Product> searchByCategory(String category) {
+    RemoteCache<String, Product> cache = cacheManager.getCache("products");
+    QueryFactory queryFactory = org.infinispan.client.hotrod.Search.getQueryFactory(cache);
+    Query<Product> query = queryFactory.create("FROM com.example.Product WHERE category = :cat");
+    query.setParameter("cat", category);
+    return query.execute().list();
+}
+```
+
+The fully qualified Protobuf type name uses `schemaPackageName` + class name. Requires the cache to have `application/x-protostream` encoding.
+
+### Cache Configuration
+
+For custom cache config (encoding, expiration, indexing), create an XML file:
+
+```xml
+<!-- src/main/resources/infinispan/products.xml -->
+<replicated-cache name="products">
+    <encoding media-type="application/x-protostream"/>
+    <expiration lifespan="3600000"/>
+</replicated-cache>
+```
+
+Reference it: `quarkus.infinispan-client.devservices.config-files=infinispan/products.xml`
+
+### Docker/Podman Networking
+
+If Dev Services returns internal container IPs causing timeouts, add:
+
+```properties
+quarkus.infinispan-client.client-intelligence=BASIC
+```
+
+This prevents the client from using cluster topology information and sticks to the configured host. Required in most Docker/Podman environments.
+
+### Testing
+
+- Dev Services provides a real Infinispan server — no mocking needed.
+- Clear caches in `@BeforeEach` for test isolation: `cache.clear()`.
+- Use `Awaitility` for async operations or TTL-based tests.
+
+### Common Pitfalls
+
+- `@Remote` is from `io.quarkus.infinispan.client.Remote`, NOT from the Infinispan library — easy to get the wrong import.
+- Set `client-intelligence=BASIC` in Docker/Podman environments to avoid connection timeouts to internal container IPs.
+- Auto-created caches use default encoding (`application/x-java-object`) — for Protobuf queries, explicitly configure `application/x-protostream` encoding.
+- `cache.getAll(cache.keySet())` works for listing all entries but is expensive for large caches — use queries instead.
+- `@Proto` works on records and classes. Records need all fields in the constructor.
+- For queries and listeners, use `cacheManager.getCache("name")` — the CDI proxy from `@Remote` breaks `Search.getQueryFactory()` and `cache.addClientListener()`.


### PR DESCRIPTION
This adds an AI skill file (`quarkus-skill.md`) for the `quarkus-infinispan-client` extension, helping AI coding assistants guide developers using Infinispan distributed caching.

## Process

1. **Tester** built a product catalog cache with CRUD and Protobuf — 3/4 tests passing, significant friction
2. **Skill creation** based on tester findings and doc verification
3. **Validator** built a session store with Ickle queries, TTL expiration, and multiple caches — 6/6 tests passing, rated GOOD

## What the tester struggled with

- **`@Remote` import path**: `io.quarkus.infinispan.client.Remote`, not from the Infinispan library
- **Docker/Podman networking**: Dev Services returned internal container IPs; fixed with `client-intelligence=BASIC`
- **Cache encoding**: Auto-created caches use `application/x-java-object`, need explicit `application/x-protostream` for queries

## What the skill teaches

- Protobuf serialization with `@Proto` and `@ProtoSchema`
- Cache injection with `@Remote` (correct import path)
- CRUD operations including TTL-based puts
- Ickle queries with `RemoteCacheManager.getCache()` (CDI proxy workaround)
- Cache configuration for encoding and expiration
- Docker/Podman networking fix (`client-intelligence=BASIC`)
- Key pitfall: CDI proxy from `@Remote` breaks `Search.getQueryFactory()` and listeners

## Validation result

- **Rating**: Good
- **Tests**: 6/6 passing on advanced scenario
- **Critical finding**: CDI proxy issue with `@Remote` — skill documents the `cacheManager.getCache()` workaround

Closes https://github.com/quarkusio/quarkus/issues/54067