### PR TITLE
Exclude transitive dependencies from narayana-jta

### DIFF
--- a/extensions/narayana-jta/runtime/pom.xml
+++ b/extensions/narayana-jta/runtime/pom.xml
@@ -70,14 +70,14 @@
             <exclusions>
                 <!-- Brought by CDI with proper version -->
                 <exclusion>
-                    <groupId>jakarta.enterprise</groupId>
-                    <artifactId>jakarta.enterprise.lang-model</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>jakarta.ejb</groupId>
-                    <artifactId>jakarta.ejb-api</artifactId>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jboss-transaction-spi</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.narayana.jts</groupId>


### PR DESCRIPTION
This PR relates to https://github.com/quarkusio/quarkus/pull/54198

The idea is to remove all transitive dependencies from narayana-jta and add only needed dependencies (with the version specified in the quarkus boms)

WDYT @jamesnetherton