### PR TITLE
Apply security provider specific configuration at runtime

### DIFF
--- a/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityProcessor.java
+++ b/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityProcessor.java
@@ -295,6 +295,15 @@ public class SecurityProcessor {
     }
 
     @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void configureJCAProvidersAtRuntime(SecurityProviderRecorder recorder,
+            List<JCAProviderBuildItem> jcaProviders) {
+        for (JCAProviderBuildItem provider : jcaProviders) {
+            recorder.configureProvider(provider.getProviderName(), provider.getProviderConfig());
+        }
+    }
+
+    @BuildStep
     void prepareBouncyCastleProviders(CurateOutcomeBuildItem curateOutcomeBuildItem,
             BuildProducer<ReflectiveClassBuildItem> reflection,
             BuildProducer<RuntimeInitializedClassBuildItem> runtimeReInitialized,

--- a/extensions/security/deployment/src/test/java/io/quarkus/security/test/InvalidSunPKCS11ConfigTest.java
+++ b/extensions/security/deployment/src/test/java/io/quarkus/security/test/InvalidSunPKCS11ConfigTest.java
@@ -1,0 +1,24 @@
+package io.quarkus.security.test;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class InvalidSunPKCS11ConfigTest {
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .assertException(throwable -> {
+                Assertions.assertTrue(throwable instanceof ConfigurationException);
+                Assertions.assertTrue(throwable.getMessage().contains("SunPKCS11"));
+            })
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("application-invalid-sunpkcs11-config.properties", "application.properties"));
+
+    @Test
+    void shouldThrow() {
+        Assertions.fail("A ConfigurationException should have been thrown due to invalid SunPKCS11 configuration");
+    }
+}

--- a/extensions/security/deployment/src/test/resources/application-invalid-sunpkcs11-config.properties
+++ b/extensions/security/deployment/src/test/resources/application-invalid-sunpkcs11-config.properties
@@ -1,0 +1,2 @@
+quarkus.security.security-providers=SunPKCS11
+quarkus.security.security-provider-config.SunPKCS11=/non-existent/pkcs11.cfg

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/SecurityProviderRecorder.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/SecurityProviderRecorder.java
@@ -10,15 +10,35 @@ import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
 import java.security.SecureRandom;
 import java.security.Security;
+import java.util.Set;
 
 import org.jboss.logging.Logger;
 
 import io.quarkus.runtime.annotations.Recorder;
+import io.quarkus.runtime.configuration.ConfigurationException;
 
 @Recorder
 public class SecurityProviderRecorder {
 
     private static final Logger LOG = Logger.getLogger(SecurityProviderRecorder.class);
+
+    public void configureProvider(String providerName, String providerConfig) {
+        Provider provider = Security.getProvider(providerName);
+        if (provider == null) {
+            throw new ConfigurationException(
+                    String.format("Security provider '%s' is not available", providerName),
+                    Set.of("quarkus.security.security-providers"));
+        }
+        if (providerConfig != null) {
+            try {
+                SecurityProviderUtils.addProvider(provider.configure(providerConfig));
+            } catch (Exception e) {
+                throw new ConfigurationException(
+                        String.format("Failed to configure security provider '%s'", providerName), e,
+                        Set.of("quarkus.security.security-provider-config." + providerName));
+            }
+        }
+    }
 
     public void addBouncyCastleProvider(boolean inFipsMode) {
         final String providerName = inFipsMode ? SecurityProviderUtils.BOUNCYCASTLE_FIPS_PROVIDER_CLASS_NAME


### PR DESCRIPTION
This PR makes sure JCA providers that have additional configurations are configured at runtime. `SunPKCS11` in particular is a bridge that would create a new configured `Provider` instance - that must be added as a security provider.

Testing it positively is hard since we'd need to build a docker image where a sudo command would be used to install SoftHSM2 and it is problematic not only for technical but also security reasons in case the sudo accesses the host somehow.

So I'm only adding a negative test for the non existent pkcs11 config that at least confirms that it was indeed SunPKCS11 provider that tried to process this configuration.

I can also confirm that with this fix, and only with
```
quarkus.security.security-providers=SunPKCS11
quarkus.security.security-provider-config.SunPKCS11=pkcs11.cfg
```

Quarkus REST endpoint can do `Keystore.getInstance("PKCS11")` and access HSM keys.

CC @DimitriFankhauser

Also CC @cescoffier. FYI, @DimitriFankhauser will follow up with Vert.x and Quarkus PRs to support HSM with TLS, this PR only fixes the existing constraint

- Fixes: #54146