### PR TITLE
Bump Hibernate ORM to 7.4.0.Final, Reactive to 3.4.0.Final, Search to 8.4.0.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -100,7 +100,7 @@
         <narayana-lra.version>1.2.0.Final</narayana-lra.version>
         <agroal.version>3.2</agroal.version>
         <jboss-transaction-spi.version>8.0.0.Final</jboss-transaction-spi.version>
-        <elasticsearch-opensource-components.version>9.3.5</elasticsearch-opensource-components.version>
+        <elasticsearch-opensource-components.version>9.4.1</elasticsearch-opensource-components.version>
         <rxjava.version>2.2.21</rxjava.version>
         <wildfly.openssl-java.version>2.3.0.Final</wildfly.openssl-java.version>
         <wildfly.openssl-linux.version>2.3.0.Final</wildfly.openssl-linux.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -74,12 +74,12 @@
         <volume.access.modifier>:Z</volume.access.modifier>
 
         <!-- Defaults for integration tests -->
-        <elasticsearch-server.version>9.3.2</elasticsearch-server.version>
+        <elasticsearch-server.version>9.4.1</elasticsearch-server.version>
         <elasticsearch.image>docker.io/elastic/elasticsearch:${elasticsearch-server.version}</elasticsearch.image>
         <logstash.image>docker.io/elastic/logstash:${elasticsearch-server.version}</logstash.image>
         <kibana.image>docker.io/elastic/kibana:${elasticsearch-server.version}</kibana.image>
         <elasticsearch.protocol>http</elasticsearch.protocol>
-        <opensearch-server.version>3.5.0</opensearch-server.version>
+        <opensearch-server.version>3.6.0</opensearch-server.version>
         <opensearch.image>docker.io/opensearchproject/opensearch:${opensearch-server.version}</opensearch.image>
         <opensearch.protocol>http</opensearch.protocol>
         <junit-pioneer.version>2.3.0</junit-pioneer.version>

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/ClassNames.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/ClassNames.java
@@ -96,6 +96,7 @@ public final class ClassNames {
             createConstant("org.hibernate.id.enhanced.TableGenerator"),
             createConstant("org.hibernate.id.uuid.UuidGenerator"),
             createConstant("org.hibernate.tuple.entity.CompositeGeneratorBuilder$CompositeBeforeExecutionGenerator"),
+            createConstant("org.hibernate.tuple.entity.CompositeGeneratorBuilder$CompositeOnAndBeforeExecutionGenerator"),
             createConstant("org.hibernate.tuple.entity.CompositeGeneratorBuilder$CompositeOnExecutionGenerator"),
             createConstant("org.hibernate.tuple.entity.CompositeGeneratorBuilder$DummyGenerator"));
 
