### PR TITLE
Add quarkus-jackson dependency to SmallRye Stork extension

### DIFF
--- a/extensions/smallrye-stork/deployment/pom.xml
+++ b/extensions/smallrye-stork/deployment/pom.xml
@@ -31,6 +31,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit-internal</artifactId>
             <scope>test</scope>
         </dependency>

--- a/extensions/smallrye-stork/runtime/pom.xml
+++ b/extensions/smallrye-stork/runtime/pom.xml
@@ -35,6 +35,10 @@
             <artifactId>quarkus-vertx</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Stork depends on `quarkus-vertx` which declares `jackson-databind`as optional. When Stork service discovery implementations (e.g. Consul) use the Vert.x `JsonObject` API, the `QuarkusJacksonFactory` SPI is triggered but fails with `NoClassDefFoundError` for Jackson core classes.

Adding `quarkus-jackson` ensures Jackson is on the classpath whenever Stork is used.

- Fixes: https://github.com/quarkusio/quarkus/issues/6588
