### PR TITLE
Use Quarkus Gauge builder

### DIFF
--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/NetworkMetrics.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/NetworkMetrics.java
@@ -4,12 +4,12 @@ import java.util.concurrent.atomic.LongAdder;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
-import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.LongTaskTimer;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
+import io.quarkus.micrometer.runtime.meters.Gauges;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.spi.metrics.TCPMetrics;
 
@@ -19,17 +19,19 @@ public class NetworkMetrics implements TCPMetrics<LongTaskTimer.Sample> {
     final DistributionSummary received;
     final DistributionSummary sent;
     final Meter.MeterProvider<Counter> exceptionCounter;
-    final Gauge activeConnections;
 
     final Tags tags;
     private final LongTaskTimer connDuration;
     private final LongAdder connCount;
 
     public NetworkMetrics(MeterRegistry registry, Tags tags, String prefix, String receivedDesc, String sentDesc,
-            String connDurationDesc, String connCountDesc) {
+            String connDurationDesc, String connCountDesc, Gauges<LongAdder> gauges) {
         this.registry = registry;
         this.tags = tags == null ? Tags.empty() : tags;
-        connCount = new LongAdder();
+        connCount = gauges.builder(prefix + ".active.connections", LongAdder::longValue)
+                .description(connCountDesc)
+                .tags(this.tags)
+                .register(registry);
         received = DistributionSummary.builder(prefix + ".bytes.read")
                 .description(receivedDesc)
                 .tags(this.tags)
@@ -44,10 +46,6 @@ public class NetworkMetrics implements TCPMetrics<LongTaskTimer.Sample> {
                 .register(registry);
         exceptionCounter = Counter.builder(prefix + ".errors")
                 .withRegistry(registry);
-        activeConnections = Gauge.builder(prefix + ".active.connections", connCount, LongAdder::longValue)
-                .description(connCountDesc)
-                .tags(this.tags)
-                .register(registry);
     }
 
     /**

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxClientMetrics.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxClientMetrics.java
@@ -1,13 +1,12 @@
 package io.quarkus.micrometer.runtime.binder.vertx;
 
 import java.util.concurrent.atomic.LongAdder;
-import java.util.function.Supplier;
 
 import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
+import io.quarkus.micrometer.runtime.meters.Gauges;
 import io.vertx.core.spi.metrics.ClientMetrics;
 
 public class VertxClientMetrics
@@ -15,13 +14,13 @@ public class VertxClientMetrics
 
     private final String type;
     private final Timer processing;
-    private final LongAdder current = new LongAdder();
-    private final LongAdder queue = new LongAdder();
+    private final LongAdder current;
+    private final LongAdder queue;
     private final Counter resetCount;
     private final Counter completed;
     private final Timer queueDelay;
 
-    VertxClientMetrics(MeterRegistry registry, String type, Tags tags) {
+    VertxClientMetrics(MeterRegistry registry, String type, Tags tags, Gauges<LongAdder> gauges) {
         this.type = type;
 
         queueDelay = Timer.builder(name("queue.delay"))
@@ -34,26 +33,14 @@ public class VertxClientMetrics
                 .tags(tags)
                 .register(registry);
 
-        Gauge.builder(name("queue.size"), new Supplier<Number>() {
-            @Override
-            public Number get() {
-                return queue.doubleValue();
-            }
-        })
+        queue = gauges.builder(name("queue.size"), LongAdder::doubleValue)
                 .description("Number of pending elements in the waiting queue")
                 .tags(tags)
-                .strongReference(true)
                 .register(registry);
 
-        Gauge.builder(name("current"), new Supplier<Number>() {
-            @Override
-            public Number get() {
-                return current.doubleValue();
-            }
-        })
+        current = gauges.builder(name("current"), LongAdder::doubleValue)
                 .description("The number of requests currently handled by the client")
                 .tags(tags)
-                .strongReference(true)
                 .register(registry);
 
         completed = Counter.builder(name("completed"))

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxEventBusMetrics.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxEventBusMetrics.java
@@ -6,10 +6,10 @@ import java.util.concurrent.atomic.LongAdder;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
-import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
+import io.quarkus.micrometer.runtime.meters.Gauges;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.eventbus.ReplyFailure;
 import io.vertx.core.spi.metrics.EventBusMetrics;
@@ -19,6 +19,7 @@ public class VertxEventBusMetrics implements EventBusMetrics<VertxEventBusMetric
     private final Tags tags;
     private final MeterRegistry registry;
     private final Handler ignored;
+    private final Gauges<LongAdder> gauges;
 
     private Map<String, Handler> handlers = new ConcurrentHashMap<>();
 
@@ -28,10 +29,11 @@ public class VertxEventBusMetrics implements EventBusMetrics<VertxEventBusMetric
     private final Meter.MeterProvider<DistributionSummary> read;
     private final Meter.MeterProvider<Counter> replyFailures;
 
-    VertxEventBusMetrics(MeterRegistry registry, Tags tags) {
+    VertxEventBusMetrics(MeterRegistry registry, Tags tags, Gauges<LongAdder> gauges) {
         this.registry = registry;
         this.tags = tags;
         this.ignored = new Handler(null);
+        this.gauges = gauges;
 
         published = Counter.builder("eventBus.published")
                 .description("Number of messages published to the event bus")
@@ -150,20 +152,17 @@ public class VertxEventBusMetrics implements EventBusMetrics<VertxEventBusMetric
             }
 
             this.address = address;
-            this.count = new LongAdder();
-            this.delivered = new LongAdder();
-            this.discarded = new LongAdder();
-            Gauge.builder("eventBus.handlers", count::longValue)
+            this.count = gauges.builder("eventBus.handlers", LongAdder::longValue)
                     .description("Number of handlers per address")
                     .tags(tags.and("address", address))
                     .register(registry);
 
-            Gauge.builder("eventBus.delivered", delivered::longValue)
+            this.delivered = gauges.builder("eventBus.delivered", LongAdder::longValue)
                     .description("Number of messages delivered")
                     .tags(tags.and("address", address))
                     .register(registry);
 
-            Gauge.builder("eventBus.discarded", discarded::longValue)
+            this.discarded = gauges.builder("eventBus.discarded", LongAdder::longValue)
                     .description("Number of messages discarded")
                     .tags(tags.and("address", address))
                     .register(registry);

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxHttpClientMetrics.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxHttpClientMetrics.java
@@ -7,13 +7,10 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
-import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 import org.jboss.logging.Logger;
 
-import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.LongTaskTimer;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -26,6 +23,7 @@ import io.quarkus.micrometer.runtime.HttpClientMetricsTagsContributor;
 import io.quarkus.micrometer.runtime.binder.HttpBinderConfiguration;
 import io.quarkus.micrometer.runtime.binder.HttpCommonTags;
 import io.quarkus.micrometer.runtime.binder.RequestMetricInfo;
+import io.quarkus.micrometer.runtime.meters.Gauges;
 import io.vertx.core.http.WebSocket;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.spi.metrics.ClientMetrics;
@@ -37,43 +35,34 @@ class VertxHttpClientMetrics extends VertxTcpClientMetrics
         implements HttpClientMetrics<VertxHttpClientMetrics.RequestTracker, String, LongTaskTimer.Sample, EventTiming> {
     static final Logger log = Logger.getLogger(VertxHttpClientMetrics.class);
 
-    private final LongAdder queue = new LongAdder();
-
-    private final LongAdder pending = new LongAdder();
-
+    private final LongAdder queue;
+    private final LongAdder pending;
     private final Timer queueDelay;
     private final Map<String, LongAdder> webSockets = new ConcurrentHashMap<>();
     private final HttpBinderConfiguration config;
-
     private final Meter.MeterProvider<Timer> responseTimes;
-
     private final List<HttpClientMetricsTagsContributor> httpClientMetricsTagsContributors;
+    private final Gauges<LongAdder> gauges;
 
-    VertxHttpClientMetrics(MeterRegistry registry, String prefix, Tags tags, HttpBinderConfiguration httpBinderConfiguration) {
-        super(registry, prefix, tags);
+    VertxHttpClientMetrics(MeterRegistry registry, String prefix, Tags tags,
+            HttpBinderConfiguration httpBinderConfiguration, Gauges<LongAdder> gauges) {
+        super(registry, prefix, tags, gauges);
         this.config = httpBinderConfiguration;
+        this.gauges = gauges;
         queueDelay = Timer.builder("http.client.queue.delay")
                 .description("Time spent in the waiting queue before being processed")
                 .tags(tags)
                 .register(registry);
 
-        Gauge.builder("http.client.queue.size", new Supplier<Number>() {
-            @Override
-            public Number get() {
-                return queue.doubleValue();
-            }
-        })
+        queue = gauges.builder("http.client.queue.size", LongAdder::doubleValue)
                 .description("Number of pending elements in the waiting queue")
                 .tags(tags)
-                .strongReference(true)
                 .register(registry);
 
-        Gauge.builder("http.client.pending", new Supplier<Number>() {
-            @Override
-            public Number get() {
-                return pending.longValue();
-            }
-        }).description("Number of requests waiting for a response");
+        pending = gauges.builder("http.client.pending", LongAdder::longValue)
+                .description("Number of requests waiting for a response")
+                .tags(tags)
+                .register(registry);
 
         httpClientMetricsTagsContributors = resolveHttpClientMetricsTagsContributors();
 
@@ -201,16 +190,11 @@ class VertxHttpClientMetrics extends VertxTcpClientMetrics
     @Override
     public String connected(WebSocket webSocket) {
         String remote = webSocket.remoteAddress().toString();
-        webSockets.computeIfAbsent(remote, new Function<>() {
-            @Override
-            public LongAdder apply(String s) {
-                LongAdder count = new LongAdder();
-                Gauge.builder(config.getHttpClientWebSocketConnectionsName(), count::longValue)
-                        .description("The number of active web socket connections")
-                        .tags(tags.and("address", remote))
-                        .register(registry);
-                return count;
-            }
+        webSockets.computeIfAbsent(remote, s -> {
+            return gauges.builder(config.getHttpClientWebSocketConnectionsName(), LongAdder::longValue)
+                    .description("The number of active web socket connections")
+                    .tags(tags.and("address", remote))
+                    .register(registry);
         }).increment();
         return remote;
     }

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxHttpServerMetrics.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxHttpServerMetrics.java
@@ -8,11 +8,9 @@ import java.util.concurrent.atomic.LongAdder;
 import org.jboss.logging.Logger;
 
 import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.LongTaskTimer;
 import io.micrometer.core.instrument.Meter.MeterProvider;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.binder.http.Outcome;
@@ -22,6 +20,7 @@ import io.quarkus.micrometer.runtime.HttpServerMetricsTagsContributor;
 import io.quarkus.micrometer.runtime.binder.HttpBinderConfiguration;
 import io.quarkus.micrometer.runtime.binder.HttpCommonTags;
 import io.quarkus.micrometer.runtime.export.exemplars.OpenTelemetryContextUnwrapper;
+import io.quarkus.micrometer.runtime.meters.Gauges;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.http.HttpServerRequest;
@@ -56,21 +55,18 @@ public class VertxHttpServerMetrics extends VertxTcpServerMetrics
 
     VertxHttpServerMetrics(MeterRegistry registry,
             HttpBinderConfiguration config,
-            OpenTelemetryContextUnwrapper openTelemetryContextUnwrapper, HttpServerOptions httpServerOptions) {
-        super(registry, "http.server", commonTags(httpServerOptions));
+            OpenTelemetryContextUnwrapper openTelemetryContextUnwrapper, HttpServerOptions httpServerOptions,
+            Gauges<LongAdder> gauges) {
+        super(registry, "http.server", commonTags(httpServerOptions), gauges);
         this.config = config;
         this.openTelemetryContextUnwrapper = openTelemetryContextUnwrapper;
-        activeRequests = new LongAdder();
 
         Tags commonTags = commonTags(httpServerOptions);
 
-        Gauge.Builder<LongAdder> activeRequestsBuilder = Gauge
-                .builder(config.getHttpServerActiveRequestsName(), activeRequests, LongAdder::doubleValue)
-                .tag("url.scheme", httpServerOptions.isSsl() ? "https" : "http");
-        for (Tag commonTag : commonTags) {
-            activeRequestsBuilder.tag(commonTag.getKey(), commonTag.getValue());
-        }
-        activeRequestsBuilder.register(registry);
+        activeRequests = gauges.builder(config.getHttpServerActiveRequestsName(), LongAdder::doubleValue)
+                .tag("url.scheme", httpServerOptions.isSsl() ? "https" : "http")
+                .tags(commonTags)
+                .register(registry);
 
         httpServerMetricsTagsContributors = resolveHttpServerMetricsTagsContributors();
 
@@ -95,6 +91,8 @@ public class VertxHttpServerMetrics extends VertxTcpServerMetrics
         // not the public one which we can't know easily) only if it's not random
         if (httpServerOptions.getPort() > 0) {
             result = result.and("server.port", "" + httpServerOptions.getPort());
+        } else {
+            result = result.and("server.port", "UNSET");
         }
         return result;
     }

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxMeterBinderAdapter.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxMeterBinderAdapter.java
@@ -1,6 +1,8 @@
 package io.quarkus.micrometer.runtime.binder.vertx;
 
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Supplier;
 
 import org.jboss.logging.Logger;
@@ -12,6 +14,7 @@ import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.quarkus.micrometer.runtime.binder.HttpBinderConfiguration;
 import io.quarkus.micrometer.runtime.export.exemplars.OpenTelemetryContextUnwrapper;
+import io.quarkus.micrometer.runtime.meters.Gauges;
 import io.quarkus.vertx.http.runtime.ExtendedQuarkusVertxHttpMetrics;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.datagram.DatagramSocketOptions;
@@ -36,6 +39,9 @@ public class VertxMeterBinderAdapter extends MetricsOptions
         implements VertxMetricsFactory, VertxMetrics, ExtendedQuarkusVertxHttpMetrics {
     private static final Logger log = Logger.getLogger(VertxMeterBinderAdapter.class);
     public static final String METRIC_NAME_SEPARATOR = "|";
+
+    private final Gauges<LongAdder> longAdderGauges = Gauges.longAdder();
+    private final Gauges<AtomicReference<Double>> doubleGauges = Gauges.of(() -> new AtomicReference<>(0.0));
 
     private HttpBinderConfiguration httpBinderConfiguration;
     private OpenTelemetryContextUnwrapper openTelemetryContextUnwrapper;
@@ -80,7 +86,7 @@ public class VertxMeterBinderAdapter extends MetricsOptions
         if (httpBinderConfiguration.isServerEnabled()) {
             log.debugf("Create HttpServerMetrics with options %s and address %s", options, localAddress);
             return new VertxHttpServerMetrics(Metrics.globalRegistry, httpBinderConfiguration, openTelemetryContextUnwrapper,
-                    options);
+                    options, longAdderGauges);
         }
         return null;
     }
@@ -100,10 +106,10 @@ public class VertxMeterBinderAdapter extends MetricsOptions
             if (clientName != null) {
                 return new VertxHttpClientMetrics(Metrics.globalRegistry, "http.client",
                         Tags.of(Tag.of("clientName", clientName)),
-                        httpBinderConfiguration);
+                        httpBinderConfiguration, longAdderGauges);
             } else {
                 return new VertxHttpClientMetrics(Metrics.globalRegistry, "http.client",
-                        Tags.of(Tag.of("clientName", "<default>")), httpBinderConfiguration);
+                        Tags.of(Tag.of("clientName", "<default>")), httpBinderConfiguration, longAdderGauges);
             }
         }
         return null;
@@ -114,7 +120,7 @@ public class VertxMeterBinderAdapter extends MetricsOptions
         return new VertxTcpServerMetrics(Metrics.globalRegistry, "tcp", Tags.of(
                 Tag.of("port", Integer.toString(localAddress.port())),
                 Tag.of("host", options.getHost()),
-                Tag.of("address", VertxTcpServerMetrics.toString(localAddress))));
+                Tag.of("address", VertxTcpServerMetrics.toString(localAddress))), longAdderGauges);
     }
 
     @Override
@@ -126,9 +132,11 @@ public class VertxMeterBinderAdapter extends MetricsOptions
         String prefix = extractPrefix(options.getMetricsName());
         String clientName = extractClientName(options.getMetricsName());
         if (clientName != null) {
-            return new VertxTcpClientMetrics(Metrics.globalRegistry, prefix, Tags.of(Tag.of("clientName", clientName)));
+            return new VertxTcpClientMetrics(Metrics.globalRegistry, prefix, Tags.of(Tag.of("clientName", clientName)),
+                    longAdderGauges);
         } else {
-            return new VertxTcpClientMetrics(Metrics.globalRegistry, prefix, Tags.of(Tag.of("clientName", "<default>")));
+            return new VertxTcpClientMetrics(Metrics.globalRegistry, prefix, Tags.of(Tag.of("clientName", "<default>")),
+                    longAdderGauges);
         }
     }
 
@@ -140,17 +148,19 @@ public class VertxMeterBinderAdapter extends MetricsOptions
         if (clientName != null) {
             return new VertxClientMetrics(Metrics.globalRegistry, prefix, Tags.of(
                     Tag.of("clientName", clientName),
-                    Tag.of("clientType", type)));
+                    Tag.of("clientType", type)), longAdderGauges);
         } else {
             return new VertxClientMetrics(Metrics.globalRegistry, prefix, Tags.of(
                     Tags.of(Tag.of("clientName", "<default>"),
-                            Tag.of("clientType", type))));
+                            Tag.of("clientType", type))),
+                    longAdderGauges);
         }
     }
 
     @Override
     public PoolMetrics<?> createPoolMetrics(String poolType, String poolName, int maxPoolSize) {
-        return new VertxPoolMetrics(Metrics.globalRegistry, poolType, poolName, maxPoolSize);
+        return new VertxPoolMetrics(Metrics.globalRegistry, poolType, poolName, maxPoolSize,
+                longAdderGauges, doubleGauges);
     }
 
     @Override
@@ -160,7 +170,7 @@ public class VertxMeterBinderAdapter extends MetricsOptions
 
     @Override
     public EventBusMetrics<?> createEventBusMetrics() {
-        return new VertxEventBusMetrics(Metrics.globalRegistry, Tags.empty());
+        return new VertxEventBusMetrics(Metrics.globalRegistry, Tags.empty(), longAdderGauges);
     }
 
     /**
@@ -206,6 +216,7 @@ public class VertxMeterBinderAdapter extends MetricsOptions
             private final Counter counter = Counter.builder("vertx.http.connections.rejected")
                     .description("Number of rejected HTTP connections")
                     .register(Metrics.globalRegistry);
+            private final Gauges<AtomicInteger> atomicIntGauges = Gauges.atomicInteger();
 
             @Override
             public void onConnectionRejected() {
@@ -214,14 +225,9 @@ public class VertxMeterBinderAdapter extends MetricsOptions
 
             @Override
             public void initialize(int maxConnections, AtomicInteger current) {
-                Gauge.builder("vertx.http.connections.current", new Supplier<Number>() {
-                    @Override
-                    public Number get() {
-                        return current.get();
-                    }
-                })
+                atomicIntGauges.builder("vertx.http.connections.current", AtomicInteger::doubleValue)
                         .description("Current number of active HTTP connections")
-                        .register(Metrics.globalRegistry);
+                        .register(Metrics.globalRegistry, current);
 
                 Gauge.builder("vertx.http.connections.max", new Supplier<Number>() {
                     @Override

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxPoolMetrics.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxPoolMetrics.java
@@ -2,14 +2,13 @@ package io.quarkus.micrometer.runtime.binder.vertx;
 
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
-import java.util.function.Supplier;
 
 import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
+import io.quarkus.micrometer.runtime.meters.Gauges;
 import io.vertx.core.spi.metrics.PoolMetrics;
 
 /**
@@ -21,14 +20,16 @@ public class VertxPoolMetrics implements PoolMetrics<EventTiming> {
     private final int maxPoolSize;
 
     private final Timer usage;
-    private final AtomicReference<Double> ratio = new AtomicReference<>();
-    private final LongAdder current = new LongAdder();
-    private final LongAdder queue = new LongAdder();
+    private final AtomicReference<Double> ratio;
+    private final LongAdder current;
+    private final LongAdder idle;
+    private final LongAdder queue;
     private final Counter completed;
     private final Counter rejected;
     private final Timer queueDelay;
 
-    VertxPoolMetrics(MeterRegistry registry, String poolType, String poolName, int maxPoolSize) {
+    VertxPoolMetrics(MeterRegistry registry, String poolType, String poolName, int maxPoolSize,
+            Gauges<LongAdder> longAdderGauges, Gauges<AtomicReference<Double>> doubleGauges) {
         this.poolType = poolType;
         this.maxPoolSize = maxPoolSize;
 
@@ -44,45 +45,30 @@ public class VertxPoolMetrics implements PoolMetrics<EventTiming> {
                 .tags(tags)
                 .register(registry);
 
-        Gauge.builder(name("queue.size"), new Supplier<Number>() {
-            @Override
-            public Number get() {
-                return queue.doubleValue();
-            }
-        })
+        queue = longAdderGauges.builder(name("queue.size"), LongAdder::doubleValue)
                 .description("Number of pending elements in the waiting queue")
                 .tags(tags)
-                .strongReference(true)
                 .register(registry);
 
-        Gauge.builder(name("active"), new Supplier<Number>() {
-            @Override
-            public Number get() {
-                return current.doubleValue();
-            }
-        })
+        current = longAdderGauges.builder(name("active"), LongAdder::doubleValue)
                 .description("The number of resources from the pool currently used")
                 .tags(tags)
-                .strongReference(true)
                 .register(registry);
 
         if (maxPoolSize > 0) {
-            Gauge.builder(name("idle"), new Supplier<Number>() {
-                @Override
-                public Number get() {
-                    return maxPoolSize - current.doubleValue();
-                }
-            })
-                    .description("The number of resources from the pool currently used")
+            idle = longAdderGauges.builder(name("idle"), LongAdder::doubleValue)
+                    .description("The number of resources from the pool currently idle")
                     .tags(tags)
-                    .strongReference(true)
                     .register(registry);
+            idle.add(maxPoolSize);
 
-            Gauge.builder(name("ratio"), ratio::get)
+            ratio = doubleGauges.builder(name("ratio"), AtomicReference::get)
                     .description("Pool usage ratio")
                     .tags(tags)
-                    .strongReference(true)
                     .register(registry);
+        } else {
+            idle = null;
+            ratio = null;
         }
 
         completed = Counter.builder(name("completed"))
@@ -94,7 +80,6 @@ public class VertxPoolMetrics implements PoolMetrics<EventTiming> {
                 .description("Number of times submissions to the pool have been rejected")
                 .tags(tags)
                 .register(registry);
-
     }
 
     private String name(String suffix) {
@@ -119,6 +104,9 @@ public class VertxPoolMetrics implements PoolMetrics<EventTiming> {
         queue.decrement();
         submitted.end();
         current.increment();
+        if (idle != null) {
+            idle.decrement();
+        }
         computeRatio(current.longValue());
         return new EventTiming(usage);
     }
@@ -126,6 +114,9 @@ public class VertxPoolMetrics implements PoolMetrics<EventTiming> {
     @Override
     public void end(EventTiming timer, boolean succeeded) {
         current.decrement();
+        if (idle != null) {
+            idle.increment();
+        }
         computeRatio(current.longValue());
         timer.end();
 
@@ -137,7 +128,7 @@ public class VertxPoolMetrics implements PoolMetrics<EventTiming> {
     }
 
     private void computeRatio(long inUse) {
-        if (maxPoolSize > 0) {
+        if (ratio != null && maxPoolSize > 0) {
             ratio.set((double) inUse / maxPoolSize);
         }
     }

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxTcpClientMetrics.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxTcpClientMetrics.java
@@ -1,16 +1,20 @@
 package io.quarkus.micrometer.runtime.binder.vertx;
 
+import java.util.concurrent.atomic.LongAdder;
+
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
+import io.quarkus.micrometer.runtime.meters.Gauges;
 
 public class VertxTcpClientMetrics extends NetworkMetrics {
 
-    VertxTcpClientMetrics(MeterRegistry registry, String prefix, Tags tags) {
+    VertxTcpClientMetrics(MeterRegistry registry, String prefix, Tags tags, Gauges<LongAdder> gauges) {
         super(registry, tags, prefix,
                 "Number of bytes received by the client",
                 "Number of bytes sent by the client",
                 "The duration of the connections",
-                "Number of connections to the remote host currently opened");
+                "Number of connections to the remote host currently opened",
+                gauges);
     }
 
 }

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxTcpServerMetrics.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxTcpServerMetrics.java
@@ -1,16 +1,20 @@
 package io.quarkus.micrometer.runtime.binder.vertx;
 
+import java.util.concurrent.atomic.LongAdder;
+
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
+import io.quarkus.micrometer.runtime.meters.Gauges;
 
 public class VertxTcpServerMetrics extends NetworkMetrics {
 
-    VertxTcpServerMetrics(MeterRegistry registry, String prefix, Tags tags) {
+    VertxTcpServerMetrics(MeterRegistry registry, String prefix, Tags tags, Gauges<LongAdder> gauges) {
         super(registry, tags, prefix,
                 "Number of bytes received by the server",
                 "Number of bytes sent by the server",
                 "The duration of the connections",
-                "Number of opened connections to the HTTP Server");
+                "Number of opened connections to the HTTP Server",
+                gauges);
     }
 
 }

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/meters/GaugeBuilder.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/meters/GaugeBuilder.java
@@ -1,0 +1,53 @@
+package io.quarkus.micrometer.runtime.meters;
+
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Supplier;
+import java.util.function.ToDoubleFunction;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+
+public class GaugeBuilder<T> {
+
+    private final GaugeSupplier<T> supplier;
+    private final Gauge.Builder<Supplier<Number>> builder;
+    private final ConcurrentMap<Meter.Id, T> map;
+    private final Supplier<T> factory;
+
+    GaugeBuilder(String name, ConcurrentMap<Meter.Id, T> map,
+            Supplier<T> factory, ToDoubleFunction<T> func) {
+        this.supplier = new GaugeSupplier<>(map, func);
+        this.builder = Gauge.builder(name, supplier);
+        this.map = map;
+        this.factory = factory;
+    }
+
+    public GaugeBuilder<T> description(String description) {
+        builder.description(description);
+        return this;
+    }
+
+    public GaugeBuilder<T> tags(Iterable<Tag> tags) {
+        builder.tags(tags);
+        return this;
+    }
+
+    public GaugeBuilder<T> tag(String key, String value) {
+        builder.tag(key, value);
+        return this;
+    }
+
+    public T register(MeterRegistry registry) {
+        Meter.Id meterId = builder.register(registry).getId();
+        supplier.setId(meterId);
+        return map.computeIfAbsent(meterId, id -> factory.get());
+    }
+
+    public T register(MeterRegistry registry, T externalValue) {
+        Meter.Id meterId = builder.register(registry).getId();
+        supplier.setId(meterId);
+        return map.computeIfAbsent(meterId, id -> externalValue);
+    }
+}

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/meters/GaugeSupplier.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/meters/GaugeSupplier.java
@@ -1,0 +1,35 @@
+package io.quarkus.micrometer.runtime.meters;
+
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Supplier;
+import java.util.function.ToDoubleFunction;
+
+import io.micrometer.core.instrument.Meter;
+
+class GaugeSupplier<T> implements Supplier<Number> {
+
+    private final ConcurrentMap<Meter.Id, T> map;
+    private final ToDoubleFunction<T> func;
+    private volatile Meter.Id id;
+
+    GaugeSupplier(ConcurrentMap<Meter.Id, T> map, ToDoubleFunction<T> func) {
+        this.map = map;
+        this.func = func;
+    }
+
+    void setId(Meter.Id id) {
+        this.id = id;
+    }
+
+    @Override
+    public Number get() {
+        Meter.Id key = id;
+        if (key != null) {
+            T value = map.get(key);
+            if (value != null) {
+                return func.applyAsDouble(value);
+            }
+        }
+        return null;
+    }
+}

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/meters/Gauges.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/meters/Gauges.java
@@ -1,0 +1,37 @@
+package io.quarkus.micrometer.runtime.meters;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Supplier;
+import java.util.function.ToDoubleFunction;
+
+import io.micrometer.core.instrument.Meter;
+
+public class Gauges<T> {
+
+    private final ConcurrentMap<Meter.Id, T> map;
+    private final Supplier<T> factory;
+
+    private Gauges(Supplier<T> factory) {
+        this.map = new ConcurrentHashMap<>();
+        this.factory = factory;
+    }
+
+    public static Gauges<LongAdder> longAdder() {
+        return new Gauges<>(LongAdder::new);
+    }
+
+    public static Gauges<AtomicInteger> atomicInteger() {
+        return new Gauges<>(AtomicInteger::new);
+    }
+
+    public static <T> Gauges<T> of(Supplier<T> factory) {
+        return new Gauges<>(factory);
+    }
+
+    public GaugeBuilder<T> builder(String name, ToDoubleFunction<T> func) {
+        return new GaugeBuilder<>(name, map, factory, func);
+    }
+}

--- a/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/meters/GaugeBuilderTest.java
+++ b/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/meters/GaugeBuilderTest.java
@@ -1,0 +1,112 @@
+package io.quarkus.micrometer.runtime.meters;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.LongAdder;
+
+import org.junit.jupiter.api.Test;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+class GaugeBuilderTest {
+
+    @Test
+    void registerCreatesNewBackingObject() {
+        ConcurrentMap<Meter.Id, LongAdder> map = new ConcurrentHashMap<>();
+        MeterRegistry registry = new SimpleMeterRegistry();
+
+        GaugeBuilder<LongAdder> builder = new GaugeBuilder<>(
+                "test.gauge", map, LongAdder::new, LongAdder::doubleValue);
+        LongAdder result = builder.register(registry);
+
+        assertNotNull(result);
+        assertEquals(1, map.size());
+    }
+
+    @Test
+    void registerReturnsSameObjectForSameMeterId() {
+        ConcurrentMap<Meter.Id, LongAdder> map = new ConcurrentHashMap<>();
+        MeterRegistry registry = new SimpleMeterRegistry();
+
+        GaugeBuilder<LongAdder> builder1 = new GaugeBuilder<>(
+                "test.gauge", map, LongAdder::new, LongAdder::doubleValue);
+        LongAdder first = builder1.register(registry);
+
+        GaugeBuilder<LongAdder> builder2 = new GaugeBuilder<>(
+                "test.gauge", map, LongAdder::new, LongAdder::doubleValue);
+        LongAdder second = builder2.register(registry);
+
+        assertSame(first, second);
+        assertEquals(1, map.size());
+    }
+
+    @Test
+    void registerWithTagsCreatesDifferentEntries() {
+        ConcurrentMap<Meter.Id, LongAdder> map = new ConcurrentHashMap<>();
+        MeterRegistry registry = new SimpleMeterRegistry();
+
+        GaugeBuilder<LongAdder> builder1 = new GaugeBuilder<>(
+                "test.gauge", map, LongAdder::new, LongAdder::doubleValue);
+        builder1.tag("env", "prod");
+        LongAdder first = builder1.register(registry);
+
+        GaugeBuilder<LongAdder> builder2 = new GaugeBuilder<>(
+                "test.gauge", map, LongAdder::new, LongAdder::doubleValue);
+        builder2.tag("env", "dev");
+        LongAdder second = builder2.register(registry);
+
+        assertNotSame(first, second);
+        assertEquals(2, map.size());
+    }
+
+    @Test
+    void registerWithExternalValueUsesProvidedInstance() {
+        ConcurrentMap<Meter.Id, AtomicInteger> map = new ConcurrentHashMap<>();
+        MeterRegistry registry = new SimpleMeterRegistry();
+        AtomicInteger external = new AtomicInteger(99);
+
+        GaugeBuilder<AtomicInteger> builder = new GaugeBuilder<>(
+                "test.gauge", map, AtomicInteger::new, AtomicInteger::doubleValue);
+        AtomicInteger result = builder.register(registry, external);
+
+        assertSame(external, result);
+        assertEquals(99, map.values().iterator().next().get());
+    }
+
+    @Test
+    void gaugeReportsValueFromBackingObject() {
+        ConcurrentMap<Meter.Id, LongAdder> map = new ConcurrentHashMap<>();
+        MeterRegistry registry = new SimpleMeterRegistry();
+
+        GaugeBuilder<LongAdder> builder = new GaugeBuilder<>(
+                "test.gauge", map, LongAdder::new, LongAdder::doubleValue);
+        LongAdder adder = builder.register(registry);
+        adder.add(42);
+
+        double value = registry.get("test.gauge").gauge().value();
+        assertEquals(42.0, value);
+    }
+
+    @Test
+    void descriptionAndTagsAreApplied() {
+        ConcurrentMap<Meter.Id, LongAdder> map = new ConcurrentHashMap<>();
+        MeterRegistry registry = new SimpleMeterRegistry();
+
+        GaugeBuilder<LongAdder> builder = new GaugeBuilder<>(
+                "test.gauge", map, LongAdder::new, LongAdder::doubleValue);
+        builder.description("A test gauge")
+                .tags(Tags.of("key", "val"));
+        builder.register(registry);
+
+        io.micrometer.core.instrument.Gauge gauge = registry.get("test.gauge")
+                .tag("key", "val").gauge();
+        assertNotNull(gauge);
+        assertEquals("A test gauge", gauge.getId().getDescription());
+    }
+}

--- a/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/meters/GaugeSupplierTest.java
+++ b/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/meters/GaugeSupplierTest.java
@@ -1,0 +1,59 @@
+package io.quarkus.micrometer.runtime.meters;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.LongAdder;
+
+import org.junit.jupiter.api.Test;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tags;
+
+class GaugeSupplierTest {
+
+    @Test
+    void returnsNullWhenIdNotSet() {
+        ConcurrentMap<Meter.Id, LongAdder> map = new ConcurrentHashMap<>();
+        GaugeSupplier<LongAdder> supplier = new GaugeSupplier<>(map, LongAdder::doubleValue);
+        assertNull(supplier.get());
+    }
+
+    @Test
+    void returnsNullWhenKeyNotInMap() {
+        ConcurrentMap<Meter.Id, LongAdder> map = new ConcurrentHashMap<>();
+        GaugeSupplier<LongAdder> supplier = new GaugeSupplier<>(map, LongAdder::doubleValue);
+        Meter.Id id = new Meter.Id("test", Tags.empty(), null, null, Meter.Type.GAUGE);
+        supplier.setId(id);
+        assertNull(supplier.get());
+    }
+
+    @Test
+    void returnsValueFromMapWhenPresent() {
+        ConcurrentMap<Meter.Id, LongAdder> map = new ConcurrentHashMap<>();
+        Meter.Id id = new Meter.Id("test", Tags.empty(), null, null, Meter.Type.GAUGE);
+        LongAdder adder = new LongAdder();
+        adder.add(42);
+        map.put(id, adder);
+
+        GaugeSupplier<LongAdder> supplier = new GaugeSupplier<>(map, LongAdder::doubleValue);
+        supplier.setId(id);
+
+        assertEquals(42.0, supplier.get().doubleValue());
+    }
+
+    @Test
+    void appliesCustomFunction() {
+        ConcurrentMap<Meter.Id, LongAdder> map = new ConcurrentHashMap<>();
+        Meter.Id id = new Meter.Id("test", Tags.empty(), null, null, Meter.Type.GAUGE);
+        LongAdder adder = new LongAdder();
+        adder.add(10);
+        map.put(id, adder);
+
+        GaugeSupplier<LongAdder> supplier = new GaugeSupplier<>(map, a -> a.doubleValue() * 2);
+        supplier.setId(id);
+
+        assertEquals(20.0, supplier.get().doubleValue());
+    }
+}

--- a/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/meters/GaugesTest.java
+++ b/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/meters/GaugesTest.java
@@ -1,0 +1,50 @@
+package io.quarkus.micrometer.runtime.meters;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.LongAdder;
+
+import org.junit.jupiter.api.Test;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+class GaugesTest {
+
+    @Test
+    void longAdderFactoryCreatesWorkingGauge() {
+        Gauges<LongAdder> gauges = Gauges.longAdder();
+        MeterRegistry registry = new SimpleMeterRegistry();
+
+        LongAdder adder = gauges.builder("test.longadder", LongAdder::doubleValue)
+                .register(registry);
+        adder.add(5);
+
+        assertEquals(5.0, registry.get("test.longadder").gauge().value());
+    }
+
+    @Test
+    void atomicIntegerFactoryCreatesWorkingGauge() {
+        Gauges<AtomicInteger> gauges = Gauges.atomicInteger();
+        MeterRegistry registry = new SimpleMeterRegistry();
+
+        AtomicInteger value = gauges.builder("test.atomicint", AtomicInteger::doubleValue)
+                .register(registry);
+        value.set(7);
+
+        assertEquals(7.0, registry.get("test.atomicint").gauge().value());
+    }
+
+    @Test
+    void customFactoryCreatesWorkingGauge() {
+        Gauges<double[]> gauges = Gauges.of(() -> new double[] { 0.0 });
+        MeterRegistry registry = new SimpleMeterRegistry();
+
+        double[] arr = gauges.builder("test.custom", a -> a[0])
+                .register(registry);
+        arr[0] = 3.14;
+
+        assertEquals(3.14, registry.get("test.custom").gauge().value(), 0.001);
+    }
+}


### PR DESCRIPTION
Adding the `GaugeBuilder` pattern instead of directly using Micrometer's `Gauge` directly has several implications: 

- Use `GaugeBuilder` to prevent `Gauge` re-registration warnings in Micrometer 1.14+. The source of this issue: https://github.com/micrometer-metrics/micrometer/issues/6931)
- Report consistency - If a `MeterFilter` changed tags on a `Gauge`, the re-registration would create a new `Gauge` with a new `Meter.Id`. However, the old backing object (e.g. `LongAdder`) was still being incremented/decremented by the application code, while the new `Gauge` pointed to a fresh object with value 0. This would cause the reported metrics to diverge from reality.
The `GaugeBuilder` pattern fixes this because `computeIfAbsent(meterId, ...)` returns the same backing object regardless of how many times the gauge is registered with that `Meter.Id`.
- Prevent GC-related `Gauge` value loss - This is a known Micrometer behavior documented in the [`Gauge` javadoc](https://docs.micrometer.io/micrometer/reference/concepts/gauges.html): gauges hold the observed object via a WeakReference by default.
- Performance: redundant registry lookups - Like this implementation: https://github.com/vert-x3/vertx-micrometer-metrics/pull/200. This PR eliminates repeated meter registry filter invocations and hashCode/equals computations on every gauge read... Sometimes this happens on the hot path. 

This also fixes:
- `Gauge` re-registration because of missing `server.port` tag, when port is not known.

One `Gauges` remain out of the `GaugeBuilder` patern, intentionally kept as standard `Gauge.builder`:
* VertxMeterBinderAdapter:232 — vertx.http.connections.max — a `static int` value that never changes.

----

- Fixes: https://github.com/quarkusio/quarkus/issues/53279
- Closes: https://github.com/quarkusio/quarkus/issues/47504