### PR TITLE
Remove incorrect references to quarkus.version in reactive-transactions pom

### DIFF
--- a/extensions/reactive-transactions/deployment/pom.xml
+++ b/extensions/reactive-transactions/deployment/pom.xml
@@ -38,7 +38,7 @@
                                 <path>
                                     <groupId>io.quarkus</groupId>
                                     <artifactId>quarkus-extension-processor</artifactId>
-                                    <version>${quarkus.version}</version>
+                                    <version>${project.version}</version>
                                 </path>
                             </annotationProcessorPaths>
                         </configuration>

--- a/extensions/reactive-transactions/pom.xml
+++ b/extensions/reactive-transactions/pom.xml
@@ -15,16 +15,4 @@
         <module>deployment</module>
         <module>runtime</module>
     </modules>
-
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>io.quarkus</groupId>
-                    <artifactId>quarkus-maven-plugin</artifactId>
-                    <version>${quarkus.version}</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
 </project>


### PR DESCRIPTION
They're causing IDEA to choke when importing the project (cannot resolve `quarkus.version`, leading to not finding some dependencies).

Don't ask me why the Maven CLI was fine with it, or why nobody experienced the problems I did.


cc @lucamolteni 