### PR TITLE
Add compatibility constructors for downstream consumers

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/GeneratedClassGizmo2Adaptor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/GeneratedClassGizmo2Adaptor.java
@@ -30,6 +30,13 @@ public class GeneratedClassGizmo2Adaptor implements ClassOutput {
         this.applicationClassPredicate = ignored -> applicationClass;
     }
 
+    @Deprecated
+    public GeneratedClassGizmo2Adaptor(BuildProducer<GeneratedClassBuildItem> generatedClasses,
+            final BuildProducer<GeneratedResourceBuildItem> generatedResources,
+            boolean applicationClass) {
+        this(generatedClasses, generatedResources, null, applicationClass);
+    }
+
     public GeneratedClassGizmo2Adaptor(BuildProducer<GeneratedClassBuildItem> generatedClasses,
             BuildProducer<GeneratedResourceBuildItem> generatedResources,
             BuildProducer<GeneratedServiceProviderBuildItem> generatedServiceProviders,
@@ -38,6 +45,13 @@ public class GeneratedClassGizmo2Adaptor implements ClassOutput {
         this.generatedResources = generatedResources;
         this.generatedServiceProviders = generatedServiceProviders;
         this.applicationClassPredicate = applicationClassPredicate;
+    }
+
+    @Deprecated
+    public GeneratedClassGizmo2Adaptor(BuildProducer<GeneratedClassBuildItem> generatedClasses,
+            final BuildProducer<GeneratedResourceBuildItem> generatedResources,
+            Predicate<String> applicationClassPredicate) {
+        this(generatedClasses, generatedResources, null, applicationClassPredicate);
     }
 
     public GeneratedClassGizmo2Adaptor(BuildProducer<GeneratedClassBuildItem> generatedClasses,
@@ -53,6 +67,13 @@ public class GeneratedClassGizmo2Adaptor implements ClassOutput {
                 return isApplicationClass(generatedToBaseNameFunction.apply(s));
             }
         };
+    }
+
+    @Deprecated
+    public GeneratedClassGizmo2Adaptor(BuildProducer<GeneratedClassBuildItem> generatedClasses,
+            final BuildProducer<GeneratedResourceBuildItem> generatedResources,
+            Function<String, String> generatedToBaseNameFunction) {
+        this(generatedClasses, generatedResources, null, generatedToBaseNameFunction);
     }
 
     @Override


### PR DESCRIPTION
This is an urgent fix for #53699, which broke downstream consumers of `GeneratedClassGizmo2Adaptor` which were merged after the original authorship of the PR.