### PR TITLE
Use Mode.RUN for the Gradle quarkusRun task to fix indexing crash

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusRun.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusRun.java
@@ -115,7 +115,7 @@ public abstract class QuarkusRun extends QuarkusBuildTask {
                 .setAppArtifact(appModel.getAppArtifact())
                 .setLocalProjectDiscovery(false)
                 .setIsolateDeployment(true)
-                .setMode(QuarkusBootstrap.Mode.TEST)
+                .setMode(QuarkusBootstrap.Mode.RUN)
                 .build().bootstrap()) {
 
             AugmentAction action = curatedApplication.createAugmentor();

--- a/integration-tests/gradle/pom.xml
+++ b/integration-tests/gradle/pom.xml
@@ -86,6 +86,10 @@
         <!-- START update-dependencies.sh -->
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-agroal</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
         </dependency>
         <dependency>
@@ -115,6 +119,10 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-orm-panache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm-rest-data-panache</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -158,6 +166,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-liquibase</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-reactive-pg-client</artifactId>
         </dependency>
         <dependency>
@@ -195,6 +207,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx-http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-agroal-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -289,6 +314,19 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm-rest-data-panache-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-reactive-panache-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
@@ -368,6 +406,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-kubernetes-client-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-liquibase-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/gradle/src/main/resources/quarkus-run-mode-panache-liquibase/build.gradle
+++ b/integration-tests/gradle/src/main/resources/quarkus-run-mode-panache-liquibase/build.gradle
@@ -1,0 +1,28 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+}
+
+repositories {
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+            includeGroup 'org.hibernate.orm'
+        }
+    }
+    mavenCentral()
+    gradlePluginPortal()
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-arc'
+    implementation 'io.quarkus:quarkus-rest'
+    implementation 'io.quarkus:quarkus-hibernate-orm-rest-data-panache'
+    implementation 'io.quarkus:quarkus-jdbc-h2'
+    implementation 'io.quarkus:quarkus-agroal'
+    implementation 'io.quarkus:quarkus-liquibase'
+}
+
+group 'org.acme'
+version '1.0.0-SNAPSHOT'

--- a/integration-tests/gradle/src/main/resources/quarkus-run-mode-panache-liquibase/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/quarkus-run-mode-panache-liquibase/gradle.properties
@@ -1,0 +1,2 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus

--- a/integration-tests/gradle/src/main/resources/quarkus-run-mode-panache-liquibase/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/quarkus-run-mode-panache-liquibase/settings.gradle
@@ -1,0 +1,16 @@
+pluginManagement {
+    repositories {
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+                includeGroup 'org.hibernate.orm'
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+      id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+rootProject.name = 'quarkus-run-mode-panache-liquibase'

--- a/integration-tests/gradle/src/main/resources/quarkus-run-mode-panache-liquibase/src/main/java/org/acme/GreetingResource.java
+++ b/integration-tests/gradle/src/main/resources/quarkus-run-mode-panache-liquibase/src/main/java/org/acme/GreetingResource.java
@@ -1,0 +1,16 @@
+package org.acme;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class GreetingResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "Hello from Quarkus REST...";
+    }
+}

--- a/integration-tests/gradle/src/main/resources/quarkus-run-mode-panache-liquibase/src/main/resources/application.properties
+++ b/integration-tests/gradle/src/main/resources/quarkus-run-mode-panache-liquibase/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:mem:test
+quarkus.hibernate-orm.database.generation=none
+quarkus.liquibase.migrate-at-start=false

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/run/QuarkusRunWithRestDataPanacheAndLiquibaseTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/run/QuarkusRunWithRestDataPanacheAndLiquibaseTest.java
@@ -1,0 +1,29 @@
+package io.quarkus.gradle.run;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.quarkus.gradle.devmode.QuarkusDevGradleTestBase;
+
+// Reproduces https://github.com/quarkusio/quarkus/issues/54001.
+// Despite extending QuarkusDevGradleTestBase, this test does not use dev mode,
+// but rather runs the application in production mode using the `quarkusRun` task.
+// The combination of `hibernate-orm-rest-data-panache` and `liquibase` triggered
+// the regression introduced when `quarkusRun` was bootstrapping the app with
+// `QuarkusBootstrap.Mode.TEST` (see #48950 and `46ce666581d` for the Maven-side fix).
+public class QuarkusRunWithRestDataPanacheAndLiquibaseTest extends QuarkusDevGradleTestBase {
+
+    @Override
+    protected String projectDirectoryName() {
+        return "quarkus-run-mode-panache-liquibase";
+    }
+
+    @Override
+    protected String[] buildArguments() {
+        return new String[] { "clean", "quarkusRun" };
+    }
+
+    @Override
+    protected void testDevMode() throws Exception {
+        assertThat(getHttpResponse("/hello")).contains("Hello from Quarkus REST...");
+    }
+}


### PR DESCRIPTION
When the Gradle `quarkusRun` task bootstraps an application, it currently sets `QuarkusBootstrap.Mode.TEST`. That activates `ArcTestSteps` (gated on `onlyIf = IsTest.class`), which registers an `AdditionalBeanBuildItem` for `io.quarkus.test.ActivateSessionContext`. That class lives only in `quarkus-test-common`, which is not on the deployment classpath of `quarkusRun`, so the build fails:

```
Failed to index: io.quarkus.test.ActivateSessionContext, class not present in class loader: QuarkusClassLoader:Deployment Class Loader: TEST
```

The bug appears whenever a project combines extensions that pull `AdditionalBeanBuildItem` consumers into the `RunCommandActionResultBuildItem` graph — for example `hibernate-orm-rest-data-panache` together with `liquibase`. The Maven side already addressed this in 46ce666 (#48950 — "Make quarkus:run a proper launch mode") by switching `RunMojo` to `Mode.RUN`; the Gradle plugin was not updated in that change.

Downstream impact has already been seen in production: Apache Polaris had to switch their `gradlew run` convenience task from `quarkusRun` to `quarkusDev` (apache/polaris#4390) to work around this issue.

`Mode.RUN` now properly supports DevServices via `IsDevServicesSupportedByLaunchMode`, so the original rationale for forcing `Mode.TEST` (DevServices wiring) no longer applies.

The new integration test exercises the same dependency combination reported in #48950 and confirms `quarkusRun` starts cleanly with `Profile prod activated`.

- Fixes: #54001