### PR TITLE
Some doc improvements

### DIFF
--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -9,13 +9,28 @@ include::_attributes.adoc[]
 :summary: Build native executables with GraalVM or Mandrel.
 :topics: native,graalvm,mandrel
 
-This guide covers:
+Quarkus applications can be compiled to native executables, producing a standalone binary that starts in milliseconds and uses a fraction of the memory of a JVM process.
 
-* Compiling the application to a native executable
-* Packaging the native executable in a container
-* Debugging native executable
+In this guide, you will compile the application from the xref:getting-started.adoc[Getting Started Guide] to a native executable, test it, and package it in a container.
 
-This guide takes as input the application developed in the xref:getting-started.adoc[Getting Started Guide].
+== Do you need a native executable?
+
+Quarkus on the JVM is already fast, sub-second startup, low memory footprint, and optimized throughput.
+For many applications, JVM mode is the right choice.
+
+Native executables shine when:
+
+* *Startup time is critical*: serverless/FaaS, CLI tools, or scale-to-zero environments where cold starts matter.
+* *Memory is constrained*: dense container deployments or edge devices with tight RAM budgets.
+* *You want the smallest possible container image*: native binaries produce images under 50MB.
+
+JVM mode is typically better when:
+
+* *Peak throughput matters most*: the JVM's JIT compiler optimizes hot paths at runtime, which can outperform native on long-running workloads.
+* *Build time is a constraint*: native compilation takes minutes, JVM builds take seconds.
+* *You rely heavily on reflection or dynamic class loading*: these require explicit configuration for native images.
+
+TIP: Start with JVM mode. Move to native when you have a concrete need. Both modes use the same code and the same Quarkus optimizations: native just changes how the binary is produced.
 
 == Prerequisites
 
@@ -51,39 +66,14 @@ xcode-select --install
 * On Windows, you will need to install the https://aka.ms/vs/17/release/vs_buildtools.exe[Visual Studio 2022 Visual C++ Build Tools]
 ====
 
-=== Background
+=== Choosing a GraalVM distribution
 
-Building a native executable requires using a distribution of GraalVM.
-There are three distributions:
-Oracle GraalVM Community Edition (CE), Oracle GraalVM Enterprise Edition (EE) and Mandrel.
-The differences between the Oracle and Mandrel distributions are as follows:
+Building a native executable requires a GraalVM distribution. There are two main options:
 
-* Mandrel is a downstream distribution of the Oracle GraalVM CE.
-Mandrel's main goal is to provide a way to build native executables specifically designed to support Quarkus.
+* *https://www.graalvm.org[Oracle GraalVM]* — the standard distribution from Oracle. Supports Linux, macOS (both Intel and Apple Silicon), and Windows.
+* *https://github.com/graalvm/mandrel[Mandrel]* — a downstream distribution tailored for Quarkus. It excludes components not needed by Quarkus (such as polyglot support) to provide a smaller distribution.
 
-* Mandrel releases are built from a code base derived from the upstream Oracle GraalVM CE code base,
-with only minor changes but some significant exclusions that are not necessary for Quarkus native apps.
-They support the same capabilities to build native executables as Oracle GraalVM CE,
-with no significant changes to functionality.
-Notably, they do not include support for polyglot programming.
-The reason for these exclusions is to provide a better level of support for the majority of Quarkus users.
-These exclusions also mean Mandrel offers a considerable reduction in its distribution size
-when compared with Oracle GraalVM CE/EE.
-
-* Mandrel is built slightly differently to Oracle GraalVM CE, using the standard OpenJDK project.
-This means that it does not profit from a few small enhancements that Oracle have added to the version of OpenJDK used to build their own GraalVM downloads.
-These enhancements are omitted because upstream OpenJDK does not manage them, and cannot vouch for.
-This is particularly important when it comes to conformance and security.
-
-* Mandrel is recommended for building native executables that target Linux containerized environments.
-This means that Mandrel users are encouraged to use containers to build their native executables.
-If you are building native executables for macOS on amd64/x86,
-you should consider using Oracle GraalVM instead,
-because Mandrel does not currently target this platform.
-Building native executables directly on bare metal Linux, macOS (on M processors), or Windows is possible,
-with details available in the https://github.com/graalvm/mandrel/blob/default/README.md[Mandrel README]
-and https://github.com/graalvm/mandrel/releases[Mandrel releases].
-
+GraalVM {graalvm-version} is required.
 
 [[configuring-graalvm]]
 === Configuring GraalVM
@@ -97,15 +87,13 @@ For generating native executables targeting Linux, you can optionally skip this 
 [TIP]
 ====
 If you cannot install GraalVM, you can use a multi-stage Docker build to run Maven inside a Docker container that embeds GraalVM.
-There is an explanation of how to do this at <<#multistage-docker,the end of this guide>>.
+There is an explanation of how to do this in the xref:native-reference.adoc#multistage-docker[Native Reference Guide].
 ====
 
-GraalVM {graalvm-version} is required.
-
 1. Install GraalVM if you haven't already. You have a few options for this:
-** Download the appropriate archive from <https://github.com/graalvm/mandrel/releases> or <https://github.com/graalvm/graalvm-ce-builds/releases>, and unpack it like you would any other JDK.
+** Download the appropriate archive from <https://github.com/graalvm/mandrel/releases> or <https://www.graalvm.org/downloads/>, and unpack it like you would any other JDK.
 ** Use platform-specific installer tools like https://sdkman.io/jdks#graalce[sdkman], https://github.com/graalvm/homebrew-tap[homebrew], or https://github.com/ScoopInstaller/Java[scoop].
-We recommend the _community edition_ of GraalVM. For example, install it with `sdk install java 21-graalce`.
+For example, install it with `sdk install java {graalvm-flavor}`.
 2. Configure the runtime environment. Set `GRAALVM_HOME` environment variable to the GraalVM installation directory, for example:
 +
 [source,bash]
