### PR TITLE
Add `description` property to `@Scheduled` annotation

### DIFF
--- a/docs/src/main/asciidoc/quartz.adoc
+++ b/docs/src/main/asciidoc/quartz.adoc
@@ -138,6 +138,8 @@ public class TaskBean {
 <3> Create a new `Task` with the current start time.
 <4> Persist the task in database using xref:hibernate-orm-panache.adoc[Panache].
 
+TIP: The `@Scheduled#description()` value, if set, is stored in the `DESCRIPTION` column of the `QRTZ_JOB_DETAILS` table.
+
 === Scheduling Jobs Programmatically
 
 An injected `io.quarkus.scheduler.Scheduler` can be used to <<scheduler-reference.adoc#programmatic_scheduling,schedule a job programmatically>>.

--- a/docs/src/main/asciidoc/scheduler-reference.adoc
+++ b/docs/src/main/asciidoc/scheduler-reference.adoc
@@ -220,6 +220,30 @@ Property Expressions. (Note that `"{property.path}"` style expressions are still
 void myMethod() { }
 ----
 
+[[description]]
+=== Description
+
+An optional description can be attached to a scheduled method to document what the job does.
+
+.Description Example
+[source,java]
+----
+@Scheduled(every = "1s", description = "Checks the status of external services")
+void checkStatus() { }
+----
+
+The `description` attribute supports <<config-reference#property-expressions,Property Expressions>> including default values and nested
+Property Expressions. (Note that `"{property.path}"` style expressions are still supported but don't offer the full functionality of Property Expressions.)
+
+.Description Config Property Example
+[source,java]
+----
+@Scheduled(every = "1s", description = "${myJob.description}")
+void checkStatus() { }
+----
+
+NOTE: When using the xref:quartz.adoc[Quartz extension] with a JDBC job store, the description is limited to 250 characters due to database column constraints.
+
 [[delayed_start]]
 === Delayed Start of a Trigger
 

--- a/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/InvalidDescriptionLengthTest.java
+++ b/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/InvalidDescriptionLengthTest.java
@@ -1,0 +1,37 @@
+package io.quarkus.quartz.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.scheduler.Scheduled;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class InvalidDescriptionLengthTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .assertException(t -> {
+                assertThat(t).cause().isInstanceOf(IllegalStateException.class)
+                        .hasMessageContaining(
+                                "description() must not exceed " + Scheduled.DESCRIPTION_MAX_LENGTH + " characters");
+            })
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Jobs.class));
+
+    @Test
+    public void test() {
+    }
+
+    static class Jobs {
+
+        @Scheduled(every = "1s", description = "A" +
+                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" +
+                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" +
+                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+        void ping() {
+        }
+    }
+
+}

--- a/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/ScheduledDescriptionTest.java
+++ b/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/ScheduledDescriptionTest.java
@@ -1,0 +1,69 @@
+package io.quarkus.quartz.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
+import org.quartz.SchedulerException;
+
+import io.quarkus.quartz.QuartzScheduler;
+import io.quarkus.scheduler.Scheduled;
+import io.quarkus.scheduler.Scheduler;
+import io.quarkus.scheduler.Trigger;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class ScheduledDescriptionTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Jobs.class));
+
+    @Inject
+    Scheduler scheduler;
+
+    @Inject
+    QuartzScheduler quartzScheduler;
+
+    @Test
+    public void testDescriptionViaQuartzApi() throws SchedulerException {
+        JobDetail jobDetail = quartzScheduler.getScheduler()
+                .getJobDetail(new JobKey("with_description", Scheduler.class.getName()));
+        assertEquals("A job that pings", jobDetail.getDescription());
+    }
+
+    @Test
+    public void testDescriptionViaTrigger() {
+        List<Trigger> triggers = scheduler.getScheduledJobs();
+        Trigger withDescription = triggers.stream()
+                .filter(t -> "with_description".equals(t.getId()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals("A job that pings", withDescription.getDescription());
+
+        Trigger withoutDescription = triggers.stream()
+                .filter(t -> "without_description".equals(t.getId()))
+                .findFirst()
+                .orElseThrow();
+        assertNull(withoutDescription.getDescription());
+    }
+
+    static class Jobs {
+
+        @Scheduled(identity = "with_description", every = "1s", description = "A job that pings")
+        void ping() {
+        }
+
+        @Scheduled(identity = "without_description", every = "1s")
+        void pong() {
+        }
+    }
+
+}

--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzSchedulerImpl.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzSchedulerImpl.java
@@ -227,10 +227,13 @@ public class QuartzSchedulerImpl extends BaseScheduler implements QuartzSchedule
                                 invoker.isBlocking() && runtimeConfig.runBlockingScheduledMethodOnQuartzThread(),
                                 SchedulerUtils.parseExecutionMaxDelayAsMillis(scheduled), blockingExecutor);
 
