### PR TITLE
Fix NPE in RemoteUserAttribute with anonymous identity

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/RemoteUserAttribute.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/RemoteUserAttribute.java
@@ -27,9 +27,11 @@ public class RemoteUserAttribute implements ExchangeAttribute {
             return null;
         }
         if (user instanceof QuarkusHttpUser quarkusUser) {
-            return quarkusUser.getSecurityIdentity().getPrincipal().getName();
+            var principal = quarkusUser.getSecurityIdentity().getPrincipal();
+            return principal != null ? principal.getName() : null;
         } else {
-            return user.principal().getString(VERTX_USER_NAME);
+            var principal = user.principal();
+            return principal != null ? principal.getString(VERTX_USER_NAME) : null;
         }
     }
 

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/attribute/RemoteUserAttributeTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/attribute/RemoteUserAttributeTest.java
@@ -1,0 +1,39 @@
+package io.quarkus.vertx.http.runtime.attribute;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
+import io.vertx.ext.web.RoutingContext;
+
+@ExtendWith(MockitoExtension.class)
+class RemoteUserAttributeTest {
+
+    @Mock
+    RoutingContext routingContext;
+
+    @Mock
+    SecurityIdentity securityIdentity;
+
+    @Test
+    void shouldReturnNullWhenPrincipalIsNull() {
+        when(securityIdentity.getPrincipal()).thenReturn(null);
+        when(routingContext.user()).thenReturn(new QuarkusHttpUser(securityIdentity));
+
+        assertThat(RemoteUserAttribute.INSTANCE.readAttribute(routingContext)).isNull();
+    }
+
+    @Test
+    void shouldReturnUserNameWhenPrincipalIsNotNull() {
+        when(securityIdentity.getPrincipal()).thenReturn(() -> "alice");
+        when(routingContext.user()).thenReturn(new QuarkusHttpUser(securityIdentity));
+
+        assertThat(RemoteUserAttribute.INSTANCE.readAttribute(routingContext)).isEqualTo("alice");
+    }
+}


### PR DESCRIPTION
Avoid NPE when logging an anonymous identity name