### PR TITLE
Fix intermittent INTERNAL half-close errors in BlockingServerInterceptor (severe bug - grpc virtual thread bug fails concurrency)

### DIFF
--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/blocking/BlockingServerInterceptor.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/blocking/BlockingServerInterceptor.java
@@ -1,6 +1,7 @@
 package io.quarkus.grpc.runtime.supports.blocking;
 
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.List;
@@ -246,6 +247,9 @@ public class BlockingServerInterceptor implements ServerInterceptor, Function<St
                 if (!this.isConsumingFromIncomingEvents) {
                     reorderForRequestBeforeHalfClose(incomingEvents);
                     first = incomingEvents.poll();
+                    if (first != null) {
+                        this.isConsumingFromIncomingEvents = true;
+                    }
                 }
             }
             if (first != null) {
@@ -254,16 +258,17 @@ public class BlockingServerInterceptor implements ServerInterceptor, Function<St
         }
 
         private void scheduleOrEnqueue(ReplayEvent<ReqT> event) {
-            boolean executeNow = false;
+            Consumer<ServerCall.Listener<ReqT>> toRunDirectly = null;
             synchronized (incomingEvents) {
                 if (this.delegate != null && !this.isConsumingFromIncomingEvents && incomingEvents.isEmpty()) {
-                    executeNow = true;
+                    toRunDirectly = event.action;
+                    this.isConsumingFromIncomingEvents = true;
                 } else {
                     incomingEvents.add(event);
                 }
             }
-            if (executeNow) {
-                executeBlockingWithRequestContext(event.action);
+            if (toRunDirectly != null) {
+                executeBlockingWithRequestContext(toRunDirectly);
             }
         }
 
@@ -288,14 +293,9 @@ public class BlockingServerInterceptor implements ServerInterceptor, Function<St
                 blockingHandler = new DevModeBlockingExecutionHandler(Thread.currentThread().getContextClassLoader(),
                         blockingHandler);
             }
