### PR TITLE
Allow upgrade of project with CQ bom (no Quarkus bom)

### DIFF
--- a/devtools/cli/src/test/java/io/quarkus/cli/CamelQuarkusBomUpdateTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CamelQuarkusBomUpdateTest.java
@@ -1,0 +1,86 @@
+package io.quarkus.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.devtools.testing.registry.client.TestRegistryClientBuilder;
+import io.quarkus.platform.tools.ToolsConstants;
+import picocli.CommandLine;
+
+/**
+ * Integration test for Camel Quarkus BOM recognition in the update command.
+ * Tests that projects using only the Camel Quarkus BOM (without quarkus-bom)
+ * can be properly updated.
+ */
+public class CamelQuarkusBomUpdateTest extends RegistryClientBuilderTestBase {
+
+    @BeforeAll
+    static void configureRegistryAndMavenRepo() {
+        // Configure a test registry with quarkus-camel-bom under io.quarkus.platform
+        // This matches the real-world setup where quarkus-camel-bom is published
+        // under io.quarkus.platform (same as quarkus-bom)
+        TestRegistryClientBuilder.newInstance()
+                .baseDir(registryConfigDir())
+                .newRegistry("registry.test.quarkus.io")
+                .newPlatform("io.quarkus.platform")
+                .newStream("999")
+                .newRelease(getCurrentQuarkusVersion())
+                .quarkusVersion(getCurrentQuarkusVersion())
+                .addCoreMember()
+                .alignPluginsOnQuarkusVersion()
+                .addDefaultCodestartExtensions()
+                .release()
+                .newMember(ToolsConstants.CAMEL_QUARKUS_BOM_ARTIFACT_ID)
+                .addExtension("org.apache.camel.quarkus", "camel-quarkus-core", getCurrentQuarkusVersion())
+                .addExtension("org.apache.camel.quarkus", "camel-quarkus-platform-http", getCurrentQuarkusVersion())
+                .registry()
+                .clientBuilder()
+                .build();
+    }
+
+    @Test
+    void testCamelQuarkusBomOnlyProjectCanBeUpdated() throws Exception {
+        final CliDriver.Result createResult = run(workDir(), "create", "app", "camel-quarkus-only");
+        assertThat(createResult.exitCode)
+                .withFailMessage("Expected OK return code. Got: " + createResult.exitCode + "\nOutput:\n" + createResult.stdout)
+                .isEqualTo(CommandLine.ExitCode.OK);
+        assertThat(createResult.stdout)
+                .withFailMessage("Expected confirmation that the project has been created." + createResult)
+                .contains("SUCCESS");
+
+        final Path projectDir = workDir().resolve("camel-quarkus-only");
+        final Path pomFile = projectDir.resolve("pom.xml");
+
+        // Modify pom.xml to simulate a Camel-only project (only camel-quarkus-bom, no quarkus-bom)
+        // This is the actual use case: projects that use ONLY camel-quarkus-bom
+        String pomContent = CliDriver.readFileAsString(pomFile);
+
+        // Change the platform artifact-id from quarkus-bom to quarkus-camel-bom
+        // Keep the group-id as io.quarkus.platform (which is where camel-quarkus-bom is actually published)
+        pomContent = pomContent.replace(
+                "<quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>",
+                "<quarkus.platform.artifact-id>quarkus-camel-bom</quarkus.platform.artifact-id>");
+
+        // Remove standard Quarkus dependencies that aren't in our test quarkus-camel-bom
+        // Keep only dependencies that our test BOM manages
+        pomContent = pomContent.replaceAll("(?s)<dependency>\\s*<groupId>io\\.quarkus</groupId>.*?</dependency>\\s*", "");
+        pomContent = pomContent.replaceAll("(?s)<dependency>\\s*<groupId>io\\.rest-assured</groupId>.*?</dependency>\\s*", "");
+
+        Files.writeString(pomFile, pomContent);
+
+        // The critical test: update command should work with quarkus-camel-bom
+        // Before fix #54315, this would fail with "The project state is missing the Quarkus platform BOM"
+        final CliDriver.Result updateResult = run(projectDir, "update", "-N");
+
+        assertThat(updateResult.getExitCode())
+                .withFailMessage("Update command should succeed with quarkus-camel-bom as the platform BOM. " +
+                        "Before fix #54315, this would fail with 'missing Quarkus platform BOM' error.")
+                .isEqualTo(0);
+    }
+
+}

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandler.java
@@ -225,10 +225,11 @@ public class UpdateProjectCommandHandler implements QuarkusCommandHandler {
         return updateJavaVersion;
     }
 