+                        String descriptionValue = SchedulerUtils.lookUpPropertyValue(scheduled.description());
+                        String description = descriptionValue.isEmpty() ? null : descriptionValue;
+                        validateDescriptionLength(identity, description);
                         JobDetail jobDetail = createJobBuilder(identity, method.getInvokerClassName(),
-                                quartzSupport.isNonconcurrent(method)).build();
+                                quartzSupport.isNonconcurrent(method), description).build();
                         Optional<TriggerBuilder<?>> triggerBuilder = createTrigger(identity, scheduled, runtimeConfig,
-                                jobDetail);
+                                jobDetail, description);
 
                         if (triggerBuilder.isPresent()) {
                             org.quartz.Trigger trigger = triggerBuilder.get().build();
@@ -264,7 +267,7 @@ public class QuartzSchedulerImpl extends BaseScheduler implements QuartzSchedule
                                     new QuartzTrigger(trigger.getKey(), triggerFun, invoker,
                                             SchedulerUtils.parseOverdueGracePeriod(scheduled, defaultOverdueGracePeriod),
                                             quartzSupport.getRuntimeConfig().runBlockingScheduledMethodOnQuartzThread(), false,
-                                            method.getMethodDescription()));
+                                            method.getMethodDescription(), description));
                         } else {
                             // The job is disabled
                             scheduler.deleteJob(new JobKey(identity, Scheduler.class.getName()));
@@ -666,15 +669,27 @@ public class QuartzSchedulerImpl extends BaseScheduler implements QuartzSchedule
         });
     }
 
-    private JobBuilder createJobBuilder(String identity, String invokerClassName, boolean noncurrent) {
+    private static void validateDescriptionLength(String identity, String description) {
+        if (description != null && description.length() > Scheduled.DESCRIPTION_MAX_LENGTH) {
+            throw new IllegalArgumentException(
+                    "Description for job '" + identity + "' is too long: " + description.length()
+                            + " characters (max " + Scheduled.DESCRIPTION_MAX_LENGTH + ")");
+        }
+    }
+
+    private JobBuilder createJobBuilder(String identity, String invokerClassName, boolean noncurrent, String description) {
         Class<? extends Job> jobClass = noncurrent ? NonconcurrentInvokerJob.class
                 : InvokerJob.class;
-        return JobBuilder.newJob(jobClass)
+        JobBuilder jobBuilder = JobBuilder.newJob(jobClass)
                 // new JobKey(identity, "io.quarkus.scheduler.Scheduler")
                 .withIdentity(identity, Scheduler.class.getName())
                 // this info is redundant but keep it for backward compatibility
                 .usingJobData(INVOKER_KEY, invokerClassName)
                 .requestRecovery();
+        if (description != null) {
+            jobBuilder.withDescription(description);
+        }
+        return jobBuilder;
     }
 
     /**
@@ -689,7 +704,7 @@ public class QuartzSchedulerImpl extends BaseScheduler implements QuartzSchedule
      * @see SchedulerUtils#isOff(String)
      */
     private Optional<TriggerBuilder<?>> createTrigger(String identity, Scheduled scheduled,
-            QuartzRuntimeConfig runtimeConfig, JobDetail jobDetail) {
+            QuartzRuntimeConfig runtimeConfig, JobDetail jobDetail, String description) {
 
         ScheduleBuilder<?> scheduleBuilder;
         if (!scheduled.cron().isEmpty()) {
@@ -782,6 +797,9 @@ public class QuartzSchedulerImpl extends BaseScheduler implements QuartzSchedule
                 .withIdentity(identity, Scheduler.class.getName())
                 .forJob(jobDetail)
                 .withSchedule(scheduleBuilder);
+        if (description != null) {
+            triggerBuilder.withDescription(description);
+        }
 
         Long millisToAdd = null;
         if (scheduled.delay() > 0) {
@@ -886,7 +904,8 @@ public class QuartzSchedulerImpl extends BaseScheduler implements QuartzSchedule
             }
             scheduled = true;
             SyntheticScheduled scheduled = new SyntheticScheduled(identity, cron, every, 0, TimeUnit.MINUTES, delayed,
-                    overdueGracePeriod, concurrentExecution, skipPredicate, timeZone, implementation, executionMaxDelay);
+                    overdueGracePeriod, concurrentExecution, skipPredicate, timeZone, implementation, executionMaxDelay,
+                    description);
             return createJobDefinitionQuartzTrigger(this, scheduled, null);
         }
 
@@ -964,8 +983,11 @@ public class QuartzSchedulerImpl extends BaseScheduler implements QuartzSchedule
             };
         }
 
