### PR TITLE
Add types of programmatic constraint mappings to validator config

### DIFF
--- a/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/validatorfactory/ValidatorFactoryCustomizerCascadedConstraintTest.java
+++ b/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/validatorfactory/ValidatorFactoryCustomizerCascadedConstraintTest.java
@@ -1,0 +1,79 @@
+package io.quarkus.hibernate.validator.test.validatorfactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.validation.ValidatorFactory;
+
+import org.hibernate.validator.BaseHibernateValidatorConfiguration;
+import org.hibernate.validator.cfg.ConstraintMapping;
+import org.hibernate.validator.cfg.defs.NotBlankDef;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.validator.ValidatorFactoryCustomizer;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class ValidatorFactoryCustomizerCascadedConstraintTest {
+
+    @Inject
+    ValidatorFactory validatorFactory;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest().setArchiveProducer(() -> ShrinkWrap
+            .create(JavaArchive.class)
+            .addClasses(CascadeConstraintValidatorFactoryCustomizer.class, FooService.class));
+
+    @Test
+    public void testCascadedConstraintValidatorFactoryCustomizer() {
+        assertThat(validatorFactory.getValidator().validate(new Foo("", new Bar("")))).hasSize(2);
+    }
+
+    static class Foo {
+        public String string;
+        public Bar bar;
+
+        public Foo(String string, Bar bar) {
+            this.string = string;
+            this.bar = bar;
+        }
+    }
+
+    static class Bar {
+        public String string;
+
+        public Bar(String string) {
+            this.string = string;
+        }
+    }
+
+    @ApplicationScoped
+    public static class CascadeConstraintValidatorFactoryCustomizer implements
+            ValidatorFactoryCustomizer {
+
+        @Override
+        public void customize(BaseHibernateValidatorConfiguration<?> configuration) {
+            ConstraintMapping constraintMapping = configuration.createConstraintMapping();
+            constraintMapping
+                    .type(Foo.class)
+                    .field("string").constraint(new NotBlankDef())
+                    .field("bar").valid()
+                    .type(Bar.class)
+                    .field("string")
+                    .constraint(new NotBlankDef());
+            configuration.addMapping(constraintMapping);
+        }
+    }
+
+    @ApplicationScoped
+    public static class FooService {
+        public Foo foo(@Valid Foo foo) {
+            return foo;
+        }
+    }
+
+}

--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/HibernateValidatorRecorder.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/HibernateValidatorRecorder.java
@@ -29,6 +29,7 @@ import jakarta.validation.valueextraction.ValueExtractor;
 import org.hibernate.validator.HibernateValidatorFactory;
 import org.hibernate.validator.PredefinedScopeHibernateValidator;
 import org.hibernate.validator.PredefinedScopeHibernateValidatorConfiguration;
+import org.hibernate.validator.internal.engine.AbstractConfigurationImpl;
 import org.hibernate.validator.spi.messageinterpolation.LocaleResolver;
 import org.hibernate.validator.spi.nodenameprovider.PropertyNodeNameProvider;
 import org.hibernate.validator.spi.properties.GetterPropertySelectionStrategy;
@@ -109,11 +110,7 @@ public class HibernateValidatorRecorder {
                     configuration.localeResolver(localeResolver);
                 }
 
-                // Filter out classes with incomplete hierarchy
-                filterIncompleteClasses(classesToBeValidated);
-
                 configuration.builtinConstraints(detectedBuiltinConstraints)
-                        .initializeBeanMetaData(classesToBeValidated)
                         // Locales, Locale ROOT means all locales in this setting.
                         .locales(localesBuildTimeConfig.locales().contains(Locale.ROOT) ? Set.of(Locale.getAvailableLocales())
                                 : localesBuildTimeConfig.locales())
@@ -215,9 +212,14 @@ public class HibernateValidatorRecorder {
                 for (ValidatorFactoryCustomizer validatorFactoryCustomizer : validatorFactoryCustomizers) {
                     validatorFactoryCustomizer.customize(configuration);
                 }
-
+                if (configuration instanceof AbstractConfigurationImpl<?> configurationWithProgrammaticMappings) {
+                    configurationWithProgrammaticMappings.getProgrammaticMappings()
+                            .forEach(mapping -> classesToBeValidated.addAll(mapping.getConfiguredTypes()));
+                }
+                // Filter out classes with incomplete hierarchy
+                filterIncompleteClasses(classesToBeValidated);
+                configuration.initializeBeanMetaData(classesToBeValidated);
                 ValidatorFactory validatorFactory = configuration.buildValidatorFactory();
-
                 return validatorFactory.unwrap(HibernateValidatorFactory.class);
             }
 

--- a/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/HibernateValidatorTestResource.java
+++ b/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/HibernateValidatorTestResource.java
@@ -48,6 +48,7 @@ import io.quarkus.it.hibernate.validator.injection.InjectedConstraintValidatorCo
 import io.quarkus.it.hibernate.validator.injection.InjectedRuntimeConstraintValidatorConstraint;
 import io.quarkus.it.hibernate.validator.injection.MyService;
 import io.quarkus.it.hibernate.validator.orm.TestEntity;
+import io.quarkus.it.hibernate.validator.programmatic.ValidationServiceBasedOnProgrammaticConstraints;
 import io.quarkus.it.hibernate.validator.xml.ValidationServiceBasedOnXmlConstraints;
 import io.quarkus.runtime.StartupEvent;
 