-            // Written outside the lock intentionally: this method is only ever called from
-            // the event loop thread (directly or via the onComplete handler which is also
-            // on the event loop). gRPC guarantees sequential event delivery on the event
-            // loop, so no concurrent scheduleOrEnqueue call can race with this true-write.
-            // The transition back to false is done under the lock because it happens on the
-            // worker thread (where a concurrent scheduleOrEnqueue from the event loop could
-            // otherwise observe a stale false and bypass the queue). The volatile keyword
-            // ensures both transitions are immediately visible across threads.
+            // Usually already true: setDelegate / scheduleOrEnqueue set it under
+            // incomingEvents before dispatching. This write keeps the worker-chain path
+            // consistent when chaining from executeBlocking's onComplete handler.
             this.isConsumingFromIncomingEvents = true;
             vertx.executeBlocking(blockingHandler, false).onComplete(p -> {
                 ReplayEvent<ReqT> next;
@@ -373,6 +373,9 @@ public class BlockingServerInterceptor implements ServerInterceptor, Function<St
                 if (!this.isConsumingFromIncomingEvents) {
                     reorderForRequestBeforeHalfClose(incomingEvents);
                     first = incomingEvents.poll();
+                    if (first != null) {
+                        this.isConsumingFromIncomingEvents = true;
+                    }
                 }
             }
             if (first != null) {
@@ -381,16 +384,17 @@ public class BlockingServerInterceptor implements ServerInterceptor, Function<St
         }
 
         private void scheduleOrEnqueue(ReplayEvent<ReqT> event) {
-            boolean executeNow = false;
+            Consumer<ServerCall.Listener<ReqT>> toRunDirectly = null;
             synchronized (incomingEvents) {
                 if (this.delegate != null && !this.isConsumingFromIncomingEvents && incomingEvents.isEmpty()) {
-                    executeNow = true;
+                    toRunDirectly = event.action;
+                    this.isConsumingFromIncomingEvents = true;
                 } else {
                     incomingEvents.add(event);
                 }
             }
-            if (executeNow) {
-                executeVirtualWithRequestContext(event.action);
+            if (toRunDirectly != null) {
+                executeVirtualWithRequestContext(toRunDirectly);
             }
         }
 
@@ -402,9 +406,9 @@ public class BlockingServerInterceptor implements ServerInterceptor, Function<St
                 blockingHandler = new DevModeBlockingExecutionHandler(Thread.currentThread().getContextClassLoader(),
                         blockingHandler);
             }
-            // True while a virtual-thread task is running or is about to run; cleared under
-            // incomingEvents lock when the queue is drained (same visibility pattern as the
-            // worker path, but this method may also be invoked when chaining from a virtual thread).
+            // Usually already true: setDelegate / scheduleOrEnqueue set it under incomingEvents
+            // before dispatching. Kept for the chain path that calls here after polling the next
+            // event. Cleared under incomingEvents when the queue is drained.
             this.isConsumingFromIncomingEvents = true;
             var finalBlockingHandler = blockingHandler;
             virtualThreadExecutor.execute(() -> {
@@ -470,43 +474,48 @@ public class BlockingServerInterceptor implements ServerInterceptor, Function<St
      * it. The caller must hold the queue's monitor.
      */
     private static <ReqT> void reorderForRequestBeforeHalfClose(Deque<ReplayEvent<ReqT>> queue) {
-        int halfCloseIndex = -1;
-        int i = 0;
-        for (ReplayEvent<ReqT> event : queue) {
-            if (event.kind == EventKind.HALF_CLOSE) {
-                halfCloseIndex = i;
-                break;
-            }
-            i++;
-        }
-        if (halfCloseIndex < 0) {
+        int size = queue.size();
+        if (size == 0) {
             return;
         }
-        // Collect MESSAGE events that appear after the first HALF_CLOSE.
-        Deque<ReplayEvent<ReqT>> messagesAfterHalfClose = new ArrayDeque<>();
-        int idx = 0;
-        for (ReplayEvent<ReqT> event : queue) {
-            if (idx > halfCloseIndex && event.kind == EventKind.MESSAGE) {
-                messagesAfterHalfClose.add(event);
+        // Snapshot once so we do not walk the deque multiple times.
+        List<ReplayEvent<ReqT>> snapshot = new ArrayList<>(queue);
+        int halfCloseIdx = -1;
+        for (int i = 0; i < snapshot.size(); i++) {
+            if (snapshot.get(i).kind == EventKind.HALF_CLOSE) {
+                halfCloseIdx = i;
+                break;
             }
-            idx++;
         }
-        if (messagesAfterHalfClose.isEmpty()) {
-            return; // already ordered correctly - nothing to do
+        if (halfCloseIdx < 0) {
+            return;
         }
-        // Rebuild: prefix before HALF_CLOSE, promoted messages, HALF_CLOSE, remaining non-messages.
-        Deque<ReplayEvent<ReqT>> result = new ArrayDeque<>(queue.size());
-        idx = 0;
-        for (ReplayEvent<ReqT> event : queue) {
-            if (idx < halfCloseIndex) {
-                result.add(event);
-            } else if (idx == halfCloseIndex) {
-                result.addAll(messagesAfterHalfClose);
-                result.add(event); // the HALF_CLOSE itself
-            } else if (event.kind != EventKind.MESSAGE) {
-                result.add(event); // non-message events after HALF_CLOSE are preserved
+        boolean hasTrailingMessage = false;
+        for (int i = halfCloseIdx + 1; i < snapshot.size(); i++) {
+            if (snapshot.get(i).kind == EventKind.MESSAGE) {
+                hasTrailingMessage = true;
+                break;
             }
-            idx++;
+        }
+        if (!hasTrailingMessage) {
+            return;
+        }
+        Deque<ReplayEvent<ReqT>> result = new ArrayDeque<>(snapshot.size());
+        for (int i = 0; i < halfCloseIdx; i++) {
+            result.addLast(snapshot.get(i));
+        }
+        for (int i = halfCloseIdx + 1; i < snapshot.size(); i++) {
+            ReplayEvent<ReqT> e = snapshot.get(i);
+            if (e.kind == EventKind.MESSAGE) {
+                result.addLast(e);
+            }
+        }
+        result.addLast(snapshot.get(halfCloseIdx));
+        for (int i = halfCloseIdx + 1; i < snapshot.size(); i++) {
+            ReplayEvent<ReqT> e = snapshot.get(i);
+            if (e.kind != EventKind.MESSAGE) {
+                result.addLast(e);
+            }
         }
         queue.clear();
         queue.addAll(result);

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/blocking/BlockingServerInterceptor.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/blocking/BlockingServerInterceptor.java
@@ -1,13 +1,13 @@
 package io.quarkus.grpc.runtime.supports.blocking;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -220,7 +220,12 @@ public class BlockingServerInterceptor implements ServerInterceptor, Function<St
 
         // exclusive to event loop context
         private volatile ServerCall.Listener<ReqT> delegate;
-        private final Queue<Consumer<ServerCall.Listener<ReqT>>> incomingEvents = new ConcurrentLinkedQueue<>();
+        // Guarded by its own monitor. Events queued before setDelegate runs may arrive
+        // out of order versus how the underlying UnaryServerCallListener expects them
+        // (e.g. onHalfClose before onMessage when call.request(N) was deferred — see
+        // setDelegate). The deque is reordered once at delegate-injection time to
+        // preserve the request-before-half-close invariant before draining.
+        private final Deque<ReplayEvent<ReqT>> incomingEvents = new ArrayDeque<>();
         private volatile boolean isConsumingFromIncomingEvents;
 
         private ReplayListener(InjectableContext.ContextState requestContextState) {
@@ -235,20 +240,30 @@ public class BlockingServerInterceptor implements ServerInterceptor, Function<St
          * @param delegate the original
          */
         void setDelegate(ServerCall.Listener<ReqT> delegate) {
-            this.delegate = delegate;
-            if (!this.isConsumingFromIncomingEvents) {
-                Consumer<ServerCall.Listener<ReqT>> consumer = incomingEvents.poll();
-                if (consumer != null) {
-                    executeBlockingWithRequestContext(consumer);
+            ReplayEvent<ReqT> first = null;
+            synchronized (incomingEvents) {
+                this.delegate = delegate;
+                if (!this.isConsumingFromIncomingEvents) {
+                    reorderForRequestBeforeHalfClose(incomingEvents);
+                    first = incomingEvents.poll();
                 }
+            }
+            if (first != null) {
+                executeBlockingWithRequestContext(first.action);
             }
         }
 
-        private void scheduleOrEnqueue(Consumer<ServerCall.Listener<ReqT>> consumer) {
-            if (this.delegate != null && !this.isConsumingFromIncomingEvents) {
-                executeBlockingWithRequestContext(consumer);
-            } else {
-                incomingEvents.add(consumer);
+        private void scheduleOrEnqueue(ReplayEvent<ReqT> event) {
+            boolean executeNow = false;
+            synchronized (incomingEvents) {
+                if (this.delegate != null && !this.isConsumingFromIncomingEvents && incomingEvents.isEmpty()) {
+                    executeNow = true;
+                } else {
+                    incomingEvents.add(event);
+                }
+            }
+            if (executeNow) {
+                executeBlockingWithRequestContext(event.action);
             }
         }
 
@@ -273,40 +288,52 @@ public class BlockingServerInterceptor implements ServerInterceptor, Function<St
                 blockingHandler = new DevModeBlockingExecutionHandler(Thread.currentThread().getContextClassLoader(),
                         blockingHandler);
             }
+            // Written outside the lock intentionally: this method is only ever called from
+            // the event loop thread (directly or via the onComplete handler which is also
+            // on the event loop). gRPC guarantees sequential event delivery on the event
+            // loop, so no concurrent scheduleOrEnqueue call can race with this true-write.
+            // The transition back to false is done under the lock because it happens on the
+            // worker thread (where a concurrent scheduleOrEnqueue from the event loop could
+            // otherwise observe a stale false and bypass the queue). The volatile keyword
+            // ensures both transitions are immediately visible across threads.
             this.isConsumingFromIncomingEvents = true;
             vertx.executeBlocking(blockingHandler, false).onComplete(p -> {
-                Consumer<ServerCall.Listener<ReqT>> next = incomingEvents.poll();
+                ReplayEvent<ReqT> next;
+                synchronized (incomingEvents) {
+                    next = incomingEvents.poll();
+                    if (next == null) {
+                        this.isConsumingFromIncomingEvents = false;
+                    }
+                }
                 if (next != null) {
-                    executeBlockingWithRequestContext(next);
-                } else {
-                    this.isConsumingFromIncomingEvents = false;
+                    executeBlockingWithRequestContext(next.action);
                 }
             });
         }
 
         @Override
         public void onMessage(ReqT message) {
-            scheduleOrEnqueue(t -> t.onMessage(message));
+            scheduleOrEnqueue(new ReplayEvent<>(EventKind.MESSAGE, t -> t.onMessage(message)));
         }
 
         @Override
         public void onHalfClose() {
-            scheduleOrEnqueue(ServerCall.Listener::onHalfClose);
+            scheduleOrEnqueue(new ReplayEvent<>(EventKind.HALF_CLOSE, ServerCall.Listener::onHalfClose));
         }
 
         @Override
         public void onCancel() {
-            scheduleOrEnqueue(ServerCall.Listener::onCancel);
+            scheduleOrEnqueue(new ReplayEvent<>(EventKind.OTHER, ServerCall.Listener::onCancel));
         }
 
         @Override
         public void onComplete() {
-            scheduleOrEnqueue(ServerCall.Listener::onComplete);
+            scheduleOrEnqueue(new ReplayEvent<>(EventKind.OTHER, ServerCall.Listener::onComplete));
         }
 
         @Override
         public void onReady() {
-            scheduleOrEnqueue(ServerCall.Listener::onReady);
+            scheduleOrEnqueue(new ReplayEvent<>(EventKind.OTHER, ServerCall.Listener::onReady));
         }
     }
 
@@ -324,7 +351,9 @@ public class BlockingServerInterceptor implements ServerInterceptor, Function<St
 
         // exclusive to event loop context
         private ServerCall.Listener<ReqT> delegate;
-        private final Queue<Consumer<ServerCall.Listener<ReqT>>> incomingEvents = new ConcurrentLinkedQueue<>();
+        // Guarded by its own monitor. See ReplayListener#incomingEvents for the
+        // rationale on why this is reordered before draining.
+        private final Deque<ReplayEvent<ReqT>> incomingEvents = new ArrayDeque<>();
         private volatile boolean isConsumingFromIncomingEvents = false;
 
         private VirtualReplayListener(InjectableContext.ContextState requestContextState) {
@@ -338,20 +367,30 @@ public class BlockingServerInterceptor implements ServerInterceptor, Function<St
          * @param delegate the original
          */
         void setDelegate(ServerCall.Listener<ReqT> delegate) {
-            this.delegate = delegate;
-            if (!this.isConsumingFromIncomingEvents) {
-                Consumer<ServerCall.Listener<ReqT>> consumer = incomingEvents.poll();
-                if (consumer != null) {
-                    executeVirtualWithRequestContext(consumer);
+            ReplayEvent<ReqT> first = null;
+            synchronized (incomingEvents) {
+                this.delegate = delegate;
+                if (!this.isConsumingFromIncomingEvents) {
+                    reorderForRequestBeforeHalfClose(incomingEvents);
+                    first = incomingEvents.poll();
                 }
+            }
+            if (first != null) {
+                executeVirtualWithRequestContext(first.action);
             }
         }
 
-        private void scheduleOrEnqueue(Consumer<ServerCall.Listener<ReqT>> consumer) {
-            if (this.delegate != null && !this.isConsumingFromIncomingEvents) {
-                executeVirtualWithRequestContext(consumer);
-            } else {
-                incomingEvents.add(consumer);
+        private void scheduleOrEnqueue(ReplayEvent<ReqT> event) {
+            boolean executeNow = false;
+            synchronized (incomingEvents) {
+                if (this.delegate != null && !this.isConsumingFromIncomingEvents && incomingEvents.isEmpty()) {
+                    executeNow = true;
+                } else {
+                    incomingEvents.add(event);
+                }
+            }
+            if (executeNow) {
+                executeVirtualWithRequestContext(event.action);
             }
         }
 
@@ -363,16 +402,23 @@ public class BlockingServerInterceptor implements ServerInterceptor, Function<St
                 blockingHandler = new DevModeBlockingExecutionHandler(Thread.currentThread().getContextClassLoader(),
                         blockingHandler);
             }
+            // True while a virtual-thread task is running or is about to run; cleared under
+            // incomingEvents lock when the queue is drained (same visibility pattern as the
+            // worker path, but this method may also be invoked when chaining from a virtual thread).
             this.isConsumingFromIncomingEvents = true;
             var finalBlockingHandler = blockingHandler;
             virtualThreadExecutor.execute(() -> {
                 try {
                     finalBlockingHandler.call();
-                    Consumer<ServerCall.Listener<ReqT>> next = incomingEvents.poll();
+                    ReplayEvent<ReqT> next;
+                    synchronized (incomingEvents) {
+                        next = incomingEvents.poll();
+                        if (next == null) {
+                            this.isConsumingFromIncomingEvents = false;
+                        }
+                    }
                     if (next != null) {
-                        executeVirtualWithRequestContext(next);
-                    } else {
-                        this.isConsumingFromIncomingEvents = false;
+                        executeVirtualWithRequestContext(next.action);
                     }
                 } catch (Exception e) {
                     throw new RuntimeException(e);
@@ -382,27 +428,103 @@ public class BlockingServerInterceptor implements ServerInterceptor, Function<St
 
         @Override
         public void onMessage(ReqT message) {
-            scheduleOrEnqueue(t -> t.onMessage(message));
+            scheduleOrEnqueue(new ReplayEvent<>(EventKind.MESSAGE, t -> t.onMessage(message)));
         }
 
         @Override
         public void onHalfClose() {
-            scheduleOrEnqueue(ServerCall.Listener::onHalfClose);
+            scheduleOrEnqueue(new ReplayEvent<>(EventKind.HALF_CLOSE, ServerCall.Listener::onHalfClose));
         }
 
         @Override
         public void onCancel() {
-            scheduleOrEnqueue(ServerCall.Listener::onCancel);
+            scheduleOrEnqueue(new ReplayEvent<>(EventKind.OTHER, ServerCall.Listener::onCancel));
         }
 
         @Override
         public void onComplete() {
-            scheduleOrEnqueue(ServerCall.Listener::onComplete);
+            scheduleOrEnqueue(new ReplayEvent<>(EventKind.OTHER, ServerCall.Listener::onComplete));
         }
 
         @Override
         public void onReady() {
-            scheduleOrEnqueue(ServerCall.Listener::onReady);
+            scheduleOrEnqueue(new ReplayEvent<>(EventKind.OTHER, ServerCall.Listener::onReady));
+        }
+    }
+
+    /**
+     * Reorders the head of the queued events so that any {@code onMessage} event(s)
+     * arriving before an {@code onHalfClose} are delivered first. The grpc-stub
+     * {@code UnaryServerCallHandler} only calls {@code call.request(N)} from inside
+     * its {@code startCall}, which this interceptor defers onto a worker / virtual
+     * thread. {@code onHalfClose} does not require inbound flow-control budget
+     * (END_STREAM is a wire-level marker), so on a cold or backlogged executor the
+     * replay listener can observe {@code onHalfClose} before the deframer is allowed
+     * to deliver {@code onMessage}. Replaying the queue in arrival order would then
+     * cause the underlying unary listener to see a half-close with no request and
+     * close the call with {@code Status.INTERNAL: Half-closed without a request}.
+     * <p>
+     * This method preserves the relative order of all non-message events and the
+     * relative order of all message events; it only promotes any {@code MESSAGE}
+     * entries that appear after the first {@code HALF_CLOSE} to immediately before
+     * it. The caller must hold the queue's monitor.
+     */
+    private static <ReqT> void reorderForRequestBeforeHalfClose(Deque<ReplayEvent<ReqT>> queue) {
+        int halfCloseIndex = -1;
+        int i = 0;
+        for (ReplayEvent<ReqT> event : queue) {
+            if (event.kind == EventKind.HALF_CLOSE) {
+                halfCloseIndex = i;
+                break;
+            }
+            i++;
+        }
+        if (halfCloseIndex < 0) {
+            return;
+        }
+        // Collect MESSAGE events that appear after the first HALF_CLOSE.
+        Deque<ReplayEvent<ReqT>> messagesAfterHalfClose = new ArrayDeque<>();
+        int idx = 0;
+        for (ReplayEvent<ReqT> event : queue) {
+            if (idx > halfCloseIndex && event.kind == EventKind.MESSAGE) {
+                messagesAfterHalfClose.add(event);
+            }
+            idx++;
+        }
+        if (messagesAfterHalfClose.isEmpty()) {
+            return; // already ordered correctly - nothing to do
+        }
+        // Rebuild: prefix before HALF_CLOSE, promoted messages, HALF_CLOSE, remaining non-messages.
+        Deque<ReplayEvent<ReqT>> result = new ArrayDeque<>(queue.size());
+        idx = 0;
+        for (ReplayEvent<ReqT> event : queue) {
+            if (idx < halfCloseIndex) {
+                result.add(event);
+            } else if (idx == halfCloseIndex) {
+                result.addAll(messagesAfterHalfClose);
+                result.add(event); // the HALF_CLOSE itself
+            } else if (event.kind != EventKind.MESSAGE) {
+                result.add(event); // non-message events after HALF_CLOSE are preserved
+            }
+            idx++;
+        }
+        queue.clear();
+        queue.addAll(result);
+    }
+
+    private enum EventKind {
+        MESSAGE,
+        HALF_CLOSE,
+        OTHER
+    }
+
+    private static final class ReplayEvent<ReqT> {
+        final EventKind kind;
+        final Consumer<ServerCall.Listener<ReqT>> action;
+
+        ReplayEvent(EventKind kind, Consumer<ServerCall.Listener<ReqT>> action) {
+            this.kind = kind;
+            this.action = action;
         }
     }
 

--- a/extensions/grpc/runtime/src/test/java/io/quarkus/grpc/runtime/supports/blocking/BlockingServerInterceptorEventOrderingTest.java
+++ b/extensions/grpc/runtime/src/test/java/io/quarkus/grpc/runtime/supports/blocking/BlockingServerInterceptorEventOrderingTest.java
@@ -1,0 +1,374 @@
+package io.quarkus.grpc.runtime.supports.blocking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.quarkus.arc.InjectableContext;
+import io.quarkus.arc.ManagedContext;
+import io.vertx.core.Vertx;
+
+/**
+ * Verifies that {@link BlockingServerInterceptor} does not deliver {@code onHalfClose}
+ * to the underlying unary listener before {@code onMessage}, even when the wire-level
+ * race condition causes the replay listener to receive {@code onHalfClose} first.
+ * <p>
+ * Background: {@code next.startCall} (grpc-stub's {@code UnaryServerCallHandler.startCall})
+ * is the call site that grants flow-control budget via {@code call.request(2)}. The blocking
+ * interceptor defers that call onto a worker / virtual thread executor. If that executor is
+ * delayed (cold pool, GC, executor backlog), the gRPC framework can deliver {@code onHalfClose}
+ * (which does not require budget — it rides END_STREAM) to the replay listener BEFORE the
+ * deframer is allowed to deliver {@code onMessage} (which is gated on {@code call.request(N)}).
+ * Without protection, the replay listener queues events in arrival order and replays them
+ * FIFO, so the real {@code UnaryServerCallListener} sees {@code onHalfClose} with
+ * {@code request == null} and closes the call with
+ * {@code Status.INTERNAL.withDescription("Half-closed without a request")}.
+ */
+@SuppressWarnings({ "rawtypes", "unchecked" })
+class BlockingServerInterceptorEventOrderingTest {
+
+    Vertx vertx;
+    InjectableContext.ContextState contextState;
+    ManagedContext requestContext;
+    /** Single-slot executor we drive manually so we can inject the race deterministically. */
+    BlockingQueue<Runnable> deferred;
+    Executor controllableVirtualExecutor;
+
+    @BeforeEach
+    void setup() {
+        vertx = Vertx.vertx();
+        contextState = mock(InjectableContext.ContextState.class);
+        requestContext = mock(ManagedContext.class);
+        when(requestContext.getState()).thenReturn(contextState);
+        deferred = new ArrayBlockingQueue<>(4);
+        controllableVirtualExecutor = deferred::add;
+    }
+
+    @AfterEach
+    void teardown() {
+        if (vertx != null) {
+            vertx.close().toCompletionStage().toCompletableFuture().orTimeout(5, TimeUnit.SECONDS).join();
+        }
+    }
+
+    /**
+     * Reproduces the production race for the {@code @RunOnVirtualThread} (virtual-thread) path.
+     * The replay listener receives {@code onHalfClose} before {@code onMessage} (because budget
+     * was deferred), then the virtual-thread executor finally runs {@code next.startCall} and
+     * {@code setDelegate}. The real listener MUST observe {@code onMessage} before
+     * {@code onHalfClose}.
+     */
+    @Test
+    @Timeout(10)
+    void virtualThreadPath_deliversOnMessageBeforeOnHalfClose_evenIfEnqueuedInReverse() throws Exception {
+        BlockingServerInterceptor interceptor = newInterceptor(Collections.emptyList(),
+                Collections.singletonList("unary"));
+
+        ServerCall serverCall = mock(ServerCall.class);
+        MethodDescriptor methodDescriptor = mock(MethodDescriptor.class);
+        when(methodDescriptor.getFullMethodName()).thenReturn("my-service/unary");
+        when(methodDescriptor.getType()).thenReturn(MethodDescriptor.MethodType.UNARY);
+        when(serverCall.getMethodDescriptor()).thenReturn(methodDescriptor);
+
+        RecordingServerCallHandler next = new RecordingServerCallHandler();
+
+        ServerCall.Listener replayListener = interceptor.interceptCall(serverCall, new Metadata(), next);
+
+        // Simulate the framework delivering events to the replay listener BEFORE the virtual-thread
+        // executor has run next.startCall. onHalfClose arrives first because END_STREAM does not
+        // require flow-control budget; onMessage was held in the deframer until budget was granted.
+        replayListener.onHalfClose();
+        replayListener.onMessage("hi");
+
+        // Now run the deferred next.startCall. This grants budget (call.request(2)) and installs
+        // the real listener as the replay delegate, draining the queued events.
+        runAllDeferredTasks();
+
+        // The real listener must see onMessage first, then onHalfClose. If the bug is present,
+        // the recorded order will be [onHalfClose, onMessage], which is what triggers
+        // UnaryServerCallListener to close the call with INTERNAL: Half-closed without a request.
+        next.awaitEvents(2);
+        assertThat(next.events)
+                .as("real listener must receive onMessage before onHalfClose to satisfy "
+                        + "UnaryServerCallListener's request-not-null invariant")
+                .containsExactly("onMessage:hi", "onHalfClose");
+    }
+
+    /**
+     * Same race on the {@code @Blocking} (Vert.x worker) path. Uses
+     * {@code vertx.executeBlocking} which we cannot easily control, so we rely on the fact
+     * that {@code scheduleOrEnqueue} enqueues both events synchronously while the worker task
+     * is still in-flight, then we await replay completion via the recording handler's latch.
+     */
+    @Test
+    @Timeout(10)
+    void blockingPath_deliversOnMessageBeforeOnHalfClose_evenIfEnqueuedInReverse() throws Exception {
+        BlockingServerInterceptor interceptor = newInterceptor(Collections.singletonList("unary"),
+                Collections.emptyList());
+
+        ServerCall serverCall = mock(ServerCall.class);
+        MethodDescriptor methodDescriptor = mock(MethodDescriptor.class);
+        when(methodDescriptor.getFullMethodName()).thenReturn("my-service/unary");
+        when(methodDescriptor.getType()).thenReturn(MethodDescriptor.MethodType.UNARY);
+        when(serverCall.getMethodDescriptor()).thenReturn(methodDescriptor);
+
+        RecordingServerCallHandler next = new RecordingServerCallHandler();
+        // Hold up next.startCall just long enough that we can enqueue events before setDelegate runs.
+        next.startCallGate.set(true);
+
+        ServerCall.Listener replayListener = interceptor.interceptCall(serverCall, new Metadata(), next);
+
+        // Enqueue events in the buggy order while the worker thread is still blocked inside
+        // next.startCall (i.e. before setDelegate has been invoked).
+        replayListener.onHalfClose();
+        replayListener.onMessage("hi");
+
+        // Release next.startCall so the worker thread can finish, setDelegate runs, and the
+        // queue is drained.
+        next.startCallGate.set(false);
+        synchronized (next.startCallGate) {
+            next.startCallGate.notifyAll();
+        }
+
+        next.awaitEvents(2);
+        assertThat(next.events)
+                .as("real listener must receive onMessage before onHalfClose to satisfy "
+                        + "UnaryServerCallListener's request-not-null invariant")
+                .containsExactly("onMessage:hi", "onHalfClose");
+    }
+
+    /**
+     * Happy-path: events arrive in the correct order on the virtual-thread path.
+     * The reordering logic must not disturb a queue that is already correctly ordered.
+     */
+    @Test
+    @Timeout(10)
+    void virtualThreadPath_preservesCorrectOrderWhenEventsArriveInOrder() throws Exception {
+        BlockingServerInterceptor interceptor = newInterceptor(Collections.emptyList(),
+                Collections.singletonList("unary"));
+
+        ServerCall serverCall = mock(ServerCall.class);
+        MethodDescriptor methodDescriptor = mock(MethodDescriptor.class);
+        when(methodDescriptor.getFullMethodName()).thenReturn("my-service/unary");
+        when(methodDescriptor.getType()).thenReturn(MethodDescriptor.MethodType.UNARY);
+        when(serverCall.getMethodDescriptor()).thenReturn(methodDescriptor);
+
+        RecordingServerCallHandler next = new RecordingServerCallHandler();
+        ServerCall.Listener replayListener = interceptor.interceptCall(serverCall, new Metadata(), next);
+
+        // Events arrive in the correct order: onMessage before onHalfClose.
+        replayListener.onMessage("hi");
+        replayListener.onHalfClose();
+
+        runAllDeferredTasks();
+
+        next.awaitEvents(2);
+        assertThat(next.events)
+                .as("correctly ordered events must not be reordered")
+                .containsExactly("onMessage:hi", "onHalfClose");
+    }
+
+    /**
+     * Happy-path: events arrive in the correct order on the blocking path.
+     */
+    @Test
+    @Timeout(10)
+    void blockingPath_preservesCorrectOrderWhenEventsArriveInOrder() throws Exception {
+        BlockingServerInterceptor interceptor = newInterceptor(Collections.singletonList("unary"),
+                Collections.emptyList());
+
+        ServerCall serverCall = mock(ServerCall.class);
+        MethodDescriptor methodDescriptor = mock(MethodDescriptor.class);
+        when(methodDescriptor.getFullMethodName()).thenReturn("my-service/unary");
+        when(methodDescriptor.getType()).thenReturn(MethodDescriptor.MethodType.UNARY);
+        when(serverCall.getMethodDescriptor()).thenReturn(methodDescriptor);
+
+        RecordingServerCallHandler next = new RecordingServerCallHandler();
+        next.startCallGate.set(true);
+
+        ServerCall.Listener replayListener = interceptor.interceptCall(serverCall, new Metadata(), next);
+
+        // Events arrive in the correct order while the worker thread is still blocked.
+        replayListener.onMessage("hi");
+        replayListener.onHalfClose();
+
+        next.startCallGate.set(false);
+        synchronized (next.startCallGate) {
+            next.startCallGate.notifyAll();
+        }
+
+        next.awaitEvents(2);
+        assertThat(next.events)
+                .as("correctly ordered events must not be reordered")
+                .containsExactly("onMessage:hi", "onHalfClose");
+    }
+
+    /**
+     * Verifies that when multiple messages are queued after {@code onHalfClose}, all of them
+     * are promoted before the half-close and their relative order is preserved.
+     * Queue before fix: [onHalfClose, onMessage:first, onMessage:second]
+     * Expected after fix: [onMessage:first, onMessage:second, onHalfClose]
+     */
+    @Test
+    @Timeout(10)
+    void virtualThreadPath_promotesMultipleMessagesBeforeHalfClose() throws Exception {
+        BlockingServerInterceptor interceptor = newInterceptor(Collections.emptyList(),
+                Collections.singletonList("unary"));
+
+        ServerCall serverCall = mock(ServerCall.class);
+        MethodDescriptor methodDescriptor = mock(MethodDescriptor.class);
+        when(methodDescriptor.getFullMethodName()).thenReturn("my-service/unary");
+        when(methodDescriptor.getType()).thenReturn(MethodDescriptor.MethodType.UNARY);
+        when(serverCall.getMethodDescriptor()).thenReturn(methodDescriptor);
+
+        RecordingServerCallHandler next = new RecordingServerCallHandler();
+        ServerCall.Listener replayListener = interceptor.interceptCall(serverCall, new Metadata(), next);
+
+        // All three arrive before the deferred executor runs.
+        replayListener.onHalfClose();
+        replayListener.onMessage("first");
+        replayListener.onMessage("second");
+
+        runAllDeferredTasks();
+
+        next.awaitEvents(3);
+        assertThat(next.events)
+                .as("both messages must be promoted before onHalfClose, preserving their relative order")
+                .containsExactly("onMessage:first", "onMessage:second", "onHalfClose");
+    }
+
+    /**
+     * Same multi-message promotion on the blocking ({@code @Blocking}) path.
+     */
+    @Test
+    @Timeout(10)
+    void blockingPath_promotesMultipleMessagesBeforeHalfClose() throws Exception {
+        BlockingServerInterceptor interceptor = newInterceptor(Collections.singletonList("unary"),
+                Collections.emptyList());
+
+        ServerCall serverCall = mock(ServerCall.class);
+        MethodDescriptor methodDescriptor = mock(MethodDescriptor.class);
+        when(methodDescriptor.getFullMethodName()).thenReturn("my-service/unary");
+        when(methodDescriptor.getType()).thenReturn(MethodDescriptor.MethodType.UNARY);
+        when(serverCall.getMethodDescriptor()).thenReturn(methodDescriptor);
+
+        RecordingServerCallHandler next = new RecordingServerCallHandler();
+        next.startCallGate.set(true);
+
+        ServerCall.Listener replayListener = interceptor.interceptCall(serverCall, new Metadata(), next);
+
+        replayListener.onHalfClose();
+        replayListener.onMessage("first");
+        replayListener.onMessage("second");
+
+        next.startCallGate.set(false);
+        synchronized (next.startCallGate) {
+            next.startCallGate.notifyAll();
+        }
+
+        next.awaitEvents(3);
+        assertThat(next.events)
+                .as("both messages must be promoted before onHalfClose, preserving their relative order")
+                .containsExactly("onMessage:first", "onMessage:second", "onHalfClose");
+    }
+
+    private BlockingServerInterceptor newInterceptor(List<String> blocking, List<String> virtual) {
+        return new BlockingServerInterceptor(vertx, blocking, virtual, controllableVirtualExecutor, false) {
+            @Override
+            protected boolean isExecutable() {
+                return true;
+            }
+
+            @Override
+            protected ManagedContext getRequestContext() {
+                return requestContext;
+            }
+        };
+    }
+
+    private void runAllDeferredTasks() {
+        Runnable task;
+        while ((task = deferred.poll()) != null) {
+            task.run();
+        }
+    }
+
+    /**
+     * A {@link ServerCallHandler} whose returned listener records every event in order on a
+     * shared list, and whose {@code startCall} can be gated to simulate a slow executor.
+     */
+    static class RecordingServerCallHandler implements ServerCallHandler {
+
+        final List<String> events = new CopyOnWriteArrayList<>();
+        final java.util.concurrent.atomic.AtomicBoolean startCallGate = new java.util.concurrent.atomic.AtomicBoolean(false);
+
+        @Override
+        public ServerCall.Listener startCall(ServerCall serverCall, Metadata metadata) {
+            // If gated, block this thread until released. Used to widen the race window for the
+            // @Blocking path which uses vertx.executeBlocking (an executor we don't directly drive).
+            synchronized (startCallGate) {
+                while (startCallGate.get()) {
+                    try {
+                        startCallGate.wait();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+            return new ServerCall.Listener() {
+                @Override
+                public void onMessage(Object message) {
+                    events.add("onMessage:" + message);
+                }
+
+                @Override
+                public void onHalfClose() {
+                    events.add("onHalfClose");
+                }
+
+                @Override
+                public void onCancel() {
+                    events.add("onCancel");
+                }
+
+                @Override
+                public void onComplete() {
+                    events.add("onComplete");
+                }
+
+                @Override
+                public void onReady() {
+                    events.add("onReady");
+                }
+            };
+        }
+
+        void awaitEvents(int count) throws InterruptedException {
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+            while (events.size() < count && System.nanoTime() < deadline) {
+                Thread.sleep(10);
+            }
+            if (events.size() < count) {
+                throw new AssertionError("Expected " + count + " events, got " + events);
+            }
+        }
+    }
+}


### PR DESCRIPTION
**I cannot use virtual threads with this bug as it makes a thread issue with grpc on vert.x**.  It's a deep quarkus class, so I don't have a workaround except not to use virtual threads.

This PR fixes a long-standing bug in the gRPC server blocking path: when unary `startCall` is deferred to a Vert.x worker or a virtual thread (`@Blocking` / `@RunOnVirtualThread`), the replay listener could receive `onHalfClose` before `onMessage`. That broke unary handling with intermittent `Status.INTERNAL` (`Half-closed without a request`), especially under load, cold pools, or executor backlog.

`BlockingServerInterceptor` defers `next.startCall` to that executor; for unary calls, `startCall` is where grpc-stub grants inbound flow-control via `call.request(2)`. `onHalfClose` does not need that budget (it is tied to `END_STREAM`), so when the executor is slow or backlogged the replay listener can queue `onHalfClose` before `onMessage`. Replaying FIFO makes `UnaryServerCallListener` see half-close with `request == null` and fail the call.

The fix tags queued events and, when the real listener is installed, promotes any `MESSAGE` events that were queued after the first `HALF_CLOSE` to immediately before it (preserving relative order among messages and among other events). **Blast radius:** only the `@Blocking` and `@RunOnVirtualThread` replay paths; reordering runs only when the buffered queue contains a half-close with trailing messages. Delegate assignment and queue reordering share the same monitor so `scheduleOrEnqueue` cannot observe a half-baked state.

`BlockingServerInterceptorEventOrderingTest` covers the bad arrival order for both paths (virtual-thread case is fully deterministic; blocking path uses a gated `startCall` to widen the window).