### PR TITLE
Remove long deprecated constructors of `ReflectiveClassBuildItem`

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveClassBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveClassBuildItem.java
@@ -59,52 +59,6 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
                 unsafeAllocated, reason, stream(classes).map(Class::getName).toArray(String[]::new));
     }
 
-    /**
-     * @deprecated Use {@link ReflectiveClassBuildItem#builder(Class...)} or {@link ReflectiveClassBuildItem#builder(String...)}
-     *             instead.
-     */
-    @Deprecated(since = "3.0", forRemoval = true)
-    public ReflectiveClassBuildItem(boolean methods, boolean fields, Class<?>... classes) {
-        this(true, methods, fields, classes);
-    }
-
-    /**
-     * @deprecated Use {@link ReflectiveClassBuildItem#builder(Class...)} or {@link ReflectiveClassBuildItem#builder(String...)}
-     *             instead.
-     */
-    @Deprecated(since = "3.0", forRemoval = true)
-    public ReflectiveClassBuildItem(boolean constructors, boolean methods, boolean fields, Class<?>... classes) {
-        this(constructors, false, methods, false, fields, false, false, false, false, null, classes);
-    }
-
-    /**
-     * @deprecated Use {@link ReflectiveClassBuildItem#builder(Class...)} or {@link ReflectiveClassBuildItem#builder(String...)}
-     *             instead.
-     */
-    @Deprecated(since = "3.0", forRemoval = true)
-    public ReflectiveClassBuildItem(boolean methods, boolean fields, String... classNames) {
-        this(true, methods, fields, classNames);
-    }
-
-    /**
-     * @deprecated Use {@link ReflectiveClassBuildItem#builder(Class...)} or {@link ReflectiveClassBuildItem#builder(String...)}
-     *             instead.
-     */
-    @Deprecated(since = "3.0", forRemoval = true)
-    public ReflectiveClassBuildItem(boolean constructors, boolean methods, boolean fields, String... classNames) {
-        this(constructors, false, methods, false, fields, false, false, false, classNames);
-    }
-
-    /**
-     * @deprecated Use {@link ReflectiveClassBuildItem#builder(Class...)} or {@link ReflectiveClassBuildItem#builder(String...)}
-     *             instead.
-     */
-    @Deprecated(since = "3.0", forRemoval = true)
-    public ReflectiveClassBuildItem(boolean constructors, boolean methods, boolean fields, boolean serialization,
-            String... classNames) {
-        this(constructors, false, methods, false, fields, false, serialization, false, classNames);
-    }
-
     public static ReflectiveClassBuildItem weakClass(String... classNames) {
         return ReflectiveClassBuildItem.builder(classNames).constructors().methods().fields().weak().build();
     }

--- a/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
+++ b/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
@@ -103,7 +103,7 @@ public final class HibernateReactiveProcessor {
 
     @BuildStep
     void reflections(BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, REFLECTIVE_CONSTRUCTORS_NEEDED));
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(REFLECTIVE_CONSTRUCTORS_NEEDED).build());
     }
 
     @BuildStep

--- a/extensions/panache/hibernate-reactive-panache-kotlin/deployment/src/main/java/io/quarkus/hibernate/reactive/panache/kotlin/deployment/HibernateReactivePanacheKotlinProcessor.java
+++ b/extensions/panache/hibernate-reactive-panache-kotlin/deployment/src/main/java/io/quarkus/hibernate/reactive/panache/kotlin/deployment/HibernateReactivePanacheKotlinProcessor.java
@@ -111,7 +111,7 @@ public class HibernateReactivePanacheKotlinProcessor {
             String name = classInfo.name().toString();
             if (modelClasses.add(name)) {
                 transformers.produce(new BytecodeTransformerBuildItem(name, entityEnhancer));
-                reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, name));
+                reflectiveClass.produce(ReflectiveClassBuildItem.builder(name).methods().fields().build());
             }
         }
 
@@ -161,7 +161,8 @@ public class HibernateReactivePanacheKotlinProcessor {
 
         for (org.jboss.jandex.Type parameterType : typeParameters) {
             // Register for reflection the type parameters of the repository: this should be the entity class and the ID class
-            reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, parameterType.name().toString()));
+            reflectiveClass
+                    .produce(ReflectiveClassBuildItem.builder(parameterType.name().toString()).methods().fields().build());
         }
     }
 
@@ -180,7 +181,8 @@ public class HibernateReactivePanacheKotlinProcessor {
         }
         for (org.jboss.jandex.Type parameterType : typeParameters) {
             // Register for reflection the type parameters of the repository: this should be the entity class and the ID class
-            reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, parameterType.name().toString()));
+            reflectiveClass
+                    .produce(ReflectiveClassBuildItem.builder(parameterType.name().toString()).methods().fields().build());
         }
     }
 

--- a/extensions/resteasy-classic/resteasy-jaxb/deployment/src/main/java/io/quarkus/resteasy/jaxb/deployment/ResteasyJaxbProcessor.java
+++ b/extensions/resteasy-classic/resteasy-jaxb/deployment/src/main/java/io/quarkus/resteasy/jaxb/deployment/ResteasyJaxbProcessor.java
@@ -82,6 +82,6 @@ public class ResteasyJaxbProcessor {
 
     private void addReflectiveClass(BuildProducer<ReflectiveClassBuildItem> reflectiveClass, boolean methods, boolean fields,
             String... className) {
-        reflectiveClass.produce(new ReflectiveClassBuildItem(methods, fields, className));
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(className).methods(methods).fields(fields).build());
     }
 }

--- a/extensions/resteasy-classic/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
+++ b/extensions/resteasy-classic/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
@@ -736,7 +736,7 @@ public class ResteasyServerCommonProcessor {
             if (classInfo != null) {
                 includeFields = classInfo.annotationsMap().containsKey(CONTEXT);
             }
-            reflectiveClass.produce(new ReflectiveClassBuildItem(false, includeFields, providerToRegister));
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(providerToRegister).fields(includeFields).build());
         }
 
         // special case: our config providers


### PR DESCRIPTION
Remove long deprecated (since Quarkus 3.0) constructors of `ReflectiveClassBuildItem`