### PR TITLE
Signals: introduce configurable concurrency limiter

### DIFF
--- a/docs/src/main/asciidoc/signals.adoc
+++ b/docs/src/main/asciidoc/signals.adoc
@@ -509,3 +509,7 @@ public class TimestampEnricher implements SignalMetadataEnricher {
 <1> The `correlation-id` enricher runs _before_ the `timestamp` enricher.
 
 Cycles in the ordering are detected at build time and result in a deployment error.
+
+=== Configuration Reference
+
+include::{generated-dir}/config/quarkus-signals.adoc[leveloffset=+1, opts=optional]

--- a/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/BlockingConcurrencyLimitTest.java
+++ b/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/BlockingConcurrencyLimitTest.java
@@ -1,0 +1,92 @@
+package io.quarkus.signals.deployment.test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.signals.Receivers;
+import io.quarkus.signals.Receivers.ExecutionModel;
+import io.quarkus.signals.Receivers.Registration;
+import io.quarkus.signals.Signal;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.smallrye.mutiny.Uni;
+
+public class BlockingConcurrencyLimitTest extends AbstractSignalTest {
+
+    static final int CONCURRENCY_LIMIT = 2;
+    static final int TOTAL_RECEIVERS = 5;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot(root -> root.addClasses(Cmd.class))
+            .overrideRuntimeConfigKey("quarkus.signals.receivers.blocking-concurrency-limit",
+                    String.valueOf(CONCURRENCY_LIMIT));
+
+    @Inject
+    Signal<Cmd> signal;
+
+    @Inject
+    Receivers receivers;
+
+    @Test
+    public void testConcurrencyLimit() throws InterruptedException {
+        AtomicInteger activeTasks = new AtomicInteger(0);
+        AtomicInteger peakConcurrency = new AtomicInteger(0);
+        CountDownLatch batchStarted = new CountDownLatch(CONCURRENCY_LIMIT);
+        CountDownLatch gate = new CountDownLatch(1);
+        CountDownLatch allDone = new CountDownLatch(TOTAL_RECEIVERS);
+
+        List<Registration> registrations = new ArrayList<>(TOTAL_RECEIVERS);
+        for (int i = 0; i < TOTAL_RECEIVERS; i++) {
+            registrations.add(receivers.newReceiver(Cmd.class)
+                    .setExecutionModel(ExecutionModel.BLOCKING)
+                    .notify(ctx -> {
+                        int current = activeTasks.incrementAndGet();
+                        peakConcurrency.updateAndGet(peak -> Math.max(peak, current));
+                        batchStarted.countDown();
+                        try {
+                            gate.await(defaultTimeout().toMillis(), TimeUnit.MILLISECONDS);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        } finally {
+                            activeTasks.decrementAndGet();
+                            allDone.countDown();
+                        }
+                        return Uni.createFrom().voidItem();
+                    }));
+        }
+
+        try {
+            signal.publish(new Cmd());
+
+            // Wait for the first batch of receivers to start
+            assertTrue(batchStarted.await(defaultTimeout().toMillis(), TimeUnit.MILLISECONDS),
+                    "First batch of receivers should start within timeout");
+
+            assertTrue(peakConcurrency.get() <= CONCURRENCY_LIMIT,
+                    "Peak concurrency " + peakConcurrency.get() + " exceeded limit " + CONCURRENCY_LIMIT);
+
+            // Open the gate so all receivers can finish
+            gate.countDown();
+
+            assertTrue(allDone.await(defaultTimeout().toMillis(), TimeUnit.MILLISECONDS),
+                    "All receivers should complete within timeout");
+        } finally {
+            for (Receivers.Registration reg : registrations) {
+                reg.unregister();
+            }
+        }
+    }
+
+    record Cmd() {
+    }
+}

--- a/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/VirtualThreadConcurrencyLimitTest.java
+++ b/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/VirtualThreadConcurrencyLimitTest.java
@@ -1,0 +1,90 @@
+package io.quarkus.signals.deployment.test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.signals.Receivers;
+import io.quarkus.signals.Receivers.ExecutionModel;
+import io.quarkus.signals.Receivers.Registration;
+import io.quarkus.signals.Signal;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.smallrye.mutiny.Uni;
+
+public class VirtualThreadConcurrencyLimitTest extends AbstractSignalTest {
+
+    static final int CONCURRENCY_LIMIT = 2;
+    static final int TOTAL_RECEIVERS = 5;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot(root -> root.addClasses(Cmd.class))
+            .overrideRuntimeConfigKey("quarkus.signals.receivers.virtual-thread-concurrency-limit",
+                    String.valueOf(CONCURRENCY_LIMIT));
+
+    @Inject
+    Signal<Cmd> signal;
+
+    @Inject
+    Receivers receivers;
+
+    @Test
+    public void testConcurrencyLimit() throws InterruptedException {
+        AtomicInteger activeTasks = new AtomicInteger(0);
+        AtomicInteger peakConcurrency = new AtomicInteger(0);
+        CountDownLatch batchStarted = new CountDownLatch(CONCURRENCY_LIMIT);
+        CountDownLatch gate = new CountDownLatch(1);
+        CountDownLatch allDone = new CountDownLatch(TOTAL_RECEIVERS);
+
+        List<Registration> registrations = new ArrayList<>(TOTAL_RECEIVERS);
+        for (int i = 0; i < TOTAL_RECEIVERS; i++) {
+            registrations.add(receivers.newReceiver(Cmd.class)
+                    .setExecutionModel(ExecutionModel.VIRTUAL_THREAD)
+                    .notify(ctx -> {
+                        int current = activeTasks.incrementAndGet();
+                        peakConcurrency.updateAndGet(peak -> Math.max(peak, current));
+                        batchStarted.countDown();
+                        try {
+                            gate.await(defaultTimeout().toMillis(), TimeUnit.MILLISECONDS);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        } finally {
+                            activeTasks.decrementAndGet();
+                            allDone.countDown();
+                        }
+                        return Uni.createFrom().voidItem();
+                    }));
+        }
+
+        try {
+            signal.publish(new Cmd());
+
+            assertTrue(batchStarted.await(defaultTimeout().toMillis(), TimeUnit.MILLISECONDS),
+                    "First batch of receivers should start within timeout");
+
+            assertTrue(peakConcurrency.get() <= CONCURRENCY_LIMIT,
+                    "Peak concurrency " + peakConcurrency.get() + " exceeded limit " + CONCURRENCY_LIMIT);
+
+            gate.countDown();
+
+            assertTrue(allDone.await(defaultTimeout().toMillis(), TimeUnit.MILLISECONDS),
+                    "All receivers should complete within timeout");
+        } finally {
+            for (Registration reg : registrations) {
+                reg.unregister();
+            }
+        }
+    }
+
+    record Cmd() {
+    }
+}

--- a/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/impl/ConcurrencyLimiter.java
+++ b/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/impl/ConcurrencyLimiter.java
@@ -1,0 +1,80 @@
+package io.quarkus.signals.runtime.impl;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+import org.jboss.logging.Logger;
+
+class ConcurrencyLimiter {
+
+    private static final Logger LOG = Logger.getLogger(ConcurrencyLimiter.class);
+
+    private final int limit;
+    private final AtomicInteger running;
+    private final Queue<Action> queue;
+
+    ConcurrencyLimiter(int limit) {
+        if (limit <= 0) {
+            throw new IllegalArgumentException(
+                    "Limit must be a positive integer: " + limit);
+        }
+        this.limit = limit;
+        this.running = new AtomicInteger();
+        this.queue = new ConcurrentLinkedQueue<>();
+    }
+
+    void run(Runnable task, Consumer<Throwable> onError) {
+        queue.offer(new Action(task, onError));
+        LOG.debugf("Queue action [running=%s, limit=%s]", running, limit);
+        tryDrain();
+    }
+
+    /**
+     * Signals that a previously started action has finished. Must be called exactly once per started action, and must not be
+     * called synchronously inside the action's {@link Runnable#run()} — doing so causes recursive {@link #tryDrain()} calls
+     * whose stack depth equals the queue size.
+     */
+    void complete() {
+        int current = running.get();
+        while (current > 0) {
+            if (running.compareAndSet(current, current - 1)) {
+                tryDrain();
+                return;
+            }
+            current = running.get();
+        }
+    }
+
+    private void tryDrain() {
+        int current = running.get();
+        while (current < limit) {
+            if (running.compareAndSet(current, current + 1)) {
+                Action action = queue.poll();
+                if (action != null) {
+                    try {
+                        LOG.debugf("Run queued action [running=%s, limit=%s]", current + 1, limit);
+                        action.task.run();
+                    } catch (Throwable t) {
+                        running.decrementAndGet();
+                        try {
+                            action.onError.accept(t);
+                        } catch (Throwable handlerError) {
+                            LOG.errorf(handlerError, "Error handler failed");
+                        }
+                    }
+                } else {
+                    running.decrementAndGet();
+                    if (queue.isEmpty()) {
+                        return;
+                    }
+                }
+            }
+            current = running.get();
+        }
+    }
+
+    private record Action(Runnable task, Consumer<Throwable> onError) {
+    }
+}

--- a/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/impl/DefaultBlockingReceiverExecutor.java
+++ b/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/impl/DefaultBlockingReceiverExecutor.java
@@ -4,7 +4,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 
-import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
 import org.jboss.logging.Logger;
@@ -19,8 +18,15 @@ public class DefaultBlockingReceiverExecutor implements ReceiverExecutor {
 
     private static final Logger LOG = Logger.getLogger(DefaultBlockingReceiverExecutor.class);
 
-    @Inject
-    ExecutorService executorService;
+    private final ExecutorService executorService;
+
+    private final ConcurrencyLimiter blockingLimiter;
+
+    DefaultBlockingReceiverExecutor(ExecutorService executorService, SignalsRuntimeConfig config) {
+        this.executorService = executorService;
+        int limit = config.receivers().blockingConcurrencyLimit().orElse(-1);
+        this.blockingLimiter = limit > 0 ? new ConcurrencyLimiter(limit) : null;
+    }
 
     @Override
     public boolean supportsExecutionModel(ExecutionModel val) {
@@ -47,16 +53,37 @@ public class DefaultBlockingReceiverExecutor implements ReceiverExecutor {
 
     protected <RESULT> CompletableFuture<RESULT> execute(ExecutionModel executionModel, Callable<Uni<RESULT>> action) {
         CompletableFuture<RESULT> ret = new CompletableFuture<>();
-        executorService.execute(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    action.call().subscribe().with(ret::complete, ret::completeExceptionally);
-                } catch (Throwable e) {
-                    ret.completeExceptionally(e);
+        ConcurrencyLimiter limiter = blockingLimiter;
+        if (limiter != null) {
+            limiter.run(new Runnable() {
+                @Override
+                public void run() {
+                    executorService.execute(new Runnable() {
+                        @Override
+                        public void run() {
+                            try {
+                                action.call().eventually(limiter::complete).subscribe().with(ret::complete,
+                                        ret::completeExceptionally);
+                            } catch (Throwable e) {
+                                limiter.complete();
+                                ret.completeExceptionally(e);
+                            }
+                        }
+                    });
                 }
-            }
-        });
+            }, ret::completeExceptionally);
+        } else {
+            executorService.execute(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        action.call().subscribe().with(ret::complete, ret::completeExceptionally);
+                    } catch (Throwable e) {
+                        ret.completeExceptionally(e);
+                    }
+                }
+            });
+        }
         return ret;
     }
 

