### PR TITLE
Quarkus upgrade with gradle kotlin dsl

### DIFF
--- a/docs/src/main/asciidoc/update-quarkus.adoc
+++ b/docs/src/main/asciidoc/update-quarkus.adoc
@@ -20,7 +20,6 @@ Post-update, if expected updates are missing, consider the following reasons:
 
 - The recipe might not include a specific item in your project.
 - Your project might use an extension that is incompatible with the latest {project-name} version.
-- If you have Gradle Kotlin build files (`.kts`), Quarkus Update https://github.com/quarkusio/quarkus/issues/33046[will fail] until OpenRewrite supports these.
 
 [IMPORTANT]
 ====

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdateCommand.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdateCommand.java
@@ -57,6 +57,7 @@ public class QuarkusUpdateCommand {
                 runMavenUpdate(log, baseDir, rewritePluginVersion, recipesGAV, recipe, logFile, dryRun);
                 break;
             case GRADLE:
+            case GRADLE_KOTLIN_DSL:
                 runGradleUpdate(log, baseDir, rewritePluginVersion, recipesGAV, recipe, logFile, dryRun);
                 break;
             default:


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
and the AI/LLM usage policy at https://github.com/quarkusio/quarkus/blob/main/AI_POLICY.md
-->

Enabling gradle kts support for `quarkus update` CLI command.
* Fixes #33046
