### PR TITLE
Stabilize ordering of 2 core build items used by bytecode recording

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/ConfigPropertiesBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/ConfigPropertiesBuildItem.java
@@ -20,7 +20,7 @@ import io.quarkus.builder.item.MultiBuildItem;
  *
  * @see org.eclipse.microprofile.config.inject.ConfigProperties
  */
-public final class ConfigPropertiesBuildItem extends MultiBuildItem {
+public final class ConfigPropertiesBuildItem extends MultiBuildItem implements Comparable<ConfigPropertiesBuildItem> {
     private final Class<?> configClass;
     private final String prefix;
 
@@ -65,6 +65,15 @@ public final class ConfigPropertiesBuildItem extends MultiBuildItem {
         final ConfigPropertiesBuildItem that = (ConfigPropertiesBuildItem) o;
         return configClass.equals(that.configClass) &&
                 prefix.equals(that.prefix);
+    }
+
+    @Override
+    public int compareTo(ConfigPropertiesBuildItem o) {
+        int result = this.configClass.getName().compareTo(o.configClass.getName());
+        if (result != 0) {
+            return result;
+        }
+        return this.prefix.compareTo(o.prefix);
     }
 
     @Override

--- a/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingDecorateBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingDecorateBuildItem.java
@@ -3,6 +3,7 @@ package io.quarkus.deployment.logging;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import org.jboss.jandex.ClassInfo;
@@ -33,12 +34,24 @@ public final class LoggingDecorateBuildItem extends SimpleBuildItem {
         return knowClassesIndex;
     }
 
+    /**
+     * Returns a list of ordered known classes. Normally, we don't require the build items
+     * to have reproducible collections, since stabilizing order is a responsibility of
+     * {@code io.quarkus.deployment.annotations.Record} annotated build steps.
+     * <p>
+     * However, this build item is used by the number of bytecode-recording build steps.
+     * Repeating the ordering logic in all of them seems like a waste, so we do it here instead.
+     *
+     * @return a list of ordered known classes, sorted by their name.
+     *
+     */
     public List<String> getKnowClasses() {
         List<String> knowClasses = new ArrayList<>();
         Collection<ClassInfo> knownClasses = knowClassesIndex.getKnownClasses();
         for (ClassInfo ci : knownClasses) {
             knowClasses.add(ci.name().toString());
         }
+        Collections.sort(knowClasses);
         return knowClasses;
     }
 


### PR DESCRIPTION
Make ConfigPropertiesBuildItem comparable and sort known class names returned by LoggingDecorateBuildItem. This removes unstable iteration order when recording bytecode and improves build reproducibility.