### PR TITLE
Stabilize ordering in gRPC processors for bytecode recording

### DIFF
--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcClientProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcClientProcessor.java
@@ -413,13 +413,15 @@ public class GrpcClientProcessor {
         }
 
         Set<Class<?>> perClientInterceptors = new LinkedHashSet<>();
-        for (String perClientInterceptor : interceptors.nonGlobalInterceptors) {
+        var sortedNonGlobalInterceptors = interceptors.nonGlobalInterceptors.stream().sorted().toList();
+        for (String perClientInterceptor : sortedNonGlobalInterceptors) {
             reflectiveClassBuildItemBuildProducer
                     .produce(ReflectiveClassBuildItem.builder(perClientInterceptor).constructors(false).build());
             perClientInterceptors.add(recorderContext.classProxy(perClientInterceptor));
         }
         Set<Class<?>> globalInterceptors = new LinkedHashSet<>();
-        for (String globalInterceptor : interceptors.globalInterceptors) {
+        var sortedGlobalInterceptors = interceptors.globalInterceptors.stream().sorted().toList();
+        for (String globalInterceptor : sortedGlobalInterceptors) {
             reflectiveClassBuildItemBuildProducer
                     .produce(ReflectiveClassBuildItem.builder(globalInterceptor).constructors(false).build());
             globalInterceptors.add(recorderContext.classProxy(globalInterceptor));

--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcServerProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcServerProcessor.java
@@ -237,7 +237,11 @@ public class GrpcServerProcessor {
     void discoverBindableServices(BuildProducer<BindableServiceBuildItem> bindables,
             CombinedIndexBuildItem combinedIndexBuildItem) {
         IndexView index = combinedIndexBuildItem.getIndex();
-        Collection<ClassInfo> bindableServices = index.getAllKnownImplementors(GrpcDotNames.BINDABLE_SERVICE);
+        // TODO: this can be reverted once Jandex outputs stably ordered collections
+        List<ClassInfo> bindableServices = index.getAllKnownImplementors(GrpcDotNames.BINDABLE_SERVICE)
+                .stream()
+                .sorted(Comparator.comparing(ClassInfo::name))
+                .toList();
 
         for (ClassInfo service : bindableServices) {
             if (service.interfaceNames().contains(GrpcDotNames.MUTINY_BEAN)) {
@@ -679,7 +683,7 @@ public class GrpcServerProcessor {
 
         Map<String, Set<Class<?>>> perClientInterceptors = new LinkedHashMap<>();
         for (Entry<String, Set<String>> entry : registeredInterceptors.entrySet()) {
-            Set<Class<?>> interceptorClasses = new HashSet<>();
+            Set<Class<?>> interceptorClasses = new LinkedHashSet<>();
             for (String interceptorClass : entry.getValue()) {
                 interceptorClasses.add(recorderContext.classProxy(interceptorClass));
             }
@@ -833,7 +837,7 @@ public class GrpcServerProcessor {
         if (capabilities.isPresent(Capability.SECURITY)) {
 
             // Grpc service to blocking method
-            Map<String, List<String>> blocking = new HashMap<>();
+            Map<String, List<String>> blocking = new LinkedHashMap<>();
             for (BindableServiceBuildItem bindable : bindables) {
                 if (bindable.hasBlockingMethods()) {
                     blocking.put(bindable.serviceClass.toString(), bindable.blockingMethods);


### PR DESCRIPTION
Sort discovered interceptor and service class names and use insertion-ordered collections where relevant. This removes order variability and improves reproducible builds.