### PR TITLE
Support full realm export in Keycloak Dev Services from DEV UI

### DIFF
--- a/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakAdminPageBuildItem.java
+++ b/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakAdminPageBuildItem.java
@@ -10,6 +10,7 @@ import io.quarkus.devui.spi.page.CardPageBuildItem;
 public final class KeycloakAdminPageBuildItem extends MultiBuildItem {
 
     final CardPageBuildItem cardPage;
+    private final String capability;
 
     /**
      * @param cardPage created inside extension that requires Keycloak Dev Service, this way, card page
@@ -17,5 +18,16 @@ public final class KeycloakAdminPageBuildItem extends MultiBuildItem {
      */
     public KeycloakAdminPageBuildItem(CardPageBuildItem cardPage) {
         this.cardPage = cardPage;
+        this.capability = null;
     }
+
+    public KeycloakAdminPageBuildItem(CardPageBuildItem cardPage, String capability) {
+        this.cardPage = cardPage;
+        this.capability = capability;
+    }
+
+    boolean belongsToCapability(String other) {
+        return capability != null && capability.equals(other);
+    }
+
 }

--- a/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesPreparedBuildItem.java
+++ b/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesPreparedBuildItem.java
@@ -1,5 +1,7 @@
 package io.quarkus.devservices.keycloak;
 
+import java.util.Optional;
+
 import io.quarkus.builder.item.SimpleBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 
@@ -11,12 +13,22 @@ import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 public final class KeycloakDevServicesPreparedBuildItem extends SimpleBuildItem {
 
     private final String devServiceConfigHashCode;
+    private final boolean realmExportSupported;
 
-    KeycloakDevServicesPreparedBuildItem(String devServiceConfigHashCode) {
+    KeycloakDevServicesPreparedBuildItem(String devServiceConfigHashCode, boolean realmExportSupported) {
         this.devServiceConfigHashCode = devServiceConfigHashCode;
+        this.realmExportSupported = realmExportSupported;
     }
 
     public String getDevServiceConfigHashCode() {
         return devServiceConfigHashCode;
+    }
+
+    static boolean isRealmExportSupported(Optional<KeycloakDevServicesPreparedBuildItem> optionalSelf) {
+        return optionalSelf.isPresent() && optionalSelf.get().realmExportSupported;
+    }
+
+    static boolean isRealmExportNotSupported(Optional<KeycloakDevServicesPreparedBuildItem> optionalSelf) {
+        return !isRealmExportSupported(optionalSelf);
     }
 }

--- a/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesProcessor.java
+++ b/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesProcessor.java
@@ -3,10 +3,12 @@ package io.quarkus.devservices.keycloak;
 import static io.quarkus.devservices.common.ConfigureUtil.getDefaultImageNameFor;
 import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
 import static io.quarkus.devservices.common.Labels.QUARKUS_DEV_SERVICE;
+import static io.quarkus.devservices.keycloak.KeycloakDevServicesPreparedBuildItem.isRealmExportNotSupported;
 import static io.quarkus.devservices.keycloak.KeycloakDevServicesRequiredBuildItem.getDevServicesConfigurator;
 import static io.quarkus.devservices.keycloak.KeycloakDevServicesUtils.createWebClient;
 import static io.quarkus.devservices.keycloak.KeycloakDevServicesUtils.getPasswordAccessToken;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -15,6 +17,7 @@ import java.net.ServerSocket;
 import java.net.SocketException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -31,6 +34,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -44,17 +48,30 @@ import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.RolesRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.util.JsonSerialization;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.async.ResultCallback;
+import com.github.dockerjava.api.command.ExecCreateCmdResponse;
+import com.github.dockerjava.api.model.Frame;
+import com.github.dockerjava.api.model.StreamType;
+
+import io.quarkus.builder.item.EmptyBuildItem;
+import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.IsDevServicesSupportedByLaunchMode;
 import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsLocalDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
+import io.quarkus.deployment.annotations.Consume;
+import io.quarkus.deployment.annotations.Produce;
 import io.quarkus.deployment.builditem.DevServicesComposeProjectBuildItem;
+import io.quarkus.deployment.builditem.DevServicesRegistryBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
 import io.quarkus.deployment.builditem.DockerStatusBuildItem;
@@ -65,6 +82,7 @@ import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerAddress;
 import io.quarkus.devservices.common.ContainerLocator;
 import io.quarkus.devservices.common.StartableContainer;
+import io.quarkus.devui.spi.buildtime.BuildTimeActionBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
 import io.quarkus.runtime.LaunchMode;
@@ -183,7 +201,9 @@ public class KeycloakDevServicesProcessor {
         devServicesResultProducer.produce(devServicesResultBuildItem);
 
         // now we know that Keycloak Dev Services will start
-        keycloakDevServicesPreparedProducer.produce(new KeycloakDevServicesPreparedBuildItem(serviceConfigHashCode));
+        boolean realmExportSupported = devServicesResultBuildItem.isStartable() && usesH2DevFile(config);
+        keycloakDevServicesPreparedProducer
+                .produce(new KeycloakDevServicesPreparedBuildItem(serviceConfigHashCode, realmExportSupported));
     }
 
     private static String getServiceConfigIdentifier(KeycloakDevServicesConfig config) {
@@ -276,6 +296,7 @@ public class KeycloakDevServicesProcessor {
         }
     }
 
+    @Consume(RealmExportPageRegisteredBuildItem.class)
     @BuildStep(onlyIf = IsDevelopment.class)
     void produceDevUiCardWithKeycloakUrl(
             Optional<KeycloakDevServicesPreparedBuildItem> keycloakDevServicesPreparedBuildItem,
@@ -291,6 +312,134 @@ public class KeycloakDevServicesProcessor {
                 cardPageProducer.produce(i.cardPage);
             });
         }