@@ -113,7 +101,7 @@ We recommend the _community edition_ of GraalVM. For example, install it with `s
 export GRAALVM_HOME=$HOME/Development/mandrel/
 ----
 +
-On macOS (amd64/x86 based Macs not supported), point the variable to the `Home` sub-directory:
+On macOS, point the variable to the `Home` sub-directory:
 +
 [source,bash]
 ----
@@ -143,11 +131,12 @@ export PATH=${GRAALVM_HOME}/bin:$PATH
 .Issues using GraalVM with macOS
 [NOTE]
 ====
-GraalVM binaries are not (yet) notarized for macOS as reported in this https://github.com/oracle/graal/issues/1724[GraalVM issue]. This means that you may see the following error when using `native-image`:
+GraalVM binaries are not (yet) notarized for macOS as reported in this https://github.com/oracle/graal/issues/1724[GraalVM issue].
+This means that you may see the following error when using `native-image`:
 
 [source,bash]
 ----
-“native-image” cannot be opened because the developer cannot be verified
+"native-image" cannot be opened because the developer cannot be verified
 ----
 
 Use the following command to recursively delete the `com.apple.quarantine` extended attribute on the GraalVM install directory as a workaround:
@@ -158,55 +147,22 @@ xattr -r -d com.apple.quarantine ${GRAALVM_HOME}/../..
 -----
 ====
 
-== Solution
-
-We recommend that you follow the instructions in the next sections and package the application step by step. However, you can go right to the completed example.
-
-Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {quickstarts-archive-url}[archive].
-
-The solution is located in the `getting-started` directory.
-
 == Producing a native executable
 
-The native executable for our application will contain the application code, required libraries, Java APIs, and a reduced version of a VM. The smaller VM base improves the startup time of the application and produces a minimal disk footprint.
+The native executable for your application will contain the application code, required libraries, Java APIs, and a reduced version of a VM.
+The smaller VM base improves the startup time of the application and produces a minimal disk footprint.
 
 image:native-executable-process.png[Creating a native executable]
-
-If you have generated the application from the previous tutorial, you can find in the `pom.xml` the following Maven profile section:
-
-[source,xml]
-----
-<profiles>
-    <profile>
-        <id>native</id>
-        <activation>
-            <property>
-                <name>native</name>
-            </property>
-        </activation>
-        <properties>
-            <skipITs>false</skipITs>
-            <quarkus.native.enabled>true</quarkus.native.enabled>
-        </properties>
-    </profile>
-</profiles>
-----
 
 [TIP]
 ====
 You can provide custom options for the `native-image` command using the `quarkus.native.additional-build-args` and `quarkus.native.additional-build-args-append` properties.
 Multiple options may be separated by a comma.
 
-By convention `quarkus.native.additional-build-args-append` is meant to be defined at the command line (e.g. `-Dquarkus.native.additional-build-args-append=--verbose`), while `quarkus.native.additional-build-args` may be defined either at the command line or in your `application.properties`. Note that, any arguments included in `quarkus.native.additional-build-args-append` may override those included in `quarkus.native.additional-build-args`.
-
 You can find more information about how to configure the native image building process in the <<configuration-reference>> section below.
 ====
 
-We use a profile because, you will see very soon, packaging the native executable takes a _few_ minutes. You could
-just pass -Dquarkus.native.enabled=true as a property on the command line, however it is better to use a profile as
-this allows native image tests to also be run.
-
-Create a native executable using:
+Native compilation takes significantly longer than a regular JVM build. Create a native executable using:
 
 include::{includes}/devtools/build-native.adoc[]
 
@@ -217,65 +173,46 @@ include::{includes}/devtools/build-native.adoc[]
 The Microsoft Native Tools for Visual Studio must first be initialized before packaging.
 You can do this by starting the `x64 Native Tools Command Prompt` that was installed with the Visual Studio Build Tools.
 At the `x64 Native Tools Command Prompt`, you can navigate to your project folder and run `./mvnw package -Dnative`.
+====
 
-Another solution is to write a script to do this for you:
+The build produces `target/getting-started-1.0.0-SNAPSHOT-runner`.
+You can run it directly:
 
 [source,bash]
 ----
-cmd /c 'call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat" && mvn package -Dnative'
+./target/getting-started-1.0.0-SNAPSHOT-runner
 ----
-====
 
-In addition to the regular files, the build also produces `target/getting-started-1.0.0-SNAPSHOT-runner`.
-You can run it using: `./target/getting-started-1.0.0-SNAPSHOT-runner`.
-
-[[graal-package-preview]]
-[NOTE]
-.Java preview features
-====
-Java code that relies on preview features requires special attention.
-To produce a native executable, this means that the `--enable-preview` flag needs to be passed to the underlying native image invocation.
-You can do so by prepending the flag with `-J` and passing it as additional native build argument: `-Dquarkus.native.additional-build-args=-J--enable-preview`.
-====
-
-=== Build fully static native executables
-
-IMPORTANT: Fully static native executables support is experimental.
-
-On Linux it's possible to package a native executable that doesn't depend on any system shared library.
-There are link:https://www.graalvm.org/{graalvm-docs-version}/reference-manual/native-image/guides/build-static-executables/#prerequisites-and-preparation[some system requirements] to be fulfilled and additional build arguments to be used along with the `native-image` invocation, a minimum is `-Dquarkus.native.additional-build-args="--static","--libc=musl"`.
-
-Compiling fully static binaries is done by statically linking https://musl.libc.org/[musl] instead of `glibc` and should not be used in production without rigorous testing.
+[source,shell]
+----
+__  ____  __  _____   ___  __ ____  ______
+ --/ __ \/ / / / _ | / _ \/ //_/ / / / __/
+ -/ /_/ / /_/ / __ |/ , _/ ,< / /_/ /\ \
+--\___\_\____/_/ |_/_/|_/_/|_|\____/___/
+INFO  [io.quarkus] (main) getting-started 1.0.0-SNAPSHOT native (powered by Quarkus {quarkus-version}) started in 0.012s. Listening on: http://0.0.0.0:8080
+INFO  [io.quarkus] (main) Profile prod activated.
+INFO  [io.quarkus] (main) Installed features: [cdi, rest, smallrye-context-propagation, vertx]
+----
 
 == Testing the native executable
 
-Producing a native executable can lead to a few issues, and so it's also a good idea to run some tests against the application running in the native file. The reasoning is explained in the link:getting-started-testing#quarkus-integration-test[Testing Guide].
+Producing a native executable can lead to a few issues, and so it's also a good idea to run some tests against the application running in the native file.
+The reasoning is explained in the xref:getting-started-testing.adoc#quarkus-integration-test[Testing Guide].
 
 To see the `GreetingResourceIT` run against the native executable, use `./mvnw verify -Dnative`:
 [source,shell,subs=attributes+]
 ----
 $ ./mvnw verify -Dnative
 ...
-Finished generating 'getting-started-1.0.0-SNAPSHOT-runner' in 22.0s.
-[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildRunner] docker run --env LANG=C --rm --user 1000:1000 -v /home/zakkak/code/quarkus-quickstarts/getting-started/target/getting-started-1.0.0-SNAPSHOT-native-image-source-jar:/project:z --entrypoint /bin/bash quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor} -c objcopy --strip-debug getting-started-1.0.0-SNAPSHOT-runner
-[INFO] [io.quarkus.deployment.QuarkusAugmentor] Quarkus augmentation completed in 70686ms
-[INFO]
-[INFO] --- maven-failsafe-plugin:3.0.0-M7:integration-test (default) @ getting-started ---
-[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
-[INFO]
 [INFO] -------------------------------------------------------
 [INFO]  T E S T S
 [INFO] -------------------------------------------------------
 [INFO] Running org.acme.getting.started.GreetingResourceIT
-Executing "/home/zakkak/code/quarkus-quickstarts/getting-started/target/getting-started-1.0.0-SNAPSHOT-runner -Dquarkus.http.port=8081 -Dquarkus.http.ssl-port=8444 -Dquarkus.log.file.path=/home/zakkak/code/quarkus-quickstarts/getting-started/target/quarkus.log -Dquarkus.log.file.enable=true -Dquarkus.log.category."io.quarkus".level=INFO"
-__  ____  __  _____   ___  __ ____  ______
- --/ __ \/ / / / _ | / _ \/ //_/ / / / __/
- -/ /_/ / /_/ / __ |/ , _/ ,< / /_/ /\ \
---\___\_\____/_/ |_/_/|_/_/|_|\____/___/
-2023-05-05 10:55:52,068 INFO  [io.quarkus] (main) getting-started 1.0.0-SNAPSHOT native (powered by Quarkus 3.0.2.Final) started in 0.009s. Listening on: http://0.0.0.0:8081
-2023-05-05 10:55:52,069 INFO  [io.quarkus] (main) Profile prod activated.
-2023-05-05 10:55:52,069 INFO  [io.quarkus] (main) Installed features: [cdi, rest, smallrye-context-propagation, vertx]
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.99 s - in org.acme.getting.started.GreetingResourceIT
+...
+INFO  [io.quarkus] (main) getting-started 1.0.0-SNAPSHOT native (powered by Quarkus {quarkus-version}) started in 0.012s. Listening on: http://0.0.0.0:8081
+INFO  [io.quarkus] (main) Profile prod activated.
+INFO  [io.quarkus] (main) Installed features: [cdi, rest, smallrye-context-propagation, vertx]
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
 ...
 ----
 
@@ -286,112 +223,13 @@ duration can be changed using the `quarkus.test.wait-time` system property. For 
 to 300 seconds, use: `./mvnw verify -Dnative -Dquarkus.test.wait-time=300`.
 ====
 
-[WARNING]
-====
-This procedure was formerly accomplished using the `@NativeImageTest` annotation. `@NativeImageTest` was replaced by `@QuarkusIntegrationTest` which provides a superset of the testing
-capabilities of `@NativeImageTest`. More information about `@QuarkusIntegrationTest` can be found in the xref:getting-started-testing.adoc#quarkus-integration-test[Testing Guide].
-====
-
-=== Profiles
-By default, integration tests both *build* and *run* the native executable using the `prod` profile.
-
-You can override the profile the executable *runs* with during the test using the `quarkus.test.integration-test-profile` property.
-Either by adding it to `application.properties` or by appending it to the command line:
-`./mvnw verify -Dnative -Dquarkus.test.integration-test-profile=test`.
-Your `%test.` prefixed properties will be used at the test runtime.
-
-
-You can override the profile the executable is *built* with and *runs* with using the `quarkus.profile=test` property, e.g.
-`./mvnw clean verify -Dnative -Dquarkus.profile=test`. This might come handy if there are test specific resources to be processed,
-such as importing test data into the database.
-
-[source,properties]
-----
-quarkus.native.resources.includes=version.txt
-%test.quarkus.native.resources.includes=version.txt,import-dev.sql
-%test.quarkus.hibernate-orm.schema-management.strategy=drop-and-create
-%test.quarkus.hibernate-orm.sql-load-script=import-dev.sql
-----
-
-With the aforementioned example in your `application.properties`, your Hibernate ORM managed database will be populated with test
-data both during the JVM mode test run and during the native mode test run. The production
-executable will contain only the `version.txt` resource, no superfluous test data.
-
-[WARNING]
-====
-The executable built with `-Dquarkus.profile=test` is not suitable for production deployment.
-It contains your test resources files and settings. Once the testing is done, the executable would have to be built again,
-using the default, `prod` profile.
-
-Alternatively, if you need to specify specific properties when running tests against the native executable
-built using the `prod` profile, an option is to put those properties in file `src/test/resources/application-nativeit.yaml`, and refer to it from the `failsafe` plugin configuration using the `QUARKUS_CONFIG_LOCATIONS` environment variable. For instance:
-
-[source,xml]
-----
-<plugin>
-  <artifactId>maven-failsafe-plugin</artifactId>
-  <version>${surefire-plugin.version}</version>
-  <executions>
-    <execution>
-      <goals>
-        <goal>integration-test</goal>
-        <goal>verify</goal>
-      </goals>
-      <configuration>
-        <systemPropertyVariables>
-          <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-          <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-          <maven.home>${maven.home}</maven.home>
-        </systemPropertyVariables>
-        <environmentVariables>
-          <QUARKUS_CONFIG_LOCATIONS>./src/test/resources/application-nativeit.yaml</QUARKUS_CONFIG_LOCATIONS>
-        </environmentVariables>
-      </configuration>
-    </execution>
-  </executions>
-</plugin>
-----
-====
-
-=== Java preview features
-
-[[graal-test-preview]]
-[NOTE]
-.Java preview features
-====
-Java code that relies on preview features requires special attention.
-To test a native executable, this means that the `--enable-preview` flag needs to be passed to the Surefire plugin.
-Adding `<argLine>--enable-preview</argLine>` to its `configuration` section is one way to do so.
-====
-
-=== Excluding tests when running as a native executable
-
-When running tests this way, the only things that actually run natively are your application endpoints, which
-you can only test via HTTP calls. Your test code does not actually run natively, so if you are testing code
-that does not call your HTTP endpoints, it's probably not a good idea to run them as part of native tests.
-
-If you share your test class between JVM and native executions like we advise above, you can mark certain tests
-with the `@DisabledOnIntegrationTest` annotation in order to skip them when testing against a native image.
-
-[NOTE]
-====
-Using `@DisabledOnIntegrationTest` will also disable the test in all integration test instances, including
-testing the application in JVM mode, in a container image, and native image.
-====
-
-=== Testing an existing native executable
-
-It is also possible to re-run the tests against a native executable that has already been built. To do this run
-`./mvnw test-compile failsafe:integration-test -Dnative`. This will discover the existing native image and run the tests against it using failsafe.
-
-If the process cannot find the native image for some reason, or you want to test a native image that is no longer in the
-target directory you can specify the executable with the `-Dnative.image.path=` system property.
+For advanced testing scenarios, test profiles, excluding tests from native runs, or testing an existing binary, see the xref:native-reference.adoc#native-testing[Native Reference Guide].
 
 [[container-runtime]]
 == Creating a Linux executable without GraalVM installed
 
-IMPORTANT: Before going further, be sure to have a working container runtime (Docker, podman) environment. If you use Docker
-on Windows you should share your project's drive at Docker Desktop file share settings and restart Docker Desktop.
+IMPORTANT: Before going further, be sure to have a working container runtime (Docker, podman) environment.
+If you use Docker on Windows you should share your project's drive at Docker Desktop file share settings and restart Docker Desktop.
 
 Quite often one only needs to create a native Linux executable for their Quarkus application (for example in order to run in a containerized environment) and would like to avoid
 the trouble of installing the proper GraalVM version in order to accomplish this task (for example, in CI environments it's common practice
@@ -499,20 +337,10 @@ See <<tip-quarkus-native-remote-container-build,Creating a Linux executable with
 
 See the xref:container-image.adoc[Container Image guide] for more details.
 
-=== Manually using the micro base image
+=== Using the micro base image
 
-You can run the application in a container using the JAR produced by the Quarkus Maven Plugin.
-However, in this section, we focus on creating a container image using the produced native executable.
-
-image:containerization-process.png[Containerization Process]
-
-When using a local GraalVM installation, the native executable targets your local operating system (Linux, macOS, Windows etc).
-However, as a container may not use the same _executable_ format as the one produced by your operating system,
-we will instruct the Maven build to produce an executable by leveraging a container runtime (as described in <<#container-runtime,this section>>):
-
-The produced executable will be a 64-bit Linux executable, so depending on your operating system, it may no longer be runnable.
-However, it's not an issue as we are going to copy it to a container.
-The project generation has provided a `Dockerfile.native-micro` in the `src/main/docker` directory with the following content:
+You can also build a container manually using the generated Dockerfile.
+The project generation provides a `Dockerfile.native-micro` in the `src/main/docker` directory with the following content:
 
 [source,dockerfile]
 ----
@@ -534,489 +362,21 @@ ENTRYPOINT ["./application", "-Dquarkus.http.host=0.0.0.0"]
 ====
 The Quarkus Micro Image is a small container image providing the right set of dependencies to run your native application.
 It is based on https://catalog.redhat.com/software/containers/ubi9-micro/61832b36dd607bfc82e66399?container-tabs=overview[UBI Micro].
-This base image has been tailored to work perfectly in containers.
-
-You can read more about UBI images on:
-
-* https://www.redhat.com/en/blog/introducing-red-hat-universal-base-image[Introduction to Universal Base Image]
-* https://catalog.redhat.com/software/containers/ubi9/ubi/615bcf606feffc5384e8452e[Red Hat Universal Base Image 9]
-
-UBI images can be used without any limitations.
 
 xref:quarkus-runtime-base-image.adoc[This page] explains how to extend the `quarkus-micro` image when your application has specific requirements.
 ====
 
-Then, if you didn't delete the generated native executable, you can build the docker image with:
+Build and run the container:
 
 [source,bash]
 ----
 docker build -f src/main/docker/Dockerfile.native-micro -t quarkus-quickstart/getting-started .
-----
-
-And finally, run it with:
-
-[source,bash]
-----
 docker run -i --rm -p 8080:8080 quarkus-quickstart/getting-started
 ----
 
-=== Manually using the minimal base image
-
-The project generation has also provided a `Dockerfile.native` in the `src/main/docker` directory with the following content:
-
-[source,dockerfile]
-----
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6
-WORKDIR /work/
-RUN chown 1001 /work \
-    && chmod "g+rwX" /work \
-    && chown 1001:root /work
-COPY --chown=1001:root --chmod=0755 target/*-runner /work/application
-
-EXPOSE 8080
-USER 1001
-
-CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
-----
-
-The UBI minimal image is bigger than the micro one mentioned above.
-It contains more utilities such as the `microdnf` package manager.
-
-[[multistage-docker]]
-=== Using a multi-stage Docker build
-
-The previous section showed you how to build a native executable using Maven or Gradle, but it requires you to have created the native executable first.
-In addition, this native executable must be a Linux 64 bits executable.
-
-You may want to build the native executable directly in a container without having a final container containing the build tools.
-That approach is possible with a multi-stage Docker build:
-
-1. The first stage builds the native executable using Maven or Gradle
-2. The second stage is a minimal image copying the produced native executable
-
-
-[WARNING]
-====
-Before building a container image from the Dockerfiles shown below, you need to update the default `.dockerignore` file, as it filters everything except the `target` directory. In order to build inside a container, you need to copy the `src` directory. Thus, edit your `.dockerignore` and remove the `*` line.
-====
-
-Such a multi-stage build can be achieved as follows:
-
-Sample Dockerfile for building with Maven:
-[source,dockerfile,subs=attributes+]
-----
-## Stage 1 : build with maven builder image with native capabilities
-FROM quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor} AS build
-COPY --chown=quarkus:quarkus --chmod=0755 mvnw /code/mvnw
-COPY --chown=quarkus:quarkus .mvn /code/.mvn
-COPY --chown=quarkus:quarkus pom.xml /code/
-USER quarkus
-WORKDIR /code
-RUN ./mvnw -B org.apache.maven.plugins:maven-dependency-plugin:3.8.1:go-offline
-COPY src /code/src
-RUN ./mvnw package -Dnative
-
-## Stage 2 : create the docker final image
-FROM quay.io/quarkus/ubi9-quarkus-micro-image:2.0
-WORKDIR /work/
-COPY --from=build /code/target/*-runner /work/application
-
-# set up permissions for user `1001`
-RUN chmod 775 /work /work/application \
-  && chown -R 1001 /work \
-  && chmod -R "g+rwX" /work \
-  && chown -R 1001:root /work
-
-EXPOSE 8080
-USER 1001
-
-CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
-----
-
-NOTE: This multi-stage Docker build copies the Maven wrapper from the host machine.
-The Maven wrapper (or the Gradle wrapper) is a convenient way to provide a specific version of Maven/Gradle.
-It avoids having to create a base image with Maven and Gradle.
-To provision the Maven Wrapper in your project, use: `mvn wrapper:wrapper`.
-
-Save this file in `src/main/docker/Dockerfile.multistage` as it is not included in the getting started quickstart.
-
-Sample Dockerfile for building with Gradle:
-[source,dockerfile,subs=attributes+]
-----
-## Stage 1 : build with maven builder image with native capabilities
-FROM quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor} AS build
-USER root
-RUN microdnf install findutils -y
-COPY --chown=quarkus:quarkus gradlew /code/gradlew
-COPY --chown=quarkus:quarkus gradle /code/gradle
-COPY --chown=quarkus:quarkus build.gradle /code/
-COPY --chown=quarkus:quarkus settings.gradle /code/
-COPY --chown=quarkus:quarkus gradle.properties /code/
-USER quarkus
-WORKDIR /code
-COPY src /code/src
-RUN ./gradlew build -Dquarkus.native.enabled=true
-
-## Stage 2 : create the docker final image
-FROM quay.io/quarkus/ubi9-quarkus-micro-image:2.0
-WORKDIR /work/
-COPY --from=build /code/build/*-runner /work/application
-RUN chmod 775 /work
-EXPOSE 8080
-CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
-----
-
-If you are using Gradle in your project, you can use this sample Dockerfile.  Save it in `src/main/docker/Dockerfile.multistage`.
-
-[source,bash]
-----
-docker build -f src/main/docker/Dockerfile.multistage -t quarkus-quickstart/getting-started .
-----
-
-And, finally, run it with:
-
-[source,bash]
-----
-docker run -i --rm -p 8080:8080 quarkus-quickstart/getting-started
-----
-
-[TIP]
-====
-If you need SSL support in your native executable, you can easily include the necessary libraries in your Docker image.
-
-Please see xref:native-and-ssl.adoc#working-with-containers[our Using SSL With Native Executables guide] for more information.
-====
-
-[NOTE,subs=attributes+]
-====
-To use GraalVM CE instead of Mandrel, update the `FROM` clause to: `FROM quay.io/quarkus/ubi9-quarkus-graalvmce-builder-image:{graalvm-flavor} AS build`.
-====
-
-=== Using a Distroless base image
-
-IMPORTANT: Distroless image support is experimental.
-
-If you are looking for small container images, the https://github.com/GoogleContainerTools/distroless[distroless] approach reduces the size of the base layer.
-The idea behind _distroless_ is the usage of a single and minimal base image containing all the requirements, and sometimes even the application itself.
-
-Quarkus provides a distroless base image that you can use in your `Dockerfile`.
-You only need to copy your application, and you are done:
-
-[source, dockerfile]
-----
-FROM quay.io/quarkus/quarkus-distroless-image:2.0
-COPY target/*-runner /application
-
-EXPOSE 8080
-USER nonroot
-
-CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
-----
-
-Quarkus provides the `quay.io/quarkus/quarkus-distroless-image:2.0` image.
-It contains the required packages to run a native executable and is only **9Mb**.
-Just add your application on top of this image, and you will get a tiny container image.
-
-Distroless images should not be used in production without rigorous testing.
-
-=== Build a container image from scratch
-
-IMPORTANT: Scratch image support is experimental.
-
-Building fully statically linked binaries enables the usage of a https://hub.docker.com/_/scratch[scratch image] containing solely the resulting native executable.
-
-Sample multistage Dockerfile for building an image from `scratch`:
-
-[source,dockerfile,subs=attributes+]
-----
-## Stage 1 : build with maven builder image with native capabilities
-FROM quay.io/quarkus/ubi9-quarkus-graalvmce-builder-image:{graalvm-flavor} AS build
-USER root
-RUN microdnf install make gcc -y
-COPY --chown=quarkus:quarkus mvnw /code/mvnw
-COPY --chown=quarkus:quarkus .mvn /code/.mvn
-COPY --chown=quarkus:quarkus pom.xml /code/
-RUN mkdir /musl && \
-    curl -L -o musl.tar.gz https://more.musl.cc/11.2.1/x86_64-linux-musl/x86_64-linux-musl-native.tgz && \
-    tar -xvzf musl.tar.gz -C /musl --strip-components 1 && \
-    curl -L -o zlib.tar.gz https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz && \
-    mkdir zlib && tar -xvzf zlib.tar.gz -C zlib --strip-components 1 && \
-    cd zlib && ./configure --static --prefix=/musl && \
-    make && make install && \
-    cd .. && rm -rf zlib && rm -f zlib.tar.gz && rm -f musl.tar.gz
-ENV PATH="/musl/bin:${PATH}"
-USER quarkus
-WORKDIR /code
-RUN ./mvnw -B org.apache.maven.plugins:maven-dependency-plugin:3.8.1:go-offline
-COPY src /code/src
-RUN ./mvnw package -Dnative -DskipTests -Dquarkus.native.additional-build-args="--static","--libc=musl"
-
-## Stage 2 : create the final image
-FROM scratch
-COPY --from=build /code/target/*-runner /application
-EXPOSE 8080
-ENTRYPOINT [ "/application" ]
-----
-
-Scratch images should not be used in production without rigorous testing.
-
-NOTE: The versions of musl and zlib may need to be updated to meet the native-image executable requirements (and UPX if you use native image compression).
-
-=== Compress native images
-
-Quarkus can compress the produced native executable using UPX.
-More details on xref:./upx.adoc[UPX Compression documentation].
-
-=== Separating Java and native image compilation
-
-In certain circumstances, you may want to build the native image in a separate step.
-For example, in a CI/CD pipeline, you may want to have one step to generate the source that will be used for the native image generation and another step to use these sources to actually build the native executable.
-For this use case, you can set the additional flag `quarkus.native.sources-only=true`.
-This will execute the java compilation as if you had started native compilation (`-Dnative`), but stops before triggering the actual call to GraalVM's `native-image`.
-
-[source,bash]
-----
-$ ./mvnw clean package -Dnative -Dquarkus.native.sources-only=true
-----
-
-After compilation has finished, you find the build artifact in `target/native-sources`:
-
-[source,bash]
-----
-$ cd target/native-sources
-$ ls
-getting-started-1.0.0-SNAPSHOT-runner.jar  graalvm.version  lib  native-image.args
-----
-
-From the output above one can see that, in addition to the produced jar file and the associated lib directory, a text file named `native-image.args` was created.
-This file holds all parameters (including the name of the JAR to compile) to pass along to GraalVM's `native-image` command.
-A text file named `graalvm.version` was also created and holds the GraalVM version that should be used.
-If you have GraalVM installed and it matches this version, you can start the native compilation by executing:
-
-[source,bash]
-----
-$ cd target/native-sources
-$ native-image $(cat native-image.args)
-...
-$ ls
-native-image.args
-getting-started-1.0.0-SNAPSHOT-runner
-getting-started-1.0.0-SNAPSHOT-runner.build_artifacts.txt
-getting-started-1.0.0-SNAPSHOT-runner.jar
-----
-
-The process for Gradle is analogous.
-
-Running the build process in a container is also possible:
-
-[source,bash]
-----
-$ ./mvnw clean package -Dquarkus.native.enabled=true -Dquarkus.native.sources-only=true -Dquarkus.native.container-build=true
-----
-
-`-Dquarkus.native.container-build=true` will produce an additional text file named `native-builder.image` holding the docker image name to be used to build the native image.
-
-[source,bash,subs=attributes+]
-----
-cd target/native-sources
-docker run \
-  -it \
-  --user $(id -ur):$(id -gr) \
-  --rm \
-  -v $(pwd):/work \# <1>
-  -w /work \# <2>
-  --entrypoint /bin/sh \
-  $(cat native-builder.image) \# <3>
-  -c "native-image $(cat native-image.args) -J-Xmx4g"# <4>
-----
-
-<1> Mount the host's directory `target/native-image` to the container's `/work`. Thus, the generated binary will also be written to this directory.
-<2> Switch the working directory to `/work`, which we have mounted in <1>.
-<3> Use the docker image from the file `native-builder.image`.
-<4> Call `native-image` with the content of file `native-image.args` as arguments. We also supply an additional argument to limit the process's maximum memory to 4 Gigabytes (this may vary depending on the project being built and the machine building it).
-
-[WARNING]
-====
-If you are running on a Windows machine, please keep in mind that the binary was created within a Linux docker container.
-Hence, the binary will not be executable on the host Windows machine.
-====
-
-A high level overview of what the various steps of a CI/CD pipeline would look is the following:
-
-1. Register the output of the step executing `./mvnw ...` command (i.e. directory `target/native-image`) as a build artifact,
-2. Require this artifact in the step executing the `native-image ...` command, and
-3. Register the output of the step executing the `native-image ...` command (i.e. files matching `target/*runner`) as build artifact.
-
-The environment executing step `1` only needs Java and Maven (or Gradle) installed, while the environment executing step `3` only needs a GraalVM installation (including the `native-image` feature).
-
-Depending on what the final desired output of the CI/CD pipeline is, the generated binary might then be used to create a container image.
-
-== Debugging native executable
-
-Native executables can be debugged using tools such as `gdb`.
-For this to be possible native executables need to be generated with debug symbols.
-
-[NOTE]
-Debug symbol generation is only supported on Linux.
-Windows support is still under development, while macOS is not supported.
-
-To generate debug symbols,
-add `-Dquarkus.native.debug.enabled=true` flag when generating the native executable.
-You will find the debug symbols for the native executable in a `.debug` file next to the native executable.
-
-[NOTE]
-====
-The generation of the `.debug` file depends on `objcopy`.
-As a result, when using a local GraalVM installation on common Linux distributions, you will need to install the `binutils` package:
-
-[source,bash]
-----
-# dnf (rpm-based)
-sudo dnf install binutils
-# Debian-based distributions
-sudo apt-get install binutils
-----
-
-When `objcopy` is not available, debug symbols are embedded in the executable.
-====
-
-Aside from debug symbols,
-setting `-Dquarkus.native.debug.enabled=true` flag generates a cache of source files
-for any JDK runtime classes, GraalVM classes, and application classes resolved during native executable generation.
-This source cache is useful for native debugging tools,
-to establish the link between the symbols and the matching source code.
-It provides a convenient way of making just the necessary sources available to the debugger/IDE when debugging a native executable.
-
-Sources for third party jar dependencies, including Quarkus source code,
-are not added to the source cache by default.
-To include those, make sure you invoke `mvn dependency:sources` first.
-This step is required in order to pull the sources for these dependencies,
-and get them included in the source cache.
-
-The source cache is located in the `target/sources` folder.
-
-[TIP]
-====
-If running `gdb` from a different directory than `target`, then the sources can be loaded by running:
-
-[source,bash]
-----
-directory path/to/target
-----
-
-in the `gdb` prompt.
-
-Or start `gdb` with:
-
-[source,bash]
-----
-gdb -ex 'directory path/to/target' path/to/target/{project.name}-{project.version}-runner
-----
-
-e.g.,
-[source,bash]
-----
-gdb -ex 'directory ./target' ./target/getting-started-1.0.0-SNAPSHOT-runner
-----
-====
-
-For a more detailed guide about debugging native images please refer to the xref:native-reference.adoc[Native Reference Guide].
-
-== Using Monitoring Options
-
-Monitoring options such as JDK flight recorder, jvmstat, heap dumps, NMT (starting with Mandrel 24.1 for JDK 23), and remote JMX
-can be added to the native executable build. Simply supply a comma separated list of the monitoring options you wish to
-include at build time.
-[source,bash]
-----
--Dquarkus.native.monitoring=<comma separated list of options>
-----
-
-|===
-|Monitoring Option |Description |Availability As Of
-
-|jcmd
-|Include JCMD support
-|GraalVM CE for JDK 24 Mandrel 24.2
-
-|jfr
-|Include JDK Flight Recorder support
-|GraalVM CE 21.3 Mandrel 21.3
-
-|jvmstat
-|Adds jvmstat support
-|GraalVM 22.3, GraalVM CE 17.0.7 Mandrel 22.3 Mandrel 23.0 (17.0.7)
-
-|heapdump
-|Adds support for generating heap dumps
-|GraalVM 22.3, GraalVM CE 17.0.7 Mandrel 22.3 Mandrel 23.0 (17.0.7)
-
-|jmxclient
-|Adds support for connections to JMX servers.
-|GraalVM for JDK 17/20 Mandrel 23.0
-
-|jmxserver
-|Adds support for accepting connections from JMX clients.
-|GraalVM for JDK 17/20 Mandrel 23.0 (17.0.7)
-
-|nmt
-|Adds support for native memory tracking.
-|GraalVM for JDK 23 Mandrel 24.1
-
-|threaddump
-|Adds support for dumping thread stacks on SIGQUIT/SIGBREAK.
-|GraalVM for JDK 22 Mandrel 24.0
-
-|none
-|Disables support for all monitoring options that would be enabled by default in Quarkus
-|Pseudo option used by Quarkus
-
-|all
-|Adds all monitoring options.
-|GraalVM 22.3, GraalVM CE 17.0.7 Mandrel 22.3 Mandrel 23.0 (17.0.7)
-|===
-
-Please see the Quarkus Native Reference Guide for more detailed information on these monitoring options.
+For advanced container options — multi-stage builds, distroless images, scratch images, or UPX compression — see the xref:native-reference.adoc#native-container-options[Native Reference Guide].
 
 [[configuration-reference]]
-
-== Creating a Native Image Bundle
-
-A native image bundle containing everything required to build a native image can be generated.
-This is useful to inspect the build inputs and configuration.
-
-The generation of the bundle can be activated by setting any of the following parameters:
-
-|===
-|Parameter |Description |Default
-
-|quarkus.native.bundle.enabled
-|Enables the native-image bundle generation
-|`false`
-
-|quarkus.native.bundle.dry-run
-|Generates the bundle without building the native executable
-|`false`
-
-|quarkus.native.bundle.name
-|Sets the name of the bundle
-|
-|===
-
-To use this feature, run:
-
-[source,bash]
-----
-./mvnw package -Dnative -Dquarkus.native.bundle.enabled=true
-----
-
-This command will generate all the files and configuration needed for the native image build in `target/{project.name}-{project.version}-runner.nib`.
-
-[NOTE]
-====
-More details on the GraalVM native-image bundle are available in the link:https://www.graalvm.org/{graalvm-docs-version}/reference-manual/native-image/overview/Bundles[GraalVM documentation].
-====
-
 == Configuring the Native Executable
 
 There are a lot of different configuration options that can affect how the native executable is generated.
@@ -1030,6 +390,7 @@ include::{generated-dir}/config/quarkus-core_quarkus.native.adoc[opts=optional]
 
 This guide covered the creation of a native (binary) executable for your application.
 It provides an application exhibiting a swift startup time and consuming less memory.
-However, there is much more.
 
-We recommend continuing the journey with the xref:deploying-to-kubernetes.adoc[deployment to Kubernetes and OpenShift].
+* xref:native-reference.adoc[Native Reference Guide] — advanced topics: memory management, debugging, monitoring, testing profiles, and more
+* xref:deploying-to-kubernetes.adoc[Deploying to Kubernetes and OpenShift]
+* xref:container-image.adoc[Container Image Guide] — Jib, Docker, and Buildpack integrations

--- a/docs/src/main/asciidoc/getting-started-dev-services.adoc
+++ b/docs/src/main/asciidoc/getting-started-dev-services.adoc
@@ -160,7 +160,7 @@ Change the method to the following:
 @GET
 @Transactional
 @Produces(MediaType.TEXT_PLAIN)
-public String hello(@QueryParam("name") String name) {
+public String hello(@RestQuery String name) {
    Greeting greeting = new Greeting();
    greeting.name = name;
    greeting.persist();

--- a/docs/src/main/asciidoc/getting-started.adoc
+++ b/docs/src/main/asciidoc/getting-started.adoc
@@ -6,20 +6,16 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Creating Your First Application
 include::_attributes.adoc[]
 :categories: getting-started
-:summary: Discover how to create your first Quarkus application.
+:summary: Build a REST API with live reload, dependency injection, and tests, in under 15 minutes.
 :numbered:
 :sectnums:
 :sectnumlevels: 4
 :topics: getting-started
 
-Learn how to create a Hello World Quarkus app.
-This guide covers:
+In this guide, you'll create a REST endpoint, see live coding in action, add a service with dependency injection, and write tests.
+No boilerplate, no restarts.
 
-* Bootstrapping an application
-* Creating a Jakarta REST endpoint
-* Injecting beans
-* Functional tests
-* Packaging of the application
+TIP: *Already ran the link:/get-started/[Quick Start]?* Skip to <<using-injection>>.
 
 == Prerequisites
 
@@ -35,30 +31,6 @@ You can verify which JDK Maven uses by running `mvn --version`.
 ====
 
 
-== Architecture
-
-In this guide, we create a straightforward application serving a `hello` endpoint. To demonstrate
-dependency injection, this endpoint uses a `greeting` bean.
-
-image::getting-started-architecture.png[alt=Architecture, align=center]
-
-This guide also covers the testing of the endpoint.
-
-== Solution
-
-We recommend that you follow the instructions from <<bootstrapping-the-project,Bootstrapping the project>> and onwards to create the application step by step.
-
-However, you can go right to the completed example.
-
-Download an {quickstarts-archive-url}[archive] or clone the git repository:
-
-[source,bash,subs=attributes+]
-----
-git clone {quickstarts-clone-url}
-----
-
-The solution is located in the `getting-started` link:{quickstarts-tree-url}/getting-started[directory].
-
 == Bootstrapping the project
 
 The easiest way to create a new Quarkus project is to open a terminal and run the following command:
@@ -71,65 +43,13 @@ include::{includes}/devtools/create-app.adoc[]
 It generates the following in `./getting-started`:
 
 * the Maven structure
-* an `org.acme.GreetingResource` resource exposed on `/hello`
+* an `org.acme.GreetingResource` REST endpoint exposed on `/hello`
 * an associated unit test
 * a landing page that is accessible on `http://localhost:8080` after starting the application
 * example `Dockerfile` files for both `native` and `jvm` modes in `src/main/docker`
 * the application configuration file
 
-Once generated, look at the `pom.xml`.
-You will find the import of the Quarkus BOM, allowing you to omit the version of the different Quarkus dependencies.
-In addition, you can see the `quarkus-maven-plugin` responsible of the packaging of the application and also providing the development mode.
-
-[source,xml,subs=attributes+]
-----
-<dependencyManagement>
-    <dependencies>
-        <dependency>
-            <groupId>${quarkus.platform.group-id}</groupId>
-            <artifactId>${quarkus.platform.artifact-id}</artifactId>
-            <version>${quarkus.platform.version}</version>
-            <type>pom</type>
-            <scope>import</scope>
-        </dependency>
-    </dependencies>
-</dependencyManagement>
-
-<build>
-    <plugins>
-        <plugin>
-            <groupId>${quarkus.platform.group-id}</groupId>
-            <artifactId>quarkus-maven-plugin</artifactId>
-            <version>${quarkus.platform.version}</version>
-            <extensions>true</extensions>
-        </plugin>
-    </plugins>
-</build>
-----
-
-In a Gradle project, you would find a similar setup:
-
-* the Quarkus Gradle plugin
-* an `enforcedPlatform` directive for the Quarkus BOM
-
-If we focus on the dependencies section, you can see the extension allowing the development of REST applications:
-
-[source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
-.pom.xml
-----
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-rest</artifactId>
-</dependency>
-----
-
-[source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
-.build.gradle
-----
-implementation("io.quarkus:quarkus-rest")
-----
-
-=== The Jakarta REST resources
+=== The REST endpoint
 
 During the project creation, the `src/main/java/org/acme/GreetingResource.java` file has been created with the following content:
 
@@ -155,13 +75,6 @@ public class GreetingResource {
 
 It's a very simple REST endpoint, returning "Hello from Quarkus REST" to requests on "/hello".
 
-[TIP]
-.Differences with vanilla Jakarta REST
-====
-With Quarkus, there is no need to create an `Application` class. It's supported, but not required. In addition, only one instance
-of the resource is created and not one per request. You can configure this using the different `*Scoped` annotations (`ApplicationScoped`, `RequestScoped`, etc).
-====
-
 == Running the application
 
 Now we are ready to run our application:
@@ -170,24 +83,14 @@ include::{includes}/devtools/dev.adoc[]
 
 [source,shell]
 ----
-[INFO] --------------------< org.acme:getting-started >---------------------
-[INFO] Building getting-started 1.0.0-SNAPSHOT
-[INFO] --------------------------------[ jar ]---------------------------------
-[INFO]
-[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ getting-started ---
-[INFO] Using 'UTF-8' encoding to copy filtered resources.
-[INFO] skip non existing resourceDirectory <path>/getting-started/src/main/resources
-[INFO]
-[INFO] --- maven-compiler-plugin:3.1:compile (default-compile) @ getting-started ---
-[INFO] Changes detected - recompiling the module!
-[INFO] Compiling 2 source files to <path>/getting-started/target/classes
-[INFO]
-[INFO] --- quarkus-maven-plugin:<version>:dev (default-cli) @ getting-started ---
-Listening for transport dt_socket at address: 5005
-2019-02-28 17:05:22,347 INFO  [io.qua.dep.QuarkusAugmentor] (main) Beginning quarkus augmentation
-2019-02-28 17:05:22,635 INFO  [io.qua.dep.QuarkusAugmentor] (main) Quarkus augmentation completed in 288ms
-2019-02-28 17:05:22,770 INFO  [io.quarkus] (main) Quarkus started in 0.668s. Listening on: http://localhost:8080
-2019-02-28 17:05:22,771 INFO  [io.quarkus] (main) Installed features: [cdi, rest]
+...
+__  ____  __  _____   ___  __ ____  ______
+ --/ __ \/ / / / _ | / _ \/ //_/ / / / __/
+ -/ /_/ / /_/ / __ |/ , _/ ,< / /_/ /\ \
+--\___\_\____/_/ |_/_/|_/_/|_|\____/___/
+INFO  [io.quarkus] (Quarkus Main Thread) getting-started 1.0.0-SNAPSHOT on JVM (powered by Quarkus {quarkus-version}) started in 0.968s. Listening on: http://localhost:8080
+INFO  [io.quarkus] (Quarkus Main Thread) Profile dev activated. Live Coding activated.
+INFO  [io.quarkus] (Quarkus Main Thread) Installed features: [cdi, rest, smallrye-context-propagation, vertx]
 ----
 
 Once started, you can request the provided endpoint:
@@ -198,7 +101,7 @@ $ curl -w "\n" http://localhost:8080/hello
 Hello from Quarkus REST
 ----
 
-Hit `CTRL+C` to stop the application, or keep it running and enjoy the blazing fast hot-reload.
+Keep it running and enjoy the blazing fast hot-reload. If you really want shutdown the application, hit `CTRL+C`.
 
 [TIP]
 .Automatically add newline with `curl -w "\n"`
@@ -206,6 +109,21 @@ Hit `CTRL+C` to stop the application, or keep it running and enjoy the blazing f
 We are using `curl -w "\n"` in this example to avoid your terminal printing a '%' or put both result and next command prompt on the same line.
 ====
 
+== Live coding
+
+`quarkus:dev` runs Quarkus in development mode.
+Edit your Java files or resource files, save, and refresh your browser, changes take effect immediately, no restart needed.
+If there are any issues with compilation or deployment an error page will let you know.
+
+Try it: open `src/main/java/org/acme/GreetingResource.java`, change `"Hello from Quarkus REST"` to `"Hola from Quarkus"`, save, and refresh http://localhost:8080/hello.
+Then, switch back to `"Hello from Quarkus REST"`, refresh again... changed again!
+
+While dev mode is running, open http://localhost:8080/q/dev-ui/[the Dev UI], a dashboard where you can browse installed extensions, configuration, endpoints, and more, all live-updated as you code.
+
+This will also listen for a debugger on port `5005`. If you want to wait for the debugger to attach before running you
+can pass `-Dsuspend` on the command line. If you don't want the debugger at all you can use `-Ddebug=false`.
+
+[#using-injection]
 == Using injection
 
 Dependency injection in Quarkus is based on ArC which is a CDI-based dependency injection solution tailored for Quarkus' architecture.
@@ -281,18 +199,6 @@ $ curl -w "\n" http://localhost:8080/hello/greeting/quarkus
 hello quarkus
 ----
 
-== Development Mode
-
-`quarkus:dev` runs Quarkus in development mode. This enables live reload with background compilation, which means
-that when you modify your Java files and/or your resource files and refresh your browser, these changes will automatically take effect.
-This works too for resource files like the configuration property file.
-Refreshing the browser triggers a scan of the workspace, and if any changes are detected, the Java files are recompiled
-and the application is redeployed; your request is then serviced by the redeployed application. If there are any issues
-with compilation or deployment an error page will let you know.
-
-This will also listen for a debugger on port `5005`. If you want to wait for the debugger to attach before running you
-can pass `-Dsuspend` on the command line. If you don't want the debugger at all you can use `-Ddebug=false`.
-
 == Testing
 
 All right, so far so good, but wouldn't it be better with a few tests, just in case.
@@ -331,6 +237,7 @@ Because of this, in the case of Maven, the version of the https://maven.apache.o
     <artifactId>maven-surefire-plugin</artifactId>
     <version>${surefire-plugin.version}</version>
     <configuration>
+       <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
        <systemPropertyVariables>
           <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
           <maven.home>${maven.home}</maven.home>
@@ -357,11 +264,11 @@ import java.util.UUID;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
 
-@QuarkusTest
-public class GreetingResourceTest {
+@QuarkusTest  // <1>
+class GreetingResourceTest {
 
-    @Test    // <1>
-    public void testHelloEndpoint() {
+    @Test
+    void testHelloEndpoint() {
         given()
           .when().get("/hello")
           .then()
@@ -370,7 +277,7 @@ public class GreetingResourceTest {
     }
 
     @Test
-    public void testGreetingEndpoint() {
+    void testGreetingEndpoint() {
         String uuid = UUID.randomUUID().toString();
         given()
           .pathParam("name", uuid)
@@ -382,7 +289,7 @@ public class GreetingResourceTest {
 
 }
 ----
-<1> By using the `QuarkusTest` runner, you instruct JUnit to start the application before the tests.
+<1> By using the `@QuarkusTest`, you instruct JUnit to start the application before the tests.
 <2> Check the HTTP response status code and content
 
 These tests use https://rest-assured.io/[RestAssured], but feel free to use your favorite library.
@@ -397,35 +304,32 @@ You can run these using Maven:
 You can also run the test from your IDE directly (be sure you stopped the application first).
 
 By default, tests will run on port `8081` so as not to conflict with the running application. We automatically
-configure RestAssured to use this port. If you want to use a different client you should use the `@TestHTTPResource`
-annotation to directly inject the URL of the tested application into a field on the test class. This field can be of the type
-`String`, `URL` or `URI`. This annotation can also be given a value for the test path. For example, if I want to test
-a Servlet mapped to `/myservlet` I would just add the following to my test:
+configure RestAssured to use this port.
 
+
+[TIP]
+====
+If you want to use a different client you should use the `@TestHTTPResource` annotation to directly inject the URL of
+the tested application into a field on the test class. This field can be of the type `String`, `URL` or `URI`.
+This annotation can also be given a value for the test path.
+For example, if you want to test an endpoint mapped to `/hello`, you would just add the following to your `@QuarkusTest` test:
 
 [source,java]
 ----
-@TestHTTPResource("/myservlet")
+@TestHTTPResource("/hello")
 URL testUrl;
 ----
 
+====
+
+
 The test port can be controlled via the `quarkus.http.test-port` config property.
 
-== Working with multi-module project or external modules
+=== Continuous testing
 
-Quarkus heavily utilizes https://github.com/smallrye/jandex[Jandex] at build time, to discover various classes or annotations. One immediately recognizable application of this, is CDI bean discovery.
-As a result, most of the Quarkus extensions will not work properly if this build time discovery isn't properly setup.
-
-This index is created by default on the project on which Quarkus is configured for, thanks to our Maven and Gradle plugins.
-
-However, when working with a multi-module project, be sure to read the `Working with multi-module projects` section of the
-xref:maven-tooling.adoc#multi-module-maven[Maven] or xref:gradle-tooling.adoc#multi-module-gradle[Gradle] guides.
-
-If you plan to use external modules (for example, an external library for all your domain objects),
-you will need to make these modules known to the indexing process either by adding the Jandex plugin (if you can modify them)
-or via the `quarkus.index-dependency` property inside your `application.properties` (useful in cases where you can't modify the module).
-
-Be sure to read the xref:cdi-reference.adoc#bean_discovery[Bean Discovery] section of the CDI guide for more information.
+You can also have Quarkus run your tests automatically as you code.
+In the dev mode terminal, press `r`, and then Quarkus re-runs affected tests on every save, giving you instant feedback without leaving your editor.
+See the xref:continuous-testing.adoc[Continuous Testing guide] for more details.
 
 == Packaging and run the application
 
@@ -433,61 +337,29 @@ The application is packaged using:
 
 include::{includes}/devtools/build.adoc[]
 
-It produces several outputs in `/target`:
+It produces the `quarkus-app` directory in `/target`, which contains the `quarkus-run.jar` file.
+This is a _fast-jar_, not an _über-jar_, the dependencies are copied into subdirectories of `quarkus-app/lib/`.
 
-* `getting-started-1.0.0-SNAPSHOT.jar` - containing just the classes and resources of the projects, it's the regular
-artifact produced by the Maven build - it is *not* the runnable jar;
-* the `quarkus-app` directory which contains the `quarkus-run.jar` jar file - being an executable _jar_. Be aware that it's not an _über-jar_ as
-the dependencies are copied into subdirectories of `quarkus-app/lib/`.
+You can run the application using: `java -jar target/quarkus-app/quarkus-run.jar`.
 
-You can run the application using: `java -jar target/quarkus-app/quarkus-run.jar`
-
-NOTE: If you want to deploy your application somewhere (typically in a container), you need to deploy the whole `quarkus-app` directory.
+NOTE: If you want to deploy your application somewhere (typically in a container), you need to copy/deploy the whole `quarkus-app` directory.
 
 NOTE: Before running the application, don't forget to stop the hot reload mode (hit `CTRL+C`), or you will have a port conflict.
 
-[[banner]]
-== Configuring the banner
-
-By default, when a Quarkus application starts (in regular or dev mode), it will display an ASCII art banner. The banner can be disabled by setting `quarkus.banner.enabled=false` in `application.properties`,
-by setting the `-Dquarkus.banner.enabled=false` Java System Property, or by setting the `QUARKUS_BANNER_ENABLED` environment variable to `false`.
-Furthermore, users can supply a custom banner by placing the banner file in `src/main/resources` and configuring `quarkus.banner.path=name-of-file` in `application.properties`.
-
-== Non Application endpoints
-
-Various Quarkus extensions contribute non-application endpoints that provide different kinds of information about the application.
-Examples of such extensions are the xref:smallrye-health.adoc[health], xref:telemetry-micrometer.adoc[metrics], xref:openapi-swaggerui.adoc[OpenAPI] and info extensions.
-
-These non application endpoints are normally accessible under the `/q` prefix like so:
-
-* `/q/health`
-* `/q/metrics`
-* `/q/openapi`
-* `/q/info`
-
-but users can also choose to expose one that might present a security risk under a different TCP port using a dedicated xref:management-interface-reference.adoc[management interface].
-
-=== Info endpoint
-
-If the application contains the `quarkus-info` extension, then Quarkus will by default expose the `/q/info` endpoint which provides information about the build, java version, version control, and operating system. The level of detail of the exposed information is configurable.
-
-All CDI beans implementing the `InfoContributor` will be picked up and their data will be appended to the endpoint.
-
-==== Configuration Reference
-
-include::{generated-dir}/config/quarkus-info.adoc[opts=optional, leveloffset=+2]
-
 == What's next?
 
-This guide covered the creation of an application using Quarkus.
-However, there is much more.
-We recommend continuing the journey by creating xref:getting-started-dev-services.adoc[your second Quarkus application], with Dev Services and persistence.
-You can learn about creating a native executable and packaging it in a container with the xref:building-native-image.adoc[building a native executable guide].
-If you are interested in reactive, we recommend the xref:getting-started-reactive.adoc[getting started with reactive guide], where you can see how to implement reactive applications with Quarkus.
+You now have a running Quarkus application with dependency injection and tests. Here's where to go next:
 
-In addition, the xref:tooling.adoc[tooling guide] document explains how to:
+* xref:getting-started-dev-services.adoc[Your Second Quarkus Application] — add a database without installing one, using Dev Services
+* xref:building-native-image.adoc[Building a Native Executable] — compile to a native binary and package it in a container
+* xref:kafka-getting-started.adoc[Getting Started with Quarkus and Kafka] — build event-driven and streaming applications with Quarkus and Apache Kafka
+* xref:tooling.adoc[Tooling Guide] — IDE setup, scaffolding, and development mode tips
 
-* scaffold a project in a single command line
-* enable the _development mode_ (hot reload)
-* import the project in your favorite IDE
-* and more
+=== Solution
+
+You can find the completed example in the {quickstarts-tree-url}/getting-started[getting-started directory] of the Quarkus quickstarts repository:
+
+[source,bash,subs=attributes+]
+----
+git clone {quickstarts-clone-url}
+----

--- a/docs/src/main/asciidoc/info.adoc
+++ b/docs/src/main/asciidoc/info.adoc
@@ -1,0 +1,248 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
+= Application Info Endpoint
+include::_attributes.adoc[]
+:categories: observability
+:summary: Expose build, git, Java, and OS information via the /q/info endpoint.
+:topics: info,observability
+:extensions: io.quarkus:quarkus-info
+
+The `quarkus-info` extension exposes an HTTP endpoint at `/q/info` that returns information about the application: build metadata, git commit, Java version, and operating system.
+
+== Adding the extension
+
+Add the `quarkus-info` extension to your project:
+
+:add-extension-extensions: info
+include::{includes}/devtools/extension-add.adoc[]
+
+This will add the following to your build file:
+
+[source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
+.pom.xml
+----
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-info</artifactId>
+</dependency>
+----
+
+[source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
+.build.gradle
+----
+implementation("io.quarkus:quarkus-info")
+----
+
+Once added, start your application and access the info endpoint:
+
+[source,shell]
+----
+$ curl -s http://localhost:8080/q/info | jq
+----
+
+== Response structure
+
+The endpoint returns a JSON object with up to four sections:
+
+[source,json]
+----
+{
+  "os": {
+    "name": "Mac OS X",
+    "version": "15.5",
+    "arch": "aarch64"
+  },
+  "java": {
+    "version": "21.0.7",
+    "vendor": "Eclipse Adoptium",
+    "vendorVersion": "Temurin-21.0.7+6"
+  },
+  "build": {
+    "group": "org.acme",
+    "artifact": "getting-started",
+    "version": "1.0.0-SNAPSHOT",
+    "time": "2026-05-21T10:30:00Z",
+    "quarkusVersion": "{quarkus-version}"
+  },
+  "git": {
+    "branch": "main",
+    "commit": {
+      "id": "a1b2c3d",
+      "time": "2026-05-20T14:22:00Z"
+    }
+  }
+}
+----
+
+Each section can be individually enabled or disabled via configuration.
+
+NOTE: Git information is only available if the project is in a Git repository. If no `.git` directory is found, the `git` section is omitted.
+
+== Git information modes
+
+The `quarkus.info.git.mode` property controls how much git information is included.
+
+`standard` (default):: Branch name, abbreviated commit ID, and commit time.
+`full`:: Adds remote URL, tags, full commit ID, commit message, author and committer details.
+
+[source,properties]
+----
+quarkus.info.git.mode=full
+----
+
+With `full` mode, the `git` section expands to:
+
+[source,json]
+----
+{
+  "git": {
+    "branch": "main",
+    "remote": "https://github.com/acme/getting-started.git",
+    "tags": [],
+    "commit": {
+      "id": {
+        "full": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+        "abbrev": "a1b2c3d"
+      },
+      "time": "2026-05-20T14:22:00Z",
+      "message": {
+        "full": "Add greeting endpoint",
+        "short": "Add greeting endpoint"
+      },
+      "user": {
+        "name": "Jane Doe",
+        "email": "jane@example.com"
+      }
+    }
+  }
+}
+----
+
+== Adding custom build properties
+
+You can add custom key-value pairs to the `build` section:
+
+[source,properties]
+----
+quarkus.info.build.my-custom-key=my-value
+quarkus.info.build.environment=staging
+----
+
+These will appear alongside the standard build properties:
+
+[source,json]
+----
+{
+  "build": {
+    "group": "org.acme",
+    "artifact": "getting-started",
+    "version": "1.0.0-SNAPSHOT",
+    "time": "2026-05-21T10:30:00Z",
+    "quarkusVersion": "{quarkus-version}",
+    "my-custom-key": "my-value",
+    "environment": "staging"
+  }
+}
+----
+
+== Custom info contributors
+
+You can contribute your own sections to the info endpoint by implementing the `InfoContributor` interface and making it a CDI bean:
+
+[source,java]
+----
+package org.acme;
+
+import java.util.Map;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.info.runtime.spi.InfoContributor;
+
+@ApplicationScoped
+public class CustomInfoContributor implements InfoContributor {
+
+    @Override
+    public String name() {
+        return "aws";
+    }
+
+    @Override
+    public Map<String, Object> data() {
+        return Map.of(
+            "region", "eu-west-1",
+            "instance", System.getenv().getOrDefault("HOSTNAME", "unknown")
+        );
+    }
+}
+----
+
+This adds a `custom` section to the info endpoint response:
+
+[source,json]
+----
+{
+  "aws": {
+    "region": "eu-west-1",
+    "instance": "app-7f8d9c-xk2lp"
+  }
+}
+----
+
+The `name()` method determines the key in the JSON output.
+The `data()` method is called once at startup, use it for values that don't change at runtime.
+
+== Programmatic access
+
+The extension also exposes injectable beans that you can use directly in your code:
+
+[source,java]
+----
+import io.quarkus.info.GitInfo;
+import io.quarkus.info.BuildInfo;
+import io.quarkus.info.JavaInfo;
+import io.quarkus.info.OsInfo;
+
+@Path("/version")
+public class VersionResource {
+
+    @Inject
+    BuildInfo buildInfo;
+
+    @Inject
+    GitInfo gitInfo;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String version() {
+        return buildInfo.version() + " (" + gitInfo.latestCommitId() + ")";
+    }
+}
+----
+
+The available beans are:
+
+* `GitInfo`: `branch()`, `latestCommitId()`, `commitTime()`
+* `BuildInfo`: `group()`, `artifact()`, `version()`, `time()`, `quarkusVersion()`
+* `JavaInfo`: `version()`, `vendor()`, `vendorVersion()`
+* `OsInfo`: `name()`, `version()`, `architecture()`
+
+NOTE: These beans are only available if the corresponding section is enabled in configuration.
+
+== Management interface
+
+If you use the xref:management-interface-reference.adoc[management interface], the info endpoint is automatically exposed on the management port instead of the main HTTP port:
+
+[source,properties]
+----
+quarkus.management.enabled=true
+----
+
+The info endpoint will then be available at `http://0.0.0.0:9000/q/info` instead of `http://localhost:8080/q/info`.
+
+== Configuration reference
+
+include::{generated-dir}/config/quarkus-info.adoc[opts=optional, leveloffset=+2]

--- a/docs/src/main/asciidoc/kafka-getting-started.adoc
+++ b/docs/src/main/asciidoc/kafka-getting-started.adoc
@@ -3,14 +3,14 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Getting Started to Quarkus Messaging with Apache Kafka
+= Getting Started with Quarkus Messaging and Apache Kafka
 include::_attributes.adoc[]
 :categories: messaging
-:summary: This guide demonstrates how your Quarkus application can utilize Quarkus Messaging to interact with Apache Kafka.
+:summary: Build two applications that communicate via Apache Kafka using Quarkus Messaging.
 :topics: messaging,kafka,reactive-messaging
 :extensions: io.quarkus:quarkus-messaging-kafka
 
-This guide demonstrates how your Quarkus application can utilize Quarkus Messaging to interact with Apache Kafka.
+In this guide, you will build two applications that exchange messages through Apache Kafka using Quarkus Messaging: a _producer_ that sends quote requests and a _processor_ that replies with prices.
 
 == Prerequisites
 
@@ -19,7 +19,7 @@ include::{includes}/prerequisites.adoc[]
 
 == Architecture
 
-In this guide, we are going to develop two applications communicating with Kafka.
+The two applications communicate via Kafka.
 The first application sends a _quote request_ to Kafka and consumes Kafka messages from the _quote_ topic.
 The second application receives the _quote request_ and sends a _quote_ back.
 
@@ -38,8 +38,8 @@ The user will therefore see the quote price updated from _pending_ to the receiv
 
 == Solution
 
-We recommend that you follow the instructions in the next sections and create applications step by step.
-However, you can go right to the completed example.
+Follow the instructions below to create the applications step by step.
+You can also go directly to the completed example.
 
 Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {quickstarts-archive-url}[archive].
 
@@ -47,7 +47,7 @@ The solution is located in the `kafka-quickstart` link:{quickstarts-tree-url}/ka
 
 == Creating the Maven Project
 
-First, we need to create two projects: the _producer_ and the _processor_.
+First, create two projects: the _producer_ and the _processor_.
 
 To create the _producer_ project, in a terminal run:
 
@@ -56,7 +56,7 @@ To create the _producer_ project, in a terminal run:
 :create-app-post-command:
 include::{includes}/devtools/create-app.adoc[]
 
-This command creates the project structure and selects two Quarkus extensions we will be using:
+This command creates the project structure and selects two Quarkus extensions:
 
 1. Quarkus REST (formerly RESTEasy Reactive) and its Jackson support (to handle JSON) to serve the HTTP endpoint.
 2. The Kafka connector for Reactive Messaging
@@ -97,20 +97,20 @@ At that point, you should have the following structure:
             └── application.properties
 ----
 
-Open the two projects in your favorite IDE.
+Open the two projects in your IDE.
 
 [TIP]
 .Dev Services
 ====
-No need to start a Kafka broker when using the dev mode or for tests.
-Quarkus starts a broker for you automatically.
+No need to start a Kafka broker in dev mode or for tests.
+Quarkus starts one automatically.
 See xref:kafka-dev-services.adoc[Dev Services for Kafka] for details.
 ====
 
 == The Quote object
 
-The `Quote` class will be used in both _producer_ and _processor_ projects.
-For the sake of simplicity, we will duplicate the class.
+The `Quote` class is used in both the _producer_ and _processor_ projects.
+For simplicity, duplicate the class.
 In both projects, create the `src/main/java/org/acme/kafka/model/Quote.java` file, with the following content:
 
 [source,java]
@@ -144,9 +144,7 @@ public class Quote {
 
 JSON representation of `Quote` objects will be used in messages sent to the Kafka topic
 and also in the server-sent events sent to web browsers.
-
-Quarkus has built-in capabilities to deal with JSON Kafka messages.
-In a following section, we will create serializer/deserializer classes for Jackson.
+Quarkus has built-in capabilities to deal with JSON Kafka messages and automatically generates the required serializers and deserializers.
 
 == Sending quote request
 
@@ -158,13 +156,11 @@ package org.acme.kafka.producer;
 
 import java.util.UUID;
 
-import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
-import org.acme.kafka.model.Quote;
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Emitter;
 
@@ -192,16 +188,16 @@ public class QuotesResource {
 <3> Return the same UUID to the client.
 
 
-The `quote-requests` channel is going to be managed as a Kafka topic, as that's the only connector on the classpath.
+The `quote-requests` channel is managed as a Kafka topic, as that's the only connector on the classpath.
 If not indicated otherwise, like in this example, Quarkus uses the channel name as topic name.
 So, in this example, the application writes into the `quote-requests` topic.
 Quarkus also configures the serializer automatically, because it finds that the `Emitter` produces `String` values.
 
-TIP: When you have multiple connectors, you would need to indicate which connector you want to use in the application configuration.
+TIP: When you have multiple connectors, you need to indicate which connector to use in the application configuration.
 
 == Processing quote requests
 
-Now let's consume the quote request and give out a price.
+Now consume the quote request and give out a price.
 Inside the _processor_ project, create the `src/main/java/org/acme/kafka/processor/QuotesProcessor.java` file and add the following content:
 
 [source, java]
@@ -243,7 +239,7 @@ public class QuotesProcessor {
 <3> Indicates that the processing is _blocking_ and cannot be run on the caller thread.
 
 For every Kafka _record_ from the `quote-requests` topic, Reactive Messaging calls the `process` method, and sends the returned `Quote` object to the `quotes` channel.
-In this case, we need to configure the channel in the `application.properties` file, to configures the `requests` and `quotes` channels:
+In this case, configure the channels in the `application.properties` file:
 
 [source, properties]
 ----
@@ -254,15 +250,14 @@ mp.messaging.incoming.requests.topic=quote-requests
 mp.messaging.incoming.requests.auto.offset.reset=earliest
 ----
 
-Note that in this case we have one incoming and one outgoing connector configuration, each one distinctly named.
 The configuration properties are structured as follows:
 
 `mp.messaging.[outgoing|incoming].{channel-name}.property=value`
 
 The `channel-name` segment must match the value set in the `@Incoming` and `@Outgoing` annotation:
 
-* `quote-requests` -> Kafka topic from which we read the quote requests
-* `quotes` -> Kafka topic in which we write the quotes
+* `quote-requests` -> Kafka topic from which the quote requests are read
+* `quotes` -> Kafka topic to which the quotes are written
 
 [NOTE]
 ====
@@ -271,15 +266,15 @@ An exhaustive list of configuration properties is available in xref:kafka.adoc#k
 ====
 
 `mp.messaging.incoming.requests.auto.offset.reset=earliest` instructs the application to start reading the topics from the first offset, when there is no committed offset for the consumer group.
-In other words, it will also process messages sent before we start the processor application.
+In other words, it will also process messages sent before the processor application started.
 
 There is no need to set serializers or deserializers.
 Quarkus detects them, and if none are found, generates them using JSON serialization.
 
 == Receiving quotes
 
-Back to our _producer_ project.
-Let's modify the `QuotesResource` to consume quotes from Kafka and send them back to the client via Server-Sent Events:
+Back to the _producer_ project.
+Modify the `QuotesResource` to consume quotes from Kafka and send them back to the client via Server-Sent Events:
 
 [source,java]
 ----
@@ -312,15 +307,14 @@ It will also generate a deserializer for the `Quote` class.
 In this example we used Jackson to serialize/deserialize Kafka messages.
 For more options on message serialization, see xref:kafka.adoc#kafka-serialization[Kafka Reference Guide - Serialization].
 
-We strongly suggest adopting a contract-first approach using a schema registry.
-To learn more about how to use Apache Kafka with the schema registry and Avro, follow the
-xref:kafka-schema-registry-avro.adoc[Using Apache Kafka with Schema Registry and Avro] guide for Avro
-or you can follow the xref:kafka-schema-registry-json-schema.adoc[Using Apache Kafka with Schema Registry and JSON Schema] guide..
+A contract-first approach using a schema registry is strongly recommended.
+See the xref:kafka-schema-registry-avro.adoc[Using Apache Kafka with Schema Registry and Avro] guide
+or the xref:kafka-schema-registry-json-schema.adoc[Using Apache Kafka with Schema Registry and JSON Schema] guide.
 ====
 
 == The HTML page
 
-Final touch, the HTML page requesting quotes and displaying the prices obtained over SSE.
+The final piece is an HTML page that requests quotes and displays the prices received over SSE.
 
 Inside the _producer_ project, create the `src/main/resources/META-INF/resources/quotes.html` file with the following content:
 
@@ -370,13 +364,12 @@ Inside the _producer_ project, create the `src/main/resources/META-INF/resources
 </html>
 ----
 
-Nothing spectacular here.
-When the user clicks the button, HTTP request is made to request a quote, and a pending quote is added to the list.
+When the user clicks the button, an HTTP request is made to request a quote, and a pending quote is added to the list.
 On each quote received over SSE, the corresponding item in the list is updated.
 
 == Get it running
 
-You just need to run both applications.
+Run both applications.
 In one terminal, run:
 
 [source,bash]
@@ -405,7 +398,7 @@ You can follow the instructions from the https://kafka.apache.org/quickstart[Apa
 ----
 services:
 
-    kafka:
+  kafka:
     image: quay.io/strimzi/kafka:latest-kafka-4.1.0
     command: [
       "sh", "-c",
@@ -462,7 +455,7 @@ Once packaged, run `docker-compose up`.
 
 NOTE: This is a development cluster, do not use in production.
 
-You can also build and run our applications as native executables.
+You can also build and run the applications as native executables.
 First, compile both applications as native:
 
 [source, bash]
@@ -481,14 +474,8 @@ docker-compose up --build
 
 == Going further
 
-This guide has shown how you can interact with Kafka using Quarkus.
-It utilizes https://smallrye.io/smallrye-reactive-messaging[SmallRye Reactive Messaging] to build data streaming applications.
+This guide demonstrated how to interact with Kafka using Quarkus and https://smallrye.io/smallrye-reactive-messaging[SmallRye Reactive Messaging] to build data streaming applications.
 
-For the exhaustive list of features and configuration options, check the xref:kafka.adoc[Reference guide for Apache Kafka Extension].
+For the full list of features and configuration options, see the xref:kafka.adoc[Reference guide for Apache Kafka Extension].
 
-[NOTE]
-====
-In this guide we explore how we can interact with Apache Kafka using the Quarkus Messaging extensions.
-Quarkus extension for Kafka also allows
-xref:kafka.adoc#kafka-bare-clients[using Kafka clients directly].
-====
+NOTE: The Quarkus Kafka extension also supports xref:kafka.adoc#kafka-bare-clients[using Kafka clients directly].

--- a/docs/src/main/asciidoc/management-interface-reference.adoc
+++ b/docs/src/main/asciidoc/management-interface-reference.adoc
@@ -13,9 +13,17 @@ include::_attributes.adoc[]
 :topics: management,observability
 :extensions: io.quarkus:quarkus-vertx-http
 
-By default, Quarkus exposes the _management_ endpoints under `/q` on the main HTTP server.
-The same HTTP server provides the application endpoints and the management endpoints.
+Various Quarkus extensions contribute non-application endpoints that provide different kinds of information about the application.
+Examples of such extensions are the xref:smallrye-health.adoc[health], xref:telemetry-micrometer.adoc[metrics], xref:openapi-swaggerui.adoc[OpenAPI] and xref:info.adoc[info] extensions.
 
+These non-application endpoints are normally accessible under the `/q` prefix like so:
+
+* `/q/health`
+* `/q/metrics`
+* `/q/openapi`
+* `/q/info`
+
+By default, these management endpoints are served by the same HTTP server as your application endpoints.
 This document presents how you can use a separate HTTP server (bound to a different network interface and port) for the management endpoints.
 It avoids exposing these endpoints on the main server and, therefore, prevents undesired accesses.
 

--- a/docs/src/main/asciidoc/native-reference.adoc
+++ b/docs/src/main/asciidoc/native-reference.adoc
@@ -19,7 +19,13 @@ increase the reliability and improve the runtime performance of native executabl
 These are the high level sections to be found in this guide:
 
 * <<native-memory-management,Native Memory Management>>
+* <<native-image-agent-integration,Native Image Tracing Agent Integration>>
 * <<inspecting-and-debugging,Inspecting and Debugging Native Executables>>
+* <<native-testing,Advanced Native Testing>>
+* <<native-container-options,Advanced Container Image Options>>
+* <<native-ci-cd,CI/CD and Build Pipeline Options>>
+* <<native-monitoring,Monitoring Options>>
+* <<native-bundles,Native Image Bundles>>
 * <<native-faq,Frequently Asked Questions>>
 
 [[native-memory-management]]
@@ -2119,6 +2125,575 @@ We can now examine line `169` and get a first hint of what might be wrong
 or walk up the stack using `gdb`’s `up` command to see what part of our code led to this situation.
 For more information about using `gdb` to debug native executables, see the
 link:https://www.graalvm.org/{graalvm-docs-version}/reference-manual/native-image/debugging-and-diagnostics/DebugInfo/[GraalVM Debug Info Feature] guide.
+
+[[native-testing]]
+== Advanced Native Testing
+
+The xref:building-native-image.adoc[Building a Native Executable] guide covers the basics of testing native executables.
+This section covers advanced testing topics: test profiles, Java preview features, excluding tests, and testing a pre-built binary.
+
+=== Profiles
+By default, integration tests both *build* and *run* the native executable using the `prod` profile.
+
+You can override the profile the executable *runs* with during the test using the `quarkus.test.integration-test-profile` property.
+Either by adding it to `application.properties` or by appending it to the command line:
+`./mvnw verify -Dnative -Dquarkus.test.integration-test-profile=test`.
+Your `%test.` prefixed properties will be used at the test runtime.
+
+
+You can override the profile the executable is *built* with and *runs* with using the `quarkus.profile=test` property, e.g.
+`./mvnw clean verify -Dnative -Dquarkus.profile=test`. This might come handy if there are test specific resources to be processed,
+such as importing test data into the database.
+
+[source,properties]
+----
+quarkus.native.resources.includes=version.txt
+%test.quarkus.native.resources.includes=version.txt,import-dev.sql
+%test.quarkus.hibernate-orm.schema-management.strategy=drop-and-create
+%test.quarkus.hibernate-orm.sql-load-script=import-dev.sql
+----
+
+With the aforementioned example in your `application.properties`, your Hibernate ORM managed database will be populated with test
+data both during the JVM mode test run and during the native mode test run. The production
+executable will contain only the `version.txt` resource, no superfluous test data.
+
+[WARNING]
+====
+The executable built with `-Dquarkus.profile=test` is not suitable for production deployment.
+It contains your test resources files and settings. Once the testing is done, the executable would have to be built again,
+using the default, `prod` profile.
+
+Alternatively, if you need to specify specific properties when running tests against the native executable
+built using the `prod` profile, an option is to put those properties in file `src/test/resources/application-nativeit.yaml`, and refer to it from the `failsafe` plugin configuration using the `QUARKUS_CONFIG_LOCATIONS` environment variable. For instance:
+
+[source,xml]
+----
+<plugin>
+  <artifactId>maven-failsafe-plugin</artifactId>
+  <version>${surefire-plugin.version}</version>
+  <executions>
+    <execution>
+      <goals>
+        <goal>integration-test</goal>
+        <goal>verify</goal>
+      </goals>
+      <configuration>
+        <systemPropertyVariables>
+          <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+          <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+          <maven.home>${maven.home}</maven.home>
+        </systemPropertyVariables>
+        <environmentVariables>
+          <QUARKUS_CONFIG_LOCATIONS>./src/test/resources/application-nativeit.yaml</QUARKUS_CONFIG_LOCATIONS>
+        </environmentVariables>
+      </configuration>
+    </execution>
+  </executions>
+</plugin>
+----
+====
+
+=== Java preview features
+
+[[graal-test-preview]]
+[NOTE]
+.Java preview features
+====
+Java code that relies on preview features requires special attention.
+To test a native executable, this means that the `--enable-preview` flag needs to be passed to the Surefire plugin.
+Adding `<argLine>--enable-preview</argLine>` to its `configuration` section is one way to do so.
+====
+
+=== Excluding tests when running as a native executable
+
+When running tests this way, the only things that actually run natively are your application endpoints, which
+you can only test via HTTP calls. Your test code does not actually run natively, so if you are testing code
+that does not call your HTTP endpoints, it's probably not a good idea to run them as part of native tests.
+
+If you share your test class between JVM and native executions like we advise above, you can mark certain tests
+with the `@DisabledOnIntegrationTest` annotation in order to skip them when testing against a native image.
+
+[NOTE]
+====
+Using `@DisabledOnIntegrationTest` will also disable the test in all integration test instances, including
+testing the application in JVM mode, in a container image, and native image.
+====
+
+=== Testing an existing native executable
+
+It is also possible to re-run the tests against a native executable that has already been built. To do this run
+`./mvnw test-compile failsafe:integration-test -Dnative`. This will discover the existing native image and run the tests against it using failsafe.
+
+If the process cannot find the native image for some reason, or you want to test a native image that is no longer in the
+target directory you can specify the executable with the `-Dnative.image.path=` system property.
+
+[[native-container-options]]
+== Advanced Container Image Options
+
+The xref:building-native-image.adoc[Building a Native Executable] guide covers the basics of creating containers with the micro base image and the container-image extensions.
+This section covers additional container strategies: the minimal (UBI) base image, multi-stage Docker builds, distroless images, scratch images, static linking, and UPX compression.
+
+=== Using the minimal base image
+
+The project generation provides a `Dockerfile.native` in the `src/main/docker` directory with the following content:
+
+[source,dockerfile]
+----
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6
+WORKDIR /work/
+RUN chown 1001 /work \
+    && chmod "g+rwX" /work \
+    && chown 1001:root /work
+COPY --chown=1001:root --chmod=0755 target/*-runner /work/application
+
+EXPOSE 8080
+USER 1001
+
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
+----
+
+The UBI minimal image is bigger than the micro image mentioned in the xref:building-native-image.adoc[Building a Native Executable] guide.
+It contains more utilities such as the `microdnf` package manager.
+
+[[multistage-docker]]
+=== Using a multi-stage Docker build
+
+You may want to build the native executable directly in a container without having a final container containing the build tools.
+That approach is possible with a multi-stage Docker build:
+
+1. The first stage builds the native executable using Maven or Gradle
+2. The second stage is a minimal image copying the produced native executable
+
+
+[WARNING]
+====
+Before building a container image from the Dockerfiles shown below, you need to update the default `.dockerignore` file, as it filters everything except the `target` directory. In order to build inside a container, you need to copy the `src` directory. Thus, edit your `.dockerignore` and remove the `*` line.
+====
+
+Such a multi-stage build can be achieved as follows:
+
+Sample Dockerfile for building with Maven:
+[source,dockerfile,subs=attributes+]
+----
+## Stage 1 : build with maven builder image with native capabilities
+FROM quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor} AS build
+COPY --chown=quarkus:quarkus --chmod=0755 mvnw /code/mvnw
+COPY --chown=quarkus:quarkus .mvn /code/.mvn
+COPY --chown=quarkus:quarkus pom.xml /code/
+USER quarkus
+WORKDIR /code
+RUN ./mvnw -B org.apache.maven.plugins:maven-dependency-plugin:3.8.1:go-offline
+COPY src /code/src
+RUN ./mvnw package -Dnative
+
+## Stage 2 : create the docker final image
+FROM quay.io/quarkus/ubi9-quarkus-micro-image:2.0
+WORKDIR /work/
+COPY --from=build /code/target/*-runner /work/application
+
+# set up permissions for user `1001`
+RUN chmod 775 /work /work/application \
+  && chown -R 1001 /work \
+  && chmod -R "g+rwX" /work \
+  && chown -R 1001:root /work
+
+EXPOSE 8080
+USER 1001
+
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
+----
+
+NOTE: This multi-stage Docker build copies the Maven wrapper from the host machine.
+The Maven wrapper (or the Gradle wrapper) is a convenient way to provide a specific version of Maven/Gradle.
+It avoids having to create a base image with Maven and Gradle.
+To provision the Maven Wrapper in your project, use: `mvn wrapper:wrapper`.
+
+Save this file in `src/main/docker/Dockerfile.multistage` as it is not included in the getting started quickstart.
+
+Sample Dockerfile for building with Gradle:
+[source,dockerfile,subs=attributes+]
+----
+## Stage 1 : build with maven builder image with native capabilities
+FROM quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor} AS build
+USER root
+RUN microdnf install findutils -y
+COPY --chown=quarkus:quarkus gradlew /code/gradlew
+COPY --chown=quarkus:quarkus gradle /code/gradle
+COPY --chown=quarkus:quarkus build.gradle /code/
+COPY --chown=quarkus:quarkus settings.gradle /code/
+COPY --chown=quarkus:quarkus gradle.properties /code/
+USER quarkus
+WORKDIR /code
+COPY src /code/src
+RUN ./gradlew build -Dquarkus.native.enabled=true
+
+## Stage 2 : create the docker final image
+FROM quay.io/quarkus/ubi9-quarkus-micro-image:2.0
+WORKDIR /work/
+COPY --from=build /code/build/*-runner /work/application
+RUN chmod 775 /work
+EXPOSE 8080
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
+----
+
+If you are using Gradle in your project, you can use this sample Dockerfile.  Save it in `src/main/docker/Dockerfile.multistage`.
+
+[source,bash]
+----
+docker build -f src/main/docker/Dockerfile.multistage -t quarkus-quickstart/getting-started .
+----
+
+And, finally, run it with:
+
+[source,bash]
+----
+docker run -i --rm -p 8080:8080 quarkus-quickstart/getting-started
+----
+
+[TIP]
+====
+If you need SSL support in your native executable, you can easily include the necessary libraries in your Docker image.
+
+Please see xref:native-and-ssl.adoc#working-with-containers[our Using SSL With Native Executables guide] for more information.
+====
+
+[NOTE,subs=attributes+]
+====
+To use GraalVM CE instead of Mandrel, update the `FROM` clause to: `FROM quay.io/quarkus/ubi9-quarkus-graalvmce-builder-image:{graalvm-flavor} AS build`.
+====
+
+=== Using a Distroless base image
+
+IMPORTANT: Distroless image support is experimental.
+
+If you are looking for small container images, the https://github.com/GoogleContainerTools/distroless[distroless] approach reduces the size of the base layer.
+The idea behind _distroless_ is the usage of a single and minimal base image containing all the requirements, and sometimes even the application itself.
+
+Quarkus provides a distroless base image that you can use in your `Dockerfile`.
+You only need to copy your application, and you are done:
+
+[source, dockerfile]
+----
+FROM quay.io/quarkus/quarkus-distroless-image:2.0
+COPY target/*-runner /application
+
+EXPOSE 8080
+USER nonroot
+
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
+----
+
+Quarkus provides the `quay.io/quarkus/quarkus-distroless-image:2.0` image.
+It contains the required packages to run a native executable and is only **9Mb**.
+Just add your application on top of this image, and you will get a tiny container image.
+
+Distroless images should not be used in production without rigorous testing.
+
+=== Building fully static native executables
+
+IMPORTANT: Fully static native executables support is experimental.
+
+On Linux it's possible to package a native executable that doesn't depend on any system shared library.
+There are link:https://www.graalvm.org/{graalvm-docs-version}/reference-manual/native-image/guides/build-static-executables/#prerequisites-and-preparation[some system requirements] to be fulfilled and additional build arguments to be used along with the `native-image` invocation, a minimum is `-Dquarkus.native.additional-build-args="--static","--libc=musl"`.
+
+Compiling fully static binaries is done by statically linking https://musl.libc.org/[musl] instead of `glibc` and should not be used in production without rigorous testing.
+
+=== Building a container image from scratch
+
+IMPORTANT: Scratch image support is experimental.
+
+Building fully statically linked binaries enables the usage of a https://hub.docker.com/_/scratch[scratch image] containing solely the resulting native executable.
+
+Sample multistage Dockerfile for building an image from `scratch`:
+
+[source,dockerfile,subs=attributes+]
+----
+## Stage 1 : build with maven builder image with native capabilities
+FROM quay.io/quarkus/ubi9-quarkus-graalvmce-builder-image:{graalvm-flavor} AS build
+USER root
+RUN microdnf install make gcc -y
+COPY --chown=quarkus:quarkus mvnw /code/mvnw
+COPY --chown=quarkus:quarkus .mvn /code/.mvn
+COPY --chown=quarkus:quarkus pom.xml /code/
+RUN mkdir /musl && \
+    curl -L -o musl.tar.gz https://more.musl.cc/11.2.1/x86_64-linux-musl/x86_64-linux-musl-native.tgz && \
+    tar -xvzf musl.tar.gz -C /musl --strip-components 1 && \
+    curl -L -o zlib.tar.gz https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz && \
+    mkdir zlib && tar -xvzf zlib.tar.gz -C zlib --strip-components 1 && \
+    cd zlib && ./configure --static --prefix=/musl && \
+    make && make install && \
+    cd .. && rm -rf zlib && rm -f zlib.tar.gz && rm -f musl.tar.gz
+ENV PATH="/musl/bin:${PATH}"
+USER quarkus
+WORKDIR /code
+RUN ./mvnw -B org.apache.maven.plugins:maven-dependency-plugin:3.8.1:go-offline
+COPY src /code/src
+RUN ./mvnw package -Dnative -DskipTests -Dquarkus.native.additional-build-args="--static","--libc=musl"
+
+## Stage 2 : create the final image
+FROM scratch
+COPY --from=build /code/target/*-runner /application
+EXPOSE 8080
+ENTRYPOINT [ "/application" ]
+----
+
+Scratch images should not be used in production without rigorous testing.
+
+=== Compressing native executables
+
+Quarkus can compress the produced native executable using UPX.
+More details on xref:./upx.adoc[UPX Compression documentation].
+
+[[native-ci-cd]]
+== CI/CD and Build Pipeline Options
+
+=== Separating Java and native image compilation
+
+In certain circumstances, you may want to build the native image in a separate step.
+For example, in a CI/CD pipeline, you may want to have one step to generate the source that will be used for the native image generation and another step to use these sources to actually build the native executable.
+For this use case, you can set the additional flag `quarkus.native.sources-only=true`.
+This will execute the java compilation as if you had started native compilation (`-Dnative`), but stops before triggering the actual call to GraalVM's `native-image`.
+
+[source,bash]
+----
+$ ./mvnw clean package -Dnative -Dquarkus.native.sources-only=true
+----
+
+After compilation has finished, you find the build artifact in `target/native-sources`:
+
+[source,bash]
+----
+$ cd target/native-sources
+$ ls
+getting-started-1.0.0-SNAPSHOT-runner.jar  graalvm.version  lib  native-image.args
+----
+
+From the output above one can see that, in addition to the produced jar file and the associated lib directory, a text file named `native-image.args` was created.
+This file holds all parameters (including the name of the JAR to compile) to pass along to GraalVM's `native-image` command.
+A text file named `graalvm.version` was also created and holds the GraalVM version that should be used.
+If you have GraalVM installed and it matches this version, you can start the native compilation by executing:
+
+[source,bash]
+----
+$ cd target/native-sources
+$ native-image $(cat native-image.args)
+...
+$ ls
+native-image.args
+getting-started-1.0.0-SNAPSHOT-runner
+getting-started-1.0.0-SNAPSHOT-runner.build_artifacts.txt
+getting-started-1.0.0-SNAPSHOT-runner.jar
+----
+
+The process for Gradle is analogous.
+
+Running the build process in a container is also possible:
+
+[source,bash]
+----
+$ ./mvnw clean package -Dquarkus.native.enabled=true -Dquarkus.native.sources-only=true -Dquarkus.native.container-build=true
+----
+
+`-Dquarkus.native.container-build=true` will produce an additional text file named `native-builder.image` holding the docker image name to be used to build the native image.
+
+[source,bash,subs=attributes+]
+----
+cd target/native-sources
+docker run \
+  -it \
+  --user $(id -ur):$(id -gr) \
+  --rm \
+  -v $(pwd):/work \# <1>
+  -w /work \# <2>
+  --entrypoint /bin/sh \
+  $(cat native-builder.image) \# <3>
+  -c "native-image $(cat native-image.args) -J-Xmx4g"# <4>
+----
+
+<1> Mount the host's directory `target/native-image` to the container's `/work`. Thus, the generated binary will also be written to this directory.
+<2> Switch the working directory to `/work`, which we have mounted in <1>.
+<3> Use the docker image from the file `native-builder.image`.
+<4> Call `native-image` with the content of file `native-image.args` as arguments. We also supply an additional argument to limit the process's maximum memory to 4 Gigabytes (this may vary depending on the project being built and the machine building it).
+
+[WARNING]
+====
+If you are running on a Windows machine, please keep in mind that the binary was created within a Linux docker container.
+Hence, the binary will not be executable on the host Windows machine.
+====
+
+A high level overview of what the various steps of a CI/CD pipeline would look is the following:
+
+1. Register the output of the step executing `./mvnw ...` command (i.e. directory `target/native-image`) as a build artifact,
+2. Require this artifact in the step executing the `native-image ...` command, and
+3. Register the output of the step executing the `native-image ...` command (i.e. files matching `target/*runner`) as build artifact.
+
+The environment executing step `1` only needs Java and Maven (or Gradle) installed, while the environment executing step `3` only needs a GraalVM installation (including the `native-image` feature).
+
+Depending on what the final desired output of the CI/CD pipeline is, the generated binary might then be used to create a container image.
+
+=== Debugging native executables
+
+Native executables can be debugged using tools such as `gdb`.
+For this to be possible native executables need to be generated with debug symbols.
+
+[NOTE]
+Debug symbol generation is only supported on Linux.
+Windows support is still under development, while macOS is not supported.
+
+To generate debug symbols,
+add `-Dquarkus.native.debug.enabled=true` flag when generating the native executable.
+You will find the debug symbols for the native executable in a `.debug` file next to the native executable.
+
+[NOTE]
+====
+The generation of the `.debug` file depends on `objcopy`.
+As a result, when using a local GraalVM installation on common Linux distributions, you will need to install the `binutils` package:
+
+[source,bash]
+----
+# dnf (rpm-based)
+sudo dnf install binutils
+# Debian-based distributions
+sudo apt-get install binutils
+----
+
+When `objcopy` is not available, debug symbols are embedded in the executable.
+====
+
+Aside from debug symbols,
+setting `-Dquarkus.native.debug.enabled=true` flag generates a cache of source files
+for any JDK runtime classes, GraalVM classes, and application classes resolved during native executable generation.
+This source cache is useful for native debugging tools,
+to establish the link between the symbols and the matching source code.
+It provides a convenient way of making just the necessary sources available to the debugger/IDE when debugging a native executable.
+
+Sources for third party jar dependencies, including Quarkus source code,
+are not added to the source cache by default.
+To include those, make sure you invoke `mvn dependency:sources` first.
+This step is required in order to pull the sources for these dependencies,
+and get them included in the source cache.
+
+The source cache is located in the `target/sources` folder.
+
+[TIP]
+====
+If running `gdb` from a different directory than `target`, then the sources can be loaded by running:
+
+[source,bash]
+----
+directory path/to/target
+----
+
+in the `gdb` prompt.
+
+Or start `gdb` with:
+
+[source,bash]
+----
+gdb -ex 'directory path/to/target' path/to/target/{project.name}-{project.version}-runner
+----
+
+e.g.,
+[source,bash]
+----
+gdb -ex 'directory ./target' ./target/getting-started-1.0.0-SNAPSHOT-runner
+----
+====
+
+For more in-depth debugging and inspection techniques, see the <<inspecting-and-debugging>> section above.
+
+[[native-monitoring]]
+== Monitoring Options
+
+Monitoring options such as JDK flight recorder, jvmstat, heap dumps, NMT (starting with Mandrel 24.1 for JDK 23), and remote JMX
+can be added to the native executable build. Simply supply a comma separated list of the monitoring options you wish to
+include at build time.
+[source,bash]
+----
+-Dquarkus.native.monitoring=<comma separated list of options>
+----
+
+|===
+|Monitoring Option |Description |Availability As Of
+
+|jcmd
+|Include JCMD support
+|GraalVM CE for JDK 24 Mandrel 24.2
+
+|jfr
+|Include JDK Flight Recorder support
+|GraalVM CE 21.3 Mandrel 21.3
+
+|jvmstat
+|Adds jvmstat support
+|GraalVM 22.3, GraalVM CE 17.0.7 Mandrel 22.3 Mandrel 23.0 (17.0.7)
+
+|heapdump
+|Adds support for generating heap dumps
+|GraalVM 22.3, GraalVM CE 17.0.7 Mandrel 22.3 Mandrel 23.0 (17.0.7)
+
+|jmxclient
+|Adds support for connections to JMX servers.
+|GraalVM for JDK 17/20 Mandrel 23.0
+
+|jmxserver
+|Adds support for accepting connections from JMX clients.
+|GraalVM for JDK 17/20 Mandrel 23.0 (17.0.7)
+
+|nmt
+|Adds support for native memory tracking.
+|GraalVM for JDK 23 Mandrel 24.1
+
+|threaddump
+|Adds support for dumping thread stacks on SIGQUIT/SIGBREAK.
+|GraalVM for JDK 22 Mandrel 24.0
+
+|none
+|Disables support for all monitoring options that would be enabled by default in Quarkus
+|Pseudo option used by Quarkus
+
+|all
+|Adds all monitoring options.
+|GraalVM 22.3, GraalVM CE 17.0.7 Mandrel 22.3 Mandrel 23.0 (17.0.7)
+|===
+
+[[native-bundles]]
+== Native Image Bundles
+
+A native image bundle containing everything required to build a native image can be generated.
+This is useful to inspect the build inputs and configuration.
+
+The generation of the bundle can be activated by setting any of the following parameters:
+
+|===
+|Parameter |Description |Default
+
+|quarkus.native.bundle.enabled
+|Enables the native-image bundle generation
+|`false`
+
+|quarkus.native.bundle.dry-run
+|Generates the bundle without building the native executable
+|`false`
+
+|quarkus.native.bundle.name
+|Sets the name of the bundle
+|
+|===
+
+To use this feature, run:
+
+[source,bash]
+----
+./mvnw package -Dnative -Dquarkus.native.bundle.enabled=true
+----
+
+This command will generate all the files and configuration needed for the native image build in `target/{project.name}-{project.version}-runner.nib`.
+
+[NOTE]
+====
+More details on the GraalVM native-image bundle are available in the link:https://www.graalvm.org/{graalvm-docs-version}/reference-manual/native-image/overview/Bundles[GraalVM documentation].
+====
 
 [[native-faq]]
 == Frequently Asked Questions

--- a/extensions/info/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/info/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -4,6 +4,7 @@ name: "Info"
 metadata:
   keywords:
   - "info"
+  guide: "https://quarkus.io/guides/info"
   categories:
   - "observability"
   status: "stable"


### PR DESCRIPTION
Some of the content from our getting-started guide was really outdated (2019, according to the log date), mentioned technologies like servlets, and included too much content for a getting-started guide. So, I decided to improve it a bit, move the content to its more natural place. Also, it was still mentioning the Maven "main" artifact (that we do not produce anymore)

At the same time, I:

- created a guide about the info endpoint (we did not have one; it was mentioned in the getting started guide)
- The second application guide was silently switching from @RestQuery to the JAX-RS annotation
- The native image guide was really long, so, moved the content to the reference guide and also added a blurb about when and why to use native
- I also did a few edits in the Kafka guide