### PR TITLE
Fix "Kafka OAuthBearer authentication fails in native mode" again

### DIFF
--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
@@ -26,8 +26,11 @@ import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.security.authenticator.AbstractLogin;
 import org.apache.kafka.common.security.authenticator.DefaultLogin;
 import org.apache.kafka.common.security.authenticator.SaslClientCallbackHandler;
+import org.apache.kafka.common.security.oauthbearer.BrokerJwtValidator;
+import org.apache.kafka.common.security.oauthbearer.ClientJwtValidator;
 import org.apache.kafka.common.security.oauthbearer.DefaultJwtValidator;
 import org.apache.kafka.common.security.oauthbearer.JwtRetriever;
+import org.apache.kafka.common.security.oauthbearer.JwtValidator;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
 import org.apache.kafka.common.security.oauthbearer.internals.OAuthBearerRefreshingLogin;
 import org.apache.kafka.common.security.oauthbearer.internals.OAuthBearerSaslClient;
@@ -69,7 +72,6 @@ import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBundleBuil
 import io.quarkus.deployment.builditem.nativeimage.NativeImageSecurityProviderBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassConditionBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.ReflectiveMethodBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedPackageBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.logging.LogCleanupFilterBuildItem;
@@ -236,9 +238,9 @@ public class KafkaProcessor {
             BuildProducer<ConfigDescriptionBuildItem> configDescBuildItems,
             CombinedIndexBuildItem indexBuildItem,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
-            BuildProducer<ReflectiveMethodBuildItem> reflectiveMethod,
             BuildProducer<ServiceProviderBuildItem> serviceProviders,
             BuildProducer<NativeImageProxyDefinitionBuildItem> proxies,
+            BuildProducer<RunTimeConfigurationDefaultBuildItem> runtimeConfig,
             Capabilities capabilities,
             BuildProducer<UnremovableBeanBuildItem> beans,
             BuildProducer<ExtensionSslNativeSupportBuildItem> sslNativeSupport) {
@@ -264,9 +266,19 @@ public class KafkaProcessor {
                 .reason(getClass().getName() + " OAuthBearerSaslClient classes")
                 .build());
 
-        // This is done to avoid loading jose4j classes when not needed, as DefaultJwtValidator is the default validator used by Kafka clients if no other validator is specified.
-        reflectiveMethod.produce(new ReflectiveMethodBuildItem(getClass().getName() + " DefaultJwtValidator class",
-                DefaultJwtValidator.class.getName(), "<init>", new String[0]));
+        // Kafka's DefaultJwtValidator delegates to BrokerJwtValidator or ClientJwtValidator.
+        // Both DefaultJwtValidator and BrokerJwtValidator reference jose4j's VerificationKeyResolver
+        // while ClientJwtValidator does not depend on jose4j at all.
+        // When jose4j is absent, we exclude DefaultJwtValidator and BrokerJwtValidator from reflection
+        // and default the validator config to ClientJwtValidator, which covers the common client-side use case.
+        // See https://github.com/quarkusio/quarkus/issues/52662.
+        collectImplementors(toRegister, indexBuildItem, JwtValidator.class);
+        if (!QuarkusClassLoader.isClassPresentAtRuntime("org.jose4j.keys.resolvers.VerificationKeyResolver")) {
+            toRegister.remove(DotName.createSimple(DefaultJwtValidator.class.getName()));
+            toRegister.remove(DotName.createSimple(BrokerJwtValidator.class.getName()));
+            runtimeConfig.produce(new RunTimeConfigurationDefaultBuildItem("kafka.sasl.oauthbearer.jwt.validator.class",
+                    ClientJwtValidator.class.getName()));
+        }
 
         for (Class<?> i : BUILT_INS) {
             reflectiveClass.produce(ReflectiveClassBuildItem.builder(i.getName())

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
@@ -237,7 +237,6 @@ public class KafkaProcessor {
             CombinedIndexBuildItem indexBuildItem,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<ReflectiveMethodBuildItem> reflectiveMethod,
-            BuildProducer<ReflectiveClassConditionBuildItem> reflectiveClassCondition,
             BuildProducer<ServiceProviderBuildItem> serviceProviders,
             BuildProducer<NativeImageProxyDefinitionBuildItem> proxies,
             Capabilities capabilities,
@@ -265,11 +264,9 @@ public class KafkaProcessor {
                 .reason(getClass().getName() + " OAuthBearerSaslClient classes")
                 .build());
 
-        // Register DefaultJwtValidator only when jose4j is present to avoid NoClassDefFoundError
-        // with GraalVM 25's --future-defaults=complete-reflection-types flag
-        reflectiveClassCondition.produce(new ReflectiveClassConditionBuildItem(
-                DefaultJwtValidator.class.getName(),
-                "org.jose4j.keys.resolvers.VerificationKeyResolver"));
+        // This is done to avoid loading jose4j classes when not needed, as DefaultJwtValidator is the default validator used by Kafka clients if no other validator is specified.
+        reflectiveMethod.produce(new ReflectiveMethodBuildItem(getClass().getName() + " DefaultJwtValidator class",
+                DefaultJwtValidator.class.getName(), "<init>", new String[0]));
 
         for (Class<?> i : BUILT_INS) {
             reflectiveClass.produce(ReflectiveClassBuildItem.builder(i.getName())


### PR DESCRIPTION
Follow up to #53194 and #54403

- Fixes" #52662 

that reappeared after #53194 , which has it's problems discussed in #52662. 

---

- Reverts: #53194 

- Collect all `JwtValidator` implementors for reflection registration
- When jose4j is not on the classpath, exclude `DefaultJwtValidator` and `BrokerJwtValidator` from reflection registration since both reference jose4j's `VerificationKeyResolver`
- Default value `kafka.sasl.oauthbearer.jwt.validator.class` to `ClientJwtValidator` which does not depend on jose4j 

In my tests with these changes the native compilation passes with or without `--future-defaults=complete-reflection-types`                                                                  