### PR TITLE
Replace deprecated `Runtime.version().major()` with `Runtime.version().feature()`

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/QuarkusAugmentor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/QuarkusAugmentor.java
@@ -96,7 +96,7 @@ public class QuarkusAugmentor {
     }
 
     public BuildResult run() throws Exception {
-        if (!(Runtime.version().major() >= 17)) {
+        if (!(Runtime.version().feature() >= 17)) {
             throw new IllegalStateException("Quarkus applications require Java 17 or higher to build");
         }
         long start = System.nanoTime();

--- a/core/runtime/src/main/java/io/quarkus/runtime/util/JavaVersionUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/util/JavaVersionUtil.java
@@ -11,17 +11,17 @@ public class JavaVersionUtil {
 
     @Deprecated(forRemoval = true)
     public static boolean isJava17OrHigher() {
-        return Runtime.version().major() >= 17;
+        return Runtime.version().feature() >= 17;
     }
 
     @Deprecated(forRemoval = true)
     public static boolean isJava19OrHigher() {
-        return Runtime.version().major() >= 19;
+        return Runtime.version().feature() >= 19;
     }
 
     @Deprecated(forRemoval = true)
     public static boolean isJava21OrHigher() {
-        return Runtime.version().major() >= 21;
+        return Runtime.version().feature() >= 21;
     }
 
     public static boolean isGraalvmJdk() {

--- a/extensions/awt/runtime/src/main/java/io/quarkus/awt/runtime/graal/AwtFeature.java
+++ b/extensions/awt/runtime/src/main/java/io/quarkus/awt/runtime/graal/AwtFeature.java
@@ -7,7 +7,7 @@ public class AwtFeature implements Feature {
     @Override
     public void afterRegistration(AfterRegistrationAccess access) {
         // Added for JDK 19+ due to: https://github.com/openjdk/jdk20/commit/9bc023220 calling FontUtilities
-        if (Runtime.version().major() >= 19) {
+        if (Runtime.version().feature() >= 19) {
             try {
                 Class<?> fontUtilitiesClass = Class.forName("sun.font.FontUtilities");
                 RuntimeJNIAccess.register(fontUtilitiesClass);

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/virtualthreads/VirtualThreadCollector.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/virtualthreads/VirtualThreadCollector.java
@@ -40,7 +40,7 @@ public class VirtualThreadCollector {
     @Inject
     public VirtualThreadCollector(MicrometerConfig mc) {
         var config = mc.binder().virtualThreads();
-        this.enabled = Runtime.version().major() >= 21 && config.enabled().orElse(true);
+        this.enabled = Runtime.version().feature() >= 21 && config.enabled().orElse(true);
         MeterBinder instantiated = null;
         if (enabled) {
             if (config.tags().isPresent()) {


### PR DESCRIPTION
`Runtime.Version.major()` has been deprecated since JDK 10 in favor of `Runtime.Version.feature()`, which better reflects the versioning scheme introduced by JEP 322.

