### PR TITLE
Bump Vineflower to 1.12.0

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/VineflowerDecompiler.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/VineflowerDecompiler.java
@@ -15,7 +15,7 @@ import io.smallrye.common.process.ProcessUtil;
 class VineflowerDecompiler implements Decompiler {
 
     private static final Logger LOG = Logger.getLogger(VineflowerDecompiler.class);
-    private static final String DEFAULT_VINEFLOWER_VERSION = "1.11.1";
+    private static final String DEFAULT_VINEFLOWER_VERSION = "1.12.0";
 
     private Context context;
     private Path decompilerJar;


### PR DESCRIPTION
See https://github.com/Vineflower/vineflower/releases/tag/1.12.0


> Vineflower 1.12.0 is the next major release of Vineflower, improving how variables are handled, beautifying the decompiler output, improving Kotlin support, as well as dozens of bug fixes and smaller features. Thanks to all the contributors who submitted patches for this release!


I have tested by removing my vineflower jar and use the decompiler on my quarkus project.

