### PR TITLE
Manage org.infinispan:infinispan-core in quarkus-bom

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -5863,6 +5863,11 @@
             </dependency>
             <dependency>
                 <groupId>org.infinispan</groupId>
+                <artifactId>infinispan-core</artifactId>
+                <version>${infinispan.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.infinispan</groupId>
                 <artifactId>infinispan-query</artifactId>
                 <version>${infinispan.version}</version>
             </dependency>


### PR DESCRIPTION
Small thing I noticed when upgrading Camel Quarkus to Quarkus 3.36.0.CR1. The latest `narayana-jta` `7.3.4.Final` release now brings some `org.infinispan` transitives. One of which is `infinispan-core`. It's not currently managed by `quarkus-bom`, thus there is some dependency misalignment.

Before:

```
+- org.jboss.narayana.jta:narayana-jta:jar:7.3.4.Final:compile
|  +- org.infinispan:infinispan-core:jar:16.1.4:compile
|  +- org.infinispan:infinispan-commons:jar:16.0.9:compile
|  +- org.infinispan:infinispan-counter-api:jar:16.0.9:compile
```

After:

```
+- org.jboss.narayana.jta:narayana-jta:jar:7.3.4.Final:compile
|  +- org.infinispan:infinispan-core:jar:16.0.9:compile
|  +- org.infinispan:infinispan-commons:jar:16.0.9:compile
|  +- org.infinispan:infinispan-counter-api:jar:16.0.9:compile
```
