### PR TITLE
Signals: improvements

### DIFF
--- a/docs/src/main/asciidoc/signals.adoc
+++ b/docs/src/main/asciidoc/signals.adoc
@@ -164,17 +164,17 @@ Receivers can access this metadata via the `SignalContext`.
 ----
 // Attach metadata to a single emission
 orderPlaced
-    .putMetadata("traceId", "abc-123")
-    .putMetadata("source", "web")
+    .withMetadata("traceId", "abc-123")
+    .withMetadata("source", "web")
     .publish(new OrderPlaced("123", BigDecimal.TEN));
 
 // Or replace all metadata at once
 orderPlaced
-    .setMetadata(Map.of("traceId", "abc-123", "source", "web"))
+    .withReplacedMetadata(Map.of("traceId", "abc-123", "source", "web"))
     .publish(new OrderPlaced("123", BigDecimal.TEN));
 ----
 
-NOTE: Both `putMetadata()` and `setMetadata()` return a new child `Signal` instance; the original instance is not modified.
+NOTE: Both `withMetadata()` and `withReplacedMetadata()` return a new child `Signal` instance; the original instance is not modified.
 
 === No Matching Receiver
 

--- a/extensions/signals/deployment/src/main/java/io/quarkus/signals/deployment/ReceiverExecutorImplementationBuildItem.java
+++ b/extensions/signals/deployment/src/main/java/io/quarkus/signals/deployment/ReceiverExecutorImplementationBuildItem.java
@@ -4,7 +4,7 @@ import java.util.EnumSet;
 import java.util.Set;
 
 import io.quarkus.builder.item.SimpleBuildItem;
