### PR TITLE
Add extension-rag module to generate RAG vector embeddings from core documentation

### DIFF
--- a/devtools/extension-rag/pom.xml
+++ b/devtools/extension-rag/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>quarkus-build-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../../build-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-documentation-core-rag</artifactId>
+    <name>Quarkus - Documentation Core RAG</name>
+    <description>Aggregated RAG vector embeddings for core Quarkus documentation</description>
+
+    <properties>
+        <skipRagGeneration>true</skipRagGeneration>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-extension-descriptor</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-documentation-rag-maven-plugin</artifactId>
+                <version>0.0.5</version>
+                <executions>
+                    <execution>
+                        <id>generate-core-rag</id>
+                        <goals>
+                            <goal>generate-rag</goal>
+                        </goals>
+                        <configuration>
+                            <guidesDirectory>${project.basedir}/../../docs/src/main/asciidoc</guidesDirectory>
+                            <skip>${skipRagGeneration}</skip>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/devtools/pom.xml
+++ b/devtools/pom.xml
@@ -29,5 +29,6 @@
         <module>cli</module>
         <module>config-doc-maven-plugin</module>
         <module>extension-skills</module>
+        <module>extension-rag</module>
     </modules>
 </project>


### PR DESCRIPTION
Adds a `devtools/extension-rag/` module that uses the [quarkus-documentation-rag](https://github.com/quarkusio/quarkus-documentation-rag) Maven plugin to process all ~274 AsciiDoc guides into vector embeddings for pgvector.

Each guide is parsed via AsciidoctorJ, split into semantic chunks at section boundaries, and embedded using the BGE Small EN v1.5 ONNX model (384 dimensions). The result is an idempotent SQL file (`META-INF/quarkus-rag.sql`) packaged as `io.quarkus:quarkus-documentation-core-rag:{version}`.

This artifact is downloaded at runtime by `quarkus-agent-mcp` and `chappie-server` to populate a generic `pgvector/pgvector:pg17` container for documentation search, replacing the monolithic `chappie-docling-rag` Docker image that had to be rebuilt on every Quarkus release.

Each guide's source identity is derived from its `:extensions:` metadata (e.g., `io.quarkus:quarkus-rest` becomes `quarkus-rest`). Guides without `:extensions:` (getting-started, config, CDI concepts) get `quarkus-<filename>` as their source.

The module is gated behind `-Prag` since RAG generation takes ~2 minutes for all 274 guides and shouldn't slow normal dev builds.