### PR TITLE
Adding an exit throwable to asyncExit

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
@@ -79,7 +79,8 @@ public class ApplicationLifecycleManager {
     private static final Condition stateCond = stateLock.newCondition();
     private static ShutdownHookThread shutdownHookThread;
 
-    private static int exitCode = -1;
+    private static volatile int exitCode = -1;
+    private static volatile Throwable exitThrowable;
     private static volatile boolean shutdownRequested;
     private static volatile Application currentApplication;
     private static boolean vmShuttingDown;
@@ -117,6 +118,7 @@ public class ApplicationLifecycleManager {
                 throw new IllegalStateException("Quarkus already running");
             }
             exitCode = -1;
+            exitThrowable = null;
             shutdownRequested = false;
             currentApplication = application;
         } finally {
@@ -239,7 +241,7 @@ public class ApplicationLifecycleManager {
             application.stop(); //this could have already been called
         }
         currentApplication = null;
-        (exitCodeHandler == null ? defaultExitCodeHandler : exitCodeHandler).accept(getExitCode(), null); //this may not be called if shutdown was initiated by a signal
+        (exitCodeHandler == null ? defaultExitCodeHandler : exitCodeHandler).accept(getExitCode(), exitThrowable); //this may not be called if shutdown was initiated by a signal
     }
 
     // this is needed only when async console logging is enabled
@@ -392,10 +394,24 @@ public class ApplicationLifecycleManager {
      * @param code The exit code
      */
     public static void exit(int code) {
+        exit(code, null);
+    }
+
+    /**
+     * Signals that the application should exit with the given code.
+     *
+     * Note that the first positive exit code will 'win', so if the exit code
+     * has already been set then the exit code and throwable will be ignored.
+     *
+     * @param code The exit code
+     * @param throwable The exception causing the exit
+     */
+    public static void exit(int code, Throwable throwable) {
         stateLock.lock();
         try {
             if (code >= 0 && exitCode == -1) {
                 exitCode = code;
+                exitThrowable = throwable;
             }
             if (shutdownRequested) {
                 return;

--- a/core/runtime/src/main/java/io/quarkus/runtime/Quarkus.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/Quarkus.java
@@ -156,11 +156,34 @@ public class Quarkus {
      *
      * The error code supplied here will override the value returned from the main application.
      *
+     * The first call to asyncExit that sets the error code will have that error code and throwable
+     * supplied to the {@link #run(Class, BiConsumer, String...)} exitHandler
+     *
+     * @param code The exit code. This may be overridden if an exception occurs on shutdown
+     * @param throwable The exit exception. This may be overridden if an exception occurs on shutdown.
+     */
+    public static void asyncExit(int code, Throwable throwable) {
+        terminateForIDE();
+        ApplicationLifecycleManager.exit(code, throwable);
+    }
+
+    /**
+     * Exits the application in an async manner. Calling this method
+     * will initiate the Quarkus shutdown process, and then immediately return.
+     *
+     * This method will unblock the {@link #waitForExit()} method.
+     *
+     * Note that if the main thread is executing a Quarkus application this will only take
+     * effect if {@link #waitForExit()} has been called, otherwise the application will continue
+     * to execute (i.e. this does not initiate the shutdown process, it just signals the main
+     * thread that the application is done so that shutdown can run when the main thread returns).
+     *
+     * The error code supplied here will override the value returned from the main application.
+     *
      * @param code The exit code. This may be overridden if an exception occurs on shutdown
      */
     public static void asyncExit(int code) {
-        terminateForIDE();
-        ApplicationLifecycleManager.exit(code);
+        asyncExit(code, null);
     }
 
     /**
@@ -176,8 +199,7 @@ public class Quarkus {
      *
      */
     public static void asyncExit() {
-        terminateForIDE();
-        ApplicationLifecycleManager.exit(-1);
+        asyncExit(-1);
     }
 
     /**

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/commandmode/ExitCodeTestCase.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/commandmode/ExitCodeTestCase.java
@@ -55,6 +55,30 @@ public class ExitCodeTestCase {
     }
 
     @Test
+    public void testWaitToExitWithThrowable() throws ExecutionException, InterruptedException {
+        CompletableFuture<Integer> future = new CompletableFuture<>();
+        CompletableFuture<Throwable> throwableFuture = new CompletableFuture<>();
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                ApplicationLifecycleManager.run(Application.currentApplication(), WaitToExitApplication.class,
+                        new BiConsumer<Integer, Throwable>() {
+                            @Override
+                            public void accept(Integer integer, Throwable cause) {
+                                future.complete(integer);
+                                throwableFuture.complete(cause);
+                            }
+                        });
+            }
+        }).start();
+        Thread.sleep(500);
+        Assertions.assertFalse(future.isDone());
+        Quarkus.asyncExit(10, new RuntimeException("I've failed"));
+        Assertions.assertEquals(10, future.get());
+        Assertions.assertEquals("I've failed", throwableFuture.get().getMessage());
+    }
+
+    @Test
     public void testWaitToExitWithNoCode() throws ExecutionException, InterruptedException {
         CompletableFuture<Integer> future = new CompletableFuture<>();
         new Thread(new Runnable() {


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
and the AI/LLM usage policy at https://github.com/quarkusio/quarkus/blob/main/AI_POLICY.md
-->

Allows asyncExit calls to provide a throwable for the exitHandler.

* Fixes #54044

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:


* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