@@ -121,6 +122,8 @@ public final class ClassNames {
             createConstant("jakarta.persistence.SequenceGenerators"),
             createConstant("jakarta.persistence.TableGenerator"),
             createConstant("jakarta.persistence.TableGenerators"),
+            createConstant("org.hibernate.annotations.Audited"),
+            createConstant("org.hibernate.annotations.Audited$Table"),
             createConstant("org.hibernate.annotations.CollectionTypeRegistration"),
             createConstant("org.hibernate.annotations.CompositeTypeRegistration"),
             createConstant("org.hibernate.annotations.CompositeTypeRegistrations"),
@@ -149,8 +152,10 @@ public final class ClassNames {
             createConstant("org.hibernate.annotations.NamedNativeQuery"),
             createConstant("org.hibernate.annotations.NamedQueries"),
             createConstant("org.hibernate.annotations.NamedQuery"),
+            createConstant("org.hibernate.annotations.Nationalized"),
             createConstant("org.hibernate.annotations.NativeGenerator"),
             createConstant("org.hibernate.annotations.SoftDelete"),
+            createConstant("org.hibernate.annotations.Temporal"),
             createConstant("org.hibernate.annotations.TypeRegistration"),
             createConstant("org.hibernate.annotations.TypeRegistrations"));
 
@@ -260,12 +265,22 @@ public final class ClassNames {
             createConstant("org.hibernate.annotations.AnyKeyJdbcType"),
             createConstant("org.hibernate.annotations.AnyKeyJdbcTypeCode"),
             createConstant("org.hibernate.annotations.Array"),
+            createConstant("org.hibernate.annotations.Audited"),
+            createConstant("org.hibernate.annotations.Audited$CollectionTable"),
+            createConstant("org.hibernate.annotations.Audited$Excluded"),
+            createConstant("org.hibernate.annotations.Audited$SecondaryTable"),
+            createConstant("org.hibernate.annotations.Audited$SecondaryTables"),
+            createConstant("org.hibernate.annotations.Audited$Table"),
             createConstant("org.hibernate.annotations.AttributeAccessor"),
             createConstant("org.hibernate.annotations.AttributeBinderType"),
             createConstant("org.hibernate.annotations.Bag"),
             createConstant("org.hibernate.annotations.BatchSize"),
             createConstant("org.hibernate.annotations.Cache"),
             createConstant("org.hibernate.annotations.Cascade"),
+            createConstant("org.hibernate.annotations.Changelog"),
+            createConstant("org.hibernate.annotations.Changelog$ChangesetId"),
+            createConstant("org.hibernate.annotations.Changelog$ModifiedEntities"),
+            createConstant("org.hibernate.annotations.Changelog$Timestamp"),
             createConstant("org.hibernate.annotations.Check"),
             createConstant("org.hibernate.annotations.Checks"),
             createConstant("org.hibernate.annotations.Collate"),
@@ -421,6 +436,10 @@ public final class ClassNames {
             createConstant("org.hibernate.annotations.Struct"),
             createConstant("org.hibernate.annotations.Subselect"),
             createConstant("org.hibernate.annotations.Synchronize"),
+            createConstant("org.hibernate.annotations.Temporal"),
+            createConstant("org.hibernate.annotations.Temporal$Excluded"),
+            createConstant("org.hibernate.annotations.Temporal$HistoryPartitioning"),
+            createConstant("org.hibernate.annotations.Temporal$HistoryTable"),
             createConstant("org.hibernate.annotations.TargetEmbeddable"),
             createConstant("org.hibernate.annotations.TenantId"),
             createConstant("org.hibernate.annotations.TimeZoneColumn"),
@@ -543,5 +562,7 @@ public final class ClassNames {
             // Accessed in org.hibernate.event.spi.EventEngine.<init>
             createConstant("org.hibernate.event.spi.EventEngineContributor"),
             // Accessed in org.hibernate.service.internal.SessionFactoryServiceRegistryFactoryImpl.buildServiceRegistry
-            createConstant("org.hibernate.service.spi.SessionFactoryServiceContributor"));
+            createConstant("org.hibernate.service.spi.SessionFactoryServiceContributor"),
+            // Accessed in org.hibernate.engine.extension.internal.ExtensionIntegrationServiceImpl.create
+            createConstant("org.hibernate.engine.extension.spi.ExtensionIntegration"));
 }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/registry/PreconfiguredServiceRegistryBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/registry/PreconfiguredServiceRegistryBuilder.java
@@ -27,6 +27,7 @@ import org.hibernate.persister.internal.PersisterFactoryInitiator;
 import org.hibernate.property.access.internal.PropertyAccessStrategyResolverInitiator;
 import org.hibernate.query.sqm.mutation.internal.SqmMultiTableMutationStrategyProviderInitiator;
 import org.hibernate.resource.transaction.internal.TransactionCoordinatorBuilderInitiator;
+import org.hibernate.service.internal.ChangesetCoordinatorInitiator;
 import org.hibernate.service.internal.ProvidedService;
 import org.hibernate.service.internal.SessionFactoryServiceRegistryFactoryInitiator;
 import org.hibernate.sql.ast.internal.ParameterMarkerStrategyInitiator;
@@ -250,6 +251,9 @@ public class PreconfiguredServiceRegistryBuilder {
 
         // Custom Quarkus implementation: overrides the internal cache to leverage Caffeine
         serviceInitiators.add(QuarkusInternalCacheFactoryInitiator.INSTANCE);
+
+        // Default implementation
+        serviceInitiators.add(ChangesetCoordinatorInitiator.INSTANCE);
 
         serviceInitiators.trimToSize();
         return serviceInitiators;

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/registry/PreconfiguredReactiveServiceRegistryBuilder.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/registry/PreconfiguredReactiveServiceRegistryBuilder.java
@@ -34,6 +34,7 @@ import org.hibernate.reactive.provider.service.ReactiveSessionFactoryBuilderInit
 import org.hibernate.reactive.provider.service.ReactiveSqmMultiTableMutationStrategyProviderInitiator;
 import org.hibernate.reactive.provider.service.ReactiveValuesMappingProducerProviderInitiator;
 import org.hibernate.resource.transaction.internal.TransactionCoordinatorBuilderInitiator;
+import org.hibernate.service.internal.ChangesetCoordinatorInitiator;
 import org.hibernate.service.internal.ProvidedService;
 import org.hibernate.service.internal.SessionFactoryServiceRegistryFactoryInitiator;
 import org.hibernate.tool.schema.internal.SchemaManagementToolInitiator;
@@ -252,6 +253,9 @@ public class PreconfiguredReactiveServiceRegistryBuilder {
 
         // Custom Quarkus implementation: overrides the internal cache to leverage Caffeine
         serviceInitiators.add(QuarkusInternalCacheFactoryInitiator.INSTANCE);
+
+        // Default implementation
+        serviceInitiators.add(ChangesetCoordinatorInitiator.INSTANCE);
 
         serviceInitiators.trimToSize();
         return serviceInitiators;

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-devui-active-false-and-named-pu-active-true.properties
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-devui-active-false-and-named-pu-active-true.properties
@@ -17,11 +17,11 @@ quarkus.hibernate-orm."namedpu".schema-management.strategy=drop-and-create
 
 # Hibernate Search is inactive for the default PU
 quarkus.hibernate-search-orm.active=false
-quarkus.hibernate-search-orm.elasticsearch.version=9.3
+quarkus.hibernate-search-orm.elasticsearch.version=9.4
 quarkus.hibernate-search-orm.elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
 quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create-and-drop
 
 # ... but it's (implicitly) active for a named PU
-quarkus.hibernate-search-orm."namedpu".elasticsearch.version=9.3
+quarkus.hibernate-search-orm."namedpu".elasticsearch.version=9.4
 quarkus.hibernate-search-orm."namedpu".elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
 quarkus.hibernate-search-orm."namedpu".schema-management.strategy=drop-and-create-and-drop

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-devui-active-false.properties
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-devui-active-false.properties
@@ -7,6 +7,6 @@ quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
 quarkus.hibernate-search-orm.active=false
-quarkus.hibernate-search-orm.elasticsearch.version=9.3
+quarkus.hibernate-search-orm.elasticsearch.version=9.4
 quarkus.hibernate-search-orm.elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
 quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create-and-drop

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-devui.properties
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-devui.properties
@@ -6,6 +6,6 @@ quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1
 
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
-quarkus.hibernate-search-orm.elasticsearch.version=9.3
+quarkus.hibernate-search-orm.elasticsearch.version=9.4
 quarkus.hibernate-search-orm.elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
 quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create-and-drop

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-start-offline.properties
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-start-offline.properties
@@ -3,7 +3,7 @@ quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1
 
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
-quarkus.hibernate-search-orm.elasticsearch.version=9.3
+quarkus.hibernate-search-orm.elasticsearch.version=9.4
 # Simulate an offline Elasticsearch instance by pointing to a non-existing cluster
 quarkus.hibernate-search-orm.elasticsearch.hosts=localhost:14800
 quarkus.hibernate-search-orm.schema-management.strategy=none

--- a/extensions/hibernate-search-standalone-elasticsearch/deployment/src/test/resources/application-devui-active-false.properties
+++ b/extensions/hibernate-search-standalone-elasticsearch/deployment/src/test/resources/application-devui-active-false.properties
@@ -2,6 +2,6 @@
 quarkus.devservices.enabled=false
 
 quarkus.hibernate-search-standalone.active=false
-quarkus.hibernate-search-standalone.elasticsearch.version=9.3
+quarkus.hibernate-search-standalone.elasticsearch.version=9.4
 quarkus.hibernate-search-standalone.elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
 quarkus.hibernate-search-standalone.schema-management.strategy=drop-and-create-and-drop

--- a/extensions/hibernate-search-standalone-elasticsearch/deployment/src/test/resources/application-devui.properties
+++ b/extensions/hibernate-search-standalone-elasticsearch/deployment/src/test/resources/application-devui.properties
@@ -1,6 +1,6 @@
 # We already start Elasticsearch with Maven
 quarkus.devservices.enabled=false
 
-quarkus.hibernate-search-standalone.elasticsearch.version=9.3
+quarkus.hibernate-search-standalone.elasticsearch.version=9.4
 quarkus.hibernate-search-standalone.elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
 quarkus.hibernate-search-standalone.schema-management.strategy=drop-and-create-and-drop

--- a/extensions/hibernate-search-standalone-elasticsearch/deployment/src/test/resources/application-start-offline.properties
+++ b/extensions/hibernate-search-standalone-elasticsearch/deployment/src/test/resources/application-start-offline.properties
@@ -1,4 +1,4 @@
-quarkus.hibernate-search-standalone.elasticsearch.version=9.3
+quarkus.hibernate-search-standalone.elasticsearch.version=9.4
 # Simulate an offline Elasticsearch instance by pointing to a non-existing cluster
 quarkus.hibernate-search-standalone.elasticsearch.hosts=localhost:14800
 quarkus.hibernate-search-standalone.schema-management.strategy=none

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest.java
@@ -37,7 +37,7 @@ public class HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest {
                     // But here it doesn't matter as we won't send a request to Elasticsearch anyway,
                     // so we're free to put anything.
                     // Just make sure to set something consistent with what we have in application.properties.
-                    "quarkus.hibernate-search-orm.elasticsearch.version", "9.3"));
+                    "quarkus.hibernate-search-orm.elasticsearch.version", "9.4"));
             return config;
         }
 

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest.java
@@ -36,7 +36,7 @@ public class HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest {
                     // But here it doesn't matter as we won't send a request to Elasticsearch anyway,
                     // so we're free to put anything.
                     // Just make sure to set something consistent with what we have in application.properties.
-                    "quarkus.hibernate-search-orm.elasticsearch.version", "9.3");
+                    "quarkus.hibernate-search-orm.elasticsearch.version", "9.4");
         }
 
         @Override

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchWithElasticsearchJavaClientDevServicesTest.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchWithElasticsearchJavaClientDevServicesTest.java
@@ -30,7 +30,7 @@ public class HibernateSearchElasticsearchWithElasticsearchJavaClientDevServicesT
         public Map<String, String> getConfigOverrides() {
             Map<String, String> config = new HashMap<>();
             config.put("quarkus.elasticsearch.devservices.enabled", "true");
-            config.put("quarkus.hibernate-search-orm.elasticsearch.version", "9.3");
+            config.put("quarkus.hibernate-search-orm.elasticsearch.version", "9.4");
             return config;
         }
 

