### PR TITLE
Add generated bytecode reproducibility checks

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -106,6 +106,8 @@
         <unboundid-ldap.version>7.0.4</unboundid-ldap.version>
 
         <assertj.version>3.27.7</assertj.version>
+        <!-- Keep in sync with VineflowerDecompiler.DEFAULT_VINEFLOWER_VERSION -->
+        <vineflower.version>1.12.0</vineflower.version>
 
         <wiremock.version>3.13.2</wiremock.version>
         <wiremock-maven-plugin.version>7.3.0</wiremock-maven-plugin.version>
@@ -302,6 +304,11 @@
                 <artifactId>junit-pioneer</artifactId>
                 <version>${junit-pioneer.version}</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.vineflower</groupId>
+                <artifactId>vineflower</artifactId>
+                <version>${vineflower.version}</version>
             </dependency>
 
             <dependency>

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/VineflowerDecompiler.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/VineflowerDecompiler.java
@@ -15,6 +15,8 @@ import io.smallrye.common.process.ProcessUtil;
 class VineflowerDecompiler implements Decompiler {
 
     private static final Logger LOG = Logger.getLogger(VineflowerDecompiler.class);
+
+    // Keep in sync with the vineflower.version property in build-parent/pom.xml.
     private static final String DEFAULT_VINEFLOWER_VERSION = "1.12.0";
 
     private Context context;

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
@@ -15,6 +15,7 @@ import java.sql.Driver;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -237,6 +238,51 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
             this.transformedClasses = new MemoryClassPathElement(transformedClasses, true);
             resettableElement.reset(generatedResources);
             classPathResourceIndex = null;
+        }
+    }
+
+    /**
+     * Returns all in-memory generated and transformed class bytes, keyed by
+     * resource path (e.g. {@code io/quarkus/runner/Foo.class}).
+     * <p>
+     * Classes are collected in classloader priority order: transformed classes
+     * first, then resettable element, then normal priority elements, then
+     * lesser priority elements. Only {@link MemoryClassPathElement} instances
+     * are included. Uses {@code putIfAbsent} so higher-priority entries win.
+     * <p>
+     * Intended for reproducibility testing infrastructure.
+     */
+    public Map<String, byte[]> getInMemoryClassBytes() {
+        ensureOpen();
+        synchronized (this) {
+            Map<String, byte[]> result = new HashMap<>();
+            collectClassBytes(result, transformedClasses);
+            collectClassBytes(result, resettableElement);
+            for (ClassPathElement element : normalPriorityElements) {
+                if (element instanceof MemoryClassPathElement memoryElement) {
+                    collectClassBytes(result, memoryElement);
+                }
+            }
+            for (ClassPathElement element : lesserPriorityElements) {
+                if (element instanceof MemoryClassPathElement memoryElement) {
+                    collectClassBytes(result, memoryElement);
+                }
+            }
+            return result;
+        }
+    }
+
+    private static void collectClassBytes(Map<String, byte[]> destination, MemoryClassPathElement element) {
+        if (element == null) {
+            return;
+        }
+        for (String resource : element.getProvidedResources()) {
+            if (resource.endsWith(".class")) {
+                ClassPathResource classPathResource = element.getResource(resource);
+                if (classPathResource != null) {
+                    destination.putIfAbsent(resource, classPathResource.getData());
+                }
+            }
         }
     }
 

--- a/test-framework/junit-internal/pom.xml
+++ b/test-framework/junit-internal/pom.xml
@@ -64,8 +64,22 @@
             <artifactId>awaitility</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus.gizmo</groupId>
+            <artifactId>gizmo2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.vineflower</groupId>
+            <artifactId>vineflower</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/test-framework/junit-internal/src/main/java/io/quarkus/test/AbstractQuarkusExtensionTest.java
+++ b/test-framework/junit-internal/src/main/java/io/quarkus/test/AbstractQuarkusExtensionTest.java
@@ -49,6 +49,7 @@ import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.extension.TestInstantiationException;
+import org.opentest4j.TestAbortedException;
 
 import io.quarkus.bootstrap.app.AdditionalDependency;
 import io.quarkus.bootstrap.app.CuratedApplication;