+        String descriptionValue = SchedulerUtils.lookUpPropertyValue(scheduled.description());
+        String description = descriptionValue.isEmpty() ? null : descriptionValue;
+        validateDescriptionLength(scheduled.identity(), description);
         JobBuilder jobBuilder = createJobBuilder(scheduled.identity(), QuartzSchedulerImpl.class.getName(),
-                executionMetadata.nonconcurrent());
+                executionMetadata.nonconcurrent(), description);
         if (storeType.isDbStore()) {
             jobBuilder.usingJobData(SCHEDULED_METADATA, scheduled.toJson())
                     .usingJobData(EXECUTION_METADATA_RUN_ON_VIRTUAL_THREAD, Boolean.toString(runOnVirtualThread));
@@ -984,7 +1006,7 @@ public class QuartzSchedulerImpl extends BaseScheduler implements QuartzSchedule
 
         org.quartz.Trigger trigger;
         Optional<TriggerBuilder<?>> triggerBuilder = createTrigger(scheduled.identity(), scheduled, runtimeConfig,
-                jobDetail);
+                jobDetail, description);
         if (triggerBuilder.isPresent()) {
             if (oldTrigger != null) {
                 trigger = triggerBuilder.get().startAt(oldTrigger.getNextFireTime()).build();
@@ -1019,7 +1041,7 @@ public class QuartzSchedulerImpl extends BaseScheduler implements QuartzSchedule
                     }
                 }, invoker,
                 SchedulerUtils.parseOverdueGracePeriod(scheduled, defaultOverdueGracePeriod),