--- a/integration-tests/hibernate-search-standalone-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/standalone/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest.java
+++ b/integration-tests/hibernate-search-standalone-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/standalone/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest.java
@@ -37,7 +37,7 @@ public class HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest {
                     // But here it doesn't matter as we won't send a request to Elasticsearch anyway,
                     // so we're free to put anything.
                     // Just make sure to set something consistent with what we have in application.properties.
-                    "quarkus.hibernate-search-standalone.elasticsearch.version", "9.3"));
+                    "quarkus.hibernate-search-standalone.elasticsearch.version", "9.4"));
             return config;
         }
 

--- a/integration-tests/hibernate-search-standalone-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/standalone/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest.java
+++ b/integration-tests/hibernate-search-standalone-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/standalone/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest.java
@@ -36,7 +36,7 @@ public class HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest {
                     // But here it doesn't matter as we won't send a request to Elasticsearch anyway,
                     // so we're free to put anything.
                     // Just make sure to set something consistent with what we have in application.properties.
-                    "quarkus.hibernate-search-standalone.elasticsearch.version", "9.3");
+                    "quarkus.hibernate-search-standalone.elasticsearch.version", "9.4");
         }
 
         @Override

--- a/pom.xml
+++ b/pom.xml
@@ -71,16 +71,16 @@
         <jacoco.version>0.8.14</jacoco.version>
         <kubernetes-client.version>7.7.0</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
         <rest-assured.version>6.0.0</rest-assured.version>
