### PR TITLE
Enable RAG generation during release builds

### DIFF
--- a/devtools/extension-rag/pom.xml
+++ b/devtools/extension-rag/pom.xml
@@ -50,4 +50,13 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <properties>
+                <skipRagGeneration>false</skipRagGeneration>
+            </properties>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
The `extension-rag` module defaults `skipRagGeneration=true` so normal and CI builds skip the embedding generation. This adds a `release` profile that sets the flag to `false`, so running with `-Prelease` (as the release workflow does) will automatically generate the documentation vector embeddings.