### PR TITLE
Open archive path tree interrupt workaround

### DIFF
--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/ArchivePathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/ArchivePathTree.java
@@ -2,8 +2,6 @@ package io.quarkus.paths;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.nio.file.FileSystem;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
@@ -16,6 +14,7 @@ import java.util.function.Function;
 import java.util.jar.Manifest;
 
 import io.quarkus.fs.util.ZipUtils;
+import io.quarkus.fs.util.rozip.ReadOnlyZipFileSystem;
 
 public class ArchivePathTree extends PathTreeWithManifest implements PathTree {
 
@@ -100,9 +99,8 @@ public class ArchivePathTree extends PathTreeWithManifest implements PathTree {
 
     @Override
     public void walk(PathVisitor visitor) {
-        try (FileSystem fs = openFs()) {
-            final Path dir = fs.getPath("/");
-            PathTreeVisit.walk(archive, dir, dir, pathFilter, getMultiReleaseMapping(), visitor);
+        try (OpenPathTree open = open()) {
+            open.walk(visitor);
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to read " + archive, e);
         }
@@ -110,9 +108,8 @@ public class ArchivePathTree extends PathTreeWithManifest implements PathTree {
 
     @Override
     public void walkRaw(PathVisitor visitor) {
-        try (FileSystem fs = openFs()) {
-            final Path dir = fs.getPath("/");
-            PathTreeVisit.walk(archive, dir, dir, pathFilter, Map.of(), visitor);
+        try (OpenPathTree open = open()) {
+            open.walkRaw(visitor);
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to read " + archive, e);
         }
@@ -124,14 +121,8 @@ public class ArchivePathTree extends PathTreeWithManifest implements PathTree {
         if (!PathFilter.isVisible(pathFilter, resourceDirName)) {
             return;
         }
-        try (FileSystem fs = openFs()) {
-            final String dirPath = PathTreeVisit.resourceNameToFsPath(resourceDirName, fs);
-            for (Path root : fs.getRootDirectories()) {
-                final Path walkDir = root.resolve(dirPath);
-                if (Files.exists(walkDir)) {
-                    PathTreeVisit.walk(archive, root, walkDir, pathFilter, getMultiReleaseMapping(), visitor);
-                }
-            }
+        try (OpenPathTree open = open()) {
+            open.walkIfContains(resourceDirName, visitor);
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to read " + archive, e);
         }
@@ -146,30 +137,17 @@ public class ArchivePathTree extends PathTreeWithManifest implements PathTree {
         return resourceNames == null ? resourceNames = super.getResourceNames() : resourceNames;
     }
 
-    private String resolveResourceName(String resourceName, boolean manifestEnabled) {
-        return manifestEnabled ? toMultiReleaseResourceName(resourceName) : resourceName;
-    }
-
     @Override
     protected <T> T apply(String resourceName, Function<PathVisit, T> func, boolean manifestEnabled) {
         ensureResourcePath(resourceName);
         if (!PathFilter.isVisible(pathFilter, resourceName)) {
             return func.apply(null);
         }
-        try (FileSystem fs = openFs()) {
-            final String relativePath = PathTreeVisit.resourceNameToFsPath(
-                    resolveResourceName(resourceName, manifestEnabled), fs);
-            for (Path root : fs.getRootDirectories()) {
-                final Path path = root.resolve(relativePath);
-                if (!Files.exists(path)) {
-                    continue;
-                }
-                return PathTreeVisit.process(archive, root, path, pathFilter, func);
-            }
+        try (OpenPathTree open = open()) {
+            return open.apply(resourceName, func);
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to read " + archive, e);
         }
-        return func.apply(null);
     }
 
     @Override
@@ -179,21 +157,11 @@ public class ArchivePathTree extends PathTreeWithManifest implements PathTree {
             consumer.accept(null);
             return;
         }
-        try (FileSystem fs = openFs()) {
-            final String relativePath = PathTreeVisit.resourceNameToFsPath(
-                    resolveResourceName(resourceName, manifestEnabled), fs);
-            for (Path root : fs.getRootDirectories()) {
-                final Path path = root.resolve(relativePath);
-                if (!Files.exists(path)) {
-                    continue;
-                }
-                PathTreeVisit.consume(archive, root, path, pathFilter, consumer);
-                return;
-            }
+        try (OpenPathTree open = open()) {
+            open.accept(resourceName, consumer);
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to read " + archive, e);
         }
-        consumer.accept(null);
     }
 
     @Override
@@ -202,23 +170,15 @@ public class ArchivePathTree extends PathTreeWithManifest implements PathTree {
         if (!PathFilter.isVisible(pathFilter, resourceName)) {
             return false;
         }
-        try (FileSystem fs = openFs()) {
-            final String relativePath = PathTreeVisit.resourceNameToFsPath(
-                    resolveResourceName(resourceName, manifestEnabled), fs);
-            for (Path root : fs.getRootDirectories()) {
-                final Path path = root.resolve(relativePath);
-                if (Files.exists(path)) {
-                    return true;
-                }
-            }
+        try (OpenPathTree open = open()) {
+            return open.contains(resourceName);
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to read " + archive, e);
         }
-        return false;
     }
 
-    protected FileSystem openFs() throws IOException {
-        return ZipUtils.newFileSystem(archive);
+    protected ReadOnlyZipFileSystem openFs() throws IOException {
+        return (ReadOnlyZipFileSystem) ZipUtils.openReadOnly(archive);
     }
 
     @Override
@@ -253,17 +213,27 @@ public class ArchivePathTree extends PathTreeWithManifest implements PathTree {
         return archive.toString();
     }
 
+    /**
+     * Thread-safe view of an open archive backed by a {@link ReadOnlyZipFileSystem}.
+     * <p>
+     * {@link ReadOnlyZipFileSystem} uses {@code RandomAccessFile} instead of
+     * {@code FileChannel}, making it immune to the JDK issue (JDK-8316882) where an
+     * interrupted thread closes the shared {@code FileChannel} (via
+     * {@code InterruptibleChannel}), breaking the entire filesystem for all other threads.
+     * Because {@code RandomAccessFile} is not interruptible, the thread's interrupt flag is
+     * naturally preserved without explicit clearing or restoring.
+     */
     protected class OpenArchivePathTree extends OpenContainerPathTree {
 
         private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
         // we don't make these fields final as we want to nullify them on close
-        private FileSystem fs;
+        private ReadOnlyZipFileSystem fs;
         private Path rootPath;
 
         private volatile boolean open = true;
 
-        protected OpenArchivePathTree(FileSystem fs) {
+        protected OpenArchivePathTree(ReadOnlyZipFileSystem fs) {
             super(ArchivePathTree.this.pathFilter, ArchivePathTree.this);
             this.fs = fs;
             this.rootPath = fs.getPath("/");
@@ -327,12 +297,34 @@ public class ArchivePathTree extends PathTreeWithManifest implements PathTree {
             }
         }
 
+        /**
+         * Validates the resource name and resolves it to an entry name accounting for
+         * multi-release JARs, or returns {@code null} if the resource is filtered out.
+         * Must be called under the read lock.
+         */
+        private String resolveEntryName(String resourceName) {
+            PathTreeVisit.ensureResourcePath(fs, resourceName);
+            if (!PathFilter.isVisible(pathFilter, resourceName)) {
+                return null;
+            }
+            return manifestEnabled ? toMultiReleaseResourceName(resourceName) : resourceName;
+        }
+
+        private Path resolveEntryPath(String resourceName) {
+            String entryName = resolveEntryName(resourceName);
+            return entryName != null && fs.entryExists(entryName) ? rootPath.resolve(entryName) : null;
+        }
+
         @Override
         protected <T> T apply(String resourceName, Function<PathVisit, T> func, boolean manifestEnabled) {
             lock.readLock().lock();
             try {
                 ensureOpen();
-                return super.apply(resourceName, func, manifestEnabled);
+                Path entry = resolveEntryPath(resourceName);
+                if (entry == null) {
+                    return func.apply(null);
+                }
+                return PathTreeVisit.process(getContainerPath(), rootPath, entry, pathFilter, func);
             } finally {
                 lock.readLock().unlock();
             }
@@ -343,7 +335,12 @@ public class ArchivePathTree extends PathTreeWithManifest implements PathTree {
             lock.readLock().lock();
             try {
                 ensureOpen();
-                super.accept(resourceName, consumer);
+                Path entry = resolveEntryPath(resourceName);
+                if (entry == null) {
+                    consumer.accept(null);
+                    return;
+                }
+                PathTreeVisit.consume(getContainerPath(), rootPath, entry, pathFilter, consumer);
             } finally {
                 lock.readLock().unlock();
             }
@@ -392,7 +389,8 @@ public class ArchivePathTree extends PathTreeWithManifest implements PathTree {
             lock.readLock().lock();
             try {
                 ensureOpen();
-                return super.contains(resourceName);
+                String entryName = resolveEntryName(resourceName);
+                return entryName != null && fs.entryExists(entryName);
             } finally {
                 lock.readLock().unlock();
             }
@@ -403,7 +401,7 @@ public class ArchivePathTree extends PathTreeWithManifest implements PathTree {
             lock.readLock().lock();
             try {
                 ensureOpen();
-                return super.getPath(resourceName);
+                return resolveEntryPath(resourceName);
             } finally {
                 lock.readLock().unlock();
             }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/OpenContainerPathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/OpenContainerPathTree.java
@@ -73,7 +73,7 @@ public abstract class OpenContainerPathTree extends PathTreeWithManifest impleme
         if (!Files.exists(rootPath)) {
             return;
         }
-        PathTreeVisit.walk(rootPath, rootPath, rootPath, pathFilter, getMultiReleaseMapping(),
+        PathTreeVisit.walk(getContainerPath(), rootPath, rootPath, pathFilter, getMultiReleaseMapping(),
                 visitor);
 
     }
@@ -84,7 +84,7 @@ public abstract class OpenContainerPathTree extends PathTreeWithManifest impleme
         if (!Files.exists(rootPath)) {
             return;
         }
-        PathTreeVisit.walk(rootPath, rootPath, rootPath, pathFilter, Map.of(), visitor);
+        PathTreeVisit.walk(getContainerPath(), rootPath, rootPath, pathFilter, Map.of(), visitor);
 
     }
 
@@ -98,8 +98,7 @@ public abstract class OpenContainerPathTree extends PathTreeWithManifest impleme
         if (!Files.exists(walkDir)) {
             return;
         }
-        final Path root = getRootPath();
-        PathTreeVisit.walk(root, root, walkDir, pathFilter, getMultiReleaseMapping(), visitor);
+        PathTreeVisit.walk(getContainerPath(), getRootPath(), walkDir, pathFilter, getMultiReleaseMapping(), visitor);
     }
 
     private void ensureResourcePath(String path) {
@@ -125,8 +124,7 @@ public abstract class OpenContainerPathTree extends PathTreeWithManifest impleme
         if (!Files.exists(path)) {
             return func.apply(null);
         }
-        final Path root = getRootPath();
-        return PathTreeVisit.process(root, root, path, pathFilter, func);
+        return PathTreeVisit.process(getContainerPath(), getRootPath(), path, pathFilter, func);
     }
 
     @Override
@@ -141,8 +139,7 @@ public abstract class OpenContainerPathTree extends PathTreeWithManifest impleme
             consumer.accept(null);
             return;
         }
-        final Path root = getRootPath();
-        PathTreeVisit.consume(root, root, path, pathFilter, consumer);
+        PathTreeVisit.consume(getContainerPath(), getRootPath(), path, pathFilter, consumer);
     }
 
     @Override

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/SharedArchivePathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/SharedArchivePathTree.java
@@ -1,15 +1,17 @@
 package io.quarkus.paths;
 
 import java.io.IOException;
-import java.nio.file.FileSystem;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
+
+import io.quarkus.fs.util.rozip.ReadOnlyZipFileSystem;
 
 /**
  * While {@link ArchivePathTree} implementation is thread-safe, this implementation
@@ -71,7 +73,7 @@ class SharedArchivePathTree extends ArchivePathTree {
 
         private final AtomicInteger users = new AtomicInteger(1);
 
-        protected SharedOpenArchivePathTree(FileSystem fs) {
+        protected SharedOpenArchivePathTree(ReadOnlyZipFileSystem fs) {
             super(fs);
             openCount.incrementAndGet();
         }
@@ -107,18 +109,28 @@ class SharedArchivePathTree extends ArchivePathTree {
 
         @Override
         public void close() throws IOException {
+            // Fast path: if other users remain, no cleanup needed — avoid the write lock entirely.
+            if (users.decrementAndGet() > 0) {
+                return;
+            }
+            // Slow path: we may be the last user. Acquire the write lock to perform cleanup.
+            // Re-check under the lock because between our decrement and lock acquisition,
+            // another thread could have called acquire() (incrementing users) and then closed
+            // (decrementing back to 0), meaning two threads both saw 0 and race for the lock.
+            // The !isOpen() guard handles this: the first closer sets open=false via super.close(),
+            // so the second closer sees !isOpen() and skips the duplicate cleanup.
             writeLock().lock();
-            final boolean close = users.decrementAndGet() == 0;
             try {
-                if (close) {
-                    if (lastOpen == this) {
-                        lastOpen = null;
-                    }
-                    if (openCount.decrementAndGet() == 0) {
-                        removeFromCache(archive);
-                    }
-                    super.close();
+                if (users.get() > 0 || !isOpen()) {
+                    return;
                 }
+                if (lastOpen == this) {
+                    lastOpen = null;
+                }
+                if (openCount.decrementAndGet() == 0) {
+                    removeFromCache(archive);
+                }
+                super.close();
             } finally {
                 writeLock().unlock();
             }
@@ -138,7 +150,7 @@ class SharedArchivePathTree extends ArchivePathTree {
     private static class CallerOpenPathTree implements OpenPathTree {
 
         private final SharedOpenArchivePathTree delegate;
-        private volatile boolean closed;
+        private final AtomicBoolean closed = new AtomicBoolean();
 
         private CallerOpenPathTree(SharedOpenArchivePathTree delegate) {
             this.delegate = delegate;
@@ -156,7 +168,7 @@ class SharedArchivePathTree extends ArchivePathTree {
 
         @Override
         public boolean isOpen() {
-            return !closed && delegate.isOpen();
+            return !closed.get() && delegate.isOpen();
         }
 
         @Override
@@ -221,18 +233,10 @@ class SharedArchivePathTree extends ArchivePathTree {
 
         @Override
         public void close() throws IOException {
-            if (closed) {
+            if (!closed.compareAndSet(false, true)) {
                 return;
             }
-            delegate.writeLock().lock();
-            try {
-                if (!closed) {
-                    closed = true;
-                    delegate.close();
-                }
-            } finally {
-                delegate.writeLock().unlock();
-            }
+            delegate.close();
         }
 
         @Override

--- a/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/paths/JarPathTreeTest.java
+++ b/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/paths/JarPathTreeTest.java
@@ -9,6 +9,7 @@ import java.io.UncheckedIOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -155,5 +156,92 @@ public class JarPathTreeTest {
         var visitor = new PathCollectingVisitor();
         tree.walk(visitor);
         assertThat(visitor.visitedPaths).containsExactlyInAnyOrderEntriesOf(DirectoryPathTreeTest.getMultiReleaseMappedPaths());
+    }
+
+    @Test
+    public void openAcceptGetRoot() throws Exception {
+        final PathTree tree = PathTree.ofDirectoryOrArchive(root);
+        try (OpenPathTree open = tree.open()) {
+            open.accept("README.md", visit -> {
+                assertThat(visit).isNotNull();
+                assertThat(visit.getRelativePath("/")).isEqualTo("README.md");
+                assertThat(visit.getRoot()).isEqualTo(root);
+                try {
+                    assertThat(Files.readString(visit.getPath())).isEqualTo("test readme");
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+        }
+    }
+
+    @Test
+    public void openWalkGetRoot() throws Exception {
+        final PathTree tree = PathTree.ofDirectoryOrArchive(root);
+        try (OpenPathTree open = tree.open()) {
+            open.walk(visit -> {
+                assertThat(visit.getRoot()).isEqualTo(root);
+            });
+        }
+    }
+
+    @Test
+    public void openApplyGetRoot() throws Exception {
+        final PathTree tree = PathTree.ofDirectoryOrArchive(root);
+        try (OpenPathTree open = tree.open()) {
+            String content = open.apply("README.md", visit -> {
+                assertThat(visit).isNotNull();
+                assertThat(visit.getRoot()).isEqualTo(root);
+                try {
+                    return Files.readString(visit.getPath());
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+            assertThat(content).isEqualTo("test readme");
+        }
+    }
+
+    @Test
+    public void interruptFlagPreservedDuringAccept() throws Exception {
+        final PathTree tree = PathTree.ofDirectoryOrArchive(root);
+        try (OpenPathTree open = tree.open()) {
+            Thread.currentThread().interrupt();
+            final AtomicBoolean visited = new AtomicBoolean();
+            open.accept("README.md", visit -> {
+                assertThat(visit).isNotNull();
+                visited.set(true);
+            });
+            assertThat(visited).isTrue();
+            assertThat(Thread.interrupted()).as("interrupt flag should be restored after accept").isTrue();
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    public void interruptFlagPreservedDuringWalk() throws Exception {
+        final PathTree tree = PathTree.ofDirectoryOrArchive(root);
+        try (OpenPathTree open = tree.open()) {
+            Thread.currentThread().interrupt();
+            final AtomicBoolean visited = new AtomicBoolean();
+            open.walk(visit -> visited.set(true));
+            assertThat(visited).isTrue();
+            assertThat(Thread.interrupted()).as("interrupt flag should be restored after walk").isTrue();
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    public void interruptFlagPreservedDuringContains() throws Exception {
+        final PathTree tree = PathTree.ofDirectoryOrArchive(root);
+        try (OpenPathTree open = tree.open()) {
+            Thread.currentThread().interrupt();
+            assertThat(open.contains("README.md")).isTrue();
+            assertThat(Thread.interrupted()).as("interrupt flag should be restored after contains").isTrue();
+        } finally {
+            Thread.interrupted();
+        }
     }
 }

--- a/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/paths/SharedArchivePathTreeTest.java
+++ b/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/paths/SharedArchivePathTreeTest.java
@@ -1,6 +1,10 @@
 package io.quarkus.paths;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -15,10 +19,79 @@ import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import io.quarkus.fs.util.ZipUtils;
 
 public class SharedArchivePathTreeTest {
     private static final int WORKERS_COUNT = 128;
+    private static final String BASE_DIR = "paths/directory-path-tree";
+
+    private static Path testJar;
+
+    @BeforeAll
+    static void createTestJar() throws Exception {
+        final URL url = Thread.currentThread().getContextClassLoader().getResource(BASE_DIR + "/root");
+        if (url == null) {
+            throw new IllegalStateException("Failed to locate " + BASE_DIR + " on the classpath");
+        }
+        final Path rootDir = Path.of(url.toURI()).toAbsolutePath();
+        testJar = rootDir.getParent().resolve("shared-root.jar");
+        ZipUtils.zip(rootDir, testJar);
+    }
+
+    @AfterAll
+    static void cleanup() {
+        SharedArchivePathTree.removeFromCache(testJar);
+    }
+
+    @Test
+    void walk() {
+        final ArchivePathTree tree = SharedArchivePathTree.forPath(testJar);
+        var visitor = new PathCollectingVisitor();
+        tree.walk(visitor);
+        assertThat(visitor.visitedPaths)
+                .containsExactlyInAnyOrderEntriesOf(DirectoryPathTreeTest.getMultiReleaseMappedPaths());
+    }
+
+    @Test
+    void accept() {
+        final ArchivePathTree tree = SharedArchivePathTree.forPath(testJar);
+        tree.accept("README.md", visit -> {
+            assertThat(visit).isNotNull();
+            assertThat(visit.getRelativePath("/")).isEqualTo("README.md");
+            assertThat(visit.getRoot()).isEqualTo(testJar);
+            try {
+                assertThat(Files.readString(visit.getPath())).isEqualTo("test readme");
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        });
+    }
+
+    @Test
+    void apply() {
+        final ArchivePathTree tree = SharedArchivePathTree.forPath(testJar);
+        String content = tree.apply("README.md", visit -> {
+            assertThat(visit).isNotNull();
+            assertThat(visit.getRoot()).isEqualTo(testJar);
+            try {
+                return Files.readString(visit.getPath());
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        });
+        assertThat(content).isEqualTo("test readme");
+    }
+
+    @Test
+    void contains() {
+        final ArchivePathTree tree = SharedArchivePathTree.forPath(testJar);
+        assertThat(tree.contains("README.md")).isTrue();
+        assertThat(tree.contains("non-existent")).isFalse();
+    }
 
     @Test
     void nullPointerException() throws IOException, InterruptedException, ExecutionException {

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -74,7 +74,7 @@
         <smallrye-classfile.version>26</smallrye-classfile.version>
         <smallrye-beanbag.version>1.6.1</smallrye-beanbag.version>
         <gradle-tooling.version>9.5.1</gradle-tooling.version>
-        <quarkus-fs-util.version>1.3.0</quarkus-fs-util.version>
+        <quarkus-fs-util.version>1.4.0</quarkus-fs-util.version>
         <crac.version>1.5.0</crac.version>
     </properties>
     <modules>


### PR DESCRIPTION
Integrates `ReadOnlyZipFileSystem` implementation as a backend for classpath resources. Also fixes a couple of race conditions in `SharedArchivePathTree`.

Fixes #53785