### PR TITLE
[4.0] Migration of Panache extensions

### DIFF
--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/ReactiveTransactionalInterceptor.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/ReactiveTransactionalInterceptor.java
@@ -9,6 +9,7 @@ import jakarta.interceptor.AroundInvoke;
 import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.InvocationContext;
 
+import io.smallrye.common.vertx.ContextLocals;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Context;
 
@@ -22,7 +23,7 @@ public class ReactiveTransactionalInterceptor {
         // Note that intercepted methods annotated with @ReactiveTransactional are validated at build time
         // The build fails if the method does not return Uni
         Context vertxContext = SessionOperations.vertxContext();
-        if (vertxContext.getLocal(TRANSACTIONAL_METHOD_KEY) != null) {
+        if (ContextLocals.get(vertxContext, TRANSACTIONAL_METHOD_KEY, null) != null) {
             return Uni.createFrom().failure(
                     new UnsupportedOperationException(
                             "Calling a method annotated with @ReactiveTransactional from a method annotated with @Transactional is not supported. "
@@ -31,7 +32,7 @@ public class ReactiveTransactionalInterceptor {
         }
 
         // Annotate current method so that we can validate mixing of @ReactiveTransactional with @Transactional
-        vertxContext.putLocal(REACTIVE_TRANSACTIONAL_METHOD_KEY, true);
+        ContextLocals.put(vertxContext, REACTIVE_TRANSACTIONAL_METHOD_KEY, true);
 
         return SessionOperations.withTransaction(() -> proceedUni(context));
     }

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/SessionOperations.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/SessionOperations.java
@@ -8,6 +8,8 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -24,9 +26,11 @@ import io.quarkus.arc.ClientProxy;
 import io.quarkus.arc.impl.ComputingCache;
 import io.quarkus.hibernate.orm.PersistenceUnit;
 import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle;
+import io.smallrye.common.vertx.ContextLocals;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
+import io.vertx.core.internal.ContextInternal;
 
 /**
  * Static util methods for {@link Mutiny.Session}.
@@ -73,6 +77,23 @@ public final class SessionOperations {
         return new BaseKey<>(Mutiny.StatelessSession.class, implementor.getUuid());
     }
 
+    private static ConcurrentMap<Object, Object> getLocalMap(Context context) {
+        return ContextInternal.LOCAL_MAP.get(context, ConcurrentHashMap::new);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T getFromLocalMap(Context context, Object key) {
+        return (T) getLocalMap(context).get(key);
+    }
+
+    private static void putInLocalMap(Context context, Object key, Object value) {
+        getLocalMap(context).put(key, value);
+    }
+
+    private static void removeFromLocalMap(Context context, Object key) {
+        getLocalMap(context).remove(key);
+    }
+
     // This key is used to keep track of the Set<String> sessions (managed or stateless) created on demand
     private static final String SESSION_ON_DEMAND_OPENED_KEY = "hibernate.reactive.panache.sessionOnDemandOpened";
 
@@ -89,7 +110,7 @@ public final class SessionOperations {
     static <T> Uni<T> withSessionOnDemand(Supplier<Uni<T>> work) {
         Context context = vertxContext();
 
-        if (context.getLocal(TRANSACTIONAL_METHOD_KEY) != null) {
+        if (ContextLocals.get(context, TRANSACTIONAL_METHOD_KEY, null) != null) {
             return Uni.createFrom().failure(
                     new UnsupportedOperationException(
                             "Calling a method annotated with @WithSessionOnDemand from a method annotated with @Transactional is not supported. "
@@ -97,16 +118,16 @@ public final class SessionOperations {
                                     + "but not both, throughout your whole application."));
         }
 
-        if (context.getLocal(SESSION_ON_DEMAND_KEY) != null) {
+        if (ContextLocals.get(context, SESSION_ON_DEMAND_KEY, null) != null) {
             // context already marked - no need to set the key and close the session
             return work.get();
         } else {
             // mark the lazy session
-            context.putLocal(SESSION_ON_DEMAND_KEY, true);
+            ContextLocals.put(context, SESSION_ON_DEMAND_KEY, true);
             // perform the work and eventually close the session and remove the key
             return work.get().eventually(() -> {
-                context.removeLocal(SESSION_ON_DEMAND_KEY);
-                Set<String> onDemandSessionCreated = context.getLocal(SESSION_ON_DEMAND_OPENED_KEY);
+                ContextLocals.remove(context, SESSION_ON_DEMAND_KEY);
+                Set<String> onDemandSessionCreated = ContextLocals.get(context, SESSION_ON_DEMAND_OPENED_KEY, null);
                 // Close only the sessions that have been created lazily (onDemand) in withSession
                 // See this.getSession(String persistenceUnitName)
                 if (onDemandSessionCreated != null) {
@@ -114,7 +135,7 @@ public final class SessionOperations {
                     for (String s : onDemandSessionCreated) {
                         closedSessions.add(closeSession(s));
                     }
-                    context.removeLocal(SESSION_ON_DEMAND_OPENED_KEY);
+                    ContextLocals.remove(context, SESSION_ON_DEMAND_OPENED_KEY);
                     return Uni.combine().all().unis(closedSessions).discardItems();
                 } else {
                     return Uni.createFrom().voidItem();
@@ -206,7 +227,7 @@ public final class SessionOperations {
             return error;
         }
         Key<Mutiny.Session> key = SESSION_KEY_MAP.getValue(persistenceUnitName);
-        Mutiny.Session current = context.getLocal(key);
+        Mutiny.Session current = getFromLocalMap(context, key);
         if (current != null && current.isOpen()) {
             // reactive session exists - reuse this session
             return work.apply(current);
@@ -215,7 +236,7 @@ public final class SessionOperations {
             return SESSION_FACTORY_MAP.getValue(persistenceUnitName)
                     .openSession()
                     .invoke(() -> LOG.debugf("Opening lazy managed session for Persistence Unit '%s'", persistenceUnitName))
-                    .invoke(s -> context.putLocal(key, s))
+                    .invoke(s -> putInLocalMap(context, key, s))
                     .chain(work::apply)
                     .eventually(() -> closeSession(persistenceUnitName));
         }
@@ -223,7 +244,7 @@ public final class SessionOperations {
 
     private static <T> Uni<T> checkNoStatelessSession(Context context, String persistenceUnitName) {
         Key<Mutiny.StatelessSession> statelessKey = STATELESS_SESSION_KEY_MAP.getValue(persistenceUnitName);
-        Mutiny.StatelessSession currentStateless = context.getLocal(statelessKey);
+        Mutiny.StatelessSession currentStateless = getFromLocalMap(context, statelessKey);
         if (currentStateless != null && currentStateless.isOpen()) {
             return Uni.createFrom().failure(
                     new IllegalStateException("There is already a stateless session opened for this persistence unit"));
@@ -260,7 +281,7 @@ public final class SessionOperations {
             return error;
         }
         Key<Mutiny.StatelessSession> key = STATELESS_SESSION_KEY_MAP.getValue(persistenceUnitName);
-        Mutiny.StatelessSession current = context.getLocal(key);
+        Mutiny.StatelessSession current = getFromLocalMap(context, key);
         if (current != null && current.isOpen()) {
             // reactive session exists - reuse this session
             return work.apply(current);
@@ -269,7 +290,7 @@ public final class SessionOperations {
             return SESSION_FACTORY_MAP.getValue(persistenceUnitName)
                     .openStatelessSession()
                     .invoke(() -> LOG.debugf("Opening lazy stateless session for Persistence Unit '%s'", persistenceUnitName))
-                    .invoke(s -> context.putLocal(key, s))
+                    .invoke(s -> putInLocalMap(context, key, s))
                     .chain(work::apply)
                     .eventually(() -> closeSession(persistenceUnitName));
         }
@@ -277,7 +298,7 @@ public final class SessionOperations {
 
     private static <T> Uni<T> checkNoManagedSession(Context context, String persistenceUnitName) {
         Key<Mutiny.Session> managedKey = SESSION_KEY_MAP.getValue(persistenceUnitName);
-        Mutiny.Session currentManaged = context.getLocal(managedKey);
+        Mutiny.Session currentManaged = getFromLocalMap(context, managedKey);
         if (currentManaged != null && currentManaged.isOpen()) {
             return Uni.createFrom()
                     .failure(new IllegalStateException("There is already a managed session opened for this persistence unit"));
@@ -323,17 +344,17 @@ public final class SessionOperations {
             return error;
         }
         Key<Mutiny.Session> key = SESSION_KEY_MAP.getValue(persistenceUnitName);
-        Mutiny.Session current = context.getLocal(key);
+        Mutiny.Session current = getFromLocalMap(context, key);
         if (current != null && current.isOpen()) {
             // reuse the existing reactive session
             return Uni.createFrom().item(current);
         } else {
-            if (context.getLocal(SESSION_ON_DEMAND_KEY) != null) {
+            if (ContextLocals.get(context, SESSION_ON_DEMAND_KEY, null) != null) {
                 // This will keep track of all on-demand opened sessions
-                Set<String> onDemandSessionsCreated = context.getLocal(SESSION_ON_DEMAND_OPENED_KEY);
+                Set<String> onDemandSessionsCreated = ContextLocals.get(context, SESSION_ON_DEMAND_OPENED_KEY, null);
                 if (onDemandSessionsCreated == null) {
                     onDemandSessionsCreated = new HashSet<>();
-                    context.putLocal(SESSION_ON_DEMAND_OPENED_KEY, onDemandSessionsCreated);
+                    ContextLocals.put(context, SESSION_ON_DEMAND_OPENED_KEY, onDemandSessionsCreated);
                 }
 
                 if (onDemandSessionsCreated.contains(persistenceUnitName)) {
@@ -346,7 +367,7 @@ public final class SessionOperations {
                     onDemandSessionsCreated.add(persistenceUnitName);
                     return SESSION_FACTORY_MAP.getValue(persistenceUnitName).openSession()
                             .invoke(() -> LOG.debugf("Opening lazy session for Persistence Unit '%s'", persistenceUnitName))
-                            .invoke(s -> context.putLocal(key, s));
+                            .invoke(s -> putInLocalMap(context, key, s));
                 }
             } else {
                 throw new IllegalStateException("No current Mutiny.Session found"
@@ -386,17 +407,17 @@ public final class SessionOperations {
             return error;
         }
         Key<Mutiny.StatelessSession> key = STATELESS_SESSION_KEY_MAP.getValue(persistenceUnitName);
-        Mutiny.StatelessSession current = context.getLocal(key);
+        Mutiny.StatelessSession current = getFromLocalMap(context, key);
         if (current != null && current.isOpen()) {
             // reuse the existing reactive session
             return Uni.createFrom().item(current);
         } else {
-            if (context.getLocal(SESSION_ON_DEMAND_KEY) != null) {
+            if (ContextLocals.get(context, SESSION_ON_DEMAND_KEY, null) != null) {
                 // This will keep track of all on-demand opened sessions
-                Set<String> onDemandSessionsCreated = context.getLocal(SESSION_ON_DEMAND_OPENED_KEY);
+                Set<String> onDemandSessionsCreated = ContextLocals.get(context, SESSION_ON_DEMAND_OPENED_KEY, null);
                 if (onDemandSessionsCreated == null) {
                     onDemandSessionsCreated = new HashSet<>();
-                    context.putLocal(SESSION_ON_DEMAND_OPENED_KEY, onDemandSessionsCreated);
+                    ContextLocals.put(context, SESSION_ON_DEMAND_OPENED_KEY, onDemandSessionsCreated);
                 }
 
                 if (onDemandSessionsCreated.contains(persistenceUnitName)) {
@@ -410,7 +431,7 @@ public final class SessionOperations {
                     return SESSION_FACTORY_MAP.getValue(persistenceUnitName).openStatelessSession()
                             .invoke(() -> LOG.debugf("Opening lazy stateless session for Persistence Unit '%s'",
                                     persistenceUnitName))
-                            .invoke(s -> context.putLocal(key, s));
+                            .invoke(s -> putInLocalMap(context, key, s));
                 }
             } else {
                 throw new IllegalStateException("No current Mutiny.StatelessSession found"
@@ -426,8 +447,8 @@ public final class SessionOperations {
      */
     public static Mutiny.Session getCurrentSession(String persistenceUnitName) {
         Context context = vertxContext();
-        Key<Mutiny.Session> value = SESSION_KEY_MAP.getValue(persistenceUnitName);
-        Mutiny.Session current = context.getLocal(value);
+        Key<Mutiny.Session> key = SESSION_KEY_MAP.getValue(persistenceUnitName);
+        Mutiny.Session current = getFromLocalMap(context, key);
         if (current != null && current.isOpen()) {
             return current;
         }
@@ -439,7 +460,8 @@ public final class SessionOperations {
      */
     public static Mutiny.StatelessSession getCurrentStatelessSession(String persistenceUnitName) {
         Context context = vertxContext();
-        Mutiny.StatelessSession current = context.getLocal(STATELESS_SESSION_KEY_MAP.getValue(persistenceUnitName));
+        Mutiny.StatelessSession current = getFromLocalMap(context,
+                STATELESS_SESSION_KEY_MAP.getValue(persistenceUnitName));
         if (current != null && current.isOpen()) {
             return current;
         }
@@ -469,16 +491,16 @@ public final class SessionOperations {
         LOG.debugf("Closing session for Persistence Unit '%s'", persistenceUnitName);
         Context context = vertxContext();
         Key<Mutiny.Session> key = SESSION_KEY_MAP.getValue(persistenceUnitName);
-        Mutiny.Session current = context.getLocal(key);
+        Mutiny.Session current = getFromLocalMap(context, key);
         if (current != null && current.isOpen()) {
             LOG.debugf("Closing opened managed session for Persistence Unit '%s'", persistenceUnitName);
-            return current.close().eventually(() -> context.removeLocal(key));
+            return current.close().eventually(() -> removeFromLocalMap(context, key));
         }
         Key<Mutiny.StatelessSession> statelessKey = STATELESS_SESSION_KEY_MAP.getValue(persistenceUnitName);
-        Mutiny.StatelessSession currentStateless = context.getLocal(statelessKey);
+        Mutiny.StatelessSession currentStateless = getFromLocalMap(context, statelessKey);
         if (currentStateless != null && currentStateless.isOpen()) {
             LOG.debugf("Closing opened stateless session for Persistence Unit '%s'", persistenceUnitName);
-            return currentStateless.close().eventually(() -> context.removeLocal(statelessKey));
+            return currentStateless.close().eventually(() -> removeFromLocalMap(context, statelessKey));
         }
         return Uni.createFrom().voidItem();
     }

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/WithTransactionInterceptor.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/WithTransactionInterceptor.java
@@ -9,6 +9,7 @@ import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.InvocationContext;
 
 import io.quarkus.hibernate.reactive.panache.common.WithTransaction;
+import io.smallrye.common.vertx.ContextLocals;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Context;
 
@@ -23,7 +24,7 @@ public class WithTransactionInterceptor extends AbstractUniInterceptor {
         // However, a class-level binding implies that methods that do not return Uni are just a no-op
         if (isUniReturnType(context)) {
             Context vertxContext = SessionOperations.vertxContext();
-            if (vertxContext.getLocal(TRANSACTIONAL_METHOD_KEY) != null) {
+            if (ContextLocals.get(vertxContext, TRANSACTIONAL_METHOD_KEY, null) != null) {
                 return Uni.createFrom().failure(
                         new UnsupportedOperationException(
                                 "Calling a method annotated with @WithTransaction from a method annotated with @Transactional is not supported. "
@@ -32,7 +33,7 @@ public class WithTransactionInterceptor extends AbstractUniInterceptor {
             }
 
             // Annotate current method so that we can validate mixing of @WithTransaction and @Transactional
-            vertxContext.putLocal(WITH_TRANSACTION_METHOD_KEY, true);
+            ContextLocals.put(vertxContext, WITH_TRANSACTION_METHOD_KEY, true);
 
             WithTransaction withTransaction = getAnnotation(context);
             String persistenceUnitName = withTransaction.value();
@@ -48,7 +49,7 @@ public class WithTransactionInterceptor extends AbstractUniInterceptor {
     }
 
     private static boolean clearWithTransactionMethod(Context vertxContext) {
-        return vertxContext.removeLocal(WITH_TRANSACTION_METHOD_KEY);
+        return ContextLocals.remove(vertxContext, WITH_TRANSACTION_METHOD_KEY);
     }
 
     private WithTransaction getAnnotation(InvocationContext context) {

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/reactive/Panache.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/reactive/Panache.java
@@ -10,6 +10,7 @@ import com.mongodb.reactivestreams.client.ClientSession;
 import io.quarkus.mongodb.reactive.ReactiveMongoClient;
 import io.quarkus.mongodb.runtime.MongoClientBeanUtil;
 import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle;
+import io.smallrye.common.vertx.ContextLocals;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
@@ -21,7 +22,7 @@ import mutiny.zero.flow.adapters.AdaptersToFlow;
 public class Panache {
     private static final String ERROR_MSG = "MongoDB reactive with Panache requires a safe (isolated) Vert.x sub-context, but the current context hasn't been flagged as such.";
 
-    private static final UUID SESSION_KEY = UUID.randomUUID();
+    private static final String SESSION_KEY = UUID.randomUUID().toString();
 
     /**
      * Performs the given work within the scope of a MongoDB transaction.
@@ -33,7 +34,7 @@ public class Panache {
      */
     public static <T> Uni<T> withTransaction(Supplier<Uni<T>> work) {
         Context context = vertxContext();
-        ClientSession current = context.getLocal(SESSION_KEY);
+        ClientSession current = ContextLocals.get(context, SESSION_KEY, null);
         if (current != null && current.hasActiveTransaction()) {
             // reactive session exists - reuse this session
             return work.get();
@@ -41,7 +42,7 @@ public class Panache {
             // reactive session does not exist - open a new one and close it when the returned Uni completes
             return Panache.startSession()
                     .invoke(s -> s.startTransaction())
-                    .invoke(s -> context.putLocal(SESSION_KEY, s))
+                    .invoke(s -> ContextLocals.put(context, SESSION_KEY, s))
                     .chain(s -> work.get())
                     .call(() -> commitTransaction())
                     .onFailure().call(() -> abortTransaction())
@@ -59,18 +60,21 @@ public class Panache {
      */
     public static ClientSession getCurrentSession() {
         Context context = Vertx.currentContext();
-        return context != null ? context.getLocal(SESSION_KEY) : null;
+        if (context == null) {
+            return null;
+        }
+        return ContextLocals.get(context, SESSION_KEY, null);
     }
 
     private static Uni<?> abortTransaction() {
         Context context = vertxContext();
-        ClientSession current = context.getLocal(SESSION_KEY);
+        ClientSession current = ContextLocals.get(context, SESSION_KEY, null);
         return toUni(current.abortTransaction());
     }
 
     private static Uni<?> commitTransaction() {
         Context context = vertxContext();
-        ClientSession current = context.getLocal(SESSION_KEY);
+        ClientSession current = ContextLocals.get(context, SESSION_KEY, null);
         return toUni(current.commitTransaction());
     }
 
@@ -90,11 +94,11 @@ public class Panache {
 
     private static void closeSession() {
         Context context = vertxContext();
-        ClientSession current = context.getLocal(SESSION_KEY);
+        ClientSession current = ContextLocals.get(context, SESSION_KEY, null);
         try {
             current.close();
         } finally {
-            context.removeLocal(SESSION_KEY);
+            ContextLocals.remove(context, SESSION_KEY);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <bytebuddy.version>1.18.8</bytebuddy.version> <!-- version controlled by Hibernate ORM's needs; checked by maven-enforcer-plugin in bom -->
         <geolatte.version>1.10</geolatte.version> <!-- version controlled by Hibernate ORM's needs; checked by maven-enforcer-plugin in bom -->
         <hibernate-models.version>1.1.1</hibernate-models.version> <!-- version controlled by Hibernate ORM's needs; checked by maven-enforcer-plugin in bom -->
-        <hibernate-reactive.version>3.3.6.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
+        <hibernate-reactive.version>4.3.5.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
         <hibernate-validator.version>9.1.0.Final</hibernate-validator.version>
         <hibernate-search.version>8.3.1.Final</hibernate-search.version>
 


### PR DESCRIPTION
Transitional migration of the Panache extensions

This is a temporary migration by using old/deprecated *Local context APIs.

This will need to take advantage of Vert.x 5 `ContextLocal`.
Also while the code compiles with this commit, there are TX-related test failures.
