### PR TITLE
Migrate custom enforcer rules to the current Maven Enforcer Plugin API

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -6758,7 +6758,7 @@
                         </goals>
                         <configuration>
                             <rules>
-                                <dependencyAlignmentRule implementation="io.quarkus.enforcer.DependencyAlignmentRule">
+                                <dependencyAlignmentRule>
                                     <referenceArtifact>org.hibernate.orm:hibernate-platform:${hibernate-orm.version}</referenceArtifact>
                                     <dependencies>
                                         <dependency>
@@ -6778,7 +6778,7 @@
                                         </dependency>
                                     </dependencies>
                                 </dependencyAlignmentRule>
-                                <dependencyAlignmentRule implementation="io.quarkus.enforcer.DependencyAlignmentRule">
+                                <dependencyAlignmentRule>
                                     <referenceArtifact>org.hibernate.orm:hibernate-spatial:${hibernate-orm.version}</referenceArtifact>
                                     <dependencies>
                                         <dependency>

--- a/core/deployment/pom.xml
+++ b/core/deployment/pom.xml
@@ -223,7 +223,7 @@
                                 <externalRules>
                                     <location>classpath:enforcer-rules/quarkus-banned-dependencies-okhttp.xml</location>
                                 </externalRules>
-                                <requiresMinimalDeploymentDependency implementation="io.quarkus.enforcer.RequiresMinimalDeploymentDependency"/>
+                                <requiresMinimalDeploymentDependency/>
                                 <bannedDependencies>
                                     <excludes>
                                         <!-- findbugs is not required at runtime -->

--- a/devtools/config-doc-maven-plugin/pom.xml
+++ b/devtools/config-doc-maven-plugin/pom.xml
@@ -74,7 +74,7 @@
             <plugin>
                 <groupId>org.eclipse.sisu</groupId>
                 <artifactId>sisu-maven-plugin</artifactId>
-                <version>0.9.0.M3</version>
+                <version>1.0.0</version>
                 <executions>
                     <execution>
                         <id>index-project</id>

--- a/devtools/maven/pom.xml
+++ b/devtools/maven/pom.xml
@@ -250,7 +250,7 @@
             <plugin>
                 <groupId>org.eclipse.sisu</groupId>
                 <artifactId>sisu-maven-plugin</artifactId>
-                <version>0.3.5</version>
+                <version>1.0.0</version>
                 <executions>
                     <execution>
                         <id>index-project</id>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -250,7 +250,7 @@
                         </goals>
                         <configuration>
                             <rules combine.children="append">
-                                <bansRuntimeDependency implementation="io.quarkus.enforcer.BansRuntimeDependency"/>
+                                <bansRuntimeDependency/>
                             </rules>
                         </configuration>
                     </execution>

--- a/independent-projects/enforcer-rules/pom.xml
+++ b/independent-projects/enforcer-rules/pom.xml
@@ -32,8 +32,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <!-- Keeping 3.0.0.M3 because 3.2.1 requires class changes -->
-        <enforcer-api.version>3.0.0-M3</enforcer-api.version>
+        <enforcer-api.version>3.6.2</enforcer-api.version>
         <maven-invoker-plugin.version>3.9.1</maven-invoker-plugin.version>
         <maven-core.version>3.9.15</maven-core.version>
         <aether.version>1.1.0</aether.version>
@@ -50,13 +49,12 @@
             <artifactId>enforcer-api</artifactId>
             <version>${enforcer-api.version}</version>
             <scope>provided</scope>
