### PR TITLE
Improve sort order for ReceiverMethodBuildItem

### DIFF
--- a/extensions/signals/deployment/src/main/java/io/quarkus/signals/deployment/ReceiverMethodBuildItem.java
+++ b/extensions/signals/deployment/src/main/java/io/quarkus/signals/deployment/ReceiverMethodBuildItem.java
@@ -79,7 +79,10 @@ final class ReceiverMethodBuildItem extends MultiBuildItem implements Comparable
 
     @Override
     public int compareTo(ReceiverMethodBuildItem other) {
-        int cmp = method.declaringClass().name().compareTo(other.method.declaringClass().name());
+        int cmp = bean.getBeanClass().compareTo(other.bean.getBeanClass());
+        if (cmp == 0) {
+            cmp = method.declaringClass().name().compareTo(other.method.declaringClass().name());
+        }
         if (cmp == 0) {
             cmp = method.toString().compareTo(other.method.toString());
         }


### PR DESCRIPTION
Sort by bean name first and fall-back to old logic in case of a tie.
Cases when declaring class (e.g. a superclass) is same cause ties and unstable build item iteration order.
A better tie-breaker helps with binary reproducibility.