### PR TITLE
OIDC: discover metadata for DEV UI component only when necessary and with request timeout

### DIFF
--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/AbstractDevUIProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/AbstractDevUIProcessor.java
@@ -3,6 +3,7 @@ package io.quarkus.oidc.deployment.devservices;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 
@@ -15,9 +16,9 @@ import io.quarkus.devui.spi.page.Page;
 import io.quarkus.oidc.runtime.OidcTenantConfig;
 import io.quarkus.oidc.runtime.dev.ui.OidcDevUiRecorder;
 import io.quarkus.oidc.runtime.dev.ui.OidcDevUiRpcSvcPropertiesBean;
-import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
+import io.smallrye.mutiny.Uni;
 
 public abstract class AbstractDevUIProcessor {
     protected static final String CONFIG_PREFIX = "quarkus.oidc.";
@@ -76,7 +77,7 @@ public abstract class AbstractDevUIProcessor {
 
         cardPage.addBuildTimeData("devRoot", nonApplicationRootPathBuildItem.getNonApplicationRootPath());
 
-        RuntimeValue<OidcDevUiRpcSvcPropertiesBean> runtimeProperties = recorder.getRpcServiceProperties(
+        Supplier<Uni<OidcDevUiRpcSvcPropertiesBean>> runtimeProperties = recorder.getRpcServiceProperties(
                 webClientTimeout, grantOptions, oidcProviderName, oidcGrantType, introspectionIsAvailable,
                 swaggerIsAvailable, graphqlIsAvailable, swaggerUiPath, graphqlUiPath, devServiceConfigHashCode,
                 discoverMetadata, devUiLogoutPath, devUiReadSessionCookiePath, authServerUrl, buildTimeKeycloakAdminUrl,

--- a/extensions/oidc/runtime-dev/src/main/java/io/quarkus/oidc/runtime/dev/ui/OidcDevJsonRpcService.java
+++ b/extensions/oidc/runtime-dev/src/main/java/io/quarkus/oidc/runtime/dev/ui/OidcDevJsonRpcService.java
@@ -2,18 +2,20 @@ package io.quarkus.oidc.runtime.dev.ui;
 
 import static io.quarkus.oidc.runtime.dev.ui.OidcDevServicesUtils.getTokens;
 
+import java.util.function.Function;
+
 import jakarta.inject.Inject;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 
 import io.quarkus.vertx.http.runtime.VertxHttpConfig;
-import io.smallrye.common.annotation.NonBlocking;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Vertx;
 
 public class OidcDevJsonRpcService {
-    private OidcDevUiRpcSvcPropertiesBean props;
+    private Uni<OidcDevUiRpcSvcPropertiesBean> propertiesBeanUni;
+    private volatile OidcDevUiRpcSvcPropertiesBean resolvedProperties;
     private VertxHttpConfig httpConfig;
 
     @Inject
@@ -22,53 +24,61 @@ public class OidcDevJsonRpcService {
     @Inject
     Vertx vertx;
 
-    @NonBlocking
-    public String getAdminConsoleUrl() {
-        return props.getKeycloakAdminUrl();
+    public Uni<String> getAdminConsoleUrl() {
+        return withProperties(props -> Uni.createFrom().item(props.getKeycloakAdminUrl()));
     }
 
-    @NonBlocking
-    public OidcDevUiRuntimePropertiesDTO getProperties() {
-        return new OidcDevUiRuntimePropertiesDTO(props.getAuthorizationUrl(), props.getTokenUrl(), props.getLogoutUrl(),
-                ConfigProvider.getConfig(), httpConfig.port(),
+    public Uni<OidcDevUiRuntimePropertiesDTO> getProperties() {
+        return withProperties(props -> Uni.createFrom().item(new OidcDevUiRuntimePropertiesDTO(props.getAuthorizationUrl(),
+                props.getTokenUrl(), props.getLogoutUrl(), ConfigProvider.getConfig(), httpConfig.port(),
                 props.getOidcProviderName(), props.getOidcApplicationType(), props.getOidcGrantType(),
                 props.isIntrospectionIsAvailable(), props.getKeycloakAdminUrl(),
                 props.getKeycloakRealms(), props.isSwaggerIsAvailable(), props.isGraphqlIsAvailable(), props.getSwaggerUiPath(),
-                props.getGraphqlUiPath(),
-                props.getDevServiceConfigHashCode(), props.getPropertiesStateId(),
-                props.getLogoutPath(), props.getReadSessionCookiePath());
+                props.getGraphqlUiPath(), props.getDevServiceConfigHashCode(), props.getPropertiesStateId(),
+                props.getLogoutPath(), props.getReadSessionCookiePath())));
     }
 
     public Uni<String> exchangeCodeForTokens(String tokenUrl, String clientId, String clientSecret,
             String authorizationCode, String redirectUri) {
-        return getTokens(tokenUrl, clientId, clientSecret, authorizationCode, redirectUri, vertx, props.getCodeGrantOptions())
-                .ifNoItem().after(props.getWebClientTimeout()).fail();
+        return withProperties(props -> getTokens(tokenUrl, clientId, clientSecret, authorizationCode, redirectUri,
+                vertx, props.getCodeGrantOptions()).ifNoItem().after(props.getWebClientTimeout()).fail());
     }
 
     public Uni<Integer> testServiceWithToken(String token, String serviceUrl) {
-        return OidcDevServicesUtils
+        return withProperties(props -> OidcDevServicesUtils
                 .testServiceWithToken(serviceUrl, token, vertx)
-                .ifNoItem().after(props.getWebClientTimeout()).fail();
+                .ifNoItem().after(props.getWebClientTimeout()).fail());
     }
 
     public Uni<String> testServiceWithPassword(String tokenUrl, String serviceUrl, String clientId,
             String clientSecret, String username, String password) {
-        return OidcDevServicesUtils.testServiceWithPassword(tokenUrl, serviceUrl, clientId, clientSecret, username,
-                password, vertx, props.getWebClientTimeout(), props.getPasswordGrantOptions(), props.getOidcUsers());
+        return withProperties(
+                props -> OidcDevServicesUtils.testServiceWithPassword(tokenUrl, serviceUrl, clientId, clientSecret, username,
+                        password, vertx, props.getWebClientTimeout(), props.getPasswordGrantOptions(), props.getOidcUsers()));
     }
 
     public Uni<String> testServiceWithClientCred(String tokenUrl, String serviceUrl, String clientId,
             String clientSecret) {
-        return OidcDevServicesUtils.testServiceWithClientCred(tokenUrl, serviceUrl, clientId, clientSecret, vertx,
-                props.getWebClientTimeout(), props.getClientCredGrantOptions());
+        return withProperties(props -> OidcDevServicesUtils.testServiceWithClientCred(tokenUrl,
+                serviceUrl, clientId, clientSecret, vertx, props.getWebClientTimeout(), props.getClientCredGrantOptions()));
     }
 
     public Multi<Boolean> streamOidcLoginEvent() {
         return oidcDevTokensObserver.streamOidcLoginEvent();
     }
 
-    void hydrate(OidcDevUiRpcSvcPropertiesBean properties, VertxHttpConfig httpConfig) {
-        this.props = properties;
+    private <T> Uni<T> withProperties(Function<OidcDevUiRpcSvcPropertiesBean, Uni<T>> function) {
+        if (resolvedProperties == null) {
+            return propertiesBeanUni.flatMap(props -> {
+                this.resolvedProperties = props;
+                return function.apply(props);
+            });
+        }
+        return function.apply(resolvedProperties);
+    }
+
+    void hydrate(Uni<OidcDevUiRpcSvcPropertiesBean> propertiesBeanUni, VertxHttpConfig httpConfig) {
+        this.propertiesBeanUni = propertiesBeanUni;
         this.httpConfig = httpConfig;
     }
 }

--- a/extensions/oidc/runtime-dev/src/main/java/io/quarkus/oidc/runtime/dev/ui/OidcDevUiRecorder.java
+++ b/extensions/oidc/runtime-dev/src/main/java/io/quarkus/oidc/runtime/dev/ui/OidcDevUiRecorder.java
@@ -3,6 +3,7 @@ package io.quarkus.oidc.runtime.dev.ui;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -15,12 +16,11 @@ import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.vertx.core.runtime.VertxCoreRecorder;
 import io.quarkus.vertx.http.runtime.VertxHttpConfig;
+import io.smallrye.mutiny.Uni;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.mutiny.core.buffer.Buffer;
-import io.vertx.mutiny.ext.web.client.HttpResponse;
 import io.vertx.mutiny.ext.web.client.WebClient;
 
 @Recorder
@@ -41,12 +41,24 @@ public class OidcDevUiRecorder {
     }
 
     public void createJsonRPCService(BeanContainer beanContainer,
-            RuntimeValue<OidcDevUiRpcSvcPropertiesBean> oidcDevUiRpcSvcPropertiesBean) {
+            Supplier<Uni<OidcDevUiRpcSvcPropertiesBean>> oidcDevUiRpcSvcPropertiesBeanSupplier) {
         OidcDevJsonRpcService jsonRpcService = beanContainer.beanInstance(OidcDevJsonRpcService.class);
-        jsonRpcService.hydrate(oidcDevUiRpcSvcPropertiesBean.getValue(), httpConfig.getValue());
+        jsonRpcService.hydrate(oidcDevUiRpcSvcPropertiesBeanSupplier.get(), httpConfig.getValue());
     }
 
-    public RuntimeValue<OidcDevUiRpcSvcPropertiesBean> getRpcServiceProperties(Duration webClientTimeout,
+    public Supplier<Uni<OidcDevUiRpcSvcPropertiesBean>> getRpcServiceProperties(Duration webClientTimeout,
+            Map<String, Map<String, String>> grantOptions,
+            String oidcProviderName, String oidcGrantType, boolean introspectionIsAvailable, boolean swaggerIsAvailable,
+            boolean graphqlIsAvailable, String swaggerUiPath, String graphqlUiPath, String devServiceConfigHashCode,
+            boolean discoverMetadata, String devUiLogoutPath, String devUiReadSessionCookiePath, String authServerUrl,
+            String buildTimeKeycloakAdminUrl, String buildTimeOidcApplicationType, DevServiceType devServiceType) {
+        return () -> getRpcServicePropertiesInternal(webClientTimeout, grantOptions, oidcProviderName, oidcGrantType,
+                introspectionIsAvailable, swaggerIsAvailable, graphqlIsAvailable, swaggerUiPath, graphqlUiPath,
+                devServiceConfigHashCode, discoverMetadata, devUiLogoutPath, devUiReadSessionCookiePath, authServerUrl,
+                buildTimeKeycloakAdminUrl, buildTimeOidcApplicationType, devServiceType);
+    }
+
+    public Uni<OidcDevUiRpcSvcPropertiesBean> getRpcServicePropertiesInternal(Duration webClientTimeout,
             Map<String, Map<String, String>> grantOptions,
             String oidcProviderName, String oidcGrantType, boolean introspectionIsAvailable, boolean swaggerIsAvailable,
             boolean graphqlIsAvailable, String swaggerUiPath, String graphqlUiPath, String devServiceConfigHashCode,
@@ -115,22 +127,31 @@ public class OidcDevUiRecorder {
             oidcApplicationType = buildTimeOidcApplicationType;
         }
 
+        final var beanWithoutDiscovery = new OidcDevUiRpcSvcPropertiesBean(authorizationUrl, tokenUrl, logoutUrl,
+                webClientTimeout, grantOptions, oidcUsers, oidcProviderName, oidcApplicationType, oidcGrantType,
+                introspectionIsAvailable, keycloakAdminUrl, keycloakRealms, swaggerIsAvailable,
+                graphqlIsAvailable, swaggerUiPath, graphqlUiPath, devServiceConfigHashCode,
+                devUiLogoutPath, devUiReadSessionCookiePath);
         if (discoverMetadata) {
-            JsonObject metadata = discoverMetadata(authServerUrl);
-            if (metadata != null) {
-                authorizationUrl = metadata.getString("authorization_endpoint");
-                tokenUrl = metadata.getString("token_endpoint");
-                logoutUrl = metadata.getString("end_session_endpoint");
-                introspectionIsAvailable = metadata.containsKey("introspection_endpoint")
-                        || metadata.containsKey("userinfo_endpoint");
-            }
+            return discoverMetadata(authServerUrl, webClientTimeout)
+                    .map(metadata -> {
+                        if (metadata != null) {
+                            return new OidcDevUiRpcSvcPropertiesBean(metadata.getString("authorization_endpoint"),
+                                    metadata.getString("token_endpoint"), metadata.getString("end_session_endpoint"),
+                                    webClientTimeout, grantOptions, oidcUsers, oidcProviderName, oidcApplicationType,
+                                    oidcGrantType,
+                                    metadata.containsKey("introspection_endpoint") || metadata.containsKey("userinfo_endpoint"),
+                                    keycloakAdminUrl, keycloakRealms, swaggerIsAvailable,
+                                    graphqlIsAvailable, swaggerUiPath, graphqlUiPath, devServiceConfigHashCode,
+                                    devUiLogoutPath, devUiReadSessionCookiePath);
+                        } else {
+                            return beanWithoutDiscovery;
+                        }
+                    })
+                    .memoize().indefinitely();
+        } else {
+            return Uni.createFrom().item(beanWithoutDiscovery);
         }
-        return new RuntimeValue<>(
-                new OidcDevUiRpcSvcPropertiesBean(authorizationUrl, tokenUrl, logoutUrl,
-                        webClientTimeout, grantOptions, oidcUsers, oidcProviderName, oidcApplicationType, oidcGrantType,
-                        introspectionIsAvailable, keycloakAdminUrl, keycloakRealms, swaggerIsAvailable,
-                        graphqlIsAvailable, swaggerUiPath, graphqlUiPath, devServiceConfigHashCode,
-                        devUiLogoutPath, devUiReadSessionCookiePath));
     }
 
     public Handler<RoutingContext> readSessionCookieHandler() {
@@ -141,25 +162,29 @@ public class OidcDevUiRecorder {
         return new OidcDevSessionLogoutHandler();
     }
 
-    private static JsonObject discoverMetadata(String authServerUrl) {
-        WebClient client = OidcDevServicesUtils.createWebClient(VertxCoreRecorder.getVertx().get());
-        try {
+    private static Uni<JsonObject> discoverMetadata(String authServerUrl, Duration webClientTimeout) {
+        return Uni.createFrom().deferred(() -> {
+            WebClient client = OidcDevServicesUtils.createWebClient(VertxCoreRecorder.getVertx().get());
+
             String metadataUrl = authServerUrl + OidcConstants.WELL_KNOWN_CONFIGURATION;
+
             LOG.infof("OIDC Dev Console: discovering the provider metadata at %s", metadataUrl);
 
-            HttpResponse<Buffer> resp = client.getAbs(metadataUrl)
-                    .putHeader(HttpHeaders.ACCEPT.toString(), "application/json").send().await().indefinitely();
-            if (resp.statusCode() == 200) {
-                return resp.bodyAsJsonObject();
-            } else {
-                LOG.errorf("OIDC metadata discovery failed: %s", resp.bodyAsString());
-                return null;
-            }
-        } catch (Throwable t) {
-            LOG.infof("OIDC metadata can not be discovered: %s", t.toString());
-            return null;
-        } finally {
-            client.close();
-        }
+            return client.getAbs(metadataUrl)
+                    .putHeader(HttpHeaders.ACCEPT.toString(), "application/json")
+                    .timeout(webClientTimeout.toMillis())
+                    .send()
+                    .map(resp -> {
+                        if (resp.statusCode() == 200) {
+                            return resp.bodyAsJsonObject();
+                        } else {
+                            LOG.errorf("OIDC metadata discovery failed: %s", resp.bodyAsString());
+                            return null;
+                        }
+                    })
+                    .onFailure().invoke(t -> LOG.infof("OIDC metadata can not be discovered: %s", t.toString()))
+                    .onFailure().recoverWithNull()
+                    .onTermination().invoke(client::close);
+        });
     }
 }


### PR DESCRIPTION
* Closes: https://github.com/quarkusio/quarkus/issues/54053
* Instead of calling discovering OIDC provider metadata on startup, we only discover it when user actually decided to use DEV UI  OpenID Connect provider component. This we avoid issues described in the linked issue when user don't use DEV UI but we still try to connect to the provider
  * apart of the fact that it works around the reported issue, I also think it is a good idea as we cannot assume that every time users starts Quarkus app in a DEV Mode they are going to use our DEV UI component :smile: so we save resources
* Apply per-request timeout because as user described, right now there is only the default connection timeout (60 seconds) and it can hang if the client connected to app but there is no response data (no timeout)