### PR TITLE
Fix OpenTelemetryQuartzIT and OpenTelemetrySchedulerIT native mode tests

### DIFF
--- a/integration-tests/opentelemetry-quartz/src/main/java/io/quarkus/it/opentelemetry/quartz/SpanDataModuleSerializer.java
+++ b/integration-tests/opentelemetry-quartz/src/main/java/io/quarkus/it/opentelemetry/quartz/SpanDataModuleSerializer.java
@@ -1,0 +1,20 @@
+package io.quarkus.it.opentelemetry.quartz;
+
+import jakarta.inject.Singleton;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.quarkus.jackson.ObjectMapperCustomizer;
+
+@Singleton
+public class SpanDataModuleSerializer implements ObjectMapperCustomizer {
+
+    @Override
+    public void customize(ObjectMapper objectMapper) {
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(SpanData.class, new SpanDataSerializer());
+        objectMapper.registerModule(module);
+    }
+}

--- a/integration-tests/opentelemetry-quartz/src/main/java/io/quarkus/it/opentelemetry/quartz/SpanDataSerializer.java
+++ b/integration-tests/opentelemetry-quartz/src/main/java/io/quarkus/it/opentelemetry/quartz/SpanDataSerializer.java
@@ -1,0 +1,52 @@
+package io.quarkus.it.opentelemetry.quartz;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import io.opentelemetry.sdk.trace.data.EventData;
+import io.opentelemetry.sdk.trace.data.ExceptionEventData;
+import io.opentelemetry.sdk.trace.data.SpanData;
+
+public class SpanDataSerializer extends StdSerializer<SpanData> {
+
+    public SpanDataSerializer() {
+        this(null);
+    }
+
+    public SpanDataSerializer(Class<SpanData> type) {
+        super(type);
+    }
+
+    @Override
+    public void serialize(SpanData spanData, JsonGenerator gen, SerializerProvider provider)
+            throws IOException {
+        gen.writeStartObject();
+
+        gen.writeStringField("name", spanData.getName());
+        gen.writeStringField("kind", spanData.getKind().name());
+        gen.writeNumberField("startEpochNanos", spanData.getStartEpochNanos());
+        gen.writeNumberField("endEpochNanos", spanData.getEndEpochNanos());
+
+        gen.writeObjectFieldStart("status");
+        gen.writeStringField("statusCode", spanData.getStatus().getStatusCode().name());
+        gen.writeEndObject();
+
+        gen.writeArrayFieldStart("events");
+        for (EventData event : spanData.getEvents()) {
+            gen.writeStartObject();
+            if (event instanceof ExceptionEventData) {
+                ExceptionEventData exEvent = (ExceptionEventData) event;
+                gen.writeObjectFieldStart("exception");
+                gen.writeStringField("message", exEvent.getException().getMessage());
+                gen.writeEndObject();
+            }
+            gen.writeEndObject();
+        }
+        gen.writeEndArray();
+
+        gen.writeEndObject();
+    }
+}

--- a/integration-tests/opentelemetry-quartz/src/test/java/io/quarkus/it/opentelemetry/quartz/OpenTelemetryQuartzIT.java
+++ b/integration-tests/opentelemetry-quartz/src/test/java/io/quarkus/it/opentelemetry/quartz/OpenTelemetryQuartzIT.java
@@ -1,16 +1,7 @@
 package io.quarkus.it.opentelemetry.quartz;
 
-import org.junit.jupiter.api.Test;
-
-import io.quarkus.test.junit.DisabledOnIntegrationTest;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
 public class OpenTelemetryQuartzIT extends OpenTelemetryQuartzTest {
-    @Test
-    @DisabledOnIntegrationTest("native mode testing span does not have a field 'exception' (only in integration-test, not in quarkus app)")
-    @Override
-    public void quartzSpanTest() {
-        super.quartzSpanTest();
-    }
 }

