### PR TITLE
Disable the Kotlin compiler daemon

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -5,3 +5,4 @@
 -Daether.remoteRepositoryFilter.groupId=true
 -Daether.remoteRepositoryFilter.groupId.basedir=${session.rootDirectory}/.mvn/rrf/
 -Ddevelocity.scan.captureResourceUsage=false
+-Dkotlin.compiler.daemon=false


### PR DESCRIPTION
We don't have that many Kotlin sources that it's worth using the daemon, considering how much memory it ends up consuming.
