### PR TITLE
Correct SupplierMap `putAll`

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/SupplierMap.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/SupplierMap.java
@@ -36,6 +36,7 @@ public class SupplierMap<K, V> implements Map<K, V> {
 
     public void clear() {
         suppliers.clear();
+        cache.clear();
     }
 
     @Override
@@ -95,7 +96,7 @@ public class SupplierMap<K, V> implements Map<K, V> {
     @Override
     public void putAll(Map<? extends K, ? extends V> m) {
         for (Map.Entry<? extends K, ? extends V> entry : m.entrySet()) {
-            cache.put(entry.getKey(), entry.getValue());
+            suppliers.put(entry.getKey(), entry::getValue);
         }
     }
 

--- a/integration-tests/devservices/tests/src/test/java/io/quarkus/devservices/test/DevServicesTest.java
+++ b/integration-tests/devservices/tests/src/test/java/io/quarkus/devservices/test/DevServicesTest.java
@@ -17,7 +17,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -60,6 +64,9 @@ public class DevServicesTest {
 
     @ConfigProperty(name = QUARKUS_DEPENDENT_EXTENSION_CONFIG_CONTAMINATED, defaultValue = "false")
     String dependentExtensionConfigContaminated;
+
+    @Inject
+    Config config;
 
     @Test
     public void testTheLazyDevServicesConfigIsAvailable() {
@@ -122,6 +129,21 @@ public class DevServicesTest {
     @Test
     public void testDevServiceConfigIsNotContaminatedByOtherDevServices() {
         assertEquals("false", dependentExtensionConfigContaminated);
+    }
+
+    @Test
+    public void testStaticConfigIsVisibleInDevServicesConfigSource() {
+        ConfigSource devServicesConfigSource = null;
+        for (ConfigSource source : config.getConfigSources()) {
+            if ("DevServicesConfigSource".equals(source.getName())) {
+                devServicesConfigSource = source;
+                break;
+            }
+        }
+        Assertions.assertNotNull(devServicesConfigSource, "DevServicesConfigSource should be present");
+        assertTrue(devServicesConfigSource.getPropertyNames().contains(QUARKUS_SIMPLE_EXTENSION_STATIC_THING),
+                "DevServicesConfigSource should contain " + QUARKUS_SIMPLE_EXTENSION_STATIC_THING);
+        assertEquals("some value", devServicesConfigSource.getValue(QUARKUS_SIMPLE_EXTENSION_STATIC_THING));
     }
 
     @Test


### PR DESCRIPTION
Yet more cherry picks from @gsmet's https://github.com/quarkusio/quarkus/pull/53656. This is actually a revival of an older PR, also from Guillaume, https://github.com/quarkusio/quarkus/pull/53831. 

As discussed on #53831, I still have some doubts about `SupplierMap`, because it's so hard to reason about. But removing it, https://github.com/quarkusio/quarkus/pull/53850, wasn't trivial, so while we have it, we want it to be correct. 

I thought #53656 changed the behaviour in a way that wouldn't match developer expectations, but after a long conversation with Claude, I've changed my mind, and now agree with @gsmet that there's a bug. The reason we missed it is that at bug didn't affect anything except for the `configResolver` API that Guillaume was proposing in #53656, and the classloader sharing code included in #53656. 

Why is the map hard to reason about? Well, several reasons, but the problem in this case is that there's an asymmetry. We have two `put` methods, one which takes a value, and one which takes a supplier. But we can only have one `putAll()` method, because it takes a map, and the type erasure on the generic means post-compile, no one knows what's in the map. It could be suppliers, or it could be values. The implementation has opted for taking values, which it kind of has to, because of inheritance. When we pass in values to `putAll()`, we can't just put them in the map, because we need suppliers. We handle this in the `put` by wrapping the value in a supplier. The old implementation avoided the problem by putting the values into the cache, which takes values. The new implementation avoids it more satisfactorily by putting into the suppliers map, but using `::getEntry`, which is a method reference and so wraps the value for `free`.  

I didn't want to push the change without a test to show the problem, so I've added one, but it's kind of low level (because otherwise it can't reproduce). That reproducing problem is why all our existing tests for `@ConfigProperty` in dev services don't reproduce this bug: there's a redundant legacy path `DevServicesConfigBuildStep` also publishes static config via `RunTimeConfigurationDefaultBuildItem`, which feeds a separate, higher-priority config source. So `@ConfigProperty` finds the value through that fallback even when the `DevServicesConfigSource` is broken. 

By coupling slightly to internals (yuck) and inspecting the DevServicesConfigSource directly, the test exercises the code path that breaks: `DevServicesResultBuildItem.getConfig(Startable)`  puts static config into a `SupplierMap` via `putAll()`, which (before the fix) writes to cache. When that SupplierMap is later copied to a HashMap via `HashMap.putAll(supplierMap)`, it calls `entrySet()` which only reads from suppliers — so the static entries are silently lost. The `DevServicesConfigSource` reads from that HashMap, so it never sees the static config. I did wonder if `entrySet()` should use the cache, but that's only a performance thing, so probably ok for now. 

Since we just copy the `SupplierMap` into a HashMap later in processing I also still wonder if we need the `SupplierMap`, but we think about that later.
   
I've confirmed the test is red without Guillaume's changes, and green with them. 



