### PR TITLE
Add tests for old model dev services

### DIFF
--- a/integration-tests/devservices/old-model-extension/deployment/disable-unbind-executions
+++ b/integration-tests/devservices/old-model-extension/deployment/disable-unbind-executions
@@ -1,0 +1,1 @@
+This file disables the unbind-executions profile in the quarkus-integration-tests-parent.

--- a/integration-tests/devservices/old-model-extension/deployment/pom.xml
+++ b/integration-tests/devservices/old-model-extension/deployment/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-integration-test-devservices-old-model-extension-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-integration-test-devservices-old-model-extension-deployment</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-integration-test-devservices-old-model-extension</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devservices-deployment</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.quarkus</groupId>
+                                    <artifactId>quarkus-extension-processor</artifactId>
+                                </path>
+                            </annotationProcessorPaths>
+                            <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
+                            <compilerArgs>
+                                <arg>-AgenerateDoc=false</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/integration-tests/devservices/old-model-extension/deployment/src/main/java/io/quarkus/tests/oldmodelextension/deployment/OldModelDevServicesProcessor.java
+++ b/integration-tests/devservices/old-model-extension/deployment/src/main/java/io/quarkus/tests/oldmodelextension/deployment/OldModelDevServicesProcessor.java
@@ -1,0 +1,83 @@
+package io.quarkus.tests.oldmodelextension.deployment;
+
+import static io.quarkus.tests.oldmodelextension.Constants.OLD_MODEL_EXTENSION_BASE_URL;
+import static io.quarkus.tests.oldmodelextension.Constants.OLD_MODEL_EXTENSION_STATIC_THING;
+
+import java.util.Map;
+
+import org.jboss.logging.Logger;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.CuratedApplicationShutdownBuildItem;
+import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
+import io.quarkus.deployment.builditem.DevServicesResultBuildItem.RunningDevService;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.dev.devservices.DevServicesConfig;
+
+@SuppressWarnings("deprecation")
+public class OldModelDevServicesProcessor {
+
+    private static final Logger log = Logger.getLogger(OldModelDevServicesProcessor.class);
+
+    private static final String FEATURE = "OldModel";
+    private static final int HTTPD_PORT = 80;
+
+    static volatile RunningDevService devService;
+    static volatile boolean first = true;
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
+
+    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = DevServicesConfig.Enabled.class)
+    public DevServicesResultBuildItem createContainer(CuratedApplicationShutdownBuildItem closeBuildItem) {
+
+        if (devService != null) {
+            return devService.toBuildItem();
+        }
+
+        GenericContainer<?> container = new GenericContainer<>(DockerImageName.parse("httpd"))
+                .withReuse(true)
+                .withExposedPorts(HTTPD_PORT);
+        container.start();
+
+        String baseUrl = "http://" + container.getHost() + ":" + container.getMappedPort(HTTPD_PORT);
+
+        devService = new RunningDevService(
+                FEATURE,
+                container.getContainerId(),
+                container::stop,
+                Map.of(OLD_MODEL_EXTENSION_BASE_URL, baseUrl,
+                        OLD_MODEL_EXTENSION_STATIC_THING, "old model value"));
+
+        if (first) {
+            first = false;
+            Runnable closeTask = () -> {
+                if (devService != null) {
+                    shutdownOldModel();
+                }
+                first = true;
+                devService = null;
+            };
+            closeBuildItem.addCloseTask(closeTask, true);
+        }
+
+        return devService.toBuildItem();
+    }
+
+    private void shutdownOldModel() {
+        if (devService != null) {
+            try {
+                devService.close();
+            } catch (Throwable e) {
+                log.error("Failed to stop the old model dev service", e);
+            } finally {
+                devService = null;
+            }
+        }
+    }
+}

--- a/integration-tests/devservices/old-model-extension/disable-unbind-executions
+++ b/integration-tests/devservices/old-model-extension/disable-unbind-executions
@@ -1,0 +1,1 @@
+This file disables the unbind-executions profile in the quarkus-integration-tests-parent.

--- a/integration-tests/devservices/old-model-extension/pom.xml
+++ b/integration-tests/devservices/old-model-extension/pom.xml
@@ -3,20 +3,19 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <artifactId>quarkus-integration-test-devservices</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>quarkus-integration-test-devservices</artifactId>
-    <name>Quarkus - Integration Tests - Dev services</name>
+    <artifactId>quarkus-integration-test-devservices-old-model-extension-parent</artifactId>
+    <name>Quarkus - Integration Tests - Dev Services - Old Model Extension</name>
     <packaging>pom</packaging>
 
+
     <modules>
