### PR TITLE
Update Hibernate/Datasource deprecation documentation to reference config properties

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
@@ -91,7 +91,7 @@ public interface HibernateOrmConfigPersistenceUnit {
      *
      * `-1` means batch loading is disabled.
      *
-     * @deprecated {@link #fetch} should be used to configure fetching properties.
+     * @deprecated Use {@code quarkus.hibernate-orm.fetch.batch-size} to configure the batch fetch size.
      * @asciidoclet
      */
     @ConfigDocDefault("16")
@@ -103,7 +103,7 @@ public interface HibernateOrmConfigPersistenceUnit {
      *
      * A `0` disables default outer join fetching.
      *
-     * @deprecated {@link #fetch} should be used to configure fetching properties.
+     * @deprecated Use {@code quarkus.hibernate-orm.fetch.max-depth} to configure the maximum fetch depth.
      * @asciidoclet
      */
     @Deprecated
@@ -136,7 +136,8 @@ public interface HibernateOrmConfigPersistenceUnit {
      *
      * This setting is exposed mainly to allow registration of types, converters and SQL functions.
      * ====
-     * * @deprecated Use TypeContributor, FunctionContributor or AdditionalMappingContributor instead.
+     *
+     * @deprecated Use {@code TypeContributor}, {@code FunctionContributor}, or {@code AdditionalMappingContributor} instead.
      *
      * @asciidoclet
      */
@@ -229,7 +230,7 @@ public interface HibernateOrmConfigPersistenceUnit {
      * Defines the name of the datasource to use in case of SCHEMA approach. The datasource of the persistence unit will be used
      * if not set.
      *
-     * @deprecated Use {@link #datasource()} instead.
+     * @deprecated Use {@code quarkus.hibernate-orm.datasource} to configure the datasource for the persistence unit.
      */
     @Deprecated
     Optional<@WithConverter(TrimmedStringConverter.class) String> multitenantSchemaDatasource();
@@ -307,8 +308,8 @@ public interface HibernateOrmConfigPersistenceUnit {
          *
          * E.g. `MyISAM` or `InnoDB` for MySQL.
          *
-         * @deprecated Use {@code mysql.}{@linkplain MySQLDialectConfig#storageEngine storage-engine}
-         *             or {@code mariadb.}{@linkplain MySQLDialectConfig#storageEngine storage-engine} instead
+         * @deprecated Use {@code quarkus.hibernate-orm.dialect.mysql.storage-engine}
+         *             or {@code quarkus.hibernate-orm.dialect.mariadb.storage-engine} instead.
          *
          * @asciidoclet
          */
@@ -661,7 +662,7 @@ public interface HibernateOrmConfigPersistenceUnit {
         /**
          * Whether Hibernate should quote all identifiers.
          *
-         * @deprecated {@link #quoteIdentifiers} should be used to configure quoting strategy.
+         * @deprecated Use {@code quarkus.hibernate-orm.quote-identifiers.strategy} to configure the quoting strategy.
          */
         @Deprecated
         @WithDefault("false")
@@ -830,7 +831,7 @@ public interface HibernateOrmConfigPersistenceUnit {
         /**
          * Enables the Bean Validation integration.
          *
-         * @deprecated Use {@link #mode()} instead.
+         * @deprecated Use {@code quarkus.hibernate-orm.validation.mode} instead.
          */
         @Deprecated(since = "3.19", forRemoval = true)
         @WithDefault("true")

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfigPersistenceUnit.java
@@ -91,6 +91,8 @@ public interface HibernateOrmRuntimeConfigPersistenceUnit {
 
         /**
          * Schema generation configuration.
+         *
+         * @deprecated Use {@code quarkus.hibernate-orm.schema-management} instead.
          */
         @Deprecated(forRemoval = true, since = "3.22")
         HibernateOrmConfigPersistenceUnitDatabaseGeneration generation();
@@ -243,6 +245,9 @@ public interface HibernateOrmRuntimeConfigPersistenceUnit {
         }
     }
 
+    /**
+     * @deprecated Use {@code quarkus.hibernate-orm.schema-management} instead.
+     */
     @ConfigGroup
     @Deprecated(forRemoval = true, since = "3.22")
     interface HibernateOrmConfigPersistenceUnitDatabaseGeneration {
@@ -256,6 +261,8 @@ public interface HibernateOrmRuntimeConfigPersistenceUnit {
          * this will default to 'drop-and-create'.
          *
          * Accepted values: `none`, `create`, `drop-and-create`, `drop`, `update`, `validate`.
+         *
+         * @deprecated Use {@code quarkus.hibernate-orm.schema-management.strategy} instead.
          */
         @WithParentName
         @Deprecated(forRemoval = true, since = "3.22")
@@ -263,12 +270,16 @@ public interface HibernateOrmRuntimeConfigPersistenceUnit {
 
         /**
          * If Hibernate ORM should create the schemas automatically (for databases supporting them).
+         *
+         * @deprecated Use {@code quarkus.hibernate-orm.schema-management.create-schemas} instead.
          */
         @Deprecated(forRemoval = true, since = "3.22")
         Optional<Boolean> createSchemas();
 
         /**
          * Whether we should stop on the first error when applying the schema.
+         *
+         * @deprecated Use {@code quarkus.hibernate-orm.schema-management.halt-on-error} instead.
          */
         @Deprecated(forRemoval = true, since = "3.22")
         Optional<Boolean> haltOnError();

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfigPersistenceUnit.java
@@ -63,7 +63,7 @@ public interface HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
     /**
      * Configuration for automatic indexing.
      *
-     * @deprecated Use {@link #indexing()} instead.
+     * @deprecated Use {@code quarkus.hibernate-search-orm.indexing} instead.
      */
     @Deprecated
     AutomaticIndexingConfig automaticIndexing();
@@ -192,7 +192,7 @@ public interface HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
         /**
          * Configuration for synchronization with the index when indexing automatically.
          *
-         * @deprecated Use {@code quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy} instead.
+         * @deprecated Use {@code quarkus.hibernate-search-orm.indexing.plan.synchronization} instead.
          */
         AutomaticIndexingSynchronizationConfig synchronization();
 


### PR DESCRIPTION
I think this addresses the issue properly. At the very least it's a step in the right direction. Will need to have a look at the documentation preview, though...

* Fixes #51157

---

AI boilerplate:

Replace internal @link references with user-facing property keys in @deprecated javadoc tags. This ensures deprecation messages are clear and actionable when forwarded to documentation.

Changes:
- Hibernate ORM: Use quarkus.hibernate-orm.* property keys
- Hibernate Search: Use quarkus.hibernate-search-orm.* property keys
- Hibernate Validator: Nothing to do.
- Datasource, Agroal, Reactive Datasource, Reactive SQL Clients: nothing to do.

All deprecated properties now use {@code} formatting with fully qualified property names instead of @link or @linkplain references.

Fixes #51157

Assisted-By: Claude Code <noreply@anthropic.com>