-                runtimeConfig.runBlockingScheduledMethodOnQuartzThread(), true, null);
+                runtimeConfig.runBlockingScheduledMethodOnQuartzThread(), true, null, description);
         QuartzTrigger existing = scheduledTasks.putIfAbsent(scheduled.identity(), quartzTrigger);
 
         if (existing != null) {
@@ -1110,12 +1132,13 @@ public class QuartzSchedulerImpl extends BaseScheduler implements QuartzSchedule
         private final Duration gracePeriod;
         private final boolean isProgrammatic;
         private final String methodDescription;
+        private final String description;
 
         final boolean runBlockingMethodOnQuartzThread;
 
         QuartzTrigger(org.quartz.TriggerKey triggerKey, Function<TriggerKey, org.quartz.Trigger> triggerFunction,
                 ScheduledInvoker invoker, Duration gracePeriod, boolean runBlockingMethodOnQuartzThread,
-                boolean isProgrammatic, String methodDescription) {
+                boolean isProgrammatic, String methodDescription, String description) {
             this.triggerKey = triggerKey;
             this.triggerFunction = triggerFunction;
             this.invoker = invoker;
@@ -1123,6 +1146,7 @@ public class QuartzSchedulerImpl extends BaseScheduler implements QuartzSchedule
             this.runBlockingMethodOnQuartzThread = runBlockingMethodOnQuartzThread;
             this.isProgrammatic = isProgrammatic;
             this.methodDescription = methodDescription;
+            this.description = description;
         }
 
         @Override
@@ -1155,6 +1179,11 @@ public class QuartzSchedulerImpl extends BaseScheduler implements QuartzSchedule
         @Override
         public String getMethodDescription() {
             return methodDescription;
+        }
+
+        @Override
+        public String getDescription() {
+            return description;
         }
 
         private org.quartz.Trigger trigger() {

--- a/extensions/scheduler/api/src/main/java/io/quarkus/scheduler/Scheduled.java
+++ b/extensions/scheduler/api/src/main/java/io/quarkus/scheduler/Scheduled.java
@@ -85,6 +85,12 @@ public @interface Scheduled {
     String QUARTZ = "QUARTZ";
 
     /**
+     * Maximum length of the {@link #description()} value. This limit is derived from the {@code VARCHAR(250)} column used
+     * in Quartz JDBC schemas for the {@code DESCRIPTION} column in {@code QRTZ_JOB_DETAILS} and {@code QRTZ_TRIGGERS} tables.
+     */
+    int DESCRIPTION_MAX_LENGTH = 250;
+
+    /**
      * Optionally defines a unique identifier for this job.
      * <p>
      * The value can be a property expression. In this case, the scheduler attempts to use the configured value instead:
@@ -97,6 +103,21 @@ public @interface Scheduled {
      * @return the unique identity of the schedule
      */
     String identity() default "";
+
+    /**
+     * Optionally defines a brief description of what the job does.
+     * <p>
+     * The value can be a property expression. In this case, the scheduler attempts to use the configured value instead:
+     * {@code @Scheduled(description = "${myJob.description}")}.
+     * Additionally, the property expression can specify a default value: {@code @Scheduled(description =
+     * "${myJob.description:My job}")}.
+     * <p>
+     * Note that when using the Quartz scheduler with a JDBC job store, the description is limited to
+     * {@value #DESCRIPTION_MAX_LENGTH} characters.
+     *
+     * @return the description
+     */
+    String description() default "";
 
     /**
      * Defines a cron-like expression. For example "0 15 10 * * ?" fires at 10:15am every day.

--- a/extensions/scheduler/api/src/main/java/io/quarkus/scheduler/Scheduler.java
+++ b/extensions/scheduler/api/src/main/java/io/quarkus/scheduler/Scheduler.java
@@ -232,6 +232,15 @@ public interface Scheduler {
         THIS setExecutionMaxDelay(String maxDelay);
 
         /**
+         * {@link Scheduled#description()}
+         *
+         * @param description
+         * @return self
+         * @see Scheduled#description()
+         */
+        THIS setDescription(String description);
+
+        /**
          *
          * @param task
          * @return self

--- a/extensions/scheduler/api/src/main/java/io/quarkus/scheduler/Trigger.java
+++ b/extensions/scheduler/api/src/main/java/io/quarkus/scheduler/Trigger.java
@@ -63,4 +63,13 @@ public interface Trigger {
         return null;
     }
 
+    /**
+     *
+     * @return the description or {@code null} if not set
+     * @see Scheduled#description()
+     */
+    default String getDescription() {
+        return null;
+    }
+
 }

--- a/extensions/scheduler/common/src/main/java/io/quarkus/scheduler/common/runtime/AbstractJobDefinition.java
+++ b/extensions/scheduler/common/src/main/java/io/quarkus/scheduler/common/runtime/AbstractJobDefinition.java
@@ -31,6 +31,7 @@ public abstract class AbstractJobDefinition<THIS extends JobDefinition<THIS>> im
     protected boolean runOnVirtualThread;
     protected String implementation = Scheduled.AUTO;
     protected String executionMaxDelay = "";
+    protected String description = "";
 
     public AbstractJobDefinition(String identity) {
         this.identity = identity;
@@ -103,6 +104,13 @@ public abstract class AbstractJobDefinition<THIS extends JobDefinition<THIS>> im
     public THIS setExecutionMaxDelay(String maxDelay) {
         checkScheduled();
         this.executionMaxDelay = maxDelay;
+        return self();
+    }
+
+    @Override
+    public THIS setDescription(String description) {
+        checkScheduled();
+        this.description = Objects.requireNonNull(description);
         return self();
     }
 

--- a/extensions/scheduler/common/src/main/java/io/quarkus/scheduler/common/runtime/SyntheticScheduled.java
+++ b/extensions/scheduler/common/src/main/java/io/quarkus/scheduler/common/runtime/SyntheticScheduled.java
@@ -24,10 +24,11 @@ public final class SyntheticScheduled extends AnnotationLiteral<Scheduled> imple
     private final String timeZone;
     private final String implementation;
     private final String executionMaxDelay;
+    private final String description;
 
     public SyntheticScheduled(String identity, String cron, String every, long delay, TimeUnit delayUnit, String delayed,
             String overdueGracePeriod, ConcurrentExecution concurrentExecution, SkipPredicate skipPredicate, String timeZone,
-            String implementation, String executionMaxDelay) {
+            String implementation, String executionMaxDelay, String description) {
         this.identity = Objects.requireNonNull(identity);
         this.cron = Objects.requireNonNull(cron);
         this.every = Objects.requireNonNull(every);
@@ -40,6 +41,7 @@ public final class SyntheticScheduled extends AnnotationLiteral<Scheduled> imple
         this.timeZone = timeZone;
         this.implementation = implementation;
         this.executionMaxDelay = executionMaxDelay;
+        this.description = Objects.requireNonNull(description);
     }
 
     @Override
@@ -102,6 +104,11 @@ public final class SyntheticScheduled extends AnnotationLiteral<Scheduled> imple
         return executionMaxDelay;
     }
 
+    @Override
+    public String description() {
+        return description;
+    }
+
     public String toJson() {
         if (skipPredicate != null) {
             throw new IllegalStateException("A skipPredicate instance may not be serialized");
@@ -118,6 +125,7 @@ public final class SyntheticScheduled extends AnnotationLiteral<Scheduled> imple
         json.put("timeZone", timeZone);
         json.put("executeWith", implementation);
         json.put("executionMaxDelay", executionMaxDelay);
+        json.put("description", description);
         return json.encode();
     }
 
@@ -126,7 +134,8 @@ public final class SyntheticScheduled extends AnnotationLiteral<Scheduled> imple
         return new SyntheticScheduled(jsonObj.getString("identity"), jsonObj.getString("cron"), jsonObj.getString("every"),
                 jsonObj.getLong("delay"), TimeUnit.valueOf(jsonObj.getString("delayUnit")), jsonObj.getString("delayed"),
                 jsonObj.getString("overdueGracePeriod"), ConcurrentExecution.valueOf(jsonObj.getString("concurrentExecution")),
-                null, jsonObj.getString("timeZone"), jsonObj.getString("executeWith"), jsonObj.getString("executionMaxDelay"));
+                null, jsonObj.getString("timeZone"), jsonObj.getString("executeWith"), jsonObj.getString("executionMaxDelay"),
+                jsonObj.getString("description", ""));
     }
 
     @Override

--- a/extensions/scheduler/common/src/test/java/io/quarkus/scheduler/common/runtime/util/SchedulerUtilsTest.java
+++ b/extensions/scheduler/common/src/test/java/io/quarkus/scheduler/common/runtime/util/SchedulerUtilsTest.java
@@ -145,6 +145,11 @@ public class SchedulerUtilsTest {
                 return "";
             }
 
+            @Override
+            public String description() {
+                return "";
+            }
+
         };
     }
 }

