### PR TITLE
Clarify tree-shake saving message is about bytecode

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarTreeShaker.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarTreeShaker.java
@@ -125,7 +125,7 @@ class JarTreeShaker {
         input.releaseAnalysisData();
 
         // Report
-        log.infof("Tree-shaking removed %d unreachable classes from %d dependencies, saving %s (%.1f%%)",
+        log.infof("Tree-shaking removed %d unreachable classes from %d dependencies, saving %s (%.1f%%) of bytecode",
                 removedClassCount,
                 removedClassesPerDep.size(),
                 formatSize(removedBytes),

--- a/docs/src/main/asciidoc/jar-tree-shaking.adoc
+++ b/docs/src/main/asciidoc/jar-tree-shaking.adoc
@@ -184,8 +184,11 @@ When tree-shaking is enabled, the build log includes a one-line summary at info 
 
 [source]
 ----
-Tree-shaking removed 2469 unreachable classes from 15 dependencies, saving 1.5 MB (20.0%)
+Tree-shaking removed 2469 unreachable classes from 15 dependencies, saving 1.5 MB (20.0%) of bytecode
 ----
+
+The reported savings represent raw (uncompressed) bytecode removed from dependency classes.
+The actual reduction in packaged application size will be smaller because JARs are ZIP-compressed and also contain non-class resources (such as `META-INF` entries) that tree-shaking does not affect.
 
 For a detailed per-dependency breakdown, enable debug logging for the tree shaker. The debug output includes total/reachable/removed class counts and a list of affected dependencies.
 


### PR DESCRIPTION
It just adds `of bytecode` at the end of the message, resulting in something like
```
 Tree-shaking removed 2243 unreachable classes from 81 dependencies, saving 5.6 MB (24.2%) of bytecode
```

The current message is too general and is confusing when comparing packaged application sizes.

Ideally, it should be more clear this about raw uncompressed bytecode.
