### PR TITLE
Stabilize generated bytecode in Arc

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcTestSteps.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcTestSteps.java
@@ -1,7 +1,7 @@
 package io.quarkus.arc.deployment;
 
-import java.util.HashSet;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.Predicate;
 
 import org.jboss.jandex.AnnotationInstance;
@@ -59,7 +59,11 @@ public class ArcTestSteps {
     void initTestApplicationClassPredicateBean(ArcRecorder recorder, BeanContainerBuildItem beanContainer,
             BeanDiscoveryFinishedBuildItem beanDiscoveryFinished,
             CompletedApplicationClassPredicateBuildItem predicate) {
-        Set<String> applicationBeanClasses = new HashSet<>();
+        // TODO: We use TreeSet below since beanStream() does not return elements in a stable order.
+        //  As of May 2026, there are ongoing efforts to stabilize ArC / Jandex components that emit
+        //  elements in such unstable fashion.
+        //  Once that is done, we could switch to a less performance hungry LinkedHashSet.
+        Set<String> applicationBeanClasses = new TreeSet<>();
         for (BeanInfo bean : beanDiscoveryFinished.beanStream().classBeans()) {
             if (predicate.test(bean.getBeanClass())) {
                 applicationBeanClasses.add(bean.getBeanClass().toString());

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.eclipse.microprofile.config.ConfigValue;
@@ -484,7 +485,7 @@ public class ConfigBuildStep {
         recorder.registerConfigProperties(
                 configProperties.stream()
                         .map(p -> configClass(p.getConfigClass(), p.getPrefix()))
-                        .collect(toSet()));
+                        .collect(Collectors.toCollection(LinkedHashSet::new)));
 
         // Ensure that @ConfigProperties are registered before Startup events
         serviceStart.produce(new ServiceStartBuildItem("microprofile-config-properties"));

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/LookupConditionsProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/LookupConditionsProcessor.java
@@ -134,8 +134,6 @@ public class LookupConditionsProcessor {
         }
 
         generators.produce(new SuppressConditionGeneratorBuildItem(new Consumer<>() {
-            final AtomicInteger patternCounter = new AtomicInteger();
-
             @Override
             public void accept(BeanGenerator.SuppressConditionGeneration suppressConditionGeneration) {
                 BeanInfo bean = suppressConditionGeneration.bean();
@@ -158,15 +156,16 @@ public class LookupConditionsProcessor {
 
                 if (!ifPropertyList.isEmpty() || !unlessPropertyList.isEmpty()) {
                     ClassCreator cc = suppressConditionGeneration.beanClass();
+                    AtomicInteger patternCounter = new AtomicInteger();
 
                     // pre-create static Pattern fields for all REGEX annotations on this bean
                     List<StaticFieldVar> ifPatternFields = new ArrayList<>();
                     for (AnnotationInstance ann : ifPropertyList) {
-                        ifPatternFields.add(createPatternFieldIfRegex(cc, ann));
+                        ifPatternFields.add(createPatternFieldIfRegex(cc, ann, patternCounter));
                     }
                     List<StaticFieldVar> unlessPatternFields = new ArrayList<>();
                     for (AnnotationInstance ann : unlessPropertyList) {
-                        unlessPatternFields.add(createPatternFieldIfRegex(cc, ann));
+                        unlessPatternFields.add(createPatternFieldIfRegex(cc, ann, patternCounter));
                     }
 
                     BlockCreator bc = suppressConditionGeneration.method();
@@ -221,7 +220,8 @@ public class LookupConditionsProcessor {
                 }
             }
 
-            private StaticFieldVar createPatternFieldIfRegex(ClassCreator cc, AnnotationInstance ann) {
+            private StaticFieldVar createPatternFieldIfRegex(ClassCreator cc, AnnotationInstance ann,
+                    AtomicInteger patternCounter) {
                 if (getMatch(ann) == StringValueMatch.REGEX) {
                     String regex = ann.value(STRING_VALUE).asString();
                     String fieldName = "REGEX_PATTERN_" + patternCounter.getAndIncrement();


### PR DESCRIPTION
Sort bean discovery iteration, preserve insertion order for collected config properties, and scope regex pattern counters per bean generation. These changes remove nondeterministic naming and ordering in generated bytecode for reproducible builds.