@@ -67,6 +68,9 @@ public class HibernateValidatorTestResource
 
     @Inject
     ValidationServiceBasedOnXmlConstraints validationServiceBasedOnXmlConstraints;
+
+    @Inject
+    ValidationServiceBasedOnProgrammaticConstraints validationServiceBasedOnProgrammaticConstraints;
 
     @Inject
     ZipCodeService zipCodeResource;
@@ -352,6 +356,17 @@ public class HibernateValidatorTestResource
         ResultBuilder result = new ResultBuilder();
 
         result.append(formatViolations(validationServiceBasedOnXmlConstraints.validateSomeMyXmlBean()));
+
+        return result.build();
+    }
+
+    @GET
+    @Path("/constraints-defined-programmatically")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String testConstraintsDefinedProgrammatically() {
+        ResultBuilder result = new ResultBuilder();
+
+        result.append(formatViolations(validationServiceBasedOnProgrammaticConstraints.validateSomeMyProgrammaticBean()));
 
         return result.build();
     }

--- a/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/programmatic/MyProgrammaticBean.java
+++ b/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/programmatic/MyProgrammaticBean.java
@@ -1,0 +1,20 @@
+package io.quarkus.it.hibernate.validator.programmatic;
+
+public class MyProgrammaticBean {
+    String string;
+
+    NestedBean nestedBean;
+
+    public MyProgrammaticBean(String string, NestedBean nestedBean) {
+        this.string = string;
+        this.nestedBean = nestedBean;
+    }
+
+    public static class NestedBean {
+        public String string;
+
+        public NestedBean(String string) {
+            this.string = string;
+        }
+    }
+}

--- a/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/programmatic/MyProgrammaticBeanValidatorCustomizer.java
+++ b/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/programmatic/MyProgrammaticBeanValidatorCustomizer.java
@@ -1,0 +1,28 @@
+package io.quarkus.it.hibernate.validator.programmatic;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.hibernate.validator.BaseHibernateValidatorConfiguration;
+import org.hibernate.validator.cfg.ConstraintMapping;
+import org.hibernate.validator.cfg.defs.NotBlankDef;
+
+import io.quarkus.hibernate.validator.ValidatorFactoryCustomizer;
+import io.quarkus.it.hibernate.validator.programmatic.MyProgrammaticBean.NestedBean;
+
+@ApplicationScoped
+public class MyProgrammaticBeanValidatorCustomizer implements
+        ValidatorFactoryCustomizer {
+
+    @Override
+    public void customize(BaseHibernateValidatorConfiguration<?> configuration) {
+        ConstraintMapping constraintMapping = configuration.createConstraintMapping();
+        constraintMapping
+                .type(MyProgrammaticBean.class)
+                .field("string").constraint(new NotBlankDef())
+                .field("nestedBean").valid()
+                .type(NestedBean.class)
+                .field("string")
+                .constraint(new NotBlankDef());
+        configuration.addMapping(constraintMapping);
+    }
+}

--- a/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/programmatic/ValidationServiceBasedOnProgrammaticConstraints.java
+++ b/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/programmatic/ValidationServiceBasedOnProgrammaticConstraints.java
@@ -1,0 +1,21 @@
+package io.quarkus.it.hibernate.validator.programmatic;
+
+import java.util.Set;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+
+import io.quarkus.it.hibernate.validator.programmatic.MyProgrammaticBean.NestedBean;
+
+@ApplicationScoped
+public class ValidationServiceBasedOnProgrammaticConstraints {
+
+    @Inject
+    Validator validator;
+
+    public Set<ConstraintViolation<MyProgrammaticBean>> validateSomeMyProgrammaticBean() {
+        return validator.validate(new MyProgrammaticBean("", new NestedBean("")));
+    }
+}

--- a/integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
+++ b/integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
@@ -554,4 +554,17 @@ public class HibernateValidatorFunctionalityTest {
                         containsString("id (must be greater than 0)"),
                         containsString("name (must not be null)"));
     }
+
+    @Test
+    void testConstraintsDefinedProgrammatically() {
+        RestAssured.given()
+                .when()
+                .get("/hibernate-validator/test/constraints-defined-programmatically")
+                .then()
+                .statusCode(200)
+                .body(containsString("failed"),
+                        containsString("string (must not be blank)"),
+                        containsString("nestedBean.string (must not be blank)"));
+    }
+
 }

--- a/integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
+++ b/integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
@@ -552,4 +552,17 @@ public class HibernateValidatorFunctionalityTest {
                         containsString("id (must be greater than 0)"),
                         containsString("name (must not be null)"));
     }
+
+    @Test
+    void testConstraintsDefinedProgrammatically() {
+        RestAssured.given()
+                .when()
+                .get("/hibernate-validator/test/constraints-defined-programmatically")
+                .then()
+                .statusCode(200)
+                .body(containsString("failed"),
+                        containsString("string (must not be blank)"),
+                        containsString("nestedBean.string (must not be blank)"));
+    }
+
 }


### PR DESCRIPTION
* Fixes #54252

When defining programmatic constraint mappings, the `DefaultConstraintMapping.configuredTypes` need to be added to the `classesToBeValidated`, to properly support programmatic constraints with cascaded validations (see `ValidatorFactoryCustomizerCascadedConstraintTest`)