-        <hibernate-orm.version>7.3.7.Final</hibernate-orm.version> <!-- WARNING when updating, also align the versions below; checked by maven-enforcer-plugin in bom -->
+        <hibernate-orm.version>7.4.0.Final</hibernate-orm.version> <!-- WARNING when updating, also align the versions below; checked by maven-enforcer-plugin in bom -->
         <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version> <!-- version controlled by Hibernate ORM's needs; checked by maven-enforcer-plugin in bom -->
         <jakarta.data-api.version>1.0.1</jakarta.data-api.version> <!-- version controlled by Hibernate ORM's needs; checked by maven-enforcer-plugin in bom -->
         <antlr.version>4.13.2</antlr.version> <!-- version controlled by Hibernate ORM's needs; checked by maven-enforcer-plugin in bom -->
         <bytebuddy.version>1.18.8</bytebuddy.version> <!-- version controlled by Hibernate ORM's needs; checked by maven-enforcer-plugin in bom -->
-        <geolatte.version>1.10</geolatte.version> <!-- version controlled by Hibernate ORM's needs; checked by maven-enforcer-plugin in bom -->
+        <geolatte.version>1.11</geolatte.version> <!-- version controlled by Hibernate ORM's needs; checked by maven-enforcer-plugin in bom -->
         <hibernate-models.version>1.1.1</hibernate-models.version> <!-- version controlled by Hibernate ORM's needs; checked by maven-enforcer-plugin in bom -->
