### PR TITLE
Move conversion methods to the related config objects

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/BaseAddResourceDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/BaseAddResourceDecorator.java
@@ -1,6 +1,5 @@
 package io.quarkus.kubernetes.deployment;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -201,7 +200,7 @@ abstract class BaseAddResourceDecorator<T extends HasMetadata, B extends Visitab
      */
     protected Map<String, String> mergeLabelsFromDeploymentWith(List<HasMetadata> items, Map<String, String> labels,
             @Nullable String deploymentName) {
-        Map<String, String> merged = new HashMap<>(labels);
+        Map<String, String> merged = new TreeMap<>(labels);
         deploymentNamed(items, deploymentName)
                 .map(hasMetadata -> hasMetadata.getMetadata().getLabels())
                 .ifPresent(merged::putAll);
@@ -217,7 +216,7 @@ abstract class BaseAddResourceDecorator<T extends HasMetadata, B extends Visitab
      */
     protected <S extends LabelSelectorFluent<?>> S initSelectorMatchLabels(S selector) {
         if (!selector.hasMatchLabels()) {
-            selector.withMatchLabels(new HashMap<>());
+            selector.withMatchLabels(new TreeMap<>());
         }
         return selector;
     }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/BaseKubeProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/BaseKubeProcessor.java
@@ -24,13 +24,9 @@ import io.dekorate.kubernetes.annotation.ImagePullPolicy;
 import io.dekorate.kubernetes.annotation.JobCompletionMode;
 import io.dekorate.kubernetes.annotation.JobRestartPolicy;
 import io.dekorate.kubernetes.config.Annotation;
-import io.dekorate.kubernetes.config.ConfigMapVolumeBuilder;
 import io.dekorate.kubernetes.config.EnvBuilder;
-import io.dekorate.kubernetes.config.MountBuilder;
 import io.dekorate.kubernetes.config.Port;
-import io.dekorate.kubernetes.config.SecretVolumeBuilder;
 import io.dekorate.kubernetes.decorator.AddAnnotationDecorator;
-import io.dekorate.kubernetes.decorator.AddConfigMapVolumeDecorator;
 import io.dekorate.kubernetes.decorator.AddDockerConfigJsonSecretDecorator;
 import io.dekorate.kubernetes.decorator.AddEnvVarDecorator;
 import io.dekorate.kubernetes.decorator.AddImagePullSecretDecorator;
@@ -40,7 +36,6 @@ import io.dekorate.kubernetes.decorator.AddLivenessProbeDecorator;
 import io.dekorate.kubernetes.decorator.AddMetadataToTemplateDecorator;
 import io.dekorate.kubernetes.decorator.AddMountDecorator;
 import io.dekorate.kubernetes.decorator.AddReadinessProbeDecorator;
-import io.dekorate.kubernetes.decorator.AddSecretVolumeDecorator;
 import io.dekorate.kubernetes.decorator.AddSelectorToDeploymentSpecDecorator;
 import io.dekorate.kubernetes.decorator.AddSidecarDecorator;
 import io.dekorate.kubernetes.decorator.AddStartupProbeDecorator;
@@ -312,8 +307,6 @@ public abstract class BaseKubeProcessor<P, C extends PlatformConfiguration> {
         createLabelDecorators(context, config, labels);
         createAnnotationDecorators(context, project, config, metricsConfiguration, annotations, port);
         createContainerDecorators(context, namespace, config);
-        createMountAndVolumeDecorators(context, config);
-        createAppConfigVolumeAndEnvDecorators(context, config);
         createCommandDecorator(context, config, command);
         createArgsDecorator(context, config, command);
 
@@ -628,46 +621,6 @@ public abstract class BaseKubeProcessor<P, C extends PlatformConfiguration> {
         });
 
         config.workingDir().ifPresent(w -> context.add(new ApplyWorkingDirDecorator(context.name, w)));
-    }
-
-    private void createAppConfigVolumeAndEnvDecorators(DecoratorsContext context, C config) {
-        Set<String> paths = new HashSet<>();
-
-        config.appSecret().ifPresent(s -> {
-            context.add(new AddSecretVolumeDecorator(new SecretVolumeBuilder()
-                    .withSecretName(s)
-                    .withVolumeName("app-secret")
-                    .build()));
-            context.add(new AddMountDecorator(new MountBuilder()
-                    .withName("app-secret")
-                    .withPath("/mnt/app-secret")
-                    .build()));
-            paths.add("/mnt/app-secret");
-        });
-
-        config.appConfigMap().ifPresent(s -> {
-            context.add(new AddConfigMapVolumeDecorator(new ConfigMapVolumeBuilder()
-                    .withConfigMapName(s)
-                    .withVolumeName("app-config-map")
-                    .build()));
-            context.add(new AddMountDecorator(new MountBuilder()
-                    .withName("app-config-map")
-                    .withPath("/mnt/app-config-map")
-                    .build()));
-            paths.add("/mnt/app-config-map");
-        });
-
-        if (!paths.isEmpty()) {
-            context.add(new AddEnvVarDecorator(ApplicationContainerDecorator.ANY, context.name, new EnvBuilder()
-                    .withName("SMALLRYE_CONFIG_LOCATIONS")
-                    .withValue(String.join(",", paths))
-                    .build()));
-        }
-    }
-
-    private void createMountAndVolumeDecorators(DecoratorsContext context, C config) {
-        config.mounts().entrySet()
-                .forEach(e -> context.add(new AddMountDecorator(ANY, context.name, MountConverter.convert(e))));
     }
 
     private void createAnnotationDecorators(DecoratorsContext context, Optional<Project> project,

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ContainerConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ContainerConfig.java
@@ -8,6 +8,8 @@ import java.util.stream.Collectors;
 
 import io.dekorate.kubernetes.annotation.ImagePullPolicy;
 import io.dekorate.kubernetes.config.Env;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.EnvFromSource;
 import io.fabric8.kubernetes.api.model.EnvFromSourceBuilder;
 import io.fabric8.kubernetes.api.model.EnvVar;
@@ -143,5 +145,29 @@ public interface ContainerConfig extends EnvVarHolder {
                     return envFromBuilder.build();
                 })
                 .toList();
