### PR TITLE
Oracle Test Pilot: add Autonomous databases 19c and 26ai support

### DIFF
--- a/.github/oracle-test-pilot-jvm-tests.json
+++ b/.github/oracle-test-pilot-jvm-tests.json
@@ -8,6 +8,13 @@
             "java-version": 17
         },
         {
+            "category": "19c-atps",
+            "oci-service": "autonomous-transaction-processing-serverless-19c",
+            "timeout": 20,
+            "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle",
+            "java-version": 17
+        },
+        {
             "category": "21c",
             "oci-service": "base-database-service-21c",
             "timeout": 20,
@@ -17,6 +24,13 @@
         {
             "category": "26ai",
             "oci-service": "base-database-service-26ai",
+            "timeout": 20,
+            "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle",
+            "java-version": 17
+        },
+        {
+            "category": "26ai-atps",
+            "oci-service": "autonomous-transaction-processing-serverless-26ai",
             "timeout": 20,
             "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle",
             "java-version": 17

--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -1784,7 +1784,7 @@ jobs:
           develocity-token-expiry: 6
       - name: Create Oracle Test Pilot Database
         id: create_database
-        uses: oracle-actions/setup-testpilot@f620f11f9f26dacfe80ba1823342e3e92604c55f # v1.0.23
+        uses: oracle-actions/setup-testpilot@aec84678697e1648ddb8e8a480cf3ceda746ce5c # v1.0.24
         with:
           oci-service: ${{ matrix.oci-service }}
           action: create
@@ -1800,8 +1800,8 @@ jobs:
           TESTPILOT_CLIENT_ID: ""
           TESTPILOT_TOKEN: ""
           # Needed for TFO (TCP fast open)
-          #LD_PRELOAD: /home/ubuntu/libtfojdbc1.so
-          #LD_LIBRARY_PATH: /home/ubuntu
+          LD_PRELOAD: /home/ubuntu/ojdbc_tfo/ojdbc17/23.26.0.0.0/libtfojdbc1.so
+          LD_LIBRARY_PATH: /home/ubuntu/ojdbc_tfo/ojdbc17/23.26.0.0.0
           # End OTP setup
           TEST_MODULES: ${{matrix.test-modules}}
           CAPTURE_BUILD_SCAN: true
@@ -1818,7 +1818,7 @@ jobs:
       - name: Delete Oracle Test Pilot Database
         id: delete_database
         if: always() && steps.create_database.outcome == 'success'
-        uses: oracle-actions/setup-testpilot@f620f11f9f26dacfe80ba1823342e3e92604c55f # v1.0.23
+        uses: oracle-actions/setup-testpilot@aec84678697e1648ddb8e8a480cf3ceda746ce5c # v1.0.24
         with:
           oci-service: ${{ matrix.oci-service }}
           action: delete
@@ -1902,7 +1902,7 @@ jobs:
           develocity-token-expiry: 6
       - name: Create Oracle Test Pilot Database
         id: create_database
-        uses: oracle-actions/setup-testpilot@f620f11f9f26dacfe80ba1823342e3e92604c55f # v1.0.23
+        uses: oracle-actions/setup-testpilot@aec84678697e1648ddb8e8a480cf3ceda746ce5c # v1.0.24
         with:
           oci-service: ${{ matrix.oci-service }}
           action: create
@@ -1919,8 +1919,10 @@ jobs:
           TESTPILOT_CLIENT_ID: ""
           TESTPILOT_TOKEN: ""
           # Needed for TFO (TCP fast open)
-          #LD_PRELOAD: /home/ubuntu/libtfojdbc1.so
-          #LD_LIBRARY_PATH: /home/ubuntu
+          # TODO: enable after fixing https://github.com/quarkusio/quarkus/issues/54479
+          #LD_PRELOAD: /home/ubuntu/ojdbc_tfo/ojdbc17/23.26.0.0.0/libtfojdbc1.so
+          #LD_LIBRARY_PATH: /home/ubuntu/ojdbc_tfo/ojdbc17/23.26.0.0.0
+          #  -Dquarkus.native.additional-build-args='-ELD_PRELOAD,-ELD_LIBRARY_PATH' \
           # End OTP setup
           TEST_MODULES: ${{matrix.test-modules}}
           CONTAINER_BUILD: false # Docker is not available on Oracle Test Pilot
@@ -1937,7 +1939,7 @@ jobs:
       - name: Delete Oracle Test Pilot Database
         id: delete_database
         if: always() && steps.create_database.outcome == 'success'
-        uses: oracle-actions/setup-testpilot@f620f11f9f26dacfe80ba1823342e3e92604c55f # v1.0.23
+        uses: oracle-actions/setup-testpilot@aec84678697e1648ddb8e8a480cf3ceda746ce5c # v1.0.24
         with:
           oci-service: ${{ matrix.oci-service }}
           action: delete


### PR DESCRIPTION
This PR adds the support for Autonomous databases 19c and 26ai on the Oracle Test Pilot platform

* Fixes #54414