### PR TITLE
Add preauthorized_code as OidcClient grant type enum

### DIFF
--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientConfig.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientConfig.java
@@ -114,7 +114,12 @@ public interface OidcClientConfig extends OidcClientCommonConfig {
              * 'device_code'
              * parameter which must be passed to OidcClient at the token request time.
              */
-            DEVICE("urn:ietf:params:oauth:grant-type:device_code");
+            DEVICE("urn:ietf:params:oauth:grant-type:device_code"),
+            /**
+             * 'urn:ietf:params:oauth:grant-type:pre-authorized_code' grant requiring an OIDC client authentication as well as
+             * at least a 'pre-authorized_code' parameter which must be passed to OidcClient at the token request time.
+             */
+            PREAUTHORIZED_CODE("urn:ietf:params:oauth:grant-type:pre-authorized_code");
 
             private final String grantType;
 


### PR DESCRIPTION
This PR only adds a single enum value to support https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#pre-authz-code-flow in scope of the OIDC verifiable credentials work/demo