-        <module>simple-extension</module>
-        <module>dependent-extension</module>
-        <module>old-model-extension</module>
-        <module>tests</module>
+        <module>runtime</module>
+        <module>deployment</module>
     </modules>
 </project>

--- a/integration-tests/devservices/old-model-extension/runtime/disable-unbind-executions
+++ b/integration-tests/devservices/old-model-extension/runtime/disable-unbind-executions
@@ -1,0 +1,1 @@
+This file disables the unbind-executions profile in the quarkus-integration-tests-parent.

--- a/integration-tests/devservices/old-model-extension/runtime/pom.xml
+++ b/integration-tests/devservices/old-model-extension/runtime/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-integration-test-devservices-old-model-extension-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-integration-test-devservices-old-model-extension</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devservices</artifactId>
+        </dependency>
+
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devservices-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <configuration>
+                    <capabilities>
+                        <provides>io.quarkus.old-model-extension</provides>
+                    </capabilities>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.quarkus</groupId>
+                                    <artifactId>quarkus-extension-processor</artifactId>
+                                </path>
+                            </annotationProcessorPaths>
+                            <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
+                            <compilerArgs>
+                                <arg>-AgenerateDoc=false</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integration-tests/devservices/old-model-extension/runtime/src/main/java/io/quarkus/tests/oldmodelextension/Constants.java
+++ b/integration-tests/devservices/old-model-extension/runtime/src/main/java/io/quarkus/tests/oldmodelextension/Constants.java
@@ -1,0 +1,6 @@
+package io.quarkus.tests.oldmodelextension;
+
+public class Constants {
+    public static final String OLD_MODEL_EXTENSION_BASE_URL = "acme.oldmodelextension.base-url";
+    public static final String OLD_MODEL_EXTENSION_STATIC_THING = "acme.oldmodelextension.static-thing";
+}

--- a/integration-tests/devservices/tests/pom.xml
+++ b/integration-tests/devservices/tests/pom.xml
@@ -53,6 +53,12 @@
             <version>${project.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-integration-test-devservices-old-model-extension</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -109,6 +115,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-integration-test-devservices-simple-extension-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-integration-test-devservices-old-model-extension-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/devservices/tests/src/test/java/io/quarkus/devservices/test/DevServicesDisabledTest.java
+++ b/integration-tests/devservices/tests/src/test/java/io/quarkus/devservices/test/DevServicesDisabledTest.java
@@ -1,0 +1,44 @@
+package io.quarkus.devservices.test;
+
+import static io.quarkus.tests.oldmodelextension.Constants.OLD_MODEL_EXTENSION_BASE_URL;
+import static io.quarkus.tests.oldmodelextension.Constants.OLD_MODEL_EXTENSION_STATIC_THING;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(DevServicesDisabledTest.Profile.class)
+public class DevServicesDisabledTest {
+
+    private static final String UNSET = "unset";
+
+    public static class Profile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("quarkus.devservices.enabled", "false");
+        }
+    }
+
+    @ConfigProperty(name = OLD_MODEL_EXTENSION_BASE_URL, defaultValue = UNSET)
+    String oldModelExtensionBaseUrl;
+
+    @ConfigProperty(name = OLD_MODEL_EXTENSION_STATIC_THING, defaultValue = UNSET)
+    String oldModelStaticProperty;
+
+    @Test
+    public void testOldModelServiceIsNotStartedWhenDevServicesDisabled() {
+        assertEquals(UNSET, oldModelExtensionBaseUrl);
+    }
+
+    @Test
+    public void testOldModelStaticConfigIsNotSetWhenDevServicesDisabled() {
+        assertEquals(UNSET, oldModelStaticProperty);
+    }
+}

