### PR TITLE
Use LinkedHashMap in JacksonProcessor#supportMixins

### DIFF
--- a/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
+++ b/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
@@ -9,8 +9,8 @@ import java.lang.constant.MethodTypeDesc;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -483,7 +483,7 @@ public class JacksonProcessor {
             return;
         }
 
-        Map<Class<?>, Class<?>> mixinsMap = new HashMap<>();
+        Map<Class<?>, Class<?>> mixinsMap = new LinkedHashMap<>();
         for (AnnotationInstance instance : jacksonMixins) {
             if (instance.target().kind() != CLASS) {
                 continue;


### PR DESCRIPTION
Stable iteration order helps with binary reproducibility.