### PR TITLE
Improve secret access scoping in quarkus-kubernetes-config

### DIFF
--- a/docs/src/main/asciidoc/kubernetes-config.adoc
+++ b/docs/src/main/asciidoc/kubernetes-config.adoc
@@ -72,6 +72,12 @@ Thankfully, when using the `kubernetes-config` extension along with the xref:dep
 By default, the xref:deploying-to-kubernetes.adoc[Kubernetes] extension doesn't generate the necessary resources to allow accessing secrets.
 Set `quarkus.kubernetes-config.secrets.enabled=true` to generate the necessary role and corresponding role binding.
 
+The generated `Role` automatically restricts read access to the secrets listed in `quarkus.kubernetes-config.secrets`, following the principle of least privilege.
+If no secrets are specified, the role grants access to all secrets in the namespace.
+
+Additionally, the `quarkus.kubernetes-config.secrets-role-config.prefix-name` property prefixes the role name with the application name (e.g. `my-app-view-secrets`).
+This is useful when multiple applications share the same namespace, avoiding conflicts over the default `view-secrets` role name.
+
 == Example configuration
 
 A very common use case is to deploy a Quarkus application that needs to access a relational database which has itself already been deployed on Kubernetes. Using the `quarkus-kubernetes-config` extension makes this use case very simple to handle.

--- a/extensions/kubernetes-config/deployment/src/main/java/io/quarkus/kubernetes/config/deployment/KubernetesConfigProcessor.java
+++ b/extensions/kubernetes-config/deployment/src/main/java/io/quarkus/kubernetes/config/deployment/KubernetesConfigProcessor.java
@@ -1,11 +1,16 @@
 package io.quarkus.kubernetes.config.deployment;
 
+import java.util.Collections;
 import java.util.List;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.logging.Logger;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigBuilderBuildItem;
 import io.quarkus.kubernetes.config.runtime.KubernetesConfigBuildTimeConfig;
 import io.quarkus.kubernetes.config.runtime.KubernetesConfigRecorder;
@@ -16,8 +21,12 @@ import io.quarkus.kubernetes.spi.KubernetesRoleBindingBuildItem;
 import io.quarkus.kubernetes.spi.KubernetesRoleBuildItem;
 import io.quarkus.kubernetes.spi.KubernetesServiceAccountBuildItem;
 import io.quarkus.kubernetes.spi.PolicyRule;
