### PR TITLE
Prometheus compression header fix

### DIFF
--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/PrometheusEnabledTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/export/PrometheusEnabledTest.java
@@ -16,6 +16,8 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+import io.restassured.config.DecoderConfig;
 
 public class PrometheusEnabledTest {
     @RegisterExtension
@@ -69,7 +71,16 @@ public class PrometheusEnabledTest {
 
     @Test
     public void metricsEndpointCompressed() {
-        given().header("Accept-Encoding", "gzip")
+        // Register a metric so the scrape response is non-empty;
+        // Vert.x/Netty skips compression on empty bodies.
+        promRegistry.counter("test.compression.verify").increment();
+
+        // Use DecoderConfig instead of .header("Accept-Encoding", "gzip")
+        // because RestAssured silently ignores manually set Accept-Encoding headers.
+        // See CompressionTest and Testflow for details.
+        given().config(RestAssured.config
+                .decoderConfig(DecoderConfig.decoderConfig()
+                        .contentDecoders(DecoderConfig.ContentDecoder.GZIP)))
                 .get("/q/metrics")
                 .then()
                 .log().all()

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/export/handlers/PrometheusHandler.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/export/handlers/PrometheusHandler.java
@@ -16,7 +16,6 @@ import io.prometheus.client.exporter.common.TextFormat;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ManagedContext;
 import io.quarkus.vertx.http.runtime.HttpCompressionHandler;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServerResponse;
@@ -53,13 +52,11 @@ public class PrometheusHandler implements Handler<RoutingContext> {
         }
 
         if (enableCompression) {
-            routingContext.addEndHandler(new Handler<>() {
+            routingContext.addHeadersEndHandler(new Handler<>() {
 
                 @Override
-                public void handle(AsyncResult<Void> result) {
-                    if (result.succeeded()) {
-                        HttpCompressionHandler.compressIfNeeded(routingContext, compressMediaTypes);
-                    }
+                public void handle(Void result) {
+                    HttpCompressionHandler.compressIfNeeded(routingContext, compressMediaTypes);
                 }
             });
         }


### PR DESCRIPTION
@gsmet, it turns out we had a bug in the code and the test. There was a race condition. 

`addHeadersEndHandler` ensures we always run before the response is returned and the test will always expect a zipped content.
