### PR TITLE
Support for multiple SunPKCS11 configurations

### DIFF
--- a/docs/src/main/asciidoc/security-customization.adoc
+++ b/docs/src/main/asciidoc/security-customization.adoc
@@ -630,6 +630,14 @@ quarkus.security.security-providers=SunPKCS11
 quarkus.security.security-provider-config.SunPKCS11=pkcs11.cfg
 ----
 
+You can also register multiple SunPKCS11 configurations:
+
+[source,properties]
+----
+quarkus.security.security-providers=SunPKCS11
+quarkus.security.security-provider-config.SunPKCS11=pkcs11-slot0.cfg,pkcs11-slot1.cfg
+----
+
 [NOTE]
 ====
 Note that while accessing the `SunPKCS11` bridge provider is supported in native image, configuring `SunPKCS11` is currently not supported in native image at the Quarkus level.

--- a/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/JCAProviderBuildItem.java
+++ b/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/JCAProviderBuildItem.java
@@ -1,5 +1,7 @@
 package io.quarkus.security.deployment;
 
+import java.util.List;
+
 import io.quarkus.builder.item.MultiBuildItem;
 
 /**
@@ -7,22 +9,22 @@ import io.quarkus.builder.item.MultiBuildItem;
  */
 public final class JCAProviderBuildItem extends MultiBuildItem {
     final private String providerName;
-    final private String providerConfig;
+    final private List<String> providerConfigs;
 
     public JCAProviderBuildItem(String providerName) {
-        this(providerName, null);
+        this(providerName, List.of());
     }
 
-    public JCAProviderBuildItem(String providerName, String providerConfig) {
+    public JCAProviderBuildItem(String providerName, List<String> providerConfigs) {
         this.providerName = providerName;
-        this.providerConfig = providerConfig;
+        this.providerConfigs = providerConfigs != null ? providerConfigs : List.of();
     }
 
     public String getProviderName() {
         return providerName;
     }
 
-    public String getProviderConfig() {
-        return providerConfig;
+    public List<String> getProviderConfigs() {
+        return providerConfigs;
     }
 }

--- a/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityConfig.java
+++ b/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityConfig.java
@@ -1,5 +1,6 @@
 package io.quarkus.security.deployment;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -33,7 +34,7 @@ public interface SecurityConfig {
      * Security provider configuration
      */
     @ConfigDocMapKey("provider-name")
-    Map<String, String> securityProviderConfig();
+    Map<String, List<String>> securityProviderConfig();
 
     /**
      * If set to true, access to all methods of beans that have any security annotations on other members will be denied by

--- a/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityProcessor.java
+++ b/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityProcessor.java
@@ -248,8 +248,8 @@ public class SecurityProcessor {
             } else if (SecurityProviderUtils.BOUNCYCASTLE_FIPS_JSSE_PROVIDER_NAME.equals(providerName)) {
                 bouncyCastleJsseProvider.produce(new BouncyCastleJsseProviderBuildItem(true));
             } else {
-                jcaProviders
-                        .produce(new JCAProviderBuildItem(providerName, security.securityProviderConfig().get(providerName)));
+                List<String> configs = security.securityProviderConfig().getOrDefault(providerName, List.of());
+                jcaProviders.produce(new JCAProviderBuildItem(providerName, configs));
             }
             log.debugf("Added providerName: %s", providerName);
         }
@@ -285,7 +285,7 @@ public class SecurityProcessor {
             List<JCAProviderBuildItem> jcaProviders,
             BuildProducer<NativeImageSecurityProviderBuildItem> additionalProviders) throws IOException, URISyntaxException {
         for (JCAProviderBuildItem provider : jcaProviders) {
-            List<String> providerClasses = registerProvider(provider.getProviderName(), provider.getProviderConfig(),
+            List<String> providerClasses = registerProvider(provider.getProviderName(), provider.getProviderConfigs(),
                     additionalProviders);
             for (String className : providerClasses) {
                 classes.produce(ReflectiveClassBuildItem.builder(className).methods().fields().build());
@@ -299,7 +299,7 @@ public class SecurityProcessor {
     void configureJCAProvidersAtRuntime(SecurityProviderRecorder recorder,
             List<JCAProviderBuildItem> jcaProviders) {
         for (JCAProviderBuildItem provider : jcaProviders) {
-            recorder.configureProvider(provider.getProviderName(), provider.getProviderConfig());
+            recorder.configureProvider(provider.getProviderName(), provider.getProviderConfigs());
         }
     }
 
@@ -608,7 +608,7 @@ public class SecurityProcessor {
      * @return class names that make up the provider and its services
      */
     private static List<String> registerProvider(String providerName,
-            String providerConfig,
+            List<String> providerConfigs,
             BuildProducer<NativeImageSecurityProviderBuildItem> additionalProviders) {
         List<String> providerClasses = new ArrayList<>();
         Provider provider = Security.getProvider(providerName);
@@ -623,7 +623,7 @@ public class SecurityProcessor {
                 }
             }
 
-            if (providerConfig != null) {
+            for (String providerConfig : providerConfigs) {
                 Provider configuredProvider = provider.configure(providerConfig);
                 if (configuredProvider != null) {
                     Security.addProvider(configuredProvider);

--- a/extensions/security/deployment/src/test/java/io/quarkus/security/test/JCAProviderBuildItemTest.java
+++ b/extensions/security/deployment/src/test/java/io/quarkus/security/test/JCAProviderBuildItemTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.security.test;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.security.deployment.JCAProviderBuildItem;
+
+public class JCAProviderBuildItemTest {
+
+    @Test
+    void singleConfigConstructor() {
+        var item = new JCAProviderBuildItem("SunPKCS11");
+        Assertions.assertEquals("SunPKCS11", item.getProviderName());
+        Assertions.assertTrue(item.getProviderConfigs().isEmpty());
+    }
+
+    @Test
+    void multipleConfigs() {
+        var item = new JCAProviderBuildItem("SunPKCS11",
+                List.of("/etc/pkcs11.cfg", "/etc/pkcs11-truststore.cfg"));
+        Assertions.assertEquals("SunPKCS11", item.getProviderName());
+        Assertions.assertEquals(2, item.getProviderConfigs().size());
+        Assertions.assertEquals("/etc/pkcs11.cfg", item.getProviderConfigs().get(0));
+        Assertions.assertEquals("/etc/pkcs11-truststore.cfg", item.getProviderConfigs().get(1));
+    }
+
+    @Test
+    void nullConfigsTreatedAsEmpty() {
+        var item = new JCAProviderBuildItem("SunPKCS11", null);
+        Assertions.assertEquals("SunPKCS11", item.getProviderName());
+        Assertions.assertTrue(item.getProviderConfigs().isEmpty());
+    }
+}

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/SecurityProviderRecorder.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/SecurityProviderRecorder.java
@@ -10,6 +10,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
 import java.security.SecureRandom;
 import java.security.Security;
+import java.util.List;
 import java.util.Set;
 
 import org.jboss.logging.Logger;
@@ -22,16 +23,18 @@ public class SecurityProviderRecorder {
 
     private static final Logger LOG = Logger.getLogger(SecurityProviderRecorder.class);
 
-    public void configureProvider(String providerName, String providerConfig) {
+    public void configureProvider(String providerName, List<String> providerConfigs) {
         Provider provider = Security.getProvider(providerName);
         if (provider == null) {
             throw new ConfigurationException(
                     String.format("Security provider '%s' is not available", providerName),
                     Set.of("quarkus.security.security-providers"));
         }
-        if (providerConfig != null) {
+        for (String providerConfig : providerConfigs) {
             try {
-                SecurityProviderUtils.addProvider(provider.configure(providerConfig));
+                Provider configured = provider.configure(providerConfig);
+                LOG.debugf("Registering security provider: %s (configured from %s)", configured.getName(), providerConfig);
+                SecurityProviderUtils.addProvider(configured);
             } catch (Exception e) {
                 throw new ConfigurationException(
                         String.format("Failed to configure security provider '%s'", providerName), e,


### PR DESCRIPTION
This PR is a follow up for #54147.

It was not obvious to me yesterday, but it is true that `SunPKCS11` only acts as a bridge, the actual providers are the ones that are created by `SunPKCS11` by applying a given pkcs11 configuration.

For example, given

```
quarkus.security.security-providers=SunPKCS11
quarkus.security.security-provider-config.SunPKCS11=pkcs11.cfg
```

and `pkcs11.cfg`, see its `name` property:

```
name = keystore
library = /usr/lib64/libsofthsm2.so
slotListIndex=  0
```

the registered provider name is `SunPKCS11-keystore`.

The other interesting detail about HSM is that it has slots. Each slot (or token) can have independent keys/certificates.

So far so good. Now, let's say we want a complete HSM based mTLS with keys and certs stored in the hardware, for ex in the cloud with the CloudHSM or other providers. Or simply create a REST endpoint that uses keys from one HSM slot for signing something and keys from another slot for encrypting something. 

To achieve it, one must supply `2` pkcs configurations, one per each slot, for example:

`pkcs11-keystore.cfg`:

```
name = keystore
library = /usr/lib64/libsofthsm2.so
slotListIndex=  0
```

`pkcs11-truststore.cfg`:

```
name = truststore
library = /usr/lib64/libsofthsm2.so
slotListIndex=  1
```

With 2 providers, `SunPKCS11-keystore` and `SunPKCS11-truststore` to be registered. Next these providers can be used to initialize keystores and trustores or simply use these security providers directly in the code.

But at the moment, in Quarkus, one can only have a single configuration associated with a given security provider.

Therefore this PR makes a simple update to the security processor and recorder to allow listing multiple provider configurations.

While this is relevant to the project @DimitriFankhauser works upon, this PR is technically independent from the HSM TLS effort as users should be able to access multiple HSM slots when needed in their application code. 

We can only confirm that the changes in this PR alongside other minor updates to Vert.x and Quarkus to be done by @DimitriFankhauser, we have a complete HSM MTLS working.