+    }
+
+    @Produce(RealmExportPageRegisteredBuildItem.class)
+    @BuildStep(onlyIf = IsLocalDevelopment.class)
+    void registerRealmExportPage(
+            Optional<KeycloakDevServicesPreparedBuildItem> keycloakDevServicesPreparedBuildItem,
+            List<KeycloakAdminPageBuildItem> keycloakAdminPageBuildItems,
+            List<KeycloakDevServicesRequiredBuildItem> devSvcRequiredMarkerItems,
+            KeycloakDevServicesConfig config,
+            DevServicesRegistryBuildItem devServicesRegistry,
+            BuildProducer<BuildTimeActionBuildItem> buildTimeActionProducer) {
+
+        // TODO: this is workaround to keep this only for Quarkus OIDC extension, but once we get DEV UI enhancements
+        //  we will be able to provide this even when Quarkus OIDC is not present
+        var oidcPage = keycloakAdminPageBuildItems.stream().filter(i -> i.belongsToCapability(Capability.OIDC)).findAny()
+                .orElse(null);
+        if (oidcPage == null) {
+            return;
+        }
+
+        if (isRealmExportNotSupported(keycloakDevServicesPreparedBuildItem)) {
+            return;
+        }
+
+        String realmName = config.realmName().orElse(config.realmPath().isPresent() ? null : "quarkus");
+        String exportTitle = realmName != null ? "Export '" + realmName + "' realm" : "Export realms";
+        String featureName = KeycloakDevServicesRequiredBuildItem.getFeature(devSvcRequiredMarkerItems).getName();
+        String serviceConfigHashCode = keycloakDevServicesPreparedBuildItem.get().getDevServiceConfigHashCode();
+
+        var actions = new BuildTimeActionBuildItem();
+        actions.actionBuilder()
+                .methodName("exportRealm")
+                .description("Export the Keycloak realm as JSON from the running Dev Service container")
+                .function(ignored -> CompletableFuture.supplyAsync(
+                        () -> executeRealmExport(devServicesRegistry, featureName, serviceConfigHashCode, realmName)))
+                .build();
+        buildTimeActionProducer.produce(actions);
+
+        oidcPage.cardPage.addPage(Page
+                .webComponentPageBuilder()
+                .title(exportTitle)
+                .icon("font-awesome-solid:file-export")
+                .componentLink("qwc-keycloak-realm-export.js"));
+    }
+
+    private static Map<String, Object> executeRealmExport(DevServicesRegistryBuildItem devServicesRegistry,
+            String featureName, String serviceConfigHashCode, String realmName) {
+        var runningService = devServicesRegistry.getRunningServices(featureName, featureName, serviceConfigHashCode);
+        if (runningService == null || runningService.containerId() == null) {
+            return Map.of("success", false, "error", "Keycloak Dev Service container not found");
+        }
+
+        String containerId = runningService.containerId();
+        DockerClient dockerClient = DockerClientFactory.lazyClient();
+
+        try {
+            execInContainer(dockerClient, containerId, "rm", "-f", "/tmp/keycloakdb.mv.db", "/tmp/quarkus-realm.json");
+
+            var copyResult = execInContainer(dockerClient, containerId, "cp", "/opt/keycloak/data/h2/keycloakdb.mv.db",
+                    "/tmp/keycloakdb.mv.db");
+            if (copyResult.exitCode != 0) {
+                return Map.of("success", false, "error", "Failed to copy H2 database: " + copyResult.stderr);
+            }
+
+            List<String> exportCmd = new ArrayList<>(List.of(
+                    "/opt/keycloak/bin/kc.sh", "export",
+                    "--db-url=jdbc:h2:file:/tmp/keycloakdb;NON_KEYWORDS=VALUE",
+                    "--file=/tmp/quarkus-realm.json"));
+            if (realmName != null) {
+                exportCmd.add("--realm=" + realmName);
+            }
+            ExecResult exportResult = execInContainer(dockerClient, containerId, exportCmd.toArray(String[]::new));
+            if (exportResult.exitCode != 0) {
+                return Map.of("success", false, "error", "Failed to export realm: " + exportResult.stderr);
+            }
+
+            ExecResult catResult = execInContainer(dockerClient, containerId, "cat", "/tmp/quarkus-realm.json");
+            if (catResult.exitCode != 0) {
+                return Map.of("success", false, "error", "Failed to read exported realm file: " + catResult.stderr);
+            }
+
+            return Map.of("success", true, "realmJson", catResult.stdout);
+        } catch (IOException | InterruptedException e) {
+            LOG.error("Failed to export Keycloak realm", e);
+            return Map.of("success", false, "error", "Export failed: " + e.getMessage());
+        }
+    }
+
+    private static ExecResult execInContainer(DockerClient dockerClient, String containerId, String... command)
+            throws IOException, InterruptedException {
+        ExecCreateCmdResponse exec = dockerClient.execCreateCmd(containerId)
+                .withAttachStdout(true)
+                .withAttachStderr(true)
+                .withCmd(command)
+                .exec();
+
+        var stdout = new ByteArrayOutputStream();
+        var stderr = new ByteArrayOutputStream();
+        try (var callback = dockerClient.execStartCmd(exec.getId()).exec(new ResultCallback.Adapter<Frame>() {
+            @Override
+            public void onNext(Frame frame) {
+                if (frame.getStreamType() == StreamType.STDOUT || frame.getStreamType() == StreamType.RAW) {
+                    stdout.writeBytes(frame.getPayload());
+                } else if (frame.getStreamType() == StreamType.STDERR) {
+                    stderr.writeBytes(frame.getPayload());
+                }
+            }
+        })) {
+            callback.awaitCompletion();
+        }
+
+        int exitCode = dockerClient.inspectExecCmd(exec.getId()).exec().getExitCodeLong().intValue();
+        return new ExecResult(exitCode, stdout.toString(StandardCharsets.UTF_8), stderr.toString(StandardCharsets.UTF_8));
+    }
+
+    private record ExecResult(int exitCode, String stdout, String stderr) {
+    }
+
+    private static boolean usesH2DevFile(KeycloakDevServicesConfig config) {
+        String dbEnv = config.containerEnv().get("KC_DB");
+        if (dbEnv != null && !"dev-file".equals(dbEnv)) {
+            return false;
+        }
+        if (config.startCommand().isPresent()) {
+            String cmd = config.startCommand().get();
+            return !cmd.contains("--db=") || cmd.contains("--db=dev-file");
+        }
+        return true;
     }
 
     private static String getBaseURL(String scheme, String host, Integer port) {
@@ -956,4 +1105,6 @@ public class KeycloakDevServicesProcessor {
                 .orElse(config.createClient() ? "secret" : "");
     }
 
+    private static final class RealmExportPageRegisteredBuildItem extends EmptyBuildItem {
+    }
 }

