### PR TITLE
Use COPY_ATTRIBUTES when copying dependency jars to enable CoW on JDK 20+/APFS

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractFastJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractFastJarBuilder.java
@@ -16,6 +16,7 @@ import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.PosixFilePermission;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -230,12 +231,13 @@ abstract class AbstractFastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
             }
         }
         final Map<ArtifactKey, List<Path>> copiedArtifacts = new HashMap<>();
+        Set<PosixFilePermission> newFilePermissions = probeNewFilePermissions(baseLib);
         for (ResolvedDependency appDep : curateOutcome.getApplicationModel().getRuntimeDependencies()) {
             if (!rebuild) {
                 copyDependency(parentFirstArtifactKeys, outputTarget, copiedArtifacts, mainLib, baseLib,
                         fastJarJarsBuilder::addDependency, fastJarJarsBuilder::addParentFirstDependency, true,
                         appDep, transformedClasses, removedArtifactKeys, packageConfig, manifestConfig,
-                        executorService, treeShakeResult);
+                        executorService, treeShakeResult, newFilePermissions);
             } else if (includeAppDependency(appDep, outputTarget.getIncludedOptionalDependencies(), removedArtifactKeys)) {
                 appDep.getResolvedPaths().forEach(fastJarJarsBuilder::addDependency);
             }
@@ -312,7 +314,7 @@ abstract class AbstractFastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
                     copyDependency(parentFirstArtifactKeys, outputTarget, copiedArtifacts, deploymentLib, baseLib, p -> {
                     }, p -> {
                     }, false, appDep, new TransformedClassesBuildItem(Map.of()), removedArtifactKeys, packageConfig,
-                            manifestConfig, executorService, null); //we don't care about transformation or tree shaking here
+                            manifestConfig, executorService, null, newFilePermissions); //we don't care about transformation or tree shaking here
                 }
                 Map<ArtifactKey, List<String>> relativePaths = new HashMap<>();
                 for (Entry<ArtifactKey, List<Path>> e : copiedArtifacts.entrySet()) {
@@ -400,7 +402,7 @@ abstract class AbstractFastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
             Consumer<Path> parentFirstDependenciesConsumer, boolean allowParentFirst, ResolvedDependency appDep,
             TransformedClassesBuildItem transformedClasses, Set<ArtifactKey> removedDeps,
             PackageConfig packageConfig, CoreSbomContributionConfig manifestConfig, ExecutorService executorService,
-            JarTreeShakeBuildItem treeShakeResult)
+            JarTreeShakeBuildItem treeShakeResult, Set<PosixFilePermission> newFilePermissions)
             throws IOException {
 
         // Exclude files that are not jars (typically, we can have XML files here, see https://github.com/quarkusio/quarkus/issues/2852)
@@ -487,9 +489,16 @@ abstract class AbstractFastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
                     }
                 }
                 if (removedFromThisArchive.isEmpty()) {
-                    // let's not use COPY_ATTRIBUTES to make sure we respect the system umask
-                    Files.copy(resolvedDep, targetPath, StandardCopyOption.REPLACE_EXISTING);
+                    // COPY_ATTRIBUTES triggers clonefile(2) on JDK 20+/macOS APFS, enabling
+                    // instant copy-on-write clones with no data duplication (JDK-8293122).
+                    // COPY_ATTRIBUTES preserves source permissions verbatim and ignores the umask,
+                    // so we explicitly restore the default new-file permissions afterwards.
+                    Files.copy(resolvedDep, targetPath, StandardCopyOption.REPLACE_EXISTING,
+                            StandardCopyOption.COPY_ATTRIBUTES);
                     Files.setLastModifiedTime(targetPath, Files.getLastModifiedTime(resolvedDep));
+                    if (newFilePermissions != null) {
+                        Files.setPosixFilePermissions(targetPath, newFilePermissions);
+                    }
                 } else {
                     // we copy jars for which we remove entries to the same directory
                     // which seems a bit odd to me
@@ -498,6 +507,19 @@ abstract class AbstractFastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
                 manifestConfig.addComponent(appDep, targetPath,
                         treeShakeResult != null ? treeShakeResult.computePedigree(appDep.getKey()) : null);
             }
+        }
+    }
+
+    private static Set<PosixFilePermission> probeNewFilePermissions(Path dir) {
+        try {
+            Path probe = Files.createTempFile(dir, ".permissions-probe", null);
+            try {
+                return Files.getPosixFilePermissions(probe);
+            } finally {
+                Files.deleteIfExists(probe);
+            }
+        } catch (IOException | UnsupportedOperationException e) {
+            return null;
         }
     }
 


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
and the AI/LLM usage policy at https://github.com/quarkusio/quarkus/blob/main/AI_POLICY.md
-->

On JDK 20+, `Files.copy()` uses clonefile(2) on macOS/APFS when `StandardCopyOption.COPY_ATTRIBUTES` is set ([JDK-8293122](https://bugs.openjdk.org/browse/JDK-8293122)), enabling instant copy-on-write clones that avoid duplicating dependency jars on disk across builds.

`COPY_ATTRIBUTES` was previously used but deliberately removed in commit 4e615d2d923 (fix for [#50556](https://github.com/quarkusio/quarkus/issues/50556), originally reported via [keycloak/keycloak#43437](https://github.com/keycloak/keycloak/issues/43437)) because `clonefile(2)` copies source file permissions verbatim, ignoring the system umask. This could produce output jars with permissions inherited verbatim from the source artifact rather than those the OS would assign to a freshly created file, potentially breaking deployments where files are expected to conform to the system umask.

This PR restores `COPY_ATTRIBUTES` while fixing the umask issue: before the dependency copy loop, the effective new-file permissions are probed by creating a temporary file in the output lib directory and reading its POSIX permissions — the same permissions the OS would assign to any freshly created file under the current umask. After each jar is cloned, its permissions are explicitly set to this probed value via `Files.setPosixFilePermissions()`.

On non-POSIX filesystems (e.g. Windows), `probeNewFilePermissions()` returns `null` and the `setPosixFilePermissions()` call is skipped entirely. On Linux, `Files.copy()` already uses `copy_file_range(2)` unconditionally regardless of `COPY_ATTRIBUTES` ([JDK-8264744](https://bugs.openjdk.org/browse/JDK-8264744)), so this change has no effect there. On JDK < 20 and non-APFS volumes, the JDK falls back silently — no regression on any platform.

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

Fixes #54094
