### PR TITLE
Add AI skill for quarkus-spring-di

### DIFF
--- a/extensions/spring-di/deployment/src/main/resources/META-INF/quarkus-skill.md
+++ b/extensions/spring-di/deployment/src/main/resources/META-INF/quarkus-skill.md
@@ -1,0 +1,107 @@
+
+### Annotation Mapping
+
+Spring DI annotations are mapped to CDI at build time:
+
+| Spring | CDI Equivalent | Notes |
+|--------|---------------|-------|
+| `@Component`, `@Service`, `@Repository` | `@Singleton` | Singleton by default |
+| `@Autowired` | `@Inject` | Field, constructor, and setter injection |
+| `@Qualifier("name")` | `@Named("name")` | Named bean selection |
+| `@Configuration` + `@Bean` | `@Produces` + `@Singleton` | Bean producer methods |
+| `@Value("${prop}")` | `@ConfigProperty(name="prop")` | Config injection |
+| `@Scope("prototype")` | `@Dependent` | New instance per injection |
+| `@Scope("request")` | `@RequestScoped` | Request scope |
+
+### Service Pattern
+
+```java
+@Service
+public class GreetingService {
+
+    @Value("${greeting.message:Hello}")
+    String message;
+
+    public String greet(String name) {
+        return message + ", " + name + "!";
+    }
+}
+```
+
+`@Value` supports `${property}` and `${property:default}` syntax. SpEL expressions (`#{...}`) are **not supported**.
+
+### Bean Producers
+
+```java
+@Configuration
+public class AppConfig {
+
+    @Bean(name = "jsonFormatter")
+    public Formatter jsonFormatter() {
+        return new JsonFormatter();
+    }
+
+    @Bean(name = "xmlFormatter")
+    public Formatter xmlFormatter() {
+        return new XmlFormatter();
+    }
+}
+```
+
+`@Bean` methods default to singleton scope. Use `@Scope("prototype")` on the method for dependent scope.
+
+### Qualified Injection
+
+```java
+@Autowired
+@Qualifier("jsonFormatter")
+Formatter formatter;
+```
+
+The `@Qualifier` value must match the `@Bean(name = "...")` value exactly.
+
+### Constructor Injection
+
+```java
+@Service
+public class OrderService {
+
+    private final PaymentService paymentService;
+
+    @Autowired
+    public OrderService(PaymentService paymentService) {
+        this.paymentService = paymentService;
+    }
+}
+```
+
+### Mixing Spring and CDI
+
+Spring and CDI annotations interoperate — a `@Service` bean can be injected with `@Inject`, and a CDI `@ApplicationScoped` bean can be injected with `@Autowired`.
+
+### Testing
+
+Spring annotations work in `@QuarkusTest` — use `@Autowired` to inject beans directly:
+
+```java
+@QuarkusTest
+class GreetingServiceTest {
+
+    @Autowired
+    GreetingService service;
+
+    @Test
+    void testGreeting() {
+        assertEquals("Hello, World!", service.greet("World"));
+    }
+}
+```
+
+### Common Pitfalls
+
+- **SpEL not supported**: `@Value("#{expression}")` throws `IllegalArgumentException`. Use `@Value("${property}")` or `@ConfigProperty` for config values.
+- **Default scope is singleton**: Unlike Spring Boot's conditional scanning, `@Component`/`@Service`/`@Repository` always map to `@Singleton` in Quarkus.
+- **`@Bean` default is singleton**: Bean producer methods in `@Configuration` classes default to singleton scope, matching Spring behavior.
+- **No `@ComponentScan`**: Quarkus discovers beans at build time from the application classpath — no scanning configuration needed.
+- **No `@Conditional` support**: Spring's `@Conditional*` annotations are not supported. Use Quarkus build-time conditions or CDI alternatives.
+- **This is a compatibility layer**: For new code, consider using CDI annotations (`@ApplicationScoped`, `@Inject`) directly. The Spring DI extension is primarily for migrating existing Spring code.


### PR DESCRIPTION
Adds an AI skill file for the Spring DI compatibility extension to help developers use Spring annotations in Quarkus.

### Key content in the skill

- **Annotation mapping table**: Complete Spring → CDI equivalent mapping including scope annotations
- **SpEL not supported**: `@Value` only supports `${property}` syntax, not `#{expression}` — this is a common trap for Spring developers
- **Bean producer pattern**: Shows `@Configuration` + `@Bean` with named beans and `@Qualifier` injection
- **Mixed annotations**: Documents that Spring and CDI annotations interoperate freely
- **Compatibility layer note**: Recommends CDI annotations for new code, clarifying the extension is primarily for migration

### Verification

All claims verified against source:
- Annotation mappings confirmed (SpringDIProcessor.java: `@Component`/`@Service`/`@Repository` → singleton, `@Autowired` → `@Inject`, `@Qualifier` → `@Named`)
- Scope mappings confirmed: `singleton`→Singleton, `prototype`→Dependent, `request`→RequestScoped, `session`→SessionScoped, `application`→ApplicationScoped
- `@Value` SpEL rejection confirmed (SpringDIProcessor.java:578-581: throws IllegalArgumentException for `#{}` expressions)
- `@Configuration` + `@Bean` → `@Produces` + `@Singleton` confirmed (SpringDIProcessor.java:416-423)
- No `@ComponentScan` support confirmed (build-time discovery only)

### Validation

Tester rated experience as **smooth** — all 6 tests passed. Spring annotations worked exactly as expected.

Closes #54137