### PR TITLE
Bump smallrye-open-api from 4.3.1 to 4.3.3

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -48,7 +48,7 @@
         <smallrye-common.version>2.17.0</smallrye-common.version>
         <smallrye-config.version>3.17.2</smallrye-config.version>
         <smallrye-health.version>4.3.0</smallrye-health.version>
-        <smallrye-open-api.version>4.3.1</smallrye-open-api.version>
+        <smallrye-open-api.version>4.3.3</smallrye-open-api.version>
         <smallrye-graphql.version>2.18.1</smallrye-graphql.version>
         <smallrye-fault-tolerance.version>6.11.1</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>4.6.3</smallrye-jwt.version>

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -1260,7 +1260,10 @@ public class SmallRyeOpenApiProcessor {
                 .withOperationHandler(operationHandler)
                 .enableUnannotatedPathParameters(capabilities.isPresent(Capability.RESTEASY_REACTIVE))
                 .enableStandardFilter(false)
-                .withFilters(oasFilters);
+                .withFilters(oasFilters)
+                // Mark the model as intermediate so that private extensions remain
+                // available for filters running at startup.
+                .withIntermediateModel(true);
 
         getUserDefinedFilters(index, documentName, OpenApiFilter.RunStage.BUILD).forEach(builder::addFilterName);
 

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiDocumentService.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiDocumentService.java
@@ -82,6 +82,9 @@ public class OpenApiDocumentService {
                 if (requestFilters.isEmpty()) {
                     this.documentHolders.put(documentName, new StaticDocument(builder.build()));
                 } else {
+                    // Mark the model as intermediate so that private extensions remain
+                    // available for filters running at each request.
+                    builder.withIntermediateModel(true);
                     var perRequestFilterSetup = addFilters(requestFilters, loader);
                     // Only regenerate the OpenAPI document when configured and there are filters to run
                     this.documentHolders.put(documentName,


### PR DESCRIPTION
Bump smallrye-open-api to version [4.3.2](https://github.com/smallrye/smallrye-open-api/releases/tag/4.3.2), [4.3.3](https://github.com/smallrye/smallrye-open-api/releases/tag/4.3.3).

- Fixes: #51109
- Fixes: #53479
- Fixes: OAuth2 authorization code flow in Swagger UI, as described in https://github.com/smallrye/smallrye-open-api/issues/2560