+import io.quarkus.kubernetes.spi.RoleRef;
+import io.quarkus.kubernetes.spi.Subject;
 
 public class KubernetesConfigProcessor {
+
+    private static final Logger log = Logger.getLogger(KubernetesConfigProcessor.class);
 
     private static final String ANY_TARGET = null;
     private static final List<PolicyRule> POLICY_RULE_FOR_ROLE = List.of(new PolicyRule(
@@ -34,6 +43,7 @@ public class KubernetesConfigProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     public void handleAccessToSecrets(
             KubernetesConfigBuildTimeConfig buildTimeConfig,
+            ApplicationInfoBuildItem applicationInfo,
             BuildProducer<KubernetesRoleBuildItem> roleProducer,
             BuildProducer<KubernetesClusterRoleBuildItem> clusterRoleProducer,
             BuildProducer<KubernetesServiceAccountBuildItem> serviceAccountProducer,
@@ -41,22 +51,44 @@ public class KubernetesConfigProcessor {
             KubernetesConfigRecorder recorder) {
         if (buildTimeConfig.secretsEnabled()) {
             SecretsRoleConfig roleConfig = buildTimeConfig.secretsRoleConfig();
-            String roleName = roleConfig.name();
+
+            String roleName = roleConfig.prefixName()
+                    ? applicationInfo.getName() + "-" + roleConfig.name()
+                    : roleConfig.name();
+
+            List<String> secretNames = ConfigProvider.getConfig()
+                    .getOptionalValues("quarkus.kubernetes-config.secrets", String.class)
+                    .orElse(List.of());
+
+            List<PolicyRule> policyRules;
+            if (secretNames.isEmpty()) {
+                policyRules = POLICY_RULE_FOR_ROLE;
+            } else {
+                log.warnf("The generated Role scopes secret access to %s, based on the build-time value of "
+                        + "quarkus.kubernetes-config.secrets. If this value changes at runtime, the generated "
+                        + "Kubernetes manifests will be incorrect and need to be regenerated.", secretNames);
+                policyRules = List.of(new PolicyRule(List.of(""), null, secretNames, List.of("secrets"), List.of("get")));
+            }
+
             if (roleConfig.generate()) {
                 if (roleConfig.clusterWide()) {
                     clusterRoleProducer.produce(new KubernetesClusterRoleBuildItem(roleName,
-                            POLICY_RULE_FOR_ROLE,
+                            policyRules,
                             ANY_TARGET));
                 } else {
                     roleProducer.produce(new KubernetesRoleBuildItem(roleName,
                             roleConfig.namespace().orElse(null),
-                            POLICY_RULE_FOR_ROLE,
+                            policyRules,
                             ANY_TARGET));
                 }
             }
 
             serviceAccountProducer.produce(new KubernetesServiceAccountBuildItem(true));
-            roleBindingProducer.produce(new KubernetesRoleBindingBuildItem(roleName, roleConfig.clusterWide()));
+            String bindingName = roleConfig.prefixName() ? roleName : null;
+            roleBindingProducer.produce(new KubernetesRoleBindingBuildItem(
+                    bindingName, null, ANY_TARGET, Collections.emptyMap(),
+                    new RoleRef(roleName, roleConfig.clusterWide()),
+                    new Subject("", "ServiceAccount", null, null)));
         }
 
         recorder.warnAboutSecrets();

--- a/extensions/kubernetes-config/runtime/src/main/java/io/quarkus/kubernetes/config/runtime/SecretsRoleConfig.java
+++ b/extensions/kubernetes-config/runtime/src/main/java/io/quarkus/kubernetes/config/runtime/SecretsRoleConfig.java
@@ -28,4 +28,12 @@ public interface SecretsRoleConfig {
      */
     @WithDefault("true")
     boolean generate();
+
+    /**
+     * If set to true, the role name is prefixed with the application name, producing a unique name per application
+     * (e.g. {@code my-app-view-secrets}). This prevents name conflicts when multiple applications sharing the same
+     * namespace each manage their own role.
+     */
+    @WithDefault("false")
+    boolean prefixName();
 }

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesConfigWithSecretsAndClusterRoleTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesConfigWithSecretsAndClusterRoleTest.java
@@ -53,6 +53,7 @@ public class KubernetesConfigWithSecretsAndClusterRoleTest {
                         assertThat(rule.getApiGroups()).containsExactly("");
                         assertThat(rule.getResources()).containsExactly("secrets");
                         assertThat(rule.getVerbs()).containsExactly("get");
+                        assertThat(rule.getResourceNames()).containsExactly("my-secret");
                     });
                 });
             });

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesConfigWithSecretsScopedTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesConfigWithSecretsScopedTest.java
@@ -19,9 +19,9 @@ import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
 