--- a/extensions/scheduler/common/src/test/java/io/quarkus/scheduler/common/runtime/util/SyntheticScheduledTest.java
+++ b/extensions/scheduler/common/src/test/java/io/quarkus/scheduler/common/runtime/util/SyntheticScheduledTest.java
@@ -15,7 +15,8 @@ public class SyntheticScheduledTest {
     @Test
     public void testJson() {
         SyntheticScheduled s1 = new SyntheticScheduled("foo", "", "2s", 0, TimeUnit.SECONDS, "1s", "15m",
-                ConcurrentExecution.PROCEED, null, Scheduled.DEFAULT_TIMEZONE, Scheduled.AUTO, "200ms");
+                ConcurrentExecution.PROCEED, null, Scheduled.DEFAULT_TIMEZONE, Scheduled.AUTO, "200ms",
+                "A test job description");
         SyntheticScheduled s2 = SyntheticScheduled.fromJson(s1.toJson());
         assertEquals(s1.identity(), s2.identity());
         assertEquals(s1.concurrentExecution(), s2.concurrentExecution());
@@ -28,6 +29,7 @@ public class SyntheticScheduledTest {
         assertEquals(s1.timeZone(), s2.timeZone());
         assertEquals(s1.executeWith(), s2.executeWith());
         assertEquals(s1.executionMaxDelay(), s2.executionMaxDelay());
+        assertEquals(s1.description(), s2.description());
     }
 
 }

--- a/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerProcessor.java
+++ b/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerProcessor.java
@@ -735,6 +735,17 @@ public class SchedulerProcessor {
             }
         }
 