-import io.quarkus.signals.spi.Receiver.ExecutionModel;
+import io.quarkus.signals.Receivers.ExecutionModel;
 
 final class ReceiverExecutorImplementationBuildItem extends SimpleBuildItem {
 

--- a/extensions/signals/deployment/src/main/java/io/quarkus/signals/deployment/ReceiverMethodBuildItem.java
+++ b/extensions/signals/deployment/src/main/java/io/quarkus/signals/deployment/ReceiverMethodBuildItem.java
@@ -11,7 +11,7 @@ import org.jboss.jandex.Type.Kind;
 import io.quarkus.arc.processor.BeanInfo;
 import io.quarkus.arc.processor.InvokerInfo;
 import io.quarkus.builder.item.MultiBuildItem;
-import io.quarkus.signals.spi.Receiver.ExecutionModel;
+import io.quarkus.signals.Receivers.ExecutionModel;
 
 final class ReceiverMethodBuildItem extends MultiBuildItem implements Comparable<ReceiverMethodBuildItem> {
 

--- a/extensions/signals/deployment/src/main/java/io/quarkus/signals/deployment/SignalsProcessor.java
+++ b/extensions/signals/deployment/src/main/java/io/quarkus/signals/deployment/SignalsProcessor.java
@@ -70,17 +70,17 @@ import io.quarkus.gizmo2.desc.ConstructorDesc;
 import io.quarkus.gizmo2.desc.FieldDesc;
 import io.quarkus.gizmo2.desc.MethodDesc;
 import io.quarkus.runtime.util.HashUtil;
+import io.quarkus.signals.Receivers.ExecutionModel;
 import io.quarkus.signals.Signal;
 import io.quarkus.signals.runtime.impl.DefaultBlockingReceiverExecutor;
 import io.quarkus.signals.runtime.impl.InvokerReceiver;
-import io.quarkus.signals.runtime.impl.InvokerReceiver.ReceiverInfo;
+import io.quarkus.signals.runtime.impl.InvokerReceiver.InvokerReceiverInfo;
 import io.quarkus.signals.runtime.impl.ReceiverManager;
 import io.quarkus.signals.runtime.impl.RequestContextInterceptor;
 import io.quarkus.signals.runtime.impl.SignalBeanCreator;
 import io.quarkus.signals.runtime.impl.SignalsRecorder;
 import io.quarkus.signals.runtime.impl.SignalsRecorder.SignalsContext;
 import io.quarkus.signals.runtime.impl.VertxReceiverExecutor;
-import io.quarkus.signals.spi.Receiver.ExecutionModel;
 
 class SignalsProcessor {
 
@@ -263,11 +263,11 @@ class SignalsProcessor {
                 cc.constructor(con -> {
                     con.body(bc -> {
                         Expr invoker = bc.new_(receiver.getInvoker().getClassDesc());
-                        Expr receiveInfo = bc.new_(ReceiverInfo.class,
+                        Expr receiveInfo = bc.new_(InvokerReceiverInfo.class,
                                 Const.of(receiver.getSignalParam().position()),
                                 Const.of(receiver.getSignalParam().type().name().equals(DotNames.SIGNAL_CONTEXT)),
                                 Const.of((short) receiver.getMethod().parametersCount()));
-                        bc.invokeSpecial(ConstructorDesc.of(InvokerReceiver.class, Invoker.class, ReceiverInfo.class),
+                        bc.invokeSpecial(ConstructorDesc.of(InvokerReceiver.class, Invoker.class, InvokerReceiverInfo.class),
                                 cc.this_(), invoker, receiveInfo);
 
                         LocalVar tccl = bc.localVar("tccl", bc.invokeVirtual(
@@ -285,7 +285,7 @@ class SignalsProcessor {
                         if (responseType != null) {
                             bc.set(cc.this_().field(responseTypeField), rttc.create(responseType));
                         } else {
-                            bc.set(cc.this_().field(responseTypeField), Const.ofNull(Type.class));
+                            bc.set(cc.this_().field(responseTypeField), Const.of(void.class));
                         }
 
                         bc.return_();

--- a/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/BlockingEmissionFailureTest.java
+++ b/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/BlockingEmissionFailureTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.logging.LogRecord;
 
@@ -16,9 +15,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.signals.Receivers;
+import io.quarkus.signals.Receivers.ExecutionModel;
 import io.quarkus.signals.Signal;
 import io.quarkus.signals.SignalContext;
-import io.quarkus.signals.spi.Receiver.ExecutionModel;
 import io.quarkus.test.QuarkusExtensionTest;
 import io.smallrye.mutiny.Uni;
 
@@ -33,10 +32,6 @@ public class BlockingEmissionFailureTest extends AbstractSignalTest {
             .withApplicationRoot(root -> root.addClasses(Cmd.class))
             .setLogRecordPredicate(r -> r.getLoggerName().contains("SignalImpl"))
             .assertLogRecords(records -> {
-                assertFailureLogged(records, "publish-worker-boom");
-                assertFailureLogged(records, "publish-eventloop-boom");
-                assertFailureLogged(records, "send-worker-boom");
-                assertFailureLogged(records, "send-eventloop-boom");
                 assertFailureLogged(records, "publish-uni-boom");
                 assertFailureLogged(records, "send-uni-boom");
             });
@@ -48,86 +43,6 @@ public class BlockingEmissionFailureTest extends AbstractSignalTest {
     Receivers receivers;
 
     @Test
-    public void testPublishFailureWorkerThread() throws InterruptedException {
-        CountDownLatch latch = new CountDownLatch(1);
-        var reg = receivers.newReceiver(Cmd.class)
-                .setExecutionModel(ExecutionModel.BLOCKING)
-                .notify(new Consumer<SignalContext<Cmd>>() {
-                    @Override
-                    public void accept(SignalContext<Cmd> t) {
-                        latch.countDown();
-                        throw new IllegalStateException("publish-worker-boom");
-                    }
-                });
-        try {
-            cmd.publish(new Cmd());
-            assertTrue(latch.await(defaultTimeout().toMillis(), TimeUnit.MILLISECONDS));
-        } finally {
-            reg.unregister();
-        }
-    }
-
-    @Test
-    public void testPublishFailureEventLoop() throws InterruptedException {
-        CountDownLatch latch = new CountDownLatch(1);
-        var reg = receivers.newReceiver(Cmd.class)
-                .setExecutionModel(ExecutionModel.NON_BLOCKING)
-                .notify(new Consumer<SignalContext<Cmd>>() {
-                    @Override
-                    public void accept(SignalContext<Cmd> t) {
-                        latch.countDown();
-                        throw new IllegalStateException("publish-eventloop-boom");
-                    }
-                });
-        try {
-            cmd.publish(new Cmd());
-            assertTrue(latch.await(defaultTimeout().toMillis(), TimeUnit.MILLISECONDS));
-        } finally {
-            reg.unregister();
-        }
-    }
-
-    @Test
-    public void testSendFailureWorkerThread() throws InterruptedException {
-        CountDownLatch latch = new CountDownLatch(1);
-        var reg = receivers.newReceiver(Cmd.class)
-                .setExecutionModel(ExecutionModel.BLOCKING)
-                .notify(new Consumer<SignalContext<Cmd>>() {
-                    @Override
-                    public void accept(SignalContext<Cmd> t) {
-                        latch.countDown();
-                        throw new IllegalStateException("send-worker-boom");
-                    }
-                });
-        try {
-            cmd.send(new Cmd());
-            assertTrue(latch.await(defaultTimeout().toMillis(), TimeUnit.MILLISECONDS));
-        } finally {
-            reg.unregister();
-        }
-    }
-
-    @Test
-    public void testSendFailureEventLoop() throws InterruptedException {
-        CountDownLatch latch = new CountDownLatch(1);
-        var reg = receivers.newReceiver(Cmd.class)
-                .setExecutionModel(ExecutionModel.NON_BLOCKING)
-                .notify(new Consumer<SignalContext<Cmd>>() {
-                    @Override
-                    public void accept(SignalContext<Cmd> t) {
-                        latch.countDown();
-                        throw new IllegalStateException("send-eventloop-boom");
-                    }
-                });
-        try {
-            cmd.send(new Cmd());
-            assertTrue(latch.await(defaultTimeout().toMillis(), TimeUnit.MILLISECONDS));
-        } finally {
-            reg.unregister();
-        }
-    }
-
-    @Test
     public void testPublishUniFailure() throws InterruptedException {
         CountDownLatch latch = new CountDownLatch(1);
         var reg = receivers.newReceiver(Cmd.class)
@@ -135,8 +50,8 @@ public class BlockingEmissionFailureTest extends AbstractSignalTest {
                 .notify(new Function<SignalContext<Cmd>, Uni<Void>>() {
                     @Override
                     public Uni<Void> apply(SignalContext<Cmd> ctx) {
-                        latch.countDown();
-                        return Uni.createFrom().failure(new IllegalStateException("publish-uni-boom"));
+                        return Uni.createFrom().<Void> failure(new IllegalStateException("publish-uni-boom"))
+                                .eventually(latch::countDown);
                     }
                 });
         try {
@@ -155,8 +70,8 @@ public class BlockingEmissionFailureTest extends AbstractSignalTest {
                 .notify(new Function<SignalContext<Cmd>, Uni<Void>>() {
                     @Override
                     public Uni<Void> apply(SignalContext<Cmd> ctx) {
-                        latch.countDown();
-                        return Uni.createFrom().failure(new IllegalStateException("send-uni-boom"));
+                        return Uni.createFrom().<Void> failure(new IllegalStateException("send-uni-boom"))
+                                .eventually(latch::countDown);
                     }
                 });
         try {

--- a/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/EnricherFailureTest.java
+++ b/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/EnricherFailureTest.java
@@ -1,0 +1,93 @@
+package io.quarkus.signals.deployment.test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.signals.Receives;
+import io.quarkus.signals.Signal;
+import io.quarkus.signals.spi.SignalMetadataEnricher;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.smallrye.common.annotation.Identifier;
+
+public class EnricherFailureTest extends AbstractSignalTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot(root -> root.addClasses(
+                    Cmd.class, FailingEnricher.class, MyReceiver.class));
+
+    @Inject
+    Signal<Cmd> signal;
+
+    @Test
+    public void testEnricherExceptionPropagatesOnRequest() {
+        assertThatThrownBy(() -> signal.reactive().request(new Cmd("boom"), String.class)
+                .ifNoItem().after(defaultTimeout()).fail()
+                .await().indefinitely())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("enricher failed");
+    }
+
+    @Test
+    public void testEnricherExceptionPropagatesOnPublish() {
+        assertThatThrownBy(() -> signal.reactive().publish(new Cmd("boom"))
+                .ifNoItem().after(defaultTimeout()).fail()
+                .await().indefinitely())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("enricher failed");
+    }
+
+    @Test
+    public void testEnricherExceptionPropagatesOnSend() {
+        assertThatThrownBy(() -> signal.reactive().send(new Cmd("boom"))
+                .ifNoItem().after(defaultTimeout()).fail()
+                .await().indefinitely())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("enricher failed");
+    }
+
+    @Test
+    public void testEnricherExceptionPropagatesOnBlockingRequest() {
+        assertThatThrownBy(() -> signal.request(new Cmd("boom"), String.class))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("enricher failed");
+    }
+
+    @Test
+    public void testEnricherExceptionSwallowedOnFireAndForgetPublish() {
+        // publish() is fire-and-forget; the exception is logged but not propagated
+        signal.publish(new Cmd("boom"));
+    }
+
+    @Test
+    public void testEnricherExceptionSwallowedOnFireAndForgetSend() {
+        // send() is fire-and-forget; the exception is logged but not propagated
+        signal.send(new Cmd("boom"));
+    }
+
+    record Cmd(String value) {
+    }
+
+    @Identifier("failing")
+    @Singleton
+    public static class FailingEnricher implements SignalMetadataEnricher {
+
+        @Override
+        public void enrich(EnrichmentContext context) {
+            throw new IllegalStateException("enricher failed");
+        }
+    }
+
+    @Singleton
+    public static class MyReceiver {
+
+        String onCmd(@Receives Cmd cmd) {
+            return cmd.value();
+        }
+    }
+}

--- a/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/ReceiverFailureTest.java
+++ b/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/ReceiverFailureTest.java
@@ -16,10 +16,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.signals.Receivers;
+import io.quarkus.signals.Receivers.ExecutionModel;
 import io.quarkus.signals.Receives;
 import io.quarkus.signals.Signal;
 import io.quarkus.signals.SignalContext;
-import io.quarkus.signals.spi.Receiver.ExecutionModel;
 import io.quarkus.test.QuarkusExtensionTest;
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Uni;

--- a/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/ReceiverInheritanceComplexTest.java
+++ b/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/ReceiverInheritanceComplexTest.java
@@ -55,7 +55,7 @@ public class ReceiverInheritanceComplexTest extends AbstractSignalTest {
         inheritingReceiver.sequence.clear();
 
         String reply = stringEnvelope
-                .setMetadata(Map.of("priority", "high"))
+                .withReplacedMetadata(Map.of("priority", "high"))
                 .reactive().request(new Envelope<>("beta", "data"), String.class)
                 .ifNoItem().after(defaultTimeout()).fail()
                 .await().indefinitely();

--- a/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/ReceiversTest.java
+++ b/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/ReceiversTest.java
@@ -29,8 +29,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.arc.Arc;
 import io.quarkus.runtime.BlockingOperationControl;
 import io.quarkus.signals.Receivers;
+import io.quarkus.signals.Receivers.ExecutionModel;
 import io.quarkus.signals.Signal;
-import io.quarkus.signals.spi.Receiver.ExecutionModel;
 import io.quarkus.test.QuarkusExtensionTest;
 import io.smallrye.mutiny.Uni;
 

--- a/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/ResolveReceiversTest.java
+++ b/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/ResolveReceiversTest.java
@@ -1,0 +1,129 @@
+package io.quarkus.signals.deployment.test;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Inject;
+import jakarta.inject.Qualifier;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.signals.Receivers;
+import io.quarkus.signals.Receivers.ExecutionModel;
+import io.quarkus.signals.Receivers.ReceiverInfo;
+import io.quarkus.signals.Receivers.ReceiverKind;
+import io.quarkus.signals.Receives;
+import io.quarkus.signals.SignalContext;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.smallrye.mutiny.Uni;
+
+public class ResolveReceiversTest extends AbstractSignalTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot(root -> root.addClasses(
+                    Event.class, Urgent.class, MyReceivers.class));
+
+    @Inject
+    Receivers receivers;
+
+    @Test
+    public void testDeclarativeReceivers() {
+        List<ReceiverInfo> infos = receivers.resolveReceivers(Event.class);
+        // [onEvent]
+        assertThat(infos).hasSize(1);
+        assertThat(infos).allMatch(i -> i.kind() == ReceiverKind.DECLARATIVE);
+        assertThat(infos).allMatch(i -> i.signalType() == Event.class);
+        assertThat(infos).allMatch(i -> i.responseType() == void.class);
+    }
+
+    @Test
+    public void testProgrammaticReceiver() {
+        Function<SignalContext<Event>, Uni<String>> callback = ctx -> Uni.createFrom().item("ok");
+        Receivers.Registration reg = receivers.newReceiver(Event.class)
+                .setExecutionModel(ExecutionModel.NON_BLOCKING)
+                .setResponseType(String.class)
+                .notify(callback);
+        try {
+            List<ReceiverInfo> infos = receivers.resolveReceivers(Event.class);
+            // [onEvent, reg]
+            assertThat(infos).hasSize(2);
+            assertThat(infos).anyMatch(i -> i.kind() == ReceiverKind.PROGRAMMATIC
+                    && i.executionModel() == ExecutionModel.NON_BLOCKING
+                    && i.responseType() == String.class);
+        } finally {
+            reg.unregister();
+        }
+    }
+
+    @Test
+    public void testQualifierFiltering() {
+        // [onEvent]
+        List<ReceiverInfo> unqualifiedReceivers = receivers.resolveReceivers(Event.class);
+        // [onUrgentEvent]
+        List<ReceiverInfo> urgentReceivers = receivers.resolveReceivers(Event.class, Urgent.Literal.INSTANCE);
+        assertThat(urgentReceivers).hasSameSizeAs(unqualifiedReceivers).hasSize(1);
+        // Only the @Urgent receiver has the @Urgent qualifier
+        assertThat(urgentReceivers).allMatch(i -> i.qualifiers().stream()
+                .anyMatch(q -> q.annotationType() == Urgent.class));
+    }
+
+    @Test
+    public void testNoMatchingReceivers() {
+        List<ReceiverInfo> infos = receivers.resolveReceivers(String.class);
+        assertThat(infos).isEmpty();
+    }
+
+    @Test
+    public void testProgrammaticReceiverUnregistered() {
+        Consumer<SignalContext<Event>> noop = ctx -> {
+        };
+        Receivers.Registration reg = receivers.newReceiver(Event.class)
+                .notify(noop);
+        try {
+            int sizeWithProgrammatic = receivers.resolveReceivers(Event.class).size();
+            reg.unregister();
+            int sizeAfterUnregister = receivers.resolveReceivers(Event.class).size();
+            assertThat(sizeAfterUnregister).isLessThan(sizeWithProgrammatic);
+        } finally {
+            reg.unregister();
+        }
+    }
+
+    record Event(String name) {
+    }
+
+    @Qualifier
+    @Target({ FIELD, METHOD, PARAMETER })
+    @Retention(RUNTIME)
+    public @interface Urgent {
+
+        final class Literal extends AnnotationLiteral<Urgent> implements Urgent {
+            public static final Literal INSTANCE = new Literal();
+            private static final long serialVersionUID = 1L;
+        }
+    }
+
+    @Singleton
+    public static class MyReceivers {
+
+        void onEvent(@Receives Event event) {
+        }
+
+        Uni<String> onUrgentEvent(@Receives @Urgent SignalContext<Event> ctx) {
+            return Uni.createFrom().item(ctx.signal().name());
+        }
+    }
+}

--- a/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/SignalMetadataTest.java
+++ b/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/SignalMetadataTest.java
@@ -19,8 +19,7 @@ import io.quarkus.test.QuarkusExtensionTest;
 import io.smallrye.mutiny.Uni;
 
 /**
- * Verifies that metadata attached via {@link Signal.Emission#withMeta(String, Object)}
- * is accessible in the receiver through {@link SignalContext#metadata()}.
+ * Verifies that attached metadata is accessible in the receiver through {@link SignalContext#metadata()}.
  */
 public class SignalMetadataTest extends AbstractSignalTest {
 
@@ -38,7 +37,7 @@ public class SignalMetadataTest extends AbstractSignalTest {
     public void testMetadata() {
         receivers.captured.clear();
 
-        Signal<Event> eventWithMeta = event.setMetadata(Map.of("traceId", "abc-123", "source", "test"));
+        Signal<Event> eventWithMeta = event.withReplacedMetadata(Map.of("traceId", "abc-123", "source", "test"));
 
         Uni<String> uni = eventWithMeta
                 .reactive().request(new Event("hello"), String.class);
@@ -54,7 +53,7 @@ public class SignalMetadataTest extends AbstractSignalTest {
 
         receivers.captured.clear();
 
-        result = eventWithMeta.putMetadata("traceId", "def-123")
+        result = eventWithMeta.withMetadata("traceId", "def-123")
                 .reactive().request(new Event("hi"), String.class)
                 .ifNoItem()
                 .after(defaultTimeout())
@@ -69,10 +68,10 @@ public class SignalMetadataTest extends AbstractSignalTest {
     public void testSetMetadataReplacesAll() {
         receivers.captured.clear();
 
-        // First: setMetadata with traceId + source
-        Signal<Event> first = event.setMetadata(Map.of("traceId", "aaa", "source", "test"));
-        // Second: setMetadata replaces all metadata — only "traceId" and "source" present
-        Signal<Event> second = first.setMetadata(Map.of("traceId", "bbb", "source", "test"));
+        // First: withReplacedMetadata with traceId + source
+        Signal<Event> first = event.withReplacedMetadata(Map.of("traceId", "aaa", "source", "test"));
+        // Second: withReplacedMetadata replaces all metadata — only "traceId" and "source" present
+        Signal<Event> second = first.withReplacedMetadata(Map.of("traceId", "bbb", "source", "test"));
 
         String result = second.reactive().request(new Event("replaced"), String.class)
                 .ifNoItem().after(defaultTimeout()).fail()
@@ -90,9 +89,9 @@ public class SignalMetadataTest extends AbstractSignalTest {
     public void testPutMetadataReplacesExistingKey() {
         receivers.captured.clear();
 
-        Signal<Event> withTrace = event.setMetadata(Map.of("traceId", "first", "source", "test"));
-        // putMetadata with same key should replace the value
-        Signal<Event> replaced = withTrace.putMetadata("traceId", "second");
+        Signal<Event> withTrace = event.withReplacedMetadata(Map.of("traceId", "first", "source", "test"));
+        // withMetadata with same key should replace the value
+        Signal<Event> replaced = withTrace.withMetadata("traceId", "second");
 
         String result = replaced.reactive().request(new Event("check"), String.class)
                 .ifNoItem().after(defaultTimeout()).fail()

--- a/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/SpiTest.java
+++ b/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/SpiTest.java
@@ -95,7 +95,7 @@ public class SpiTest extends AbstractSignalTest {
     public void testEnricherPutMetadataThrowsOnDuplicateKey() {
         // Signal already has "correlationId" in metadata — enricher tries to put the same key
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
-            signal.putMetadata("correlationId", "existing")
+            signal.withMetadata("correlationId", "existing")
                     .reactive().request(new Cmd("dup"), String.class)
                     .ifNoItem().after(defaultTimeout()).fail()
                     .await().indefinitely();

--- a/extensions/signals/deployment/src/test/java21/io/quarkus/signals/deployment/test/ReceiverFailureVirtualThreadTest.java
+++ b/extensions/signals/deployment/src/test/java21/io/quarkus/signals/deployment/test/ReceiverFailureVirtualThreadTest.java
@@ -16,7 +16,7 @@ import io.quarkus.signals.Receivers;
 import io.quarkus.signals.Receives;
 import io.quarkus.signals.Signal;
 import io.quarkus.signals.SignalContext;
-import io.quarkus.signals.spi.Receiver.ExecutionModel;
+import io.quarkus.signals.Receivers.ExecutionModel;
 import io.quarkus.test.QuarkusExtensionTest;
 import io.smallrye.common.annotation.RunOnVirtualThread;
 import io.smallrye.mutiny.CompositeException;

--- a/extensions/signals/deployment/src/test/java21/io/quarkus/signals/deployment/test/ReceiversVirtualThreadTest.java
+++ b/extensions/signals/deployment/src/test/java21/io/quarkus/signals/deployment/test/ReceiversVirtualThreadTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.signals.Receivers;
 import io.quarkus.signals.Signal;
-import io.quarkus.signals.spi.Receiver.ExecutionModel;
+import io.quarkus.signals.Receivers.ExecutionModel;
 import io.quarkus.test.QuarkusExtensionTest;
 
 public class ReceiversVirtualThreadTest {

--- a/extensions/signals/runtime-api/src/main/java/io/quarkus/signals/Receivers.java
+++ b/extensions/signals/runtime-api/src/main/java/io/quarkus/signals/Receivers.java
@@ -1,19 +1,20 @@
 package io.quarkus.signals;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
 import jakarta.enterprise.util.TypeLiteral;
 
-import io.quarkus.signals.spi.Receiver;
-import io.quarkus.signals.spi.Receiver.ExecutionModel;
 import io.smallrye.common.annotation.Experimental;
 import io.smallrye.mutiny.Uni;
 
 /**
- * Allows programmatic registration of {@link Receiver} instances at runtime.
+ * Allows programmatic registration of receivers at runtime.
  * <p>
  * An instance can be injected as a CDI bean; the implementation is provided by the extension.
  *
@@ -51,6 +52,64 @@ public interface Receivers {
      * @return a new receiver builder
      */
     <SIGNAL> ReceiverDefinition<SIGNAL, Void> newReceiver(TypeLiteral<SIGNAL> signalType);
+
+    /**
+     * Resolves the receivers matching the given signal type and qualifiers.
+     * <p>
+     * The resolution rules are the same as for signal emissions.
+     * If no qualifiers are given, the {@linkplain jakarta.enterprise.inject.Default default qualifier} is assumed.
+     *
+     * @param signalType the signal type
+     * @param qualifiers the qualifiers
+     * @return the list of matching receivers, never {@code null}
+     * @see Signal
+     */
+    List<ReceiverInfo> resolveReceivers(Class<?> signalType, Annotation... qualifiers);
+
+    /**
+     * Resolves the receivers matching the given signal type and qualifiers.
+     * <p>
+     * The resolution rules are the same as for signal emissions.
+     * If no qualifiers are given, the {@linkplain jakarta.enterprise.inject.Default default qualifier} is assumed.
+     *
+     * @param signalType the signal type
+     * @param qualifiers the qualifiers
+     * @return the list of matching receivers, never {@code null}
+     * @see Signal
+     */
+    List<ReceiverInfo> resolveReceivers(TypeLiteral<?> signalType, Annotation... qualifiers);
+
+    /**
+     * Read-only information about a resolved receiver.
+     */
+    interface ReceiverInfo {
+
+        /**
+         * @return the received signal type
+         */
+        Type signalType();
+
+        /**
+         * @return the set of qualifiers, never {@code null}
+         */
+        Set<Annotation> qualifiers();
+
+        /**
+         * @return the response type
+         */
+        Type responseType();
+
+        /**
+         * @return the execution model
+         */
+        ExecutionModel executionModel();
+
+        /**
+         * @return the kind of the receiver
+         */
+        ReceiverKind kind();
+
+    }
 
     /**
      * A builder for creating {@link Receiver} instances programmatically.
@@ -111,7 +170,7 @@ public interface Receivers {
          */
         default Registration notify(Consumer<SignalContext<SIGNAL>> callback) {
             Objects.requireNonNull(callback);
-            return setResponseType(Void.class).notify(new Function<SignalContext<SIGNAL>, Uni<Void>>() {
+            return setResponseType(void.class).notify(new Function<SignalContext<SIGNAL>, Uni<Void>>() {
                 @Override
                 public Uni<Void> apply(SignalContext<SIGNAL> ctx) {
                     try {
@@ -149,6 +208,48 @@ public interface Receivers {
          * method executes. When the method returns, the receiver is fully unregistered.
          */
         void unregister();
+
+    }
+
+    /**
+     * Determines the threading model used to execute a receiver.
+     */
+    enum ExecutionModel {
+
+        /**
+         * The receiver performs blocking operations and is offloaded to a worker thread.
+         * This is the default for receiver methods with a blocking signature (i.e., not returning {@link Uni}
+         * or {@link java.util.concurrent.CompletionStage}).
+         */
+        BLOCKING,
+
+        /**
+         * The receiver is executed on a virtual thread.
+         */
+        VIRTUAL_THREAD,
+
+        /**
+         * The receiver performs non-blocking operations. When Vert.x is available, it is executed on the event loop.
+         * This is the default for receiver methods returning {@link Uni}.
+         */
+        NON_BLOCKING
+
+    }
+
+    /**
+     * The kind of receiver definition.
+     */
+    enum ReceiverKind {
+
+        /**
+         * A declarative receiver defined as a method annotated with {@link Receives}.
+         */
+        DECLARATIVE,
+
+        /**
+         * A programmatic receiver registered via {@link Receivers#newReceiver(Class)}.
+         */
+        PROGRAMMATIC
 
     }
 

--- a/extensions/signals/runtime-api/src/main/java/io/quarkus/signals/Signal.java
+++ b/extensions/signals/runtime-api/src/main/java/io/quarkus/signals/Signal.java
@@ -131,14 +131,13 @@ public interface Signal<T> {
      * Obtains a child {@code Signal} with the given metadata entry, replacing any previously added entry for the given key
      * entries.
      * <p>
-     * <p>
      * The metadata entries will be used for all emissions from the returned signal instance.
      *
      * @param key
      * @param value
      * @return the child {@code Signal}
      */
-    Signal<T> putMetadata(String key, Object value);
+    Signal<T> withMetadata(String key, Object value);
 
     /**
      * Obtains a child {@code Signal} with the given metadata, replacing any previously added metadata entries.
@@ -148,7 +147,7 @@ public interface Signal<T> {
      * @param metadata
      * @return the child {@code Signal}
      */
-    Signal<T> setMetadata(Map<String, Object> metadata);
+    Signal<T> withReplacedMetadata(Map<String, Object> metadata);
 
     /**
      * Sends a signal to <em>all</em> receivers matching the specified signal type and qualifiers (multicast, fire-and-forget).

--- a/extensions/signals/runtime-api/src/main/java/io/quarkus/signals/SignalContext.java
+++ b/extensions/signals/runtime-api/src/main/java/io/quarkus/signals/SignalContext.java
@@ -17,8 +17,8 @@ public interface SignalContext<T> {
 
     /**
      * @return the metadata attached to the emission, never {@code null}
-     * @see Signal#putMetadata(String, Object)
-     * @see Signal#setMetadata(Map)
+     * @see Signal#withMetadata(String, Object)
+     * @see Signal#withReplacedMetadata(Map)
      */
     Map<String, Object> metadata();
 

--- a/extensions/signals/runtime-api/src/main/java/io/quarkus/signals/spi/Receiver.java
+++ b/extensions/signals/runtime-api/src/main/java/io/quarkus/signals/spi/Receiver.java
@@ -1,9 +1,5 @@
 package io.quarkus.signals.spi;
 
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Type;
-import java.util.Set;
-
 import io.quarkus.signals.Receivers;
 import io.quarkus.signals.Receives;
 import io.quarkus.signals.Signal;
@@ -43,36 +39,7 @@ import io.smallrye.mutiny.Uni;
  * @see Receivers
  */
 @Experimental("This API is experimental and may change in the future")
-public interface Receiver<SIGNAL, RESPONSE> {
-
-    /**
-     * @return the received signal type
-     */
-    Type signalType();
-
-    /**
-     * The qualifiers are used during type-safe resolution together with the {@linkplain #signalType() signal type}.
-     *
-     * @return the set of qualifiers, never {@code null}
-     */
-    Set<Annotation> qualifiers();
-
-    /**
-     * The response type is used during type-safe resolution for request emissions. Only receivers whose
-     * response type is assignable to the requested type are considered.
-     *
-     * @return the response type, or {@code null} for fire-and-forget receivers
-     * @see Signal#request(Object, Class)
-     */
-    Type responseType();
-
-    /**
-     * Determines how the receiver is executed.
-     *
-     * @return the execution model
-     * @see ExecutionModel
-     */
-    ExecutionModel executionModel();
+public interface Receiver<SIGNAL, RESPONSE> extends Receivers.ReceiverInfo {
 
     /**
      * Invoked when a matching signal is emitted. The {@link SignalContext} provides access to the signal object,
@@ -83,29 +50,5 @@ public interface Receiver<SIGNAL, RESPONSE> {
      */
     @CheckReturnValue
     Uni<RESPONSE> notify(SignalContext<SIGNAL> context);
-
-    /**
-     * Determines the threading model used to execute a receiver.
-     */
-    enum ExecutionModel {
-
-        /**
-         * The receiver performs blocking operations and is offloaded to a worker thread.
-         * This is the default for receiver methods with a blocking signature (i.e., not returning {@link Uni}).
-         */
-        BLOCKING,
-
-        /**
-         * The receiver is executed on a virtual thread.
-         */
-        VIRTUAL_THREAD,
-
-        /**
-         * The receiver performs non-blocking operations. When Vert.x is available, it is executed on the event loop.
-         * This is the default for receiver methods returning {@link Uni}.
-         */
-        NON_BLOCKING
-
-    }
 
 }

--- a/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/impl/DefaultBlockingReceiverExecutor.java
+++ b/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/impl/DefaultBlockingReceiverExecutor.java
@@ -9,9 +9,9 @@ import jakarta.inject.Singleton;
 
 import org.jboss.logging.Logger;
 
+import io.quarkus.signals.Receivers.ExecutionModel;
 import io.quarkus.signals.SignalContext;
 import io.quarkus.signals.spi.Receiver;
-import io.quarkus.signals.spi.Receiver.ExecutionModel;
 import io.smallrye.mutiny.Uni;
 
 @Singleton

--- a/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/impl/InvokerReceiver.java
+++ b/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/impl/InvokerReceiver.java
@@ -4,6 +4,7 @@ import java.util.concurrent.CompletionStage;
 
 import jakarta.enterprise.invoke.Invoker;
 
+import io.quarkus.signals.Receivers.ReceiverKind;
 import io.quarkus.signals.SignalContext;
 import io.quarkus.signals.spi.Receiver;
 import io.smallrye.mutiny.Uni;
@@ -11,9 +12,9 @@ import io.smallrye.mutiny.Uni;
 public abstract class InvokerReceiver<SIGNAL, RESPONSE> implements Receiver<SIGNAL, RESPONSE> {
 
     private final Invoker<SIGNAL, RESPONSE> invoker;
-    private final ReceiverInfo receiveInfo;
+    private final InvokerReceiverInfo receiveInfo;
 
-    public InvokerReceiver(Invoker<SIGNAL, RESPONSE> invoker, ReceiverInfo receiverInfo) {
+    public InvokerReceiver(Invoker<SIGNAL, RESPONSE> invoker, InvokerReceiverInfo receiverInfo) {
         this.invoker = invoker;
         this.receiveInfo = receiverInfo;
     }
@@ -43,7 +44,12 @@ public abstract class InvokerReceiver<SIGNAL, RESPONSE> implements Receiver<SIGN
         }
     }
 
-    public record ReceiverInfo(short signalArgPosition, boolean receiveContext, short totalParams) {
+    public record InvokerReceiverInfo(short signalArgPosition, boolean receiveContext, short totalParams) {
+    }
+
+    @Override
+    public ReceiverKind kind() {
+        return ReceiverKind.DECLARATIVE;
     }
 
     public String toString() {

--- a/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/impl/ReceiverDefinitionImpl.java
+++ b/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/impl/ReceiverDefinitionImpl.java
@@ -11,10 +11,11 @@ import jakarta.enterprise.inject.spi.BeanContainer;
 import jakarta.enterprise.util.TypeLiteral;
 
 import io.quarkus.signals.Receivers;
+import io.quarkus.signals.Receivers.ExecutionModel;
+import io.quarkus.signals.Receivers.ReceiverKind;
 import io.quarkus.signals.Receivers.Registration;
 import io.quarkus.signals.SignalContext;
 import io.quarkus.signals.spi.Receiver;
-import io.quarkus.signals.spi.Receiver.ExecutionModel;
 import io.smallrye.mutiny.Uni;
 
 class ReceiverDefinitionImpl<SIGNAL, RESPONSE> implements Receivers.ReceiverDefinition<SIGNAL, RESPONSE> {
@@ -22,7 +23,7 @@ class ReceiverDefinitionImpl<SIGNAL, RESPONSE> implements Receivers.ReceiverDefi
     private final Function<CallbackReceiver<SIGNAL, RESPONSE>, Receivers.Registration> registerFun;
     private final BeanContainer beanContainer;
     private final Type signalType;
-    private Type responseType;
+    private Type responseType = void.class;
     private Set<Annotation> qualifiers = Set.of();
     private ExecutionModel executionModel = ExecutionModel.BLOCKING;
 
@@ -112,6 +113,11 @@ class ReceiverDefinitionImpl<SIGNAL, RESPONSE> implements Receivers.ReceiverDefi
         @Override
         public ExecutionModel executionModel() {
             return executionModel;
+        }
+
+        @Override
+        public ReceiverKind kind() {
+            return ReceiverKind.PROGRAMMATIC;
         }
 
         @Override

--- a/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/impl/ReceiverExecutor.java
+++ b/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/impl/ReceiverExecutor.java
@@ -1,8 +1,8 @@
 package io.quarkus.signals.runtime.impl;
 
+import io.quarkus.signals.Receivers.ExecutionModel;
 import io.quarkus.signals.SignalContext;
 import io.quarkus.signals.spi.Receiver;
-import io.quarkus.signals.spi.Receiver.ExecutionModel;
 import io.smallrye.mutiny.Uni;
 
 /**
@@ -10,9 +10,9 @@ import io.smallrye.mutiny.Uni;
  * <p>
  * This interface is pluggable &mdash; other Quarkus extensions can provide a custom implementation as a CDI bean to
  * override the default behavior. The default implementation is based on Vert.x and respects the receiver's
- * {@link Receiver.ExecutionModel execution model} (event loop, worker thread, or virtual thread).
+ * {@link ExecutionModel execution model} (event loop, worker thread, or virtual thread).
  *
- * @see Receiver.ExecutionModel
+ * @see ExecutionModel
  */
 public interface ReceiverExecutor {
 

--- a/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/impl/ReceiverManager.java
+++ b/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/impl/ReceiverManager.java
@@ -128,6 +128,16 @@ public class ReceiverManager implements Receivers, Signals {
     }
 
     @Override
+    public List<ReceiverInfo> resolveReceivers(Class<?> signalType, Annotation... qualifiers) {
+        return cast(resolveReceivers(signalType, Set.of(qualifiers)));
+    }
+
+    @Override
+    public List<ReceiverInfo> resolveReceivers(TypeLiteral<?> signalType, Annotation... qualifiers) {
+        return cast(resolveReceivers(signalType.getType(), Set.of(qualifiers)));
+    }
+
+    @Override
     public <SIGNAL> ReceiverDefinition<SIGNAL, Void> newReceiver(Class<SIGNAL> signalType) {
         return new ReceiverDefinitionImpl<>(signalType, beanContainer, this::register);
     }
@@ -243,6 +253,11 @@ public class ReceiverManager implements Receivers, Signals {
         }
 
         @Override
+        public ReceiverKind kind() {
+            return delegate.kind();
+        }
+
+        @Override
         public Uni<RESPONSE> notify(SignalContext<SIGNAL> context) {
             return cast(new InterceptorChain(interceptors, delegate, context).proceed());
         }
@@ -252,10 +267,6 @@ public class ReceiverManager implements Receivers, Signals {
             return delegate.toString();
         }
 
-        @SuppressWarnings("unchecked")
-        private static <T> T cast(Object obj) {
-            return (T) obj;
-        }
     }
 
     private static class InterceptorChain implements ReceiverInterceptor.InterceptionContext {
@@ -292,9 +303,10 @@ public class ReceiverManager implements Receivers, Signals {
             return (Uni<Object>) receiver.notify(cast(signalContext));
         }
 
-        @SuppressWarnings("unchecked")
-        private static <T> T cast(Object obj) {
-            return (T) obj;
-        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T cast(Object obj) {
+        return (T) obj;
     }
 }

--- a/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/impl/SignalImpl.java
+++ b/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/impl/SignalImpl.java
@@ -63,7 +63,7 @@ class SignalImpl<T> implements Signal<T> {
     }
 
     @Override
-    public Signal<T> putMetadata(String key, Object value) {
+    public Signal<T> withMetadata(String key, Object value) {
         Objects.requireNonNull(key);
         Objects.requireNonNull(value);
         Map<String, Object> meta;
@@ -78,7 +78,7 @@ class SignalImpl<T> implements Signal<T> {
     }
 
     @Override
-    public Signal<T> setMetadata(Map<String, Object> metadata) {
+    public Signal<T> withReplacedMetadata(Map<String, Object> metadata) {
         Objects.requireNonNull(metadata);
         return new SignalImpl<>(signalType, qualifiers, Map.copyOf(metadata), manager);
     }

--- a/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/impl/VertxReceiverExecutor.java
+++ b/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/impl/VertxReceiverExecutor.java
@@ -7,9 +7,9 @@ import jakarta.inject.Singleton;
 
 import org.jboss.logging.Logger;
 
+import io.quarkus.signals.Receivers.ExecutionModel;
 import io.quarkus.signals.SignalContext;
 import io.quarkus.signals.spi.Receiver;
-import io.quarkus.signals.spi.Receiver.ExecutionModel;
 import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle;
 import io.quarkus.virtual.threads.VirtualThreadsRecorder;
 import io.smallrye.common.vertx.VertxContext;


### PR DESCRIPTION
- rename putMetadata()/setMetadata() to
  withMetadata()/withReplacedMetadata(); to make it clear that methods are not mutating the current Signal
instance, but returning a new child instance
- add Receivers#resolveReceivers()
- also move ExecutionModel to API
- add Receiver.ReceiverKind
- add Receivers.ReceiverInfo
- add EnricherFailureTest