### PR TITLE
Add support for Kotlin suspend functions in @QuarkusTest

### DIFF
--- a/integration-tests/kotlin/pom.xml
+++ b/integration-tests/kotlin/pom.xml
@@ -38,6 +38,11 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
         <dependency>

--- a/integration-tests/kotlin/src/test/kotlin/io/quarkus/it/kotser/SuspendTest.kt
+++ b/integration-tests/kotlin/src/test/kotlin/io/quarkus/it/kotser/SuspendTest.kt
@@ -1,0 +1,32 @@
+package io.quarkus.it.kotser
+
+import io.quarkus.test.junit.QuarkusTest
+import kotlinx.coroutines.delay
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
+
+@QuarkusTest
+class SuspendTest {
+
+    @Test
+    suspend fun testSuspendFunction() {
+        delay(10)
+        assertEquals(39, 30 + 9)
+    }
+
+    @Test
+    suspend fun testSuspendFunctionException() {
+        try {
+            throwAfterDelay()
+            fail("Expected exception")
+        } catch (exception: IllegalStateException) {
+            assertEquals("boom", exception.message)
+        }
+    }
+
+    private suspend fun throwAfterDelay() {
+        delay(10)
+        throw IllegalStateException("boom")
+    }
+}

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/KotlinSuspendTestMethodInvoker.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/KotlinSuspendTestMethodInvoker.java
@@ -1,0 +1,136 @@
+package io.quarkus.test.junit;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import io.quarkus.test.TestMethodInvoker;
+
+public class KotlinSuspendTestMethodInvoker implements TestMethodInvoker {
+
+    private static final String KOTLIN_RESULT_FAILURE_CLASS_NAME = "kotlin.Result$Failure";
+
+    @Override
+    public boolean supportsMethod(Class<?> originalTestClass, Method originalMethod) {
+        int parameterCount = originalMethod.getParameterCount();
+        if (parameterCount == 0) {
+            return false;
+        }
+        Class<?> lastParam = originalMethod.getParameterTypes()[parameterCount - 1];
+        return "kotlin.coroutines.Continuation".equals(lastParam.getName());
+    }
+
+    @Override
+    public Object invoke(Object actualTestInstance, Method actualTestMethod, List<Object> actualTestMethodArgs,
+            String testClassName) throws Throwable {
+        ClassLoader methodClassLoader = actualTestMethod.getDeclaringClass().getClassLoader();
+
+        Class<?> continuationClass = Class.forName("kotlin.coroutines.Continuation", false, methodClassLoader);
+
+        var future = new CompletableFuture<Object>();
+
+        var continuationProxy = Proxy.newProxyInstance(methodClassLoader,
+                new Class<?>[] { continuationClass }, new ContinuationInvocationHandler(future, methodClassLoader));
+
+        var invokeArgs = new ArrayList<Object>(actualTestMethodArgs);
+        invokeArgs.add(continuationProxy);
+
+        Object result;
+        try {
+            result = actualTestMethod.invoke(actualTestInstance, invokeArgs.toArray());
+        } catch (InvocationTargetException ex) {
+            throw ex.getCause();
+        }
+
+        if (isCoroutineSuspended(result, methodClassLoader)) {
+            try {
+                return future.get();
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+                throw ex;
+            } catch (ExecutionException ex) {
+                throw ex.getCause();
+            }
+        }
+
+        return result;
+    }
+
+    private static boolean isCoroutineSuspended(Object result, ClassLoader classLoader) {
+        try {
+            Class<?> intrinsicsClass = Class.forName("kotlin.coroutines.intrinsics.CoroutineSingletons", false,
+                    classLoader);
+            Field field = intrinsicsClass.getDeclaredField("COROUTINE_SUSPENDED");
+            Object coroutineSuspended = field.get(null);
+            return result == coroutineSuspended;
+        } catch (Exception ex) {
+            return false;
+        }
+    }
+
+    private static final class ContinuationInvocationHandler implements InvocationHandler {
+
+        private final CompletableFuture<Object> future;
+        private final ClassLoader classLoader;
+
+        ContinuationInvocationHandler(CompletableFuture<Object> future, ClassLoader classLoader) {
+            this.future = future;
+            this.classLoader = classLoader;
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            String methodName = method.getName();
+            int argCount = args == null ? 0 : args.length;
+            if ("resumeWith".equals(methodName) && argCount == 1) {
+                Object result = args[0];
+                if (isKotlinResultFailure(result)) {
+                    try {
+                        Field exceptionField = result.getClass().getDeclaredField("exception");
+                        exceptionField.setAccessible(true);
+                        this.future.completeExceptionally((Throwable) exceptionField.get(result));
+                    } catch (ReflectiveOperationException ex) {
+                        this.future.completeExceptionally(ex);
+                    }
+                } else {
+                    this.future.complete(result);
+                }
+                return null;
+            }
+            if ("getContext".equals(methodName) && argCount == 0) {
+                Object dispatcher = tryLoadDefaultDispatcher(this.classLoader);
+                if (dispatcher != null) {
+                    return dispatcher;
+                }
+                try {
+                    Class<?> emptyContextClass = Class.forName("kotlin.coroutines.EmptyCoroutineContext", false,
+                            this.classLoader);
+                    return emptyContextClass.getDeclaredField("INSTANCE").get(null);
+                } catch (Exception ex) {
+                    throw new RuntimeException(ex);
+                }
+            }
+            throw new UnsupportedOperationException(methodName);
+        }
+    }
+
+    private static boolean isKotlinResultFailure(Object result) {
+        return result != null && KOTLIN_RESULT_FAILURE_CLASS_NAME.equals(result.getClass().getName());
+    }
+
+    private static Object tryLoadDefaultDispatcher(ClassLoader classLoader) {
+        try {
+            Class<?> dispatchersClass = Class.forName("kotlinx.coroutines.Dispatchers", false, classLoader);
+            return dispatchersClass.getDeclaredField("Default").get(null);
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+
+}

--- a/test-framework/junit/src/main/resources/META-INF/services/io.quarkus.test.TestMethodInvoker
+++ b/test-framework/junit/src/main/resources/META-INF/services/io.quarkus.test.TestMethodInvoker
@@ -1,0 +1,1 @@
+io.quarkus.test.junit.KotlinSuspendTestMethodInvoker


### PR DESCRIPTION
Add `KotlinSuspendTestMethodInvoker` to support Kotlin `suspend` test methods in `@QuarkusTest`. Depends on the corresponding JUnit's PR being merged first.

* Fixes #52480 

Also related to:

* junit-team/junit-framework/issues/5375