--- a/integration-tests/opentelemetry-scheduler/src/main/java/io/quarkus/it/opentelemetry/scheduler/SpanDataModuleSerializer.java
+++ b/integration-tests/opentelemetry-scheduler/src/main/java/io/quarkus/it/opentelemetry/scheduler/SpanDataModuleSerializer.java
@@ -1,0 +1,20 @@
+package io.quarkus.it.opentelemetry.scheduler;
+
+import jakarta.inject.Singleton;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.quarkus.jackson.ObjectMapperCustomizer;
+
+@Singleton
+public class SpanDataModuleSerializer implements ObjectMapperCustomizer {
+
+    @Override
+    public void customize(ObjectMapper objectMapper) {
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(SpanData.class, new SpanDataSerializer());
+        objectMapper.registerModule(module);
+    }
+}

--- a/integration-tests/opentelemetry-scheduler/src/main/java/io/quarkus/it/opentelemetry/scheduler/SpanDataSerializer.java
+++ b/integration-tests/opentelemetry-scheduler/src/main/java/io/quarkus/it/opentelemetry/scheduler/SpanDataSerializer.java
@@ -1,0 +1,52 @@
+package io.quarkus.it.opentelemetry.scheduler;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import io.opentelemetry.sdk.trace.data.EventData;
+import io.opentelemetry.sdk.trace.data.ExceptionEventData;
+import io.opentelemetry.sdk.trace.data.SpanData;
+
+public class SpanDataSerializer extends StdSerializer<SpanData> {
+
+    public SpanDataSerializer() {
+        this(null);
+    }
+
+    public SpanDataSerializer(Class<SpanData> type) {
+        super(type);
+    }
+
+    @Override
+    public void serialize(SpanData spanData, JsonGenerator gen, SerializerProvider provider)
+            throws IOException {
+        gen.writeStartObject();
+
+        gen.writeStringField("name", spanData.getName());
+        gen.writeStringField("kind", spanData.getKind().name());
+        gen.writeNumberField("startEpochNanos", spanData.getStartEpochNanos());
+        gen.writeNumberField("endEpochNanos", spanData.getEndEpochNanos());
+
+        gen.writeObjectFieldStart("status");
+        gen.writeStringField("statusCode", spanData.getStatus().getStatusCode().name());
+        gen.writeEndObject();
+
+        gen.writeArrayFieldStart("events");
+        for (EventData event : spanData.getEvents()) {
+            gen.writeStartObject();
+            if (event instanceof ExceptionEventData) {
+                ExceptionEventData exEvent = (ExceptionEventData) event;
+                gen.writeObjectFieldStart("exception");
+                gen.writeStringField("message", exEvent.getException().getMessage());
+                gen.writeEndObject();
+            }
+            gen.writeEndObject();
+        }
+        gen.writeEndArray();
+
+        gen.writeEndObject();
+    }
+}

--- a/integration-tests/opentelemetry-scheduler/src/test/java/io/quarkus/it/opentelemetry/scheduler/OpenTelemetrySchedulerIT.java
+++ b/integration-tests/opentelemetry-scheduler/src/test/java/io/quarkus/it/opentelemetry/scheduler/OpenTelemetrySchedulerIT.java
@@ -1,16 +1,7 @@
 package io.quarkus.it.opentelemetry.scheduler;
 
-import org.junit.jupiter.api.Test;
-
-import io.quarkus.test.junit.DisabledOnIntegrationTest;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
 public class OpenTelemetrySchedulerIT extends OpenTelemetrySchedulerTest {
-    @Test
-    @DisabledOnIntegrationTest("native mode testing span does not have a field 'exception' (only in integration-test, not in quarkus app)")
-    @Override
-    public void schedulerSpanTest() {
-        super.schedulerSpanTest();
-    }
 }


### PR DESCRIPTION
/cc @mkouba @brunobat 

The fix adds a custom Jackson `SpanDataSerializer` to each IT module that explicitly calls the public OTel SDK interface methods (`SpanData.getName()`, `SpanData.getEvents()`, `ExceptionEventData.getException()`, etc.) instead of relying on reflection. This way native mode produces the same JSON shape as JVM mode. The same pattern is already used by other OTel integration tests in the repo (`opentelemetry`, `opentelemetry-quickstart`).

- Fixes: #37399