### PR TITLE
Improve binary reproducibility in extensions/undertow

### DIFF
--- a/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
+++ b/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -650,8 +651,8 @@ public class UndertowBuildStep {
         }
 
         for (ServletContainerInitializerBuildItem sci : servletContainerInitializerBuildItems) {
-            Set<Class<?>> handlesTypes = new HashSet<>();
-            for (String handledType : sci.handlesTypes) {
+            Set<Class<?>> handlesTypes = new LinkedHashSet<>();
+            for (String handledType : sci.handlesTypes.stream().sorted().toList()) {
                 handlesTypes.add(context.classProxy(handledType));
             }
 

--- a/extensions/undertow/spi/src/main/java/io/quarkus/undertow/deployment/ServletContainerInitializerBuildItem.java
+++ b/extensions/undertow/spi/src/main/java/io/quarkus/undertow/deployment/ServletContainerInitializerBuildItem.java
@@ -1,17 +1,20 @@
 package io.quarkus.undertow.deployment;
 
+import java.util.Iterator;
 import java.util.Set;
+import java.util.TreeSet;
 
 import io.quarkus.builder.item.MultiBuildItem;
 
-public final class ServletContainerInitializerBuildItem extends MultiBuildItem {
+public final class ServletContainerInitializerBuildItem extends MultiBuildItem
+        implements Comparable<ServletContainerInitializerBuildItem> {
 
     final String sciClass;
     final Set<String> handlesTypes;
 
     public ServletContainerInitializerBuildItem(String sciClass, Set<String> handlesTypes) {
         this.sciClass = sciClass;
-        this.handlesTypes = handlesTypes;
+        this.handlesTypes = new TreeSet<>(handlesTypes);
     }
 
     public String getSciClass() {
@@ -21,4 +24,26 @@ public final class ServletContainerInitializerBuildItem extends MultiBuildItem {
     public Set<String> getHandlesTypes() {
         return handlesTypes;
     }
+
+    @Override
+    public int compareTo(ServletContainerInitializerBuildItem o) {
+        int result = sciClass.compareTo(o.sciClass);
+        if (result != 0) {
+            return result;
+        }
+        result = Integer.compare(handlesTypes.size(), o.handlesTypes.size());
+        if (result != 0) {
+            return result;
+        }
+        Iterator<String> thisIterator = handlesTypes.iterator();
+        Iterator<String> otherIterator = o.handlesTypes.iterator();
+        while (thisIterator.hasNext()) {
+            result = thisIterator.next().compareTo(otherIterator.next());
+            if (result != 0) {
+                return result;
+            }
+        }
+        return 0;
+    }
+
 }


### PR DESCRIPTION
Make sure `RecorderContext#classProxy()` is called on a stable collection, via sorting `ServletContainerInitializerBuildItem` and their corresponding `handlesTypes`.