### PR TITLE
Use a per-request TaskQueue for ordered blocking of GraphQL resolvers

### DIFF
--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/PerRequestOrderingTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/PerRequestOrderingTest.java
@@ -1,0 +1,175 @@
+package io.quarkus.smallrye.graphql.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+import io.smallrye.common.annotation.Blocking;
+
+/**
+ * Verifies that ordered blocking GraphQL resolvers serialize <em>per request</em>, not across all
+ * requests sharing an event loop.
+ */
+public class PerRequestOrderingTest extends AbstractGraphQLTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot((JavaArchive jar) -> jar
+                    .addClasses(ManagedLockResource.class, ThreadLocker.class)
+                    // Pin to a single event loop
+                    .addAsResource(new StringAsset(
+                            "quarkus.http.io-threads=1\n"
+                                    + "quarkus.vertx.event-loops-pool-size=1\n"),
+                            "application.properties")
+                    .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"));
+
+    @BeforeEach
+    public void resetState() {
+        ManagedLockResource.locker = new ThreadLocker();
+        ManagedLockResource.maxInFlight.set(0);
+        ManagedLockResource.inFlight.set(0);
+    }
+
+    /**
+     * Two concurrent HTTP requests, each invoking a single blocking resolver that parks until the
+     * test releases it. With per-request ordering, both resolvers must park simultaneously on the
+     * worker pool. With the previous per-event-loop ordering, the second request would queue
+     * behind the first and only one would ever be parked at a time.
+     */
+    @Test
+    public void concurrentRequestsAreNotSerialized() throws Exception {
+        var pool = Executors.newFixedThreadPool(2);
+        CompletableFuture<Void> a = null;
+        CompletableFuture<Void> b = null;
+        try {
+            a = CompletableFuture.runAsync(() -> postOk(getPayload("{ lock }")), pool);
+            b = CompletableFuture.runAsync(() -> postOk(getPayload("{ lock }")), pool);
+
+            assertTrue(ManagedLockResource.locker.awaitParked(2, 5, TimeUnit.SECONDS),
+                    "Expected 2 blocking resolvers to be parked simultaneously, but they appear to be serialized");
+        } finally {
+            ManagedLockResource.locker.releaseAll();
+            if (a != null && b != null) {
+                CompletableFuture.allOf(a, b).get(10, TimeUnit.SECONDS);
+            }
+            pool.shutdown();
+        }
+    }
+
+    /**
+     * A single request that selects three parallel root fields. With per-request ordering (and the
+     * default ordered=true), the three resolvers must run one-at-a-time on the worker pool even
+     * though graphql-java's async execution strategy fans them out concurrently.
+     * <p>
+     * Asserts that exactly one resolver is ever parked at a time; a second never shows up while
+     * the first is held.
+     */
+    @Test
+    public void parallelFieldsWithinOneRequestAreSerialized() throws Exception {
+        var pool = Executors.newSingleThreadExecutor();
+        CompletableFuture<Void> f = null;
+        try {
+            f = CompletableFuture.runAsync(() -> postOk(getPayload("{ a: lock b: lock c: lock }")), pool);
+
+            assertTrue(ManagedLockResource.locker.awaitParked(1, 5, TimeUnit.SECONDS),
+                    "Expected the first resolver to park within 5s");
+            assertFalse(ManagedLockResource.locker.awaitParked(1, 500, TimeUnit.MILLISECONDS),
+                    "Expected within-request ordering but a second resolver parked concurrently");
+        } finally {
+            ManagedLockResource.locker.releaseAll();
+            if (f != null) {
+                f.get(10, TimeUnit.SECONDS);
+            }
+            pool.shutdown();
+        }
+        assertEquals(1, ManagedLockResource.maxInFlight.get(),
+                "Within a single request, ordered blocking resolvers must not overlap, but maxInFlight="
+                        + ManagedLockResource.maxInFlight.get());
+    }
+
+    private static void postOk(String request) {
+        RestAssured.given()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(request)
+                .post("/graphql")
+                .then()
+                .statusCode(200);
+    }
+
+    /**
+     * GraphQL resource whose single resolver parks on a {@link ThreadLocker} until the test
+     * releases it. Used to deterministically observe how many resolvers run concurrently.
+     */
+    @GraphQLApi
+    public static class ManagedLockResource {
+
+        static volatile ThreadLocker locker = new ThreadLocker();
+        static final AtomicInteger inFlight = new AtomicInteger();
+        static final AtomicInteger maxInFlight = new AtomicInteger();
+
+        @Query
+        @Blocking
+        public String lock() throws InterruptedException {
+            int n = inFlight.incrementAndGet();
+            maxInFlight.accumulateAndGet(n, Math::max);
+            try {
+                locker.park();
+            } finally {
+                inFlight.decrementAndGet();
+            }
+            return "done";
+        }
+    }
+
+    /**
+     * Synchronization helper that parks calling threads and lets the test observe how many are
+     * parked at the same time before releasing them. Deterministic alternative to {@code sleep}
+     * for asserting concurrent vs. serialized execution.
+     */
+    public static class ThreadLocker {
+
+        private final Semaphore parked = new Semaphore(0);
+        private final CompletableFuture<Void> release = new CompletableFuture<>();
+
+        public void park() throws InterruptedException {
+            parked.release();
+            try {
+                release.get();
+            } catch (ExecutionException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+
+        /**
+         * Returns {@code true} as soon as {@code n} threads are simultaneously parked; returns
+         * {@code false} if the timeout elapses first.
+         */
+        public boolean awaitParked(int n, long timeout, TimeUnit unit) throws InterruptedException {
+            return parked.tryAcquire(n, timeout, unit);
+        }
+
+        /** Release every parked thread, and let any future {@link #park()} call return immediately. */
+        public void releaseAll() {
+            release.complete(null);
+        }
+    }
+}

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/RequestScopedTaskQueue.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/RequestScopedTaskQueue.java
@@ -1,0 +1,47 @@
+package io.quarkus.smallrye.graphql.runtime;
+
+import io.vertx.core.Context;
+import io.vertx.core.impl.TaskQueue;
+
+/**
+ * Installs and retrieves a per-request {@link TaskQueue} on a Vert.x {@link Context}'s local map.
+ * This allows us to preserve ordering, and scope it to the request so resolvers from different requests can run in parallel
+ */
+public final class RequestScopedTaskQueue {
+
+    static final String LOCAL_KEY = RequestScopedTaskQueue.class.getName();
+
+    private RequestScopedTaskQueue() {
+    }
+
+    /**
+     * Returns the {@link TaskQueue} already installed on the given context, or installs and
+     * returns a fresh one if none was present. Safe to call multiple times for the same request.
+     *
+     * @param vc the (typically per-request duplicated) Vert.x context; may be {@code null}
+     * @return the request-scoped {@link TaskQueue}, or {@code null} if {@code vc} was {@code null}
+     */
+    public static TaskQueue installIfAbsent(Context vc) {
+        if (vc == null) {
+            return null;
+        }
+        TaskQueue existing = vc.getLocal(LOCAL_KEY);
+        if (existing != null) {
+            return existing;
+        }
+        TaskQueue queue = new TaskQueue();
+        vc.putLocal(LOCAL_KEY, queue);
+        return queue;
+    }
+
+    /**
+     * Returns the {@link TaskQueue} previously installed on the given context, or {@code null}
+     * if none has been installed (for example, when called outside of a GraphQL HTTP request).
+     */
+    public static TaskQueue get(Context vc) {
+        if (vc == null) {
+            return null;
+        }
+        return vc.getLocal(LOCAL_KEY);
+    }
+}

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLExecutionHandler.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLExecutionHandler.java
@@ -25,8 +25,11 @@ import graphql.GraphqlErrorBuilder;
 import graphql.execution.AbortExecutionException;
 import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
+import io.smallrye.common.vertx.VertxContext;
 import io.smallrye.graphql.execution.ExecutionResponse;
 import io.smallrye.graphql.execution.ExecutionResponseWriter;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerRequest;
@@ -65,6 +68,12 @@ public class SmallRyeGraphQLExecutionHandler extends SmallRyeGraphQLAbstractHand
 
     @Override
     protected void doHandle(final RoutingContext ctx) {
+        // Install a per-request TaskQueue on the Vert.x context
+        Context vc = Vertx.currentContext();
+        if (vc != null && VertxContext.isDuplicatedContext(vc)) {
+            RequestScopedTaskQueue.installIfAbsent(vc);
+        }
+
         HttpServerRequest request = ctx.request();
         HttpServerResponse response = ctx.response();
 

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/BlockingHelper.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/BlockingHelper.java
@@ -3,11 +3,14 @@ package io.quarkus.smallrye.graphql.runtime.spi.datafetcher;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 
+import io.quarkus.smallrye.graphql.runtime.RequestScopedTaskQueue;
 import io.quarkus.virtual.threads.VirtualThreadsRecorder;
 import io.smallrye.graphql.schema.model.Execute;
 import io.smallrye.graphql.schema.model.Operation;
 import io.vertx.core.Context;
 import io.vertx.core.Promise;
+import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.impl.TaskQueue;
 
 public final class BlockingHelper {
 
@@ -43,7 +46,15 @@ public final class BlockingHelper {
                 }
             });
         } else if (vc != null) {
-            vc.executeBlocking(contextualCallable).onComplete(result);
+            // Prefer the request-scoped TaskQueue installed by the GraphQL HTTP handler
+            // This allows us to preserve ordering and scope it to the request so resolvers
+            // from different requests can run in parallel
+            TaskQueue queue = RequestScopedTaskQueue.get(vc);
+            if (queue != null) {
+                ((ContextInternal) vc).executeBlocking(contextualCallable, queue).onComplete(result);
+            } else {
+                vc.executeBlocking(contextualCallable).onComplete(result);
+            }
         } else {
             // No Vert.x context (e.g. ForkJoinPool thread after CompletableFuture.supplyAsync) —
             // already off the event loop, safe to execute directly


### PR DESCRIPTION
I am a human, and I ran into this problem today: https://github.com/quarkusio/quarkus/issues/54361

It looks like the previous approach to solve this in https://github.com/quarkusio/quarkus/pull/29306 was abandoned because of concerns around concurrency and request-scoped objects.

So I figured, what if we scope the ordering to the request, and not to the whole event loop? Helps with throughput & stays safe.

Happy to adapt as needed.