+    }
+
+    default Container toContainer(String name) {
+        final var b = new ContainerBuilder()
+                .withName(name)
+                .withImagePullPolicy(imagePullPolicy().name());
+        image().ifPresent(b::withImage);
+        workingDir().ifPresent(b::withWorkingDir);
+        command().ifPresent(b::withCommand);
+        arguments().ifPresent(b::withArgs);
+        if (readinessProbe() != null && readinessProbe().hasUserSuppliedAction()) {
+            b.withReadinessProbe(readinessProbe().toProbe(name));
+        }
+        if (livenessProbe() != null && livenessProbe().hasUserSuppliedAction()) {
+            b.withLivenessProbe(livenessProbe().toProbe(name));
+        }
+        b.addAllToEnv(getEnvVars());
+        b.addAllToEnvFrom(getEnvFroms());
+        b.addAllToPorts(ports().entrySet().stream().map(e -> e.getValue().toContainerPort(e.getKey())).toList());
+        b.addAllToVolumeMounts(mounts().entrySet().stream().map(esm -> esm.getValue().toVolumeMount(esm.getKey())).toList());
+
+        resources().applyToContainer(b);
+
+        return b.build();
     }
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ContainerConverter.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ContainerConverter.java
@@ -4,8 +4,6 @@ import java.util.Map;
 
 import io.dekorate.kubernetes.config.Container;
 import io.dekorate.kubernetes.config.ContainerBuilder;
