### PR TITLE
Fix JSON logging excluded keys config ignoring nested fields

### DIFF
--- a/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/ConsoleJsonFormatterJsonProviderExcludedKeyTest.java
+++ b/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/ConsoleJsonFormatterJsonProviderExcludedKeyTest.java
@@ -26,13 +26,13 @@ public class ConsoleJsonFormatterJsonProviderExcludedKeyTest {
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withApplicationRoot((jar) -> jar
                     .addClasses(ConsoleJsonFormatterDefaultConfigTest.class, SequenceWritingProvider.class,
-                            NestedObjectProvider.class)
+                            NestedObjectProvider.class, NestedArrayProvider.class, DeeplyNestedObjectProvider.class)
                     .addAsResource(new StringAsset("""
                             quarkus.log.level=INFO
                             quarkus.log.console.enabled=true
                             quarkus.log.console.level=WARNING
                             quarkus.log.console.json.enabled=true
-                            quarkus.log.console.json.excluded-keys=sequence,metadata
+                            quarkus.log.console.json.excluded-keys=sequence,metadata,tags,context
                             """), "application.properties"));
 
     @Test
@@ -67,6 +67,27 @@ public class ConsoleJsonFormatterJsonProviderExcludedKeyTest {
         }
     }
 
+    @Test
+    public void excludedKeyIsFilteredForArray() throws Exception {
+        String line = getJsonFormatter().format(new LogRecord(Level.INFO, "Test message"));
+
+        JsonNode node = new ObjectMapper().readTree(line);
+        assertThat(node.has("tags")).isFalse();
+        assertThat(node.has("customfield")).isTrue();
+    }
+
+    @Test
+    public void excludedKeyIsFilteredForDeeplyNestedContent() throws Exception {
+        String line = getJsonFormatter().format(new LogRecord(Level.INFO, "Test message"));
+
+        JsonNode node = new ObjectMapper().readTree(line);
+        assertThat(node.has("context")).isFalse();
+        // nested keys inside the excluded object must not leak to the top level
+        assertThat(node.has("inner")).isFalse();
+        assertThat(node.has("deepkey")).isFalse();
+        assertThat(node.has("customfield")).isTrue();
+    }
+
     @ApplicationScoped
     public static class NestedObjectProvider implements JsonProvider {
 
@@ -77,6 +98,35 @@ public class ConsoleJsonFormatterJsonProviderExcludedKeyTest {
                     .add("version", "1.0")
                     .add("source", "test")
                     .endObject();
+        }
+    }
+
+    @ApplicationScoped
+    public static class NestedArrayProvider implements JsonProvider {
+
+        @Override
+        public void writeTo(JsonLogGenerator generator, ExtLogRecord record) throws Exception {
+            // "tags" is in excluded-keys — the entire array should be filtered
+            generator.startArray("tags")
+                    .add("env", "production")
+                    .add("region", "us-east-1")
+                    .endArray();
+            generator.add("customfield", "present");
+        }
+    }
+
+    @ApplicationScoped
+    public static class DeeplyNestedObjectProvider implements JsonProvider {
+
+        @Override
+        public void writeTo(JsonLogGenerator generator, ExtLogRecord record) throws Exception {
+            // "context" is in excluded-keys — all nested content must be absorbed, not leaked
+            generator.startObject("context")
+                    .startObject("inner")
+                    .add("deepkey", "value")
+                    .endObject()
+                    .endObject();
+            generator.add("customfield", "present");
         }
     }
 }

--- a/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/JsonFormatter.java
+++ b/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/JsonFormatter.java
@@ -325,6 +325,7 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
          * the short process name (e.g. {@code java}).
          */
         private final String processNameKey;
+        private int skippedDepth = 0;
 
         private FormatterJsonGenerator(final Generator delegate, final Set<String> excludedKeys,
                 final String stackTraceKeyToTrim, final String processNameKey) {
@@ -342,7 +343,7 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
 
         @Override
         public Generator add(final String key, final int value) throws Exception {
-            if (!excludedKeys.contains(key)) {
+            if (skippedDepth == 0 && !excludedKeys.contains(key)) {
                 delegate.add(key, value);
             }
             return this;
@@ -350,7 +351,7 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
 
         @Override
         public Generator add(final String key, final long value) throws Exception {
-            if (!excludedKeys.contains(key)) {
+            if (skippedDepth == 0 && !excludedKeys.contains(key)) {
                 delegate.add(key, value);
             }
             return this;
@@ -358,7 +359,7 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
 
         @Override
         public Generator add(final String key, final Map<String, ?> value) throws Exception {
-            if (!excludedKeys.contains(key)) {
+            if (skippedDepth == 0 && !excludedKeys.contains(key)) {
                 delegate.add(key, value);
             }
             return this;
@@ -366,7 +367,7 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
 
         @Override
         public Generator add(final String key, final String value) throws Exception {
-            if (!excludedKeys.contains(key)) {
+            if (skippedDepth == 0 && !excludedKeys.contains(key)) {
                 String actual = value;
                 // Strip the leading ": " that jboss's StackTraceFormatter prepends to the rendered
                 // stack trace string. Only applied to the specific key configured for this purpose.
@@ -386,25 +387,41 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
 
         @Override
         public Generator startObject(final String key) throws Exception {
-            delegate.startObject(key);
+            if (skippedDepth > 0 || excludedKeys.contains(key)) {
+                skippedDepth++;
+            } else {
+                delegate.startObject(key);
+            }
             return this;
         }
 
         @Override
         public Generator endObject() throws Exception {
-            delegate.endObject();
+            if (skippedDepth > 0) {
+                skippedDepth--;
+            } else {
+                delegate.endObject();
+            }
             return this;
         }
 
         @Override
         public Generator startArray(final String key) throws Exception {
-            delegate.startArray(key);
+            if (skippedDepth > 0 || excludedKeys.contains(key)) {
+                skippedDepth++;
+            } else {
+                delegate.startArray(key);
+            }
             return this;
         }
 
         @Override
         public Generator endArray() throws Exception {
-            delegate.endArray();
+            if (skippedDepth > 0) {
+                skippedDepth--;
+            } else {
+                delegate.endArray();
+            }
             return this;
         }
 


### PR DESCRIPTION
-

Note from @gsmet: if this gets backported at some point, we will also need to backport: https://github.com/quarkusio/quarkus/pull/54769