### PR TITLE
Remove deprecated `DevServicesAdditionalConfigBuildItem` constructors

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesAdditionalConfigBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesAdditionalConfigBuildItem.java
@@ -2,7 +2,6 @@ package io.quarkus.deployment.builditem;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 import io.quarkus.builder.item.MultiBuildItem;
@@ -23,87 +22,12 @@ public final class DevServicesAdditionalConfigBuildItem extends MultiBuildItem {
     private final String value;
     private final Runnable callbackWhenEnabled;
 
-    /**
-     * @deprecated Call
-     *             {@link DevServicesAdditionalConfigBuildItem#DevServicesAdditionalConfigBuildItem(DevServicesAdditionalConfigProvider)}
-     *             instead.
-     */
-    @Deprecated
-    public DevServicesAdditionalConfigBuildItem(String triggeringKey,
-            String key, String value, Runnable callbackWhenEnabled) {
-        this(List.of(triggeringKey), key, value, callbackWhenEnabled);
-    }
-
-    /**
-     * @deprecated Call
-     *             {@link DevServicesAdditionalConfigBuildItem#DevServicesAdditionalConfigBuildItem(DevServicesAdditionalConfigProvider)}
-     *             instead.
-     */
-    @Deprecated
-    public DevServicesAdditionalConfigBuildItem(Collection<String> triggeringKeys,
-            String key, String value, Runnable callbackWhenEnabled) {
-        this.triggeringKeys = triggeringKeys;
-        this.key = key;
-        this.value = value;
-        this.callbackWhenEnabled = callbackWhenEnabled;
-        this.configProvider = devServicesConfig -> {
-            if (triggeringKeys.stream().anyMatch(devServicesConfig::containsKey)) {
-                if (callbackWhenEnabled != null) {
-                    callbackWhenEnabled.run();
-                }
-                return Map.of(key, value);
-            } else {
-                return Map.of();
-            }
-        };
-    }
-
     public DevServicesAdditionalConfigBuildItem(DevServicesAdditionalConfigProvider configProvider) {
         this.triggeringKeys = Collections.emptyList();
         this.key = null;
         this.value = null;
         this.callbackWhenEnabled = null;
         this.configProvider = configProvider;
-    }
-
-    /**
-     * @deprecated Don't call this method, use {@link #getConfigProvider()} instead.
-     */
-    @Deprecated
-    public String getTriggeringKey() {
-        return getTriggeringKeys().iterator().next();
-    }
-
-    /**
-     * @deprecated Don't call this method, use {@link #getConfigProvider()} instead.
-     */
-    @Deprecated
-    public Collection<String> getTriggeringKeys() {
-        return triggeringKeys;
-    }
-
-    /**
-     * @deprecated Don't call this method, use {@link #getConfigProvider()} instead.
-     */
-    @Deprecated
-    public String getKey() {
-        return key;
-    }
-
-    /**
-     * @deprecated Don't call this method, use {@link #getConfigProvider()} instead.
-     */
-    @Deprecated
-    public String getValue() {
-        return value;
-    }
-
-    /**
-     * @deprecated Don't call this method, use {@link #getConfigProvider()} instead.
-     */
-    @Deprecated
-    public Runnable getCallbackWhenEnabled() {
-        return callbackWhenEnabled;
     }
 
     public DevServicesAdditionalConfigProvider getConfigProvider() {


### PR DESCRIPTION
The removed constructors have been deprecated at least since 2.13 in

* https://github.com/quarkusio/quarkus/pull/26815
* https://github.com/quarkusio/quarkus/pull/27480