@@ -57,6 +58,7 @@ import io.quarkus.bootstrap.app.RunningQuarkusApplication;
 import io.quarkus.bootstrap.classloading.ClassLoaderEventListener;
 import io.quarkus.bootstrap.classloading.ClassPathElement;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.builder.BuildChainBuilder;
 import io.quarkus.builder.BuildContext;
 import io.quarkus.builder.BuildException;
@@ -92,6 +94,7 @@ public abstract class AbstractQuarkusExtensionTest<S extends AbstractQuarkusExte
 
     public static final String THE_BUILD_WAS_EXPECTED_TO_FAIL = "The build was expected to fail";
     private static final String APP_ROOT = "app-root";
+    private static final String REPRODUCIBILITY_CHECK_PROPERTY_NAME = "quarkus.test.reproducibility-check";
 
     private static final Logger rootLogger;
     private Handler[] originalHandlers;
@@ -142,8 +145,8 @@ public abstract class AbstractQuarkusExtensionTest<S extends AbstractQuarkusExte
     private List<Consumer<QuarkusBootstrap.Builder>> bootstrapCustomizers = new ArrayList<>();
 
     private boolean debugBytecode = false;
+    private boolean reproducibilityCheckActive = false;
     private List<String> traceCategories = new ArrayList<>();
-
     private Map<String, String> systemPropertiesToRestore = new HashMap<>();
     private Map<String, java.util.logging.Level> loggerLevelsToRestore = new HashMap<>();
 
@@ -551,6 +554,25 @@ public abstract class AbstractQuarkusExtensionTest<S extends AbstractQuarkusExte
         if (beforeAllCustomizer != null) {
             beforeAllCustomizer.run();
         }
