### PR TITLE
Docs: clarify inbound HTTP decompression behavior and GraalVM native limits

### DIFF
--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -162,11 +162,14 @@ Quarkus can also decompress incoming request bodies.
 Enable this with `quarkus.http.enable-decompression=true`.
 The client must indicate the compression format in the `Content-Encoding` request header (e.g., `gzip`, `deflate`, or `br`).
 
+[[inbound-http-decompression]]
 ==== HTTP request body decompression (inbound)
 
 By default (`quarkus.http.enable-decompression=false`), the HTTP server delivers the request body exactly as sent on the wire and does not interpret `Content-Encoding` for inbound decompression.
 
-When you set `quarkus.http.enable-decompression=true`, Vert.x adds Netty's `HttpContentDecompressor`, which may decode the body before it reaches JAX-RS, Reactive Routes, or other application handlers, according to the `Content-Encoding` header.
+When you set `quarkus.http.enable-decompression=true`, Vert.x adds Netty's `HttpContentDecompressor`, which may decode the body before it reaches Quarkus REST, Reactive Routes, or other application handlers, according to the `Content-Encoding` header.
+
+WARNING: Enabling inbound decompression without a sensible request body size limit can expose the server to decompression bomb attacks, where a small compressed payload expands to a very large decompressed body. Set `quarkus.http.limits.max-body-size` (default `10240K`) to cap accepted request bodies; see <<http-limits-configuration>> for other HTTP limits.
 
 NOTE: Quarkus leaves inbound decompression to Vert.x / Netty. If decompression fails (invalid compressed data, malformed framing, unsupported coding for this stack, and similar), Vert.x may close the connection without a normal application-level HTTP response; behavior can differ between HTTP versions and inbound pipeline timing.
 
@@ -175,8 +178,8 @@ Supported inbound codings follow Netty's implementation:
 * `gzip` / `x-gzip`
 * `deflate` / `x-deflate`
 * `br` when Brotli is available (same optional native stack as for response compression)
-* `snappy` using Netty's Snappy *framing* format (`SnappyFrameDecoder`) on the JVM only. Payloads must be valid framed Snappy (for example as emitted by Netty's `SnappyFrameEncoder`). Raw Snappy block compression without the framing envelope is not accepted. GraalVM native images do not wire Snappy inbound decoding (the body is not decoded).
-* On the JVM only: `zstd` when Netty's Zstd support is available at runtime (not decoded in GraalVM native images)
+* On the JVM only, `snappy` uses Netty's Snappy *framing* format (`SnappyFrameDecoder`). Payloads must be valid framed Snappy (for example as emitted by Netty's `SnappyFrameEncoder`). Raw Snappy block compression without the framing envelope is not accepted.
+* On the JVM only, `zstd` is supported when Netty's Zstd support is available at runtime.
 
 If the coding is not recognized, Netty passes the request through without decoding; Quarkus does not automatically respond with `415 Unsupported Media Type` in that case.
 
@@ -580,6 +583,7 @@ This works with both the standard `Forwarded` header and the `X-Forwarded-Host` 
 
 include::{generated-dir}/config/quarkus-vertx-http_quarkus.http.host-validation.adoc[leveloffset=+1, opts=optional]
 
+[[http-limits-configuration]]
 == HTTP Limits Configuration
 
 include::{generated-dir}/config/quarkus-vertx-http_quarkus.http.limits.adoc[leveloffset=+1, opts=optional]

--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -162,6 +162,26 @@ Quarkus can also decompress incoming request bodies.
 Enable this with `quarkus.http.enable-decompression=true`.
 The client must indicate the compression format in the `Content-Encoding` request header (e.g., `gzip`, `deflate`, or `br`).
 
