### PR TITLE
Stabilize cache manager bytecode recording

### DIFF
--- a/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CacheProcessor.java
+++ b/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CacheProcessor.java
@@ -264,8 +264,9 @@ class CacheProcessor {
             CacheManagerRecorder cacheManagerRecorder) {
 
         boolean micrometerSupported = metricsCapability.isPresent() && metricsCapability.get().metricsSupported(MICROMETER);
+        List<String> sortedCacheNames = cacheNames.getNames().stream().sorted().toList();
         Supplier<CacheManager> cacheManagerSupplier = cacheManagerRecorder.resolveCacheInfo(
-                infos.stream().map(CacheManagerInfoBuildItem::get).collect(toList()), cacheNames.getNames(),
+                infos.stream().map(CacheManagerInfoBuildItem::get).collect(toList()), sortedCacheNames,
                 micrometerSupported);
 
         return SyntheticBeanBuildItem.configure(CacheManager.class)

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheManagerRecorder.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheManagerRecorder.java
@@ -5,6 +5,7 @@ import static io.quarkus.cache.runtime.CacheBuildConfig.CAFFEINE_CACHE_TYPE;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -58,7 +59,7 @@ public class CacheManagerRecorder {
         };
     }
 
-    private Map<String, String> mapCacheTypeByCacheName(Set<String> cacheNames) {
+    private Map<String, String> mapCacheTypeByCacheName(List<String> cacheNames) {
         Map<String, String> cacheTypeByName = new HashMap<>(cacheNames.size());
         for (String cacheName : cacheNames) {
             CacheBuildConfig.CacheTypeBuildConfig cacheTypeBuildConfig = cacheBuildConfig.cacheTypeByName().get(cacheName);
@@ -88,7 +89,7 @@ public class CacheManagerRecorder {
 
     private Map<String, Supplier<CacheManager>> createCacheSupplierByCacheType(
             Collection<CacheManagerInfo> infos,
-            Set<String> cacheNames,
+            List<String> cacheNames,
             boolean micrometerMetricsEnabled) {
 
         Map<String, String> cacheTypeByCacheName = mapCacheTypeByCacheName(cacheNames);
@@ -116,7 +117,7 @@ public class CacheManagerRecorder {
     }
 
     public Supplier<CacheManager> resolveCacheInfo(
-            Collection<CacheManagerInfo> infos, Set<String> cacheNames,
+            Collection<CacheManagerInfo> infos, List<String> cacheNames,
             boolean micrometerMetricsEnabled) {
 
         Map<String, Supplier<CacheManager>> suppliersByType = createCacheSupplierByCacheType(


### PR DESCRIPTION
Sort cache names before passing them to CacheManagerRecorder and use an ordered List throughout cache resolution. This removes set iteration nondeterminism from recording paths and improves reproducible builds.