+        AnnotationValue descriptionValue = schedule.value("description");
+        if (descriptionValue != null) {
+            String description = descriptionValue.asString().trim();
+            if (!description.isEmpty() && !SchedulerUtils.isConfigValue(description)
+                    && description.length() > Scheduled.DESCRIPTION_MAX_LENGTH) {
+                return new IllegalStateException(
+                        errorMessage("description() must not exceed " + Scheduled.DESCRIPTION_MAX_LENGTH
+                                + " characters, found " + description.length(), schedule, method));
+            }
+        }
+
         AnnotationValue executeWithValue = schedule.value("executeWith");
         if (executeWithValue != null) {
             String implementation = executeWithValue.asString();

--- a/extensions/scheduler/deployment/src/main/resources/dev-ui/qwc-scheduler-scheduled-methods.js
+++ b/extensions/scheduler/deployment/src/main/resources/dev-ui/qwc-scheduler-scheduled-methods.js
@@ -265,6 +265,15 @@ export class QwcSchedulerScheduledMethods extends observeState(LitElement) {
                         (${msg('delayed for', { id: 'quarkus-scheduler-delayed-for' })}
                         <code>${schedule.delayed}</code>)`;
         }
+        if (schedule.description) {
+            trigger = schedule.descriptionConfig
+                ? html`${trigger}
+                        — <em>${schedule.description}</em>
+                        ${msg('configured as', { id: 'quarkus-scheduler-configured-as' })}
+                        <em>${schedule.descriptionConfig}</em>`
+                : html`${trigger}
+                        — <em>${schedule.description}</em>`;
+        }
         return trigger;
     }
 
@@ -424,7 +433,9 @@ export class QwcSchedulerScheduledMethods extends observeState(LitElement) {
                 (s.cron && s.cron.toLowerCase().includes(searchTerm)) ||
                 (s.cronConfig && s.cronConfig.toLowerCase().includes(searchTerm)) ||
                 (s.every && s.every.toLowerCase().includes(searchTerm)) ||
-                (s.everyConfig && s.everyConfig.toLowerCase().includes(searchTerm));
+                (s.everyConfig && s.everyConfig.toLowerCase().includes(searchTerm)) ||
+                (s.description && s.description.toLowerCase().includes(searchTerm)) ||
+                (s.descriptionConfig && s.descriptionConfig.toLowerCase().includes(searchTerm));
         }).length > 0;
     }
     

--- a/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/DescriptionConfigExpressionTest.java
+++ b/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/DescriptionConfigExpressionTest.java
@@ -1,0 +1,66 @@
+package io.quarkus.scheduler.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.scheduler.Scheduled;
+import io.quarkus.scheduler.Scheduler;
+import io.quarkus.scheduler.Trigger;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class DescriptionConfigExpressionTest {
+
+    private static final String EXPECTED_DESCRIPTION = "Resolved description";
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Jobs.class)
+                    .addAsResource(new StringAsset("myJob.description=" + EXPECTED_DESCRIPTION),
+                            "application.properties"));
+
+    @Inject
+    Scheduler scheduler;
+
+    @Test
+    public void testConfigExpressionDescription() throws InterruptedException {
+        assertTrue(Jobs.LATCH.await(5, TimeUnit.SECONDS), "Scheduler was not triggered");
+        Trigger trigger = scheduler.getScheduledJob("myConfigDescJob");
+        assertNotNull(trigger);
+        assertEquals(EXPECTED_DESCRIPTION, trigger.getDescription());
+    }
+
+    @Test
+    public void testDefaultValueDescription() throws InterruptedException {
+        assertTrue(Jobs.DEFAULT_LATCH.await(5, TimeUnit.SECONDS), "Scheduler was not triggered");
+        Trigger trigger = scheduler.getScheduledJob("myDefaultDescJob");
+        assertNotNull(trigger);
+        assertEquals("Default description", trigger.getDescription());
+    }
+
+    static class Jobs {
+
+        static final CountDownLatch LATCH = new CountDownLatch(1);
+        static final CountDownLatch DEFAULT_LATCH = new CountDownLatch(1);
+
+        @Scheduled(identity = "myConfigDescJob", every = "1s", description = "${myJob.description}")
+        void configDescription() {
+            LATCH.countDown();
+        }
+
+        @Scheduled(identity = "myDefaultDescJob", every = "1s", description = "${myJob.nonexistent:Default description}")
+        void defaultDescription() {
+            DEFAULT_LATCH.countDown();
+        }
+    }
+}

--- a/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/InvalidDescriptionLengthTest.java
+++ b/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/InvalidDescriptionLengthTest.java
@@ -1,0 +1,37 @@
+package io.quarkus.scheduler.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.scheduler.Scheduled;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class InvalidDescriptionLengthTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .assertException(t -> {
+                assertThat(t).cause().isInstanceOf(IllegalStateException.class)
+                        .hasMessageContaining(
+                                "description() must not exceed " + Scheduled.DESCRIPTION_MAX_LENGTH + " characters");
+            })
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(InvalidBean.class));
+
+    @Test
+    public void test() {
+    }
+
+    static class InvalidBean {
+
+        @Scheduled(every = "1s", description = "A" +
+                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" +
+                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" +
+                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+        void ping() {
+        }
+    }
+
+}

--- a/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/programmatic/ProgrammaticDescriptionTest.java
+++ b/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/programmatic/ProgrammaticDescriptionTest.java
@@ -1,0 +1,64 @@
+package io.quarkus.scheduler.test.programmatic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.scheduler.Scheduled;
+import io.quarkus.scheduler.Scheduler;
+import io.quarkus.scheduler.Trigger;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class ProgrammaticDescriptionTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Jobs.class));
+
+    @Inject
+    Scheduler scheduler;
+
+    static final CountDownLatch WITH_DESC_LATCH = new CountDownLatch(1);
+    static final CountDownLatch WITHOUT_DESC_LATCH = new CountDownLatch(1);
+
+    @Test
+    public void testProgrammaticDescription() throws InterruptedException {
+        Trigger withDesc = scheduler.newJob("withDescription")
+                .setInterval("1s")
+                .setDescription("My programmatic job description")
+                .setTask(ec -> WITH_DESC_LATCH.countDown())
+                .schedule();
+        assertNotNull(withDesc);
+        assertEquals("My programmatic job description", withDesc.getDescription());
+
+        Trigger withoutDesc = scheduler.newJob("withoutDescription")
+                .setInterval("1s")
+                .setTask(ec -> WITHOUT_DESC_LATCH.countDown())
+                .schedule();
+        assertNotNull(withoutDesc);
+        assertNull(withoutDesc.getDescription());
+
+        WITH_DESC_LATCH.await(5, TimeUnit.SECONDS);
+        WITHOUT_DESC_LATCH.await(5, TimeUnit.SECONDS);
+
+        scheduler.unscheduleJob("withDescription");
+        scheduler.unscheduleJob("withoutDescription");
+    }
+
+    static class Jobs {
+
+        @Scheduled(identity = "dummy", every = "60m")
+        static void dummy() {
+        }
+    }
+
+}

--- a/extensions/scheduler/runtime-dev/src/main/java/io/quarkus/scheduler/runtime/dev/ui/SchedulerJsonRPCService.java
+++ b/extensions/scheduler/runtime-dev/src/main/java/io/quarkus/scheduler/runtime/dev/ui/SchedulerJsonRPCService.java
@@ -119,6 +119,9 @@ public class SchedulerJsonRPCService {
                 } else {
                     putConfigLookup("every", schedule.every(), scheduleJson);
                 }
+                if (!schedule.description().isBlank()) {
+                    putConfigLookup("description", schedule.description(), scheduleJson);
+                }
                 if (schedule.delay() > 0) {
                     scheduleJson.put("delay", schedule.delay());
                     scheduleJson.put("delayUnit", schedule.delayUnit().toString().toLowerCase());

--- a/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/SimpleScheduler.java
+++ b/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/SimpleScheduler.java
@@ -353,6 +353,8 @@ public class SimpleScheduler extends BaseScheduler implements Scheduler {
             start = start.toInstant().plusMillis(millisToAdd).atZone(start.getZone());
         }
 
+        String descriptionValue = SchedulerUtils.lookUpPropertyValue(scheduled.description());
+        String description = descriptionValue.isEmpty() ? null : descriptionValue;
         if (!scheduled.cron().isEmpty()) {
             String cron = SchedulerUtils.lookUpPropertyValue(scheduled.cron());
             if (SchedulerUtils.isOff(cron)) {
@@ -360,14 +362,14 @@ public class SimpleScheduler extends BaseScheduler implements Scheduler {
             }
             return Optional.of(new CronTrigger(id, start, cronParser.parse(cron),
                     SchedulerUtils.parseOverdueGracePeriod(scheduled, defaultGracePeriod),
-                    SchedulerUtils.parseCronTimeZone(scheduled), methodDescription));
+                    SchedulerUtils.parseCronTimeZone(scheduled), methodDescription, description));
         } else if (!scheduled.every().isEmpty()) {
             final OptionalLong everyMillis = SchedulerUtils.parseEveryAsMillis(scheduled);
             if (everyMillis.isEmpty()) {
                 return Optional.empty();
             }
             return Optional.of(new IntervalTrigger(id, start, everyMillis.getAsLong(),
-                    SchedulerUtils.parseOverdueGracePeriod(scheduled, defaultGracePeriod), methodDescription));
+                    SchedulerUtils.parseOverdueGracePeriod(scheduled, defaultGracePeriod), methodDescription, description));
         } else {
             throw new IllegalArgumentException("Either the 'cron' expression or the 'every' period must be set: " + scheduled);
         }
@@ -405,15 +407,17 @@ public class SimpleScheduler extends BaseScheduler implements Scheduler {
 
         protected final String id;
         protected final String methodDescription;
+        protected final String description;
         private volatile boolean running;
         protected final ZonedDateTime start;
         protected volatile ZonedDateTime lastFireTime;
 
-        SimpleTrigger(String id, ZonedDateTime start, String description) {
+        SimpleTrigger(String id, ZonedDateTime start, String methodDescription, String description) {
             this.id = id;
             this.start = start;
             this.running = true;
-            this.methodDescription = description;
+            this.methodDescription = methodDescription;
+            this.description = description;
         }
 
         /**
@@ -444,6 +448,11 @@ public class SimpleScheduler extends BaseScheduler implements Scheduler {
             return methodDescription;
         }
 
+        @Override
+        public String getDescription() {
+            return description;
+        }
+
     }
 
     static class IntervalTrigger extends SimpleTrigger {
@@ -452,8 +461,9 @@ public class SimpleScheduler extends BaseScheduler implements Scheduler {
         private final long interval;
         private final Duration gracePeriod;
 
-        IntervalTrigger(String id, ZonedDateTime start, long interval, Duration gracePeriod, String description) {
-            super(id, start, description);
+        IntervalTrigger(String id, ZonedDateTime start, long interval, Duration gracePeriod, String methodDescription,
+                String description) {
+            super(id, start, methodDescription, description);
             this.interval = interval;
             this.gracePeriod = gracePeriod;
             if (interval < CHECK_PERIOD) {
@@ -518,8 +528,9 @@ public class SimpleScheduler extends BaseScheduler implements Scheduler {
         private final Duration gracePeriod;
         private final ZoneId timeZone;
 
-        CronTrigger(String id, ZonedDateTime start, Cron cron, Duration gracePeriod, ZoneId timeZone, String description) {
-            super(id, start, description);
+        CronTrigger(String id, ZonedDateTime start, Cron cron, Duration gracePeriod, ZoneId timeZone,
+                String methodDescription, String description) {
+            super(id, start, methodDescription, description);
             this.cron = cron;
             this.executionTime = ExecutionTime.forCron(cron);
             this.gracePeriod = gracePeriod;
@@ -657,7 +668,8 @@ public class SimpleScheduler extends BaseScheduler implements Scheduler {
                 };
             }
             Scheduled scheduled = new SyntheticScheduled(identity, cron, every, 0, TimeUnit.MINUTES, delayed,
-                    overdueGracePeriod, concurrentExecution, skipPredicate, timeZone, implementation, executionMaxDelay);
+                    overdueGracePeriod, concurrentExecution, skipPredicate, timeZone, implementation, executionMaxDelay,
+                    description);
             Optional<SimpleTrigger> trigger = createTrigger(identity, null, scheduled, defaultOverdueGracePeriod);
             if (trigger.isPresent()) {
                 SimpleTrigger simpleTrigger = trigger.get();


### PR DESCRIPTION
The new `description` attribute allows users to provide a brief description of what a scheduled job does. When the Quartz scheduler is used, this value is stored in the DESCRIPTION column of the `QRTZ_JOB_DETAILS` table. The property supports config expressions.

The description is also available via the programmatic `JobDefinition` API through the new `setDescription()` method.