-    private static ArtifactCoords getProjectQuarkusPlatformBOM(ProjectState currentState) {
+    static ArtifactCoords getProjectQuarkusPlatformBOM(ProjectState currentState) {
         for (ArtifactCoords c : currentState.getPlatformBoms()) {
             if (c.getArtifactId().equals(ToolsConstants.DEFAULT_PLATFORM_BOM_ARTIFACT_ID)
-                    || c.getArtifactId().equals(ToolsConstants.UNIVERSE_PLATFORM_BOM_ARTIFACT_ID)) {
+                    || c.getArtifactId().equals(ToolsConstants.UNIVERSE_PLATFORM_BOM_ARTIFACT_ID)
+                    || c.getArtifactId().equals(ToolsConstants.CAMEL_QUARKUS_BOM_ARTIFACT_ID)) {
                 return c;
             }
         }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/tools/ToolsConstants.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/tools/ToolsConstants.java
@@ -13,6 +13,7 @@ public interface ToolsConstants {
     String DEFAULT_PLATFORM_BOM_GROUP_ID = IO_QUARKUS + ".platform";
     String DEFAULT_PLATFORM_BOM_ARTIFACT_ID = "quarkus-bom";
     String UNIVERSE_PLATFORM_BOM_ARTIFACT_ID = "quarkus-universe-bom";
+    String CAMEL_QUARKUS_BOM_ARTIFACT_ID = "quarkus-camel-bom";
 
     String PROP_QUARKUS_CORE_VERSION = "quarkus-core-version";
 

--- a/independent-projects/tools/devtools-common/src/test/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandlerTest.java
+++ b/independent-projects/tools/devtools-common/src/test/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandlerTest.java
@@ -1,0 +1,119 @@
+package io.quarkus.devtools.commands.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.devtools.project.state.ProjectState;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.platform.tools.ToolsConstants;
+
+class UpdateProjectCommandHandlerTest {
+
+    private static final String VERSION = "3.0.0";
+
+    @Test
+    void shouldRecognizeQuarkusBomAsPlatformBom() {
+        ProjectState state = projectStateWithBom(ToolsConstants.DEFAULT_PLATFORM_BOM_ARTIFACT_ID, VERSION);
+
+        ArtifactCoords result = UpdateProjectCommandHandler.getProjectQuarkusPlatformBOM(state);
+
+        assertRecognizedBom(result, ToolsConstants.DEFAULT_PLATFORM_BOM_ARTIFACT_ID, VERSION);
+    }
+
+    @Test
+    void shouldRecognizeUniverseBomAsPlatformBom() {
+        ProjectState state = projectStateWithBom(ToolsConstants.UNIVERSE_PLATFORM_BOM_ARTIFACT_ID, VERSION);
+
+        ArtifactCoords result = UpdateProjectCommandHandler.getProjectQuarkusPlatformBOM(state);
+
+        assertRecognizedBom(result, ToolsConstants.UNIVERSE_PLATFORM_BOM_ARTIFACT_ID, VERSION);
+    }
+
+    @Test
+    void shouldRecognizeCamelQuarkusBomAsPlatformBom() {
+        ProjectState state = projectStateWithBom(ToolsConstants.CAMEL_QUARKUS_BOM_ARTIFACT_ID, VERSION);
+
+        ArtifactCoords result = UpdateProjectCommandHandler.getProjectQuarkusPlatformBOM(state);
+
+        assertRecognizedBom(result, ToolsConstants.CAMEL_QUARKUS_BOM_ARTIFACT_ID, VERSION);
+    }
+
+    @Test
+    void shouldHandleMultiplePlatformBoms() {
+        ProjectState state = projectStateWithBoms(
+                ToolsConstants.DEFAULT_PLATFORM_BOM_ARTIFACT_ID,
+                ToolsConstants.CAMEL_QUARKUS_BOM_ARTIFACT_ID);
+
+        ArtifactCoords result = UpdateProjectCommandHandler.getProjectQuarkusPlatformBOM(state);
+
+        // Returns first recognized BOM (quarkus-bom in this case)
+        assertRecognizedBom(result, ToolsConstants.DEFAULT_PLATFORM_BOM_ARTIFACT_ID, VERSION);
+    }
+
+    @Test
+    void shouldRecognizeCamelBomWhenNoQuarkusBomPresent() {
+        // Main use case: Camel Quarkus projects that don't import quarkus-bom
+        ProjectState state = projectStateWithBom(ToolsConstants.CAMEL_QUARKUS_BOM_ARTIFACT_ID, "3.2.11.Final");
+
+        ArtifactCoords result = UpdateProjectCommandHandler.getProjectQuarkusPlatformBOM(state);
+
+        assertRecognizedBom(result, ToolsConstants.CAMEL_QUARKUS_BOM_ARTIFACT_ID, "3.2.11.Final");
+    }
+
+    @Test
+    void shouldReturnNullWhenNoRecognizedBomPresent() {
+        ProjectState state = projectStateWithBom("com.example", "some-other-bom", "1.0.0");
+
+        ArtifactCoords result = UpdateProjectCommandHandler.getProjectQuarkusPlatformBOM(state);
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void shouldReturnNullWhenNoPlatformBomsPresent() {
+        ProjectState state = ProjectState.builder().build();
+
+        ArtifactCoords result = UpdateProjectCommandHandler.getProjectQuarkusPlatformBOM(state);
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void shouldReturnFirstRecognizedBomRegardlessOfOrder() {
+        // Camel BOM first, Quarkus BOM second
+        ProjectState state = projectStateWithBoms(
+                ToolsConstants.CAMEL_QUARKUS_BOM_ARTIFACT_ID,
+                ToolsConstants.DEFAULT_PLATFORM_BOM_ARTIFACT_ID);
+
+        ArtifactCoords result = UpdateProjectCommandHandler.getProjectQuarkusPlatformBOM(state);
+
+        // Returns first recognized BOM (camel-quarkus-bom in this case)
+        assertRecognizedBom(result, ToolsConstants.CAMEL_QUARKUS_BOM_ARTIFACT_ID, VERSION);
+    }
+
+    private static ProjectState projectStateWithBom(String artifactId, String version) {
+        return projectStateWithBom(ToolsConstants.DEFAULT_PLATFORM_BOM_GROUP_ID, artifactId, version);
+    }
+
+    private static ProjectState projectStateWithBom(String groupId, String artifactId, String version) {
+        ProjectState.Builder builder = ProjectState.builder();
+        builder.addPlatformBom(ArtifactCoords.pom(groupId, artifactId, version));
+        return builder.build();
+    }
+
+    private static ProjectState projectStateWithBoms(String... artifactIds) {
+        ProjectState.Builder builder = ProjectState.builder();
+        for (String artifactId : artifactIds) {
+            builder.addPlatformBom(ArtifactCoords.pom(
+                    ToolsConstants.DEFAULT_PLATFORM_BOM_GROUP_ID, artifactId, VERSION));
+        }
+        return builder.build();
+    }
+
+    private static void assertRecognizedBom(ArtifactCoords result, String expectedArtifactId, String expectedVersion) {
+        assertThat(result).isNotNull();
+        assertThat(result.getArtifactId()).isEqualTo(expectedArtifactId);
+        assertThat(result.getVersion()).isEqualTo(expectedVersion);
+    }
+}


### PR DESCRIPTION
Done by allowing the Quarkus CLI update command to recognize and upgrade projects that use the Camel Quarkus BOM (quarkus-camel-bom) without requiring the main Quarkus BOM.
  Previously, the update logic only recognized quarkus-bom and quarkus-universe-bom as platform BOMs, causing update failures for Camel Quarkus-only projects. The fix adds quarkus-camel-bom
  to the list of recognized platform BOMs and includes comprehensive test coverage.

- Fixes: #54315