-import io.fabric8.kubernetes.api.model.ContainerFluent;
-import io.fabric8.kubernetes.api.model.Quantity;
 
 public class ContainerConverter {
 
@@ -40,64 +38,5 @@ public class ContainerConverter {
             b.withNewLimitResources(c.resources().limits().memory().orElse(null), c.resources().limits().cpu().orElse(null));
         }
         return b;
-    }
-
-    private static final String CPU = "cpu";
-    private static final String MEMORY = "memory";
-
-    public static io.fabric8.kubernetes.api.model.Container toKubeContainer(Map.Entry<String, ContainerConfig> e) {
-        final var b = new io.fabric8.kubernetes.api.model.ContainerBuilder();
-        final var name = e.getKey();
-        b.withName(name);
-        final var c = e.getValue();
-        b.withImagePullPolicy(c.imagePullPolicy().name());
-        c.image().ifPresent(b::withImage);
-        c.workingDir().ifPresent(b::withWorkingDir);
-        c.command().ifPresent(b::withCommand);
-        c.arguments().ifPresent(b::withArgs);
-        if (c.readinessProbe() != null && c.readinessProbe().hasUserSuppliedAction()) {
-            b.withReadinessProbe(ProbeConverter.toKubeProbe(name, c.readinessProbe()));
-        }
-        if (c.livenessProbe() != null && c.livenessProbe().hasUserSuppliedAction()) {
-            b.withLivenessProbe(ProbeConverter.toKubeProbe(name, c.livenessProbe()));
-        }
-        b.addAllToEnv(c.getEnvVars());
-        b.addAllToEnvFrom(c.getEnvFroms());
-        b.addAllToPorts(c.ports().entrySet().stream().map(PortConverter::toKubeContainerPort).toList());
-        b.addAllToVolumeMounts(c.mounts().entrySet().stream().map(MountConverter::toVolumeMount).toList());
-
-        setLimitsAndRequests(c.resources(), b);
-
-        return b.build();
-    }
-
-    public static void setLimitsAndRequests(ResourcesConfig c, io.fabric8.kubernetes.api.model.ContainerFluent<?> b) {
-        final var requests = c.requests();
-        var mem = requests.memory().orElse(null);
-        var cpu = requests.cpu().orElse(null);
-        if (mem != null || cpu != null) {
-            final var resources = b.withNewResources();
-            if (mem != null) {
-                resources.addToRequests(MEMORY, new Quantity(mem));
-            }
-            if (cpu != null) {
-                resources.addToRequests(CPU, new Quantity(cpu));
-            }
-            resources.endResources();
-        }
-
-        final var limits = c.limits();
-        mem = limits.memory().orElse(null);
-        cpu = limits.cpu().orElse(null);
-        if (mem != null || cpu != null) {
-            final var resources = b.editOrNewResources();
-            if (mem != null) {
-                resources.addToLimits(MEMORY, new Quantity(mem));
-            }
-            if (cpu != null) {
-                resources.addToLimits(CPU, new Quantity(cpu));
-            }
-            resources.endResources();
-        }
     }
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeProcessor.java
@@ -1,29 +1,18 @@
 package io.quarkus.kubernetes.deployment;
 
-import static io.quarkus.kubernetes.deployment.Constants.*;
+import static io.quarkus.kubernetes.deployment.Constants.KNATIVE;
 import static io.quarkus.kubernetes.spi.KubernetesDeploymentTargetBuildItem.DEFAULT_PRIORITY;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
-import io.dekorate.knative.decorator.AddConfigMapVolumeToRevisionDecorator;
 import io.dekorate.knative.decorator.AddHostAliasesToRevisionDecorator;
-import io.dekorate.knative.decorator.AddSecretVolumeToRevisionDecorator;
 import io.dekorate.knative.decorator.AddSidecarToRevisionDecorator;
 import io.dekorate.knative.decorator.ApplyServiceAccountToRevisionSpecDecorator;
-import io.dekorate.kubernetes.config.ConfigMapVolumeBuilder;
-import io.dekorate.kubernetes.config.EnvBuilder;
-import io.dekorate.kubernetes.config.MountBuilder;
 import io.dekorate.kubernetes.config.Port;
-import io.dekorate.kubernetes.config.SecretVolumeBuilder;
-import io.dekorate.kubernetes.decorator.AddEnvVarDecorator;
 import io.dekorate.kubernetes.decorator.AddImagePullSecretToServiceAccountDecorator;
 import io.dekorate.kubernetes.decorator.AddLabelDecorator;
-import io.dekorate.kubernetes.decorator.AddMountDecorator;
 import io.dekorate.kubernetes.decorator.AddServiceAccountResourceDecorator;
-import io.dekorate.kubernetes.decorator.ApplicationContainerDecorator;
 import io.quarkus.container.spi.ContainerImageInfoBuildItem;
 import io.quarkus.container.spi.ContainerImageLabelBuildItem;
 import io.quarkus.deployment.Capabilities;
@@ -192,7 +181,6 @@ public class KnativeProcessor extends BaseKubeProcessor<AddPortToKnativeConfig, 
         context.add(new ApplyHttpGetActionPortDecorator(name, null));
 
         //Add revision decorators
-        createAppConfigVolumeAndEnvDecorators(context);
         config.hostAliases().entrySet()
                 .forEach(e -> context.add(new AddHostAliasesToRevisionDecorator(name, HostAliasConverter.convert(e))));
         config.nodeSelector().ifPresent(n -> context.add(new AddNodeSelectorDecorator(name, n.key(), n.value())));
