### PR TITLE
Using `copyRecursive` instead of registering configuration for QuarkusComponentVariants

### DIFF
--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/dependency/QuarkusComponentVariants.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/dependency/QuarkusComponentVariants.java
@@ -185,7 +185,6 @@ public class QuarkusComponentVariants {
     private final List<ConditionalDependencyVariant> dependencyVariantQueue = new ArrayList<>();
     private final Map<String, SatisfiedExtensionDeps> satisfiedExtensionDeps = new HashMap<>();
     private final LaunchMode mode;
-    private final AtomicInteger configCopyCounter = new AtomicInteger();
 
     private QuarkusComponentVariants(Project project, LaunchMode mode,
             Property<PlatformSpec> platformSpecProperty) {
@@ -364,12 +363,18 @@ public class QuarkusComponentVariants {
     }
 
     private Configuration copyBaseConfig(Configuration baseConfig) {
-        return project.getConfigurations()
-                .resolvable(baseConfig.getName() + "Copy" + configCopyCounter.incrementAndGet(), c -> {
-                    c.setCanBeConsumed(false);
-                    c.extendsFrom(baseConfig);
-                    setIterativeConditionalAttributes(c, project, satisfiedExtensionDeps.values());
-                }).get();
+        // copyRecursive() returns a fully independent copy that is not registered in the
+        // project's configurations container. Using it (instead of adding a named copy via
+        // configurations.resolvable(name, ...) and later removing it) avoids re-firing
+        // configureEach listeners — including Kotlin's withDependencies callback — which
+        // would mark Configuration as a subscribed type and trigger an addPending re-fire
+        // during later container iteration (e.g. htmlDependencyReport), failing with
+        // "Cannot mutate the state of configuration ... after the configuration was resolved".
+        // See https://github.com/quarkusio/quarkus/issues/54142.
+        Configuration c = baseConfig.copyRecursive();
+        c.setCanBeConsumed(false);
+        setIterativeConditionalAttributes(c, project, satisfiedExtensionDeps.values());
+        return c;
     }
 
     private void processConfiguration(Configuration baseConfig) {
@@ -378,8 +383,6 @@ public class QuarkusComponentVariants {
         for (var dep : config.getResolvedConfiguration().getFirstLevelModuleDependencies()) {
             processDependency(null, dep, visited, true);
         }
-        // drop the temporary configuration
-        project.getConfigurations().remove(config);
     }
 
     private void processDependency(ProcessedDependency parent,

--- a/integration-tests/gradle/src/main/resources/html-dependency-report/build.gradle
+++ b/integration-tests/gradle/src/main/resources/html-dependency-report/build.gradle
@@ -1,0 +1,29 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+    id 'project-report'
+}
+
+repositories {
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+            includeGroup 'org.hibernate.orm'
+        }
+    }
+    mavenCentral()
+}
+
+// Mirrors the Kotlin Gradle plugin's `configureDefaultVersionsResolutionStrategy`:
+// a listener over the configurations container that calls Configuration#withDependencies.
+// Registering it marks Configuration as a subscribed type, which exercises the addPending
+// re-add path in Gradle's SortedSetElementSource (htmlDependencyReport's iteration is the
+// usual trigger for that re-fire).
+configurations.configureEach {
+    withDependencies { /* no-op */ }
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-arc'
+}

--- a/integration-tests/gradle/src/main/resources/html-dependency-report/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/html-dependency-report/gradle.properties
@@ -1,0 +1,2 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus

--- a/integration-tests/gradle/src/main/resources/html-dependency-report/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/html-dependency-report/settings.gradle
@@ -1,0 +1,16 @@
+pluginManagement {
+    repositories {
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+                includeGroup 'org.hibernate.orm'
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+        id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+rootProject.name = 'html-dependency-report'

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/HtmlDependencyReportTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/HtmlDependencyReportTest.java
@@ -1,0 +1,33 @@
+package io.quarkus.gradle;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Regression test for https://github.com/quarkusio/quarkus/issues/54142.
+ *
+ * htmlDependencyReport (from the project-report plugin) iterates the configurations
+ * container, which re-fires whenObjectAdded listeners on temporary copies that Quarkus's
+ * variant resolution creates, resolves, and removes. If any such listener mutates the
+ * configuration (e.g. Kotlin's withDependencies), the build fails with
+ * "Cannot mutate the state of configuration ... after the configuration was resolved".
+ *
+ * The bug reproduces both with and without the configuration cache, so we exercise both.
+ */
+public class HtmlDependencyReportTest extends QuarkusGradleWrapperTestBase {
+
+    @ParameterizedTest(name = "configurationCache={0}")
+    @ValueSource(booleans = { true, false })
+    public void shouldRunHtmlDependencyReportWithoutMutationFailure(boolean configurationCache)
+            throws IOException, URISyntaxException, InterruptedException {
+        final File projectDir = getProjectDir("html-dependency-report");
+
+        gradleConfigurationCache(configurationCache);
+
+        runGradleWrapper(projectDir, "htmlDependencyReport");
+    }
+}


### PR DESCRIPTION
Issue #54142
This PR avoids registering the temporary configuration in project.configurations and instead uses baseConfig.copyRecursive().

The goal is to keep the temporary configuration independent from the project’s configuration container. This should avoid creating pending entries, triggering whenObjectAdded / configureEach listeners, or being picked up later by tasks that iterate over project.configurations.

@aloubyansky What do you think of this approach, and how could I cover more cases that might surface detached configuration issues?