+==== HTTP request body decompression (inbound)
+
+By default (`quarkus.http.enable-decompression=false`), the HTTP server delivers the request body exactly as sent on the wire and does not interpret `Content-Encoding` for inbound decompression.
+
+When you set `quarkus.http.enable-decompression=true`, Vert.x adds Netty's `HttpContentDecompressor`, which may decode the body before it reaches JAX-RS, Reactive Routes, or other application handlers, according to the `Content-Encoding` header.
+
+NOTE: Quarkus leaves inbound decompression to Vert.x / Netty. If decompression fails (invalid compressed data, malformed framing, unsupported coding for this stack, and similar), Vert.x may close the connection without a normal application-level HTTP response; behavior can differ between HTTP versions and inbound pipeline timing.
+
+Supported inbound codings follow Netty's implementation:
+
+* `gzip` / `x-gzip`
+* `deflate` / `x-deflate`
+* `br` when Brotli is available (same optional native stack as for response compression)
+* `snappy` using Netty's Snappy *framing* format (`SnappyFrameDecoder`) on the JVM only. Payloads must be valid framed Snappy (for example as emitted by Netty's `SnappyFrameEncoder`). Raw Snappy block compression without the framing envelope is not accepted. GraalVM native images do not wire Snappy inbound decoding (the body is not decoded).
+* On the JVM only: `zstd` when Netty's Zstd support is available at runtime (not decoded in GraalVM native images)
+
+If the coding is not recognized, Netty passes the request through without decoding; Quarkus does not automatically respond with `415 Unsupported Media Type` in that case.
+
+IMPORTANT: GraalVM native image builds use Netty substitutions for the inbound decompressor that only support `gzip`, `deflate`, and `br` (when Brotli loads). Inbound `snappy` and `zstd` are not decompressed in native executables even when `quarkus.http.enable-decompression=true`.
+
 [[static-resources-config]]
 === Other Configurations
 

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/DecompressionTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/DecompressionTest.java
@@ -14,23 +14,28 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.compression.SnappyFrameEncoder;
 import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.BodyHandler;
 
 public class DecompressionTest {
-    private static final String APP_PROPS = "" +
-            "quarkus.http.enable-decompression=true\n";
 
     private static final String LONG_STRING = IntStream.range(0, 1000).mapToObj(i -> "Hello World;")
             .collect(Collectors.joining());
+
+    private static final String APP_PROPS = "quarkus.http.enable-decompression=true\n";
 
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withApplicationRoot((jar) -> jar
                     .addAsResource(new StringAsset(APP_PROPS), "application.properties")
-                    .addClasses(CompressionTest.BeanRegisteringRouteUsingObserves.class));
+                    .addClasses(EchoRoute.class));
 
     @Test
     public void test() throws Exception {
@@ -57,16 +62,51 @@ public class DecompressionTest {
                 .body(Matchers.equalTo(LONG_STRING));
     }
 
+    @Test
+    public void testSnappyFramedRoundTrip() {
+        byte[] input = LONG_STRING.getBytes(StandardCharsets.UTF_8);
+        byte[] compressed = snappyFramed(input);
+
+        RestAssured.given()
+                .header("content-encoding", "snappy")
+                .body(compressed)
+                .post("/echo").then().statusCode(200)
+                .body(Matchers.equalTo(LONG_STRING));
+    }
+
+    private static byte[] snappyFramed(byte[] input) {
+        EmbeddedChannel encoder = new EmbeddedChannel(new SnappyFrameEncoder());
+        encoder.writeOutbound(Unpooled.wrappedBuffer(input));
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        ByteBuf part;
+        while ((part = encoder.readOutbound()) != null) {
+            try {
+                int n = part.readableBytes();
+                if (n > 0) {
+                    byte[] chunk = new byte[n];
+                    part.getBytes(part.readerIndex(), chunk);
+                    part.skipBytes(n);
+                    bout.write(chunk, 0, chunk.length);
+                }
+            } finally {
+                part.release();
+            }
+        }
+        encoder.finishAndReleaseAll();
+        return bout.toByteArray();
+    }
+
     @ApplicationScoped
-    static class BeanRegisteringRouteUsingObserves {
+    static class EchoRoute {
 
         public void register(@Observes Router router) {
             router.post("/echo").handler(BodyHandler.create());
             router.post("/echo").handler(rc -> {
                 rc.response().end(rc.body().asString());
+                Buffer body = rc.body().buffer();
+                rc.response().end(body != null ? body : Buffer.buffer());
             });
         }
-
     }
 
 }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/DecompressionTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/DecompressionTest.java
@@ -1,6 +1,8 @@
 package io.quarkus.vertx.http;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -132,6 +134,8 @@ public class DecompressionTest {
                 }
                 return bout.toByteArray();
             }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         } finally {
             channel.finishAndReleaseAll();
         }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/DecompressionTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/DecompressionTest.java
@@ -11,13 +11,21 @@ import jakarta.enterprise.event.Observes;
 
 import org.hamcrest.Matchers;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.compression.Brotli;
