### PR TITLE
Add AI skill for quarkus-narayana-jta

### DIFF
--- a/extensions/narayana-jta/deployment/src/main/resources/META-INF/quarkus-skill.md
+++ b/extensions/narayana-jta/deployment/src/main/resources/META-INF/quarkus-skill.md
@@ -1,0 +1,100 @@
+
+### Declarative Transactions
+
+```java
+@Transactional
+public void transfer(Long fromId, Long toId, BigDecimal amount) {
+    Account from = Account.findById(fromId);
+    Account to = Account.findById(toId);
+    from.balance = from.balance.subtract(amount);
+    to.balance = to.balance.add(amount);
+    // commits on success, rolls back on RuntimeException
+}
+```
+
+- `@Transactional` on CDI bean methods (including REST endpoints) starts a JTA transaction.
+- `RuntimeException` crossing the transaction boundary causes automatic rollback.
+- Checked exceptions do NOT cause rollback by default.
+
+### Transaction Types
+
+```java
+@Transactional(REQUIRED)       // default — join existing or start new
+@Transactional(REQUIRES_NEW)   // always start a new transaction (suspends existing)
+@Transactional(MANDATORY)      // must be called within an existing transaction
+@Transactional(SUPPORTS)       // join if exists, run without if not
+@Transactional(NOT_SUPPORTED)  // suspend existing transaction
+@Transactional(NEVER)          // fail if a transaction is active
+```
+
+### Rollback Rules
+
+```java
+@Transactional(rollbackOn = BusinessException.class)        // roll back on this checked exception
+@Transactional(dontRollbackOn = WarningException.class)     // don't roll back on this
+```
+
+### Programmatic Rollback
+
+```java
+@Inject TransactionManager tm;
+
+@Transactional
+public void process() {
+    if (somethingWrong) {
+        tm.setRollbackOnly();  // mark for rollback without throwing
+    }
+}
+```
+
+### QuarkusTransaction API
+
+Programmatic transaction boundaries without `@Transactional`:
+
+```java
+import io.quarkus.narayana.jta.QuarkusTransaction;
+
+// Run in a new transaction
+QuarkusTransaction.requiringNew().run(() -> {
+    Account account = new Account("Alice", BigDecimal.valueOf(1000));
+    account.persist();
+});
+
+// Run and return a value
+Account result = QuarkusTransaction.requiringNew().call(() -> {
+    Account account = new Account("Bob", BigDecimal.valueOf(500));
+    account.persist();
+    return account;
+});
+
+// Join existing or start new
+QuarkusTransaction.joiningExisting().run(() -> { ... });
+```
+
+- `requiringNew()` — always starts a new transaction.
+- `joiningExisting()` — joins an active transaction or starts a new one.
+- `.run(Runnable)` for void operations, `.call(Callable)` for returning values.
+
+### Transaction Timeout
+
+```java
+@Transactional
+@TransactionConfiguration(timeout = 10)  // 10 seconds
+public void slowOperation() { ... }
+```
+
+Or globally: `quarkus.transaction-manager.default-transaction-timeout=30s`
+
+### Testing Transactions
+
+- Use `@TestTransaction` on test methods — the transaction is rolled back after each test for isolation.
+- `@Transactional` works in `@QuarkusTest` tests.
+- To verify rollback, perform an operation that should fail, then query to confirm data wasn't persisted.
+
+### Common Pitfalls
+
+- `@Transactional` only works on CDI bean methods — not on private methods.
+- `RuntimeException` = automatic rollback. Checked exception = NO rollback (unless `rollbackOn` is set).
+- `REQUIRES_NEW` suspends the outer transaction — changes in the inner transaction persist even if the outer rolls back. Use this for audit logs.
+- `MANDATORY` throws `TransactionRequiredException` if no active transaction exists — useful for service methods that must be called from a transactional context.
+- `QuarkusTransaction` is preferred over `UserTransaction` for programmatic boundaries — it's more concise and Quarkus-native.


### PR DESCRIPTION
This adds an AI skill file (`quarkus-skill.md`) for the `quarkus-narayana-jta` extension, helping AI coding assistants guide developers through JTA transaction management.

## Process

1. **Tester** built a bank account service with transfers and rollback — 6/6 tests, rated SMOOTH
2. **Skill creation** based on tester findings and doc verification
3. **Validator** built an order processing system with propagation, rollback rules, and programmatic transactions — 8/8 tests, rated GOOD

## What the skill teaches

- `@Transactional` declarative transactions with all propagation types (REQUIRED, REQUIRES_NEW, MANDATORY, etc.)
- Rollback rules: `rollbackOn` for checked exceptions, automatic rollback for RuntimeException
- Programmatic rollback via `TransactionManager.setRollbackOnly()`
- `QuarkusTransaction` API: `requiringNew().run()`, `joiningExisting().call()`
- `@TransactionConfiguration(timeout = N)` for per-method timeouts
- `@TestTransaction` for test isolation
- Self-invocation pitfall (bypasses interceptor)

## Validation result

- **Rating**: Good
- **Tests**: 8/8 passing
- **All skill content verified** against source code (`TransactionConfiguration` exists at `io.quarkus.narayana.jta.runtime`)

Closes https://github.com/quarkusio/quarkus/issues/54075