### PR TITLE
Support nested JSON paths in token.principal-claim for UserInfo

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -463,9 +463,15 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                     return Uni.createFrom().failure(new AuthenticationCompletionException(errorMessage));
                 }
                 final String principalClaim = resolvedContext.oidcConfig().token().principalClaim().orElse(null);
-                if (principalClaim != null && !tokenJson.containsKey(principalClaim) && userInfo != null
-                        && userInfo.contains(principalClaim)) {
-                    tokenJson.put(principalClaim, userInfo.getString(principalClaim));
+                if (principalClaim != null && !tokenJson.containsKey(principalClaim) && userInfo != null) {
+                    String value = userInfo.getString(principalClaim);
+                    if (value == null && principalClaim.contains("/")) {
+                        value = OidcUtils.findStringClaimValue(principalClaim,
+                                new JsonObject(userInfo.getJsonObject().toString()));
+                    }
+                    if (value != null) {
+                        tokenJson.put(principalClaim, value);
+                    }
                 }
                 JsonObject rolesJson = getRolesJson(requestData, resolvedContext, tokenCred, tokenJson,
                         userInfo);
@@ -499,7 +505,13 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                 if (resolvedContext.oidcConfig().token().allowOpaqueTokenIntrospection() &&
                         resolvedContext.oidcConfig().token().verifyAccessTokenWithUserInfo().orElse(false)) {
                     if (resolvedContext.oidcConfig().token().principalClaim().isPresent() && userInfo != null) {
-                        userName = userInfo.getString(resolvedContext.oidcConfig().token().principalClaim().get());
+                        String principalClaimPath = resolvedContext.oidcConfig().token().principalClaim().get();
+                        String value = userInfo.getString(principalClaimPath);
+                        if (value == null && principalClaimPath.contains("/")) {
+                            value = OidcUtils.findStringClaimValue(principalClaimPath,
+                                    new JsonObject(userInfo.getJsonObject().toString()));
+                        }
+                        userName = value != null ? value : "";
                     } else {
                         userName = "";
                     }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -309,6 +309,17 @@ public final class OidcUtils {
         return claimPath.indexOf('/') > 0 ? CLAIM_PATH_PATTERN.split(claimPath) : new String[] { claimPath };
     }
 
+    static String findStringClaimValue(String claimPath, JsonObject json) {
+        Object value = findClaimValue(claimPath, json, splitClaimPath(claimPath), 0);
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof String) {
+            return (String) value;
+        }
+        throw new OIDCException("Claim value at path '" + claimPath + "' is not a string");
+    }
+
     private static Object findClaimValue(String claimPath, JsonObject json, String[] pathArray, int step) {
         Object claimValue = json.getValue(pathArray[step].replace("\"", ""));
         if (claimValue == null) {

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
@@ -346,6 +346,46 @@ public class OidcUtilsTest {
     }
 
     @Test
+    public void testFindStringClaimValueFlat() {
+        JsonObject json = new JsonObject().put("name", "johndoe");
+        assertEquals("johndoe", OidcUtils.findStringClaimValue("name", json));
+    }
+
+    @Test
+    public void testFindStringClaimValueNested() {
+        JsonObject json = new JsonObject()
+                .put("metadata", new JsonObject().put("name", "johndoe"));
+        assertEquals("johndoe", OidcUtils.findStringClaimValue("metadata/name", json));
+    }
+
+    @Test
+    public void testFindStringClaimValueDeeplyNested() {
+        JsonObject json = new JsonObject()
+                .put("a", new JsonObject()
+                        .put("b", new JsonObject()
+                                .put("c", "deep")));
+        assertEquals("deep", OidcUtils.findStringClaimValue("a/b/c", json));
+    }
+
+    @Test
+    public void testFindStringClaimValueMissingPath() {
+        JsonObject json = new JsonObject().put("metadata", new JsonObject().put("name", "johndoe"));
+        assertNull(OidcUtils.findStringClaimValue("metadata/missing", json));
+    }
+
+    @Test
+    public void testFindStringClaimValueNonString() {
+        JsonObject json = new JsonObject()
+                .put("metadata", new JsonObject().put("count", 42));
+        try {
+            OidcUtils.findStringClaimValue("metadata/count", json);
+            fail("Expected OIDCException for non-string claim value");
+        } catch (OIDCException ex) {
+            // expected
+        }
+    }
+
+    @Test
     public void testJwtContentTypeCheck() {
         assertTrue(OidcUtils.isApplicationJwtContentType("application/jwt"));
         assertTrue(OidcUtils.isApplicationJwtContentType(" application/jwt "));


### PR DESCRIPTION
Fixes #53106

When using `quarkus.oidc.token.verify-access-token-with-user-info=true` to validate opaque Bearer tokens, `quarkus.oidc.token.principal-claim` only resolves top-level string fields from the UserInfo response. Nested `/`-separated paths like `metadata/name` return `null`, even though `quarkus.oidc.roles.role-claim-path` already supports them via `OidcUtils.findClaimValue()`.

This change reuses the same path-aware `findClaimValue()` / `splitClaimPath()` utilities (already used for role extraction) to resolve the principal claim in both code paths inside `OidcIdentityProvider.createSecurityIdentityWithOidcServer()`:

- **Opaque token path** (UserInfo-only verification): replaced `userInfo.getString(principalClaim)` with `OidcUtils.findClaimValue()`, which recursively traverses nested JSON objects along `/`-separated segments.
- **JWT token path** (UserInfo fallback): replaced the flat `userInfo.contains()` + `userInfo.getString()` lookup with the same `findClaimValue()` resolution when copying the principal claim from UserInfo into the token JSON. The resolved value is stored under the full path string as a literal key (e.g. `"metadata/name" → "johndoe"`), which `OidcJwtCallerPrincipal.getName()` then finds via its existing `super.claim(principalClaim)` flat lookup.

For flat claim names (e.g. `sub`, `preferred_username`), `splitClaimPath` produces a single-element array and `findClaimValue` performs a single `getValue()` — functionally identical to the previous `getString()` call, so there is no change in behavior for existing configurations.