--- a/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/impl/SignalImpl.java
+++ b/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/impl/SignalImpl.java
@@ -127,10 +127,10 @@ class SignalImpl<T> implements Signal<T> {
     private <SIGNAL> SignalContextImpl<SIGNAL> enrich(SIGNAL signal, SignalContext.EmissionType emissionType,
             Type responseType) {
         List<SignalMetadataEnricher> enrichers = manager.enrichers();
-        if (enrichers.isEmpty()) {
-            return new SignalContextImpl<>(signal, metadata, emissionType, responseType);
-        }
         SignalContextImpl<SIGNAL> signalContext = new SignalContextImpl<>(signal, metadata, emissionType, responseType);
+        if (enrichers.isEmpty()) {
+            return signalContext;
+        }
         for (SignalMetadataEnricher enricher : enrichers) {
             EnrichmentContextImpl enrichmentContext = new EnrichmentContextImpl(signalContext);
             enricher.enrich(enrichmentContext);

--- a/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/impl/SignalsRuntimeConfig.java
+++ b/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/impl/SignalsRuntimeConfig.java
@@ -1,0 +1,37 @@
+package io.quarkus.signals.runtime.impl;
+
+import java.util.OptionalInt;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+
+@ConfigMapping(prefix = "quarkus.signals")
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public interface SignalsRuntimeConfig {
+
+    /**
+     * Receivers configuration.
+     */
+    Receivers receivers();
+
+    interface Receivers {
+
+        /**
+         * The maximum number of receivers with blocking execution model that can execute concurrently.
+         * <p>
+         * Requests that exceed the limit are queued and executed as prior receivers complete.
+         * If not set, no concurrency limit is applied.
+         */
+        OptionalInt blockingConcurrencyLimit();
+
+        /**
+         * The maximum number of receivers with virtual thread execution model that can execute concurrently.
+         * <p>
+         * Requests that exceed the limit are queued and executed as prior receivers complete.
+         * If not set, no concurrency limit is applied.
+         */
+        OptionalInt virtualThreadConcurrencyLimit();
+
+    }
+}

--- a/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/impl/VertxReceiverExecutor.java
+++ b/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/impl/VertxReceiverExecutor.java
@@ -2,7 +2,6 @@ package io.quarkus.signals.runtime.impl;
 
 import java.util.concurrent.Callable;
 
-import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
 import org.jboss.logging.Logger;
@@ -26,8 +25,19 @@ public class VertxReceiverExecutor implements ReceiverExecutor {
 
     private static final Logger LOG = Logger.getLogger(VertxReceiverExecutor.class);
 
-    @Inject
-    Vertx vertx;
+    private final Vertx vertx;
+
+    private final ConcurrencyLimiter blockingLimiter;
+
+    private final ConcurrencyLimiter virtualThreadLimiter;
+
+    VertxReceiverExecutor(Vertx vertx, SignalsRuntimeConfig config) {
+        this.vertx = vertx;
+        int blockingLimit = config.receivers().blockingConcurrencyLimit().orElse(-1);
+        this.blockingLimiter = blockingLimit > 0 ? new ConcurrencyLimiter(blockingLimit) : null;
+        int vtLimit = config.receivers().virtualThreadConcurrencyLimit().orElse(-1);
+        this.virtualThreadLimiter = vtLimit > 0 ? new ConcurrencyLimiter(vtLimit) : null;
+    }
 
     @Override
     public boolean supportsExecutionModel(ExecutionModel val) {
@@ -59,28 +69,71 @@ public class VertxReceiverExecutor implements ReceiverExecutor {
     protected <RESULT> void execute(Context context, Promise<RESULT> result, ExecutionModel executionModel,
             Callable<Uni<RESULT>> action) {
         if (executionModel == ExecutionModel.VIRTUAL_THREAD) {
-            VirtualThreadsRecorder.getCurrent().execute(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        action.call().subscribe().with(result::complete, result::fail);
-                    } catch (Throwable e) {
-                        result.fail(e);
+            ConcurrencyLimiter limiter = virtualThreadLimiter;
+            if (limiter != null) {
+                limiter.run(new Runnable() {
+                    @Override
+                    public void run() {
+                        VirtualThreadsRecorder.getCurrent().execute(new Runnable() {
+                            @Override
+                            public void run() {
+                                try {
+                                    action.call().eventually(limiter::complete)
+                                            .subscribe().with(result::complete, result::fail);
+                                } catch (Throwable e) {
+                                    limiter.complete();
+                                    result.fail(e);
+                                }
+                            }
+                        });
                     }
-                }
-            });
+                }, result::fail);
+            } else {
+                VirtualThreadsRecorder.getCurrent().execute(new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            action.call().subscribe().with(result::complete, result::fail);
+                        } catch (Throwable e) {
+                            result.fail(e);
+                        }
+                    }
+                });
+            }
         } else if (executionModel == ExecutionModel.BLOCKING) {
-            context.executeBlocking(new Callable<Void>() {
-                @Override
-                public Void call() {
-                    try {
-                        action.call().subscribe().with(result::complete, result::fail);
-                    } catch (Throwable e) {
-                        result.fail(e);
+            ConcurrencyLimiter limiter = blockingLimiter;
+            if (limiter != null) {
+                limiter.run(new Runnable() {
+                    @Override
+                    public void run() {
+                        context.executeBlocking(new Callable<Void>() {
+                            @Override
+                            public Void call() {
+                                try {
+                                    action.call().eventually(limiter::complete)
+                                            .subscribe().with(result::complete, result::fail);
+                                } catch (Throwable e) {
+                                    limiter.complete();
+                                    result.fail(e);
+                                }
+                                return null;
+                            }
+                        }, false);
                     }
-                    return null;
-                }
-            }, false);
+                }, result::fail);
+            } else {
+                context.executeBlocking(new Callable<Void>() {
+                    @Override
+                    public Void call() {
+                        try {
+                            action.call().subscribe().with(result::complete, result::fail);
+                        } catch (Throwable e) {
+                            result.fail(e);
+                        }
+                        return null;
+                    }
+                }, false);
+            }
         } else {
             try {
                 action.call().subscribe().with(result::complete, result::fail);

--- a/extensions/signals/runtime/src/test/java/io/quarkus/signals/runtime/impl/ConcurrencyLimiterTest.java
+++ b/extensions/signals/runtime/src/test/java/io/quarkus/signals/runtime/impl/ConcurrencyLimiterTest.java
@@ -1,0 +1,231 @@
+package io.quarkus.signals.runtime.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+public class ConcurrencyLimiterTest {
+
+    @Test
+    public void testInvalidLimit() {
+        assertThatThrownBy(() -> new ConcurrencyLimiter(0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new ConcurrencyLimiter(-3))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testRunsBelowLimit() {
+        ConcurrencyLimiter limiter = new ConcurrencyLimiter(3);
+        List<String> executed = new ArrayList<>();
+        limiter.run(() -> executed.add("a"), t -> {
+        });
+        limiter.run(() -> executed.add("b"), t -> {
+        });
+        limiter.run(() -> executed.add("c"), t -> {
+        });
+        assertThat(executed).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    public void testQueuesAtLimit() {
+        ConcurrencyLimiter limiter = new ConcurrencyLimiter(1);
+        List<String> executed = new ArrayList<>();
+
+        // First action runs immediately but does not complete
+        limiter.run(() -> executed.add("a"), t -> {
+        });
+        assertThat(executed).containsExactly("a");
+
+        // Second action is queued because limit=1 and "a" hasn't completed
+        limiter.run(() -> executed.add("b"), t -> {
+        });
+        assertThat(executed).containsExactly("a");
+
+        // Complete "a" — "b" should be drained from the queue
+        limiter.complete();
+        assertThat(executed).containsExactly("a", "b");
+    }
+
+    @Test
+    public void testDrainsInOrderOnComplete() {
+        ConcurrencyLimiter limiter = new ConcurrencyLimiter(2);
+        List<String> executed = new ArrayList<>();
+
+        // Fill both slots
+        limiter.run(() -> executed.add("a"), t -> {
+        });
+        limiter.run(() -> executed.add("b"), t -> {
+        });
+        assertThat(executed).containsExactly("a", "b");
+
+        // Queue two more
+        limiter.run(() -> executed.add("c"), t -> {
+        });
+        limiter.run(() -> executed.add("d"), t -> {
+        });
+        assertThat(executed).containsExactly("a", "b");
+
+        // Complete "a" — "c" should drain
+        limiter.complete();
+        assertThat(executed).containsExactly("a", "b", "c");
+
+        // Complete "b" — "d" should drain
+        limiter.complete();
+        assertThat(executed).containsExactly("a", "b", "c", "d");
+    }
+
+    @Test
+    public void testCompleteWithoutQueuedActions() {
+        ConcurrencyLimiter limiter = new ConcurrencyLimiter(2);
+        List<String> executed = new ArrayList<>();
+
+        limiter.run(() -> executed.add("a"), t -> {
+        });
+        limiter.complete();
+        // No queued actions — complete is a no-op beyond decrementing
+        assertThat(executed).containsExactly("a");
+
+        // New action should still run immediately
+        limiter.run(() -> executed.add("b"), t -> {
+        });
+        assertThat(executed).containsExactly("a", "b");
+    }
+
+    @Test
+    public void testLimitOfOne() {
+        ConcurrencyLimiter limiter = new ConcurrencyLimiter(1);
+        List<String> executed = new ArrayList<>();
+
+        limiter.run(() -> executed.add("1"), t -> {
+        });
+        limiter.run(() -> executed.add("2"), t -> {
+        });
+        limiter.run(() -> executed.add("3"), t -> {
+        });
+        assertThat(executed).containsExactly("1");
+
+        limiter.complete();
+        assertThat(executed).containsExactly("1", "2");
+
+        limiter.complete();
+        assertThat(executed).containsExactly("1", "2", "3");
+    }
+
+    @Test
+    public void testExceptionDoesNotLeakSlot() {
+        ConcurrencyLimiter limiter = new ConcurrencyLimiter(1);
+        List<String> executed = new ArrayList<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+        // Action throws — slot must be released, error handler called
+        limiter.run(() -> {
+            throw new RuntimeException("boom");
+        }, error::set);
+
+        assertThat(error.get()).isInstanceOf(RuntimeException.class).hasMessage("boom");
+
+        // Slot is free — next action runs immediately
+        limiter.run(() -> executed.add("after"), t -> {
+        });
+        assertThat(executed).containsExactly("after");
+    }
+
+    @Test
+    public void testExceptionInQueuedActionDoesNotLeakSlot() {
+        ConcurrencyLimiter limiter = new ConcurrencyLimiter(1);
+        List<String> executed = new ArrayList<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+        // "a" takes the slot
+        limiter.run(() -> executed.add("a"), t -> {
+        });
+        // Throwing action is queued
+        limiter.run(() -> {
+            throw new RuntimeException("boom");
+        }, error::set);
+        // "c" is queued behind the throwing action
+        limiter.run(() -> executed.add("c"), t -> {
+        });
+        assertThat(executed).containsExactly("a");
+
+        // Complete "a" — drains the throwing action (error handler called), then drains "c"
+        limiter.complete();
+        assertThat(error.get()).isInstanceOf(RuntimeException.class).hasMessage("boom");
+        assertThat(executed).containsExactly("a", "c");
+    }
+
+    @Test
+    public void testDoubleCompleteDoesNotGoNegative() {
+        ConcurrencyLimiter limiter = new ConcurrencyLimiter(1);
+        List<String> executed = new ArrayList<>();
+
+        limiter.run(() -> executed.add("a"), t -> {
+        });
+        limiter.complete();
+        limiter.complete(); // Extra — should be harmless
+
+        // Next action runs
+        limiter.run(() -> executed.add("b"), t -> {
+        });
+        assertThat(executed).containsExactly("a", "b");
+
+        // Limit still enforced: "b" hasn't completed, so "c" is queued
+        limiter.run(() -> executed.add("c"), t -> {
+        });
+        assertThat(executed).containsExactly("a", "b");
+
+        limiter.complete();
+        assertThat(executed).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    public void testConcurrentAccessRespectLimit() throws InterruptedException {
+        int limit = 3;
+        int totalActions = 100;
+        ConcurrencyLimiter limiter = new ConcurrencyLimiter(limit);
+
+        AtomicInteger active = new AtomicInteger();
+        AtomicInteger peakConcurrency = new AtomicInteger();
+        CountDownLatch allDone = new CountDownLatch(totalActions);
+        CopyOnWriteArrayList<Integer> peakSnapshots = new CopyOnWriteArrayList<>();
+
+        ExecutorService submitter = Executors.newFixedThreadPool(8);
+        ExecutorService completer = Executors.newFixedThreadPool(4);
+
+        for (int i = 0; i < totalActions; i++) {
+            submitter.submit(() -> {
+                limiter.run(() -> {
+                    int current = active.incrementAndGet();
+                    peakConcurrency.updateAndGet(peak -> Math.max(peak, current));
+                    peakSnapshots.add(current);
+                    // Complete asynchronously to avoid recursive tryDrain
+                    completer.submit(() -> {
+                        active.decrementAndGet();
+                        limiter.complete();
+                        allDone.countDown();
+                    });
+                }, t -> allDone.countDown());
+            });
+        }
+
+        assertThat(allDone.await(10, TimeUnit.SECONDS)).isTrue();
+        submitter.shutdown();
+        completer.shutdown();
+
+        assertThat(peakConcurrency.get()).isLessThanOrEqualTo(limit);
+        assertThat(peakSnapshots).hasSize(totalActions);
+        assertThat(peakSnapshots).allSatisfy(v -> assertThat(v).isLessThanOrEqualTo(limit));
+    }
+}


### PR DESCRIPTION
- for blocking/virtual receivers
- resolves #54229

I think that a _global guard_ on the executor (one limiter per `Receivers.ExecutionModel.BLOCKING` and a separate limiter for `Receivers.ExecutionModel.VIRTUAL_THREAD` ) that applies limits _across all signals_ is the most useful thing to start with. We could add an emitter-level limiter for `publish()` emission later.

Note that an emitter-level limiter is more about throttling specific high-volume signal producers but it doesn't directly protect the shared resources (e.g. worker thread pool).