### PR TITLE
Add extensions=true to generated extension codestart POMs for external extensions

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/integration-tests/java/integration-tests/pom.tpl.qute.xml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/integration-tests/java/integration-tests/pom.tpl.qute.xml
@@ -64,6 +64,9 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
+                {#if !in-quarkus-core}
+                <extensions>true</extensions>
+                {/if}
                 <executions>
                     <execution>
                         <goals>

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/docs/pom.tpl.qute.xml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/docs/pom.tpl.qute.xml
@@ -30,6 +30,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
+                <extensions>true</extensions>
                 <executions>
                     <execution>
                         <goals>

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/extension/QuarkusExtensionCodestartCatalog.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/extension/QuarkusExtensionCodestartCatalog.java
@@ -41,6 +41,7 @@ public final class QuarkusExtensionCodestartCatalog extends GenericCodestartCata
         QUARKUS_BOM_VERSION("quarkus.bom.version"),
         JAVA_VERSION("java.version"),
         PROPERTIES_FROM_PARENT("properties.from-parent"),
+        IN_QUARKUS_CORE("in-quarkus-core"),
         PARENT_GROUP_ID("parent.group-id"),
         PARENT_ARTIFACT_ID("parent.artifact-id"),
         PARENT_VERSION("parent.version"),

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/CreateExtension.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/CreateExtension.java
@@ -9,6 +9,7 @@ import static io.quarkus.devtools.codestarts.extension.QuarkusExtensionCodestart
 import static io.quarkus.devtools.codestarts.extension.QuarkusExtensionCodestartCatalog.QuarkusExtensionData.GROUP_ID;
 import static io.quarkus.devtools.codestarts.extension.QuarkusExtensionCodestartCatalog.QuarkusExtensionData.HAS_DOCS_MODULE;
 import static io.quarkus.devtools.codestarts.extension.QuarkusExtensionCodestartCatalog.QuarkusExtensionData.HAS_INTEGRATION_TESTS_MODULE;
+import static io.quarkus.devtools.codestarts.extension.QuarkusExtensionCodestartCatalog.QuarkusExtensionData.IN_QUARKUS_CORE;
 import static io.quarkus.devtools.codestarts.extension.QuarkusExtensionCodestartCatalog.QuarkusExtensionData.IT_PARENT_ARTIFACT_ID;
 import static io.quarkus.devtools.codestarts.extension.QuarkusExtensionCodestartCatalog.QuarkusExtensionData.IT_PARENT_GROUP_ID;
 import static io.quarkus.devtools.codestarts.extension.QuarkusExtensionCodestartCatalog.QuarkusExtensionData.IT_PARENT_RELATIVE_PATH;
@@ -289,6 +290,9 @@ public class CreateExtension {
             case OTHER_PLATFORM:
                 defaultVersion = DEFAULT_VERSION;
                 extensionDirName = extensionId;
+                if (layoutType == LayoutType.QUARKUS_CORE) {
+                    data.put(IN_QUARKUS_CORE, true);
+                }
                 final Model extensionsParentModel = readPom(workingDir.resolve(extensionsRelativeDir));
                 data.putIfAbsent(PROPERTIES_FROM_PARENT, true);
                 ensureRequiredStringData(PARENT_GROUP_ID, resolveGroupId(extensionsParentModel));

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/codestarts/extension/QuarkusExtensionCodestartGenerationTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/codestarts/extension/QuarkusExtensionCodestartGenerationTest.java
@@ -1,8 +1,10 @@
 package io.quarkus.devtools.codestarts.extension;
 
 import static io.quarkus.devtools.testing.SnapshotTesting.assertThatDirectoryTreeMatchSnapshots;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -43,6 +45,28 @@ class QuarkusExtensionCodestartGenerationTest {
         final Path projectDir = testDirPath.resolve("default");
         getCatalog().createProject(input).generate(projectDir);
         assertThatDirectoryTreeMatchSnapshots(testInfo, projectDir);
+
+        // External extensions (default layout) must declare <extensions>true</extensions>
+        // on the quarkus-maven-plugin to avoid the Maven warning about missing extensions.
+        // See https://github.com/quarkusio/quarkus/issues/53533
+        final String itPom = Files.readString(projectDir.resolve("integration-tests/pom.xml"));
+        assertThat(itPom).contains("<extensions>true</extensions>");
+    }
+
+    @Test
+    void generateInQuarkusCoreProject(TestInfo testInfo) throws Throwable {
+        final QuarkusExtensionCodestartProjectInput input = prepareInput()
+                .putData(QuarkusExtensionData.IN_QUARKUS_CORE, true)
+                .build();
+        final Path projectDir = testDirPath.resolve("in-quarkus-core");
+        getCatalog().createProject(input).generate(projectDir);
+
+        // Extensions inside the Quarkus core repo must NOT declare <extensions>true</extensions>:
+        // the quarkus-maven-plugin is built in the same reactor and is not yet available
+        // as a Maven extension during the first build.
+        // See https://github.com/quarkusio/quarkus/issues/53533
+        final String itPom = Files.readString(projectDir.resolve("integration-tests/pom.xml"));
+        assertThat(itPom).doesNotContain("<extensions>true</extensions>");
     }
 
     @Test

--- a/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_docs_pom.xml
+++ b/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_docs_pom.xml
@@ -28,6 +28,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
+                <extensions>true</extensions>
                 <executions>
                     <execution>
                         <goals>

--- a/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_integration-tests_pom.xml
+++ b/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_integration-tests_pom.xml
@@ -46,6 +46,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
+                <extensions>true</extensions>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
When users create a new extension with `quarkus create extension`, the generated `integration-tests` and Quarkiverse `docs` modules declare the `quarkus-maven-plugin` without `<extensions>true</extensions>`. As a result every `mvn clean verify` prints a noisy `[WARNING] The Maven extensions for the Quarkus Maven plugin are not enabled for this build` and the user is told to manually add the element back.

For extensions inside the Quarkus core repo this declaration cannot be present — the `quarkus-maven-plugin` is built in the same reactor and is not yet available as a Maven extension during the first build, as @gsmet pointed out in the issue. For every other layout (`OTHER_PLATFORM`, `QUARKIVERSE`, `STANDALONE`) the declaration is desired and silences the warning.

This change introduces a new `in-quarkus-core` codestart data key, populated only for `LayoutType.QUARKUS_CORE`, and uses it to gate the `<extensions>true</extensions>` element in the generated `integration-tests` POM. The Quarkiverse docs POM unconditionally adds the element since that codestart is only ever rendered for external Quarkiverse extensions.

- Fixes: #53533