-            <!-- avoid dependencyConvergence issues -->
-            <exclusions>
-                <exclusion>
-                    <groupId>org.eclipse.sisu</groupId>
-                    <artifactId>org.eclipse.sisu.plexus</artifactId>
-                </exclusion>
-            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>1</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -70,6 +68,18 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>${maven-core.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+            <version>${maven-core.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.aether</groupId>
@@ -87,6 +97,20 @@
             </resource>
         </resources>
         <plugins>
+            <plugin>
+                <groupId>org.eclipse.sisu</groupId>
+                <artifactId>sisu-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <executions>
+                    <execution>
+                        <id>index-project</id>
+                        <goals>
+                            <goal>main-index</goal>
+                            <goal>test-index</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <artifactId>maven-invoker-plugin</artifactId>
                 <version>${maven-invoker-plugin.version}</version>

--- a/independent-projects/enforcer-rules/src/it/dependency-alignment-bom-test/pom.xml
+++ b/independent-projects/enforcer-rules/src/it/dependency-alignment-bom-test/pom.xml
@@ -52,7 +52,7 @@
                         </goals>
                         <configuration>
                             <rules>
-                                <dependencyAlignmentRule implementation="io.quarkus.enforcer.DependencyAlignmentRule">
+                                <dependencyAlignmentRule>
                                     <referenceArtifact>org.hibernate.orm:hibernate-platform:${hibernate-orm.version}</referenceArtifact>
                                     <dependencies>
                                         <dependency>

--- a/independent-projects/enforcer-rules/src/it/dependency-alignment-dependencies-test/pom.xml
+++ b/independent-projects/enforcer-rules/src/it/dependency-alignment-dependencies-test/pom.xml
@@ -44,7 +44,7 @@
                         </goals>
                         <configuration>
                             <rules>
-                                <dependencyAlignmentRule implementation="io.quarkus.enforcer.DependencyAlignmentRule">
+                                <dependencyAlignmentRule>
                                     <referenceArtifact>org.hibernate.orm:hibernate-spatial:${hibernate-orm.version}</referenceArtifact>
                                     <dependencies>
                                         <dependency>

--- a/independent-projects/enforcer-rules/src/it/smoketest/extensions/pom.xml
+++ b/independent-projects/enforcer-rules/src/it/smoketest/extensions/pom.xml
@@ -33,7 +33,7 @@
                                 </goals>
                                 <configuration>
                                     <rules>
-                                        <bansRuntimeDependency implementation="io.quarkus.enforcer.BansRuntimeDependency"/>
+                                        <bansRuntimeDependency/>
                                     </rules>
                                 </configuration>
                             </execution>

--- a/independent-projects/enforcer-rules/src/it/smoketest/integration-tests/pom.xml
+++ b/independent-projects/enforcer-rules/src/it/smoketest/integration-tests/pom.xml
@@ -29,7 +29,7 @@
                         </goals>
                         <configuration>
                             <rules>
-                                <requiresMinimalDeploymentDependency implementation="io.quarkus.enforcer.RequiresMinimalDeploymentDependency"/>
+                                <requiresMinimalDeploymentDependency/>
                             </rules>
                         </configuration>
                     </execution>

--- a/independent-projects/enforcer-rules/src/main/java/io/quarkus/enforcer/BansRuntimeDependency.java
+++ b/independent-projects/enforcer-rules/src/main/java/io/quarkus/enforcer/BansRuntimeDependency.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import javax.inject.Named;
+
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.apache.maven.model.Dependency;
@@ -12,6 +14,7 @@ import org.apache.maven.project.MavenProject;
 /**
  * Bans from a deployment module of an extension all runtime dependencies to "foreign" extensions.
  */
+@Named("bansRuntimeDependency")
 public class BansRuntimeDependency extends DeploymentDependencyRuleSupport {
 
     @Override

--- a/independent-projects/enforcer-rules/src/main/java/io/quarkus/enforcer/DependencyAlignmentRule.java
+++ b/independent-projects/enforcer-rules/src/main/java/io/quarkus/enforcer/DependencyAlignmentRule.java
@@ -4,16 +4,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+
 import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.enforcer.rule.api.EnforcerLevel;
-import org.apache.maven.enforcer.rule.api.EnforcerRule;
-import org.apache.maven.enforcer.rule.api.EnforcerRule2;
+import org.apache.maven.enforcer.rule.api.AbstractEnforcerRule;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
-import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
-import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
-import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.DefaultArtifact;
@@ -27,7 +25,8 @@ import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
  * This rule resolves a reference artifact (e.g., Hibernate Platform) and checks that the versions
  * declared in the project's dependencyManagement/dependencies sections match those in the reference artifact.
  */
-public class DependencyAlignmentRule implements EnforcerRule2 {
+@Named("dependencyAlignmentRule")
+public class DependencyAlignmentRule extends AbstractEnforcerRule {
 
     /**
      * The reference artifact to check against in the format "groupId:artifactId:version".
@@ -43,9 +42,14 @@ public class DependencyAlignmentRule implements EnforcerRule2 {
      */
     private List<DependencyAlignmentData> dependencies;
 
-    private Log logger;
+    @Inject
+    private MavenProject project;
 
-    private EnforcerLevel level = EnforcerLevel.ERROR;
+    @Inject
+    private MavenSession session;
+
+    @Inject
+    private RepositorySystem repositorySystem;
 
     public void setReferenceArtifact(String referenceArtifact) {
         this.referenceArtifact = referenceArtifact;
@@ -56,25 +60,14 @@ public class DependencyAlignmentRule implements EnforcerRule2 {
     }
 
     @Override
-    public EnforcerLevel getLevel() {
-        return level;
-    }
-
-    public void setLevel(EnforcerLevel level) {
-        this.level = level;
-    }
-
-    @Override
-    public void execute(EnforcerRuleHelper helper) throws EnforcerRuleException {
-        logger = helper.getLog();
-
+    public void execute() throws EnforcerRuleException {
         // Validate configuration
         if (referenceArtifact == null || referenceArtifact.trim().isEmpty()) {
             throw new EnforcerRuleException(
                     "referenceArtifact must be configured (e.g., 'org.hibernate.orm:hibernate-platform:7.3.0.Final')");
         }
         if (dependencies == null || dependencies.isEmpty()) {
-            logger.warn("No dependencies configured for alignment check");
+            getLog().warn("No dependencies configured for alignment check");
             return;
         }
 
@@ -88,22 +81,9 @@ public class DependencyAlignmentRule implements EnforcerRule2 {
         String referenceArtifactId = parts[1];
         String referenceVersion = parts[2];
 
-        logger.debug("Checking alignment with " + referenceArtifact);
+        getLog().debug("Checking alignment with " + referenceArtifact);
 
-        MavenProject project;
-        RepositorySystem repositorySystem;
-        RepositorySystemSession repositorySession;
-
-        try {
-            // With the old enforcer API (3.0.0-M3), we need to use evaluate() to get the project and session
-            // The newer API (3.2.1+) would allow cleaner dependency injection with @Inject
-            project = (MavenProject) helper.evaluate("${project}");
-            repositorySystem = helper.getComponent(RepositorySystem.class);
-            // RepositorySystemSession is not available via helper methods, must use property evaluation
-            repositorySession = (RepositorySystemSession) helper.evaluate("${repositorySystemSession}");
-        } catch (ExpressionEvaluationException | ComponentLookupException e) {
-            throw new EnforcerRuleException("Failed to get Maven components from context", e);
-        }
+        RepositorySystemSession repositorySession = session.getRepositorySession();
 
         // Get remote repositories directly from the project (no need for property evaluation)
         var remoteRepositories = project.getRemoteArtifactRepositories();
@@ -135,7 +115,7 @@ public class DependencyAlignmentRule implements EnforcerRule2 {
                     errors.append("  - Artifact '%s' not found in project's dependencyManagement or dependencies\n"
                             .formatted(artifact));
                 } else {
-                    logger.debug("Artifact '%s' not found in project (skipping)".formatted(artifact));
+                    getLog().debug("Artifact '%s' not found in project (skipping)".formatted(artifact));
                 }
                 continue;
             }
@@ -147,7 +127,7 @@ public class DependencyAlignmentRule implements EnforcerRule2 {
                             but reference artifact expects '%s'
                         """.formatted(artifact, actualVersion, expectedVersion));
             } else {
-                logger.debug("✓ %s version %s is aligned".formatted(artifact, actualVersion));
+                getLog().debug("✓ %s version %s is aligned".formatted(artifact, actualVersion));
             }
         }
 
@@ -174,7 +154,7 @@ public class DependencyAlignmentRule implements EnforcerRule2 {
                     versions.put(key, dep.getVersion());
                 }
             });
-            logger.debug("Extracted " + versions.size() + " dependencies from project's dependencyManagement");
+            getLog().debug("Extracted " + versions.size() + " dependencies from project's dependencyManagement");
         }
 
         // Also check dependencies section for artifacts not in dependencyManagement
@@ -189,11 +169,12 @@ public class DependencyAlignmentRule implements EnforcerRule2 {
                 }
             }
             if (dependenciesAdded > 0) {
-                logger.debug("Extracted " + dependenciesAdded + " additional dependencies from project's dependencies section");
+                getLog().debug(
+                        "Extracted " + dependenciesAdded + " additional dependencies from project's dependencies section");
             }
         }
 
-        logger.debug("Total: " + versions.size() + " dependencies extracted from project");
+        getLog().debug("Total: " + versions.size() + " dependencies extracted from project");
         return versions;
     }
 
@@ -234,7 +215,7 @@ public class DependencyAlignmentRule implements EnforcerRule2 {
 
             var descriptorResult = repositorySystem.readArtifactDescriptor(repositorySession, descriptorRequest);
 
-            logger.debug("Resolved reference artifact: " + artifact);
+            getLog().debug("Resolved reference artifact: " + artifact);
 
             var versions = new HashMap<String, String>();
 
@@ -245,7 +226,7 @@ public class DependencyAlignmentRule implements EnforcerRule2 {
                         .map(org.eclipse.aether.graph.Dependency::getArtifact)
                         .filter(a -> a.getVersion() != null && !a.getVersion().isEmpty())
                         .forEach(a -> versions.put(a.getGroupId() + ":" + a.getArtifactId(), a.getVersion()));
-                logger.debug("Extracted %d managed dependencies".formatted(managedDeps.size()));
+                getLog().debug("Extracted %d managed dependencies".formatted(managedDeps.size()));
             }
 
             // Extract regular dependencies (from dependencies section) for those not in managedDependencies
@@ -258,33 +239,18 @@ public class DependencyAlignmentRule implements EnforcerRule2 {
                         .peek(a -> versions.put(a.getGroupId() + ":" + a.getArtifactId(), a.getVersion()))
                         .count();
                 if (dependenciesAdded > 0) {
-                    logger.debug("Extracted %d additional dependencies from dependencies section"
+                    getLog().debug("Extracted %d additional dependencies from dependencies section"
                             .formatted(dependenciesAdded));
                 }
             }
 
-            logger.debug("Total: %d dependencies extracted from reference artifact".formatted(versions.size()));
+            getLog().debug("Total: %d dependencies extracted from reference artifact".formatted(versions.size()));
             return versions;
 
         } catch (ArtifactDescriptorException e) {
             throw new EnforcerRuleException(
                     "Failed to resolve reference artifact " + groupId + ":" + artifactId + ":" + version, e);
         }
-    }
-
-    @Override
-    public boolean isCacheable() {
-        return false;
-    }
-
-    @Override
-    public boolean isResultValid(EnforcerRule cachedRule) {
-        return false;
-    }
-
-    @Override
-    public String getCacheId() {
-        return null;
     }
 
     @Override

--- a/independent-projects/enforcer-rules/src/main/java/io/quarkus/enforcer/DeploymentDependencyRuleSupport.java
+++ b/independent-projects/enforcer-rules/src/main/java/io/quarkus/enforcer/DeploymentDependencyRuleSupport.java
@@ -15,18 +15,15 @@ import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
-import org.apache.maven.artifact.Artifact;
-import org.apache.maven.enforcer.rule.api.EnforcerLevel;
-import org.apache.maven.enforcer.rule.api.EnforcerRule;
-import org.apache.maven.enforcer.rule.api.EnforcerRule2;
-import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
-import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
-import org.apache.maven.model.Dependency;
-import org.apache.maven.plugin.logging.Log;
-import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
+import javax.inject.Inject;
 
-public abstract class DeploymentDependencyRuleSupport implements EnforcerRule2 {
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.enforcer.rule.api.AbstractEnforcerRule;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.project.MavenProject;
+
+public abstract class DeploymentDependencyRuleSupport extends AbstractEnforcerRule {
 
     protected static final String GROUP_ID_PREFIX = "io.quarkus";
     protected static final String DEPLOYMENT_ARTIFACT_ID_SUFFIX = "-deployment";
@@ -34,30 +31,11 @@ public abstract class DeploymentDependencyRuleSupport implements EnforcerRule2 {
     private static final String EXT_PROPERTIES_PATH = "META-INF/quarkus-extension.properties";
     private static final Map<String, Optional<String>> DEPLOYMENT_GAV_CACHE = new ConcurrentHashMap<>();
 
-    protected Log logger;
-
-    private EnforcerLevel level = EnforcerLevel.ERROR;
-
-    @Override
-    public final EnforcerLevel getLevel() {
-        return level;
-    }
-
-    public final void setLevel(EnforcerLevel level) {
-        this.level = level;
-    }
+    @Inject
+    private MavenProject project;
 
     @Override
-    public final void execute(EnforcerRuleHelper helper) throws EnforcerRuleException {
-        logger = helper.getLog();
-
-        MavenProject project;
-        try {
-            project = (MavenProject) helper.evaluate("${project}");
-        } catch (ExpressionEvaluationException e) {
-            throw new IllegalStateException("Failed to get project from EnforcerRuleHelper", e);
-        }
-
+    public final void execute() throws EnforcerRuleException {
         if (!isCheckRequired(project)) {
             return;
         }
@@ -78,7 +56,7 @@ public abstract class DeploymentDependencyRuleSupport implements EnforcerRule2 {
         // To avoid this "soft exit", explicit resolving would be necessary but that is pretty elaborate in an enforcer rule.
         // If the build goal is "late" enough, artifacts for the respective scope *will* be resolved automatically.
         if (nonDeploymentArtifactsByGAV.values().stream().anyMatch(artifact -> !artifact.isResolved())) {
-            logger.warn("Skipping rule " + RequiresMinimalDeploymentDependency.class.getSimpleName()
+            getLog().warn("Skipping rule " + RequiresMinimalDeploymentDependency.class.getSimpleName()
                     + ": Artifacts are not resolved, consider using a later build goal like 'package'.");
             return;
         }
@@ -145,20 +123,5 @@ public abstract class DeploymentDependencyRuleSupport implements EnforcerRule2 {
 
     protected boolean isCheckRequired(MavenProject project) {
         return true;
-    }
-
-    @Override
-    public final boolean isCacheable() {
-        return false;
-    }
-
-    @Override
-    public final boolean isResultValid(EnforcerRule cachedRule) {
-        return false;
-    }
-
-    @Override
-    public final String getCacheId() {
-        return null;
     }
 }

--- a/independent-projects/enforcer-rules/src/main/java/io/quarkus/enforcer/RequiresMinimalDeploymentDependency.java
+++ b/independent-projects/enforcer-rules/src/main/java/io/quarkus/enforcer/RequiresMinimalDeploymentDependency.java
@@ -9,6 +9,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.inject.Named;
+
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.apache.maven.model.Dependency;
@@ -18,6 +20,7 @@ import org.apache.maven.project.MavenProject;
  * Enforces that for each direct "runtime" dependency the current project also defines a direct minimal "*-deployment"
  * dependency to produce a consistent build order.
  */
+@Named("requiresMinimalDeploymentDependency")
 public class RequiresMinimalDeploymentDependency extends DeploymentDependencyRuleSupport {
 
     private static final String REQ_TYPE = "pom";

--- a/independent-projects/extension-maven-plugin/pom.xml
+++ b/independent-projects/extension-maven-plugin/pom.xml
@@ -138,7 +138,7 @@
             <plugin>
                 <groupId>org.eclipse.sisu</groupId>
                 <artifactId>sisu-maven-plugin</artifactId>
-                <version>0.3.5</version>
+                <version>1.0.0</version>
                 <executions>
                     <execution>
                         <id>index-project</id>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -61,7 +61,7 @@
                                 <externalRules>
                                     <location>classpath:enforcer-rules/quarkus-banned-dependencies-okhttp.xml</location>
                                 </externalRules>
-                                <requiresMinimalDeploymentDependency implementation="io.quarkus.enforcer.RequiresMinimalDeploymentDependency"/>
+                                <requiresMinimalDeploymentDependency/>
                             </rules>
                         </configuration>
                     </execution>

--- a/integration-tests/virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/pom.xml
@@ -73,7 +73,7 @@
                                 <externalRules>
                                     <location>classpath:enforcer-rules/quarkus-banned-dependencies-okhttp.xml</location>
                                 </externalRules>
-                                <requiresMinimalDeploymentDependency implementation="io.quarkus.enforcer.RequiresMinimalDeploymentDependency"/>
+                                <requiresMinimalDeploymentDependency/>
                             </rules>
                         </configuration>
                     </execution>

--- a/tcks/pom.xml
+++ b/tcks/pom.xml
@@ -46,7 +46,7 @@
                                 <externalRules>
                                     <location>classpath:enforcer-rules/quarkus-banned-dependencies-okhttp.xml</location>
                                 </externalRules>
-                                <requiresMinimalDeploymentDependency implementation="io.quarkus.enforcer.RequiresMinimalDeploymentDependency"/>
+                                <requiresMinimalDeploymentDependency/>
                             </rules>
                         </configuration>
                     </execution>


### PR DESCRIPTION
The custom rules implemented the deprecated `EnforcerRule2` interface (enforcer-api 3.0.0-M3), producing warnings on every build. This migrates all three rules to `AbstractEnforcerRule` with JSR 330 `@Inject/@Named`, matching the current `enforcer-api` 3.6.2.

- DeploymentDependencyRuleSupport: extends AbstractEnforcerRule, `@Inject` MavenProject, use getLog() instead of manual Log field
- BansRuntimeDependency: add `@Named("bansRuntimeDependency")`
- RequiresMinimalDeploymentDependency: add `@Named(...)`
- DependencyAlignmentRule: `extends AbstractEnforcerRule`, `@Inject MavenProject/MavenSession/RepositorySystem`
- Remove `implementation=` attributes from all consumer POMs
- Add `sisu-maven-plugin` to generate the component index
- Add explicit `maven-artifact` and `maven-model` dependencies