--- a/integration-tests/devservices/tests/src/test/java/io/quarkus/devservices/test/DevServicesUserConfigOverrideTest.java
+++ b/integration-tests/devservices/tests/src/test/java/io/quarkus/devservices/test/DevServicesUserConfigOverrideTest.java
@@ -1,0 +1,67 @@
+package io.quarkus.devservices.test;
+
+import static io.quarkus.tests.oldmodelextension.Constants.OLD_MODEL_EXTENSION_BASE_URL;
+import static io.quarkus.tests.oldmodelextension.Constants.OLD_MODEL_EXTENSION_STATIC_THING;
+import static io.quarkus.tests.simpleextension.Constants.QUARKUS_SIMPLE_EXTENSION_BASE_URL;
+import static io.quarkus.tests.simpleextension.Constants.QUARKUS_SIMPLE_EXTENSION_STATIC_THING;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.util.Map;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(DevServicesUserConfigOverrideTest.Profile.class)
+public class DevServicesUserConfigOverrideTest {
+
+    private static final String UNSET = "unset";
+    private static final String USER_PROVIDED_URL = "http://user-provided:9999";
+    private static final String USER_PROVIDED_STATIC = "user-provided-static";
+
+    public static class Profile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    OLD_MODEL_EXTENSION_BASE_URL, USER_PROVIDED_URL,
+                    OLD_MODEL_EXTENSION_STATIC_THING, USER_PROVIDED_STATIC);
+        }
+    }
+
+    @ConfigProperty(name = OLD_MODEL_EXTENSION_BASE_URL, defaultValue = UNSET)
+    String oldModelExtensionBaseUrl;
+
+    @ConfigProperty(name = OLD_MODEL_EXTENSION_STATIC_THING, defaultValue = UNSET)
+    String oldModelStaticProperty;
+
+    @ConfigProperty(name = QUARKUS_SIMPLE_EXTENSION_BASE_URL, defaultValue = UNSET)
+    String simpleExtensionBaseUrl;
+
+    @ConfigProperty(name = QUARKUS_SIMPLE_EXTENSION_STATIC_THING, defaultValue = UNSET)
+    String simpleStaticProperty;
+
+    @Test
+    public void testUserConfigOverridesOldModelDevServicesBaseUrl() {
+        assertEquals(USER_PROVIDED_URL, oldModelExtensionBaseUrl);
+    }
+
+    @Test
+    public void testUserConfigOverridesOldModelDevServicesStaticConfig() {
+        assertEquals(USER_PROVIDED_STATIC, oldModelStaticProperty);
+    }
+
+    @Test
+    public void testNewModelServiceStillStartsAlongsideUserConfig() {
+        assertNotEquals(UNSET, simpleExtensionBaseUrl);
+    }
+
+    @Test
+    public void testNewModelStaticConfigStillAvailableAlongsideUserConfig() {
+        assertNotEquals(UNSET, simpleStaticProperty);
+    }
+}

--- a/integration-tests/devservices/tests/src/test/java/io/quarkus/devservices/test/OldModelDevServicesTest.java
+++ b/integration-tests/devservices/tests/src/test/java/io/quarkus/devservices/test/OldModelDevServicesTest.java
@@ -1,0 +1,49 @@
+package io.quarkus.devservices.test;
+
+import static io.quarkus.tests.oldmodelextension.Constants.OLD_MODEL_EXTENSION_BASE_URL;
+import static io.quarkus.tests.oldmodelextension.Constants.OLD_MODEL_EXTENSION_STATIC_THING;
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class OldModelDevServicesTest {
+
+    private static final String UNSET = "unset";
+
+    @ConfigProperty(name = OLD_MODEL_EXTENSION_BASE_URL, defaultValue = UNSET)
+    String oldModelExtensionBaseUrl;
+
+    @ConfigProperty(name = OLD_MODEL_EXTENSION_STATIC_THING, defaultValue = UNSET)
+    String oldModelStaticProperty;
+
+    @Test
+    public void testOldModelDevServicesConfigIsAvailable() {
+        assertIsSet(oldModelExtensionBaseUrl);
+    }
+
+    @Test
+    public void testOldModelDevServicesStaticConfigIsAvailable() {
+        assertIsSet(oldModelStaticProperty);
+    }
+
+    @Test
+    public void testOldModelServiceIsListeningOnTheDeclaredPort() {
+        given()
+                .relaxedHTTPSValidation()
+                .when()
+                .head(oldModelExtensionBaseUrl)
+                .then()
+                .statusCode(200);
+    }
+
+    private void assertIsSet(String value) {
+        Assertions.assertNotNull(value);
+        assertNotEquals(UNSET, value);
+    }
+}


### PR DESCRIPTION
This is obviously a temporary set of tests, because we want to remove the old dev services model. However, I don't think we want to remove it yet, because it's [widely used in the quarkiverse](https://github.com/search?q=org%3Aquarkiverse%20RunningDevService&type=code) and wider ecosystem (eg microcks). 

Thanks to @gsmet's good work in https://github.com/quarkusio/quarkus/pull/53656, we're about to eliminate old-model services in our repo. This is excellent, but it means we lose test coverage and risk breaking the ecosystem. To fill this gap without holding our own dev services back artificially just for coverage, I've added some tests of the old SPIs. 

Note that Claude and I tried for a while, and we couldn't actually get any of these tests to go red with https://github.com/quarkusio/quarkus/pull/53656. So I think there's a missing test to exercise the scenario that prompted to do all the conversions as part of https://github.com/quarkusio/quarkus/pull/53656.