### PR TITLE
Add GitHub Actions job for Oracle Test Pilot

### DIFF
--- a/.github/oracle-test-pilot-jvm-tests.json
+++ b/.github/oracle-test-pilot-jvm-tests.json
@@ -1,0 +1,22 @@
+{
+    "include": [
+        {
+            "category": "19c",
+            "timeout": 20,
+            "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle",
+            "java-version": 17
+        },
+        {
+            "category": "21c",
+            "timeout": 20,
+            "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle",
+            "java-version": 17
+        },
+        {
+            "category": "26ai",
+            "timeout": 20,
+            "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle",
+            "java-version": 17
+        }
+    ]
+}

--- a/.github/oracle-test-pilot-jvm-tests.json
+++ b/.github/oracle-test-pilot-jvm-tests.json
@@ -1,19 +1,19 @@
 {
     "include": [
         {
-            "category": "19c",
+            "category": "base-database-service-19c",
             "timeout": 20,
             "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle",
             "java-version": 17
         },
         {
-            "category": "21c",
+            "category": "base-database-service-21c",
             "timeout": 20,
             "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle",
             "java-version": 17
         },
         {
-            "category": "26ai",
+            "category": "base-database-service-26ai",
             "timeout": 20,
             "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle",
             "java-version": 17

--- a/.github/oracle-test-pilot-jvm-tests.json
+++ b/.github/oracle-test-pilot-jvm-tests.json
@@ -1,19 +1,22 @@
 {
     "include": [
         {
-            "category": "base-database-service-19c",
+            "category": "19c",
+            "oci-service": "base-database-service-19c",
             "timeout": 20,
             "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle",
             "java-version": 17
         },
         {
-            "category": "base-database-service-21c",
+            "category": "21c",
+            "oci-service": "base-database-service-21c",
             "timeout": 20,
             "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle",
             "java-version": 17
         },
         {
-            "category": "base-database-service-26ai",
+            "category": "26ai",
+            "oci-service": "base-database-service-26ai",
             "timeout": 20,
             "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle",
             "java-version": 17

--- a/.github/oracle-test-pilot-native-tests.json
+++ b/.github/oracle-test-pilot-native-tests.json
@@ -1,17 +1,20 @@
 {
     "include": [
         {
-            "category": "base-database-service-19c",
+            "category": "19c",
+            "oci-service": "base-database-service-19c",
             "timeout": 15,
             "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle"
         },
         {
-            "category": "base-database-service-21c",
+            "category": "21c",
+            "oci-service": "base-database-service-21c",
             "timeout": 15,
             "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle"
         },
         {
-            "category": "base-database-service-26ai",
+            "category": "26ai",
+            "oci-service": "base-database-service-26ai",
             "timeout": 15,
             "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle"
         }

--- a/.github/oracle-test-pilot-native-tests.json
+++ b/.github/oracle-test-pilot-native-tests.json
@@ -1,17 +1,17 @@
 {
     "include": [
         {
-            "category": "19c",
+            "category": "base-database-service-19c",
             "timeout": 15,
             "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle"
         },
         {
-            "category": "21c",
+            "category": "base-database-service-21c",
             "timeout": 15,
             "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle"
         },
         {
-            "category": "26ai",
+            "category": "base-database-service-26ai",
             "timeout": 15,
             "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle"
         }

--- a/.github/oracle-test-pilot-native-tests.json
+++ b/.github/oracle-test-pilot-native-tests.json
@@ -1,0 +1,19 @@
+{
+    "include": [
+        {
+            "category": "19c",
+            "timeout": 15,
+            "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle"
+        },
+        {
+            "category": "21c",
+            "timeout": 15,
+            "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle"
+        },
+        {
+            "category": "26ai",
+            "timeout": 15,
+            "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle"
+        }
+    ]
+}

--- a/.github/oracle-test-pilot-native-tests.json
+++ b/.github/oracle-test-pilot-native-tests.json
@@ -3,19 +3,19 @@
         {
             "category": "19c",
             "oci-service": "base-database-service-19c",
-            "timeout": 15,
+            "timeout": 25,
             "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle"
         },
         {
             "category": "21c",
             "oci-service": "base-database-service-21c",
-            "timeout": 15,
+            "timeout": 25,
             "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle"
         },
         {
             "category": "26ai",
             "oci-service": "base-database-service-26ai",
-            "timeout": 15,
+            "timeout": 25,
             "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle"
         }
     ]

--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -118,9 +118,6 @@ env:
   JVM_TEST_NORMAL_TESTS_SELECTOR: "-pl !docs -Dno-test-modules"
   #PTS_MAVEN_ARGS: "-Ddevelocity.pts.enabled=${{ github.event_name == 'pull_request' && github.base_ref == 'main' && 'true' || 'false' }}"
   PTS_MAVEN_ARGS: ""
-  DB_USER: hibernate_orm_test
-  DB_PASSWORD: hibernate_orm_test
-  DB_NAME: hibernate_orm_test
   PULL_REQUEST_NUMBER: ${{ github.event.number }}
   MVNW_REPOURL: https://maven-central.storage-download.googleapis.com/maven2
 

--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -1738,8 +1738,7 @@ jobs:
     permissions:
       contents: read
     needs: [configure, build-jdk17, calculate-test-jobs]
-    # TODO Oracle Test Pilot involves specific runners that are only available in the main repo; prepend "github.repository == 'quarkusio/quarkus' &&"
-    if: needs.calculate-test-jobs.outputs.otp_jvm_matrix != '{}'
+    if: github.repository == 'quarkusio/quarkus' && needs.calculate-test-jobs.outputs.otp_jvm_matrix != '{}'
     env:
       COMMON_MAVEN_ARGS: ${{ needs.configure.outputs.common-maven-args }}
     timeout-minutes: ${{matrix.timeout}}
@@ -1848,8 +1847,7 @@ jobs:
     permissions:
       contents: read
     needs: [configure, build-jdk17, calculate-test-jobs]
-    # TODO Oracle Test Pilot involves specific runners that are only available in the main repo; prepend "github.repository == 'quarkusio/quarkus' &&"
-    if: needs.calculate-test-jobs.outputs.otp_native_matrix != '{}'
+    if: github.repository == 'quarkusio/quarkus' && needs.calculate-test-jobs.outputs.otp_native_matrix != '{}'
     env:
       COMMON_MAVEN_ARGS: ${{ needs.configure.outputs.common-maven-args }}
     timeout-minutes: ${{matrix.timeout}}

--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -1733,10 +1733,10 @@ jobs:
 
   oracle-test-pilot-jvm-tests:
     name: Oracle Test Pilot ${{matrix.category}} - JDK ${{matrix.java-version}}
-    # TODO use Oracle Test Pilot runners
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, Linux, X64, OracleTestPilot ]
     # Shared environment: make extra sure not to leak a GitHub token with any permission.
-    permissions: {}
+    permissions:
+      contents: read
     needs: [configure, build-jdk17, calculate-test-jobs]
     # TODO Oracle Test Pilot involves specific runners that are only available in the main repo; prepend "github.repository == 'quarkusio/quarkus' &&"
     if: needs.calculate-test-jobs.outputs.otp_jvm_matrix != '{}'
@@ -1744,7 +1744,7 @@ jobs:
       COMMON_MAVEN_ARGS: ${{ needs.configure.outputs.common-maven-args }}
     timeout-minutes: ${{matrix.timeout}}
     strategy:
-      max-parallel: ${{ fromJson(needs.configure.outputs.config).maxParallel || 12 }}
+      max-parallel: ${{ fromJson(needs.configure.outputs.config).maxParallel || 5 }}
       fail-fast: false
       matrix: ${{ fromJson(needs.calculate-test-jobs.outputs.otp_jvm_matrix) }}
     steps:
@@ -1785,79 +1785,46 @@ jobs:
           develocity-token-expiry: 6
       - name: Create Oracle Test Pilot Database
         id: create_database
-        # TODO Oracle Test Pilot DB creation
-        run: |
-          PASSWORD=Oracle23
-          echo "::add-mask::$PASSWORD"
-          echo "database_password=${PASSWORD}" >> $GITHUB_OUTPUT
-          echo "connection_string_suffix=localhost:1521/freepdb1" >> $GITHUB_OUTPUT
-          docker run --name oracle -d -p 1521:1521 -e ORACLE_PASSWORD=Oracle23Admin \
-            -e APP_USER=quarkus_test \
-            -e APP_USER_PASSWORD=$PASSWORD \
-            --health-cmd healthcheck.sh \
-            --health-interval 5s \
-            --health-timeout 5s \
-            --health-retries 10 \
-            docker.io/gvenzl/oracle-free:23
-          HEALTHSTATUS=""
-          TIMEOUT=300
-          ELAPSED=0
-          until [ "$HEALTHSTATUS" == "healthy" ];
-          do
-          if [ $ELAPSED -ge $TIMEOUT ]; then
-          echo "Timeout waiting for Oracle Free to start after ${TIMEOUT}s"
-          echo "Container logs:"
-          docker logs oracle
-          exit 1
-          fi
-          echo "Waiting for Oracle Free to start... (${ELAPSED}s/${TIMEOUT}s)"
-          sleep 5
-          ELAPSED=$((ELAPSED + 5))
-          HEALTHSTATUS="`docker inspect -f '{{.State.Health.Status}}' oracle`"
-          HEALTHSTATUS=${HEALTHSTATUS##+( )} #Remove longest matching series of spaces from the front
-          HEALTHSTATUS=${HEALTHSTATUS%%+( )} #Remove longest matching series of spaces from the back
-          done
-          sleep 2;
-          echo "Oracle successfully started"
-      #        uses: oracle-actions/setup-testpilot@f620f11f9f26dacfe80ba1823342e3e92604c55f # v1.0.23
-      #        with:
-      #          oci-service: ${{ matrix.category }}
-      #          action: create
-      #          user: quarkus_test
+        uses: oracle-actions/setup-testpilot@f620f11f9f26dacfe80ba1823342e3e92604c55f # v1.0.23
+        with:
+          oci-service: ${{ matrix.category }}
+          action: create
+          user: quarkus_test
       - name: Build
         env:
           # Begin OTP setup
-          TESTPILOT_MAVEN_ARGS: >-
-            -Doracle.jdbc.url=jdbc:oracle:thin:@${{ steps.create_database.outputs.connection_string_suffix }}?oracle.jdbc.enableQueryResultCache=false
-            -Doracle.reactive.url=vertx-reactive:oracle:thin:@${{ steps.create_database.outputs.connection_string_suffix }}?oracle.jdbc.enableQueryResultCache=false
-            -Doracle.username=quarkus_test
-            -Doracle.password=${{ steps.create_database.outputs.database_password }}
-          RDBMS: ${{ matrix.category }} # TODO may be useless?
-          RUNID: ${{ github.run_number }} # TODO may be useless?
-          API_HOST: "" # TODO may be useless?
-          TESTPILOT_CLIENT_ID: "" # TODO may be useless?
-          TESTPILOT_TOKEN: "" # TODO may be useless?
+          TESTPILOT_USERNAME: quarkus_test_${{ github.run_number }}
+          TESTPILOT_PASSWORD: ${{ steps.create_database.outputs.database_password }}
+          TESTPILOT_CONNECTION_STRING_SUFFIX_WDQ: ${{ steps.create_database.outputs.connection_string_suffix }}
+          RDBMS: ${{ matrix.category }}
+          RUNID: ${{ github.run_number }}
+          API_HOST: ""
+          TESTPILOT_CLIENT_ID: ""
+          TESTPILOT_TOKEN: ""
           # Needed for TFO (TCP fast open)
-          # TODO uncomment once running on actual testpilot machines
           #LD_PRELOAD: /home/ubuntu/libtfojdbc1.so
           #LD_LIBRARY_PATH: /home/ubuntu
           # End OTP setup
           TEST_MODULES: ${{matrix.test-modules}}
           CAPTURE_BUILD_SCAN: true
         run: |
-          export LANG=en_US && ./mvnw $COMMON_MAVEN_ARGS $COMMON_TEST_MAVEN_ARGS $PTS_MAVEN_ARGS \
-            $JVM_TEST_MAVEN_ARGS $TESTPILOT_MAVEN_ARGS \
+          export LANG=en_US && export TESTPILOT_CONNECTION_STRING_SUFFIX=`echo "${TESTPILOT_CONNECTION_STRING_SUFFIX_WDQ:1:-1}"` \
+            && ./mvnw $COMMON_MAVEN_ARGS $COMMON_TEST_MAVEN_ARGS $PTS_MAVEN_ARGS \
+            $JVM_TEST_MAVEN_ARGS \
+            -Doracle.jdbc.url=jdbc:oracle:thin:@${TESTPILOT_CONNECTION_STRING_SUFFIX} \
+            -Doracle.reactive.url=vertx-reactive:oracle:thin:@${TESTPILOT_CONNECTION_STRING_SUFFIX} \
+            -Doracle.username=${TESTPILOT_USERNAME} \
+            -Doracle.password=${TESTPILOT_PASSWORD} \
             -f integration-tests -pl "$TEST_MODULES" \
             clean install
       - name: Delete Oracle Test Pilot Database
-        if: always()
-        # TODO Oracle Test Pilot DB deletion
-        run: docker rm -f oracle || true
-      #        uses: oracle-actions/setup-testpilot@f620f11f9f26dacfe80ba1823342e3e92604c55f # v1.0.23
-      #        with:
-      #          oci-service: ${{ matrix.category }}
-      #          action: delete
-      #          user: quarkus_test_1
+        id: delete_database
+        if: always() && steps.create_database.outcome == 'success'
+        uses: oracle-actions/setup-testpilot@f620f11f9f26dacfe80ba1823342e3e92604c55f # v1.0.23
+        with:
+          oci-service: ${{ matrix.category }}
+          action: delete
+          user: quarkus_test
       - name: Prepare build reports archive
         if: always()
         run: |
@@ -1877,10 +1844,10 @@ jobs:
 
   oracle-test-pilot-native-tests:
     name: "Oracle Test Pilot ${{matrix.category}} - Native"
-    # TODO use Oracle Test Pilot runners
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, Linux, X64, OracleTestPilot ]
     # Shared environment: make extra sure not to leak a GitHub token with any permission.
-    permissions: {}
+    permissions:
+      contents: read
     needs: [configure, build-jdk17, calculate-test-jobs]
     # TODO Oracle Test Pilot involves specific runners that are only available in the main repo; prepend "github.repository == 'quarkusio/quarkus' &&"
     if: needs.calculate-test-jobs.outputs.otp_native_matrix != '{}'
@@ -1888,7 +1855,7 @@ jobs:
       COMMON_MAVEN_ARGS: ${{ needs.configure.outputs.common-maven-args }}
     timeout-minutes: ${{matrix.timeout}}
     strategy:
-      max-parallel: ${{ fromJson(needs.configure.outputs.config).maxParallel || 12 }}
+      max-parallel: ${{ fromJson(needs.configure.outputs.config).maxParallel || 5 }}
       fail-fast: false
       matrix: ${{ fromJson(needs.calculate-test-jobs.outputs.otp_native_matrix) }}
     steps:
@@ -1938,79 +1905,46 @@ jobs:
           develocity-token-expiry: 6
       - name: Create Oracle Test Pilot Database
         id: create_database
-      # TODO Oracle Test Pilot DB creation
-        run: |
-          PASSWORD=Oracle23
-          echo "::add-mask::$PASSWORD"
-          echo "database_password=${PASSWORD}" >> $GITHUB_OUTPUT
-          echo "connection_string_suffix=localhost:1521/freepdb1" >> $GITHUB_OUTPUT
-          docker run --name oracle -d -p 1521:1521 -e ORACLE_PASSWORD=Oracle23Admin \
-            -e APP_USER=quarkus_test \
-            -e APP_USER_PASSWORD=$PASSWORD \
-            --health-cmd healthcheck.sh \
-            --health-interval 5s \
-            --health-timeout 5s \
-            --health-retries 10 \
-            docker.io/gvenzl/oracle-free:23
-          HEALTHSTATUS=""
-          TIMEOUT=300
-          ELAPSED=0
-          until [ "$HEALTHSTATUS" == "healthy" ];
-          do
-          if [ $ELAPSED -ge $TIMEOUT ]; then
-          echo "Timeout waiting for Oracle Free to start after ${TIMEOUT}s"
-          echo "Container logs:"
-          docker logs oracle
-          exit 1
-          fi
-          echo "Waiting for Oracle Free to start... (${ELAPSED}s/${TIMEOUT}s)"
-          sleep 5
-          ELAPSED=$((ELAPSED + 5))
-          HEALTHSTATUS="`docker inspect -f '{{.State.Health.Status}}' oracle`"
-          HEALTHSTATUS=${HEALTHSTATUS##+( )} #Remove longest matching series of spaces from the front
-          HEALTHSTATUS=${HEALTHSTATUS%%+( )} #Remove longest matching series of spaces from the back
-          done
-          sleep 2;
-          echo "Oracle successfully started"
-#        uses: oracle-actions/setup-testpilot@f620f11f9f26dacfe80ba1823342e3e92604c55f # v1.0.23
-#        with:
-#          oci-service: ${{ matrix.category }}
-#          action: create
-#          user: quarkus_test
+        uses: oracle-actions/setup-testpilot@f620f11f9f26dacfe80ba1823342e3e92604c55f # v1.0.23
+        with:
+          oci-service: ${{ matrix.category }}
+          action: create
+          user: quarkus_test
       - name: Build
         env:
           # Begin OTP setup
-          TESTPILOT_MAVEN_ARGS: >-
-            -Doracle.jdbc.url=jdbc:oracle:thin:@${{ steps.create_database.outputs.connection_string_suffix }}?oracle.jdbc.enableQueryResultCache=false
-            -Doracle.reactive.url=vertx-reactive:oracle:thin:@${{ steps.create_database.outputs.connection_string_suffix }}?oracle.jdbc.enableQueryResultCache=false
-            -Doracle.username=quarkus_test
-            -Doracle.password=${{ steps.create_database.outputs.database_password }}
-          RDBMS: ${{ matrix.category }} # TODO may be useless?
-          RUNID: ${{ github.run_number }} # TODO may be useless?
-          API_HOST: "" # TODO may be useless?
-          TESTPILOT_CLIENT_ID: "" # TODO may be useless?
-          TESTPILOT_TOKEN: "" # TODO may be useless?
+          TESTPILOT_USERNAME: quarkus_test_${{ github.run_number }}
+          TESTPILOT_PASSWORD: ${{ steps.create_database.outputs.database_password }}
+          TESTPILOT_CONNECTION_STRING_SUFFIX_WDQ: ${{ steps.create_database.outputs.connection_string_suffix }}
+          RDBMS: ${{ matrix.category }}
+          RUNID: ${{ github.run_number }}
+          API_HOST: ""
+          TESTPILOT_CLIENT_ID: ""
+          TESTPILOT_TOKEN: ""
           # Needed for TFO (TCP fast open)
-          # TODO uncomment once running on actual testpilot machines
           #LD_PRELOAD: /home/ubuntu/libtfojdbc1.so
           #LD_LIBRARY_PATH: /home/ubuntu
           # End OTP setup
           TEST_MODULES: ${{matrix.test-modules}}
-          CONTAINER_BUILD: false # Docker is not available on Test Pilot
+          CONTAINER_BUILD: false # Docker is not available on Oracle Test Pilot
           CAPTURE_BUILD_SCAN: true
         run: |
-          export LANG=en_US && ./mvnw $COMMON_MAVEN_ARGS $COMMON_TEST_MAVEN_ARGS $PTS_MAVEN_ARGS \
-            $TESTPILOT_MAVEN_ARGS $NATIVE_TEST_MAVEN_ARGS -Dquarkus.native.container-build=false \
+          export LANG=en_US && export TESTPILOT_CONNECTION_STRING_SUFFIX=`echo "${TESTPILOT_CONNECTION_STRING_SUFFIX_WDQ:1:-1}"` \
+            && ./mvnw $COMMON_MAVEN_ARGS $COMMON_TEST_MAVEN_ARGS $PTS_MAVEN_ARGS \
+            -Doracle.jdbc.url=jdbc:oracle:thin:@${TESTPILOT_CONNECTION_STRING_SUFFIX} \
+            -Doracle.reactive.url=vertx-reactive:oracle:thin:@${TESTPILOT_CONNECTION_STRING_SUFFIX} \
+            -Doracle.username=${TESTPILOT_USERNAME} \
+            -Doracle.password=${TESTPILOT_PASSWORD} \
+            $NATIVE_TEST_MAVEN_ARGS -Dquarkus.native.container-build=false \
             -f integration-tests -pl "$TEST_MODULES"
       - name: Delete Oracle Test Pilot Database
-        if: always()
-      # TODO Oracle Test Pilot DB deletion
-        run: docker rm -f oracle || true
-#        uses: oracle-actions/setup-testpilot@f620f11f9f26dacfe80ba1823342e3e92604c55f # v1.0.23
-#        with:
-#          oci-service: ${{ matrix.category }}
-#          action: delete
-#          user: quarkus_test_1
+        id: delete_database
+        if: always() && steps.create_database.outcome == 'success'
+        uses: oracle-actions/setup-testpilot@f620f11f9f26dacfe80ba1823342e3e92604c55f # v1.0.23
+        with:
+          oci-service: ${{ matrix.category }}
+          action: delete
+          user: quarkus_test
       - name: Prepare build reports archive
         if: always()
         run: |

--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -1906,11 +1906,12 @@ jobs:
         with:
           oci-service: ${{ matrix.oci-service }}
           action: create
-          user: quarkus_test
+          # This needs to be unique to the job, in particular it must be different to the TestPilot JVM job
+          user: quarkus_test_native
       - name: Build
         env:
           # Begin OTP setup
-          TESTPILOT_USERNAME: quarkus_test_${{ github.run_number }}
+          TESTPILOT_USERNAME: quarkus_test_native_${{ github.run_number }}
           TESTPILOT_PASSWORD: ${{ steps.create_database.outputs.database_password }}
           TESTPILOT_CONNECTION_STRING_SUFFIX_WDQ: ${{ steps.create_database.outputs.connection_string_suffix }}
           RUNID: ${{ github.run_number }}
@@ -1940,7 +1941,7 @@ jobs:
         with:
           oci-service: ${{ matrix.oci-service }}
           action: delete
-          user: quarkus_test
+          user: quarkus_test_native
       - name: Prepare build reports archive
         if: always()
         run: |

--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -376,6 +376,10 @@ jobs:
         run: ./.github/verify-tests-json.sh native-tests.json integration-tests/
       - name: Verify virtual-threads-tests.json
         run: ./.github/verify-tests-json.sh virtual-threads-tests.json integration-tests/
+      - name: Verify oracle-test-pilot-jvm-tests.json
+        run: ./.github/verify-tests-json.sh oracle-test-pilot-jvm-tests.json integration-tests/
+      - name: Verify oracle-test-pilot-native-tests.json
+        run: ./.github/verify-tests-json.sh oracle-test-pilot-native-tests.json integration-tests/
       - name: Setup Develocity Build Scan capture
         uses: gradle/develocity-actions/setup-maven@974e8dbcbda40db6828fc35f349c80a7c0e71529 # v2.1
         with:
@@ -485,6 +489,8 @@ jobs:
       native_matrix: ${{ steps.calc-native-matrix.outputs.matrix }}
       jvm_matrix: ${{ steps.calc-jvm-matrix.outputs.matrix }}
       virtual_threads_matrix: ${{ steps.calc-virtual-threads-matrix.outputs.matrix }}
+      otp_jvm_matrix: ${{ steps.calc-otp-jvm-matrix.outputs.matrix }}
+      otp_native_matrix: ${{ steps.calc-otp-native-matrix.outputs.matrix }}
       run_devtools: ${{ steps.calc-run-flags.outputs.run_devtools }}
       run_gradle: ${{ steps.calc-run-flags.outputs.run_gradle }}
       run_maven: ${{ steps.calc-run-flags.outputs.run_maven }}
@@ -512,6 +518,20 @@ jobs:
         run: |
           echo "GIB_IMPACTED_MODULES: ${GIB_IMPACTED_MODULES}"
           json=$(.github/filter-integration-tests-json.sh virtual-threads "${GIB_IMPACTED_MODULES}" | tr -d '\n')
+          echo "${json}"
+          echo "matrix=${json}" >> $GITHUB_OUTPUT
+      - name: Calculate matrix from oracle-test-pilot-jvm-tests.json
+        id: calc-otp-jvm-matrix
+        run: |
+          echo "GIB_IMPACTED_MODULES: ${GIB_IMPACTED_MODULES}"
+          json=$(.github/filter-integration-tests-json.sh oracle-test-pilot-jvm "${GIB_IMPACTED_MODULES}" | tr -d '\n')
+          echo "${json}"
+          echo "matrix=${json}" >> $GITHUB_OUTPUT
+      - name: Calculate matrix from oracle-test-pilot-native-tests.json
+        id: calc-otp-native-matrix
+        run: |
+          echo "GIB_IMPACTED_MODULES: ${GIB_IMPACTED_MODULES}"
+          json=$(.github/filter-integration-tests-json.sh oracle-test-pilot-native "${GIB_IMPACTED_MODULES}" | tr -d '\n')
           echo "${json}"
           echo "matrix=${json}" >> $GITHUB_OUTPUT
       - name: Calculate run flags
@@ -1714,10 +1734,307 @@ jobs:
             fi
           done
 
+  oracle-test-pilot-jvm-tests:
+    name: Oracle Test Pilot ${{matrix.category}} - JDK ${{matrix.java-version}}
+    # TODO use Oracle Test Pilot runners
+    runs-on: ubuntu-latest
+    # Shared environment: make extra sure not to leak a GitHub token with any permission.
+    permissions: {}
+    needs: [configure, build-jdk17, calculate-test-jobs]
+    # TODO Oracle Test Pilot involves specific runners that are only available in the main repo; prepend "github.repository == 'quarkusio/quarkus' &&"
+    if: needs.calculate-test-jobs.outputs.otp_jvm_matrix != '{}'
+    env:
+      COMMON_MAVEN_ARGS: ${{ needs.configure.outputs.common-maven-args }}
+    timeout-minutes: ${{matrix.timeout}}
+    strategy:
+      max-parallel: ${{ fromJson(needs.configure.outputs.config).maxParallel || 12 }}
+      fail-fast: false
+      matrix: ${{ fromJson(needs.calculate-test-jobs.outputs.otp_jvm_matrix) }}
+    steps:
+      - name: Gradle Enterprise environment
+        run: |
+          category=$(echo -n '${{matrix.category}}' | tr '[:upper:]' '[:lower:]' | tr -c '[:alnum:]-' '-' | sed -E 's/-+/-/g')
+          echo "GE_TAGS=oracle-test-pilot-${{matrix.category}}-jdk-${{matrix.java-version}}" >> "$GITHUB_ENV"
+          echo "GE_CUSTOM_VALUES=gh-job-name=Oracle Test Pilot ${{matrix.category}} - JDK ${{matrix.java-version}}" >> "$GITHUB_ENV"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Restore Maven Repository
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.m2/repository
+          key: ${{ needs.configure.outputs.m2-cache-key }}
+          restore-keys: |
+            ${{ needs.configure.outputs.m2-monthly-branch-cache-key }}-
+            ${{ needs.configure.outputs.m2-monthly-cache-key }}-
+      - name: Download previously uploaded .m2 content
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: m2-content
+          path: .
+      - name: Extract previously uploaded .m2 content
+        run: tar -xzf m2-content.tgz -C ~
+      - name: Set up JDK 17
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Setup Develocity Build Scan capture
+        uses: gradle/develocity-actions/setup-maven@974e8dbcbda40db6828fc35f349c80a7c0e71529 # v2.1
+        with:
+          capture-strategy: ON_DEMAND
+          job-name: "Oracle Test Pilot ${{matrix.category}} - JDK ${{matrix.java-version}}"
+          add-pr-comment: false
+          add-job-summary: false
+          develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          develocity-token-expiry: 6
+      - name: Create Oracle Test Pilot Database
+        id: create_database
+        # TODO Oracle Test Pilot DB creation
+        run: |
+          PASSWORD=Oracle23
+          echo "::add-mask::$PASSWORD"
+          echo "database_password=${PASSWORD}" >> $GITHUB_OUTPUT
+          echo "connection_string_suffix=localhost:1521/freepdb1" >> $GITHUB_OUTPUT
+          docker run --name oracle -d -p 1521:1521 -e ORACLE_PASSWORD=Oracle23Admin \
+            -e APP_USER=quarkus_test \
+            -e APP_USER_PASSWORD=$PASSWORD \
+            --health-cmd healthcheck.sh \
+            --health-interval 5s \
+            --health-timeout 5s \
+            --health-retries 10 \
+            docker.io/gvenzl/oracle-free:23
+          HEALTHSTATUS=""
+          TIMEOUT=300
+          ELAPSED=0
+          until [ "$HEALTHSTATUS" == "healthy" ];
+          do
+          if [ $ELAPSED -ge $TIMEOUT ]; then
+          echo "Timeout waiting for Oracle Free to start after ${TIMEOUT}s"
+          echo "Container logs:"
+          docker logs oracle
+          exit 1
+          fi
+          echo "Waiting for Oracle Free to start... (${ELAPSED}s/${TIMEOUT}s)"
+          sleep 5
+          ELAPSED=$((ELAPSED + 5))
+          HEALTHSTATUS="`docker inspect -f '{{.State.Health.Status}}' oracle`"
+          HEALTHSTATUS=${HEALTHSTATUS##+( )} #Remove longest matching series of spaces from the front
+          HEALTHSTATUS=${HEALTHSTATUS%%+( )} #Remove longest matching series of spaces from the back
+          done
+          sleep 2;
+          echo "Oracle successfully started"
+      #        uses: oracle-actions/setup-testpilot@f620f11f9f26dacfe80ba1823342e3e92604c55f # v1.0.23
+      #        with:
+      #          oci-service: ${{ matrix.category }}
+      #          action: create
+      #          user: quarkus_test
+      - name: Build
+        env:
+          # Begin OTP setup
+          TESTPILOT_MAVEN_ARGS: >-
+            -Doracle.jdbc.url=jdbc:oracle:thin:@${{ steps.create_database.outputs.connection_string_suffix }}?oracle.jdbc.enableQueryResultCache=false
+            -Doracle.reactive.url=vertx-reactive:oracle:thin:@${{ steps.create_database.outputs.connection_string_suffix }}?oracle.jdbc.enableQueryResultCache=false
+            -Doracle.username=quarkus_test
+            -Doracle.password=${{ steps.create_database.outputs.database_password }}
+          RDBMS: ${{ matrix.category }} # TODO may be useless?
+          RUNID: ${{ github.run_number }} # TODO may be useless?
+          API_HOST: "" # TODO may be useless?
+          TESTPILOT_CLIENT_ID: "" # TODO may be useless?
+          TESTPILOT_TOKEN: "" # TODO may be useless?
+          # Needed for TFO (TCP fast open)
+          # TODO uncomment once running on actual testpilot machines
+          #LD_PRELOAD: /home/ubuntu/libtfojdbc1.so
+          #LD_LIBRARY_PATH: /home/ubuntu
+          # End OTP setup
+          TEST_MODULES: ${{matrix.test-modules}}
+          CAPTURE_BUILD_SCAN: true
+        run: |
+          export LANG=en_US && ./mvnw $COMMON_MAVEN_ARGS $COMMON_TEST_MAVEN_ARGS $PTS_MAVEN_ARGS \
+            $JVM_TEST_MAVEN_ARGS $TESTPILOT_MAVEN_ARGS \
+            -f integration-tests -pl "$TEST_MODULES" \
+            clean install
+      - name: Delete Oracle Test Pilot Database
+        if: always()
+        # TODO Oracle Test Pilot DB deletion
+        run: docker rm -f oracle || true
+      #        uses: oracle-actions/setup-testpilot@f620f11f9f26dacfe80ba1823342e3e92604c55f # v1.0.23
+      #        with:
+      #          oci-service: ${{ matrix.category }}
+      #          action: delete
+      #          user: quarkus_test_1
+      - name: Prepare build reports archive
+        if: always()
+        run: |
+          7z a -tzip build-reports.zip -r \
+              'integration-tests/**/target/*-reports/TEST-*.xml' \
+              'integration-tests/**/target/build-report.json' \
+              'integration-tests/**/target/gradle-build-scan-url.txt' \
+              LICENSE
+      - name: Upload build reports
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        if: always()
+        with:
+          name: "build-reports-${{ github.run_attempt }}-Oracle Test Pilot ${{matrix.category}} - JDK ${{matrix.java-version}}"
+          path: |
+            build-reports.zip
+          retention-days: 7
+
+  oracle-test-pilot-native-tests:
+    name: "Oracle Test Pilot ${{matrix.category}} - Native"
+    # TODO use Oracle Test Pilot runners
+    runs-on: ubuntu-latest
+    # Shared environment: make extra sure not to leak a GitHub token with any permission.
+    permissions: {}
+    needs: [configure, build-jdk17, calculate-test-jobs]
+    # TODO Oracle Test Pilot involves specific runners that are only available in the main repo; prepend "github.repository == 'quarkusio/quarkus' &&"
+    if: needs.calculate-test-jobs.outputs.otp_native_matrix != '{}'
+    env:
+      COMMON_MAVEN_ARGS: ${{ needs.configure.outputs.common-maven-args }}
+    timeout-minutes: ${{matrix.timeout}}
+    strategy:
+      max-parallel: ${{ fromJson(needs.configure.outputs.config).maxParallel || 12 }}
+      fail-fast: false
+      matrix: ${{ fromJson(needs.calculate-test-jobs.outputs.otp_native_matrix) }}
+    steps:
+      - name: Gradle Enterprise environment
+        run: |
+          category=$(echo -n '${{matrix.category}}' | tr '[:upper:]' '[:lower:]' | tr -c '[:alnum:]-' '-' | sed -E 's/-+/-/g')
+          echo "GE_TAGS=oracle-test-pilot-${{matrix.category}}-native" >> "$GITHUB_ENV"
+          echo "GE_CUSTOM_VALUES=gh-job-name=Oracle Test Pilot ${{matrix.category}} - Native" >> "$GITHUB_ENV"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Restore Maven Repository
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.m2/repository
+          key: ${{ needs.configure.outputs.m2-cache-key }}
+          restore-keys: |
+            ${{ needs.configure.outputs.m2-monthly-branch-cache-key }}-
+            ${{ needs.configure.outputs.m2-monthly-cache-key }}-
+      - name: Download previously uploaded .m2 content
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: m2-content
+          path: .
+      - name: Extract previously uploaded .m2 content
+        run: tar -xzf m2-content.tgz -C ~
+      - name: Setup GraalVM
+        id: setup-graalvm
+        uses: graalvm/setup-graalvm@60c26726de13f8b90771df4bc1641a52a3159994 # v1.5.2
+        with:
+          version: 'mandrel-latest'
+          java-version: '25'
+          distribution: 'mandrel'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      # We do this so we can get better analytics for the downloaded version of the build images
+      - name: Update Docker Client User Agent
+        run: |
+          if [ -f ~/.docker/config.json ]; then
+            cat <<< $(jq '.HttpHeaders += {"User-Agent": "Quarkus-CI-Docker-Client"}' ~/.docker/config.json) > ~/.docker/config.json
+          fi
+      - name: Setup Develocity Build Scan capture
+        uses: gradle/develocity-actions/setup-maven@974e8dbcbda40db6828fc35f349c80a7c0e71529 # v2.1
+        with:
+          capture-strategy: ON_DEMAND
+          job-name: "Oracle Test Pilot ${{matrix.category}} - Native"
+          add-pr-comment: false
+          add-job-summary: false
+          develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          develocity-token-expiry: 6
+      - name: Create Oracle Test Pilot Database
+        id: create_database
+      # TODO Oracle Test Pilot DB creation
+        run: |
+          PASSWORD=Oracle23
+          echo "::add-mask::$PASSWORD"
+          echo "database_password=${PASSWORD}" >> $GITHUB_OUTPUT
+          echo "connection_string_suffix=localhost:1521/freepdb1" >> $GITHUB_OUTPUT
+          docker run --name oracle -d -p 1521:1521 -e ORACLE_PASSWORD=Oracle23Admin \
+            -e APP_USER=quarkus_test \
+            -e APP_USER_PASSWORD=$PASSWORD \
+            --health-cmd healthcheck.sh \
+            --health-interval 5s \
+            --health-timeout 5s \
+            --health-retries 10 \
+            docker.io/gvenzl/oracle-free:23
+          HEALTHSTATUS=""
+          TIMEOUT=300
+          ELAPSED=0
+          until [ "$HEALTHSTATUS" == "healthy" ];
+          do
+          if [ $ELAPSED -ge $TIMEOUT ]; then
+          echo "Timeout waiting for Oracle Free to start after ${TIMEOUT}s"
+          echo "Container logs:"
+          docker logs oracle
+          exit 1
+          fi
+          echo "Waiting for Oracle Free to start... (${ELAPSED}s/${TIMEOUT}s)"
+          sleep 5
+          ELAPSED=$((ELAPSED + 5))
+          HEALTHSTATUS="`docker inspect -f '{{.State.Health.Status}}' oracle`"
+          HEALTHSTATUS=${HEALTHSTATUS##+( )} #Remove longest matching series of spaces from the front
+          HEALTHSTATUS=${HEALTHSTATUS%%+( )} #Remove longest matching series of spaces from the back
+          done
+          sleep 2;
+          echo "Oracle successfully started"
+#        uses: oracle-actions/setup-testpilot@f620f11f9f26dacfe80ba1823342e3e92604c55f # v1.0.23
+#        with:
+#          oci-service: ${{ matrix.category }}
+#          action: create
+#          user: quarkus_test
+      - name: Build
+        env:
+          # Begin OTP setup
+          TESTPILOT_MAVEN_ARGS: >-
+            -Doracle.jdbc.url=jdbc:oracle:thin:@${{ steps.create_database.outputs.connection_string_suffix }}?oracle.jdbc.enableQueryResultCache=false
+            -Doracle.reactive.url=vertx-reactive:oracle:thin:@${{ steps.create_database.outputs.connection_string_suffix }}?oracle.jdbc.enableQueryResultCache=false
+            -Doracle.username=quarkus_test
+            -Doracle.password=${{ steps.create_database.outputs.database_password }}
+          RDBMS: ${{ matrix.category }} # TODO may be useless?
+          RUNID: ${{ github.run_number }} # TODO may be useless?
+          API_HOST: "" # TODO may be useless?
+          TESTPILOT_CLIENT_ID: "" # TODO may be useless?
+          TESTPILOT_TOKEN: "" # TODO may be useless?
+          # Needed for TFO (TCP fast open)
+          # TODO uncomment once running on actual testpilot machines
+          #LD_PRELOAD: /home/ubuntu/libtfojdbc1.so
+          #LD_LIBRARY_PATH: /home/ubuntu
+          # End OTP setup
+          TEST_MODULES: ${{matrix.test-modules}}
+          CONTAINER_BUILD: false # Docker is not available on Test Pilot
+          CAPTURE_BUILD_SCAN: true
+        run: |
+          export LANG=en_US && ./mvnw $COMMON_MAVEN_ARGS $COMMON_TEST_MAVEN_ARGS $PTS_MAVEN_ARGS \
+            $TESTPILOT_MAVEN_ARGS $NATIVE_TEST_MAVEN_ARGS -Dquarkus.native.container-build=false \
+            -f integration-tests -pl "$TEST_MODULES"
+      - name: Delete Oracle Test Pilot Database
+        if: always()
+      # TODO Oracle Test Pilot DB deletion
+        run: docker rm -f oracle || true
+#        uses: oracle-actions/setup-testpilot@f620f11f9f26dacfe80ba1823342e3e92604c55f # v1.0.23
+#        with:
+#          oci-service: ${{ matrix.category }}
+#          action: delete
+#          user: quarkus_test_1
+      - name: Prepare build reports archive
+        if: always()
+        run: |
+          7z a -tzip build-reports.zip -r \
+              'integration-tests/**/target/*-reports/TEST-*.xml' \
+              'integration-tests/**/target/build-report.json' \
+              'integration-tests/**/target/gradle-build-scan-url.txt' \
+              LICENSE
+      - name: Upload build reports
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        if: always()
+        with:
+          name: "build-reports-${{ github.run_attempt }}-Oracle Test Pilot ${{matrix.category}} - Native"
+          path: |
+            build-reports.zip
+          retention-days: 7
+
   build-report:
     runs-on: ubuntu-latest
     name: Build report
-    needs: [configure,build-jdk17,jvm-tests,maven-tests,gradle-tests,devtools-tests,kubernetes-tests,quickstarts-tests,platform-tests,tcks-test,native-tests,virtual-thread-native-tests]
+    needs: [configure,build-jdk17,jvm-tests,maven-tests,gradle-tests,devtools-tests,kubernetes-tests,quickstarts-tests,platform-tests,tcks-test,native-tests,virtual-thread-native-tests,oracle-test-pilot-jvm-tests,oracle-test-pilot-native-tests]
     if: always() && needs.configure.outputs.run-ci-build == 'true'
     steps:
       - uses: runs-on/action@15385172809cc0346c6821b00c3c3dd2598785b4 # v2.1.0

--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -1787,7 +1787,7 @@ jobs:
         id: create_database
         uses: oracle-actions/setup-testpilot@f620f11f9f26dacfe80ba1823342e3e92604c55f # v1.0.23
         with:
-          oci-service: ${{ matrix.category }}
+          oci-service: ${{ matrix.oci-service }}
           action: create
           user: quarkus_test
       - name: Build
@@ -1796,7 +1796,6 @@ jobs:
           TESTPILOT_USERNAME: quarkus_test_${{ github.run_number }}
           TESTPILOT_PASSWORD: ${{ steps.create_database.outputs.database_password }}
           TESTPILOT_CONNECTION_STRING_SUFFIX_WDQ: ${{ steps.create_database.outputs.connection_string_suffix }}
-          RDBMS: ${{ matrix.category }}
           RUNID: ${{ github.run_number }}
           API_HOST: ""
           TESTPILOT_CLIENT_ID: ""
@@ -1822,7 +1821,7 @@ jobs:
         if: always() && steps.create_database.outcome == 'success'
         uses: oracle-actions/setup-testpilot@f620f11f9f26dacfe80ba1823342e3e92604c55f # v1.0.23
         with:
-          oci-service: ${{ matrix.category }}
+          oci-service: ${{ matrix.oci-service }}
           action: delete
           user: quarkus_test
       - name: Prepare build reports archive
@@ -1907,7 +1906,7 @@ jobs:
         id: create_database
         uses: oracle-actions/setup-testpilot@f620f11f9f26dacfe80ba1823342e3e92604c55f # v1.0.23
         with:
-          oci-service: ${{ matrix.category }}
+          oci-service: ${{ matrix.oci-service }}
           action: create
           user: quarkus_test
       - name: Build
@@ -1916,7 +1915,6 @@ jobs:
           TESTPILOT_USERNAME: quarkus_test_${{ github.run_number }}
           TESTPILOT_PASSWORD: ${{ steps.create_database.outputs.database_password }}
           TESTPILOT_CONNECTION_STRING_SUFFIX_WDQ: ${{ steps.create_database.outputs.connection_string_suffix }}
-          RDBMS: ${{ matrix.category }}
           RUNID: ${{ github.run_number }}
           API_HOST: ""
           TESTPILOT_CLIENT_ID: ""
@@ -1942,7 +1940,7 @@ jobs:
         if: always() && steps.create_database.outcome == 'success'
         uses: oracle-actions/setup-testpilot@f620f11f9f26dacfe80ba1823342e3e92604c55f # v1.0.23
         with:
-          oci-service: ${{ matrix.category }}
+          oci-service: ${{ matrix.oci-service }}
           action: delete
           user: quarkus_test
       - name: Prepare build reports archive

--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -1932,7 +1932,7 @@ jobs:
             -Doracle.reactive.url=vertx-reactive:oracle:thin:@${TESTPILOT_CONNECTION_STRING_SUFFIX} \
             -Doracle.username=${TESTPILOT_USERNAME} \
             -Doracle.password=${TESTPILOT_PASSWORD} \
-            $NATIVE_TEST_MAVEN_ARGS -Dquarkus.native.container-build=false \
+            $NATIVE_TEST_MAVEN_ARGS -Dquarkus.native.container-build=false -Dquarkus.native.native-image-xmx=16g \
             -f integration-tests -pl "$TEST_MODULES"
       - name: Delete Oracle Test Pilot Database
         id: delete_database

--- a/.github/workflows/jdk-early-access-build.yml
+++ b/.github/workflows/jdk-early-access-build.yml
@@ -27,9 +27,6 @@ env:
   LANG: en_US.UTF-8
   MAVEN_OPTS: -Xmx2g -XX:MaxMetaspaceSize=1g
   JVM_TEST_MAVEN_OPTS: "-e -B --settings .github/mvn-settings.xml -Dtest-containers -Dstart-containers -Dtest-resteasy-reactive-large-files -Dquarkus.test.rest-assured.enable-logging-on-failure=false -Dformat.skip"
-  DB_USER: hibernate_orm_test
-  DB_PASSWORD: hibernate_orm_test
-  DB_NAME: hibernate_orm_test
   MVNW_REPOURL: https://maven-central.storage-download.googleapis.com/maven2
 jobs:
   linux-jvm-test:

--- a/.github/workflows/native-it-selected-graalvm.yml
+++ b/.github/workflows/native-it-selected-graalvm.yml
@@ -40,9 +40,6 @@ env:
   NATIVE_TEST_MAVEN_ARGS: "-Dtest-containers -Dstart-containers -Dquarkus.native.native-image-xmx=6g -Dnative -Dnative.surefire.skip -Dno-descriptor-tests clean install -DskipDocs"
   JVM_TEST_MAVEN_ARGS: "-Dtest-containers -Dstart-containers -Dquarkus.test.hang-detection-timeout=60"
   PTS_MAVEN_ARGS: "-Ddevelocity.pts.enabled=${{ github.event_name == 'pull_request' && github.base_ref == 'main' && 'true' || 'false' }}"
-  DB_USER: hibernate_orm_test
-  DB_PASSWORD: hibernate_orm_test
-  DB_NAME: hibernate_orm_test
   PULL_REQUEST_NUMBER: ${{ github.event.number }}
   MVNW_REPOURL: https://maven-central.storage-download.googleapis.com/maven2
 

--- a/.github/workflows/podman-build.yml
+++ b/.github/workflows/podman-build.yml
@@ -15,9 +15,6 @@ env:
   COMMON_MAVEN_ARGS: "-e -B --settings .github/mvn-settings.xml --fail-at-end"
   NATIVE_TEST_MAVEN_ARGS: "-Dtest-containers -Dstart-containers -Dquarkus.native.native-image-xmx=5g -Dnative -Dnative.surefire.skip -Dformat.skip -Dno-descriptor-tests install -DskipDocs"
   JVM_TEST_MAVEN_ARGS: "-Dtest-containers -Dstart-containers -Dformat.skip -DskipDocs -Dquarkus.test.hang-detection-timeout=60"
-  DB_USER: hibernate_orm_test
-  DB_PASSWORD: hibernate_orm_test
-  DB_NAME: hibernate_orm_test
   IS_PODMAN: "true"
   MVNW_REPOURL: https://maven-central.storage-download.googleapis.com/maven2
 

--- a/integration-tests/hibernate-reactive-oracle/pom.xml
+++ b/integration-tests/hibernate-reactive-oracle/pom.xml
@@ -13,6 +13,12 @@
     <name>Quarkus - Integration Tests - Hibernate Reactive - Oracle</name>
     <description>Hibernate Reactive related tests running with the Oracle database</description>
 
+    <properties>
+        <oracle.reactive.url/><!-- Default URL is empty, meaning we'll use dev services -->
+        <oracle.username/>
+        <oracle.password/>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -160,6 +166,36 @@
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <skip>false</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>test-oracle-external</id>
+            <activation>
+                <property>
+                    <name>oracle.reactive.url</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                            <systemPropertyVariables combine.children="append">
+                                <quarkus.test.profile>test,external-db</quarkus.test.profile>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                            <systemPropertyVariables combine.children="append">
+                                <quarkus.test.profile>prod,external-db</quarkus.test.profile>
+                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/integration-tests/hibernate-reactive-oracle/src/main/resources/application.properties
+++ b/integration-tests/hibernate-reactive-oracle/src/main/resources/application.properties
@@ -2,6 +2,11 @@ quarkus.datasource.db-kind=oracle
 
 # Reactive config
 quarkus.datasource.reactive=true
+# When this profile is set (opt-in), we will use an external DB instead of dev services (the default).
+%external-db.quarkus.datasource.reactive.url=${oracle.reactive.url}
+%external-db.quarkus.datasource.username=${oracle.username}
+%external-db.quarkus.datasource.password=${oracle.password}
+%external-db.quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
 quarkus.security.users.embedded.enabled=true
 quarkus.security.users.embedded.users.scott=jb0ss

--- a/integration-tests/jpa-oracle/pom.xml
+++ b/integration-tests/jpa-oracle/pom.xml
@@ -13,6 +13,12 @@
     <name>Quarkus - Integration Tests - JPA - Oracle</name>
     <description>Module that contains JPA related tests running with the Oracle database</description>
 
+    <properties>
+        <oracle.jdbc.url/><!-- Default is empty, meaning we'll use dev services -->
+        <oracle.username/>
+        <oracle.password/>
+    </properties>
+
     <dependencies>
         <!-- Enables the JPA capabilities -->
         <dependency>
@@ -169,6 +175,36 @@
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <skip>false</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>test-oracle-external</id>
+            <activation>
+                <property>
+                    <name>oracle.jdbc.url</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                            <systemPropertyVariables combine.children="append">
+                                <quarkus.test.profile>test,external-db</quarkus.test.profile>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                            <systemPropertyVariables combine.children="append">
+                                <quarkus.test.profile>prod,external-db</quarkus.test.profile>
+                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/integration-tests/jpa-oracle/src/main/resources/application.properties
+++ b/integration-tests/jpa-oracle/src/main/resources/application.properties
@@ -1,5 +1,10 @@
 quarkus.datasource.db-kind=oracle
 quarkus.datasource.jdbc.additional-jdbc-properties."oracle.jdbc.timezoneAsRegion"=false
+# When this profile is set (opt-in), we will use an external DB instead of dev services (the default).
+%external-db.quarkus.datasource.jdbc.url=${oracle.jdbc.url}
+%external-db.quarkus.datasource.username=${oracle.username}
+%external-db.quarkus.datasource.password=${oracle.password}
+%external-db.quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
 quarkus.datasource.ldap.db-kind=oracle
 quarkus.datasource.ldap.username=SYSTEM

--- a/integration-tests/reactive-oracle-client/pom.xml
+++ b/integration-tests/reactive-oracle-client/pom.xml
@@ -14,6 +14,12 @@
 
     <name>Quarkus - Integration Tests - Reactive Oracle Client</name>
 
+    <properties>
+        <oracle.reactive.url/><!-- Default URL is empty, meaning we'll use dev services -->
+        <oracle.username/>
+        <oracle.password/>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -135,6 +141,36 @@
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <skip>false</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>test-oracle-external</id>
+            <activation>
+                <property>
+                    <name>oracle.reactive.url</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                            <systemPropertyVariables combine.children="append">
+                                <quarkus.test.profile>test,external-db</quarkus.test.profile>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                            <systemPropertyVariables combine.children="append">
+                                <quarkus.test.profile>prod,external-db</quarkus.test.profile>
+                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/integration-tests/reactive-oracle-client/src/main/resources/application.properties
+++ b/integration-tests/reactive-oracle-client/src/main/resources/application.properties
@@ -1,4 +1,9 @@
 quarkus.datasource.db-kind=oracle
+# When this profile is set (opt-in), we will use an external DB instead of dev services (the default).
+%external-db.quarkus.datasource.reactive.url=${oracle.reactive.url}
+%external-db.quarkus.datasource.username=${oracle.username}
+%external-db.quarkus.datasource.password=${oracle.password}
+%external-db.quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 #Uncomment to connect over SSL/TLS
 #quarkus.datasource.reactive.trust-all=true
 #quarkus.datasource.reactive.mssql.ssl=true


### PR DESCRIPTION
This enables running our existing (limited) tests against multiple versions of Oracle.

I think it's especially relevant in native mode, where connecting to a different version of Oracle can possibly take us through different codepath in the JDBC driver.

----

Thanks a lot to @loiclefevre for making this possible.

Opening as draft because we'll need to configure the runners before this PR can run, and because we have some onboarding tasks first. See https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/Oracle.20Test.20Pilot/near/594590247

When [run in a test organization with appropriate runners](), tests were green for 26ai (the only version supported in the dev cluster):

<img width="829" height="95" alt="image" src="https://github.com/user-attachments/assets/c740e51a-c3f8-4bee-bf91-4f30bd9a802a" />

We know the tests were correctly hitting the test pilot DB because... test pilot runners conveniently don't include docker, so we couldn't possibly have been using dev services :]
