### PR TITLE
Make Qute's ValueResolverGenerator deterministic for binary reproducibility

### DIFF
--- a/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/ValueResolverGenerator.java
+++ b/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/ValueResolverGenerator.java
@@ -13,6 +13,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -308,7 +310,7 @@ public class ValueResolverGenerator extends AbstractGenerator {
 
         // name, number of params -> list of methods; excluding no-args methods
         Map<Match, List<MethodInfo>> argsMatches() {
-            Map<Match, List<MethodInfo>> ret = new HashMap<>();
+            Map<Match, List<MethodInfo>> ret = new LinkedHashMap<>();
             for (MethodKey methodKey : methods) {
                 MethodInfo method = methodKey.method;
                 if (method.parametersCount() != 0) {
@@ -325,7 +327,7 @@ public class ValueResolverGenerator extends AbstractGenerator {
         }
 
         Map<Match, List<MethodInfo>> varargsMatches() {
-            Map<Match, List<MethodInfo>> ret = new HashMap<>();
+            Map<Match, List<MethodInfo>> ret = new LinkedHashMap<>();
             for (MethodKey methodKey : methods) {
                 MethodInfo method = methodKey.method;
                 if (method.parametersCount() != 0 && isVarArgs(method)) {
@@ -471,8 +473,7 @@ public class ValueResolverGenerator extends AbstractGenerator {
 
                     // The set of matching methods is made up of the methods matching the name and number of params + varargs methods matching the name and minimal number of params
                     // For example both the methods getList(int age, String... names) and getList(int age) match "getList" and 1 param
-                    Set<MethodInfo> methodMatches = new HashSet<>(entry
-                            .getValue());
+                    Set<MethodInfo> methodMatches = new LinkedHashSet<>(entry.getValue());
                     varargsMatches.entrySet().stream()
                             .filter(e -> e.getKey().name.equals(match.name) && e.getKey().paramsCount >= match.paramsCount)
                             .forEach(e -> methodMatches.addAll(e.getValue()));
@@ -488,7 +489,7 @@ public class ValueResolverGenerator extends AbstractGenerator {
                 }
 
                 // For varargs methods we also need to match name and any number of params
-                Map<String, List<MethodInfo>> varargsMap = new HashMap<>();
+                Map<String, List<MethodInfo>> varargsMap = new LinkedHashMap<>();
                 for (Entry<Match, List<MethodInfo>> entry : varargsMatches.entrySet()) {
                     List<MethodInfo> list = varargsMap.get(entry.getKey().name);
                     if (list == null) {
@@ -592,7 +593,7 @@ public class ValueResolverGenerator extends AbstractGenerator {
 
                     // The set of matching methods is made up of the methods matching the name and number of params + varargs methods matching the name and minimal number of params
                     // For example both the methods getList(int age, String... names) and getList(int age) match "getList" and 1 param
-                    Set<MethodInfo> methodMatches = new HashSet<>(entry.getValue());
+                    Set<MethodInfo> methodMatches = new LinkedHashSet<>(entry.getValue());
                     varargsMatches.entrySet().stream()
                             .filter(e -> e.getKey().name.equals(match.name) && e.getKey().paramsCount >= match.paramsCount)
                             .forEach(e -> methodMatches.addAll(e.getValue()));
@@ -609,7 +610,7 @@ public class ValueResolverGenerator extends AbstractGenerator {
                 }
 
                 // For varargs methods we also need to match name and any number of params
-                Map<String, List<MethodInfo>> varargsMap = new HashMap<>();
+                Map<String, List<MethodInfo>> varargsMap = new LinkedHashMap<>();
                 for (Entry<Match, List<MethodInfo>> entry : varargsMatches.entrySet()) {
                     List<MethodInfo> list = varargsMap.get(entry.getKey().name);
                     if (list == null) {


### PR DESCRIPTION
This keeps the generator behavior unchanged while making generated artifacts reproducible across runs.