@@ -213,37 +201,5 @@ public class KnativeProcessor extends BaseKubeProcessor<AddPortToKnativeConfig, 
         });
 
         return context.decorators();
-    }
-
-    private void createAppConfigVolumeAndEnvDecorators(DecoratorsContext context) {
-        Set<String> paths = new HashSet<>();
-        config.appSecret().ifPresent(s -> {
-            context.add(new AddSecretVolumeToRevisionDecorator(new SecretVolumeBuilder()
-                    .withSecretName(s)
-                    .withVolumeName("app-secret")
-                    .build()));
-            context.add(new AddMountDecorator(new MountBuilder()
-                    .withName("app-secret")
-                    .withPath("/mnt/app-secret")
-                    .build()));
-            paths.add("/mnt/app-secret");
-        });
-
-        config.appConfigMap().ifPresent(s -> {
-            context.add(new AddConfigMapVolumeToRevisionDecorator(new ConfigMapVolumeBuilder()
-                    .withConfigMapName(s)
-                    .withVolumeName("app-config-map")
-                    .build()));
-            context.add(new AddMountDecorator(
-                    new MountBuilder().withName("app-config-map").withPath("/mnt/app-config-map").build()));
-            paths.add("/mnt/app-config-map");
-        });
-
-        if (!paths.isEmpty()) {
-            context.add(new AddEnvVarDecorator(ApplicationContainerDecorator.ANY, context.name(), new EnvBuilder()
-                    .withName("SMALLRYE_CONFIG_LOCATIONS")
-                    .withValue(String.join(",", paths))
-                    .build()));
-        }
     }
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/MountConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/MountConfig.java
@@ -2,6 +2,8 @@ package io.quarkus.kubernetes.deployment;
 
 import java.util.Optional;
 
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import io.smallrye.config.WithDefault;
 
 public interface MountConfig {
@@ -25,4 +27,12 @@ public interface MountConfig {
      */
     @WithDefault("false")
     boolean readOnly();
+
+    default VolumeMount toVolumeMount(String name) {
+        VolumeMountBuilder b = new VolumeMountBuilder().withName(name);
+        path().ifPresent(b::withMountPath);
+        subPath().ifPresent(b::withSubPath);
+        b.withReadOnly(readOnly());
+        return b.build();
+    }
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/MountConverter.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/MountConverter.java
@@ -5,22 +5,11 @@ import java.util.Map;
 
 import io.dekorate.kubernetes.config.Mount;
 import io.dekorate.kubernetes.config.MountBuilder;
-import io.fabric8.kubernetes.api.model.VolumeMount;
-import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 
 public class MountConverter {
 
     public static Mount convert(Map.Entry<String, MountConfig> e) {
         return convert(e.getValue()).withName(e.getKey()).build();
-    }
-
-    public static VolumeMount toVolumeMount(Map.Entry<String, MountConfig> e) {
-        VolumeMountBuilder b = new VolumeMountBuilder().withName(e.getKey());
-        final var mount = e.getValue();
-        mount.path().ifPresent(b::withMountPath);
-        mount.subPath().ifPresent(b::withSubPath);
-        b.withReadOnly(mount.readOnly());
-        return b.build();
     }
 
     private static MountBuilder convert(MountConfig mount) {

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/PlatformConfiguration.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/PlatformConfiguration.java
@@ -21,6 +21,12 @@ import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
 
 public interface PlatformConfiguration extends EnvVarHolder {
+
+    String APP_SECRET = "app-secret";
+    String APP_SECRET_MOUNT_PATH = "/mnt/app-secret";
+    String APP_CONFIG_MAP = "app-config-map";
+    String APP_CONFIG_MAP_MOUNT_PATH = "/mnt/app-config-map";
+
     /**
      * The kind of the deployment resource to use.
      * Supported values are 'StatefulSet', 'Job', 'CronJob' and 'Deployment' defaulting to the latter.
@@ -320,21 +326,22 @@ public interface PlatformConfiguration extends EnvVarHolder {
         return DeploymentResourceKind.Deployment;
     }
 
-    default Collection<Volume> toKubeVolumes() {
+    default Collection<Volume> toVolumes() {
         List<Volume> volumes = new ArrayList<>();
+        appSecret().ifPresent(s -> volumes.add(new VolumeBuilder()
+                .withName(APP_SECRET).withNewSecret().withSecretName(s).endSecret()
+                .build()));
+        appConfigMap().ifPresent(c -> volumes.add(new VolumeBuilder()
+                .withName(APP_CONFIG_MAP).withNewConfigMap().withName(c).endConfigMap()
+                .build()));
+
         secretVolumes().forEach((k, v) -> volumes.add(v.toVolume(k)));
-
         configMapVolumes().forEach((k, v) -> volumes.add(v.toVolume(k)));
-
         emptyDirVolumes().ifPresent(v -> v.forEach(
                 e -> volumes.add(new VolumeBuilder().withName(e).withNewEmptyDir().endEmptyDir().build())));
-
         pvcVolumes().forEach((k, v) -> volumes.add(v.toVolume(k)));
-
         awsElasticBlockStoreVolumes().forEach((k, v) -> volumes.add(v.toVolume(k)));
-
         azureFileVolumes().forEach((k, v) -> volumes.add(v.toVolume(k)));
-
         azureDiskVolumes().forEach((k, v) -> volumes.add(v.toVolume(k)));
         return volumes;
     }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/PodSpecLike.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/PodSpecLike.java
@@ -1,7 +1,9 @@
 package io.quarkus.kubernetes.deployment;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -24,6 +26,9 @@ import io.fabric8.kubernetes.api.model.Volume;
  * @param <CF> the {@link ContainerFluent} subtype so that we can identify and initialize the main application container
  */
 interface PodSpecLike<C extends PlatformConfiguration, CF extends ContainerFluent<?>> {
+
+    String SMALLRYE_CONFIG_LOCATIONS = "SMALLRYE_CONFIG_LOCATIONS";
+
     Long getTerminationGracePeriodSeconds();
 
     void withTerminationGracePeriodSeconds(Long terminationGracePeriodSeconds);
@@ -67,7 +72,7 @@ interface PodSpecLike<C extends PlatformConfiguration, CF extends ContainerFluen
         final var container = createOrEditNamedContainer(name);
 
         // configure limits and requests
-        ContainerConverter.setLimitsAndRequests(config.resources(), container);
+        config.resources().applyToContainer(container);
 
         // configure application container with security options if present
         final var securityContext = config.securityContext();
@@ -80,6 +85,35 @@ interface PodSpecLike<C extends PlatformConfiguration, CF extends ContainerFluen
             containerSecContext.endSecurityContext();
         }
 
+        // volume mounts
+        final Set<String> paths = new HashSet<>();
+        config.appSecret().ifPresent(s -> {
+            container.removeMatchingFromVolumeMounts(m -> m.getName().equals(s));
+            container.addNewVolumeMount()
+                    .withName(PlatformConfiguration.APP_SECRET)
+                    .withMountPath(PlatformConfiguration.APP_SECRET_MOUNT_PATH)
+                    .endVolumeMount();
+            paths.add(PlatformConfiguration.APP_SECRET_MOUNT_PATH);
+        });
+
+        config.appConfigMap().ifPresent(s -> {
+            container.removeMatchingFromVolumeMounts(m -> m.getName().equals(s));
+            container.addNewVolumeMount()
+                    .withName(PlatformConfiguration.APP_CONFIG_MAP)
+                    .withMountPath(PlatformConfiguration.APP_CONFIG_MAP_MOUNT_PATH)
+                    .endVolumeMount();
+            paths.add(PlatformConfiguration.APP_CONFIG_MAP_MOUNT_PATH);
+        });
+
+        if (!paths.isEmpty()) {
+            container.addNewEnv().withName(SMALLRYE_CONFIG_LOCATIONS).withValue(String.join(",", paths)).endEnv();
+        }
+
+        config.mounts().forEach((k, v) -> {
+            container.removeMatchingFromVolumeMounts(m -> m.getName().equals(k));
+            container.addToVolumeMounts(v.toVolumeMount(k));
+        });
+
         if (containerCustomizer != null) {
             containerCustomizer.apply(container);
         }
@@ -88,7 +122,7 @@ interface PodSpecLike<C extends PlatformConfiguration, CF extends ContainerFluen
 
         configureMainApplicationPod(config);
 
-        addAllToVolumes(config.toKubeVolumes());
+        addAllToVolumes(config.toVolumes());
     }
 
     default void configureMainApplicationPod(C config) {

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/PortConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/PortConfig.java
@@ -4,6 +4,8 @@ import java.util.Optional;
 import java.util.OptionalInt;
 
 import io.dekorate.kubernetes.annotation.Protocol;
+import io.fabric8.kubernetes.api.model.ContainerPort;
+import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
 import io.smallrye.config.WithDefault;
 
 public interface PortConfig {
@@ -41,4 +43,13 @@ public interface PortConfig {
      */
     @WithDefault("false")
     boolean tls();
+
+    default ContainerPort toContainerPort(String name) {
+        final var b = new ContainerPortBuilder().withName(name);
+        containerPort().ifPresent(b::withContainerPort);
+        hostPort().ifPresent(b::withHostPort);
+        b.withProtocol(protocol().name());
+        // not sure how path and tls should be handled
+        return b.build();
+    }
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/PortConverter.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/PortConverter.java
@@ -4,22 +4,11 @@ import java.util.Map;
 
 import io.dekorate.kubernetes.config.Port;
 import io.dekorate.kubernetes.config.PortBuilder;
-import io.fabric8.kubernetes.api.model.ContainerPort;
-import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
 
 public class PortConverter {
 
     public static Port convert(Map.Entry<String, PortConfig> e) {
         return convert(e.getValue()).withName(e.getKey()).build();
-    }
-
-    public static ContainerPort toKubeContainerPort(Map.Entry<String, PortConfig> e) {
-        final var b = new ContainerPortBuilder().withName(e.getKey());
-        final var port = e.getValue();
-        port.containerPort().ifPresent(b::withContainerPort);
-        b.withProtocol(port.protocol().name());
-
-        return b.build();
     }
 
     private static PortBuilder convert(PortConfig port) {

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ProbeConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ProbeConfig.java
@@ -3,6 +3,8 @@ package io.quarkus.kubernetes.deployment;
 import java.time.Duration;
 import java.util.Optional;
 
+import io.fabric8.kubernetes.api.model.Probe;
+import io.fabric8.kubernetes.api.model.ProbeBuilder;
 import io.smallrye.config.WithDefault;
 
 public interface ProbeConfig {
@@ -86,5 +88,43 @@ public interface ProbeConfig {
     default boolean hasUserSuppliedAction() {
         return httpActionPath().isPresent() || tcpSocketAction().isPresent() || execAction().isPresent()
                 || grpcAction().isPresent();
+    }
+
+    default Probe toProbe(String name) {
+        final var b = new ProbeBuilder();
+        httpActionPath().ifPresent(path -> b.withNewHttpGet().withPath(path).endHttpGet());
+        execAction().ifPresent(cmd -> b.withNewExec().withCommand(cmd).endExec());
+        tcpSocketAction().ifPresent(socket -> {
+            var hostAndPort = HostAndPort.from(socket);
+            b.withNewTcpSocket().withHost(hostAndPort.host).withNewPort(hostAndPort.port).endTcpSocket();
+        });
+        if (grpcAction().isPresent()) {
+            b.withNewGrpc().withPort(Integer.parseInt(grpcAction().get())).endGrpc();
+        } else if (grpcActionEnabled()) {
+            b.withNewGrpc().withPort(ProbeConverter.getQuarkusGrpcPort()).withService(name).endGrpc();
+        }
+
+        b.withInitialDelaySeconds((int) initialDelay().getSeconds());
+        b.withPeriodSeconds((int) period().getSeconds());
+        b.withTimeoutSeconds((int) timeout().getSeconds());
+        b.withSuccessThreshold(successThreshold());
+        b.withFailureThreshold(failureThreshold());
+        return b.build();
+    }
+
+    record HostAndPort(String host, String port) {
+        static HostAndPort from(String hostAndPort) {
+            if (hostAndPort == null || hostAndPort.isEmpty()) {
+                return null;
+            }
+            int colon = hostAndPort.indexOf(':');
+            if (colon < 0) {
+                return null;
+            } else {
+                String host = hostAndPort.substring(0, colon);
+                String port = hostAndPort.substring(colon + 1);
+                return new HostAndPort(host, port);
+            }
+        }
     }
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ProbeConverter.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ProbeConverter.java
@@ -12,44 +12,6 @@ public class ProbeConverter {
         return builder(name, probe).build();
     }
 
-    public static io.fabric8.kubernetes.api.model.Probe toKubeProbe(String name, ProbeConfig probe) {
-        final var b = new io.fabric8.kubernetes.api.model.ProbeBuilder();
-        probe.httpActionPath().ifPresent(path -> b.withNewHttpGet().withPath(path).endHttpGet());
-        probe.execAction().ifPresent(cmd -> b.withNewExec().withCommand(cmd).endExec());
-        probe.tcpSocketAction().ifPresent(socket -> {
-            var hostAndPort = HostAndPort.from(socket);
-            b.withNewTcpSocket().withHost(hostAndPort.host).withNewPort(hostAndPort.port).endTcpSocket();
-        });
-        if (probe.grpcAction().isPresent()) {
-            b.withNewGrpc().withPort(Integer.parseInt(probe.grpcAction().get())).endGrpc();
-        } else if (probe.grpcActionEnabled()) {
-            b.withNewGrpc().withPort(getQuarkusGrpcPort()).withService(name).endGrpc();
-        }
-
-        b.withInitialDelaySeconds((int) probe.initialDelay().getSeconds());
-        b.withPeriodSeconds((int) probe.period().getSeconds());
-        b.withTimeoutSeconds((int) probe.timeout().getSeconds());
-        b.withSuccessThreshold(probe.successThreshold());
-        b.withFailureThreshold(probe.failureThreshold());
-        return b.build();
-    }
-
-    private record HostAndPort(String host, String port) {
-        static HostAndPort from(String hostAndPort) {
-            if (hostAndPort == null || hostAndPort.isEmpty()) {
-                return null;
-            }
-            int colon = hostAndPort.indexOf(':');
-            if (colon < 0) {
-                return null;
-            } else {
-                String host = hostAndPort.substring(0, colon);
-                String port = hostAndPort.substring(colon + 1);
-                return new HostAndPort(host, port);
-            }
-        }
-    }
-
     public static ProbeBuilder builder(String name, ProbeConfig probe) {
         ProbeBuilder b = new ProbeBuilder();
         probe.httpActionPath().ifPresent(b::withHttpActionPath);
@@ -69,7 +31,7 @@ public class ProbeConverter {
         return b;
     }
 
-    private static int getQuarkusGrpcPort() {
+    static int getQuarkusGrpcPort() {
         // TODO - Querying a runtime configuration during deployment
         return ConfigProvider.getConfig().getOptionalValue("quarkus.grpc.server.port", Integer.class)
                 .orElse(9000);

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ResourcesConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ResourcesConfig.java
@@ -2,6 +2,9 @@ package io.quarkus.kubernetes.deployment;
 
 import java.util.Optional;
 
+import io.fabric8.kubernetes.api.model.ContainerFluent;
+import io.fabric8.kubernetes.api.model.Quantity;
+
 public interface ResourcesConfig {
     /**
      * Limits Requirements
@@ -23,5 +26,38 @@ public interface ResourcesConfig {
          * Memory Requirements
          */
         Optional<String> memory();
+    }
+
+    String CPU = "cpu";
+    String MEMORY = "memory";
+
+    default void applyToContainer(ContainerFluent<?> container) {
+        final var requests = requests();
+        var mem = requests.memory().orElse(null);
+        var cpu = requests.cpu().orElse(null);
+        if (mem != null || cpu != null) {
+            final var resources = container.withNewResources();
+            if (mem != null) {
+                resources.addToRequests(MEMORY, new Quantity(mem));
+            }
+            if (cpu != null) {
+                resources.addToRequests(CPU, new Quantity(cpu));
+            }
+            resources.endResources();
+        }
+
+        final var limits = limits();
+        mem = limits.memory().orElse(null);
+        cpu = limits.cpu().orElse(null);
+        if (mem != null || cpu != null) {
+            final var resources = container.editOrNewResources();
+            if (mem != null) {
+                resources.addToLimits(MEMORY, new Quantity(mem));
+            }
+            if (cpu != null) {
+                resources.addToLimits(CPU, new Quantity(cpu));
+            }
+            resources.endResources();
+        }
     }
 }


### PR DESCRIPTION
VolumeMounts are now handled by PodSpecLike, while Secret/ConfigMap
mounts are handled in PlatformConfiguration.toVolumes where the other
Volumes are configured. Eventual goal is to remove the converters.
