### PR TITLE
Add AI skill for quarkus-spring-web

### DIFF
--- a/extensions/spring-web/core/deployment/src/main/resources/META-INF/quarkus-skill.md
+++ b/extensions/spring-web/core/deployment/src/main/resources/META-INF/quarkus-skill.md
@@ -1,0 +1,114 @@
+
+### Controller Pattern
+
+```java
+@RestController
+@RequestMapping("/api/items")
+public class ItemController {
+
+    @GetMapping
+    public List<Item> listAll() { ... }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Item> getById(@PathVariable Long id) {
+        return items.containsKey(id)
+            ? ResponseEntity.ok(items.get(id))
+            : ResponseEntity.notFound().build();
+    }
+
+    @PostMapping
+    public ResponseEntity<Item> create(@RequestBody Item item) {
+        items.put(item.getId(), item);
+        return ResponseEntity.status(HttpStatus.CREATED).body(item);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        items.remove(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/search")
+    public List<Item> search(@RequestParam String name) {
+        return items.values().stream()
+            .filter(i -> i.getName().contains(name))
+            .toList();
+    }
+}
+```
+
+### Supported Annotations
+
+| Annotation | Status |
+|-----------|--------|
+| `@RestController` | Supported |
+| `@RequestMapping` | Supported (class-level path prefix) |
+| `@GetMapping`, `@PostMapping`, `@PutMapping`, `@DeleteMapping`, `@PatchMapping` | Supported |
+| `@PathVariable` | Supported |
+| `@RequestParam` | Supported |
+| `@RequestBody` | Supported |
+| `@RequestHeader` | Supported |
+| `@CookieValue` | Supported |
+| `ResponseEntity<T>` | Supported (for status codes and headers) |
+| `@ResponseStatus` | Supported (on exceptions) |
+| `@RestControllerAdvice` + `@ExceptionHandler` | Supported (single class only) |
+
+### Exception Handling
+
+Use `@ResponseStatus` on custom exceptions:
+
+```java
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class ItemNotFoundException extends RuntimeException {
+    public ItemNotFoundException(String message) { super(message); }
+}
+```
+
+Or use `@RestControllerAdvice` for global exception handling:
+
+```java
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ItemNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNotFound(ItemNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(new ErrorResponse(ex.getMessage()));
+    }
+}
+```
+
+Only **one** `@RestControllerAdvice` class is allowed per application.
+
+### Testing
+
+```java
+@QuarkusTest
+class ItemControllerTest {
+
+    @Test
+    void testCreate() {
+        given()
+            .contentType(ContentType.JSON)
+            .body("{\"id\":1,\"name\":\"Widget\"}")
+            .when().post("/api/items")
+            .then().statusCode(201);
+    }
+
+    @Test
+    void testNotFound() {
+        given()
+            .when().get("/api/items/999")
+            .then().statusCode(404);
+    }
+}
+```
+
+### Common Pitfalls
+
+- **`params` attribute on mapping annotations is NOT supported**: `@GetMapping(params = "name")` causes a deployment error (duplicate endpoint). Use a different path like `@GetMapping("/search")` with `@RequestParam` instead.
+- **Only one `@RestControllerAdvice`**: The application fails to start if multiple `@ControllerAdvice` classes exist.
+- **`@ExceptionHandler` methods must be public instance methods** with return types: `void`, `ResponseEntity`, or a POJO.
+- **No `ModelAndView`/`Model`/`View` support**: These MVC server-side rendering types are not supported. Use Qute templates instead.
+- **No `@RequestMapping` on methods**: Use the specific `@GetMapping`/`@PostMapping` etc. instead of `@RequestMapping(method = ...)` on methods.
+- **This is a compatibility layer**: For new code, consider using Quarkus REST (`@Path`, `@GET`, etc.) directly. The Spring Web extension is primarily for migrating existing Spring code.


### PR DESCRIPTION
Adds an AI skill file for the Spring Web compatibility extension to help developers use Spring MVC annotations in Quarkus.

### Tester friction points addressed

- **`params` attribute not supported**: `@GetMapping(params = "name")` causes a deployment error — the skill warns about this upfront and shows the workaround (use different path with `@RequestParam`)
- **Single `@RestControllerAdvice` limit**: Only one class is allowed — documented in pitfalls
- **Supported vs unsupported features**: Complete annotation support table so developers know what works
- **No `ModelAndView`/`View`**: Server-side rendering types are not supported — points to Qute templates
- **Compatibility layer note**: Recommends Quarkus REST for new code

### Verification

All claims verified against source:
- Supported annotations confirmed (SpringWebProcessor.java: GetMapping, PostMapping, PutMapping, DeleteMapping, PatchMapping, PathVariable, RequestParam, RequestBody, RequestHeader, CookieValue, ResponseEntity, ResponseStatus)
- Single `@ControllerAdvice` limit confirmed (SpringWebProcessor.java:259: "You can only have a single class annotated with @ControllerAdvice")
- `@ExceptionHandler` method constraints confirmed (line 215-221: must be public instance methods, void/ResponseEntity/POJO return)
- No `ModelAndView`/`Model`/`View` — these are registered as unsupported types (SpringWebProcessor.java:71-73)

### Validation

Tester rated experience as **some-friction** — all 5 tests passed. Main friction was the unsupported `params` attribute causing a deployment error.

Closes #54156