+import io.netty.handler.codec.compression.BrotliEncoder;
+import io.netty.handler.codec.compression.JdkZlibEncoder;
 import io.netty.handler.codec.compression.SnappyFrameEncoder;
+import io.netty.handler.codec.compression.ZlibWrapper;
+import io.netty.handler.codec.compression.Zstd;
+import io.netty.handler.codec.compression.ZstdEncoder;
 import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 import io.vertx.core.buffer.Buffer;
@@ -25,11 +33,13 @@ import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.BodyHandler;
 
 public class DecompressionTest {
+    private static final String APP_PROPS = "" +
+            "quarkus.http.enable-decompression=true\n";
 
     private static final String LONG_STRING = IntStream.range(0, 1000).mapToObj(i -> "Hello World;")
             .collect(Collectors.joining());
 
-    private static final String APP_PROPS = "quarkus.http.enable-decompression=true\n";
+    private static final byte[] INPUT = LONG_STRING.getBytes(StandardCharsets.UTF_8);
 
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
@@ -38,24 +48,10 @@ public class DecompressionTest {
                     .addClasses(EchoRoute.class));
 
     @Test
-    public void test() throws Exception {
-        var input = LONG_STRING.getBytes(StandardCharsets.UTF_8);
-        var bout = new ByteArrayOutputStream(input.length);
-        var gzip = new GZIPOutputStream(bout);
-        gzip.write(input, 0, input.length);
-        gzip.close();
-        var compressed = bout.toByteArray();
-        bout.close();
-
+    public void testUncompressed() {
         // RestAssured is aware of quarkus.http.root-path
         // If this changes then please modify quarkus-azure-functions-http maven archetype to reflect this
         // in its test classes
-        RestAssured.given()
-                .header("content-encoding", "gzip")
-                .body(compressed)
-                .post("/echo").then().statusCode(200)
-                .body(Matchers.equalTo(LONG_STRING));
-
         RestAssured.given()
                 .body(LONG_STRING)
                 .post("/echo").then().statusCode(200)
@@ -63,37 +59,82 @@ public class DecompressionTest {
     }
 
     @Test
-    public void testSnappyFramedRoundTrip() {
-        byte[] input = LONG_STRING.getBytes(StandardCharsets.UTF_8);
-        byte[] compressed = snappyFramed(input);
+    public void testGzipRoundTrip() throws Exception {
+        assertRoundTrip("gzip", gzipBytes(INPUT));
+    }
 
+    @Test
+    public void testXGzipRoundTrip() throws Exception {
+        assertRoundTrip("x-gzip", gzipBytes(INPUT));
+    }
+
+    @Test
+    public void testDeflateRoundTrip() {
+        assertRoundTrip("deflate", encodeWith(new JdkZlibEncoder(ZlibWrapper.ZLIB), INPUT));
+    }
+
+    @Test
+    public void testXDeflateRoundTrip() {
+        assertRoundTrip("x-deflate", encodeWith(new JdkZlibEncoder(ZlibWrapper.ZLIB), INPUT));
+    }
+
+    @Test
+    public void testSnappyFramedRoundTrip() {
+        assertRoundTrip("snappy", encodeWith(new SnappyFrameEncoder(), INPUT));
+    }
+
+    @Test
+    public void testBrotliRoundTrip() {
+        Assumptions.assumeTrue(Brotli.isAvailable(), "Brotli is not available on this platform");
+        assertRoundTrip("br", encodeWith(new BrotliEncoder(), INPUT));
+    }
+
+    @Test
+    public void testZstdRoundTrip() {
+        Assumptions.assumeTrue(Zstd.isAvailable(), "Zstd is not available on this platform");
+        assertRoundTrip("zstd", encodeWith(new ZstdEncoder(), INPUT));
+    }
+
+    private static void assertRoundTrip(String contentEncoding, byte[] compressed) {
         RestAssured.given()
-                .header("content-encoding", "snappy")
+                .header("content-encoding", contentEncoding)
                 .body(compressed)
                 .post("/echo").then().statusCode(200)
                 .body(Matchers.equalTo(LONG_STRING));
     }
 
-    private static byte[] snappyFramed(byte[] input) {
-        EmbeddedChannel encoder = new EmbeddedChannel(new SnappyFrameEncoder());
-        encoder.writeOutbound(Unpooled.wrappedBuffer(input));
-        ByteArrayOutputStream bout = new ByteArrayOutputStream();
-        ByteBuf part;
-        while ((part = encoder.readOutbound()) != null) {
-            try {
-                int n = part.readableBytes();
-                if (n > 0) {
-                    byte[] chunk = new byte[n];
-                    part.getBytes(part.readerIndex(), chunk);
-                    part.skipBytes(n);
-                    bout.write(chunk, 0, chunk.length);
-                }
-            } finally {
-                part.release();
-            }
+    private static byte[] gzipBytes(byte[] input) throws Exception {
+        ByteArrayOutputStream bout = new ByteArrayOutputStream(input.length);
+        try (GZIPOutputStream gzip = new GZIPOutputStream(bout)) {
+            gzip.write(input);
         }
-        encoder.finishAndReleaseAll();
         return bout.toByteArray();
+    }
+
+    private static byte[] encodeWith(ChannelHandler encoder, byte[] input) {
+        EmbeddedChannel channel = new EmbeddedChannel(encoder);
+        try {
+            channel.writeOutbound(Unpooled.wrappedBuffer(input));
+            try (ByteArrayOutputStream bout = new ByteArrayOutputStream()) {
+                ByteBuf part;
+                while ((part = channel.readOutbound()) != null) {
+                    try {
+                        int n = part.readableBytes();
+                        if (n > 0) {
+                            byte[] chunk = new byte[n];
+                            part.getBytes(part.readerIndex(), chunk);
+                            part.skipBytes(n);
+                            bout.write(chunk, 0, chunk.length);
+                        }
+                    } finally {
+                        part.release();
+                    }
+                }
+                return bout.toByteArray();
+            }
+        } finally {
+            channel.finishAndReleaseAll();
+        }
     }
 
     @ApplicationScoped

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpBuildTimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpBuildTimeConfig.java
@@ -80,10 +80,27 @@ public interface VertxHttpBuildTimeConfig {
     boolean enableCompression();
 
     /**
-     * When enabled, vert.x will decompress the request's body if it's compressed.
+     * When enabled, Vert.x installs Netty's {@code HttpContentDecompressor} so request bodies may be
+     * decompressed before they reach application code, based on the {@code Content-Encoding} header.
      * <p>
-     * Note that the compression format (e.g., gzip) must be specified in the Content-Encoding header
-     * in the request.
+     * Supported codings match Netty on the JVM (and therefore depend on optional native libraries for {@code br}
+     * and {@code zstd}): {@code gzip} / {@code x-gzip}, {@code deflate} / {@code x-deflate}, and {@code br} when Brotli
+     * is available. On the JVM, inbound {@code snappy} uses Netty's Snappy framing format (as produced by Netty's
+     * {@code SnappyFrameEncoder}, not arbitrary raw Snappy blocks). On the JVM, {@code zstd} may also be supported when
+     * Netty's Zstd support is available.
+     * <p>
+     * When this flag is {@code false} (the default), the body bytes are passed through unchanged and
+     * {@code Content-Encoding} is not interpreted for inbound decompression.
+     * <p>
+     * Unrecognized codings are passed through without decompression (they do not automatically produce an HTTP error
+     * response). When decompression fails for a declared coding (invalid compressed payload, malformed framing, and so
+     * on), Vert.x / Netty may close the connection without a normal application-level HTTP response; details depend on
+     * HTTP version and timing in the inbound pipeline.
+     * <p>
+     * GraalVM native executables use substitutions for Netty's inbound decompressor that only wire {@code gzip},
+     * {@code deflate}, and {@code br} (when Brotli loads). Inbound {@code snappy} and {@code zstd} are not decoded in
+     * native mode even when this option is {@code true} (the body is passed through unchanged while the
+     * {@code Content-Encoding} header may still be set).
      */
     @WithDefault("false")
     boolean enableDecompression();

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpBuildTimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpBuildTimeConfig.java
@@ -80,27 +80,15 @@ public interface VertxHttpBuildTimeConfig {
     boolean enableCompression();
 
     /**
-     * When enabled, Vert.x installs Netty's {@code HttpContentDecompressor} so request bodies may be
-     * decompressed before they reach application code, based on the {@code Content-Encoding} header.
+     * Enables inbound request body decompression on the primary HTTP server, based on the {@code Content-Encoding}
+     * header.
      * <p>
-     * Supported codings match Netty on the JVM (and therefore depend on optional native libraries for {@code br}
-     * and {@code zstd}): {@code gzip} / {@code x-gzip}, {@code deflate} / {@code x-deflate}, and {@code br} when Brotli
-     * is available. On the JVM, inbound {@code snappy} uses Netty's Snappy framing format (as produced by Netty's
-     * {@code SnappyFrameEncoder}, not arbitrary raw Snappy blocks). On the JVM, {@code zstd} may also be supported when
-     * Netty's Zstd support is available.
+     * When {@code false} (the default), request body bytes are passed through unchanged and {@code Content-Encoding}
+     * is not interpreted for inbound decompression.
      * <p>
-     * When this flag is {@code false} (the default), the body bytes are passed through unchanged and
-     * {@code Content-Encoding} is not interpreted for inbound decompression.
-     * <p>
-     * Unrecognized codings are passed through without decompression (they do not automatically produce an HTTP error
-     * response). When decompression fails for a declared coding (invalid compressed payload, malformed framing, and so
-     * on), Vert.x / Netty may close the connection without a normal application-level HTTP response; details depend on
-     * HTTP version and timing in the inbound pipeline.
-     * <p>
-     * GraalVM native executables use substitutions for Netty's inbound decompressor that only wire {@code gzip},
-     * {@code deflate}, and {@code br} (when Brotli loads). Inbound {@code snappy} and {@code zstd} are not decoded in
-     * native mode even when this option is {@code true} (the body is passed through unchanged while the
-     * {@code Content-Encoding} header may still be set).
+     * See the <a href="https://quarkus.io/guides/http-reference#inbound-http-decompression">HTTP reference guide</a>
+     * for supported codings, GraalVM native limits, security considerations, and failure behavior.
+     * The management interface equivalent is {@code quarkus.management.enable-decompression}.
      */
     @WithDefault("false")
     boolean enableDecompression();

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementInterfaceBuildTimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementInterfaceBuildTimeConfig.java
@@ -57,10 +57,12 @@ public interface ManagementInterfaceBuildTimeConfig {
     boolean enableCompression();
 
     /**
-     * When enabled, vert.x will decompress the request's body if it's compressed.
+     * When enabled, Vert.x installs Netty's {@code HttpContentDecompressor} so request bodies may be
+     * decompressed before they reach application code, based on the {@code Content-Encoding} header.
      * <p>
-     * Note that the compression format (e.g., gzip) must be specified in the Content-Encoding header
-     * in the request.
+     * Supported codings match Netty (see {@code quarkus.http.enable-decompression} on the primary HTTP server for the
+     * full description, including Snappy framing requirements, GraalVM native limits, and behavior when inbound
+     * decompression fails).
      */
     @WithDefault("false")
     boolean enableDecompression();

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementInterfaceBuildTimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementInterfaceBuildTimeConfig.java
@@ -57,12 +57,15 @@ public interface ManagementInterfaceBuildTimeConfig {
     boolean enableCompression();
 
     /**
-     * When enabled, Vert.x installs Netty's {@code HttpContentDecompressor} so request bodies may be
-     * decompressed before they reach application code, based on the {@code Content-Encoding} header.
+     * Enables inbound request body decompression on the management interface, based on the {@code Content-Encoding}
+     * header.
      * <p>
-     * Supported codings match Netty (see {@code quarkus.http.enable-decompression} on the primary HTTP server for the
-     * full description, including Snappy framing requirements, GraalVM native limits, and behavior when inbound
-     * decompression fails).
+     * When {@code false} (the default), request body bytes are passed through unchanged and {@code Content-Encoding}
+     * is not interpreted for inbound decompression.
+     * <p>
+     * See the <a href="https://quarkus.io/guides/http-reference#inbound-http-decompression">HTTP reference guide</a>
+     * for supported codings, GraalVM native limits, security considerations, and failure behavior.
+     * The primary HTTP server equivalent is {@code quarkus.http.enable-decompression}.
      */
     @WithDefault("false")
     boolean enableDecompression();


### PR DESCRIPTION

Explain supported codings, native limits, and Vert.x / Netty failure behavior in
docs and @ConfigMapping Javadoc.

Fixes: #54251

---
Release note: Documentation clarifies inbound request decompression
(`quarkus.http.enable-decompression`), including native image limitations and
failure behavior.