### PR TITLE
Register DefaultJwtValidator constructor for reflective access 

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveClassConditionBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveClassConditionBuildItem.java
@@ -3,7 +3,15 @@ package io.quarkus.deployment.builditem.nativeimage;
 import io.quarkus.builder.item.MultiBuildItem;
 
 /**
- * Used to define a condition to register a class for reflection in native mode only when a specific type is reachable
+ * Used to define a condition to register a class for reflection in native mode only when a specific type is reachable.
+ * <br>
+ * NOTE: The use of this build item requires the class to have already been registered through another
+ * {@code Reflective*BuildItem}.
+ *
+ * @see ReflectiveClassBuildItem
+ * @see ReflectiveFieldBuildItem}
+ * @see ReflectiveMethodBuildItem
+ * @see ReflectiveHierarchyBuildItem
  */
 public final class ReflectiveClassConditionBuildItem extends MultiBuildItem {
 

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
@@ -267,6 +267,8 @@ public class KafkaProcessor {
 
         // Register DefaultJwtValidator only when jose4j is present to avoid NoClassDefFoundError
         // with GraalVM 25's --future-defaults=complete-reflection-types flag
+        reflectiveMethod.produce(new ReflectiveMethodBuildItem(getClass().getName() + " DefaultJwtValidator class",
+                DefaultJwtValidator.class.getName(), "<init>", new String[0]));
         reflectiveClassCondition.produce(new ReflectiveClassConditionBuildItem(
                 DefaultJwtValidator.class.getName(),
                 "org.jose4j.keys.resolvers.VerificationKeyResolver"));


### PR DESCRIPTION
Follow up to https://github.com/quarkusio/quarkus/pull/53194

Fixes https://github.com/quarkusio/quarkus/issues/52662
that reappeared after https://github.com/quarkusio/quarkus/pull/53194

Also extends documentation to better reflect how to use `ReflectiveClassConditionBuildItem`