### PR TITLE
Tree shake optimizaitons

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/ClassLoadingChainAnalyzer.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/ClassLoadingChainAnalyzer.java
@@ -1,23 +1,10 @@
 package io.quarkus.deployment.pkg.steps;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
-import java.util.function.Supplier;
-
-import org.jboss.logging.Logger;
 
 /**
  * Discovers classes that are loaded dynamically via {@code ClassLoader.loadClass()} or
@@ -62,10 +49,10 @@ import org.jboss.logging.Logger;
  * <h3>Phase 3 -- Dynamic execution in a forked JVM</h3>
  * <p>
  * Each entry point class is loaded and instantiated inside a forked JVM process
- * (see {@link ClassLoadingRecorder}) to dynamically capture all class load attempts that
- * occur during its initialization and construction. Running in a separate process
- * ensures complete isolation of global JVM state and that Metaspace is reclaimed
- * when the process exits.
+ * managed by {@link ForkedJvmEnvironment} (which launches {@link ClassLoadingRecorder})
+ * to dynamically capture all class load attempts that occur during its initialization
+ * and construction. Running in a separate process ensures complete isolation of global
+ * JVM state and that Metaspace is reclaimed when the process exits.
  *
  * <h2>RecordingClassLoader</h2>
  * <p>
@@ -101,22 +88,20 @@ import org.jboss.logging.Logger;
  */
 class ClassLoadingChainAnalyzer {
 
-    private static final Logger log = Logger.getLogger(ClassLoadingChainAnalyzer.class.getName());
-
-    /** JDK methods that load classes by name — the seeds for call chain propagation. */
-    static final Set<String> SEED_METHODS = Set.of(
-            "java/lang/ClassLoader.loadClass(Ljava/lang/String;)Ljava/lang/Class;",
-            "java/lang/ClassLoader.loadClass(Ljava/lang/String;Z)Ljava/lang/Class;",
-            "java/lang/ClassLoader.findClass(Ljava/lang/String;)Ljava/lang/Class;",
-            "java/lang/Class.forName(Ljava/lang/String;)Ljava/lang/Class;",
-            "java/lang/Class.forName(Ljava/lang/String;ZLjava/lang/ClassLoader;)Ljava/lang/Class;",
-            "java/lang/Class.forName(Ljava/lang/Module;Ljava/lang/String;)Ljava/lang/Class;",
-            "java/lang/invoke/MethodHandles$Lookup.findClass(Ljava/lang/String;)Ljava/lang/Class;");
-
     private final Set<String> depClassNames;
-    /** Reverse call index: callee method → set of caller methods. Built externally during BFS. */
-    private final Map<String, Set<String>> callerIndex;
-    private final Set<String> classLoadingMethods = new HashSet<>(SEED_METHODS);
+
+    /**
+     * Reverse call index: callee method → set of caller methods.
+     * Built externally by {@link JarTreeShaker#scanBytecode} during BFS reachability
+     * analysis. For each method invocation encountered in bytecode, the invoked method
+     * (callee) is mapped to the set of methods that invoke it (callers). This enables
+     * backward propagation from class-loading seed methods to discover all application
+     * methods that transitively trigger dynamic class loading.
+     */
+    private final Map<MethodKey, Set<MethodKey>> callerIndex;
+
+    private final Set<MethodKey> classLoadingMethods = new HashSet<>(MethodKey.SEED_METHOD_KEYS);
+
     /** Entry points already returned by previous {@link #findEntryPoints()} calls. */
     private final Set<String> previousEntryPoints = new HashSet<>();
     private boolean seedsPropagated = false;
@@ -125,7 +110,7 @@ class ClassLoadingChainAnalyzer {
      * @param callerIndex pre-built reverse call index (callee → callers), populated during BFS
      * @param depClassNames dependency class names (dot-separated) for entry point filtering
      */
-    ClassLoadingChainAnalyzer(Map<String, Set<String>> callerIndex, Set<String> depClassNames) {
+    ClassLoadingChainAnalyzer(Map<MethodKey, Set<MethodKey>> callerIndex, Set<String> depClassNames) {
         this.callerIndex = callerIndex;
         this.depClassNames = depClassNames;
     }
@@ -139,7 +124,7 @@ class ClassLoadingChainAnalyzer {
      * @return newly discovered entry point class names, or empty set if none found
      */
     Set<String> findEntryPoints() {
-        Set<String> newMethods = propagateFromSeeds();
+        Set<MethodKey> newMethods = propagateFromSeeds();
         if (newMethods.isEmpty()) {
             return Set.of();
         }
@@ -148,17 +133,18 @@ class ClassLoadingChainAnalyzer {
 
     /**
      * Propagates from seed methods through the caller index using a worklist algorithm.
-     * On first call, walks from all seeds. On subsequent calls, checks new edges.
+     * On first call, walks from all seeds. On subsequent calls, checks new edges added
+     * by a prior BFS iteration.
      *
      * @return methods newly added to {@link #classLoadingMethods} in this invocation
      */
-    private Set<String> propagateFromSeeds() {
-        Set<String> newMethods = new HashSet<>();
-        Queue<String> callerQueue = new ArrayDeque<>();
+    private Set<MethodKey> propagateFromSeeds() {
+        Set<MethodKey> newMethods = new HashSet<>();
+        Queue<MethodKey> callerQueue = new ArrayDeque<>();
         if (!seedsPropagated) {
             seedsPropagated = true;
-            for (String seed : SEED_METHODS) {
-                Set<String> callers = callerIndex.get(seed);
+            for (MethodKey seed : MethodKey.SEED_METHOD_KEYS) {
+                Set<MethodKey> callers = callerIndex.get(seed);
                 if (callers != null) {
                     collectAndEnqueueCallers(callers, callerQueue, newMethods);
                 }
@@ -171,8 +157,8 @@ class ClassLoadingChainAnalyzer {
             }
         }
         while (!callerQueue.isEmpty()) {
-            String method = callerQueue.poll();
-            Set<String> callers = callerIndex.get(method);
+            MethodKey method = callerQueue.poll();
+            Set<MethodKey> callers = callerIndex.get(method);
             if (callers != null) {
                 collectAndEnqueueCallers(callers, callerQueue, newMethods);
             }
@@ -180,9 +166,13 @@ class ClassLoadingChainAnalyzer {
         return newMethods;
     }
 
-    private void collectAndEnqueueCallers(Set<String> callers, Queue<String> callerQueue, Set<String> newMethods) {
-        for (String caller : callers) {
-            if (!isJdkOrInfraClass(caller) && classLoadingMethods.add(caller)) {
+    /**
+     * Adds non-JDK/infra callers to the worklist queue and marks them as class-loading methods.
+     */
+    private void collectAndEnqueueCallers(Set<MethodKey> callers, Queue<MethodKey> callerQueue,
+            Set<MethodKey> newMethods) {
+        for (MethodKey caller : callers) {
+            if (!MethodKey.isJdkOrInfraClass(caller.owner) && classLoadingMethods.add(caller)) {
                 callerQueue.add(caller);
                 newMethods.add(caller);
             }
@@ -195,33 +185,28 @@ class ClassLoadingChainAnalyzer {
      * because {@link #propagateFromSeeds()} already computed the full transitive closure
      * of callers.
      */
-    private Set<String> extractNewEntryPoints(Set<String> newMethods) {
-        Set<String> entryPointClasses = new HashSet<>();
-        for (String method : newMethods) {
+    private Set<String> extractNewEntryPoints(Set<MethodKey> newMethods) {
+        Set<String> entryPointClasses = null;
+        for (MethodKey method : newMethods) {
             String entryPoint = getEntryPointOrNull(method);
             if (entryPoint != null && previousEntryPoints.add(entryPoint)) {
+                if (entryPointClasses == null) {
+                    entryPointClasses = new HashSet<>();
+                }
                 entryPointClasses.add(entryPoint);
             }
         }
-        return entryPointClasses;
+        return entryPointClasses == null ? Set.of() : entryPointClasses;
     }
 
     /**
      * Returns the dot-separated class name if the method key is an {@code <init>} or
      * {@code <clinit>} of a known dependency class, or {@code null} otherwise.
+     * Uses {@link MethodKey#name} directly instead of parsing a concatenated string.
      */
-    private String getEntryPointOrNull(String methodKey) {
-        int parenIdx = methodKey.indexOf('(');
-        if (parenIdx < 0) {
-            return null;
-        }
-        int dotIdx = methodKey.lastIndexOf('.', parenIdx);
-        if (dotIdx < 0) {
-            return null;
-        }
-        String methodName = methodKey.substring(dotIdx + 1, parenIdx);
-        if ("<init>".equals(methodName) || "<clinit>".equals(methodName)) {
-            String dotName = methodKey.substring(0, dotIdx).replace('/', '.');
+    private String getEntryPointOrNull(MethodKey key) {
+        if (key.isInitOrClinit()) {
+            String dotName = key.ownerAsDotName();
             if (depClassNames.contains(dotName)) {
                 return dotName;
             }
@@ -236,192 +221,5 @@ class ClassLoadingChainAnalyzer {
     void release() {
         classLoadingMethods.clear();
         previousEntryPoints.clear();
-    }
-
-    /**
-     * Phase 3: Execute entry point classes in a forked JVM to capture which classes
-     * get loaded during static initialization and construction.
-     * <p>
-     * Running in a separate process ensures complete isolation of global JVM state
-     * (System.out/err, security providers, system properties, TCCL) and that all
-     * Metaspace consumed by {@code defineClass} is reclaimed when the process exits.
-     * This is critical because multiple tree-shaker instances may run in parallel
-     * during CI builds with {@code -T2C}.
-     * <p>
-     * Only generated and transformed bytecode is written to a temp directory.
-     * Dependency JARs and the app artifact are included on the classpath by path,
-     * with the temp dir first so transformed classes override originals.
-     *
-     * @param entryPointClasses classes whose init/clinit triggers dynamic class loading
-     * @param generatedBytecode generated classes (in-memory only, must be written to disk)
-     * @param transformedBytecode transformed classes that override originals in dep JARs
-     * @param allKnownClasses all known class names for Map value extraction
-     * @param depJarPaths file system paths to dependency JARs
-     * @param appPaths file system paths to the application artifact
-     */
-    static Set<String> executeEntryPoints(
-            Set<String> entryPointClasses,
-            Map<String, Supplier<byte[]>> generatedBytecode,
-            Map<String, Supplier<byte[]>> transformedBytecode,
-            Set<String> allKnownClasses,
-            List<Path> depJarPaths,
-            List<Path> appPaths) {
-
-        Path tempDir = null;
-        try {
-            tempDir = Files.createTempDirectory("tree-shake-recording");
-
-            // Write only generated and transformed bytecode to temp dir
-            writeBytecodeToDir(tempDir, generatedBytecode);
-            writeBytecodeToDir(tempDir, transformedBytecode);
-
-            // Write input file: entry points, then separator, then allKnownClasses
-            Path inputFile = tempDir.resolve("_input.txt");
-            List<String> inputLines = new ArrayList<>(entryPointClasses.size() + allKnownClasses.size() + 1);
-            inputLines.addAll(entryPointClasses);
-            inputLines.add("---");
-            inputLines.addAll(allKnownClasses);
-            Files.write(inputFile, inputLines, StandardCharsets.UTF_8);
-
-            // Copy ClassLoadingRecorder class to the temp dir
-            writeRecorderClass(tempDir);
-
-            // Build classpath: temp dir first (overrides), then dep JARs, then app
-            StringBuilder cpBuilder = new StringBuilder();
-            cpBuilder.append(tempDir);
-            for (Path p : depJarPaths) {
-                cpBuilder.append(File.pathSeparator).append(p);
-            }
-            for (Path p : appPaths) {
-                cpBuilder.append(File.pathSeparator).append(p);
-            }
-
-            // Write @argfile to avoid command-line length limits (Windows)
-            Path argFile = tempDir.resolve("_jvm.args");
-            Files.writeString(argFile,
-                    "-cp\n" + cpBuilder + "\n-XX:MaxMetaspaceSize=256m",
-                    StandardCharsets.UTF_8);
-
-            // Fork JVM
-            String javaCmd = ProcessHandle.current().info().command()
-                    .orElse(Path.of(System.getProperty("java.home"), "bin", "java").toString());
-
-            ProcessBuilder pb = new ProcessBuilder(
-                    javaCmd,
-                    "@" + argFile,
-                    ClassLoadingRecorder.class.getName(),
-                    inputFile.toString());
-            pb.redirectErrorStream(false);
-
-            Process proc = pb.start();
-
-            // Drain stderr in background to avoid blocking
-            Thread stderrDrainer = new Thread(() -> {
-                try {
-                    proc.getErrorStream().transferTo(OutputStream.nullOutputStream());
-                } catch (IOException ignored) {
-                }
-            }, "tree-shake-stderr-drainer");
-            stderrDrainer.setDaemon(true);
-            stderrDrainer.start();
-
-            // Read discovered class names from stdout
-            Set<String> discovered = new HashSet<>();
-            try (BufferedReader reader = new BufferedReader(
-                    new InputStreamReader(proc.getInputStream(), StandardCharsets.UTF_8))) {
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    if (!line.isEmpty()) {
-                        discovered.add(line);
-                    }
-                }
-            }
-
-            int exitCode = proc.waitFor();
-            if (exitCode != 0) {
-                log.warnf("Class-loading chain analysis forked JVM exited with code %d", exitCode);
-            }
-            stderrDrainer.join(5000);
-
-            return discovered;
-
-        } catch (IOException | InterruptedException e) {
-            log.warnf(e, "Failed to run class-loading chain analysis in forked JVM, skipping Phase 3");
-            return Set.of();
-        } finally {
-            if (tempDir != null) {
-                deleteRecursive(tempDir);
-            }
-        }
-    }
-
-    private static void writeBytecodeToDir(Path dir, Map<String, Supplier<byte[]>> bytecodeMap) throws IOException {
-        for (var entry : bytecodeMap.entrySet()) {
-            byte[] bytes;
-            try {
-                bytes = entry.getValue().get();
-            } catch (Exception e) {
-                continue;
-            }
-            String classFile = entry.getKey().replace('.', '/') + ".class";
-            Path target = dir.resolve(classFile);
-            Files.createDirectories(target.getParent());
-            Files.write(target, bytes);
-        }
-    }
-
-    /**
-     * Writes the {@link ClassLoadingRecorder} class files to the temp directory.
-     */
-    private static void writeRecorderClass(Path tempDir) throws IOException {
-        String baseName = ClassLoadingRecorder.class.getName().replace('.', '/');
-        for (String suffix : new String[] { ".class", "$RecordingClassLoader.class" }) {
-            String resourcePath = baseName + suffix;
-            try (var is = ClassLoadingChainAnalyzer.class.getClassLoader().getResourceAsStream(resourcePath)) {
-                if (is == null) {
-                    if (suffix.equals(".class")) {
-                        throw new IOException("Cannot find ClassLoadingRecorder.class on classpath");
-                    }
-                    continue;
-                }
-                Path target = tempDir.resolve(resourcePath);
-                Files.createDirectories(target.getParent());
-                Files.write(target, is.readAllBytes());
-            }
-        }
-    }
-
-    private static void deleteRecursive(Path path) {
-        try {
-            Files.walk(path)
-                    .sorted(java.util.Comparator.reverseOrder())
-                    .forEach(p -> {
-                        try {
-                            Files.delete(p);
-                        } catch (IOException ignored) {
-                        }
-                    });
-        } catch (IOException ignored) {
-        }
-    }
-
-    /**
-     * Checks whether a method key belongs to a JDK or infrastructure class that should not
-     * be considered as a class-loading method for propagation purposes.
-     */
-    static boolean isJdkOrInfraClass(String methodKey) {
-        return methodKey.startsWith("java/")
-                || methodKey.startsWith("javax/")
-                || methodKey.startsWith("jakarta/")
-                || methodKey.startsWith("org/objectweb/")
-                || methodKey.startsWith("sun/");
-    }
-
-    /**
-     * Returns {@code true} if a method call to {@code calleeKey} should be recorded
-     * in the caller index. Records calls to seed methods and calls to non-JDK/infra methods.
-     */
-    static boolean shouldRecordCall(String calleeKey) {
-        return SEED_METHODS.contains(calleeKey) || !isJdkOrInfraClass(calleeKey);
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/ClassLoadingRecorder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/ClassLoadingRecorder.java
@@ -13,7 +13,7 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Self-contained main class executed in a forked JVM by {@link ClassLoadingChainAnalyzer}.
+ * Self-contained main class executed in a forked JVM by {@link ForkedJvmEnvironment}.
  * <p>
  * Reads entry point class names and known class names from an input file,
  * loads and instantiates each entry point in a recording classloader that captures

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/ForkedJvmEnvironment.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/ForkedJvmEnvironment.java
@@ -1,0 +1,191 @@
+package io.quarkus.deployment.pkg.steps;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.bootstrap.util.IoUtils;
+
+/**
+ * JAR tree-shake phase 3 environment: a temp directory pre-populated with generated/transformed
+ * bytecode, the {@link ClassLoadingRecorder} class, and JVM arguments. Created once
+ * and reused across iterations of the fixed-point loop so that bytecode is written
+ * to disk only once.
+ */
+final class ForkedJvmEnvironment implements AutoCloseable {
+
+    private static final Logger log = Logger.getLogger(ForkedJvmEnvironment.class.getName());
+
+    private final Path tempDir;
+    private final Path inputFile;
+    private final String javaCmd;
+    private final Path argFile;
+
+    /**
+     * Prepares the forked JVM environment: creates a temp directory, writes bytecode,
+     * the recorder class, and JVM arguments.
+     *
+     * @param generatedBytecode generated classes (in-memory only, must be written to disk)
+     * @param transformedBytecode transformed classes that override originals in dep JARs
+     * @param depJarPaths file system paths to dependency JARs
+     * @param appPaths file system paths to the application artifact
+     */
+    static ForkedJvmEnvironment create(
+            Map<String, Supplier<byte[]>> generatedBytecode,
+            Map<String, Supplier<byte[]>> transformedBytecode,
+            List<Path> depJarPaths,
+            List<Path> appPaths) throws IOException {
+
+        Path tempDir = Files.createTempDirectory("tree-shake-recording");
+        try {
+            writeBytecodeToDir(tempDir, generatedBytecode);
+            writeBytecodeToDir(tempDir, transformedBytecode);
+            writeRecorderClass(tempDir);
+
+            StringBuilder cpBuilder = new StringBuilder();
+            cpBuilder.append(tempDir);
+            for (Path p : depJarPaths) {
+                cpBuilder.append(File.pathSeparator).append(p);
+            }
+            for (Path p : appPaths) {
+                cpBuilder.append(File.pathSeparator).append(p);
+            }
+
+            Path argFile = tempDir.resolve("_jvm.args");
+            Files.writeString(argFile,
+                    "-cp\n" + cpBuilder + "\n-XX:MaxMetaspaceSize=256m",
+                    StandardCharsets.UTF_8);
+
+            String javaCmd = ProcessHandle.current().info().command()
+                    .orElse(Path.of(System.getProperty("java.home"), "bin", "java").toString());
+
+            Path inputFile = tempDir.resolve("_input.txt");
+
+            if (log.isDebugEnabled()) {
+                log.debugf("Forked JVM environment created: %d generated + %d transformed classes written to disk",
+                        generatedBytecode.size(), transformedBytecode.size());
+            }
+
+            return new ForkedJvmEnvironment(tempDir, inputFile, javaCmd, argFile);
+        } catch (IOException | RuntimeException e) {
+            IoUtils.recursiveDelete(tempDir);
+            throw e;
+        }
+    }
+
+    private ForkedJvmEnvironment(Path tempDir, Path inputFile, String javaCmd, Path argFile) {
+        this.tempDir = tempDir;
+        this.inputFile = inputFile;
+        this.javaCmd = javaCmd;
+        this.argFile = argFile;
+    }
+
+    /**
+     * Executes entry point classes in a forked JVM to capture which classes
+     * get loaded during static initialization and construction.
+     *
+     * @param entryPointClasses classes whose init/clinit triggers dynamic class loading
+     * @param allKnownClasses all known class names for Map value extraction and result filtering
+     * @return discovered class names limited to {@code allKnownClasses}, or empty set on failure
+     */
+    Set<String> executeEntryPoints(Set<String> entryPointClasses,
+            Set<String> allKnownClasses) throws IOException, InterruptedException {
+
+        List<String> inputLines = new ArrayList<>(entryPointClasses.size() + allKnownClasses.size() + 1);
+        inputLines.addAll(entryPointClasses);
+        inputLines.add("---");
+        inputLines.addAll(allKnownClasses);
+        Files.write(inputFile, inputLines, StandardCharsets.UTF_8);
+
+        ProcessBuilder pb = new ProcessBuilder(
+                javaCmd,
+                "@" + argFile,
+                ClassLoadingRecorder.class.getName(),
+                inputFile.toString());
+        pb.redirectErrorStream(false);
+
+        Process proc = pb.start();
+
+        Thread stderrDrainer = new Thread(() -> {
+            try {
+                proc.getErrorStream().transferTo(OutputStream.nullOutputStream());
+            } catch (IOException ignored) {
+            }
+        }, "tree-shake-stderr-drainer");
+        stderrDrainer.setDaemon(true);
+        stderrDrainer.start();
+
+        Set<String> discovered = new HashSet<>();
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(proc.getInputStream(), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (!line.isEmpty() && allKnownClasses.contains(line)) {
+                    discovered.add(line);
+                }
+            }
+        }
+
+        int exitCode = proc.waitFor();
+        if (exitCode != 0) {
+            log.warnf("Class-loading chain analysis forked JVM exited with code %d", exitCode);
+        }
+        stderrDrainer.join(5000);
+
+        return discovered;
+    }
+
+    @Override
+    public void close() {
+        IoUtils.recursiveDelete(tempDir);
+    }
+
+    private static void writeBytecodeToDir(Path dir, Map<String, Supplier<byte[]>> bytecodeMap) throws IOException {
+        for (var entry : bytecodeMap.entrySet()) {
+            byte[] bytes;
+            try {
+                bytes = entry.getValue().get();
+            } catch (Exception e) {
+                continue;
+            }
+            String classFile = entry.getKey().replace('.', '/') + ".class";
+            Path target = dir.resolve(classFile);
+            Files.createDirectories(target.getParent());
+            Files.write(target, bytes);
+        }
+    }
+
+    /**
+     * Writes the {@link ClassLoadingRecorder} class files to the temp directory.
+     */
+    private static void writeRecorderClass(Path tempDir) throws IOException {
+        String baseName = ClassLoadingRecorder.class.getName().replace('.', '/');
+        for (String suffix : new String[] { ".class", "$RecordingClassLoader.class" }) {
+            String resourcePath = baseName + suffix;
+            try (var is = ForkedJvmEnvironment.class.getClassLoader().getResourceAsStream(resourcePath)) {
+                if (is == null) {
+                    if (suffix.equals(".class")) {
+                        throw new IOException("Cannot find ClassLoadingRecorder.class on classpath");
+                    }
+                    continue;
+                }
+                Path target = tempDir.resolve(resourcePath);
+                Files.createDirectories(target.getParent());
+                Files.write(target, is.readAllBytes());
+            }
+        }
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarTreeShaker.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarTreeShaker.java
@@ -38,6 +38,12 @@ class JarTreeShaker {
     private static final String SERVICE_LOADER_INTERNAL = "java/util/ServiceLoader";
     private static final String SISU_NAMED_RESOURCE = "META-INF/sisu/javax.inject.Named";
 
+    /**
+     * Suffixes for JBoss Logging companion classes that are loaded reflectively
+     * via name concatenation in {@code Logger.getMessageLogger()}.
+     */
+    private static final String[] JBOSS_LOGGING_SUFFIXES = { "_$logger", "_$bundle", "_impl" };
+
     private final JarTreeShakeInput input;
 
     /**
@@ -58,7 +64,7 @@ class JarTreeShaker {
      * ultimately triggers the dynamic loading. These entry points are then executed
      * in an isolated classloader to capture which classes are actually loaded at runtime.
      */
-    private final Map<String, Set<String>> callerIndex = new HashMap<>();
+    private final Map<MethodKey, Set<MethodKey>> callerIndex = new HashMap<>();
 
     JarTreeShaker(JarTreeShakeInput input) {
         this.input = input;
@@ -70,17 +76,30 @@ class JarTreeShaker {
      * and returns a {@link JarTreeShakeBuildItem} with the reachable set and per-dependency removals.
      */
     JarTreeShakeBuildItem run() {
-        final long startTime = log.isDebugEnabled() ? System.currentTimeMillis() : -1;
+        final long startTime = System.currentTimeMillis();
+        final boolean debug = log.isDebugEnabled();
 
         // Trace all reachable classes using bytecode analysis for full method-body coverage
         Set<String> visited = new HashSet<>();
         Set<String> reachable = traceReachableClasses(input.roots, visited);
+        if (debug) {
+            log.debugf("BFS reachability: %d classes reached from %d roots, %d caller index entries",
+                    reachable.size(), input.roots.size(), callerIndex.size());
+        }
 
         // Evaluate conditional roots to fixed point
         reachable = evaluateConditionalRoots(reachable);
 
-        // Analyze class-loading chains (fixed-point loop)
-        reachable = analyzeClassLoadingChains(reachable);
+        // Analyze class-loading chains (fixed-point loop) — skip if no seed methods
+        // (ClassLoader.loadClass, Class.forName, etc.) were called by any reachable code
+        if (hasCallerIndexSeedEntries()) {
+            reachable = analyzeClassLoadingChains(reachable);
+        } else {
+            if (debug) {
+                log.debug("Class-loading chain analysis skipped: no seed method calls found");
+            }
+            callerIndex.clear();
+        }
 
         // Mark all classes from excluded artifacts as reachable (after analysis,
         // so they don't act as roots for transitive tracing). This preserves
@@ -125,13 +144,16 @@ class JarTreeShaker {
         input.releaseAnalysisData();
 
         // Report
-        log.infof("Tree-shaking removed %d unreachable classes from %d dependencies, saving %s (%.1f%%) of bytecode",
+        long elapsedMs = System.currentTimeMillis() - startTime;
+        log.infof("Tree-shaking removed %d unreachable classes from %d dependencies,"
+                + " saving %s (%.1f%%) of bytecode in %dms",
                 removedClassCount,
                 removedClassesPerDep.size(),
                 formatSize(removedBytes),
-                totalDepClasses > 0 ? (removedClassCount * 100.0 / totalDepClasses) : 0.0);
+                totalDepClasses > 0 ? (removedClassCount * 100.0 / totalDepClasses) : 0.0,
+                elapsedMs);
 
-        if (startTime > 0) {
+        if (log.isDebugEnabled()) {
             int reachableClasses = totalDepClasses - removedClassCount;
             log.debug("============================================================");
             log.debug("  Dependency Classes Usage Analysis");
@@ -154,11 +176,27 @@ class JarTreeShaker {
     }
 
     /**
+     * Returns {@code true} if the caller index contains at least one entry for a
+     * class-loading seed method. When no seeds are present, the entire
+     * {@link ClassLoadingChainAnalyzer} phase produces no results and can be skipped.
+     */
+    private boolean hasCallerIndexSeedEntries() {
+        for (MethodKey seed : MethodKey.SEED_METHOD_KEYS) {
+            if (callerIndex.containsKey(seed)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Runs class-loading chain analysis in a fixed-point loop, discovering classes
      * that are loaded dynamically via ClassLoader.loadClass() or Class.forName()
      * during static initialization or construction of reachable classes.
      */
     private Set<String> analyzeClassLoadingChains(Set<String> reachable) {
+        final boolean debug = log.isDebugEnabled();
+
         // Build the transformed bytecode map once (optimization B)
         Map<String, Supplier<byte[]>> transformedBytecode = new HashMap<>();
         for (String name : input.transformedClassNames) {
@@ -170,35 +208,57 @@ class JarTreeShaker {
 
         ClassLoadingChainAnalyzer analyzer = new ClassLoadingChainAnalyzer(callerIndex, input.classToDep.keySet());
         Set<String> allPhase3Discovered = new HashSet<>();
+        int iteration = 0;
 
-        while (true) {
-            Set<String> newEntryPoints = analyzer.findEntryPoints();
-            if (newEntryPoints.isEmpty()) {
-                break;
+        try (var env = ForkedJvmEnvironment.create(
+                input.generatedBytecode, transformedBytecode,
+                input.depJarPaths, input.appPaths)) {
+
+            while (true) {
+                iteration++;
+                Set<String> newEntryPoints = analyzer.findEntryPoints();
+                if (newEntryPoints.isEmpty()) {
+                    if (debug) {
+                        log.debugf("Class-loading chain iteration %d: no new entry points, stopping", iteration);
+                    }
+                    break;
+                }
+
+                // Skip fork if all new entry points were already discovered by prior forks —
+                // their transitive class loads were already captured
+                if (allPhase3Discovered.containsAll(newEntryPoints)) {
+                    if (debug) {
+                        log.debugf("Class-loading chain iteration %d: %d entry points already covered, stopping",
+                                iteration, newEntryPoints.size());
+                    }
+                    break;
+                }
+
+                // Phase 3: execute only new entry points in a forked JVM
+                Set<String> discovered = env.executeEntryPoints(newEntryPoints, input.allKnownClasses);
+
+                allPhase3Discovered.addAll(discovered);
+
+                // Filter to non-reachable classes
+                discovered.removeAll(reachable);
+                if (debug) {
+                    log.debugf("Class-loading chain iteration %d: %d entry points, forked JVM discovered %d classes"
+                            + " (%d new)",
+                            iteration, newEntryPoints.size(), allPhase3Discovered.size(),
+                            discovered.size());
+                }
+                if (discovered.isEmpty()) {
+                    break;
+                }
+                traceReachableClasses(discovered, reachable);
+                evaluateConditionalRoots(reachable);
             }
-
-            // Skip fork if all new entry points were already discovered by prior forks —
-            // their transitive class loads were already captured
-            if (allPhase3Discovered.containsAll(newEntryPoints)) {
-                break;
-            }
-
-            // Phase 3: execute only new entry points in a forked JVM
-            Set<String> discovered = ClassLoadingChainAnalyzer.executeEntryPoints(
-                    newEntryPoints, input.generatedBytecode, transformedBytecode,
-                    input.allKnownClasses, input.depJarPaths, input.appPaths);
-
-            allPhase3Discovered.addAll(discovered);
-
-            // Filter to known, non-reachable classes
-            discovered.retainAll(input.allKnownClasses);
-            discovered.removeAll(reachable);
-            if (discovered.isEmpty()) {
-                break;
-            }
-            log.debugf("Class-loading chain analysis discovered %d additional classes", discovered.size());
-            traceReachableClasses(discovered, reachable);
-            evaluateConditionalRoots(reachable);
+        } catch (IOException | InterruptedException e) {
+            log.warnf(e, "Failed to run class-loading chain analysis in forked JVM, skipping Phase 3");
+        }
+        if (debug) {
+            log.debugf("Class-loading chain analysis completed: %d iterations, %d total discovered classes",
+                    iteration, allPhase3Discovered.size());
         }
         analyzer.release();
         callerIndex.clear();
@@ -311,8 +371,10 @@ class JarTreeShaker {
         }
         Map<String, Set<String>> remaining = new HashMap<>(input.conditionalRoots);
         boolean changed = true;
+        int iteration = 0;
         while (changed) {
             changed = false;
+            iteration++;
             Set<String> newRoots = new HashSet<>();
             var it = remaining.entrySet().iterator();
             while (it.hasNext()) {
@@ -325,6 +387,10 @@ class JarTreeShaker {
             newRoots.removeAll(reachable);
             if (!newRoots.isEmpty()) {
                 changed = true;
+                if (log.isDebugEnabled()) {
+                    log.debugf("Conditional roots iteration %d: %d new roots, %d conditions remaining",
+                            iteration, newRoots.size(), remaining.size());
+                }
                 traceReachableClasses(newRoots, reachable);
             }
         }
@@ -342,9 +408,12 @@ class JarTreeShaker {
         // Process reachable entries, removing them as we go to avoid re-scanning.
         // When new classes become reachable, they may have higher-version entries
         // that need processing too, so we loop until no new classes are discovered.
+        int preSize = reachable.size();
         boolean changed = true;
+        int iteration = 0;
         while (changed) {
             changed = false;
+            iteration++;
             var it = input.higherVersionBytecode.entrySet().iterator();
             while (it.hasNext()) {
                 var entry = it.next();
@@ -362,6 +431,10 @@ class JarTreeShaker {
                 }
             }
         }
+        if (log.isDebugEnabled() && reachable.size() > preSize) {
+            log.debugf("Multi-release bytecode: %d new classes discovered in %d iterations",
+                    reachable.size() - preSize, iteration);
+        }
     }
 
     /**
@@ -369,7 +442,7 @@ class JarTreeShaker {
      * via name concatenation in Logger.getMessageLogger().
      */
     private void enqueueJBossLoggingCompanions(String name, Set<String> visited, Queue<String> queue) {
-        for (String suffix : new String[] { "_$logger", "_$bundle", "_impl" }) {
+        for (String suffix : JBOSS_LOGGING_SUFFIXES) {
             String companion = name + suffix;
             if (input.depBytecode.containsKey(companion) && visited.add(companion)) {
                 queue.add(companion);
@@ -435,8 +508,24 @@ class JarTreeShaker {
             public MethodVisitor visitMethod(int access, String name, String descriptor,
                     String signature, String[] exceptions) {
                 visitMethodSignature(descriptor, signature, exceptions);
-                String callerKey = internalOwner + "." + name + descriptor;
+                // Capture the enclosing method's name/descriptor before they are
+                // shadowed by the inner visitor's visitMethodInsn parameters
+                final String mName = name;
+                final String mDesc = descriptor;
                 return new RefCollectingMethodVisitor(refs) {
+                    // Lazily constructed MethodKey for this method, built only
+                    // when a caller index entry is actually recorded
+                    private MethodKey callerKeyObj;
+
+                    private MethodKey callerKey() {
+                        MethodKey k = callerKeyObj;
+                        if (k == null) {
+                            k = callerKeyObj = new MethodKey(
+                                    internalOwner, mName, mDesc);
+                        }
+                        return k;
+                    }
+
                     // State for ServiceLoader.load(SomeClass.class) tracking
                     private org.objectweb.asm.Type lastClassConstant;
 
@@ -480,10 +569,21 @@ class JarTreeShaker {
                             hasGetResources = true;
                         }
 
-                        // Caller index for class-loading chain analysis
-                        String calleeKey = owner + "." + name + descriptor;
-                        if (ClassLoadingChainAnalyzer.shouldRecordCall(calleeKey)) {
-                            callerIndex.computeIfAbsent(calleeKey, k -> new HashSet<>()).add(callerKey);
+                        // Caller index for class-loading chain analysis.
+                        // Pre-filter on owner prefix to avoid MethodKey construction
+                        // for the ~90% of calls targeting JDK/infra classes.
+                        if (!MethodKey.isJdkOrInfraClass(owner)) {
+                            var calleeKey = new MethodKey(
+                                    owner, name, descriptor);
+                            callerIndex.computeIfAbsent(calleeKey, k -> new HashSet<>())
+                                    .add(callerKey());
+                        } else if (MethodKey.isSeedMethodOwner(owner)) {
+                            var calleeKey = new MethodKey(
+                                    owner, name, descriptor);
+                            if (MethodKey.SEED_METHOD_KEYS.contains(calleeKey)) {
+                                callerIndex.computeIfAbsent(calleeKey, k -> new HashSet<>())
+                                        .add(callerKey());
+                            }
                         }
 
                         super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
@@ -719,13 +819,22 @@ class JarTreeShaker {
 
     /**
      * Checks whether a string (or its comma/colon-delimited parts) matches known class names,
-     * adding matches to {@code refs}.
+     * adding matches to {@code refs}. Uses manual character-level splitting to avoid
+     * the per-call {@link java.util.regex.Pattern} compilation that {@link String#split}
+     * incurs for the {@code [,:]} character class.
      */
     static void matchClassNames(String str, Set<String> knownClasses, Set<String> refs) {
         if (str.indexOf(',') >= 0 || str.indexOf(':') >= 0) {
-            for (String part : str.split("[,:]")) {
-                if (knownClasses.contains(part)) {
-                    refs.add(part);
+            int start = 0;
+            for (int i = 0; i <= str.length(); i++) {
+                if (i == str.length() || str.charAt(i) == ',' || str.charAt(i) == ':') {
+                    if (i > start) {
+                        String part = str.substring(start, i);
+                        if (knownClasses.contains(part)) {
+                            refs.add(part);
+                        }
+                    }
+                    start = i + 1;
                 }
             }
         } else {
@@ -787,17 +896,17 @@ class JarTreeShaker {
         public void visit(int version, int access, String name, String signature,
                 String superName, String[] interfaces) {
             if (superName != null) {
-                refs.add(toClassName(superName));
+                addClassRef(superName, refs);
             }
             if (interfaces != null) {
                 for (String iface : interfaces) {
-                    refs.add(toClassName(iface));
+                    addClassRef(iface, refs);
                 }
             }
             addSignatureTypes(signature, refs);
             int dollar = name.lastIndexOf('$');
             if (dollar > 0) {
-                refs.add(toClassName(name.substring(0, dollar)));
+                addClassRef(name.substring(0, dollar), refs);
             }
         }
 
@@ -834,7 +943,7 @@ class JarTreeShaker {
             addSignatureTypes(signature, refs);
             if (exceptions != null) {
                 for (String ex : exceptions) {
-                    refs.add(toClassName(ex));
+                    addClassRef(ex, refs);
                 }
             }
         }
@@ -859,7 +968,7 @@ class JarTreeShaker {
         public void visitTryCatchBlock(Label start, Label end, Label handler, String type) {
             lastStringConstant = null;
             if (type != null) {
-                refs.add(toClassName(type));
+                addClassRef(type, refs);
             }
         }
 
@@ -871,13 +980,13 @@ class JarTreeShaker {
         @Override
         public void visitTypeInsn(int opcode, String type) {
             lastStringConstant = null;
-            refs.add(toClassName(type));
+            addClassRef(type, refs);
         }
 
         @Override
         public void visitFieldInsn(int opcode, String owner, String name, String descriptor) {
             lastStringConstant = null;
-            refs.add(toClassName(owner));
+            addClassRef(owner, refs);
             addDescriptorType(descriptor, refs);
         }
 
@@ -891,7 +1000,7 @@ class JarTreeShaker {
                 }
             }
             lastStringConstant = null;
-            refs.add(toClassName(owner));
+            addClassRef(owner, refs);
             addMethodDescriptorTypes(descriptor, refs);
         }
 
@@ -904,11 +1013,11 @@ class JarTreeShaker {
             }
             if (value instanceof org.objectweb.asm.Type type) {
                 if (type.getSort() == org.objectweb.asm.Type.OBJECT) {
-                    refs.add(toClassName(type.getInternalName()));
+                    addClassRef(type.getInternalName(), refs);
                 } else if (type.getSort() == org.objectweb.asm.Type.ARRAY) {
                     org.objectweb.asm.Type elem = type.getElementType();
                     if (elem.getSort() == org.objectweb.asm.Type.OBJECT) {
-                        refs.add(toClassName(elem.getInternalName()));
+                        addClassRef(elem.getInternalName(), refs);
                     }
                 }
             }
@@ -978,24 +1087,74 @@ class JarTreeShaker {
 
     // ---- Helpers ----
 
+    /**
+     * Converts a JVM internal name (e.g. {@code com/example/Foo}) to a dot-separated
+     * class name (e.g. {@code com.example.Foo}).
+     */
     private static String toClassName(String internalName) {
         return internalName.replace('/', '.');
     }
 
+    /**
+     * Adds a class reference to {@code refs} after converting from JVM internal name
+     * to dot-separated format, but only if the class is not in the {@code java/}
+     * package hierarchy. JDK classes are never present in the dependency, application,
+     * or generated bytecode maps, so they are always filtered out downstream by
+     * {@link JarTreeShakeInput#hasBytecode} — skipping them here avoids the
+     * {@link String#replace} allocation and the {@link Set#add} lookup.
+     */
+    private static void addClassRef(String internalName, Set<String> refs) {
+        if (!internalName.startsWith("java/")) {
+            refs.add(internalName.replace('/', '.'));
+        }
+    }
+
+    /**
+     * Returns {@code true} if the descriptor references at least one object type.
+     * In JVM descriptor grammar, object types are encoded as {@code Lfully/qualified/Name;},
+     * so the presence of the {@code L} character is a necessary and sufficient condition.
+     * Descriptors that contain only primitive types ({@code I}, {@code J}, {@code D}, etc.),
+     * void ({@code V}), or arrays of primitives ({@code [I}, {@code [B}) will not
+     * contain {@code L}.
+     */
+    private static boolean hasObjectType(String descriptor) {
+        return descriptor.indexOf('L') >= 0;
+    }
+
+    /**
+     * Parses a single field or type descriptor (e.g. {@code Ljava/lang/String;})
+     * and adds any object type reference to {@code refs}. Skips parsing when the
+     * descriptor contains only primitive types, void, or arrays of primitives.
+     */
     private static void addDescriptorType(String descriptor, Set<String> refs) {
+        if (!hasObjectType(descriptor)) {
+            return;
+        }
         org.objectweb.asm.Type type = org.objectweb.asm.Type.getType(descriptor);
         addAsmType(type, refs);
     }
 
+    /**
+     * Parses a method descriptor (e.g. {@code (Ljava/lang/String;I)V}) and adds
+     * all argument and return type object references to {@code refs}. Skips
+     * parsing when the descriptor contains only primitive types and void.
+     */
     private static void addMethodDescriptorTypes(String descriptor, Set<String> refs) {
+        if (!hasObjectType(descriptor)) {
+            return;
+        }
         for (org.objectweb.asm.Type argType : org.objectweb.asm.Type.getArgumentTypes(descriptor)) {
             addAsmType(argType, refs);
         }
         addAsmType(org.objectweb.asm.Type.getReturnType(descriptor), refs);
     }
 
+    /**
+     * Adds the owner class reference and descriptor type references from an
+     * {@code invokedynamic} bootstrap method handle to {@code refs}.
+     */
     private static void addHandleType(Handle handle, Set<String> refs) {
-        refs.add(toClassName(handle.getOwner()));
+        addClassRef(handle.getOwner(), refs);
         int tag = handle.getTag();
         if (tag == Opcodes.H_GETFIELD || tag == Opcodes.H_GETSTATIC
                 || tag == Opcodes.H_PUTFIELD || tag == Opcodes.H_PUTSTATIC) {
@@ -1018,14 +1177,19 @@ class JarTreeShaker {
         new SignatureReader(signature).accept(new SignatureVisitor(Opcodes.ASM9) {
             @Override
             public void visitClassType(String name) {
-                refs.add(toClassName(name));
+                addClassRef(name, refs);
             }
         });
     }
 
+    /**
+     * Adds the class reference from an ASM {@link org.objectweb.asm.Type} to {@code refs},
+     * recursing into the element type for array types. Delegates to {@link #addClassRef}
+     * to skip {@code java/} package classes.
+     */
     private static void addAsmType(org.objectweb.asm.Type type, Set<String> refs) {
         if (type.getSort() == org.objectweb.asm.Type.OBJECT) {
-            refs.add(toClassName(type.getInternalName()));
+            addClassRef(type.getInternalName(), refs);
         } else if (type.getSort() == org.objectweb.asm.Type.ARRAY) {
             addAsmType(type.getElementType(), refs);
         }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/MethodKey.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/MethodKey.java
@@ -1,0 +1,118 @@
+package io.quarkus.deployment.pkg.steps;
+
+import java.util.Set;
+
+/**
+ * Structured key for a JVM method, storing the three components provided by ASM's
+ * {@link org.objectweb.asm.MethodVisitor#visitMethodInsn} and
+ * {@link org.objectweb.asm.ClassVisitor#visitMethod} without string concatenation.
+ *
+ * <p>
+ * The three strings (owner, name, descriptor) are interned by ASM's
+ * {@link org.objectweb.asm.ClassReader} from the class file constant pool, so
+ * storing them as references avoids all allocation. Hash code is lazily cached
+ * and computed from the three pre-cached {@link String#hashCode()} values.
+ */
+final class MethodKey {
+
+    /** JDK methods that load classes by name — the seeds for call chain propagation. */
+    static final Set<MethodKey> SEED_METHOD_KEYS = Set.of(
+            new MethodKey("java/lang/ClassLoader", "loadClass", "(Ljava/lang/String;)Ljava/lang/Class;"),
+            new MethodKey("java/lang/ClassLoader", "loadClass", "(Ljava/lang/String;Z)Ljava/lang/Class;"),
+            new MethodKey("java/lang/ClassLoader", "findClass", "(Ljava/lang/String;)Ljava/lang/Class;"),
+            new MethodKey("java/lang/Class", "forName", "(Ljava/lang/String;)Ljava/lang/Class;"),
+            new MethodKey("java/lang/Class", "forName", "(Ljava/lang/String;ZLjava/lang/ClassLoader;)Ljava/lang/Class;"),
+            new MethodKey("java/lang/Class", "forName", "(Ljava/lang/Module;Ljava/lang/String;)Ljava/lang/Class;"),
+            new MethodKey("java/lang/invoke/MethodHandles$Lookup", "findClass",
+                    "(Ljava/lang/String;)Ljava/lang/Class;"));
+
+    /**
+     * Owner classes of the seed methods. Used for fast pre-filtering during caller
+     * index construction: a method call to a JDK/infra class only needs full
+     * {@link MethodKey} construction and seed set lookup if the owner is one of these.
+     */
+    private static final Set<String> SEED_METHOD_OWNERS = Set.of(
+            "java/lang/ClassLoader",
+            "java/lang/Class",
+            "java/lang/invoke/MethodHandles$Lookup");
+
+    final String owner;
+    final String name;
+    final String descriptor;
+    private int hash;
+
+    MethodKey(String owner, String name, String descriptor) {
+        this.owner = owner;
+        this.name = name;
+        this.descriptor = descriptor;
+    }
+
+    String ownerAsDotName() {
+        return owner.replace('/', '.');
+    }
+
+    /**
+     * Returns {@code true} if this method is a constructor ({@code <init>}) or
+     * static initializer ({@code <clinit>}).
+     */
+    boolean isInitOrClinit() {
+        return name.charAt(0) == '<' && name.endsWith("init>");
+    }
+
+    /**
+     * Returns {@code true} if the given method owner is one of the JDK classes
+     * that contain seed methods ({@code ClassLoader}, {@code Class}, or
+     * {@code MethodHandles.Lookup}). Used during caller index construction to
+     * avoid creating {@link MethodKey} objects for JDK/infra calls that cannot
+     * possibly be seeds.
+     */
+    static boolean isSeedMethodOwner(String owner) {
+        return SEED_METHOD_OWNERS.contains(owner);
+    }
+
+    /**
+     * Checks whether an internal class name (or method key starting with a class name)
+     * belongs to a JDK or infrastructure package that should be excluded from
+     * class-loading chain propagation. Works on both bare owner names
+     * ({@code java/lang/Class}) and full method keys ({@code java/lang/Class.forName(...)})
+     * because the check is prefix-based.
+     */
+    static boolean isJdkOrInfraClass(String nameOrKey) {
+        return nameOrKey.startsWith("java/")
+                || nameOrKey.startsWith("javax/")
+                || nameOrKey.startsWith("jakarta/")
+                || nameOrKey.startsWith("org/objectweb/")
+                || nameOrKey.startsWith("sun/");
+    }
+
+    @Override
+    public String toString() {
+        return owner + "." + name + descriptor;
+    }
+
+    @Override
+    public int hashCode() {
+        int h = hash;
+        if (h == 0) {
+            h = owner.hashCode() * 31 * 31 + name.hashCode() * 31 + descriptor.hashCode();
+            if (h == 0) {
+                h = 1;
+            }
+            hash = h;
+        }
+        return h;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o instanceof MethodKey other) {
+            return owner.equals(other.owner)
+                    && name.equals(other.name)
+                    && descriptor.equals(other.descriptor);
+        }
+        return false;
+    }
+}

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/ClassLoadingChainAnalyzerTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/ClassLoadingChainAnalyzerTest.java
@@ -241,7 +241,7 @@ class ClassLoadingChainAnalyzerTest {
      */
     private void assertSeedPropagation(Class<?> utilClass) {
         Map<String, Supplier<byte[]>> allBytecode = bytecodeMapOf(utilClass, Target.class);
-        Map<String, Set<String>> callerIndex = buildCallerIndex(allBytecode);
+        var callerIndex = buildCallerIndex(allBytecode);
         ClassLoadingChainAnalyzer analyzer = new ClassLoadingChainAnalyzer(callerIndex, allBytecode.keySet());
         Set<String> entryPoints = analyzer.findEntryPoints();
         assertTrue(entryPoints.contains(utilClass.getName()),
@@ -279,11 +279,13 @@ class ClassLoadingChainAnalyzerTest {
     }
 
     /**
-     * Builds a reverse caller index from bytecode, using
-     * {@link ClassLoadingChainAnalyzer#shouldRecordCall} for filtering.
+     * Builds a reverse caller index from bytecode using {@link MethodKey},
+     * applying the same owner-prefix filtering as the production code in
+     * {@link JarTreeShaker#scanBytecode}.
      */
-    private static Map<String, Set<String>> buildCallerIndex(Map<String, Supplier<byte[]>> allBytecode) {
-        Map<String, Set<String>> callerIndex = new HashMap<>();
+    private static Map<MethodKey, Set<MethodKey>> buildCallerIndex(
+            Map<String, Supplier<byte[]>> allBytecode) {
+        Map<MethodKey, Set<MethodKey>> callerIndex = new HashMap<>();
         for (var entry : allBytecode.entrySet()) {
             String internalOwner = entry.getKey().replace('.', '/');
             ClassReader reader = new ClassReader(entry.getValue().get());
@@ -291,14 +293,19 @@ class ClassLoadingChainAnalyzerTest {
                 @Override
                 public MethodVisitor visitMethod(int access, String name, String descriptor,
                         String signature, String[] exceptions) {
-                    String callerKey = internalOwner + "." + name + descriptor;
+                    var callerKey = new MethodKey(internalOwner, name, descriptor);
                     return new MethodVisitor(Opcodes.ASM9) {
                         @Override
                         public void visitMethodInsn(int opcode, String owner, String mname,
                                 String mdescriptor, boolean isInterface) {
-                            String calleeKey = owner + "." + mname + mdescriptor;
-                            if (ClassLoadingChainAnalyzer.shouldRecordCall(calleeKey)) {
+                            if (!MethodKey.isJdkOrInfraClass(owner)) {
+                                var calleeKey = new MethodKey(owner, mname, mdescriptor);
                                 callerIndex.computeIfAbsent(calleeKey, k -> new HashSet<>()).add(callerKey);
+                            } else if (MethodKey.isSeedMethodOwner(owner)) {
+                                var calleeKey = new MethodKey(owner, mname, mdescriptor);
+                                if (MethodKey.SEED_METHOD_KEYS.contains(calleeKey)) {
+                                    callerIndex.computeIfAbsent(calleeKey, k -> new HashSet<>()).add(callerKey);
+                                }
                             }
                         }
                     };
@@ -315,12 +322,14 @@ class ClassLoadingChainAnalyzerTest {
     private static Set<String> analyzeInForkedJvm(Set<String> reachable,
             Map<String, Supplier<byte[]>> allBytecode) {
         Set<String> allKnown = allBytecode.keySet();
-        Set<String> discovered = ClassLoadingChainAnalyzer.executeEntryPoints(
-                reachable, allBytecode, Map.of(),
-                allKnown, List.of(), List.of());
-        discovered.retainAll(allKnown);
-        discovered.removeAll(reachable);
-        return discovered;
+        try (var env = ForkedJvmEnvironment.create(
+                allBytecode, Map.of(), List.of(), List.of())) {
+            Set<String> discovered = env.executeEntryPoints(reachable, allKnown);
+            discovered.removeAll(reachable);
+            return discovered;
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException("Failed to run forked JVM analysis", e);
+        }
     }
 
     // ---- ASM generators (only used for transformed bytecode tests) ----


### PR DESCRIPTION
This PR does not change the algorithm, it includes only the following optimizations:
* eliminate string concatenations for method keys;
* reuse the forked JVM environment setup across iterations of classloading chain analysis;
* skip unnecessary work in hot paths.
* add debug logging to give more insights about tree-shaking phases, iterations, etc.

The effects of these aren't extraordinary but they still make sense. Here are some stats from Quarkus Super Heroes project.

<img width="589" height="546" alt="image" src="https://github.com/user-attachments/assets/0c067c2a-42b5-4250-b0e4-4eb5ceaab87e" />

Here are some details of the `rest-fights` project:

<img width="766" height="178" alt="image" src="https://github.com/user-attachments/assets/2aaf2e76-bfe2-41d0-aed6-e3e9e6b4837b" />

The tree-shaker reports
> 10,785 unreachable classes from 247 of the 354 dependency JARs, saving 39.6 MB of raw bytecode (23.0%)

The on-disk savings are smaller because JARs are ZIP-compressed.
The number of dependency JARs is expected to be the same, since tree shaking does not touch non-class resources atm. 
And the savings are actually the same with these changes and w/o.
This is just for a reference.

Tree-shaking spends most of the time in bytecode scanning. Optimizing that part would have the most impact.

FYI @vsevel 