--- a/extensions/oidc-client/deployment/pom.xml
+++ b/extensions/oidc-client/deployment/pom.xml
@@ -82,6 +82,11 @@
             <artifactId>quarkus-resteasy-client-deployment</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devui-test-spi</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/KeycloakCustomRealmExportDevUITest.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/KeycloakCustomRealmExportDevUITest.java
@@ -1,0 +1,47 @@
+package io.quarkus.oidc.client;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.quarkus.devui.tests.DevUIJsonRPCTest;
+import io.quarkus.test.QuarkusDevModeTest;
+
+class KeycloakCustomRealmExportDevUITest extends DevUIJsonRPCTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .withApplicationRoot(jar -> jar
+                    .addAsResource("quarkus-realm.json")
+                    .addAsResource(new StringAsset(
+                            """
+                                    quarkus.oidc.enabled=false
+                                    quarkus.keycloak.devservices.realm-path=quarkus-realm.json
+                                    """),
+                            "application.properties"));
+
+    KeycloakCustomRealmExportDevUITest() {
+        super("quarkus-devservices-keycloak");
+    }
+
+    @Test
+    void exportCustomRealmContainsExpectedEntities() throws Exception {
+        JsonNode result = super.executeJsonRPCMethod("exportRealm");
+        assertNotNull(result, "Export should return a result");
+        assertTrue(result.has("success"), "Result should have 'success' field");
+        assertTrue(result.get("success").asBoolean(), "Export should succeed: " + result);
+        String realmJson = result.get("realmJson").asText();
+        assertNotNull(realmJson, "Exported JSON should not be null");
+        assertTrue(realmJson.contains("jdoe"), "Exported JSON should contain user jdoe");
+        assertTrue(realmJson.contains("service-account-backend-service"),
+                "Exported JSON should contain user service-account-backend-service");
+        assertTrue(realmJson.contains("alice"), "Exported JSON should contain user alice");
+        assertTrue(realmJson.contains("admin"), "Exported JSON should contain user admin");
+        assertTrue(realmJson.contains("backend-service"), "Exported JSON should contain client backend-service");
+    }
+}

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/KeycloakQuarkusRealmExportDevUITest.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/KeycloakQuarkusRealmExportDevUITest.java
@@ -1,0 +1,50 @@
+package io.quarkus.oidc.client;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.quarkus.devui.tests.DevUIJsonRPCTest;
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+
+class KeycloakQuarkusRealmExportDevUITest extends DevUIJsonRPCTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .withApplicationRoot(
+                    jar -> jar.addAsResource(new StringAsset("quarkus.oidc.enabled=false\n"), "application.properties"));
+
+    KeycloakQuarkusRealmExportDevUITest() {
+        super("quarkus-devservices-keycloak");
+    }
+
+    @Test
+    void exportRealmReturnsValidJson() throws Exception {
+        JsonNode result = super.executeJsonRPCMethod("exportRealm");
+        assertNotNull(result, "Export should return a result");
+        assertTrue(result.has("success"), "Result should have 'success' field");
+        assertTrue(result.get("success").asBoolean(), "Export should succeed: " + result);
+        String realmJson = result.get("realmJson").asText();
+        assertNotNull(realmJson, "Exported JSON should not be null");
+        assertTrue(realmJson.contains("quarkus"), "Exported JSON should contain realm name");
+        assertTrue(realmJson.contains("alice"), "Exported JSON should contain user alice");
+        assertTrue(realmJson.contains("bob"), "Exported JSON should contain user bob");
+
+        assertDevUiComponentIsServed();
+    }
+
+    private static void assertDevUiComponentIsServed() {
+        RestAssured.given()
+                .get("q/dev-ui/quarkus-oidc/qwc-keycloak-realm-export.js")
+                .then()
+                .statusCode(200)
+                .body(Matchers.containsString("QwcKeycloakRealmExport"));
+    }
+}

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevUIProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevUIProcessor.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.IsLocalDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -52,7 +53,7 @@ public class KeycloakDevUIProcessor extends AbstractDevUIProcessor {
             cardPageBuildItem.setLogo("keycloak_logo.svg", "keycloak_logo.svg");
 
             // use same card page so that both pages appear on the same card
-            var keycloakAdminPageItem = new KeycloakAdminPageBuildItem(cardPageBuildItem);
+            var keycloakAdminPageItem = new KeycloakAdminPageBuildItem(cardPageBuildItem, Capability.OIDC);
             keycloakAdminPageProducer.produce(keycloakAdminPageItem);
         }
     }