-public class KubernetesConfigWithSecretsTest {
+public class KubernetesConfigWithSecretsScopedTest {
 
-    private static final String APP_NAME = "kubernetes-config-with-secrets";
+    private static final String APP_NAME = "kubernetes-config-with-secrets-scoped";
 
     @RegisterExtension
     static final QuarkusProdModeTest config = new QuarkusProdModeTest()
@@ -47,7 +47,7 @@ public class KubernetesConfigWithSecretsTest {
         assertThat(kubernetesList).anySatisfy(res -> {
             assertThat(res).isInstanceOfSatisfying(Role.class, role -> {
                 assertThat(role.getMetadata()).satisfies(m -> {
-                    assertThat(m.getName()).isEqualTo("view-secrets");
+                    assertThat(m.getName()).isEqualTo(APP_NAME + "-view-secrets");
                 });
 
                 assertThat(role.getRules()).singleElement().satisfies(r -> {
@@ -55,7 +55,7 @@ public class KubernetesConfigWithSecretsTest {
                         assertThat(rule.getApiGroups()).containsExactly("");
                         assertThat(rule.getResources()).containsExactly("secrets");
                         assertThat(rule.getVerbs()).containsExactly("get");
-                        assertThat(rule.getResourceNames()).containsExactly("my-secret");
+                        assertThat(rule.getResourceNames()).containsExactlyInAnyOrder("my-secret", "other-secret");
                     });
                 });
             });
@@ -65,22 +65,22 @@ public class KubernetesConfigWithSecretsTest {
                 .anySatisfy(res -> {
                     assertThat(res).isInstanceOfSatisfying(RoleBinding.class, roleBinding -> {
                         assertThat(roleBinding.getMetadata()).satisfies(m -> {
-                            assertThat(m.getName()).isEqualTo("kubernetes-config-with-secrets-view-secrets");
+                            assertThat(m.getName()).isEqualTo(APP_NAME + "-view-secrets");
                         });
 
                         assertThat(roleBinding.getRoleRef().getKind()).isEqualTo("Role");
-                        assertThat(roleBinding.getRoleRef().getName()).isEqualTo("view-secrets");
+                        assertThat(roleBinding.getRoleRef().getName()).isEqualTo(APP_NAME + "-view-secrets");
 
                         assertThat(roleBinding.getSubjects()).singleElement().satisfies(subject -> {
                             assertThat(subject.getKind()).isEqualTo("ServiceAccount");
-                            assertThat(subject.getName()).isEqualTo("kubernetes-config-with-secrets");
+                            assertThat(subject.getName()).isEqualTo(APP_NAME);
                         });
                     });
                 })
                 .anySatisfy(res -> {
                     assertThat(res).isInstanceOfSatisfying(RoleBinding.class, roleBinding -> {
                         assertThat(roleBinding.getMetadata()).satisfies(m -> {
-                            assertThat(m.getName()).isEqualTo("kubernetes-config-with-secrets-view");
+                            assertThat(m.getName()).isEqualTo(APP_NAME + "-view");
                         });
 
                         assertThat(roleBinding.getRoleRef().getKind()).isEqualTo("ClusterRole");
@@ -88,7 +88,7 @@ public class KubernetesConfigWithSecretsTest {
 
                         assertThat(roleBinding.getSubjects()).singleElement().satisfies(subject -> {
                             assertThat(subject.getKind()).isEqualTo("ServiceAccount");
-                            assertThat(subject.getName()).isEqualTo("kubernetes-config-with-secrets");
+                            assertThat(subject.getName()).isEqualTo(APP_NAME);
                         });
                     });
                 });

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-config-with-secrets-scoped.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-config-with-secrets-scoped.properties
@@ -1,0 +1,4 @@
+quarkus.kubernetes-config.enabled=true
+quarkus.kubernetes-config.secrets.enabled=true
+quarkus.kubernetes-config.secrets=my-secret,other-secret
+quarkus.kubernetes-config.secrets-role-config.prefix-name=true


### PR DESCRIPTION
## Describe your changes

Addresses the two points raised in #50303 for the `quarkus-kubernetes-config` extension.

**Scope the generated `Role` to the configured secrets.** The generated `Role` now
restricts `resourceNames` to the secrets listed in `quarkus.kubernetes-config.secrets`,
following the principle of least privilege. When no secrets are listed, the previous
behavior is kept (access to all secrets in the namespace). No new property is introduced
for this: the secrets the application needs are the ones it already declares as
configuration sources.

**Optional per-application role name.** A new `quarkus.kubernetes-config.secrets-role-config.prefix-name`
property (default `false`) prefixes the role name with the application name
(for example `my-app-view-secrets`), producing a unique role per application. This avoids
the `view-secrets` name conflict when multiple Quarkus applications share a namespace.
When enabled, the `RoleBinding` name is set to match, so it is not double-prefixed by the
Kubernetes extension.

### Example usage

`application.properties`:

```properties
quarkus.application.name=my-app
quarkus.kubernetes-config.enabled=true
quarkus.kubernetes-config.secrets.enabled=true
quarkus.kubernetes-config.secrets=db-credentials,api-keys
quarkus.kubernetes-config.secrets-role-config.prefix-name=true
```

Generated `target/kubernetes/kubernetes.yml` (relevant excerpt):

```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: my-app-view-secrets
rules:
  - apiGroups: [""]
    resourceNames:
      - db-credentials
      - api-keys
    resources: ["secrets"]
    verbs: ["get"]
---
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: my-app-view-secrets
roleRef:
  kind: Role
  apiGroup: rbac.authorization.k8s.io
  name: my-app-view-secrets
subjects:
  - kind: ServiceAccount
    name: my-app
```

With `prefix-name` left at its default, the role name stays `view-secrets` and the
`RoleBinding` name is auto-generated as before. The `resourceNames` scoping applies
whenever `quarkus.kubernetes-config.secrets` is set.

---

- Closes #50303
