### PR TITLE
Scope Dev Services config to the current CuratedApplication instance

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesRegistryBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesRegistryBuildItem.java
@@ -1,6 +1,7 @@
 package io.quarkus.deployment.builditem;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -33,6 +34,9 @@ import io.quarkus.runtime.LaunchMode;
  */
 public final class DevServicesRegistryBuildItem extends SimpleBuildItem {
 
+    public record DevServicesStartResult(Map<String, String> configs, Map<String, String> overrideConfigs) {
+    }
+
     private static final Logger log = Logger.getLogger(DevServicesRegistryBuildItem.class);
 
     private final UUID uuid;
@@ -63,8 +67,13 @@ public final class DevServicesRegistryBuildItem extends SimpleBuildItem {
         RunningDevServicesRegistry.INSTANCE.closeAllRunningServices(owner);
     }
 
-    public void closeAllRunningServices() {
-        RunningDevServicesRegistry.INSTANCE.closeAllRunningServices(launchMode.name());
+    public void closeOwnRunningServices(String featureName, String configName) {
+        DevServiceOwner owner = new DevServiceOwner(featureName, launchMode.name(), configName);
+        RunningDevServicesRegistry.INSTANCE.closeOwnRunningServices(uuid, owner);
+    }
+
+    public void closeOwnRunningServices() {
+        RunningDevServicesRegistry.INSTANCE.closeOwnRunningServices(uuid, launchMode.name());
     }
 
     public void closeRemainingRunningServices(Collection<DevServicesResultBuildItem> services) {
@@ -82,28 +91,31 @@ public final class DevServicesRegistryBuildItem extends SimpleBuildItem {
         return config;
     }
 
-    public void startAll(Collection<DevServicesResultBuildItem> services,
+    public DevServicesStartResult startAll(Collection<DevServicesResultBuildItem> services,
             List<DevServicesCustomizerBuildItem> customizers,
             List<DevServicesAdditionalConfigBuildItem> additionalConfigBuildItems,
             ClassLoader deploymentClassLoader) {
         closeRemainingRunningServices(services);
         Map<String, String> config = new ConcurrentHashMap<>();
+        Map<String, String> overrideConfig = new ConcurrentHashMap<>();
         startSelectedServices(services, customizers, additionalConfigBuildItems, deploymentClassLoader,
-                dr -> !dr.hasDependencies(), config);
+                dr -> !dr.hasDependencies(), config, overrideConfig);
 
         // Now start everything with a dependency
         // This won't handle the case where the dependencies also have dependencies, but that can be a follow-on work item if people ask for it
         // I think we could implement it by getting the actual dependencies and seeing if any of them are also in the list of things we're starting, and then recursing
         startSelectedServices(services, customizers, additionalConfigBuildItems, deploymentClassLoader,
-                DevServicesResultBuildItem::hasDependencies, config);
+                DevServicesResultBuildItem::hasDependencies, config, overrideConfig);
 
+        return new DevServicesStartResult(Collections.unmodifiableMap(config),
+                Collections.unmodifiableMap(overrideConfig));
     }
 
     private void startSelectedServices(Collection<DevServicesResultBuildItem> services,
             List<DevServicesCustomizerBuildItem> customizers,
             List<DevServicesAdditionalConfigBuildItem> additionalConfigBuildItems,
             ClassLoader deploymentClassLoader, Predicate<? super DevServicesResultBuildItem> filter,
-            Map<String, String> config) {
+            Map<String, String> config, Map<String, String> overrideConfig) {
         // TODO Note that this does not handle chained dependencies; dependencies can only be one level deep for now
         // It would be easy to fix that, but let's wait until we need to
         CompletableFuture.allOf(services.stream()
@@ -118,7 +130,7 @@ public final class DevServicesRegistryBuildItem extends SimpleBuildItem {
                         Thread.currentThread().setContextClassLoader(serv.getClass().getClassLoader());
                     }
                     try {
-                        this.start(serv, customizers, additionalConfigBuildItems, config);
+                        this.start(serv, customizers, additionalConfigBuildItems, config, overrideConfig);
                     } finally {
                         // Err on the side of caution and reset the TCCL to avoid leaks
                         Thread.currentThread().setContextClassLoader(orig);
@@ -128,22 +140,25 @@ public final class DevServicesRegistryBuildItem extends SimpleBuildItem {
     }
 
     public void start(DevServicesResultBuildItem request, List<DevServicesCustomizerBuildItem> customizers,
-            List<DevServicesAdditionalConfigBuildItem> additionalConfigBuildItems, Map<String, String> config) {
+            List<DevServicesAdditionalConfigBuildItem> additionalConfigBuildItems, Map<String, String> config,
+            Map<String, String> overrideConfig) {
         // RunningService class is loaded on parent classloader
         RunningService matchedDevService = this.getRunningServices(request.getName(), request.getServiceName(),
                 request.getServiceConfig());
 
         if (matchedDevService == null) {
-            // There isn't a running container that has the right config, we need to do work
-            // Let's get all the running dev services associated with this feature (+ launch mode plus named section), so we can close them
             closeAllRunningServices(request.getName(), request.getServiceName());
 
-            reallyStart(request, customizers, additionalConfigBuildItems, config);
+            reallyStart(request, customizers, additionalConfigBuildItems, config, overrideConfig);
+        } else {
+            config.putAll(matchedDevService.configs());
+            overrideConfig.putAll(matchedDevService.overrideConfigs());
         }
     }
 
     private void reallyStart(DevServicesResultBuildItem request, List<DevServicesCustomizerBuildItem> customizers,
-            List<DevServicesAdditionalConfigBuildItem> additionalConfigBuildItems, Map<String, String> allDevServicesConfig) {
+            List<DevServicesAdditionalConfigBuildItem> additionalConfigBuildItems, Map<String, String> allDevServicesConfig,
+            Map<String, String> allDevServicesOverrideConfigs) {
         StartupLogCompressor compressor = new StartupLogCompressor("Dev Services Startup", null, null);
         try {
             Supplier<Startable> startableSupplier = request.getStartableSupplier();
@@ -195,6 +210,7 @@ public final class DevServicesRegistryBuildItem extends SimpleBuildItem {
                 Map<String, String> currentDevServiceConfig = new HashMap<>();
                 currentDevServiceConfig.putAll(config);
                 currentDevServiceConfig.putAll(overrideConfig);
+                allDevServicesOverrideConfigs.putAll(overrideConfig);
 
                 for (DevServicesAdditionalConfigBuildItem additionalConfigBuildItem : additionalConfigBuildItems) {
                     Map<String, String> extraFromBuildItem = additionalConfigBuildItem.getConfigProvider()

--- a/core/deployment/src/main/java/io/quarkus/runner/bootstrap/StartupActionImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/runner/bootstrap/StartupActionImpl.java
@@ -339,10 +339,33 @@ public class StartupActionImpl implements StartupAction {
             if (deploymentClassLoader == null) {
                 throw new IllegalStateException("Dev services cannot be started without a deployment class loader.");
             }
-            devServicesRegistry.startAll(devServicesResults, devServicesCustomizers, additionalConfigBuildItems,
-                    deploymentClassLoader);
+            DevServicesRegistryBuildItem.DevServicesStartResult startResult = devServicesRegistry.startAll(
+                    devServicesResults, devServicesCustomizers, additionalConfigBuildItems, deploymentClassLoader);
 
-            devServicesProperties.putAll(devServicesRegistry.getConfigForAllRunningServices());
+            devServicesProperties.putAll(startResult.configs());
+            setDevServicesConfigSourceValues(startResult);
+        }
+    }
+
+    private void setDevServicesConfigSourceValues(DevServicesRegistryBuildItem.DevServicesStartResult startResult) {
+        try {
+            Class<?> configSourceClass = runtimeClassLoader
+                    .loadClass("io.quarkus.devservice.runtime.config.DevServicesConfigSource");
+            configSourceClass.getMethod("setConfig", Map.class).invoke(null, startResult.configs());
+        } catch (ClassNotFoundException e) {
+            // devservices runtime module not available
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Failed to set dev services config", e);
+        }
+
+        try {
+            Class<?> overrideConfigSourceClass = runtimeClassLoader
+                    .loadClass("io.quarkus.devservice.runtime.config.DevServicesOverrideConfigSource");
+            overrideConfigSourceClass.getMethod("setConfig", Map.class).invoke(null, startResult.overrideConfigs());
+        } catch (ClassNotFoundException e) {
+            // devservices runtime module not available
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Failed to set dev services override config", e);
         }
     }
 

--- a/core/runtime/src/main/java/io/quarkus/devservices/crossclassloader/runtime/RunningDevServicesRegistry.java
+++ b/core/runtime/src/main/java/io/quarkus/devservices/crossclassloader/runtime/RunningDevServicesRegistry.java
@@ -47,14 +47,19 @@ public final class RunningDevServicesRegistry {
         log.infof(e, "Failed to close dev service for %s in launch mode %s: %s", featureName, launchMode, containerId);
     }
 
-    public void closeAllRunningServices(String launchMode) {
+    public void closeOwnRunningServices(UUID uuid, String launchMode) {
+        Set<RunningService> services = servicesIndexedByLaunchMode.get(launchMode);
         Iterator<Map.Entry<ComparableDevServicesConfig, RunningService>> it = servicesIndexedByConfig.entrySet().iterator();
         while (it.hasNext()) {
             Map.Entry<ComparableDevServicesConfig, RunningService> next = it.next();
             DevServiceOwner owner = next.getKey().owner();
-            if (owner.launchMode().equals(launchMode)) {
+            UUID serviceAppUuid = next.getKey().applicationInstanceId();
+            if (owner.launchMode().equals(launchMode) && Objects.equals(serviceAppUuid, uuid)) {
                 it.remove();
                 RunningService service = next.getValue();
+                if (services != null) {
+                    services.remove(service);
+                }
                 try {
                     logClosing(owner.featureName(), launchMode, service.containerId());
                     service.close();
@@ -64,7 +69,6 @@ public final class RunningDevServicesRegistry {
                 }
             }
         }
-        servicesIndexedByLaunchMode.remove(launchMode);
     }
 
     public void closeRemainingRunningServices(UUID uuid, String launchMode, Collection<DevServiceOwner> ownersToKeep) {
@@ -104,10 +108,32 @@ public final class RunningDevServicesRegistry {
                     launchModeServices.remove(service);
                 }
                 try {
-                    logClosing(owner.featureName(), owner.featureName(), service.containerId());
+                    logClosing(owner.featureName(), owner.launchMode(), service.containerId());
                     service.close();
                 } catch (Exception e) {
-                    // We don't want to fail the shutdown hook if a service fails to close
+                    logFailedToClose(e, owner.featureName(), owner.launchMode(), service.containerId());
+                }
+            }
+        }
+    }
+
+    public void closeOwnRunningServices(UUID uuid, DevServiceOwner owner) {
+        Set<RunningService> launchModeServices = servicesIndexedByLaunchMode.get(owner.launchMode());
+        var iterator = servicesIndexedByConfig.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<ComparableDevServicesConfig, RunningService> entry = iterator.next();
+            DevServiceOwner entryOwner = entry.getKey().owner();
+            UUID serviceAppUuid = entry.getKey().applicationInstanceId();
+            if (Objects.equals(entryOwner, owner) && Objects.equals(serviceAppUuid, uuid)) {
+                iterator.remove();
+                RunningService service = entry.getValue();
+                if (launchModeServices != null) {
+                    launchModeServices.remove(service);
+                }
+                try {
+                    logClosing(owner.featureName(), owner.launchMode(), service.containerId());
+                    service.close();
+                } catch (Exception e) {
                     logFailedToClose(e, owner.featureName(), owner.launchMode(), service.containerId());
                 }
             }

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/DevServicesProcessor.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/DevServicesProcessor.java
@@ -194,7 +194,7 @@ public class DevServicesProcessor {
             CuratedApplicationShutdownBuildItem shutdownBuildItem) {
         DevServicesRegistryBuildItem registryBuildItem = new DevServicesRegistryBuildItem(applicationId.getUUID(),
                 devServicesConfig, launchMode.getLaunchMode());
-        shutdownBuildItem.addCloseTask(registryBuildItem::closeAllRunningServices, true);
+        shutdownBuildItem.addCloseTask(registryBuildItem::closeOwnRunningServices, true);
         return registryBuildItem;
     }
 

--- a/extensions/devservices/runtime/src/main/java/io/quarkus/devservice/runtime/config/DevServicesConfigBuilder.java
+++ b/extensions/devservices/runtime/src/main/java/io/quarkus/devservice/runtime/config/DevServicesConfigBuilder.java
@@ -1,6 +1,5 @@
 package io.quarkus.devservice.runtime.config;
 
-import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ConfigBuilder;
 import io.smallrye.config.SmallRyeConfigBuilder;
 
@@ -8,7 +7,7 @@ public class DevServicesConfigBuilder implements ConfigBuilder {
 
     @Override
     public SmallRyeConfigBuilder configBuilder(SmallRyeConfigBuilder builder) {
-        return builder.withSources(new DevServicesConfigSource(LaunchMode.current()));
+        return builder.withSources(new DevServicesConfigSource());
     }
 
     @Override

--- a/extensions/devservices/runtime/src/main/java/io/quarkus/devservice/runtime/config/DevServicesConfigSource.java
+++ b/extensions/devservices/runtime/src/main/java/io/quarkus/devservice/runtime/config/DevServicesConfigSource.java
@@ -1,50 +1,26 @@
 package io.quarkus.devservice.runtime.config;
 
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
 
-import io.quarkus.devservices.crossclassloader.runtime.RunningDevServicesRegistry;
-import io.quarkus.devservices.crossclassloader.runtime.RunningService;
-import io.quarkus.runtime.LaunchMode;
-
 public class DevServicesConfigSource implements ConfigSource {
 
-    private final LaunchMode launchMode;
+    private static volatile Map<String, String> config = Map.of();
 
-    public DevServicesConfigSource(LaunchMode launchMode) {
-        this.launchMode = launchMode;
+    public static void setConfig(Map<String, String> config) {
+        DevServicesConfigSource.config = config;
     }
 
     @Override
     public Set<String> getPropertyNames() {
-        Set<String> names = new HashSet<>();
-
-        Set<RunningService> allConfig = RunningDevServicesRegistry.INSTANCE.getAllRunningServices(launchMode.name());
-        if (allConfig != null) {
-            for (RunningService service : allConfig) {
-                Map<String, String> config = service.configs();
-                names.addAll(config.keySet());
-            }
-        }
-        return names;
+        return config.keySet();
     }
 
     @Override
     public String getValue(String propertyName) {
-        Set<RunningService> allConfig = RunningDevServicesRegistry.INSTANCE.getAllRunningServices(launchMode.name());
-        if (allConfig != null) {
-            for (RunningService service : allConfig) {
-                Map<String, String> config = service.configs();
-                String answer = config.get(propertyName);
-                if (answer != null) {
-                    return answer;
-                }
-            }
-        }
-        return null;
+        return config.get(propertyName);
     }
 
     @Override

--- a/extensions/devservices/runtime/src/main/java/io/quarkus/devservice/runtime/config/DevServicesOverrideConfigBuilder.java
+++ b/extensions/devservices/runtime/src/main/java/io/quarkus/devservice/runtime/config/DevServicesOverrideConfigBuilder.java
@@ -1,6 +1,5 @@
 package io.quarkus.devservice.runtime.config;
 
-import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ConfigBuilder;
 import io.smallrye.config.SmallRyeConfigBuilder;
 
@@ -12,7 +11,7 @@ public class DevServicesOverrideConfigBuilder implements ConfigBuilder {
 
     @Override
     public SmallRyeConfigBuilder configBuilder(SmallRyeConfigBuilder builder) {
-        return builder.withSources(new DevServicesOverrideConfigSource(LaunchMode.current()));
+        return builder.withSources(new DevServicesOverrideConfigSource());
     }
 
     @Override

--- a/extensions/devservices/runtime/src/main/java/io/quarkus/devservice/runtime/config/DevServicesOverrideConfigSource.java
+++ b/extensions/devservices/runtime/src/main/java/io/quarkus/devservice/runtime/config/DevServicesOverrideConfigSource.java
@@ -2,15 +2,10 @@ package io.quarkus.devservice.runtime.config;
 
 import static io.quarkus.runtime.configuration.ConfigSourceOrdinal.DEV_SERVICES_OVERRIDE;
 
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
-
-import io.quarkus.devservices.crossclassloader.runtime.RunningDevServicesRegistry;
-import io.quarkus.devservices.crossclassloader.runtime.RunningService;
-import io.quarkus.runtime.LaunchMode;
 
 /**
  * @deprecated Subject to changes due to <a href="https://github.com/quarkusio/quarkus/pull/51209">#51209</a>
@@ -18,40 +13,20 @@ import io.quarkus.runtime.LaunchMode;
 @Deprecated(forRemoval = true)
 public class DevServicesOverrideConfigSource implements ConfigSource {
 
-    private final LaunchMode launchMode;
+    private static volatile Map<String, String> config = Map.of();
 
-    public DevServicesOverrideConfigSource(LaunchMode launchMode) {
-        this.launchMode = launchMode;
+    public static void setConfig(Map<String, String> config) {
+        DevServicesOverrideConfigSource.config = config;
     }
 
     @Override
     public Set<String> getPropertyNames() {
-        // We could make this more efficient by not invoking the supplier on the other end, but it would need a more complex interface
-        Set<String> names = new HashSet<>();
-
-        Set<RunningService> allConfig = RunningDevServicesRegistry.INSTANCE.getAllRunningServices(launchMode.name());
-        if (allConfig != null) {
-            for (RunningService service : allConfig) {
-                Map<String, String> config = service.overrideConfigs();
-                names.addAll(config.keySet());
-            }
-        }
-        return names;
+        return config.keySet();
     }
 
     @Override
     public String getValue(String propertyName) {
-        Set<RunningService> allConfig = RunningDevServicesRegistry.INSTANCE.getAllRunningServices(launchMode.name());
-        if (allConfig != null) {
-            for (RunningService service : allConfig) {
-                Map<String, String> config = service.overrideConfigs();
-                String answer = config.get(propertyName);
-                if (answer != null) {
-                    return answer;
-                }
-            }
-        }
-        return null;
+        return config.get(propertyName);
     }
 
     @Override

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/NativeDevServicesHandler.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/NativeDevServicesHandler.java
@@ -33,8 +33,9 @@ public class NativeDevServicesHandler implements BiConsumer<Object, BuildResult>
         List<DevServicesAdditionalConfigBuildItem> additionalConfigBuildItems = buildResult
                 .consumeMulti(DevServicesAdditionalConfigBuildItem.class);
         if (devServicesRegistry != null) {
-            devServicesRegistry.startAll(devServices, customizers, additionalConfigBuildItems, null);
-            for (Map.Entry<String, String> entry : devServicesRegistry.getConfigForAllRunningServices().entrySet()) {
+            DevServicesRegistryBuildItem.DevServicesStartResult startResult = devServicesRegistry.startAll(devServices,
+                    customizers, additionalConfigBuildItems, null);
+            for (Map.Entry<String, String> entry : startResult.configs().entrySet()) {
                 propertyConsumer.accept(entry.getKey(), entry.getValue());
             }
         }


### PR DESCRIPTION
This is another one of @gsmet's changes from https://github.com/quarkusio/quarkus/pull/53656. It can be delivered as a standalone fix (and should be, because it fixes a situation where config leaks between subsequent profiles in test runs). I can't mark it as reviewed by me, because I'm raising the PR, but I do approve it.