+        String reproducibilityProp = System.getProperty(REPRODUCIBILITY_CHECK_PROPERTY_NAME);
+        boolean reproducibilityCheck = reproducibilityProp != null;
+        int reproducibilityRuns = 0;
+        if (reproducibilityCheck) {
+            if (reproducibilityProp.isEmpty() || Boolean.parseBoolean(reproducibilityProp)) {
+                reproducibilityRuns = 3;
+            } else {
+                reproducibilityRuns = Integer.parseInt(reproducibilityProp);
+                if (reproducibilityRuns < 2) {
+                    throw new IllegalArgumentException(
+                            "%s must be >= 2, got: %s".formatted(REPRODUCIBILITY_CHECK_PROPERTY_NAME, reproducibilityRuns));
+                }
+            }
+        }
+        if (reproducibilityCheck) {
+            reproducibilityCheckActive = true;
+            // pin the output timestamp so that build time values are stable across runs
+            overrideConfigKey("quarkus.package.output-timestamp", "1970-01-02T00:00:00Z");
+        }
         if (debugBytecode) {
             // Use a unique ID to avoid overriding dumps between test classes (and re-execution of flaky tests).
             var testRunId = extensionContext.getRequiredTestClass().getName() + "/" + UUID.randomUUID();
@@ -663,41 +685,25 @@ public abstract class AbstractQuarkusExtensionTest<S extends AbstractQuarkusExte
             try {
                 final Path testLocation = PathTestHelper.getTestClassesLocation(testClass);
                 final Path projectDir = Path.of("").normalize().toAbsolutePath();
-                QuarkusBootstrap.Builder builder = QuarkusBootstrap.builder()
-                        .setBaseName(extensionContext.getDisplayName() + " (AbstractQuarkusExtensionTest)")
-                        .setApplicationRoot(deploymentDir.resolve(APP_ROOT))
-                        .setMode(QuarkusBootstrap.Mode.TEST)
-                        .addExcludedPath(testLocation)
-                        .setProjectRoot(projectDir)
-                        .setTargetDirectory(PathTestHelper.getProjectBuildDir(projectDir, testLocation))
-                        .setFlatClassPath(flatClassPath)
-                        .setForcedDependencies(forcedDependencies);
-                for (JavaArchive dependency : additionalDependencies) {
-                    builder.addAdditionalApplicationArchive(
-                            new AdditionalDependency(deploymentDir.resolve(dependency.getName()), false, true));
-                }
-                if (!forcedDependencies.isEmpty()) {
-                    //if we have forced dependencies we can't use the cache
-                    //as it can screw everything up
-                    builder.setDisableClasspathCache(true);
-                }
                 if (!allowTestClassOutsideDeployment) {
                     quarkusUnitTestClassLoader = QuarkusClassLoader
                             .builder("AbstractQuarkusExtensionTest ClassLoader for " + extensionContext.getDisplayName(),
                                     getClass().getClassLoader(), false)
                             .addClassLoaderEventListeners(this.classLoadListeners)
                             .addBannedElement(ClassPathElement.fromPath(testLocation, true)).build();
-                    builder.setBaseClassLoader(quarkusUnitTestClassLoader);
                 }
-                builder.addClassLoaderEventListeners(this.classLoadListeners);
 
-                for (Consumer<QuarkusBootstrap.Builder> bootstrapCustomizer : bootstrapCustomizers) {
-                    bootstrapCustomizer.accept(builder);
+                if (reproducibilityCheck) {
+                    runReproducibilityCheck(extensionContext, testLocation, projectDir,
+                            reproducibilityRuns, customizers);
                 }
-                curatedApplication = builder.build().bootstrap();
+
+                // Normal path: single augmentation, start app, run tests
+                curatedApplication = createCuratedApplication(extensionContext, testLocation, projectDir, null);
 
                 StartupActionImpl startupAction = new AugmentActionImpl(curatedApplication, customizers, classLoadListeners)
                         .createInitialRuntimeApplication();
+
                 Map<String, String> overriddenConfig = new HashMap<>(testResourceManager.getConfigProperties());
                 if (customRuntimeApplicationProperties != null) {
                     overriddenConfig.putAll(customRuntimeApplicationProperties);
@@ -729,6 +735,10 @@ public abstract class AbstractQuarkusExtensionTest<S extends AbstractQuarkusExte
                 if (assertException != null) {
                     if (e instanceof AssertionError && e.getMessage().equals(THE_BUILD_WAS_EXPECTED_TO_FAIL)) {
                         //don't pass the 'no failure' assertion into the assert exception function
+                        throw e;
+                    }
+                    if (e instanceof TestAbortedException) {
+                        // reproducibility check passed; don't confuse it with an expected build failure
                         throw e;
                     }
                     if (e instanceof RuntimeException) {
@@ -803,7 +813,7 @@ public abstract class AbstractQuarkusExtensionTest<S extends AbstractQuarkusExte
                 runningQuarkusApplication.close();
                 runningQuarkusApplication = null;
             }
-            if (afterUndeployListener != null) {
+            if (afterUndeployListener != null && !reproducibilityCheckActive) {
                 afterUndeployListener.run();
             }
             if (curatedApplication != null) {
@@ -841,9 +851,96 @@ public abstract class AbstractQuarkusExtensionTest<S extends AbstractQuarkusExte
             ClearCache.clearCaches();
             TestConfigUtil.cleanUp();
         }
-        if (records != null) {
+        // skip log assertions during reproducibility checks — the app was never started
+        if (records != null && !reproducibilityCheckActive) {
             assertLogRecords.accept(records);
         }
+    }
+
+    private void runReproducibilityCheck(ExtensionContext extensionContext, Path testLocation, Path projectDir,
+            int reproducibilityRuns, List<Consumer<BuildChainBuilder>> customizers) throws Exception {
+        String testName = extensionContext.getRequiredTestClass().getSimpleName();
+        System.out.printf("[AbstractQuarkusExtensionTest] Reproducibility check (%d runs) for %s%n",
+                reproducibilityRuns, testName);
+        Map<String, byte[]> referenceInMemoryClasses = null;
+        ApplicationModel cachedApplicationModel = null;
+        for (int run = 1; run <= reproducibilityRuns; run++) {
+            CuratedApplication currentCuratedApplication = null;
+            StartupActionImpl currentStartupAction = null;
+            try {
+                currentCuratedApplication = createCuratedApplication(extensionContext, testLocation, projectDir,
+                        cachedApplicationModel);
+                if (cachedApplicationModel == null) {
+                    // Reuse the resolved model so this check focuses on repeated augmentation bytecode.
+                    cachedApplicationModel = currentCuratedApplication.getApplicationModel();
+                }
+                currentStartupAction = new AugmentActionImpl(currentCuratedApplication, customizers, classLoadListeners)
+                        .createInitialRuntimeApplication();
+
+                Map<String, byte[]> currentInMemoryClasses = currentStartupAction.getClassLoader().getInMemoryClassBytes();
+                if (referenceInMemoryClasses == null) {
+                    referenceInMemoryClasses = currentInMemoryClasses;
+                } else {
+                    var diff = BytecodeTools.diff(referenceInMemoryClasses, currentInMemoryClasses);
+                    if (!diff.isEmpty()) {
+                        String testRunId = extensionContext.getRequiredTestClass().getName()
+                                + "/" + UUID.randomUUID();
+                        Path dumpDir = Path.of("target", "debug").resolve(testRunId)
+                                .resolve("reproducibility-mismatch");
+                        Path mismatchDumpPath = BytecodeTools.dumpReproducibilityMismatch(diff,
+                                referenceInMemoryClasses, currentInMemoryClasses, run, dumpDir);
+                        throw new AssertionError("Build reproducibility check failed on run " + run + "/"
+                                + reproducibilityRuns + ": " + diff + ". Dumped to "
+                                + mismatchDumpPath);
+                    }
+                }
+            } finally {
+                if (currentStartupAction != null) {
+                    currentStartupAction.getClassLoader().close();
+                }
+                if (currentCuratedApplication != null) {
+                    currentCuratedApplication.close();
+                }
+                inMemoryLogHandler.clearRecords();
+            }
+        }
+        System.out.printf("[AbstractQuarkusExtensionTest] Reproducibility check passed for %s%n", testName);
+        throw new TestAbortedException(
+                "Reproducibility check passed (" + reproducibilityRuns + " runs). Test execution skipped.");
+    }
+
+    private CuratedApplication createCuratedApplication(ExtensionContext extensionContext, Path testLocation, Path projectDir,
+            ApplicationModel existingModel)
+            throws Exception {
+        QuarkusBootstrap.Builder builder = QuarkusBootstrap.builder()
+                .setBaseName(extensionContext.getDisplayName() + " (AbstractQuarkusExtensionTest)")
+                .setApplicationRoot(deploymentDir.resolve(APP_ROOT))
+                .setMode(QuarkusBootstrap.Mode.TEST)
+                .addExcludedPath(testLocation)
+                .setProjectRoot(projectDir)
+                .setTargetDirectory(PathTestHelper.getProjectBuildDir(projectDir, testLocation))
+                .setFlatClassPath(flatClassPath)
+                .setForcedDependencies(forcedDependencies);
+        for (JavaArchive dependency : additionalDependencies) {
+            builder.addAdditionalApplicationArchive(
+                    new AdditionalDependency(deploymentDir.resolve(dependency.getName()), false, true));
+        }
+        if (!forcedDependencies.isEmpty()) {
+            //if we have forced dependencies we can't use the cache
+            //as it can screw everything up
+            builder.setDisableClasspathCache(true);
+        }
+        if (quarkusUnitTestClassLoader != null) {
+            builder.setBaseClassLoader(quarkusUnitTestClassLoader);
+        }
+        builder.addClassLoaderEventListeners(this.classLoadListeners);
+        for (Consumer<QuarkusBootstrap.Builder> bootstrapCustomizer : bootstrapCustomizers) {
+            bootstrapCustomizer.accept(builder);
+        }
+        if (existingModel != null) {
+            builder.setExistingModel(existingModel);
+        }
+        return builder.build().bootstrap();
     }
 
     @Override

--- a/test-framework/junit-internal/src/main/java/io/quarkus/test/BytecodeTools.java
+++ b/test-framework/junit-internal/src/main/java/io/quarkus/test/BytecodeTools.java
@@ -1,0 +1,275 @@
+package io.quarkus.test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.jar.Manifest;
+
+import org.jetbrains.java.decompiler.main.decompiler.BaseDecompiler;
+import org.jetbrains.java.decompiler.main.decompiler.PrintStreamLogger;
+import org.jetbrains.java.decompiler.main.extern.IFernflowerPreferences;
+import org.jetbrains.java.decompiler.main.extern.IResultSaver;
+
+// Note: Vineflower is a compile-scope dependency because this class imports it directly.
+// To make it optional, decompilation would need to be invoked reflectively.
+class BytecodeTools {
+
+    private static final Map<String, Object> VINEFLOWER_OPTIONS = createVineflowerOptions();
+
+    // Known non-deterministic classes. Each extension should fix its non-determinism;
+    // entries here are temporary workarounds.
+    // TODO: allow extensions to declare exclusions dynamically via a build item
+    private static final Set<String> DEFAULT_EXCLUDED = Set.of(
+            // DevUI handler classes that embed non-deterministic data
+            "io/quarkus/runner/recorded/WebJarProcessor$processWebJarDevMode",
+            "io/quarkus/runner/recorded/SmallRyeHealthProcessor$registerHealthUiHandler",
+            "io/quarkus/runner/recorded/SmallRyeGraphQLProcessor$registerGraphQLUiHandler",
+            "io/quarkus/runner/recorded/SwaggerUiProcessor$registerSwaggerUiHandler");
+
+    private static final Set<String> EXCLUDED = loadExclusions();
+
+    private static Set<String> loadExclusions() {
+        Set<String> result = new TreeSet<>(DEFAULT_EXCLUDED);
+        String additional = System.getProperty("quarkus.test.reproducibility-check.excludes");
+        if (additional != null && !additional.isBlank()) {
+            for (String prefix : additional.split(",")) {
+                String trimmed = prefix.trim();
+                if (!trimmed.isEmpty()) {
+                    result.add(trimmed);
+                }
+            }
+        }
+        return Set.copyOf(result);
+    }
+
+    static void decompileClassDump(Path classInputDir, Path decompiledOutputDir, StringBuilder index) throws Exception {
+        if (!Files.exists(classInputDir)) {
+            return;
+        }
+        Files.createDirectories(decompiledOutputDir);
+
+        ByteArrayOutputStream decompilerOutputBuffer = new ByteArrayOutputStream();
+        try (PrintStream loggerStream = new PrintStream(decompilerOutputBuffer, true, StandardCharsets.UTF_8)) {
+            BaseDecompiler decompiler = new BaseDecompiler(new DirectoryResultSaver(decompiledOutputDir), VINEFLOWER_OPTIONS,
+                    new PrintStreamLogger(loggerStream));
+            decompiler.addSource(classInputDir.toFile());
+            decompiler.decompileContext();
+
+            Files.write(decompiledOutputDir.resolve("decompile.log"), decompilerOutputBuffer.toByteArray());
+            index.append("DECOMPILED ").append(classInputDir).append(" -> ").append(decompiledOutputDir).append('\n');
+        } catch (Exception e) {
+            Files.write(decompiledOutputDir.resolve("decompile.log"), decompilerOutputBuffer.toByteArray());
+            index.append("DECOMPILE_FAILED ").append(classInputDir).append(" -> ").append(decompiledOutputDir)
+                    .append(" (").append(e.getClass().getSimpleName()).append(": ")
+                    .append(Objects.toString(e.getMessage(), "no message")).append(")\n");
+        }
+    }
+
+    private static Map<String, Object> createVineflowerOptions() {
+        Map<String, Object> options = new HashMap<>(IFernflowerPreferences.getDefaults());
+        options.put(IFernflowerPreferences.REMOVE_SYNTHETIC, "0");
+        options.put(IFernflowerPreferences.REMOVE_BRIDGE, "0");
+        return Map.copyOf(options);
+    }
+
+    static InMemoryClassDiff diff(Map<String, byte[]> reference, Map<String, byte[]> current) {
+        TreeSet<String> missing = new TreeSet<>(reference.keySet());
+        missing.removeAll(current.keySet());
+
+        TreeSet<String> extra = new TreeSet<>(current.keySet());
+        extra.removeAll(reference.keySet());
+
+        // exclusions only suppress content changes, not missing/extra classes
+        TreeSet<String> changed = new TreeSet<>();
+        for (String resource : reference.keySet()) {
+            byte[] currentBytes = current.get(resource);
+            if (!isExcluded(resource) && currentBytes != null && !Arrays.equals(reference.get(resource), currentBytes)) {
+                changed.add(resource);
+            }
+        }
+        return new InMemoryClassDiff(missing, extra, changed);
+    }
+
+    private static boolean isExcluded(String resource) {
+        return EXCLUDED.stream().anyMatch(excluded -> resource.startsWith(excluded));
+    }
+
+    static Path dumpReproducibilityMismatch(InMemoryClassDiff diff, Map<String, byte[]> reference, Map<String, byte[]> current,
+            int run, Path baseDir) {
+        Path run1Dir = baseDir.resolve("run-1");
+        Path runNDir = baseDir.resolve("run-" + run);
+
+        StringBuilder index = new StringBuilder();
+        index.append("run-1 vs run-").append(run).append('\n');
+
+        try {
+            Files.createDirectories(run1Dir);
+            Files.createDirectories(runNDir);
+
+            for (String resource : diff.missing()) {
+                writeClassDump(run1Dir, resource, reference.get(resource));
+                index.append("MISSING_IN_RUN_").append(run).append(' ').append(resource)
+                        .append(" run-1-sha256=").append(sha256(reference.get(resource))).append('\n');
+            }
+            for (String resource : diff.extra()) {
+                writeClassDump(runNDir, resource, current.get(resource));
+                index.append("EXTRA_IN_RUN_").append(run).append(' ').append(resource)
+                        .append(" run-").append(run).append("-sha256=").append(sha256(current.get(resource)))
+                        .append('\n');
+            }
+            for (String resource : diff.changed()) {
+                writeClassDump(run1Dir, resource, reference.get(resource));
+                writeClassDump(runNDir, resource, current.get(resource));
+                index.append("CHANGED ").append(resource)
+                        .append(" run-1-sha256=").append(sha256(reference.get(resource)))
+                        .append(" run-").append(run).append("-sha256=").append(sha256(current.get(resource)))
+                        .append('\n');
+            }
+
+            decompileClassDump(run1Dir, baseDir.resolve("run-1-decompiled"), index);
+            decompileClassDump(runNDir, baseDir.resolve("run-" + run + "-decompiled"), index);
+
+            Files.writeString(baseDir.resolve("mismatch.txt"), index.toString());
+            return baseDir;
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to dump reproducibility mismatch classes to " + baseDir, e);
+        }
+    }
+
+    record InMemoryClassDiff(TreeSet<String> missing, TreeSet<String> extra, TreeSet<String> changed) {
+        boolean isEmpty() {
+            return missing.isEmpty() && extra.isEmpty() && changed.isEmpty();
+        }
+
+        @Override
+        public String toString() {
+            return "missing=" + missing.size() + " " + pretty(missing)
+                    + ", extra=" + extra.size() + " " + pretty(extra)
+                    + ", changed=" + changed.size() + " " + pretty(changed);
+        }
+    }
+
+    private static void writeClassDump(Path runDir, String resource, byte[] data) throws Exception {
+        Path outputFile = runDir.resolve(resource);
+        Files.createDirectories(outputFile.getParent());
+        Files.write(outputFile, data);
+    }
+
+    private static String sha256(byte[] data) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(data);
+            StringBuilder builder = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                builder.append(Character.forDigit((b >> 4) & 0xF, 16));
+                builder.append(Character.forDigit(b & 0xF, 16));
+            }
+            return builder.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+
+    private static String pretty(TreeSet<String> values) {
+        return "[" + String.join(", ", values) + "]";
+    }
+
+    private static final class DirectoryResultSaver implements IResultSaver {
+
+        private final Path outputDir;
+
+        private DirectoryResultSaver(Path outputDir) {
+            this.outputDir = outputDir;
+        }
+
+        @Override
+        public void saveFolder(String path) {
+            createDirectories(outputDir.resolve(path));
+        }
+
+        @Override
+        public void copyFile(String source, String path, String entryName) {
+            Path target = resolve(path, entryName);
+            createDirectories(target.getParent());
+            try {
+                Files.copy(Path.of(source), target);
+            } catch (IOException e) {
+                throw new IllegalStateException("Unable to copy file '" + source + "' to " + target, e);
+            }
+        }
+
+        @Override
+        public void saveClassFile(String path, String qualifiedName, String entryName, String content, int[] mapping) {
+            Path target = resolve(path, entryName);
+            createDirectories(target.getParent());
+            try {
+                Files.writeString(target, content, StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                throw new IllegalStateException("Unable to write decompiled class '" + qualifiedName + "' to " + target, e);
+            }
+        }
+
+        @Override
+        public void createArchive(String path, String archiveName, Manifest manifest) {
+        }
+
+        @Override
+        public void saveDirEntry(String path, String archiveName, String entryName) {
+            Path target = resolve(path, entryName);
+            createDirectories(target);
+        }
+
+        @Override
+        public void copyEntry(String source, String path, String archiveName, String entryName) {
+            Path target = resolve(path, entryName);
+            createDirectories(target.getParent());
+            try {
+                Files.copy(Path.of(source), target);
+            } catch (IOException e) {
+                throw new IllegalStateException("Unable to copy archive entry from '" + source + "' to " + target, e);
+            }
+        }
+
+        @Override
+        public void saveClassEntry(String path, String archiveName, String qualifiedName, String entryName, String content) {
+            Path target = resolve(path, entryName);
+            createDirectories(target.getParent());
+            try {
+                Files.writeString(target, content, StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                throw new IllegalStateException("Unable to write decompiled archive class '" + qualifiedName + "' to " + target,
+                        e);
+            }
+        }
+
+        @Override
+        public void closeArchive(String path, String archiveName) {
+        }
+
+        private Path resolve(String path, String entryName) {
+            if (path == null || path.isEmpty()) {
+                return outputDir.resolve(entryName);
+            }
+            return outputDir.resolve(path).resolve(entryName);
+        }
+
+        private static void createDirectories(Path dir) {
+            try {
+                Files.createDirectories(dir);
+            } catch (IOException e) {
+                throw new IllegalStateException("Unable to create directory " + dir, e);
+            }
+        }
+    }
+}

--- a/test-framework/junit-internal/src/test/java/io/quarkus/test/BytecodeToolsTest.java
+++ b/test-framework/junit-internal/src/test/java/io/quarkus/test/BytecodeToolsTest.java
@@ -1,0 +1,120 @@
+package io.quarkus.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.quarkus.gizmo2.Gizmo;
+
+class BytecodeToolsTest {
+
+    @Test
+    void identicalBytecodeProducesEmptyDiff() {
+        Map<String, byte[]> reference = generateSimpleClass("com.example.Hello");
+        Map<String, byte[]> current = generateSimpleClass("com.example.Hello");
+        var diff = BytecodeTools.diff(reference, current);
+        assertThat(diff.isEmpty()).isTrue();
+    }
+
+    @Test
+    void missingClassIsDetected() {
+        Map<String, byte[]> reference = generateSimpleClass("com.example.Hello");
+        Map<String, byte[]> current = new HashMap<>();
+
+        var diff = BytecodeTools.diff(reference, current);
+
+        assertThat(diff.isEmpty()).isFalse();
+        assertThat(diff.missing()).containsExactly("com/example/Hello.class");
+        assertThat(diff.extra()).isEmpty();
+        assertThat(diff.changed()).isEmpty();
+    }
+
+    @Test
+    void extraClassIsDetected() {
+        Map<String, byte[]> reference = new HashMap<>();
+        Map<String, byte[]> current = generateSimpleClass("com.example.Hello");
+
+        var diff = BytecodeTools.diff(reference, current);
+
+        assertThat(diff.isEmpty()).isFalse();
+        assertThat(diff.missing()).isEmpty();
+        assertThat(diff.extra()).containsExactly("com/example/Hello.class");
+        assertThat(diff.changed()).isEmpty();
+    }
+
+    @Test
+    void changedBytecodeIsDetected() {
+        Map<String, byte[]> reference = generateClassWithField("com.example.Hello", "fieldA");
+        Map<String, byte[]> current = generateClassWithField("com.example.Hello", "fieldB");
+
+        var diff = BytecodeTools.diff(reference, current);
+
+        assertThat(diff.isEmpty()).isFalse();
+        assertThat(diff.missing()).isEmpty();
+        assertThat(diff.extra()).isEmpty();
+        assertThat(diff.changed()).containsExactly("com/example/Hello.class");
+    }
+
+    @Test
+    void excludedClassIsNotReportedAsChanged() {
+        String excluded = "io/quarkus/runner/recorded/WebJarProcessor$processWebJarDevMode";
+        String resource = excluded + ".class";
+        Map<String, byte[]> reference = Map.of(resource, new byte[] { 1, 2, 3 });
+        Map<String, byte[]> current = Map.of(resource, new byte[] { 4, 5, 6 });
+
+        var diff = BytecodeTools.diff(reference, current);
+
+        assertThat(diff.isEmpty()).isTrue();
+    }
+
+    @Test
+    void dumpCreatesExpectedFileStructure(@TempDir Path tempDir) throws Exception {
+        Map<String, byte[]> reference = generateClassWithField("com.example.Foo", "fieldA");
+        Map<String, byte[]> current = generateClassWithField("com.example.Foo", "fieldB");
+
+        var diff = BytecodeTools.diff(reference, current);
+        assertThat(diff.isEmpty()).isFalse();
+
+        Path dumpDir = BytecodeTools.dumpReproducibilityMismatch(diff, reference, current, 2, tempDir);
+
+        assertThat(dumpDir.resolve("run-1")).isDirectory();
+        assertThat(dumpDir.resolve("run-2")).isDirectory();
+        assertThat(dumpDir.resolve("mismatch.txt")).isRegularFile();
+        assertThat(dumpDir.resolve("run-1/com/example/Foo.class")).isRegularFile();
+        assertThat(dumpDir.resolve("run-2/com/example/Foo.class")).isRegularFile();
+        assertThat(dumpDir.resolve("run-1-decompiled")).isDirectory();
+        assertThat(dumpDir.resolve("run-2-decompiled")).isDirectory();
+
+        String mismatchContent = Files.readString(dumpDir.resolve("mismatch.txt"));
+        assertThat(mismatchContent).contains("CHANGED");
+        assertThat(mismatchContent).contains("com/example/Foo.class");
+    }
+
+    private Map<String, byte[]> generateSimpleClass(String binaryName) {
+        Map<String, byte[]> result = new HashMap<>();
+        Gizmo g = Gizmo.create((path, bytes) -> result.put(path, bytes));
+        g.class_(binaryName, cc -> {
+            cc.public_();
+        });
+        return result;
+    }
+
+    private Map<String, byte[]> generateClassWithField(String binaryName, String fieldName) {
+        Map<String, byte[]> result = new HashMap<>();
+        Gizmo g = Gizmo.create((path, bytes) -> result.put(path, bytes));
+        g.class_(binaryName, cc -> {
+            cc.public_();
+            cc.field(fieldName, fc -> {
+                fc.setType(String.class);
+                fc.private_();
+            });
+        });
+        return result;
+    }
+}


### PR DESCRIPTION
Introduce a reproducibility mode for `AbstractQuarkusExtensionTest` that reruns augmentation, compares generated and transformed in-memory class bytes across runs, and dumps decompiled mismatches and diagnostics.

The mode is enabled with `-Dquarkus.test.reproducibility-check[=<runs>]`; an empty value defaults to 3 runs, and explicit values must be at least 2. Test execution is skipped after a successful check.

Co-authored-by: Matej Novotny <manovotn@ibm.com>
Co-authored-by: Ladislav Thon <lthon@redhat.com>
