### PR TITLE
 Fix build failure for Spring Data JPA dynamic projection derived methods

### DIFF
--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/AbstractMethodsAdder.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/AbstractMethodsAdder.java
@@ -69,6 +69,16 @@ public abstract class AbstractMethodsAdder {
             Integer pageableParameterIndex, Expr[] methodParams,
             ClassInfo repositoryClassInfo, ClassInfo entityClassInfo,
             DotName returnType, Integer limit, String methodName, DotName customResultType, String originalResultType) {
+        generateFindQueryResultHandling(bc, panacheQueryExpr, pageableParameterIndex, methodParams,
+                repositoryClassInfo, entityClassInfo, returnType, limit, methodName, customResultType, originalResultType,
+                entityClassInfo.name());
+    }
+
+    protected void generateFindQueryResultHandling(BlockCreator bc, Expr panacheQueryExpr,
+            Integer pageableParameterIndex, Expr[] methodParams,
+            ClassInfo repositoryClassInfo, ClassInfo entityClassInfo,
+            DotName returnType, Integer limit, String methodName, DotName customResultType, String originalResultType,
+            DotName elementTypeToCast) {
 
         // Store panacheQuery in a LocalVar so it can be used across nested blocks (try_, ifElse, etc.)
         Expr panacheQuery = bc.localVar("panacheQuery", panacheQueryExpr);
@@ -102,7 +112,7 @@ public abstract class AbstractMethodsAdder {
                             MethodDesc.of(PanacheQuery.class, panacheQueryMethodToUse, Object.class),
                             finalPanacheQuery);
 
-                    Expr casted = tb.cast(singleResult, ClassDesc.of(entityClassInfo.name().toString()));
+                    Expr casted = tb.cast(singleResult, ClassDesc.of(elementTypeToCast.toString()));
                     tb.return_(casted);
                 });
                 tc.catch_(NoResultException.class, "e", (cb, e) -> {
@@ -120,7 +130,7 @@ public abstract class AbstractMethodsAdder {
                             finalPanacheQuery);
 
                     if (customResultType == null) {
-                        Expr casted = tb.cast(singleResult, ClassDesc.of(entityClassInfo.name().toString()));
+                        Expr casted = tb.cast(singleResult, ClassDesc.of(elementTypeToCast.toString()));
                         Expr optional = tb.invokeStatic(
                                 MethodDesc.of(Optional.class, "ofNullable", Optional.class, Object.class),
                                 casted);

--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/DerivedMethodsAdder.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/DerivedMethodsAdder.java
@@ -3,6 +3,7 @@ package io.quarkus.spring.data.deployment.generate;
 import static io.quarkus.spring.data.deployment.generate.GenerationUtil.getNamedQueryForMethod;
 
 import java.lang.constant.ClassDesc;
+import java.lang.constant.ConstantDescs;
 import java.lang.constant.MethodTypeDesc;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -16,6 +17,7 @@ import java.util.function.Consumer;
 import jakarta.transaction.Transactional;
 
 import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
@@ -102,8 +104,10 @@ public class DerivedMethodsAdder extends AbstractMethodsAdder {
             List<Integer> queryParameterIndexes = new ArrayList<>(parameters.size());
             Integer pageableParameterIndex = null;
             Integer sortParameterIndex = null;
+            Integer dynamicProjectionParameterIndex = null;
             for (int i = 0; i < parameters.size(); i++) {
-                DotName parameterType = parameters.get(i).name();
+                Type paramType = parameters.get(i);
+                DotName parameterType = paramType.name();
                 parameterTypesStr[i] = parameterType.toString();
                 if (DotNames.SPRING_DATA_PAGEABLE.equals(parameterType)
                         || DotNames.SPRING_DATA_PAGE_REQUEST.equals(parameterType)) {
@@ -120,6 +124,13 @@ public class DerivedMethodsAdder extends AbstractMethodsAdder {
                                 + " can be specified");
                     }
                     sortParameterIndex = i;
+                } else if (isDynamicProjectionParameter(paramType, method)) {
+                    if (dynamicProjectionParameterIndex != null) {
+                        throw new IllegalArgumentException("Method " + method.name() + " of Repository " + repositoryClassInfo
+                                + "has invalid parameters - only a single dynamic projection parameter of type "
+                                + DotNames.CLASS + " can be specified");
+                    }
+                    dynamicProjectionParameterIndex = i;
                 } else {
                     queryParameterIndexes.add(i);
                 }
@@ -135,6 +146,8 @@ public class DerivedMethodsAdder extends AbstractMethodsAdder {
             // Need effectively final copies for use in lambdas
             final Integer finalPageableParameterIndex = pageableParameterIndex;
             final Integer finalSortParameterIndex = sortParameterIndex;
+            final Integer finalDynamicProjectionParameterIndex = dynamicProjectionParameterIndex;
+            final Type finalReturnType = returnType;
 
             MethodTypeDesc mtd = GenerationUtil.toMethodTypeDesc(returnType.name().toString(), parameterTypesStr);
             classCreator.method(method.name(), mc -> {
@@ -194,43 +207,86 @@ public class DerivedMethodsAdder extends AbstractMethodsAdder {
                                     pageableSort);
                         }
 
-                        // call JpaOperations.find()
-                        Expr panacheQuery = bc.invokeVirtual(
-                                MethodDesc.of(AbstractManagedJpaOperations.class, "find", Object.class,
-                                        Class.class, String.class, io.quarkus.panache.common.Sort.class, Object[].class),
-                                ops, entityClass,
-                                Const.of(finalQuery), sort, paramsArray);
+                        DotName customResultTypeName = null;
+                        DotName elementTypeToCast = entityClassInfo.name();
+                        Expr panacheQuery;
 
-                        Type resultType = extractResultType(repositoryClassInfo, method);
+                        if (finalDynamicProjectionParameterIndex != null) {
+                            // For DTO projections Panache needs a FROM-only query so it can build
+                            // "SELECT new Dto(...) FROM ...". Entity projections keep the full SELECT query.
+                            String fromQuery = stripEntitySelectClause(finalQuery, getEntityName(entityClassInfo));
+                            Expr projectionType = params[finalDynamicProjectionParameterIndex];
+                            Expr isEntityProjection = bc.invokeVirtual(
+                                    MethodDesc.of(Class.class, "equals", boolean.class, Object.class),
+                                    projectionType, entityClass);
 
-                        DotName customResultTypeName = resultType.name();
-
-                        if (customResultTypeName.equals(entityClassInfo.name())
-                                || isHibernateSupportedReturnType(customResultTypeName)) {
-                            // no special handling needed
-                            customResultTypeName = null;
+                            LocalVar panacheQueryVar = bc.localVar("panacheQuery",
+                                    ConstantDescs.CD_Object, Const.ofNull(ConstantDescs.CD_Object));
+                            final String entityQuery = finalQuery;
+                            final String projectionQuery = fromQuery;
+                            final Expr projectionSort = sort;
+                            bc.ifElse(isEntityProjection,
+                                    entityBranch -> {
+                                        Expr entityPanacheQuery = entityBranch.invokeVirtual(
+                                                MethodDesc.of(AbstractManagedJpaOperations.class, "find", Object.class,
+                                                        Class.class, String.class, io.quarkus.panache.common.Sort.class,
+                                                        Object[].class),
+                                                ops, entityClass, Const.of(entityQuery), projectionSort, paramsArray);
+                                        entityBranch.set(panacheQueryVar, entityPanacheQuery);
+                                    },
+                                    dtoBranch -> {
+                                        Expr dtoPanacheQuery = dtoBranch.invokeVirtual(
+                                                MethodDesc.of(AbstractManagedJpaOperations.class, "find", Object.class,
+                                                        Class.class, String.class, io.quarkus.panache.common.Sort.class,
+                                                        Object[].class),
+                                                ops, entityClass, Const.of(projectionQuery), projectionSort, paramsArray);
+                                        Expr projectedPanacheQuery = dtoBranch.invokeInterface(
+                                                MethodDesc.of(io.quarkus.hibernate.orm.panache.PanacheQuery.class, "project",
+                                                        io.quarkus.hibernate.orm.panache.PanacheQuery.class, Class.class),
+                                                dtoPanacheQuery, projectionType);
+                                        dtoBranch.set(panacheQueryVar, projectedPanacheQuery);
+                                    });
+                            panacheQuery = panacheQueryVar;
+                            elementTypeToCast = DotNames.OBJECT;
                         } else {
-                            // If the custom type is an interface, we need to generate the implementation
-                            ClassInfo resultClassInfo = index.getClassByName(customResultTypeName);
-                            if (Modifier.isInterface(resultClassInfo.flags())) {
-                                // Find the implementation name, and use that for subsequent query result generation
-                                customResultTypeName = customResultTypeImplNames.computeIfAbsent(customResultTypeName,
-                                        k -> createSimpleInterfaceImpl(k, entityClassInfo.name()));
+                            panacheQuery = bc.invokeVirtual(
+                                    MethodDesc.of(AbstractManagedJpaOperations.class, "find", Object.class,
+                                            Class.class, String.class, io.quarkus.panache.common.Sort.class, Object[].class),
+                                    ops, entityClass,
+                                    Const.of(finalQuery), sort, paramsArray);
+                            Type resultType = extractResultType(repositoryClassInfo, method);
+                            customResultTypeName = resultType.name();
 
-                                // Remember the parameters for this usage of the custom type, we'll deal with it later
-                                customResultTypes.computeIfAbsent(customResultTypeName,
-                                        k -> new ArrayList<>()).add(method.name());
+                            if (customResultTypeName.equals(entityClassInfo.name())
+                                    || isHibernateSupportedReturnType(customResultTypeName)) {
+                                // no special handling needed
+                                customResultTypeName = null;
                             } else {
-                                throw new IllegalArgumentException(
-                                        method.name() + " of Repository " + repositoryClassInfo
-                                                + " can only use interfaces to map results to non-entity types.");
+                                // If the custom type is an interface, we need to generate the implementation
+                                ClassInfo resultClassInfo = index.getClassByName(customResultTypeName);
+                                if (Modifier.isInterface(resultClassInfo.flags())) {
+                                    // Find the implementation name, and use that for subsequent query result generation
+                                    customResultTypeName = customResultTypeImplNames.computeIfAbsent(customResultTypeName,
+                                            k -> createSimpleInterfaceImpl(k, entityClassInfo.name()));
+
+                                    // Remember the parameters for this usage of the custom type, we'll deal with it later
+                                    customResultTypes.computeIfAbsent(customResultTypeName,
+                                            k -> new ArrayList<>()).add(method.name());
+                                } else {
+                                    throw new IllegalArgumentException(
+                                            method.name() + " of Repository " + repositoryClassInfo
+                                                    + " can only use interfaces to map results to non-entity types.");
+                                }
                             }
                         }
 
+                        DotName effectiveReturnTypeName = finalReturnType.kind() == Type.Kind.TYPE_VARIABLE ? DotNames.OBJECT
+                                : finalReturnType.name();
+
                         generateFindQueryResultHandling(bc, panacheQuery, finalPageableParameterIndex, params,
-                                repositoryClassInfo, entityClassInfo, returnType.name(), parseResult.getTopCount(),
+                                repositoryClassInfo, entityClassInfo, effectiveReturnTypeName, parseResult.getTopCount(),
                                 method.name(), customResultTypeName,
-                                entityClassInfo.name().toString());
+                                entityClassInfo.name().toString(), elementTypeToCast);
 
                     } else if (parseResult.getQueryType() == MethodNameParser.QueryType.COUNT) {
                         if (!DotNames.PRIMITIVE_LONG.equals(returnType.name())
@@ -457,6 +513,52 @@ public class DerivedMethodsAdder extends AbstractMethodsAdder {
         for (MethodInfo method : methods) {
             if (method.name().equals(getterName)) {
                 return true;
+            }
+        }
+        return false;
+    }
+
+    private static String getEntityName(ClassInfo entityClassInfo) {
+        AnnotationInstance annotationInstance = entityClassInfo.declaredAnnotation(DotNames.JPA_ENTITY);
+        if (annotationInstance != null && annotationInstance.value("name") != null) {
+            AnnotationValue annotationValue = annotationInstance.value("name");
+            return annotationValue.asString().length() > 0 ? annotationValue.asString() : entityClassInfo.simpleName();
+        }
+        return entityClassInfo.simpleName();
+    }
+
+    private static String stripEntitySelectClause(String query, String entityName) {
+        String prefix = "SELECT " + entityName.toLowerCase() + " ";
+        if (query.regionMatches(true, 0, prefix, 0, prefix.length())) {
+            return query.substring(prefix.length());
+        }
+        return query;
+    }
+
+    // Spring Data dynamic projection: a Class<T> argument whose type variable matches the method return type
+    // (e.g. <T> T findById(Long id, Class<T> type)). Such parameters are not query bind values; they select
+    // the result shape at runtime and are passed to PanacheQuery.project(Class) instead.
+    private boolean isDynamicProjectionParameter(Type paramType, MethodInfo method) {
+        if (!DotNames.CLASS.equals(paramType.name())) {
+            return false;
+        }
+        if (paramType.kind() != Type.Kind.PARAMETERIZED_TYPE) {
+            return false;
+        }
+        List<Type> typeArgs = paramType.asParameterizedType().arguments();
+        if (typeArgs.size() != 1 || typeArgs.get(0).kind() != Type.Kind.TYPE_VARIABLE) {
+            return false;
+        }
+        Type methodReturnType = method.returnType();
+        if (methodReturnType.kind() == Type.Kind.TYPE_VARIABLE) {
+            return methodReturnType.asTypeVariable().identifier()
+                    .equals(typeArgs.get(0).asTypeVariable().identifier());
+        }
+        if (methodReturnType.kind() == Type.Kind.PARAMETERIZED_TYPE) {
+            List<Type> retArgs = methodReturnType.asParameterizedType().arguments();
+            if (retArgs.size() == 1 && retArgs.get(0).kind() == Type.Kind.TYPE_VARIABLE) {
+                return retArgs.get(0).asTypeVariable().identifier()
+                        .equals(typeArgs.get(0).asTypeVariable().identifier());
             }
         }
         return false;

--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/GenerationUtil.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/GenerationUtil.java
@@ -98,6 +98,11 @@ public final class GenerationUtil {
      * dot-name array forms like {@code java.lang.Object[]}.
      */
     static ClassDesc toClassDesc(String typeName) {
+        // Handle type variables (e.g. "T") by erasing to Object
+        // Jandex represents method-level generics as simple identifiers which are not valid class names.
+        if (isTypeVariableName(typeName)) {
+            return ConstantDescs.CD_Object;
+        }
         // Handle JVM internal array descriptors (e.g. "[Ljava.lang.Object;", "[[I")
         if (typeName.startsWith("[")) {
             return ClassDesc.ofDescriptor(typeName.replace('.', '/'));
@@ -118,6 +123,28 @@ public final class GenerationUtil {
             case "double" -> ConstantDescs.CD_double;
             case "char" -> ConstantDescs.CD_char;
             default -> ClassDesc.of(typeName);
+        };
+    }
+
+    private static boolean isTypeVariableName(String typeName) {
+        if (typeName == null || typeName.isEmpty()) {
+            return false;
+        }
+        // If it contains a package separator, it's a normal class name.
+        if (typeName.indexOf('.') != -1) {
+            return false;
+        }
+        // Common Jandex identifier form for type variables: "T", "ID", etc.
+        for (int i = 0; i < typeName.length(); i++) {
+            char c = typeName.charAt(i);
+            if (!(Character.isLetterOrDigit(c) || c == '_' || c == '$')) {
+                return false;
+            }
+        }
+        // Avoid treating primitive names as type variables.
+        return switch (typeName) {
+            case "void", "boolean", "byte", "short", "int", "long", "float", "double", "char" -> false;
+            default -> Character.isUpperCase(typeName.charAt(0));
         };
     }
 

--- a/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/DynamicProjectionDerivedMethodTest.java
+++ b/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/DynamicProjectionDerivedMethodTest.java
@@ -1,0 +1,122 @@
+package io.quarkus.spring.data.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.transaction.Transactional;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import io.quarkus.hibernate.orm.panache.common.ProjectedFieldName;
+import io.quarkus.test.QuarkusExtensionTest;
+
+class DynamicProjectionDerivedMethodTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest TEST = new QuarkusExtensionTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(Parent.class, ParentNameOnly.class, ParentIdOnly.class, ParentRepository.class))
+            .withConfigurationResource("application.properties");
+
+    @Autowired
+    ParentRepository repository;
+
+    @Test
+    @Transactional
+    void dynamicProjectionToEntityReturnsEntity() {
+        Parent p = new Parent();
+        p.setName("parent-1");
+        p = repository.save(p);
+
+        Parent projected = repository.findById(p.getId(), Parent.class);
+        assertThat(projected).isNotNull();
+        assertThat(projected.getName()).isEqualTo("parent-1");
+    }
+
+    @Test
+    @Transactional
+    void dynamicProjectionToDtoReturnsProjectedType() {
+        Parent p = new Parent();
+        p.setName("parent-2");
+        p = repository.save(p);
+
+        ParentNameOnly projected = repository.findById(p.getId(), ParentNameOnly.class);
+        assertThat(projected).isNotNull();
+        assertThat(projected).isNotInstanceOf(Parent.class);
+        assertThat(projected.getName()).isEqualTo("parent-2");
+    }
+
+    @Test
+    @Transactional
+    void dynamicProjectionToAnotherDtoReturnsProjectedType() {
+        Parent p = new Parent();
+        p.setName("parent-3");
+        p = repository.save(p);
+
+        ParentIdOnly projected = repository.findById(p.getId(), ParentIdOnly.class);
+        assertThat(projected).isNotNull();
+        assertThat(projected).isNotInstanceOf(Parent.class);
+        assertThat(projected.getId()).isEqualTo(p.getId());
+    }
+
+    @Entity(name = "Parent")
+    public static class Parent {
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        private Long id;
+        private String name;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    // DTO projection target — Panache constructor-based projection
+    public static class ParentNameOnly {
+        private final String name;
+
+        public ParentNameOnly(@ProjectedFieldName("name") String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+    public static class ParentIdOnly {
+        private final Long id;
+
+        public ParentIdOnly(@ProjectedFieldName("id") Long id) {
+            this.id = id;
+        }
+
+        public Long getId() {
+            return id;
+        }
+    }
+
+    public interface ParentRepository extends JpaRepository<Parent, Long> {
+        <T> T findById(Long id, Class<T> type);
+    }
+}


### PR DESCRIPTION
 Spring Data JPA repositories can declare derived methods with a dynamic projection parameter such
  as `<T> T findById(Long id, Class<T> type)`. At the moment, Quarkus treats that `Class<T>`
  argument like a query parameter during repository generation, which causes augmentation to fail
  with a parameter count mismatch.

  This change updates the derived method generation logic so dynamic projection parameters are
  recognized correctly and no longer counted as query parameters.



- Fixes: https://github.com/quarkusio/quarkus/issues/46899