### PR TITLE
Publish the correct lib for the Grafana LGTM devservice

### DIFF
--- a/extensions/observability-devservices/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/observability-devservices/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,5 +1,5 @@
 name: "Observability"
-artifact: ${project.groupId}:${project.artifactId}:${project.version}
+artifact: ${project.groupId}:quarkus-observability-devservices-lgtm:${project.version}
 metadata:
   keywords:
     - "lgtm"


### PR DESCRIPTION
Publish on Code Quarkus the right artefact to code.quarkus.io.
The final module to publish is not the runtime module.