--- a/extensions/oidc/deployment/src/main/resources/dev-ui/qwc-keycloak-realm-export.js
+++ b/extensions/oidc/deployment/src/main/resources/dev-ui/qwc-keycloak-realm-export.js
@@ -1,0 +1,65 @@
+import {LitElement, html, css} from 'lit';
+import {JsonRpc} from 'jsonrpc';
+import '@vaadin/button';
+import '@vaadin/icon';
+import '@vaadin/progress-bar';
+import 'qui-alert';
+
+export class QwcKeycloakRealmExport extends LitElement {
+
+    jsonRpc = new JsonRpc("quarkus-devservices-keycloak");
+
+    static styles = css`
+        :host {
+            display: flex;
+            flex-direction: column;
+            padding: 15px;
+            gap: 10px;
+        }
+    `;
+
+    static properties = {
+        _loading: {state: true},
+        _error: {state: true}
+    };
+
+    constructor() {
+        super();
+        this._loading = false;
+        this._error = null;
+    }
+
+    render() {
+        return html`
+            <vaadin-button theme="primary" @click=${this._exportRealm} ?disabled=${this._loading}>
+                <vaadin-icon icon="font-awesome-solid:file-export" slot="prefix"></vaadin-icon>
+                Export Realm
+            </vaadin-button>
+            ${this._loading ? html`<vaadin-progress-bar indeterminate></vaadin-progress-bar>` : html``}
+            ${this._error ? html`<qui-alert level="error" showIcon><span>${this._error}</span></qui-alert>` : html``}`;
+    }
+
+    _exportRealm() {
+        this._loading = true;
+        this._error = null;
+        this.jsonRpc.exportRealm().then(response => {
+            this._loading = false;
+            const data = response.result;
+            if (data.success) {
+                const blob = new Blob([data.realmJson], {type: 'application/json'});
+                const a = document.createElement('a');
+                a.href = URL.createObjectURL(blob);
+                a.download = 'quarkus-realm.json';
+                a.click();
+                URL.revokeObjectURL(a.href);
+            } else {
+                this._error = data.error;
+            }
+        }).catch(error => {
+            this._loading = false;
+            this._error = error.message || String(error);
+        });
+    }
+}
+
+customElements.define('qwc-keycloak-realm-export', QwcKeycloakRealmExport);


### PR DESCRIPTION
* Closes: https://github.com/quarkusio/quarkus/issues/30097
* I read latest Keycloak attempts to officially support realm export like https://github.com/keycloak/keycloak/pull/47112 and related issues https://github.com/keycloak/keycloak/issues/33800 and https://github.com/keycloak/keycloak/issues/25639, but it seems it will not cover our needs anytime soon. At best, in the future we will be able to provide an export feature in a DEV Mode (now we use Keycloak in prod mode), but for now this works and is tested.

<img width="330" height="380" alt="Screenshot From 2026-05-17 13-56-05" src="https://github.com/user-attachments/assets/104e81fa-880e-42ad-8602-35a2ffc9eb5a" />
<img width="1863" height="419" alt="Screenshot From 2026-05-17 13-55-26" src="https://github.com/user-attachments/assets/cc7ca4a6-ddaa-4dbd-96c9-6ff4ffb79880" />
