### PR TITLE
Support TLS and mTLS with PKCS11 keystores and truststores

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/TlsUtils.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/TlsUtils.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.vertx.http.runtime.CertificateConfig;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.net.KeyCertOptions;
@@ -61,6 +62,10 @@ public class TlsUtils {
 
         if (singleTrustStoreFile != null) { // We have a single trust store file.
             String type = getTruststoreType(singleTrustStoreFile, certificates.trustStoreFileType());
+            if (singleTrustStoreFile.toString().equals("none") && !type.equalsIgnoreCase("PKCS11")) {
+                throw new ConfigurationException(
+                        "Truststore file property can only be set to 'none' when a truststore file type is PKCS11");
+            }
             if (type.equalsIgnoreCase("pem")) {
                 byte[] cert = getFileContent(singleTrustStoreFile);
                 return new PemTrustOptions()
@@ -158,11 +163,19 @@ public class TlsUtils {
     private static KeyStoreOptions createKeyStoreOptions(Path path, Optional<String> password, String type,
             Optional<String> provider, Optional<String> alias,
             Optional<String> aliasPassword) throws IOException {
-        byte[] data = getFileContent(path);
+        Buffer value;
+        if (path.toString().equals("none")) {
+            if (!type.equalsIgnoreCase("PKCS11")) {
+                throw new ConfigurationException(
+                        "Keystore file property can only be set to 'none' when a keystore file type is PKCS11");
+            }
+            value = null;
+        } else {
+            value = Buffer.buffer(getFileContent(path));
+        }
         return new KeyStoreOptions()
                 .setPassword(password.orElse(null))
-                .setValue(Buffer.buffer(data))
-                .setType(type.toUpperCase())
+                .setValue(value).setType(type.toUpperCase())
                 .setProvider(provider.orElse(null))
                 .setAlias(alias.orElse(null))
                 .setAliasPassword(aliasPassword.orElse(null));

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/options/TlsUtilsTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/options/TlsUtilsTest.java
@@ -1,15 +1,28 @@
 package io.quarkus.vertx.http.runtime.options;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Optional;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+
+import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.vertx.http.runtime.CertificateConfig;
+import io.vertx.core.net.KeyStoreOptions;
+import io.vertx.core.net.TrustOptions;
 
 class TlsUtilsTest {
 
@@ -35,6 +48,7 @@ class TlsUtilsTest {
             "server.keystore.key, JKS, JKS",
             "server.keystore.pom, PeM, PEM",
             "server.keystore.ca, null, null", // .ca is a truststore file
+            "none, pkcs11, PKCS11",
     })
     void testKeyStoreTypeDetection(String file, String userType, String expectedType) {
         Path path = new File("target/certs/" + file).toPath();
@@ -70,6 +84,8 @@ class TlsUtilsTest {
             "server.truststore.pom, PeM, PEM",
             "server.keystore.ca, null, PEM",
             "server.keystore.key, null, null", // .key is a key file
+            "none, pem, PEM", // Failure expected
+            "none, jks, JKS" // Failure expected
     })
     void testTrustStoreTypeDetection(String file, String userType, String expectedType) {
         Path path = new File("target/certs/" + file).toPath();
@@ -81,6 +97,81 @@ class TlsUtilsTest {
         } else {
             assertEquals(expectedType.toLowerCase(), TlsUtils.getTruststoreType(path, type));
         }
+    }
+
+    @Test
+    void testCreateKeyStoreOptionsPKCS11()
+            throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException {
+        String type = "PKCS11";
+        String password = "quarkus-pkcs11-pw";
+        String alias = "quarkus-pkcs11-alias";
+        Method createKeyStoreOptions = TlsUtils.class.getDeclaredMethod("createKeyStoreOptions", Path.class, Optional.class,
+                String.class, Optional.class, Optional.class, Optional.class);
+        createKeyStoreOptions.setAccessible(true);
+        KeyStoreOptions kso = (KeyStoreOptions) createKeyStoreOptions.invoke(null, Paths.get("none"),
+                Optional.of(password), type, Optional.of("SunPKCS11"), Optional.of(alias),
+                Optional.empty());
+        assertNotNull(kso);
+        assertEquals(null, kso.getValue());
+        assertEquals(type, kso.getType());
+        assertEquals(alias, kso.getAlias());
+    }
+
+    @Test
+    void testPKCS11KeyStoreConfigException()
+            throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException {
+        String type = "pkcs12";
+        String password = "quarkus-pkcs11-pw";
+        String alias = "quarkus-pkcs11-alias";
+        String pathString = "none";
+        Method createKeyStoreOptions = TlsUtils.class.getDeclaredMethod("createKeyStoreOptions", Path.class, Optional.class,
+                String.class, Optional.class, Optional.class, Optional.class);
+        createKeyStoreOptions.setAccessible(true);
+
+        Exception exception = assertThrows(InvocationTargetException.class, () -> {
+            createKeyStoreOptions.invoke(null, Paths.get(pathString),
+                    Optional.of(password), type, Optional.of("SunPKCS11"), Optional.of(alias),
+                    Optional.empty());
+        });
+
+        String expectedMessage = "Keystore file property can only be set to 'none' when a keystore file type is PKCS11";
+        assertEquals(ConfigurationException.class, exception.getCause().getClass());
+        assertTrue(exception.getCause().getMessage().contains(expectedMessage));
+    }
+
+    @Test
+    void testComputeTrustOptionsPKCS11() throws IOException {
+        String type = "PKCS11";
+        String password = "quarkus-pkcs11-pw";
+        String alias = "quarkus-pkcs11-alias";
+        String pathString = "none";
+        CertificateConfig config = mock(CertificateConfig.class);
+
+        when(config.trustStoreFile()).thenReturn(Optional.of(Paths.get(pathString)));
+        when(config.trustStoreFileType()).thenReturn(Optional.of(type));
+        when(config.keyStoreAlias()).thenReturn(Optional.of(alias));
+        TrustOptions to = TlsUtils.computeTrustOptions(config, Optional.of(password));
+        assertNotNull(to);
+    }
+
+    @Test
+    void testPKCS11TrustStoreConfigException() throws IOException {
+        String type = "pkcs12";
+        String password = "quarkus-pkcs11-pw";
+        String alias = "quarkus-pkcs11-alias";
+        String pathString = "none";
+        CertificateConfig config = mock(CertificateConfig.class);
+
+        when(config.trustStoreFile()).thenReturn(Optional.of(Paths.get(pathString)));
+        when(config.trustStoreFileType()).thenReturn(Optional.of(type));
+        when(config.keyStoreAlias()).thenReturn(Optional.of(alias));
+        Exception exception = assertThrows(ConfigurationException.class, () -> {
+            TlsUtils.computeTrustOptions(config, Optional.of(password));
+        });
+
+        String expectedMessage = "Truststore file property can only be set to 'none' when a truststore file type is PKCS11";
+
+        assertTrue(exception.getMessage().contains(expectedMessage));
     }
 
 }


### PR DESCRIPTION
## Topic
Due to many benefits (unextractable Keys, Side-Channel-Protection etc.) it makes sense to use Hardware Security Modules to store Private Keys for TLS/mTLS . The goal of this PR is to provide KeyStores and TrustStores via PKCS11 for TLS and mTLS. 

## Implementation
Keystore and Truststore file locations must be set to "none" to point to HSM stores. The "none" value was chosen because [Java's keytool](https://docs.oracle.com/en/java/javase/25/docs/specs/man/keytool.html) also uses it: "If NONE is specified as the URL, then a null stream is passed to the KeyStore.load method. NONE should be specified if the keystore isn't file-based. For example, when the keystore resides on a hardware token device."

## Related PRs 
#54147 
#54221
[vert.x PR 6117](https://github.com/eclipse-vertx/vert.x/pull/6117)




cc: @sberyozkin 