### PR TITLE
Add AI skill for quarkus-amazon-lambda

### DIFF
--- a/extensions/amazon-lambda/deployment/src/main/resources/META-INF/quarkus-skill.md
+++ b/extensions/amazon-lambda/deployment/src/main/resources/META-INF/quarkus-skill.md
@@ -1,0 +1,115 @@
+
+### Lambda Handler
+
+Implement `RequestHandler<Input, Output>` from the AWS Lambda SDK as a CDI bean:
+
+```java
+@Named("greeting")
+@ApplicationScoped
+public class GreetingLambda implements RequestHandler<GreetingRequest, GreetingResponse> {
+
+    @Override
+    public GreetingResponse handleRequest(GreetingRequest input, Context context) {
+        return new GreetingResponse("Hello, " + input.getName());
+    }
+}
+```
+
+If there's only one `RequestHandler` implementation, `@Named` is optional. With multiple handlers, use `@Named` and set `quarkus.lambda.handler` to select the active one.
+
+### Stream Handler
+
+For raw input/output streams, implement `RequestStreamHandler`:
+
+```java
+@Named("stream")
+@ApplicationScoped
+public class StreamLambda implements RequestStreamHandler {
+
+    @Override
+    public void handleRequest(InputStream input, OutputStream output, Context context) throws IOException {
+        // read input, write output
+    }
+}
+```
+
+### Configuration
+
+```properties
+# Select which handler to use (required when multiple exist)
+quarkus.lambda.handler=greeting
+
+# Expected exceptions (won't log stack traces)
+quarkus.lambda.expected-exceptions=com.example.BusinessException
+```
+
+### Dev Mode Testing
+
+In dev mode, a mock Lambda event server starts automatically on port 8080. Send test events via HTTP:
+
+```bash
+curl -X POST http://localhost:8080 \
+  -H "Content-Type: application/json" \
+  -d '{"name": "World"}'
+```
+
+### Testing
+
+Use `@QuarkusTest` with the mock event server:
+
+```java
+@QuarkusTest
+class GreetingLambdaTest {
+
+    @Test
+    void testGreeting() {
+        given()
+            .contentType(ContentType.JSON)
+            .body("{\"name\": \"World\"}")
+            .when().post("/")
+            .then()
+            .statusCode(200)
+            .body("greeting", equalTo("Hello, World"));
+    }
+}
+```
+
+The mock server runs on port 8081 during tests (`quarkus.lambda.test-port`).
+
+### CDI Injection
+
+Lambda handlers are CDI beans — use `@Inject` for any CDI bean:
+
+```java
+@ApplicationScoped
+public class GreetingLambda implements RequestHandler<GreetingRequest, GreetingResponse> {
+
+    @Inject GreetingService service;
+
+    @Override
+    public GreetingResponse handleRequest(GreetingRequest input, Context context) {
+        return new GreetingResponse(service.greet(input.getName()));
+    }
+}
+```
+
+### Deployment
+
+Build a native executable or uber-jar for Lambda deployment:
+
+```bash
+# Native (requires GraalVM or Mandrel)
+./mvnw package -Pnative -Dquarkus.native.container-build=true
+
+# JVM mode (uber-jar)
+./mvnw package
+```
+
+The build generates `function.zip` in `target/` — ready for upload to AWS Lambda.
+
+### Common Pitfalls
+
+- **Multiple handlers require `@Named`**: If more than one `RequestHandler` exists, the build fails unless each has `@Named` and `quarkus.lambda.handler` is set.
+- **Input/output must be serializable**: Request and response types are serialized via Jackson. Ensure they have default constructors and getters/setters.
+- **Don't use JAX-RS with this extension**: `amazon-lambda` replaces the HTTP server entirely. For REST-based lambdas, use `amazon-lambda-rest` or `amazon-lambda-http` instead.
+- **Mock server port**: Dev mode uses port 8080, test mode uses 8081. Override with `quarkus.lambda.dev-port` / `quarkus.lambda.test-port`.


### PR DESCRIPTION
Adds an AI skill file for the Amazon Lambda extension covering handler patterns, testing, and deployment.

### Key content in the skill

- **RequestHandler pattern**: Shows typed handler with CDI injection and `@Named` for multiple handlers
- **RequestStreamHandler**: For raw stream-based processing
- **Mock event server**: Documents dev mode (port 8080) and test mode (port 8081) mock servers
- **Testing pattern**: Shows how to test via HTTP POST to the mock server
- **Don't mix with JAX-RS**: Common mistake — this extension replaces the HTTP server entirely. Points to `amazon-lambda-rest`/`amazon-lambda-http` for REST-based lambdas
- **Deployment**: Documents the `function.zip` output for AWS upload

### Verification

All claims verified against source:
- `RequestHandler` and `RequestStreamHandler` patterns confirmed (QuarkusStreamHandler.java, test examples)
- Mock event server ports confirmed: dev=8080, test=8081 (MockEventServerConfig.java)
- Expected exceptions config confirmed (LambdaBuildTimeConfig.java)
- Multiple handler selection via `quarkus.lambda.handler` confirmed

Closes #54164