### PR TITLE
Ignore minor updates of  Elasticsearch dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -229,12 +229,14 @@ updates:
       - dependency-name: org.hibernate.common:*
       - dependency-name: org.hibernate.models:*
       # Elasticsearch - major updates usually require more work and synchronization, we do them manually.
+      #  and we also usually try to match minor updates with any Hibernate Search update that "enables"
+      #  compatibility with those new versions.
       - dependency-name: org.elasticsearch.client:elasticsearch-rest-client
-        update-types: ["version-update:semver-major"]
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
       - dependency-name: org.elasticsearch.client:elasticsearch-rest-client-sniffer
-        update-types: ["version-update:semver-major"]
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
       - dependency-name: co.elastic.clients:elasticsearch-java
-        update-types: ["version-update:semver-major"]
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
       # Expressly, as an EL implementation is tightly coupled with the Jakarta Validation and Hibernate Validator versions in use
       # Hence we update major/minor Expressly versions manually.
       - dependency-name: org.glassfish.expressly:expressly


### PR DESCRIPTION
We try to apply those as part of any Hibernate Search updates that "enable" compatibility with that minor version

* following up on https://github.com/quarkusio/quarkus/pull/54235#issuecomment-4476247928

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

