### PR TITLE
Introduce a better way of testing prometheus metrics

### DIFF
--- a/integration-tests/cache/pom.xml
+++ b/integration-tests/cache/pom.xml
@@ -50,6 +50,12 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-prometheus-metrics</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
         <dependency>

--- a/integration-tests/cache/src/test/java/io/quarkus/it/cache/CacheTestCase.java
+++ b/integration-tests/cache/src/test/java/io/quarkus/it/cache/CacheTestCase.java
@@ -2,10 +2,11 @@ package io.quarkus.it.cache;
 
 import static io.quarkus.it.cache.ExpensiveResource.EXPENSIVE_RESOURCE_CACHE_NAME;
 import static io.quarkus.it.cache.GetIfPresentResource.GET_IF_PRESENT_CACHE_NAME;
+import static io.quarkus.test.micrometer.PrometheusMetricsAssert.assertMetrics;
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
+import static org.assertj.core.api.Assertions.entry;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,16 +19,16 @@ public class CacheTestCase {
 
     @Test
     void testCache() {
-        assertMetrics(EXPENSIVE_RESOURCE_CACHE_NAME, 0, 0, 0);
+        assertCacheMetrics(EXPENSIVE_RESOURCE_CACHE_NAME, 0, 0, 0);
 
         runExpensiveRequest();
-        assertMetrics(EXPENSIVE_RESOURCE_CACHE_NAME, 1, 1, 0);
+        assertCacheMetrics(EXPENSIVE_RESOURCE_CACHE_NAME, 1, 1, 0);
 
         runExpensiveRequest();
-        assertMetrics(EXPENSIVE_RESOURCE_CACHE_NAME, 1, 1, 1);
+        assertCacheMetrics(EXPENSIVE_RESOURCE_CACHE_NAME, 1, 1, 1);
 
         runExpensiveRequest();
-        assertMetrics(EXPENSIVE_RESOURCE_CACHE_NAME, 1, 1, 2);
+        assertCacheMetrics(EXPENSIVE_RESOURCE_CACHE_NAME, 1, 1, 2);
 
         when().get("/expensive-resource/invocations").then().statusCode(200).body(is("1"));
     }
@@ -39,7 +40,7 @@ public class CacheTestCase {
 
     @Test
     void testGetIfPresentMetrics() {
-        assertMetrics(GET_IF_PRESENT_CACHE_NAME, 0, 0, 0);
+        assertCacheMetrics(GET_IF_PRESENT_CACHE_NAME, 0, 0, 0);
 
         String cacheKey = "foo";
         String cacheValue = "bar";
@@ -47,35 +48,35 @@ public class CacheTestCase {
         given().pathParam("key", cacheKey)
                 .when().get("/get-if-present/{key}")
                 .then().statusCode(204);
-        assertMetrics(GET_IF_PRESENT_CACHE_NAME, 0, 1, 0);
+        assertCacheMetrics(GET_IF_PRESENT_CACHE_NAME, 0, 1, 0);
 
         given().pathParam("key", cacheKey)
                 .when().get("/get-if-present/{key}")
                 .then().statusCode(204);
-        assertMetrics(GET_IF_PRESENT_CACHE_NAME, 0, 2, 0);
+        assertCacheMetrics(GET_IF_PRESENT_CACHE_NAME, 0, 2, 0);
 
         given().pathParam("key", cacheKey).body(cacheValue)
                 .when().put("/get-if-present/{key}")
                 .then().statusCode(204);
-        assertMetrics(GET_IF_PRESENT_CACHE_NAME, 1, 2, 0);
+        assertCacheMetrics(GET_IF_PRESENT_CACHE_NAME, 1, 2, 0);
 
         given().pathParam("key", cacheKey)
                 .when().get("/get-if-present/{key}")
                 .then().statusCode(200).body(is(cacheValue));
-        assertMetrics(GET_IF_PRESENT_CACHE_NAME, 1, 2, 1);
+        assertCacheMetrics(GET_IF_PRESENT_CACHE_NAME, 1, 2, 1);
 
         given().pathParam("key", cacheKey)
                 .when().get("/get-if-present/{key}")
                 .then().statusCode(200).body(is(cacheValue));
-        assertMetrics(GET_IF_PRESENT_CACHE_NAME, 1, 2, 2);
+        assertCacheMetrics(GET_IF_PRESENT_CACHE_NAME, 1, 2, 2);
     }
 
-    private void assertMetrics(String cacheName, double expectedPuts, double expectedMisses, double expectedHits) {
-        String metricsResponse = when().get("/q/metrics").then().extract().asString();
-        assertTrue(metricsResponse.contains(String.format("cache_puts_total{cache=\"%s\"} %.1f", cacheName, expectedPuts)));
-        assertTrue(metricsResponse
-                .contains(String.format("cache_gets_total{cache=\"%s\",result=\"miss\"} %.1f", cacheName, expectedMisses)));
-        assertTrue(metricsResponse
-                .contains(String.format("cache_gets_total{cache=\"%s\",result=\"hit\"} %.1f", cacheName, expectedHits)));
+    private void assertCacheMetrics(String cacheName, double expectedPuts, double expectedMisses, double expectedHits) {
+        assertMetrics(when().get("/q/metrics").then().statusCode(200).extract().asInputStream())
+                .hasMetricWithExactLabelsAndValue("cache_puts_total", expectedPuts, entry("cache", cacheName))
+                .hasMetricWithExactLabelsAndValue("cache_gets_total", expectedMisses,
+                        entry("cache", cacheName), entry("result", "miss"))
+                .hasMetricWithExactLabelsAndValue("cache_gets_total", expectedHits,
+                        entry("cache", cacheName), entry("result", "hit"));
     }
 }

--- a/integration-tests/grpc-interceptors/pom.xml
+++ b/integration-tests/grpc-interceptors/pom.xml
@@ -48,6 +48,12 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-prometheus-metrics</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-test-grpc</artifactId>
             <version>${project.version}</version> <!--kept here to not pollute the BOM-->
             <scope>test</scope>

--- a/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/HelloWorldEndpointTestBase.java
+++ b/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/HelloWorldEndpointTestBase.java
@@ -1,5 +1,6 @@
 package io.quarkus.grpc.example.interceptors;
 
+import static io.quarkus.test.micrometer.PrometheusMetricsAssert.assertMetrics;
 import static io.restassured.RestAssured.get;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -46,19 +47,16 @@ class HelloWorldEndpointTestBase {
                 .extract().asString();
         assertThat(response).isEqualTo("pong Hello neo");
 
-        String metrics = get("/q/metrics").then().statusCode(200)
-                .extract().asString();
-        assertThat(metrics).contains("http_client_requests_seconds");
+        assertMetrics(get("/q/metrics").then().statusCode(200)
+                .extract().asInputStream())
+                .hasMetricNameContaining("http_client_requests_seconds");
     }
 
     public void ensureThatMetricsAreProduced() {
-        String metrics = get("/q/metrics")
-                .then().statusCode(200)
-                .extract().asString();
-
-        assertThat(metrics)
-                .contains("grpc_server_processing_duration_seconds_max") // server
-                .contains("grpc_client_processing_duration_seconds_count"); // client
+        assertMetrics(get("/q/metrics").then().statusCode(200)
+                .extract().asInputStream())
+                .hasMetricNameContaining("grpc_server_processing_duration_seconds_max") // server
+                .hasMetricNameContaining("grpc_client_processing_duration_seconds_count"); // client
     }
 
 }

--- a/integration-tests/grpc-streaming/pom.xml
+++ b/integration-tests/grpc-streaming/pom.xml
@@ -51,6 +51,12 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-prometheus-metrics</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-test-grpc</artifactId>
             <version>${project.version}</version> <!--kept here to not pollute the BOM-->
             <scope>test</scope>

--- a/integration-tests/grpc-streaming/src/test/java/io/quarkus/grpc/example/streaming/StreamingEndpointTestBase.java
+++ b/integration-tests/grpc-streaming/src/test/java/io/quarkus/grpc/example/streaming/StreamingEndpointTestBase.java
@@ -1,5 +1,6 @@
 package io.quarkus.grpc.example.streaming;
 
+import static io.quarkus.test.micrometer.PrometheusMetricsAssert.assertMetrics;
 import static io.restassured.RestAssured.get;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -37,13 +38,10 @@ class StreamingEndpointTestBase {
     }
 
     public void ensureThatMetricsAreProduced() {
-        String metrics = get("/q/metrics")
-                .then().statusCode(200)
-                .extract().asString();
-
-        assertThat(metrics)
-                .contains("grpc_server_processing_duration_seconds_max") // server
-                .contains("grpc_client_processing_duration_seconds_count"); // client
+        assertMetrics(get("/q/metrics").then().statusCode(200)
+                .extract().asInputStream())
+                .hasMetricNameContaining("grpc_server_processing_duration_seconds_max") // server
+                .hasMetricNameContaining("grpc_client_processing_duration_seconds_count"); // client
     }
 
 }

--- a/integration-tests/hibernate-orm-panache/pom.xml
+++ b/integration-tests/hibernate-orm-panache/pom.xml
@@ -99,6 +99,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-prometheus-metrics</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <scope>test</scope>

--- a/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/defaultpu/PanacheFunctionalityTest.java
+++ b/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/defaultpu/PanacheFunctionalityTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.it.panache.defaultpu;
 
-import static org.hamcrest.Matchers.containsString;
+import static io.quarkus.test.micrometer.PrometheusMetricsAssert.assertMetrics;
+import static org.assertj.core.api.Assertions.entry;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -202,11 +203,14 @@ public class PanacheFunctionalityTest {
 
     @Test
     public void testMetrics() {
-        RestAssured.when()
+        assertMetrics(RestAssured.when()
                 .get("/q/metrics")
                 .then()
-                .body(containsString("hibernate_cache_update_timestamps_requests_total{entityManagerFactory=\""
-                        + PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME + "\",result=\"miss\"}"));
+                .statusCode(200)
+                .extract().asInputStream())
+                .hasMetricWithExactLabels("hibernate_cache_update_timestamps_requests_total",
+                        entry("entityManagerFactory", PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME),
+                        entry("result", "miss"));
     }
 
     @DisabledOnIntegrationTest

--- a/integration-tests/kafka-snappy/pom.xml
+++ b/integration-tests/kafka-snappy/pom.xml
@@ -68,6 +68,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-prometheus-metrics</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>

--- a/integration-tests/kafka-snappy/src/test/java/io/quarkus/it/kafka/KafkaSnappyConsumerTest.java
+++ b/integration-tests/kafka-snappy/src/test/java/io/quarkus/it/kafka/KafkaSnappyConsumerTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.it.kafka;
 
-import static org.hamcrest.Matchers.containsString;
+import static io.quarkus.test.micrometer.PrometheusMetricsAssert.assertMetrics;
 
 import java.util.Properties;
 
@@ -50,8 +50,9 @@ public class KafkaSnappyConsumerTest {
     @Test
     public void metrics() {
         // Look for kafka consumer metrics (add .log().all() to examine what they are
-        RestAssured.when().get("/q/metrics").then()
+        assertMetrics(RestAssured.when().get("/q/metrics").then()
                 .statusCode(200)
-                .body(containsString("kafka_consumer_"));
+                .extract().asInputStream())
+                .hasMetricNameContaining("kafka_consumer_");
     }
 }

--- a/integration-tests/kafka-snappy/src/test/java/io/quarkus/it/kafka/KafkaSnappyProducerTest.java
+++ b/integration-tests/kafka-snappy/src/test/java/io/quarkus/it/kafka/KafkaSnappyProducerTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.it.kafka;
 
+import static io.quarkus.test.micrometer.PrometheusMetricsAssert.assertMetrics;
 import static org.hamcrest.Matchers.*;
 
 import java.time.Duration;
@@ -63,8 +64,9 @@ public class KafkaSnappyProducerTest {
     @Test
     public void metrics() throws Exception {
         // Look for kafka producer metrics (add .log().all() to examine what they are
-        RestAssured.when().get("/q/metrics").then()
+        assertMetrics(RestAssured.when().get("/q/metrics").then()
                 .statusCode(200)
-                .body(containsString("kafka_producer_"));
+                .extract().asInputStream())
+                .hasMetricNameContaining("kafka_producer_");
     }
 }

--- a/integration-tests/kafka-streams/pom.xml
+++ b/integration-tests/kafka-streams/pom.xml
@@ -58,6 +58,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-prometheus-metrics</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>

--- a/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsTest.java
+++ b/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.it.kafka.streams;
 
-import static org.hamcrest.Matchers.containsString;
+import static io.quarkus.test.micrometer.PrometheusMetricsAssert.assertMetrics;
 
 import java.io.File;
 import java.time.Duration;
@@ -142,9 +142,10 @@ public class KafkaStreamsTest {
 
     private void testMetricsPresent() {
         // Look for kafka consumer metrics (add .log().all() to examine what they are
-        RestAssured.when().get("/q/metrics").then()
+        assertMetrics(RestAssured.when().get("/q/metrics").then()
                 .statusCode(200)
-                .body(containsString("kafka_stream_"));
+                .extract().asInputStream())
+                .hasMetricNameContaining("kafka_stream_");
     }
 
     public void testKafkaStreamsNotAliveAndNotReady() throws Exception {

--- a/integration-tests/kafka/pom.xml
+++ b/integration-tests/kafka/pom.xml
@@ -61,6 +61,12 @@
             <artifactId>quarkus-test-kafka-companion</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-prometheus-metrics</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
         <!-- test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/KafkaConsumerTest.java
+++ b/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/KafkaConsumerTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.it.kafka;
 
-import static org.hamcrest.Matchers.containsString;
+import static io.quarkus.test.micrometer.PrometheusMetricsAssert.assertMetrics;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.hamcrest.Matchers;
@@ -40,8 +40,9 @@ public class KafkaConsumerTest {
     @Test
     public void metrics() {
         // Look for kafka consumer metrics (add .log().all() to examine what they are
-        RestAssured.when().get("/q/metrics").then()
+        assertMetrics(RestAssured.when().get("/q/metrics").then()
                 .statusCode(200)
-                .body(containsString("kafka_consumer_"));
+                .extract().asInputStream())
+                .hasMetricNameContaining("kafka_consumer_");
     }
 }

--- a/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/KafkaProducerTest.java
+++ b/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/KafkaProducerTest.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.kafka;
 
+import static io.quarkus.test.micrometer.PrometheusMetricsAssert.assertMetrics;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -56,8 +56,9 @@ public class KafkaProducerTest {
     @Test
     public void metrics() {
         // Look for kafka producer metrics (add .log().all() to examine what they are
-        RestAssured.when().get("/q/metrics").then()
+        assertMetrics(RestAssured.when().get("/q/metrics").then()
                 .statusCode(200)
-                .body(containsString("kafka_producer_"));
+                .extract().asInputStream())
+                .hasMetricNameContaining("kafka_producer_");
     }
 }

--- a/integration-tests/management-interface-auth/pom.xml
+++ b/integration-tests/management-interface-auth/pom.xml
@@ -49,6 +49,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-prometheus-metrics</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <scope>test</scope>

--- a/integration-tests/management-interface-auth/src/test/java/io/quarkus/it/management/ManagementInterfaceTestCase.java
+++ b/integration-tests/management-interface-auth/src/test/java/io/quarkus/it/management/ManagementInterfaceTestCase.java
@@ -1,5 +1,7 @@
 package io.quarkus.it.management;
 
+import static io.quarkus.test.micrometer.PrometheusMetricsAssert.assertMetrics;
+
 import java.util.Set;
 
 import org.hamcrest.Matchers;
@@ -63,12 +65,14 @@ public class ManagementInterfaceTestCase {
 
     @Test
     void verifyThatMetricsAreExposedOnManagementInterface() {
-        RestAssured.given().auth().basic("alice", "alice").get(getPrefix() + "/q/metrics")
+        assertMetrics(RestAssured.given().auth().basic("alice", "alice").get(getPrefix() + "/q/metrics")
                 .then().statusCode(200)
-                .body(Matchers.containsString("http_server_bytes_read"));
-        RestAssured.given().auth().basic("bob", "bob").get(getPrefix() + "/q/metrics")
+                .extract().asInputStream())
+                .hasMetricNameContaining("http_server_bytes_read");
+        assertMetrics(RestAssured.given().auth().basic("bob", "bob").get(getPrefix() + "/q/metrics")
                 .then().statusCode(200)
-                .body(Matchers.containsString("http_server_bytes_read"));
+                .extract().asInputStream())
+                .hasMetricNameContaining("http_server_bytes_read");
         RestAssured.given().auth().basic("john", "john").get(getPrefix() + "/q/metrics")
                 .then().statusCode(401);
 

--- a/integration-tests/management-interface/pom.xml
+++ b/integration-tests/management-interface/pom.xml
@@ -37,6 +37,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-prometheus-metrics</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <scope>test</scope>

--- a/integration-tests/management-interface/src/test/java/io/quarkus/it/management/ManagementInterfaceTestCase.java
+++ b/integration-tests/management-interface/src/test/java/io/quarkus/it/management/ManagementInterfaceTestCase.java
@@ -1,5 +1,7 @@
 package io.quarkus.it.management;
 
+import static io.quarkus.test.micrometer.PrometheusMetricsAssert.assertMetrics;
+
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -26,9 +28,10 @@ public class ManagementInterfaceTestCase {
 
     @Test
     void verifyThatMetricsAreExposedOnManagementInterface() {
-        RestAssured.get(getPrefix() + "/q/metrics")
+        assertMetrics(RestAssured.get(getPrefix() + "/q/metrics")
                 .then().statusCode(200)
-                .body(Matchers.containsString("http_server_bytes_read"));
+                .extract().asInputStream())
+                .hasMetricNameContaining("http_server_bytes_read");
 
         RestAssured.get("/q/metrics")
                 .then().statusCode(404);

--- a/integration-tests/micrometer-prometheus/pom.xml
+++ b/integration-tests/micrometer-prometheus/pom.xml
@@ -170,6 +170,12 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-prometheus-metrics</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integration-tests/micrometer-prometheus/src/test/java/io/quarkus/it/micrometer/prometheus/ExampleResourcesTest.java
+++ b/integration-tests/micrometer-prometheus/src/test/java/io/quarkus/it/micrometer/prometheus/ExampleResourcesTest.java
@@ -1,7 +1,8 @@
 package io.quarkus.it.micrometer.prometheus;
 
+import static io.quarkus.test.micrometer.PrometheusMetricsAssert.assertMetrics;
 import static io.restassured.RestAssured.when;
-import static org.hamcrest.CoreMatchers.containsString;
+import static org.assertj.core.api.Assertions.entry;
 
 import org.junit.jupiter.api.Test;
 
@@ -16,15 +17,15 @@ public class ExampleResourcesTest {
         when().get("/example/gauge/1").then().statusCode(200);
         when().get("/example/gauge/2").then().statusCode(200);
         when().get("/example/gauge/4").then().statusCode(200);
-        when().get("/q/metrics").then().statusCode(200)
-                .body(containsString(
-                        "example_list_size{env=\"test\",env2=\"test\",registry=\"prometheus\"} 2.0"));
+        assertMetrics(when().get("/q/metrics").then().statusCode(200).extract().asInputStream())
+                .hasMetricWithExactLabelsAndValue("example_list_size", 2.0,
+                        entry("env", "test"), entry("env2", "test"), entry("registry", "prometheus"));
         when().get("/example/gauge/6").then().statusCode(200);
         when().get("/example/gauge/5").then().statusCode(200);
         when().get("/example/gauge/7").then().statusCode(200);
-        when().get("/q/metrics").then().statusCode(200)
-                .body(containsString(
-                        "example_list_size{env=\"test\",env2=\"test\",registry=\"prometheus\"} 1.0"));
+        assertMetrics(when().get("/q/metrics").then().statusCode(200).extract().asInputStream())
+                .hasMetricWithExactLabelsAndValue("example_list_size", 1.0,
+                        entry("env", "test"), entry("env2", "test"), entry("registry", "prometheus"));
     }
 
     @Test
@@ -36,32 +37,41 @@ public class ExampleResourcesTest {
         when().get("/example/prime/3").then().statusCode(200);
         when().get("/example/prime/15").then().statusCode(200);
 
-        when().get("/q/metrics").then().statusCode(200)
-                .body(containsString(
-                        "example_prime_number_total{env=\"test\",env2=\"test\",registry=\"prometheus\",type=\"prime\"}"))
-                .body(containsString(
-                        "example_prime_number_total{env=\"test\",env2=\"test\",registry=\"prometheus\",type=\"not-prime\"}"))
-                .body(containsString(
-                        "example_prime_number_total{env=\"test\",env2=\"test\",registry=\"prometheus\",type=\"one\"}"))
-                .body(containsString(
-                        "example_prime_number_total{env=\"test\",env2=\"test\",registry=\"prometheus\",type=\"even\"}"))
-                .body(containsString(
-                        "example_prime_number_total{env=\"test\",env2=\"test\",registry=\"prometheus\",type=\"not-natural\"}"));
+        assertMetrics(when().get("/q/metrics").then().statusCode(200).extract().asInputStream())
+                .hasMetricWithExactLabels("example_prime_number_total",
+                        entry("env", "test"), entry("env2", "test"),
+                        entry("registry", "prometheus"), entry("type", "prime"))
+                .hasMetricWithExactLabels("example_prime_number_total",
+                        entry("env", "test"), entry("env2", "test"),
+                        entry("registry", "prometheus"), entry("type", "not-prime"))
+                .hasMetricWithExactLabels("example_prime_number_total",
+                        entry("env", "test"), entry("env2", "test"),
+                        entry("registry", "prometheus"), entry("type", "one"))
+                .hasMetricWithExactLabels("example_prime_number_total",
+                        entry("env", "test"), entry("env2", "test"),
+                        entry("registry", "prometheus"), entry("type", "even"))
+                .hasMetricWithExactLabels("example_prime_number_total",
+                        entry("env", "test"), entry("env2", "test"),
+                        entry("registry", "prometheus"), entry("type", "not-natural"));
     }
 
     @Test
     void testTimerExample() {
         when().get("/example/prime/257").then().statusCode(200);
-        when().get("/q/metrics").then().statusCode(200)
-                .body(containsString(
-                        "example_prime_number_test_seconds_sum{env=\"test\",env2=\"test\",prime=\"true\",registry=\"prometheus\"}"))
-                .body(containsString(
-                        "example_prime_number_test_seconds_max{env=\"test\",env2=\"test\",prime=\"true\",registry=\"prometheus\"}"))
-                .body(containsString(
-                        "example_prime_number_test_seconds_count{env=\"test\",env2=\"test\",prime=\"true\",registry=\"prometheus\"} 1"));
+        assertMetrics(when().get("/q/metrics").then().statusCode(200).extract().asInputStream())
+                .hasMetricWithExactLabels("example_prime_number_test_seconds_sum",
+                        entry("env", "test"), entry("env2", "test"),
+                        entry("prime", "true"), entry("registry", "prometheus"))
+                .hasMetricWithExactLabels("example_prime_number_test_seconds_max",
+                        entry("env", "test"), entry("env2", "test"),
+                        entry("prime", "true"), entry("registry", "prometheus"))
+                .hasMetricWithExactLabelsAndValue("example_prime_number_test_seconds_count", 1.0,
+                        entry("env", "test"), entry("env2", "test"),
+                        entry("prime", "true"), entry("registry", "prometheus"));
         when().get("/example/prime/7919").then().statusCode(200);
-        when().get("/q/metrics").then().statusCode(200)
-                .body(containsString(
-                        "example_prime_number_test_seconds_count{env=\"test\",env2=\"test\",prime=\"true\",registry=\"prometheus\"} 2"));
+        assertMetrics(when().get("/q/metrics").then().statusCode(200).extract().asInputStream())
+                .hasMetricWithExactLabelsAndValue("example_prime_number_test_seconds_count", 2.0,
+                        entry("env", "test"), entry("env2", "test"),
+                        entry("prime", "true"), entry("registry", "prometheus"));
     }
 }

--- a/integration-tests/micrometer-prometheus/src/test/java/io/quarkus/it/micrometer/prometheus/PrometheusMetricsRegistryTest.java
+++ b/integration-tests/micrometer-prometheus/src/test/java/io/quarkus/it/micrometer/prometheus/PrometheusMetricsRegistryTest.java
@@ -1,10 +1,12 @@
 package io.quarkus.it.micrometer.prometheus;
 
 import static io.quarkus.micrometer.runtime.export.handlers.PrometheusHandler.CONTENT_TYPE_004;
+import static io.quarkus.micrometer.runtime.export.handlers.PrometheusHandler.CONTENT_TYPE_OPENMETRICS_100;
+import static io.quarkus.test.micrometer.PrometheusMetricsAssert.assertMetrics;
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
+import static org.assertj.core.api.Assertions.entry;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.not;
 
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -106,189 +108,322 @@ class PrometheusMetricsRegistryTest {
     @Test
     @Order(20)
     void testPrometheusScrapeEndpointTextPlain() {
-        RestAssured.given().header("Accept", CONTENT_TYPE_004)
+        assertMetrics(RestAssured.given().header("Accept", CONTENT_TYPE_004)
                 .when().get("/q/metrics")
                 .then().statusCode(200)
+                .extract().asInputStream())
 
                 // Prometheus body has ALL THE THINGS in no particular order
 
-                .body(containsString("registry=\"prometheus\""))
-                .body(containsString("env=\"test\""))
-                .body(containsString("http_server_requests"))
+                .hasMetricWithLabels("http_server_requests_seconds_count",
+                        entry("registry", "prometheus"))
+                .hasMetricWithLabels("http_server_requests_seconds_count",
+                        entry("env", "test"))
+                .hasMetric("http_server_requests_seconds_count")
 
-                .body(containsString("status=\"404\""))
-                .body(containsString("uri=\"NOT_FOUND\""))
-                .body(containsString("outcome=\"CLIENT_ERROR\""))
+                .hasMetricWithLabels("http_server_requests_seconds_count",
+                        entry("status", "404"), entry("uri", "NOT_FOUND"), entry("outcome", "CLIENT_ERROR"))
 
-                .body(containsString("status=\"500\""))
-                .body(containsString("uri=\"/message/fail\""))
-                .body(containsString("outcome=\"SERVER_ERROR\""))
+                .hasMetricWithLabels("http_server_requests_seconds_count",
+                        entry("status", "500"), entry("uri", "/message/fail"), entry("outcome", "SERVER_ERROR"))
 
-                .body(containsString("status=\"200\""))
-                .body(containsString("uri=\"/message\""))
-                .body(containsString("uri=\"/message/item/{id}\""))
-                .body(containsString("status=\"200\",uri=\"/message/item/{id}\""))
-                .body(containsString("uri=\"/secured/item/{id}\""))
-                .body(containsString("status=\"200\",uri=\"/secured/item/{id}\""))
-                .body(containsString("status=\"401\",uri=\"/secured/item/{id}\""))
-                .body(containsString("outcome=\"SUCCESS\""))
-                .body(containsString("dummy="))
-                .body(containsString("foo=\"bar\""))
-                .body(containsString("foo_response=\"value\""))
-                .body(containsString("uri=\"/message/match/{id}/{sub}\""))
-                .body(containsString("uri=\"/message/match/{other}\""))
+                .hasMetricWithLabels("http_server_requests_seconds_count",
+                        entry("status", "200"), entry("uri", "/message"), entry("outcome", "SUCCESS"))
+                .hasMetricWithLabels("http_server_requests_seconds_count",
+                        entry("uri", "/message/item/{id}"))
+                .hasMetricWithLabels("http_server_requests_seconds_count",
+                        entry("status", "200"), entry("uri", "/message/item/{id}"))
+                .hasMetricWithLabels("http_server_requests_seconds_count",
+                        entry("uri", "/secured/item/{id}"))
+                .hasMetricWithLabels("http_server_requests_seconds_count",
+                        entry("status", "200"), entry("uri", "/secured/item/{id}"))
+                .hasMetricWithLabels("http_server_requests_seconds_count",
+                        entry("status", "401"), entry("uri", "/secured/item/{id}"))
+                .hasMetricWithLabels("http_server_requests_seconds_count",
+                        entry("dummy", "value"))
+                .hasMetricWithLabels("http_server_requests_seconds_count",
+                        entry("foo", "bar"))
+                .hasMetricWithLabels("http_server_requests_seconds_count",
+                        entry("foo_response", "value"))
+                .hasMetricWithLabels("http_server_requests_seconds_count",
+                        entry("uri", "/message/match/{id}/{sub}"))
+                .hasMetricWithLabels("http_server_requests_seconds_count",
+                        entry("uri", "/message/match/{other}"))
 
-                .body(containsString(
-                        "http_server_requests_seconds_count{dummy=\"val-anything\",env=\"test\",env2=\"test\",foo=\"UNSET\",foo_response=\"UNSET\",method=\"GET\",outcome=\"SUCCESS\",registry=\"prometheus\",status=\"200\",uri=\"/template/path/{value}\""))
+                .hasMetricWithExactLabels("http_server_requests_seconds_count",
+                        entry("dummy", "val-anything"), entry("env", "test"), entry("env2", "test"),
+                        entry("foo", "UNSET"), entry("foo_response", "UNSET"), entry("method", "GET"),
+                        entry("outcome", "SUCCESS"), entry("registry", "prometheus"),
+                        entry("status", "200"), entry("uri", "/template/path/{value}"))
 
-                .body(containsString(
-                        "http_server_requests_seconds_count{dummy=\"value\",env=\"test\",env2=\"test\",foo=\"UNSET\",foo_response=\"UNSET\",method=\"GET\",outcome=\"SUCCESS\",registry=\"prometheus\",status=\"200\",uri=\"/root/{rootParam}/sub/{subParam}\""))
+                .hasMetricWithExactLabels("http_server_requests_seconds_count",
+                        entry("dummy", "value"), entry("env", "test"), entry("env2", "test"),
+                        entry("foo", "UNSET"), entry("foo_response", "UNSET"), entry("method", "GET"),
+                        entry("outcome", "SUCCESS"), entry("registry", "prometheus"),
+                        entry("status", "200"), entry("uri", "/root/{rootParam}/sub/{subParam}"))
 
                 // Verify Hibernate Metrics
-                .body(containsString(
-                        "hibernate_sessions_open_total{entityManagerFactory=\"<default>\",env=\"test\",env2=\"test\",registry=\"prometheus\"} 2.0"))
-                .body(containsString(
-                        "hibernate_sessions_closed_total{entityManagerFactory=\"<default>\",env=\"test\",env2=\"test\",registry=\"prometheus\"} 2.0"))
-                .body(containsString(
-                        "hibernate_connections_obtained_total{entityManagerFactory=\"<default>\",env=\"test\",env2=\"test\",registry=\"prometheus\"}"))
-                .body(containsString(
-                        "hibernate_entities_inserts_total{entityManagerFactory=\"<default>\",env=\"test\",env2=\"test\",registry=\"prometheus\"} 3.0"))
-                .body(containsString(
-                        "hibernate_flushes_total{entityManagerFactory=\"<default>\",env=\"test\",env2=\"test\",registry=\"prometheus\"} 1.0"))
+                .hasMetricWithExactLabelsAndValue("hibernate_sessions_open_total", 2.0,
+                        entry("entityManagerFactory", "<default>"), entry("env", "test"),
+                        entry("env2", "test"), entry("registry", "prometheus"))
+                .hasMetricWithExactLabelsAndValue("hibernate_sessions_closed_total", 2.0,
+                        entry("entityManagerFactory", "<default>"), entry("env", "test"),
+                        entry("env2", "test"), entry("registry", "prometheus"))
+                .hasMetricWithExactLabels("hibernate_connections_obtained_total",
+                        entry("entityManagerFactory", "<default>"), entry("env", "test"),
+                        entry("env2", "test"), entry("registry", "prometheus"))
+                .hasMetricWithExactLabelsAndValue("hibernate_entities_inserts_total", 3.0,
+                        entry("entityManagerFactory", "<default>"), entry("env", "test"),
+                        entry("env2", "test"), entry("registry", "prometheus"))
+                .hasMetricWithExactLabelsAndValue("hibernate_flushes_total", 1.0,
+                        entry("entityManagerFactory", "<default>"), entry("env", "test"),
+                        entry("env2", "test"), entry("registry", "prometheus"))
 
                 // Annotated counters
-                .body(not(containsString("metric_none")))
-                .body(containsString(
-                        "metric_all_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"none\",extra=\"tag\",fail=\"false\",method=\"countAllInvocations\",registry=\"prometheus\",result=\"success\"} 1.0"))
-                .body(containsString(
-                        "metric_all_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",extra=\"tag\",fail=\"true\",method=\"countAllInvocations\",registry=\"prometheus\",result=\"failure\"} 1.0"))
-                .body(containsString(
-                        "method_counted_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",fail=\"prefix true\",method=\"emptyMetricName\",registry=\"prometheus\",result=\"failure\"} 1.0"))
-                .body(containsString(
-                        "method_counted_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"none\",fail=\"prefix false\",method=\"emptyMetricName\",registry=\"prometheus\",result=\"success\"} 1.0"))
-                .body(not(containsString("async_none")))
-                .body(containsString(
-                        "async_all_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",do_fail_call=\"true\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",extra=\"tag\",method=\"countAllAsyncInvocations\",registry=\"prometheus\",result=\"failure\"} 1.0"))
-                .body(containsString(
-                        "async_all_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",do_fail_call=\"false\",env=\"test\",env2=\"test\",exception=\"none\",extra=\"tag\",method=\"countAllAsyncInvocations\",registry=\"prometheus\",result=\"success\"} 1.0"))
-                .body(containsString(
-                        "method_counted_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",fail=\"42\",method=\"emptyAsyncMetricName\",registry=\"prometheus\",result=\"failure\"} 1.0"))
-                .body(containsString(
-                        "method_counted_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"none\",fail=\"42\",method=\"emptyAsyncMetricName\",registry=\"prometheus\",result=\"success\"} 1.0"))
+                .doesNotHaveMetric("metric_none")
+                .hasMetricWithExactLabelsAndValue("metric_all_total", 1.0,
+                        entry("class", "io.quarkus.it.micrometer.prometheus.AnnotatedResource"),
+                        entry("env", "test"), entry("env2", "test"), entry("exception", "none"),
+                        entry("extra", "tag"), entry("fail", "false"),
+                        entry("method", "countAllInvocations"), entry("registry", "prometheus"),
+                        entry("result", "success"))
+                .hasMetricWithExactLabelsAndValue("metric_all_total", 1.0,
+                        entry("class", "io.quarkus.it.micrometer.prometheus.AnnotatedResource"),
+                        entry("env", "test"), entry("env2", "test"),
+                        entry("exception", "NullPointerException"), entry("extra", "tag"),
+                        entry("fail", "true"), entry("method", "countAllInvocations"),
+                        entry("registry", "prometheus"), entry("result", "failure"))
+                .hasMetricWithExactLabelsAndValue("method_counted_total", 1.0,
+                        entry("class", "io.quarkus.it.micrometer.prometheus.AnnotatedResource"),
+                        entry("env", "test"), entry("env2", "test"),
+                        entry("exception", "NullPointerException"), entry("fail", "prefix true"),
+                        entry("method", "emptyMetricName"), entry("registry", "prometheus"),
+                        entry("result", "failure"))
+                .hasMetricWithExactLabelsAndValue("method_counted_total", 1.0,
+                        entry("class", "io.quarkus.it.micrometer.prometheus.AnnotatedResource"),
+                        entry("env", "test"), entry("env2", "test"), entry("exception", "none"),
+                        entry("fail", "prefix false"), entry("method", "emptyMetricName"),
+                        entry("registry", "prometheus"), entry("result", "success"))
+                .doesNotHaveMetric("async_none")
+                .hasMetricWithExactLabelsAndValue("async_all_total", 1.0,
+                        entry("class", "io.quarkus.it.micrometer.prometheus.AnnotatedResource"),
+                        entry("do_fail_call", "true"), entry("env", "test"), entry("env2", "test"),
+                        entry("exception", "NullPointerException"), entry("extra", "tag"),
+                        entry("method", "countAllAsyncInvocations"), entry("registry", "prometheus"),
+                        entry("result", "failure"))
+                .hasMetricWithExactLabelsAndValue("async_all_total", 1.0,
+                        entry("class", "io.quarkus.it.micrometer.prometheus.AnnotatedResource"),
+                        entry("do_fail_call", "false"), entry("env", "test"), entry("env2", "test"),
+                        entry("exception", "none"), entry("extra", "tag"),
+                        entry("method", "countAllAsyncInvocations"), entry("registry", "prometheus"),
+                        entry("result", "success"))
+                .hasMetricWithExactLabelsAndValue("method_counted_total", 1.0,
+                        entry("class", "io.quarkus.it.micrometer.prometheus.AnnotatedResource"),
+                        entry("env", "test"), entry("env2", "test"),
+                        entry("exception", "NullPointerException"), entry("fail", "42"),
+                        entry("method", "emptyAsyncMetricName"), entry("registry", "prometheus"),
+                        entry("result", "failure"))
+                .hasMetricWithExactLabelsAndValue("method_counted_total", 1.0,
+                        entry("class", "io.quarkus.it.micrometer.prometheus.AnnotatedResource"),
+                        entry("env", "test"), entry("env2", "test"), entry("exception", "none"),
+                        entry("fail", "42"), entry("method", "emptyAsyncMetricName"),
+                        entry("registry", "prometheus"), entry("result", "success"))
 
                 // Annotated Timers
-                .body(containsString(
-                        "call_seconds_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",extra=\"tag\",method=\"call\",registry=\"prometheus\"} 1"))
-                .body(containsString(
-                        "call_seconds_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"none\",extra=\"tag\",method=\"call\",registry=\"prometheus\"}"))
-                .body(containsString(
-                        "async_call_seconds_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",extra=\"tag\",method=\"asyncCall\",registry=\"prometheus\"} 1"))
-                .body(containsString(
-                        "async_call_seconds_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"none\",extra=\"tag\",method=\"asyncCall\",registry=\"prometheus\"} 1"))
-                .body(containsString(
-                        "longCall_seconds_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",extra=\"tag\",method=\"longCall\",registry=\"prometheus\"}"))
-                .body(containsString(
-                        "async_longCall_seconds_sum{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",extra=\"tag\",method=\"longAsyncCall\",registry=\"prometheus\"} 0.0"))
+                .hasMetricWithExactLabelsAndValue("call_seconds_count", 1.0,
+                        entry("class", "io.quarkus.it.micrometer.prometheus.AnnotatedResource"),
+                        entry("env", "test"), entry("env2", "test"),
+                        entry("exception", "NullPointerException"), entry("extra", "tag"),
+                        entry("method", "call"), entry("registry", "prometheus"))
+                .hasMetricWithExactLabels("call_seconds_count",
+                        entry("class", "io.quarkus.it.micrometer.prometheus.AnnotatedResource"),
+                        entry("env", "test"), entry("env2", "test"), entry("exception", "none"),
+                        entry("extra", "tag"), entry("method", "call"),
+                        entry("registry", "prometheus"))
+                .hasMetricWithExactLabelsAndValue("async_call_seconds_count", 1.0,
+                        entry("class", "io.quarkus.it.micrometer.prometheus.AnnotatedResource"),
+                        entry("env", "test"), entry("env2", "test"),
+                        entry("exception", "NullPointerException"), entry("extra", "tag"),
+                        entry("method", "asyncCall"), entry("registry", "prometheus"))
+                .hasMetricWithExactLabelsAndValue("async_call_seconds_count", 1.0,
+                        entry("class", "io.quarkus.it.micrometer.prometheus.AnnotatedResource"),
+                        entry("env", "test"), entry("env2", "test"), entry("exception", "none"),
+                        entry("extra", "tag"), entry("method", "asyncCall"),
+                        entry("registry", "prometheus"))
+                .hasMetricWithExactLabels("longCall_seconds_count",
+                        entry("class", "io.quarkus.it.micrometer.prometheus.AnnotatedResource"),
+                        entry("env", "test"), entry("env2", "test"), entry("extra", "tag"),
+                        entry("method", "longCall"), entry("registry", "prometheus"))
+                .hasMetricWithExactLabelsAndValue("async_longCall_seconds_sum", 0.0,
+                        entry("class", "io.quarkus.it.micrometer.prometheus.AnnotatedResource"),
+                        entry("env", "test"), entry("env2", "test"), entry("extra", "tag"),
+                        entry("method", "longAsyncCall"), entry("registry", "prometheus"))
 
                 // Configured median, 95th percentile and histogram buckets
-                .body(containsString(
-                        "prime_number_test_seconds{env=\"test\",env2=\"test\",registry=\"prometheus\",quantile=\"0.5\"}"))
-                .body(containsString(
-                        "prime_number_test_seconds{env=\"test\",env2=\"test\",registry=\"prometheus\",quantile=\"0.95\"}"))
+                .hasMetricWithExactLabels("prime_number_test_seconds",
+                        entry("env", "test"), entry("env2", "test"),
+                        entry("registry", "prometheus"), entry("quantile", "0.5"))
+                .hasMetricWithExactLabels("prime_number_test_seconds",
+                        entry("env", "test"), entry("env2", "test"),
+                        entry("registry", "prometheus"), entry("quantile", "0.95"))
 
                 // this was defined by a tag to a non-matching registry, and should not be found
-                .body(not(containsString("class-should-not-match")))
+                .doesNotHaveMetricWithLabels("http_server_requests_seconds_count",
+                        entry("tag", "class-should-not-match"))
 
                 // should not find this ignored uri
-                .body(not(containsString("uri=\"/fruit/create\"")));
+                .doesNotHaveMetricWithLabels("http_server_requests_seconds_count",
+                        entry("uri", "/fruit/create"));
     }
 
     @Test
     @Order(20)
-    void testPrometheusScrapeEndpointOpenMetricsCompatibility() {
-        RestAssured.given().header("Accept", "application/openmetrics-text; version=1.0.0; charset=utf-8")
+    void testPrometheusScrapeEndpointOpenMetrics() {
+        assertMetrics(RestAssured.given().header("Accept", CONTENT_TYPE_OPENMETRICS_100)
                 .when().get("/q/metrics")
                 .then().statusCode(200)
+                .extract().asInputStream())
 
                 // Prometheus body has ALL THE THINGS in no particular order
 
-                .body(containsString("registry=\"prometheus\""))
-                .body(containsString("env=\"test\""))
-                .body(containsString("http_server_requests"))
+                .hasMetricWithLabels("http_server_requests_seconds_count",
+                        entry("registry", "prometheus"))
+                .hasMetricWithLabels("http_server_requests_seconds_count",
+                        entry("env", "test"))
+                .hasMetric("http_server_requests_seconds_count")
 
-                .body(containsString("status=\"404\""))
-                .body(containsString("uri=\"NOT_FOUND\""))
-                .body(containsString("outcome=\"CLIENT_ERROR\""))
+                .hasMetricWithLabels("http_server_requests_seconds_count",
+                        entry("status", "404"), entry("uri", "NOT_FOUND"), entry("outcome", "CLIENT_ERROR"))
 
-                .body(containsString("status=\"500\""))
-                .body(containsString("uri=\"/message/fail\""))
-                .body(containsString("outcome=\"SERVER_ERROR\""))
+                .hasMetricWithLabels("http_server_requests_seconds_count",
+                        entry("status", "500"), entry("uri", "/message/fail"), entry("outcome", "SERVER_ERROR"))
 
-                .body(containsString("status=\"200\""))
-                .body(containsString("uri=\"/message\""))
-                .body(containsString("uri=\"/message/item/{id}\""))
-                .body(containsString("outcome=\"SUCCESS\""))
-                .body(containsString("uri=\"/message/match/{id}/{sub}\""))
-                .body(containsString("uri=\"/message/match/{other}\""))
+                .hasMetricWithLabels("http_server_requests_seconds_count",
+                        entry("status", "200"), entry("uri", "/message"), entry("outcome", "SUCCESS"))
+                .hasMetricWithLabels("http_server_requests_seconds_count",
+                        entry("uri", "/message/item/{id}"))
+                .hasMetricWithLabels("http_server_requests_seconds_count",
+                        entry("uri", "/message/match/{id}/{sub}"))
+                .hasMetricWithLabels("http_server_requests_seconds_count",
+                        entry("uri", "/message/match/{other}"))
 
-                .body(containsString(
-                        "http_server_requests_seconds_count{dummy=\"val-anything\",env=\"test\",env2=\"test\",foo=\"UNSET\",foo_response=\"UNSET\",method=\"GET\",outcome=\"SUCCESS\",registry=\"prometheus\",status=\"200\",uri=\"/template/path/{value}\""))
+                .hasMetricWithExactLabels("http_server_requests_seconds_count",
+                        entry("dummy", "val-anything"), entry("env", "test"), entry("env2", "test"),
+                        entry("foo", "UNSET"), entry("foo_response", "UNSET"), entry("method", "GET"),
+                        entry("outcome", "SUCCESS"), entry("registry", "prometheus"),
+                        entry("status", "200"), entry("uri", "/template/path/{value}"))
 
                 // Verify Hibernate Metrics
-                .body(containsString(
-                        "hibernate_sessions_open_total{entityManagerFactory=\"<default>\",env=\"test\",env2=\"test\",registry=\"prometheus\"} 2.0"))
-                .body(containsString(
-                        "hibernate_sessions_closed_total{entityManagerFactory=\"<default>\",env=\"test\",env2=\"test\",registry=\"prometheus\"} 2.0"))
-                .body(containsString(
-                        "hibernate_connections_obtained_total{entityManagerFactory=\"<default>\",env=\"test\",env2=\"test\",registry=\"prometheus\"}"))
-                .body(containsString(
-                        "hibernate_entities_inserts_total{entityManagerFactory=\"<default>\",env=\"test\",env2=\"test\",registry=\"prometheus\"} 3.0"))
-                .body(containsString(
-                        "hibernate_flushes_total{entityManagerFactory=\"<default>\",env=\"test\",env2=\"test\",registry=\"prometheus\"} 1.0"))
+                .hasMetricWithExactLabelsAndValue("hibernate_sessions_open_total", 2.0,
+                        entry("entityManagerFactory", "<default>"), entry("env", "test"),
+                        entry("env2", "test"), entry("registry", "prometheus"))
+                .hasMetricWithExactLabelsAndValue("hibernate_sessions_closed_total", 2.0,
+                        entry("entityManagerFactory", "<default>"), entry("env", "test"),
+                        entry("env2", "test"), entry("registry", "prometheus"))
+                .hasMetricWithExactLabels("hibernate_connections_obtained_total",
+                        entry("entityManagerFactory", "<default>"), entry("env", "test"),
+                        entry("env2", "test"), entry("registry", "prometheus"))
+                .hasMetricWithExactLabelsAndValue("hibernate_entities_inserts_total", 3.0,
+                        entry("entityManagerFactory", "<default>"), entry("env", "test"),
+                        entry("env2", "test"), entry("registry", "prometheus"))
+                .hasMetricWithExactLabelsAndValue("hibernate_flushes_total", 1.0,
+                        entry("entityManagerFactory", "<default>"), entry("env", "test"),
+                        entry("env2", "test"), entry("registry", "prometheus"))
 
                 // Annotated counters
-                .body(not(containsString("metric_none")))
-                // No OTel, no span
-                .body(not(containsString(
-                        "metric_all_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"none\",extra=\"tag\",fail=\"false\",method=\"countAllInvocations\",registry=\"prometheus\",result=\"success\"} 1.0 # {span_id=")))
-                .body(containsString(
-                        "metric_all_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",extra=\"tag\",fail=\"true\",method=\"countAllInvocations\",registry=\"prometheus\",result=\"failure\"} 1.0"))
-                .body(containsString(
-                        "method_counted_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"none\",fail=\"prefix false\",method=\"emptyMetricName\",registry=\"prometheus\",result=\"success\"} 1.0"))
-                .body(not(containsString("async_none")))
-                .body(containsString(
-                        "async_all_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",do_fail_call=\"true\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",extra=\"tag\",method=\"countAllAsyncInvocations\",registry=\"prometheus\",result=\"failure\"} 1.0"))
-                .body(containsString(
-                        "async_all_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",do_fail_call=\"false\",env=\"test\",env2=\"test\",exception=\"none\",extra=\"tag\",method=\"countAllAsyncInvocations\",registry=\"prometheus\",result=\"success\"} 1.0"))
-                .body(containsString(
-                        "method_counted_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",fail=\"42\",method=\"emptyAsyncMetricName\",registry=\"prometheus\",result=\"failure\"} 1.0"))
-                .body(containsString(
-                        "method_counted_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"none\",fail=\"42\",method=\"emptyAsyncMetricName\",registry=\"prometheus\",result=\"success\"} 1.0"))
+                .doesNotHaveMetric("metric_none")
+                .hasMetricWithExactLabelsAndValue("metric_all_total", 1.0,
+                        entry("class", "io.quarkus.it.micrometer.prometheus.AnnotatedResource"),
+                        entry("env", "test"), entry("env2", "test"), entry("exception", "none"),
+                        entry("extra", "tag"), entry("fail", "false"),
+                        entry("method", "countAllInvocations"), entry("registry", "prometheus"),
+                        entry("result", "success"))
+                .hasMetricWithExactLabelsAndValue("metric_all_total", 1.0,
+                        entry("class", "io.quarkus.it.micrometer.prometheus.AnnotatedResource"),
+                        entry("env", "test"), entry("env2", "test"),
+                        entry("exception", "NullPointerException"), entry("extra", "tag"),
+                        entry("fail", "true"), entry("method", "countAllInvocations"),
+                        entry("registry", "prometheus"), entry("result", "failure"))
+                .hasMetricWithExactLabelsAndValue("method_counted_total", 1.0,
+                        entry("class", "io.quarkus.it.micrometer.prometheus.AnnotatedResource"),
+                        entry("env", "test"), entry("env2", "test"),
+                        entry("exception", "NullPointerException"), entry("fail", "prefix true"),
+                        entry("method", "emptyMetricName"), entry("registry", "prometheus"),
+                        entry("result", "failure"))
+                .hasMetricWithExactLabelsAndValue("method_counted_total", 1.0,
+                        entry("class", "io.quarkus.it.micrometer.prometheus.AnnotatedResource"),
+                        entry("env", "test"), entry("env2", "test"), entry("exception", "none"),
+                        entry("fail", "prefix false"), entry("method", "emptyMetricName"),
+                        entry("registry", "prometheus"), entry("result", "success"))
+                .doesNotHaveMetric("async_none")
+                .hasMetricWithExactLabelsAndValue("async_all_total", 1.0,
+                        entry("class", "io.quarkus.it.micrometer.prometheus.AnnotatedResource"),
+                        entry("do_fail_call", "true"), entry("env", "test"), entry("env2", "test"),
+                        entry("exception", "NullPointerException"), entry("extra", "tag"),
+                        entry("method", "countAllAsyncInvocations"), entry("registry", "prometheus"),
+                        entry("result", "failure"))
+                .hasMetricWithExactLabelsAndValue("async_all_total", 1.0,
+                        entry("class", "io.quarkus.it.micrometer.prometheus.AnnotatedResource"),
+                        entry("do_fail_call", "false"), entry("env", "test"), entry("env2", "test"),
+                        entry("exception", "none"), entry("extra", "tag"),
+                        entry("method", "countAllAsyncInvocations"), entry("registry", "prometheus"),
+                        entry("result", "success"))
+                .hasMetricWithExactLabelsAndValue("method_counted_total", 1.0,
+                        entry("class", "io.quarkus.it.micrometer.prometheus.AnnotatedResource"),
+                        entry("env", "test"), entry("env2", "test"),
+                        entry("exception", "NullPointerException"), entry("fail", "42"),
+                        entry("method", "emptyAsyncMetricName"), entry("registry", "prometheus"),
+                        entry("result", "failure"))
+                .hasMetricWithExactLabelsAndValue("method_counted_total", 1.0,
+                        entry("class", "io.quarkus.it.micrometer.prometheus.AnnotatedResource"),
+                        entry("env", "test"), entry("env2", "test"), entry("exception", "none"),
+                        entry("fail", "42"), entry("method", "emptyAsyncMetricName"),
+                        entry("registry", "prometheus"), entry("result", "success"))
 
                 // Annotated Timers
-                .body(containsString(
-                        "call_seconds_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",extra=\"tag\",method=\"call\",registry=\"prometheus\"} 1"))
-                .body(containsString(
-                        "call_seconds_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"none\",extra=\"tag\",method=\"call\",registry=\"prometheus\"}"))
-                .body(containsString(
-                        "async_call_seconds_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",extra=\"tag\",method=\"asyncCall\",registry=\"prometheus\"} 1"))
-                .body(containsString(
-                        "async_call_seconds_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"none\",extra=\"tag\",method=\"asyncCall\",registry=\"prometheus\"} 1"))
-                .body(containsString(
-                        "longCall_seconds_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",extra=\"tag\",method=\"longCall\",registry=\"prometheus\"}"))
-                .body(containsString(
-                        "async_longCall_seconds_sum{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",extra=\"tag\",method=\"longAsyncCall\",registry=\"prometheus\"} 0.0"))
+                .hasMetricWithExactLabelsAndValue("call_seconds_count", 1.0,
+                        entry("class", "io.quarkus.it.micrometer.prometheus.AnnotatedResource"),
+                        entry("env", "test"), entry("env2", "test"),
+                        entry("exception", "NullPointerException"), entry("extra", "tag"),
+                        entry("method", "call"), entry("registry", "prometheus"))
+                .hasMetricWithExactLabels("call_seconds_count",
+                        entry("class", "io.quarkus.it.micrometer.prometheus.AnnotatedResource"),
+                        entry("env", "test"), entry("env2", "test"), entry("exception", "none"),
+                        entry("extra", "tag"), entry("method", "call"),
+                        entry("registry", "prometheus"))
+                .hasMetricWithExactLabelsAndValue("async_call_seconds_count", 1.0,
+                        entry("class", "io.quarkus.it.micrometer.prometheus.AnnotatedResource"),
+                        entry("env", "test"), entry("env2", "test"),
+                        entry("exception", "NullPointerException"), entry("extra", "tag"),
+                        entry("method", "asyncCall"), entry("registry", "prometheus"))
+                .hasMetricWithExactLabelsAndValue("async_call_seconds_count", 1.0,
+                        entry("class", "io.quarkus.it.micrometer.prometheus.AnnotatedResource"),
+                        entry("env", "test"), entry("env2", "test"), entry("exception", "none"),
+                        entry("extra", "tag"), entry("method", "asyncCall"),
+                        entry("registry", "prometheus"))
+                .hasMetricWithExactLabels("longCall_seconds_count",
+                        entry("class", "io.quarkus.it.micrometer.prometheus.AnnotatedResource"),
+                        entry("env", "test"), entry("env2", "test"), entry("extra", "tag"),
+                        entry("method", "longCall"), entry("registry", "prometheus"))
+                .hasMetricWithExactLabelsAndValue("async_longCall_seconds_sum", 0.0,
+                        entry("class", "io.quarkus.it.micrometer.prometheus.AnnotatedResource"),
+                        entry("env", "test"), entry("env2", "test"), entry("extra", "tag"),
+                        entry("method", "longAsyncCall"), entry("registry", "prometheus"))
 
                 // Configured median, 95th percentile and histogram buckets
-                .body(containsString(
-                        "prime_number_test_seconds{env=\"test\",env2=\"test\",registry=\"prometheus\",quantile=\"0.5\"}"))
-                .body(containsString(
-                        "prime_number_test_seconds{env=\"test\",env2=\"test\",registry=\"prometheus\",quantile=\"0.95\"}"))
+                .hasMetricWithExactLabels("prime_number_test_seconds",
+                        entry("env", "test"), entry("env2", "test"),
+                        entry("registry", "prometheus"), entry("quantile", "0.5"))
+                .hasMetricWithExactLabels("prime_number_test_seconds",
+                        entry("env", "test"), entry("env2", "test"),
+                        entry("registry", "prometheus"), entry("quantile", "0.95"))
 
                 // this was defined by a tag to a non-matching registry, and should not be found
-                .body(not(containsString("class-should-not-match")))
+                .doesNotHaveMetricWithLabels("http_server_requests_seconds_count",
+                        entry("tag", "class-should-not-match"))
 
                 // should not find this ignored uri
-                .body(not(containsString("uri=\"/fruit/create\"")));
+                .doesNotHaveMetricWithLabels("http_server_requests_seconds_count",
+                        entry("uri", "/fruit/create"));
     }
 }

--- a/integration-tests/micrometer-security/pom.xml
+++ b/integration-tests/micrometer-security/pom.xml
@@ -44,6 +44,12 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-prometheus-metrics</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-micrometer-registry-prometheus-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>

--- a/integration-tests/micrometer-security/src/test/java/io/quarkus/it/micrometer/security/SecuredResourceTest.java
+++ b/integration-tests/micrometer-security/src/test/java/io/quarkus/it/micrometer/security/SecuredResourceTest.java
@@ -1,9 +1,8 @@
 package io.quarkus.it.micrometer.security;
 
+import static io.quarkus.test.micrometer.PrometheusMetricsAssert.assertMetrics;
 import static io.restassured.RestAssured.when;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.not;
+import static org.assertj.core.api.Assertions.entry;
 
 import org.junit.jupiter.api.Test;
 
@@ -18,15 +17,12 @@ class SecuredResourceTest {
                 .then()
                 .statusCode(403);
 
-        when().get("/q/metrics")
-                .then()
-                .statusCode(200)
-                .body(
-                        allOf(
-                                not(containsString("/secured/foo")),
-                                containsString("/secured/{message}"))
-
-                );
+        assertMetrics(when().get("/q/metrics").then().statusCode(200)
+                .extract().asInputStream())
+                .doesNotHaveMetricWithLabels("http_server_requests_seconds_count",
+                        entry("uri", "/secured/foo"))
+                .hasMetricWithLabels("http_server_requests_seconds_count",
+                        entry("uri", "/secured/{message}"));
     }
 
     @Test
@@ -42,14 +38,14 @@ class SecuredResourceTest {
                 .then()
                 .statusCode(403);
 
-        when().get("/q/metrics")
-                .then()
-                .statusCode(200)
-                .body(
-                        allOf(
-                                not(containsString("/secured/foo")),
-                                containsString("/secured/{message}"),
-                                containsString("/secured/{message}/details")));
+        assertMetrics(when().get("/q/metrics").then().statusCode(200)
+                .extract().asInputStream())
+                .doesNotHaveMetricWithLabels("http_server_requests_seconds_count",
+                        entry("uri", "/secured/foo"))
+                .hasMetricWithLabels("http_server_requests_seconds_count",
+                        entry("uri", "/secured/{message}"))
+                .hasMetricWithLabels("http_server_requests_seconds_count",
+                        entry("uri", "/secured/{message}/details"));
     }
 
 }

--- a/integration-tests/mongodb-panache/pom.xml
+++ b/integration-tests/mongodb-panache/pom.xml
@@ -74,6 +74,12 @@
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-prometheus-metrics</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
         <dependency>

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheResourceTest.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheResourceTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.it.mongodb.panache;
 
+import static io.quarkus.test.micrometer.PrometheusMetricsAssert.assertMetrics;
 import static io.restassured.RestAssured.*;
 import static org.hamcrest.Matchers.is;
 
@@ -12,7 +13,6 @@ import java.util.GregorianCalendar;
 import java.util.List;
 
 import org.apache.http.HttpStatus;
-import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -369,14 +369,15 @@ class MongodbPanacheResourceTest {
         Assertions.assertEquals(0, count);
 
         // Test prometheus metrics gathered using micrometer metrics
-        RestAssured.given()
+        assertMetrics(RestAssured.given()
                 .when().get("/q/metrics")
                 .then()
                 .statusCode(200)
-                .body(CoreMatchers.containsString("mongodb_driver_commands_seconds_max"))
-                .body(CoreMatchers.containsString("mongodb_driver_pool_checkedout"))
-                .body(CoreMatchers.containsString("mongodb_driver_pool_size"))
-                .body(CoreMatchers.containsString("mongodb_driver_pool_waitqueuesize"));
+                .extract().asInputStream())
+                .hasMetricNameContaining("mongodb_driver_commands_seconds_max")
+                .hasMetricNameContaining("mongodb_driver_pool_checkedout")
+                .hasMetricNameContaining("mongodb_driver_pool_size")
+                .hasMetricNameContaining("mongodb_driver_pool_waitqueuesize");
     }
 
     private Date yearToDate(int year) {

--- a/integration-tests/reactive-messaging-kafka/pom.xml
+++ b/integration-tests/reactive-messaging-kafka/pom.xml
@@ -90,6 +90,12 @@
             <artifactId>quarkus-test-kafka-companion</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-prometheus-metrics</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
         <dependency>

--- a/integration-tests/reactive-messaging-kafka/src/test/java/io/quarkus/it/kafka/KafkaConnectorTest.java
+++ b/integration-tests/reactive-messaging-kafka/src/test/java/io/quarkus/it/kafka/KafkaConnectorTest.java
@@ -1,10 +1,10 @@
 package io.quarkus.it.kafka;
 
+import static io.quarkus.test.micrometer.PrometheusMetricsAssert.assertMetrics;
 import static io.restassured.RestAssured.get;
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.entry;
 import static org.awaitility.Awaitility.await;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.not;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -100,16 +100,18 @@ public class KafkaConnectorTest {
     @Test
     @Order(7)
     void testPrometheusScrapeEndpointOpenMetrics() {
-        given().header("Accept", "text/plain; version=0.0.4; charset=utf-8")
+        assertMetrics(given().header("Accept", "text/plain; version=0.0.4; charset=utf-8")
                 .when().get("/q/metrics")
                 .then().statusCode(200)
-                .body(containsString("quarkus_messaging_message_duration_seconds_max"))
-                .body(containsString("quarkus_messaging_message_duration_seconds_sum"))
-                .body(containsString("quarkus_messaging_message_duration_seconds_count"))
-                .body(containsString("quarkus_messaging_message_count_total"))
-                .body(containsString("quarkus_messaging_message_acks_total"))
-                .body(containsString("kafka_app_info_start_time_ms"))
-                .body(not(containsString("kafka_version=\"unknown\"")));
+                .extract().asInputStream())
+                .hasMetric("quarkus_messaging_message_duration_seconds_max")
+                .hasMetric("quarkus_messaging_message_duration_seconds_sum")
+                .hasMetric("quarkus_messaging_message_duration_seconds_count")
+                .hasMetric("quarkus_messaging_message_count_total")
+                .hasMetric("quarkus_messaging_message_acks_total")
+                .hasMetric("kafka_app_info_start_time_ms")
+                .doesNotHaveMetricWithLabels("kafka_app_info_start_time_ms",
+                        entry("kafka_version", "unknown"));
     }
 
     @Test

--- a/integration-tests/rest-client/pom.xml
+++ b/integration-tests/rest-client/pom.xml
@@ -66,6 +66,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-prometheus-metrics</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.smallrye.certs</groupId>
             <artifactId>smallrye-certificate-generator</artifactId>
             <scope>test</scope>

--- a/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/MultipartResourceTest.java
+++ b/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/MultipartResourceTest.java
@@ -1,8 +1,9 @@
 package io.quarkus.it.rest.client;
 
+import static io.quarkus.test.micrometer.PrometheusMetricsAssert.assertMetrics;
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.entry;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.not;
 
 import org.junit.jupiter.api.Test;
 
@@ -24,12 +25,13 @@ public class MultipartResourceTest {
                         containsString("greeting.txt"),
                         containsString("Content-Disposition: form-data; name=\"uuid\""));
 
-        given()
+        assertMetrics(given()
                 .when().get("/q/metrics")
                 .then()
                 .statusCode(200)
-                // /echo is ignored in application.properties
-                .body(not(containsString(
-                        "clientName=\"localhost\",method=\"POST\",outcome=\"SUCCESS\",status=\"200\",uri=\"/echo\",} 1.0")));
+                .extract().asInputStream())
+                .doesNotHaveMetricWithLabels("http_client_requests_seconds_count",
+                        entry("clientName", "localhost"), entry("method", "POST"),
+                        entry("outcome", "SUCCESS"), entry("status", "200"), entry("uri", "/echo"));
     }
 }

--- a/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/wronghost/BaseExternalWrongHostTestCase.java
+++ b/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/wronghost/BaseExternalWrongHostTestCase.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.rest.client.wronghost;
 
-import static io.restassured.RestAssured.given;
+import static io.quarkus.test.micrometer.PrometheusMetricsAssert.assertMetrics;
 import static io.restassured.RestAssured.when;
-import static org.hamcrest.CoreMatchers.containsString;
+import static org.assertj.core.api.Assertions.entry;
 import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
@@ -17,11 +17,13 @@ public abstract class BaseExternalWrongHostTestCase {
                 .statusCode(200)
                 .body(is("200"));
 
-        given()
-                .when().get("/q/metrics")
+        assertMetrics(when()
+                .get("/q/metrics")
                 .then()
                 .statusCode(200)
-                .body(containsString(
-                        "clientName=\"localhost\",method=\"GET\",outcome=\"SUCCESS\",status=\"200\",uri=\"root\"}"));
+                .extract().asInputStream())
+                .hasMetricWithLabels("http_client_requests_seconds_count",
+                        entry("clientName", "localhost"), entry("method", "GET"),
+                        entry("outcome", "SUCCESS"), entry("status", "200"), entry("uri", "root"));
     }
 }

--- a/integration-tests/smallrye-graphql/pom.xml
+++ b/integration-tests/smallrye-graphql/pom.xml
@@ -38,6 +38,12 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-prometheus-metrics</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
         <dependency>

--- a/integration-tests/smallrye-graphql/src/test/java/io/quarkus/it/smallrye/graphql/MicrometerMetricsTest.java
+++ b/integration-tests/smallrye-graphql/src/test/java/io/quarkus/it/smallrye/graphql/MicrometerMetricsTest.java
@@ -1,17 +1,14 @@
 package io.quarkus.it.smallrye.graphql;
 
+import static io.quarkus.test.micrometer.PrometheusMetricsAssert.assertMetrics;
+import static org.assertj.core.api.Assertions.entry;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
-import org.hamcrest.Description;
-import org.hamcrest.TypeSafeMatcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -252,37 +249,39 @@ public class MicrometerMetricsTest {
     }
 
     private void assertMetricCountValue(String name, boolean source, String type, long count) {
-        RestAssured.when().get("/q/metrics").then()
-                .body(containsString(
-                        String.format("mp_graphql_seconds_count{name=\"%s\",source=\"%b\",type=\"%S\"} %d", name, source, type,
-                                count)));
+        assertMetrics(RestAssured.when().get("/q/metrics").then()
+                .extract().asInputStream())
+                .hasMetricWithExactLabelsAndValue("mp_graphql_seconds_count", (double) count,
+                        entry("name", name),
+                        entry("source", String.valueOf(source)),
+                        entry("type", type.toUpperCase()));
     }
 
     private void assertMetricTotalValue(String name, boolean source, String type, double minimumDuration) {
-        String endpoint = "/q/metrics";
-        String failureMessage = String.format(
-                "Expected metric with name '%s', source '%b', type '%s', and total minimum of %f to be present in the response body of endpoint '%s'",
-                name, source, type, minimumDuration, endpoint);
-        assertThat(failureMessage,
-                RestAssured.when().get(endpoint).asString(),
-                new TotalMetricMatcher(name, source, type, minimumDuration));
+        assertMetrics(RestAssured.when().get("/q/metrics").then()
+                .extract().asInputStream())
+                .hasMetricWithLabelsAndValueGreaterThanOrEqualTo("mp_graphql_seconds_sum", minimumDuration,
+                        entry("name", name),
+                        entry("source", String.valueOf(source)),
+                        entry("type", type));
     }
 
     private void assertMetricMaxValue(String name, boolean source, String type, double minimumDuration) {
-        // mean would be better, but it is harder to get...
-        String endpoint = "/q/metrics";
-        String failureMessage = String.format(
-                "Expected metric with name '%s', source '%b', type '%s', and at least or equal to maximum duration of %f to be present in the response body of endpoint '%s'",
-                name, source, type, minimumDuration, endpoint);
-        assertThat(failureMessage,
-                RestAssured.when().get(endpoint).asString(),
-                new MaxMetricMatcher(name, source, type, minimumDuration));
+        assertMetrics(RestAssured.when().get("/q/metrics").then()
+                .extract().asInputStream())
+                .hasMetricWithLabelsAndValueGreaterThanOrEqualTo("mp_graphql_seconds_max", minimumDuration,
+                        entry("name", name),
+                        entry("source", String.valueOf(source)),
+                        entry("type", type));
     }
 
     private void assertMetricExists(String name, boolean source, String type) {
-        RestAssured.when().get("/q/metrics").then()
-                .body(containsString(
-                        String.format("mp_graphql_seconds_count{name=\"%s\",source=\"%b\",type=\"%S\"}", name, source, type)));
+        assertMetrics(RestAssured.when().get("/q/metrics").then()
+                .extract().asInputStream())
+                .hasMetricWithExactLabels("mp_graphql_seconds_count",
+                        entry("name", name),
+                        entry("source", String.valueOf(source)),
+                        entry("type", type.toUpperCase()));
     }
 
     private Void assertResponse(String request, String response) {
@@ -298,69 +297,6 @@ public class MicrometerMetricsTest {
                 .body(containsString(response));
 
         return null;
-    }
-
-    abstract static class MetricMatcher extends TypeSafeMatcher<String> {
-        protected final String name;
-        protected final boolean source;
-        protected final String type;
-        protected final double value;
-
-        protected MetricMatcher(String name, boolean source, String type, double value) {
-            this.name = name;
-            this.source = source;
-            this.type = type;
-            this.value = value;
-        }
-
-        @Override
-        public void describeTo(Description description) {
-            description.appendText("a metric with name ").appendValue(name)
-                    .appendText(", source ").appendValue(source)
-                    .appendText(", type ").appendValue(type)
-                    .appendText(", and ").appendText(getValueDescription())
-                    .appendValue(value);
-        }
-
-        protected abstract String getValueDescription();
-    }
-
-    static class TotalMetricMatcher extends MetricMatcher {
-        public TotalMetricMatcher(String name, boolean source, String type, double total) {
-            super(name, source, type, total);
-        }
-
-        @Override
-        public boolean matchesSafely(String item) {
-            String pattern = String.format("mp_graphql_seconds_sum\\{name=\"%s\",source=\"%b\",type=\"%s\"\\} \\d+\\.\\d+",
-                    name, source, type);
-            Matcher matcher = Pattern.compile(pattern).matcher(item);
-            return matcher.find() && Double.parseDouble(matcher.group().split(" ")[1]) >= value;
-        }
-
-        @Override
-        protected String getValueDescription() {
-            return "total minimum of ";
-        }
-    }
-
-    static class MaxMetricMatcher extends MetricMatcher {
-        public MaxMetricMatcher(String name, boolean source, String type, double maxDuration) {
-            super(name, source, type, maxDuration);
-        }
-
-        @Override
-        public boolean matchesSafely(String item) {
-            String pattern = String.format("mp_graphql_seconds_max\\{name=\"%s\",source=\"%b\",type=\"%s\"\\} \\d+\\.\\d+",
-                    name, source, type);
-            Matcher matcher = Pattern.compile(pattern).matcher(item);
-            return matcher.find() && Double.parseDouble(matcher.group().split(" ")[1]) >= value;
-        }
-
-        @Override
-        protected String getValueDescription() {
-            return "maximum duration of ";
-        }
     }
 
 }

--- a/test-framework/pom.xml
+++ b/test-framework/pom.xml
@@ -45,6 +45,7 @@
         <module>observability</module>
         <module>spring-test</module>
         <module>aesh</module>
+        <module>prometheus-metrics</module>
     </modules>
 
     <build>

--- a/test-framework/prometheus-metrics/pom.xml
+++ b/test-framework/prometheus-metrics/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-test-framework</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-test-prometheus-metrics</artifactId>
+    <name>Quarkus - Test Framework - Prometheus metrics test utils</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/test-framework/prometheus-metrics/src/main/java/io/quarkus/test/micrometer/PrometheusMetric.java
+++ b/test-framework/prometheus-metrics/src/main/java/io/quarkus/test/micrometer/PrometheusMetric.java
@@ -1,0 +1,60 @@
+package io.quarkus.test.micrometer;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.assertj.core.data.MapEntry;
+
+/**
+ * A single parsed Prometheus metric line.
+ * <p>
+ * Example input: {@code http_client_requests_seconds_count{method="GET",status="200"} 1.0}
+ */
+record PrometheusMetric(String name, Map<String, String> labels, double value) {
+
+    PrometheusMetric(String name, Map<String, String> labels, double value) {
+        this.name = name;
+        this.labels = Collections.unmodifiableMap(labels);
+        this.value = value;
+    }
+
+    public String getLabel(String key) {
+        return labels.get(key);
+    }
+
+    @SafeVarargs
+    public final boolean hasLabels(MapEntry<String, String>... entries) {
+        for (MapEntry<String, String> entry : entries) {
+            if (!entry.value.equals(labels.get(entry.key))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @SafeVarargs
+    public final boolean hasExactLabels(MapEntry<String, String>... entries) {
+        if (labels.size() != entries.length) {
+            return false;
+        }
+        return hasLabels(entries);
+    }
+
+    @Override
+    public String toString() {
+        if (labels.isEmpty()) {
+            return name + " " + value;
+        }
+        StringBuilder sb = new StringBuilder(name).append('{');
+        boolean first = true;
+        for (Map.Entry<String, String> e : labels.entrySet()) {
+            if (!first) {
+                sb.append(',');
+            }
+            sb.append(e.getKey()).append("=\"").append(e.getValue()).append('"');
+            first = false;
+        }
+        sb.append("} ").append(value);
+        return sb.toString();
+    }
+}

--- a/test-framework/prometheus-metrics/src/main/java/io/quarkus/test/micrometer/PrometheusMetrics.java
+++ b/test-framework/prometheus-metrics/src/main/java/io/quarkus/test/micrometer/PrometheusMetrics.java
@@ -1,0 +1,247 @@
+package io.quarkus.test.micrometer;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.assertj.core.data.MapEntry;
+
+/**
+ * Parses Prometheus exposition text format and provides a query API
+ * for finding metrics by name and labels, independent of label ordering.
+ * <p>
+ * Supports both Prometheus text format (trailing commas in labels)
+ * and OpenMetrics format (no trailing commas, optional exemplar comments).
+ *
+ * <pre>{@code
+ * PrometheusMetrics metrics = PrometheusMetrics.parse(inputStream);
+ * List<PrometheusMetric> found = metrics.find("http_client_requests_seconds_count",
+ *         entry("method", "GET"), entry("status", "200"));
+ * }</pre>
+ */
+class PrometheusMetrics {
+
+    private final List<PrometheusMetric> metrics;
+
+    private PrometheusMetrics(List<PrometheusMetric> metrics) {
+        this.metrics = Collections.unmodifiableList(metrics);
+    }
+
+    /**
+     * Parse Prometheus exposition text format from an {@link InputStream} into a queryable collection.
+     */
+    static PrometheusMetrics parse(InputStream input) {
+        List<PrometheusMetric> result = new ArrayList<>();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                line = line.trim();
+                if (line.isEmpty() || line.startsWith("#")) {
+                    continue;
+                }
+                PrometheusMetric metric = parseLine(line);
+                if (metric != null) {
+                    result.add(metric);
+                }
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return new PrometheusMetrics(result);
+    }
+
+    /**
+     * Find all metrics with the given name.
+     */
+    List<PrometheusMetric> find(String name) {
+        List<PrometheusMetric> result = new ArrayList<>();
+        for (PrometheusMetric m : metrics) {
+            if (m.name().equals(name)) {
+                result.add(m);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Find all metrics with the given name that contain all specified label key-value pairs.
+     * Extra labels on the metric are allowed (subset matching).
+     *
+     * @param name the metric name
+     * @param entries label entries to match
+     */
+    @SafeVarargs
+    final List<PrometheusMetric> find(String name, MapEntry<String, String>... entries) {
+        List<PrometheusMetric> result = new ArrayList<>();
+        for (PrometheusMetric m : metrics) {
+            if (m.name().equals(name) && m.hasLabels(entries)) {
+                result.add(m);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Find all metrics with the given name that have exactly the specified labels (no extra labels allowed).
+     */
+    @SafeVarargs
+    final List<PrometheusMetric> findExact(String name, MapEntry<String, String>... entries) {
+        List<PrometheusMetric> result = new ArrayList<>();
+        for (PrometheusMetric m : metrics) {
+            if (m.name().equals(name) && m.hasExactLabels(entries)) {
+                result.add(m);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Check if any metric exists with the given name and labels.
+     */
+    @SafeVarargs
+    final boolean hasMetric(String name, MapEntry<String, String>... entries) {
+        return !find(name, entries).isEmpty();
+    }
+
+    /**
+     * Find all metrics whose name contains the given substring.
+     */
+    List<PrometheusMetric> findByNameContaining(String substring) {
+        List<PrometheusMetric> result = new ArrayList<>();
+        for (PrometheusMetric m : metrics) {
+            if (m.name().contains(substring)) {
+                result.add(m);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Return all parsed metrics.
+     */
+    List<PrometheusMetric> getAll() {
+        return metrics;
+    }
+
+    static PrometheusMetric parseLine(String line) {
+        String name;
+        Map<String, String> labels;
+        double value;
+
+        int braceOpen = line.indexOf('{');
+        if (braceOpen >= 0) {
+            name = line.substring(0, braceOpen);
+            int braceClose = findClosingBrace(line, braceOpen + 1);
+            if (braceClose < 0) {
+                return null;
+            }
+            labels = parseLabels(line.substring(braceOpen + 1, braceClose));
+            value = parseValue(line.substring(braceClose + 1).trim());
+        } else {
+            int space = line.indexOf(' ');
+            if (space < 0) {
+                return null;
+            }
+            name = line.substring(0, space);
+            labels = Collections.emptyMap();
+            value = parseValue(line.substring(space + 1).trim());
+        }
+
+        return new PrometheusMetric(name, labels, value);
+    }
+
+    private static int findClosingBrace(String line, int start) {
+        boolean inQuote = false;
+        for (int i = start; i < line.length(); i++) {
+            char c = line.charAt(i);
+            if (inQuote) {
+                if (c == '\\' && i + 1 < line.length()) {
+                    i++;
+                } else if (c == '"') {
+                    inQuote = false;
+                }
+            } else {
+                if (c == '"') {
+                    inQuote = true;
+                } else if (c == '}') {
+                    return i;
+                }
+            }
+        }
+        return -1;
+    }
+
+    private static Map<String, String> parseLabels(String labelsStr) {
+        Map<String, String> labels = new LinkedHashMap<>();
+        int i = 0;
+        int len = labelsStr.length();
+        while (i < len) {
+            while (i < len && (labelsStr.charAt(i) == ',' || labelsStr.charAt(i) == ' ')) {
+                i++;
+            }
+            if (i >= len) {
+                break;
+            }
+
+            int eqPos = labelsStr.indexOf('=', i);
+            if (eqPos < 0) {
+                break;
+            }
+            String key = labelsStr.substring(i, eqPos).trim();
+
+            i = eqPos + 1;
+            if (i >= len || labelsStr.charAt(i) != '"') {
+                break;
+            }
+            i++; // skip opening quote
+            StringBuilder valueBuilder = new StringBuilder();
+            while (i < len && labelsStr.charAt(i) != '"') {
+                if (labelsStr.charAt(i) == '\\' && i + 1 < len) {
+                    char next = labelsStr.charAt(i + 1);
+                    if (next == '"' || next == '\\' || next == 'n') {
+                        valueBuilder.append(next == 'n' ? '\n' : next);
+                        i += 2;
+                        continue;
+                    }
+                }
+                valueBuilder.append(labelsStr.charAt(i));
+                i++;
+            }
+            if (i < len) {
+                i++; // skip closing quote
+            }
+            labels.put(key, valueBuilder.toString());
+        }
+        return labels;
+    }
+
+    private static double parseValue(String valueStr) {
+        int space = valueStr.indexOf(' ');
+        if (space >= 0) {
+            valueStr = valueStr.substring(0, space);
+        }
+        // Handle exemplar comments in OpenMetrics: "1.0 # {span_id=...}"
+        int hash = valueStr.indexOf('#');
+        if (hash >= 0) {
+            valueStr = valueStr.substring(0, hash).trim();
+        }
+        if ("+Inf".equals(valueStr)) {
+            return Double.POSITIVE_INFINITY;
+        } else if ("-Inf".equals(valueStr)) {
+            return Double.NEGATIVE_INFINITY;
+        }
+        try {
+            return Double.parseDouble(valueStr);
+        } catch (NumberFormatException e) {
+            return Double.NaN;
+        }
+    }
+}

--- a/test-framework/prometheus-metrics/src/main/java/io/quarkus/test/micrometer/PrometheusMetricsAssert.java
+++ b/test-framework/prometheus-metrics/src/main/java/io/quarkus/test/micrometer/PrometheusMetricsAssert.java
@@ -1,0 +1,278 @@
+package io.quarkus.test.micrometer;
+
+import java.io.InputStream;
+import java.util.List;
+
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.data.MapEntry;
+
+/**
+ * AssertJ assertion for Prometheus metrics text output.
+ * <p>
+ * Parses the Prometheus exposition format and provides label-order-independent assertions.
+ *
+ * <pre>{@code
+ * assertMetrics(inputStream)
+ *         .hasMetricWithLabels("http_client_requests_seconds_count",
+ *                 entry("clientName", "localhost"), entry("method", "GET"), entry("status", "200"))
+ *         .doesNotHaveMetricWithLabels("http_client_requests_seconds_count",
+ *                 entry("uri", "/echo"));
+ * }</pre>
+ */
+public class PrometheusMetricsAssert extends AbstractAssert<PrometheusMetricsAssert, PrometheusMetrics> {
+
+    private PrometheusMetricsAssert(PrometheusMetrics actual) {
+        super(actual, PrometheusMetricsAssert.class);
+    }
+
+    /**
+     * Parse the Prometheus text body from an {@link InputStream} and return an assertion instance.
+     */
+    public static PrometheusMetricsAssert assertMetrics(InputStream input) {
+        return new PrometheusMetricsAssert(PrometheusMetrics.parse(input));
+    }
+
+    /**
+     * Assert that a metric with the given name exists.
+     */
+    public PrometheusMetricsAssert hasMetric(String name) {
+        isNotNull();
+        if (actual.find(name).isEmpty()) {
+            failWithMessage("Expected metric <%s> to be present but it was not found", name);
+        }
+        return this;
+    }
+
+    /**
+     * Assert that a metric with the given name and all specified labels exists.
+     * Extra labels on the metric are allowed (subset matching).
+     *
+     * @param name the metric name
+     * @param entries label entries to match
+     */
+    @SafeVarargs
+    public final PrometheusMetricsAssert hasMetricWithLabels(String name, MapEntry<String, String>... entries) {
+        isNotNull();
+        List<PrometheusMetric> found = actual.find(name);
+        if (found.isEmpty()) {
+            failWithMessage("Expected metric <%s> to be present but no metric with that name was found", name);
+        } else if (actual.find(name, entries).isEmpty()) {
+            failWithMessage(
+                    "Expected metric <%s> with labels %s to be present but only found:%n%s",
+                    name, formatLabels(entries), formatMetrics(found));
+        }
+        return this;
+    }
+
+    /**
+     * Assert that a metric with the given name exists and has exactly the specified labels (no extra labels allowed).
+     *
+     * @param name the metric name
+     * @param entries label entries that must match exactly
+     */
+    @SafeVarargs
+    public final PrometheusMetricsAssert hasMetricWithExactLabels(String name, MapEntry<String, String>... entries) {
+        isNotNull();
+        List<PrometheusMetric> found = actual.find(name);
+        if (found.isEmpty()) {
+            failWithMessage("Expected metric <%s> to be present but no metric with that name was found", name);
+        } else if (actual.findExact(name, entries).isEmpty()) {
+            failWithMessage(
+                    "Expected metric <%s> with exactly labels %s to be present but only found:%n%s",
+                    name, formatLabels(entries), formatMetrics(found));
+        }
+        return this;
+    }
+
+    /**
+     * Assert that a metric with the given name, labels, and exact value exists.
+     *
+     * @param name the metric name
+     * @param value the expected value
+     * @param entries label entries to match
+     */
+    @SafeVarargs
+    public final PrometheusMetricsAssert hasMetricWithLabelsAndValue(String name, double value,
+            MapEntry<String, String>... entries) {
+        isNotNull();
+        List<PrometheusMetric> found = actual.find(name, entries);
+        if (found.isEmpty()) {
+            List<PrometheusMetric> byName = actual.find(name);
+            if (byName.isEmpty()) {
+                failWithMessage("Expected metric <%s> to be present but no metric with that name was found", name);
+            } else {
+                failWithMessage(
+                        "Expected metric <%s> with labels %s to be present but only found:%n%s",
+                        name, formatLabels(entries), formatMetrics(byName));
+            }
+        } else {
+            boolean matched = false;
+            for (PrometheusMetric m : found) {
+                if (Double.compare(m.value(), value) == 0) {
+                    matched = true;
+                    break;
+                }
+            }
+            if (!matched) {
+                failWithMessage(
+                        "Expected metric <%s> with labels %s to have value <%s> but found:%n%s",
+                        name, formatLabels(entries), value, formatMetrics(found));
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Assert that a metric with the given name exists, has exactly the specified labels (no extra labels allowed),
+     * and has the specified value.
+     *
+     * @param name the metric name
+     * @param value the expected value
+     * @param entries label entries that must match exactly
+     */
+    @SafeVarargs
+    public final PrometheusMetricsAssert hasMetricWithExactLabelsAndValue(String name, double value,
+            MapEntry<String, String>... entries) {
+        isNotNull();
+        List<PrometheusMetric> found = actual.findExact(name, entries);
+        if (found.isEmpty()) {
+            List<PrometheusMetric> byName = actual.find(name);
+            if (byName.isEmpty()) {
+                failWithMessage("Expected metric <%s> to be present but no metric with that name was found", name);
+            } else {
+                failWithMessage(
+                        "Expected metric <%s> with exactly labels %s to be present but only found:%n%s",
+                        name, formatLabels(entries), formatMetrics(byName));
+            }
+        } else {
+            boolean matched = false;
+            for (PrometheusMetric m : found) {
+                if (Double.compare(m.value(), value) == 0) {
+                    matched = true;
+                    break;
+                }
+            }
+            if (!matched) {
+                failWithMessage(
+                        "Expected metric <%s> with exactly labels %s to have value <%s> but found:%n%s",
+                        name, formatLabels(entries), value, formatMetrics(found));
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Assert that a metric with the given name and labels exists with a value
+     * greater than or equal to the specified minimum.
+     *
+     * @param name the metric name
+     * @param minValue the minimum expected value (inclusive)
+     * @param entries label entries to match
+     */
+    @SafeVarargs
+    public final PrometheusMetricsAssert hasMetricWithLabelsAndValueGreaterThanOrEqualTo(String name, double minValue,
+            MapEntry<String, String>... entries) {
+        isNotNull();
+        List<PrometheusMetric> found = actual.find(name, entries);
+        if (found.isEmpty()) {
+            List<PrometheusMetric> byName = actual.find(name);
+            if (byName.isEmpty()) {
+                failWithMessage("Expected metric <%s> to be present but no metric with that name was found", name);
+            } else {
+                failWithMessage(
+                        "Expected metric <%s> with labels %s to be present but only found:%n%s",
+                        name, formatLabels(entries), formatMetrics(byName));
+            }
+        } else {
+            boolean matched = false;
+            for (PrometheusMetric m : found) {
+                if (m.value() >= minValue) {
+                    matched = true;
+                    break;
+                }
+            }
+            if (!matched) {
+                failWithMessage(
+                        "Expected metric <%s> with labels %s to have value >= <%s> but found:%n%s",
+                        name, formatLabels(entries), minValue, formatMetrics(found));
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Assert that at least one metric exists whose name contains the given substring.
+     */
+    public PrometheusMetricsAssert hasMetricNameContaining(String substring) {
+        isNotNull();
+        if (actual.findByNameContaining(substring).isEmpty()) {
+            failWithMessage("Expected a metric whose name contains <%s> but none was found", substring);
+        }
+        return this;
+    }
+
+    /**
+     * Assert that no metric exists whose name contains the given substring.
+     */
+    public PrometheusMetricsAssert doesNotHaveMetricNameContaining(String substring) {
+        isNotNull();
+        List<PrometheusMetric> found = actual.findByNameContaining(substring);
+        if (!found.isEmpty()) {
+            failWithMessage(
+                    "Expected no metric whose name contains <%s> but found:%n%s",
+                    substring, formatMetrics(found));
+        }
+        return this;
+    }
+
+    /**
+     * Assert that no metric with the given name exists.
+     */
+    public PrometheusMetricsAssert doesNotHaveMetric(String name) {
+        isNotNull();
+        List<PrometheusMetric> found = actual.find(name);
+        if (!found.isEmpty()) {
+            failWithMessage(
+                    "Expected no metric <%s> but found:%n%s",
+                    name, formatMetrics(found));
+        }
+        return this;
+    }
+
+    /**
+     * Assert that no metric with the given name and labels exists.
+     *
+     * @param name the metric name
+     * @param entries label entries to match
+     */
+    @SafeVarargs
+    public final PrometheusMetricsAssert doesNotHaveMetricWithLabels(String name, MapEntry<String, String>... entries) {
+        isNotNull();
+        List<PrometheusMetric> found = actual.find(name, entries);
+        if (!found.isEmpty()) {
+            failWithMessage(
+                    "Expected no metric <%s> with labels %s but found:%n%s",
+                    name, formatLabels(entries), formatMetrics(found));
+        }
+        return this;
+    }
+
+    private static String formatLabels(MapEntry<String, String>[] entries) {
+        StringBuilder sb = new StringBuilder("{");
+        for (int i = 0; i < entries.length; i++) {
+            if (i > 0) {
+                sb.append(", ");
+            }
+            sb.append(entries[i].key).append("=\"").append(entries[i].value).append('"');
+        }
+        return sb.append('}').toString();
+    }
+
+    private static String formatMetrics(List<PrometheusMetric> metrics) {
+        StringBuilder sb = new StringBuilder();
+        for (PrometheusMetric m : metrics) {
+            sb.append("  ").append(m).append('\n');
+        }
+        return sb.toString();
+    }
+}

--- a/test-framework/prometheus-metrics/src/test/java/io/quarkus/test/micrometer/PrometheusMetricsTest.java
+++ b/test-framework/prometheus-metrics/src/test/java/io/quarkus/test/micrometer/PrometheusMetricsTest.java
@@ -1,0 +1,361 @@
+package io.quarkus.test.micrometer;
+
+import static io.quarkus.test.micrometer.PrometheusMetricsAssert.assertMetrics;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class PrometheusMetricsTest {
+
+    private static final String SAMPLE_OUTPUT = """
+            # HELP http_client_requests_seconds_count
+            # TYPE http_client_requests_seconds_count counter
+            http_client_requests_seconds_count{clientName="localhost",method="GET",outcome="SUCCESS",status="200",uri="root"} 2.0
+            http_client_requests_seconds_count{clientName="example.com",method="POST",outcome="CLIENT_ERROR",status="404",uri="/api"} 1.0
+            # HELP http_server_requests_seconds_count
+            # TYPE http_server_requests_seconds_count counter
+            http_server_requests_seconds_count{method="GET",status="200",uri="/hello"} 5.0
+            simple_metric 42.0
+            """;
+
+    private static InputStream toStream(String text) {
+        return new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void parseSkipsCommentsAndBlanks() {
+        PrometheusMetrics metrics = PrometheusMetrics.parse(toStream(SAMPLE_OUTPUT));
+        assertThat(metrics.getAll()).hasSize(4);
+    }
+
+    @Test
+    void findByName() {
+        PrometheusMetrics metrics = PrometheusMetrics.parse(toStream(SAMPLE_OUTPUT));
+        List<PrometheusMetric> found = metrics.find("http_client_requests_seconds_count");
+        assertThat(found).hasSize(2);
+    }
+
+    @Test
+    void findByNameAndLabelsSubsetMatch() {
+        PrometheusMetrics metrics = PrometheusMetrics.parse(toStream(SAMPLE_OUTPUT));
+        List<PrometheusMetric> found = metrics.find("http_client_requests_seconds_count",
+                entry("method", "GET"), entry("status", "200"));
+        assertThat(found).hasSize(1);
+        assertThat(found.get(0).getLabel("clientName")).isEqualTo("localhost");
+    }
+
+    @Test
+    void findByNameAndLabelsNoMatch() {
+        PrometheusMetrics metrics = PrometheusMetrics.parse(toStream(SAMPLE_OUTPUT));
+        List<PrometheusMetric> found = metrics.find("http_client_requests_seconds_count",
+                entry("method", "DELETE"));
+        assertThat(found).isEmpty();
+    }
+
+    @Test
+    void hasMetric() {
+        PrometheusMetrics metrics = PrometheusMetrics.parse(toStream(SAMPLE_OUTPUT));
+        assertThat(metrics.hasMetric("simple_metric")).isTrue();
+        assertThat(metrics.hasMetric("nonexistent_metric")).isFalse();
+    }
+
+    @Test
+    void parseMetricWithoutLabels() {
+        PrometheusMetrics metrics = PrometheusMetrics.parse(toStream("simple_metric 42.0\n"));
+        List<PrometheusMetric> found = metrics.find("simple_metric");
+        assertThat(found).hasSize(1);
+        assertThat(found.get(0).labels()).isEmpty();
+        assertThat(found.get(0).value()).isEqualTo(42.0);
+    }
+
+    @Test
+    void parseValueWithTimestamp() {
+        PrometheusMetrics metrics = PrometheusMetrics.parse(
+                toStream("my_metric{label=\"val\"} 3.14 1625000000000\n"));
+        assertThat(metrics.find("my_metric").get(0).value()).isEqualTo(3.14);
+    }
+
+    @Test
+    void parseTrailingCommaInLabels() {
+        PrometheusMetrics metrics = PrometheusMetrics.parse(
+                toStream("my_metric{a=\"1\",b=\"2\",} 1.0\n"));
+        PrometheusMetric m = metrics.find("my_metric").get(0);
+        assertThat(m.getLabel("a")).isEqualTo("1");
+        assertThat(m.getLabel("b")).isEqualTo("2");
+        assertThat(m.labels()).hasSize(2);
+    }
+
+    @Test
+    void parseEscapedQuotesInLabelValue() {
+        PrometheusMetrics metrics = PrometheusMetrics.parse(
+                toStream("my_metric{path=\"/say\\\"hello\\\"\"} 1.0\n"));
+        assertThat(metrics.find("my_metric").get(0).getLabel("path"))
+                .isEqualTo("/say\"hello\"");
+    }
+
+    @Test
+    void parseEscapedNewlineInLabelValue() {
+        PrometheusMetrics metrics = PrometheusMetrics.parse(
+                toStream("my_metric{msg=\"line1\\nline2\"} 1.0\n"));
+        assertThat(metrics.find("my_metric").get(0).getLabel("msg"))
+                .isEqualTo("line1\nline2");
+    }
+
+    @Test
+    void parseLabelValueContainingBraces() {
+        PrometheusMetrics metrics = PrometheusMetrics.parse(
+                toStream("http_server_requests_seconds_count{uri=\"/message/item/{id}\"} 1.0\n"));
+        PrometheusMetric m = metrics.find("http_server_requests_seconds_count").get(0);
+        assertThat(m.getLabel("uri")).isEqualTo("/message/item/{id}");
+        assertThat(m.value()).isEqualTo(1.0);
+    }
+
+    @Test
+    void hasLabelsMatchesSubset() {
+        PrometheusMetrics metrics = PrometheusMetrics.parse(
+                toStream("m{a=\"1\",b=\"2\",c=\"3\"} 1.0\n"));
+        PrometheusMetric m = metrics.find("m").get(0);
+        assertThat(m.hasLabels(entry("a", "1"), entry("c", "3"))).isTrue();
+        assertThat(m.hasLabels(entry("a", "1"), entry("c", "wrong"))).isFalse();
+    }
+
+    @Test
+    void hasExactLabelsMatchesAll() {
+        PrometheusMetrics metrics = PrometheusMetrics.parse(
+                toStream("m{a=\"1\",b=\"2\",c=\"3\"} 1.0\n"));
+        PrometheusMetric m = metrics.find("m").get(0);
+        assertThat(m.hasExactLabels(entry("a", "1"), entry("b", "2"), entry("c", "3"))).isTrue();
+        assertThat(m.hasExactLabels(entry("a", "1"), entry("c", "3"))).isFalse();
+        assertThat(m.hasExactLabels(entry("a", "1"), entry("b", "2"), entry("c", "3"), entry("d", "4"))).isFalse();
+    }
+
+    @Test
+    void toStringWithLabels() {
+        PrometheusMetrics metrics = PrometheusMetrics.parse(
+                toStream("my_metric{a=\"1\",b=\"2\"} 3.0\n"));
+        String str = metrics.find("my_metric").get(0).toString();
+        assertThat(str).contains("my_metric{").contains("a=\"1\"").contains("b=\"2\"").contains("3.0");
+    }
+
+    @Test
+    void toStringWithoutLabels() {
+        PrometheusMetrics metrics = PrometheusMetrics.parse(toStream("simple 7.0\n"));
+        assertThat(metrics.find("simple").get(0).toString()).isEqualTo("simple 7.0");
+    }
+
+    @Test
+    void parsePlusInfValue() {
+        PrometheusMetrics metrics = PrometheusMetrics.parse(
+                toStream("my_bucket{le=\"+Inf\"} +Inf\n"));
+        PrometheusMetric m = metrics.find("my_bucket").get(0);
+        assertThat(m.value()).isEqualTo(Double.POSITIVE_INFINITY);
+        assertThat(m.getLabel("le")).isEqualTo("+Inf");
+    }
+
+    @Test
+    void parseMinusInfValue() {
+        PrometheusMetrics metrics = PrometheusMetrics.parse(toStream("gauge_metric -Inf\n"));
+        assertThat(metrics.find("gauge_metric").get(0).value()).isEqualTo(Double.NEGATIVE_INFINITY);
+    }
+
+    @Test
+    void parseNaNValue() {
+        PrometheusMetrics metrics = PrometheusMetrics.parse(toStream("stale_metric NaN\n"));
+        assertThat(metrics.find("stale_metric").get(0).value()).isNaN();
+    }
+
+    // AssertJ assertion tests
+
+    @Test
+    void assertHasMetric() {
+        assertMetrics(toStream(SAMPLE_OUTPUT)).hasMetric("simple_metric");
+    }
+
+    @Test
+    void assertHasMetricFails() {
+        assertThatThrownBy(() -> assertMetrics(toStream(SAMPLE_OUTPUT)).hasMetric("nonexistent"))
+                .isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void assertHasMetricWithLabels() {
+        assertMetrics(toStream(SAMPLE_OUTPUT))
+                .hasMetricWithLabels("http_client_requests_seconds_count",
+                        entry("clientName", "localhost"), entry("method", "GET"));
+    }
+
+    @Test
+    void assertHasMetricWithLabelsFailsNoName() {
+        assertThatThrownBy(() -> assertMetrics(toStream(SAMPLE_OUTPUT))
+                .hasMetricWithLabels("nonexistent", entry("method", "GET")))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("nonexistent");
+    }
+
+    @Test
+    void assertHasMetricWithLabelsFailsWrongLabels() {
+        assertThatThrownBy(() -> assertMetrics(toStream(SAMPLE_OUTPUT))
+                .hasMetricWithLabels("http_client_requests_seconds_count",
+                        entry("method", "DELETE")))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("method=\"DELETE\"");
+    }
+
+    @Test
+    void assertHasMetricWithExactLabels() {
+        assertMetrics(toStream(SAMPLE_OUTPUT))
+                .hasMetricWithExactLabels("http_client_requests_seconds_count",
+                        entry("clientName", "localhost"), entry("method", "GET"),
+                        entry("outcome", "SUCCESS"), entry("status", "200"), entry("uri", "root"));
+    }
+
+    @Test
+    void assertHasMetricWithExactLabelsFailsSubset() {
+        assertThatThrownBy(() -> assertMetrics(toStream(SAMPLE_OUTPUT))
+                .hasMetricWithExactLabels("http_client_requests_seconds_count",
+                        entry("clientName", "localhost"), entry("method", "GET")))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("exactly labels");
+    }
+
+    @Test
+    void assertDoesNotHaveMetricWithLabels() {
+        assertMetrics(toStream(SAMPLE_OUTPUT))
+                .doesNotHaveMetricWithLabels("http_client_requests_seconds_count",
+                        entry("method", "DELETE"));
+    }
+
+    @Test
+    void assertDoesNotHaveMetricWithLabelsFails() {
+        assertThatThrownBy(() -> assertMetrics(toStream(SAMPLE_OUTPUT))
+                .doesNotHaveMetricWithLabels("http_client_requests_seconds_count",
+                        entry("method", "GET")))
+                .isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void assertDoesNotHaveMetric() {
+        assertMetrics(toStream(SAMPLE_OUTPUT)).doesNotHaveMetric("nonexistent");
+    }
+
+    @Test
+    void assertDoesNotHaveMetricFails() {
+        assertThatThrownBy(() -> assertMetrics(toStream(SAMPLE_OUTPUT)).doesNotHaveMetric("simple_metric"))
+                .isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void assertHasMetricWithLabelsAndValue() {
+        assertMetrics(toStream(SAMPLE_OUTPUT))
+                .hasMetricWithLabelsAndValue("http_client_requests_seconds_count", 2.0,
+                        entry("clientName", "localhost"), entry("method", "GET"));
+    }
+
+    @Test
+    void assertHasMetricWithLabelsAndValueFailsWrongValue() {
+        assertThatThrownBy(() -> assertMetrics(toStream(SAMPLE_OUTPUT))
+                .hasMetricWithLabelsAndValue("http_client_requests_seconds_count", 99.0,
+                        entry("clientName", "localhost"), entry("method", "GET")))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("99.0");
+    }
+
+    @Test
+    void assertHasMetricWithLabelsAndValueFailsNoMetric() {
+        assertThatThrownBy(() -> assertMetrics(toStream(SAMPLE_OUTPUT))
+                .hasMetricWithLabelsAndValue("nonexistent", 1.0, entry("k", "v")))
+                .isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void assertHasMetricWithExactLabelsAndValue() {
+        assertMetrics(toStream(SAMPLE_OUTPUT))
+                .hasMetricWithExactLabelsAndValue("http_server_requests_seconds_count", 5.0,
+                        entry("method", "GET"), entry("status", "200"), entry("uri", "/hello"));
+    }
+
+    @Test
+    void assertHasMetricWithExactLabelsAndValueFailsSubset() {
+        assertThatThrownBy(() -> assertMetrics(toStream(SAMPLE_OUTPUT))
+                .hasMetricWithExactLabelsAndValue("http_server_requests_seconds_count", 5.0,
+                        entry("method", "GET")))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("exactly labels");
+    }
+
+    @Test
+    void assertHasMetricWithExactLabelsAndValueFailsWrongValue() {
+        assertThatThrownBy(() -> assertMetrics(toStream(SAMPLE_OUTPUT))
+                .hasMetricWithExactLabelsAndValue("http_server_requests_seconds_count", 99.0,
+                        entry("method", "GET"), entry("status", "200"), entry("uri", "/hello")))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("99.0");
+    }
+
+    @Test
+    void assertHasMetricWithLabelsAndValueGreaterThanOrEqualTo() {
+        assertMetrics(toStream(SAMPLE_OUTPUT))
+                .hasMetricWithLabelsAndValueGreaterThanOrEqualTo(
+                        "http_server_requests_seconds_count", 5.0, entry("method", "GET"))
+                .hasMetricWithLabelsAndValueGreaterThanOrEqualTo(
+                        "http_server_requests_seconds_count", 3.0, entry("method", "GET"));
+    }
+
+    @Test
+    void assertHasMetricWithLabelsAndValueGreaterThanOrEqualToFails() {
+        assertThatThrownBy(() -> assertMetrics(toStream(SAMPLE_OUTPUT))
+                .hasMetricWithLabelsAndValueGreaterThanOrEqualTo(
+                        "http_server_requests_seconds_count", 100.0, entry("method", "GET")))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining(">= <100.0>");
+    }
+
+    @Test
+    void findByNameContaining() {
+        PrometheusMetrics metrics = PrometheusMetrics.parse(toStream(SAMPLE_OUTPUT));
+        assertThat(metrics.findByNameContaining("http_client")).hasSize(2);
+        assertThat(metrics.findByNameContaining("http_server")).hasSize(1);
+        assertThat(metrics.findByNameContaining("nonexistent")).isEmpty();
+    }
+
+    @Test
+    void assertHasMetricNameContaining() {
+        assertMetrics(toStream(SAMPLE_OUTPUT)).hasMetricNameContaining("http_client");
+    }
+
+    @Test
+    void assertHasMetricNameContainingFails() {
+        assertThatThrownBy(() -> assertMetrics(toStream(SAMPLE_OUTPUT)).hasMetricNameContaining("nonexistent"))
+                .isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void assertDoesNotHaveMetricNameContaining() {
+        assertMetrics(toStream(SAMPLE_OUTPUT)).doesNotHaveMetricNameContaining("nonexistent");
+    }
+
+    @Test
+    void assertDoesNotHaveMetricNameContainingFails() {
+        assertThatThrownBy(() -> assertMetrics(toStream(SAMPLE_OUTPUT)).doesNotHaveMetricNameContaining("http_client"))
+                .isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void assertChainingWorks() {
+        assertMetrics(toStream(SAMPLE_OUTPUT))
+                .hasMetric("simple_metric")
+                .hasMetricWithLabels("http_client_requests_seconds_count",
+                        entry("clientName", "localhost"))
+                .hasMetricWithLabelsAndValue("simple_metric", 42.0)
+                .doesNotHaveMetric("nonexistent")
+                .doesNotHaveMetricWithLabels("http_client_requests_seconds_count",
+                        entry("clientName", "unknown"));
+    }
+}


### PR DESCRIPTION
This alleviates the drudgery of updating metrics related tests when a new tag is added, 
as all the existing tests simply use assertions on `String`

This is done by introducing a test library
that parses prometheus metrics entries and providing 
a simple AssertJ integration for fluent assertions