-        <hibernate-reactive.version>3.3.7.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
+        <hibernate-reactive.version>3.4.0.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
         <hibernate-validator.version>9.1.0.Final</hibernate-validator.version>
-        <hibernate-search.version>8.3.2.Final</hibernate-search.version>
+        <hibernate-search.version>8.4.0.Final</hibernate-search.version>
 
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->
         <grpc.version>1.81.0</grpc.version> <!-- when updating, verify if following versions should not be updated too: -->


### PR DESCRIPTION
## Summary
Bumps the hibernate group with 11 updates:

| Package | From | To |
| --- | --- | --- |
| org.hibernate.orm:hibernate-core | 7.3.3.Final | 7.4.0.Final |
| org.hibernate.orm:hibernate-graalvm | 7.3.3.Final | 7.4.0.Final |
| org.hibernate.orm:hibernate-envers | 7.3.3.Final | 7.4.0.Final |
| org.hibernate.orm:hibernate-spatial | 7.3.3.Final | 7.4.0.Final |
| org.hibernate.orm:hibernate-processor | 7.3.3.Final | 7.4.0.Final |
| org.hibernate.orm:hibernate-jpamodelgen | 7.3.3.Final | 7.4.0.Final |
| org.hibernate.orm:hibernate-community-dialects | 7.3.3.Final | 7.4.0.Final |
| org.hibernate.orm:hibernate-vector | 7.3.3.Final | 7.4.0.Final |
| org.hibernate.reactive:hibernate-reactive-core | 3.3.5.Final | 3.4.0.Final |
| org.hibernate.search:hibernate-search | 8.3.0.Final | 8.4.0.Final |
| org.geolatte:geolatte-geom | 1.10 | 1.11 |

Additional fixes:
- Register `ChangesetCoordinatorInitiator` in both blocking and reactive `PreconfiguredServiceRegistryBuilder` — new service in ORM 7.4 for temporal entity support (`org.hibernate.temporal.spi.ChangesetCoordinator`). Without this, SessionFactory creation fails at runtime with `UnknownServiceException`.
- Update `ClassNames` with new ORM 7.4 annotations (`@Temporal`, `@Changelog`, `@Audited` families), refactored composite generator records, and `Nationalized`/`Temporal` in `PACKAGE_ANNOTATIONS`.

