### PR TITLE
Docs: fix broken links to JUnit docs

### DIFF
--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -470,7 +470,7 @@ a bit slower, as it adds a shutdown/startup cycle to the test time, but gives a 
 
 To reduce the amount of times Quarkus needs to restart, `io.quarkus.test.junit.util.QuarkusTestProfileAwareClassOrderer`
 is registered as a global `ClassOrderer` as described in the
-link:https://docs.junit.org/current/user-guide/#writing-tests-test-execution-order-classes[JUnit User Guide].
+link:https://docs.junit.org/current/writing-tests/test-execution-order.html#classes[JUnit User Guide].
 The behavior of this `ClassOrderer` is configurable via `application.properties` using the property
 `quarkus.test.class-orderer`. The Quarkus orderer will attempt to sort according to the secondary orderer, with the constraint that tests which require the same application instance are grouped.
 The property accepts the FQCN of the `ClassOrderer` to use as a secondary orderer. It can be set to an orderer that is provided by JUnit or even your own custom one.
@@ -708,7 +708,7 @@ matches the value of `quarkus.test.profile.tags`.
 
 == Nested Tests
 
-JUnit https://docs.junit.org/current/user-guide/#writing-tests-nested[@Nested tests] are useful for structuring more complex test scenarios.
+JUnit https://docs.junit.org/current/writing-tests/nested-tests.html[@Nested tests] are useful for structuring more complex test scenarios.
 However, note that it is not possible to assign different test profiles or resources to nested tests within the same parent class.
 
 == Mock Support

--- a/docs/src/main/asciidoc/getting-started.adoc
+++ b/docs/src/main/asciidoc/getting-started.adoc
@@ -321,7 +321,7 @@ testImplementation("io.quarkus:quarkus-junit")
 testImplementation("io.rest-assured:rest-assured")
 ----
 
-Quarkus supports https://docs.junit.org/current/user-guide/[JUnit] tests.
+Quarkus supports https://docs.junit.org[JUnit] tests.
 
 Because of this, in the case of Maven, the version of the https://maven.apache.org/surefire/maven-surefire-plugin/[Surefire Maven Plugin] must be set, as the default version does not support JUnit:
 

--- a/docs/src/main/asciidoc/testing-components.adoc
+++ b/docs/src/main/asciidoc/testing-components.adoc
@@ -234,7 +234,7 @@ You can use the mock configurator API via the `QuarkusComponentTestExtensionBuil
 
 == Nested Tests
 
-JUnit https://docs.junit.org/current/user-guide/#writing-tests-nested[@Nested tests] may help to structure more complex test scenarios.
+JUnit https://docs.junit.org/current/writing-tests/nested-tests.html[@Nested tests] may help to structure more complex test scenarios.
 However, only basic use cases are tested with `@QuarkusComponentTest`.
 
 .Nested test


### PR DESCRIPTION
Fixes some broken deep links to the JUnit User Guide, which currently redirect to its overview page.