### PR TITLE
Harmonize HTTP Client tags in metrics recording

### DIFF
--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxHttpClientMetrics.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxHttpClientMetrics.java
@@ -17,7 +17,6 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.LongTaskTimer;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
 import io.quarkus.arc.Arc;
@@ -127,7 +126,6 @@ class VertxHttpClientMetrics extends VertxTcpClientMetrics
             public void requestBegin(RequestTracker requestMetric, String uri, HttpRequest request) {
                 requestMetric.request = request;
                 requestMetric.tags = tags.and(
-                        Tag.of("address", remote),
                         HttpCommonTags.method(request.method().name()),
                         HttpCommonTags.uri(request.uri(), null, -1, false));
                 String path = requestMetric.getNormalizedUriPath(
@@ -253,7 +251,6 @@ class VertxHttpClientMetrics extends VertxTcpClientMetrics
         RequestTracker(Tags origin, String address, HttpRequest request) {
             this.request = request;
             this.tags = origin.and(
-                    Tag.of("address", address),
                     HttpCommonTags.method(request.method().name()),
                     HttpCommonTags.uri(request.uri(), null, -1, false));
         }

--- a/integration-tests/grpc-interceptors/pom.xml
+++ b/integration-tests/grpc-interceptors/pom.xml
@@ -24,6 +24,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
@@ -71,6 +75,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/grpc-interceptors/src/main/java/io/quarkus/grpc/examples/interceptors/HelloWorldEndpoint.java
+++ b/integration-tests/grpc-interceptors/src/main/java/io/quarkus/grpc/examples/interceptors/HelloWorldEndpoint.java
@@ -8,6 +8,8 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.core.Response;
 
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
 import examples.GreeterGrpc;
 import examples.HelloReply;
 import examples.HelloRequest;
@@ -18,6 +20,10 @@ import io.smallrye.mutiny.Uni;
 @Path("/hello")
 public class HelloWorldEndpoint {
     static Set<String> invoked = new HashSet<>();
+
+    @RestClient
+    PingRestClient pingRestClient;
+
     @GrpcClient("hello")
     GreeterGrpc.GreeterBlockingStub blockingHelloService;
 
@@ -42,5 +48,19 @@ public class HelloWorldEndpoint {
     public Uni<String> helloMutiny(@PathParam("name") String name) {
         return mutinyHelloService.sayHello(HelloRequest.newBuilder().setName(name).build())
                 .onItem().transform(HelloReply::getMessage);
+    }
+
+    @GET
+    @Path("/ping")
+    public String ping() {
+        return "pong";
+    }
+
+    @GET
+    @Path("/rest-then-grpc/{name}")
+    public String restThenGrpc(@PathParam("name") String name) {
+        String pingResult = pingRestClient.ping();
+        HelloReply helloReply = blockingHelloService.sayHello(HelloRequest.newBuilder().setName(name).build());
+        return pingResult + " " + helloReply.getMessage();
     }
 }

--- a/integration-tests/grpc-interceptors/src/main/java/io/quarkus/grpc/examples/interceptors/PingRestClient.java
+++ b/integration-tests/grpc-interceptors/src/main/java/io/quarkus/grpc/examples/interceptors/PingRestClient.java
@@ -1,0 +1,15 @@
+package io.quarkus.grpc.examples.interceptors;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient(configKey = "ping")
+@Path("/hello")
+public interface PingRestClient {
+
+    @GET
+    @Path("/ping")
+    String ping();
+}

--- a/integration-tests/grpc-interceptors/src/main/resources/application.properties
+++ b/integration-tests/grpc-interceptors/src/main/resources/application.properties
@@ -15,3 +15,5 @@ quarkus.grpc.clients.hello.port=9001
 
 %o2n.quarkus.grpc.clients.hello.port=8081
 %o2n.quarkus.grpc.clients.hello.use-quarkus-grpc-client=false
+
+quarkus.rest-client.ping.url=http://localhost:${quarkus.http.port:8081}

--- a/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/HelloWorldEndpointTestBase.java
+++ b/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/HelloWorldEndpointTestBase.java
@@ -40,6 +40,17 @@ class HelloWorldEndpointTestBase {
         assertThat(response).isEqualTo("Hello neo-mutiny");
     }
 
+    @Test
+    public void testRestClientThenGrpcDoesNotConflictWithMetrics() {
+        String response = get("/hello/rest-then-grpc/neo").then().statusCode(200)
+                .extract().asString();
+        assertThat(response).isEqualTo("pong Hello neo");
+
+        String metrics = get("/q/metrics").then().statusCode(200)
+                .extract().asString();
+        assertThat(metrics).contains("http_client_requests_seconds");
+    }
+
     public void ensureThatMetricsAreProduced() {
         String metrics = get("/q/metrics")
                 .then().statusCode(200)


### PR DESCRIPTION
This is done because the gRPC client does not add this,
resulting in conflicting tags which are not allowed
when using the Prometheus registry

- Fixes: https://github.com/quarkusio/quarkus/issues/54187