## Test plan
- [x] Full Quarkus build passes (`build-fast.sh`)
- [x] Hibernate ORM deployment tests pass
- [x] Hibernate Reactive deployment tests pass
- [x] All integration tests pass (JPA, PostgreSQL, H2, Reactive, Tenancy, Jakarta Data, Panache)


Migration guide
----

```asciidoc
== Hibernate ORM

=== Upgrade to Hibernate ORM 7.4

The Quarkus extension for Hibernate ORM was upgraded to Hibernate ORM 7.4.

Hibernate ORM 7.4 includes several behavioral changes. Below are the ones most likely to affect existing applications.

Refer to the https://docs.hibernate.org/orm/7.4/migration-guide/[Hibernate ORM 7.4 migration guide] for more information.

=== Behavioral changes

* https://docs.hibernate.org/orm/7.4/migration-guide/#behavior-changes[HQL `current date` and `local date` on Oracle now translate to `trunc(current_date)`, zeroing out the time part].
* https://docs.hibernate.org/orm/7.4/migration-guide/#behavior-changes[MySQL no longer has a dialect-specific default for `hibernate.max_fetch_depth`. Applications relying on the implicit default of `2` should set it explicitly].
* https://docs.hibernate.org/orm/7.4/migration-guide/#behavior-changes[Eager `@Any` associations are now join-fetched by default when loading by id, instead of using a separate `SELECT`].
* https://docs.hibernate.org/orm/7.4/migration-guide/#behavior-changes[When pagination or a limit is used with a query that fetches a collection, the limit is now processed as part of the SQL query. Use the query hint `org.hibernate.limitInMemory` to recover the previous behavior].
* https://docs.hibernate.org/orm/7.4/migration-guide/#behavior-changes[Schema actions (including `import.sql` execution) are now processed even when no `@Entity` classes are mapped. Applications with an accidental `import.sql` on the classpath may see it executed].
* https://docs.hibernate.org/orm/7.4/migration-guide/#behavior-changes[`SpannerPostgreSQLDialect` moved from `hibernate-community-dialects` (`org.hibernate.community.dialect`) to `hibernate-core` (`org.hibernate.dialect`). Update dialect configuration if using it explicitly].

=== DDL changes

* https://docs.hibernate.org/orm/7.4/migration-guide/#ddl-changes[A unique constraint is now added to `@ElementCollection` set tables where appropriate].
* https://docs.hibernate.org/orm/7.4/migration-guide/#ddl-changes[`@CreationTimestamp` and `@UpdateTimestamp` columns now have a `NOT NULL` constraint added automatically].

=== Minimum database versions

* PostgreSQL: bumped minimum version from 13 to 14

See https://docs.hibernate.org/orm/7.4/dialect/dialect.html[here] for details on the current minimum versions.

== Hibernate Reactive

=== Upgrade to Hibernate Reactive 3.4

The Quarkus extension for Hibernate Reactive was upgraded to Hibernate Reactive 3.4.0.Final

Hibernate Reactive 3.4.0.Final is backwards-compatible with Hibernate Reactive 3.3, with the exception of a few breaking changes inherited from Hibernate ORM and listed above.

== Hibernate Search

=== Upgrade to Hibernate Search 8.4

The Quarkus extensions for Hibernate Search were upgraded to Hibernate Search 8.4.

Hibernate Search 8.4 is fully backwards-compatible with 8.3: no reindexing, schema updates, or code changes are necessary.

Refer to the https://docs.hibernate.org/search/8.4/migration/html_single/[Hibernate Search 8.4 migration guide] for more information.

== Elasticsearch and OpenSearch Dev Services

The Elasticsearch Dev Services now default to starting Elasticsearch 9.4, instead of 9.3 previously.

The OpenSearch Dev Services now default to starting OpenSearch 3.6, instead of 3.5 previously.

The Elasticsearch Java client was also upgraded from 9.3.2 to 9.4.1.
```
