### PR TITLE
Fix stork:// gRPC clients not recovering when the service starts after the client

### DIFF
--- a/extensions/grpc/runtime/pom.xml
+++ b/extensions/grpc/runtime/pom.xml
@@ -126,6 +126,11 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.smallrye.stork</groupId>
+            <artifactId>stork-service-discovery-static-list</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/stork/GrpcStorkServiceDiscovery.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/stork/GrpcStorkServiceDiscovery.java
@@ -6,10 +6,8 @@ import java.net.SocketAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.jboss.logging.Logger;
 
@@ -61,8 +59,6 @@ public class GrpcStorkServiceDiscovery extends NameResolverProvider {
             ServiceDiscovery serviceDiscovery;
             String serviceName;
 
-            volatile Set<Long> serviceInstanceIds = new HashSet<>();
-
             @Override
             public String getServiceAuthority() {
                 return targetUri.getAuthority();
@@ -94,7 +90,17 @@ public class GrpcStorkServiceDiscovery extends NameResolverProvider {
                 }
                 resolving = true;
                 Uni<List<ServiceInstance>> serviceInstances = serviceDiscovery.getServiceInstances();
-                serviceInstances.subscribe().with(this::informListener);
+                serviceInstances.subscribe().with(this::informListener, error -> {
+                    if (shutdown) {
+                        resolving = false;
+                        return;
+                    }
+                    log.warnf(error, "Stork service discovery failed for '%s'", serviceName);
+                    listener.onError(Status.UNAVAILABLE
+                            .withDescription("Service discovery failed for: " + serviceName)
+                            .withCause(error));
+                    resolving = false;
+                });
             }
 
             @Override
@@ -103,60 +109,63 @@ public class GrpcStorkServiceDiscovery extends NameResolverProvider {
             }
 
             private void informListener(List<ServiceInstance> instances) {
-                ArrayList<EquivalentAddressGroup> addresses = new ArrayList<>();
                 try {
-                    if (serviceInstanceIds.size() != instances.size() || areServicesRemoved(instances)) {
-                        // TODO : we can probably do a smarter refresh
-                        HashSet<Long> serviceInstanceIds = new HashSet<>();
-                        for (ServiceInstance instance : instances) {
-                            serviceInstanceIds.add(instance.getId());
-                        }
+                    if (shutdown) {
+                        return;
+                    }
+                    if (instances.isEmpty()) {
+                        // No instances were resolved for the service. This must always be
+                        // reported to the listener as an error - even when the previous
+                        // resolution was also empty - because gRPC only re-runs a
+                        // NameResolver (refresh() with backoff) after an onResult or
+                        // onError callback. Staying silent here leaves the channel wedged
+                        // in CONNECTING with no scheduled re-resolution, so it never
+                        // recovers once instances appear (e.g. the service is started
+                        // after the client).
+                        log.debugf("No service instances resolved for service-name '%s'", serviceName);
+                        listener.onError(Status.UNAVAILABLE
+                                .withDescription("No instances available for service-name: " + serviceName));
+                        return;
+                    }
 
-                        this.serviceInstanceIds = serviceInstanceIds;
-
-                        for (ServiceInstance instance : instances) {
-                            List<SocketAddress> socketAddresses = new ArrayList<>();
-                            try {
-                                for (InetAddress inetAddress : InetAddress.getAllByName(instance.getHost())) {
-                                    socketAddresses.add(new InetSocketAddress(inetAddress, instance.getPort()));
-                                }
-                            } catch (UnknownHostException e) {
-                                log.warnf(e, "Ignoring wrong host: '%s' for service name '%s'", instance.getHost(),
-                                        serviceName);
+                    // Always notify the listener for a non-empty resolution, even when the
+                    // instance set is unchanged. Skipping onResult/onError when nothing
+                    // changed can leave a refresh() with no callback and the channel stuck
+                    // waiting for re-resolution (same class of bug as the empty-list case).
+                    ArrayList<EquivalentAddressGroup> addresses = new ArrayList<>();
+                    for (ServiceInstance instance : instances) {
+                        List<SocketAddress> socketAddresses = new ArrayList<>();
+                        try {
+                            for (InetAddress inetAddress : InetAddress.getAllByName(instance.getHost())) {
+                                socketAddresses.add(new InetSocketAddress(inetAddress, instance.getPort()));
                             }
-
-                            if (!socketAddresses.isEmpty()) {
-                                Attributes attributes = Attributes.newBuilder()
-                                        .set(SERVICE_INSTANCE, instance)
-                                        .build();
-                                EquivalentAddressGroup addressGroup = new EquivalentAddressGroup(socketAddresses, attributes);
-                                addresses.add(addressGroup);
-                            }
+                        } catch (UnknownHostException e) {
+                            log.warnf(e, "Ignoring wrong host: '%s' for service name '%s'", instance.getHost(),
+                                    serviceName);
                         }
 
-                        if (addresses.isEmpty()) {
-                            log.error("Failed to determine working socket addresses for service-name: " + serviceName);
-                            listener.onError(Status.FAILED_PRECONDITION);
-                        } else {
-                            ConfigOrError serviceConfig = configParser.parseServiceConfig(mapConfigForServiceName());
-                            listener.onResult(ResolutionResult.newBuilder()
-                                    .setAddresses(addresses)
-                                    .setServiceConfig(serviceConfig)
-                                    .build());
+                        if (!socketAddresses.isEmpty()) {
+                            Attributes attributes = Attributes.newBuilder()
+                                    .set(SERVICE_INSTANCE, instance)
+                                    .build();
+                            EquivalentAddressGroup addressGroup = new EquivalentAddressGroup(socketAddresses, attributes);
+                            addresses.add(addressGroup);
                         }
+                    }
+
+                    if (addresses.isEmpty()) {
+                        log.error("Failed to determine working socket addresses for service-name: " + serviceName);
+                        listener.onError(Status.FAILED_PRECONDITION);
+                    } else {
+                        ConfigOrError serviceConfig = configParser.parseServiceConfig(mapConfigForServiceName());
+                        listener.onResult(ResolutionResult.newBuilder()
+                                .setAddresses(addresses)
+                                .setServiceConfig(serviceConfig)
+                                .build());
                     }
                 } finally {
                     resolving = false;
                 }
-            }
-
-            private boolean areServicesRemoved(List<ServiceInstance> instances) {
-                for (ServiceInstance instance : instances) {
-                    if (!serviceInstanceIds.contains(instance.getId())) {
-                        return true;
-                    }
-                }
-                return false;
             }
 
             private Map<String, List<Map<String, Map<String, String>>>> mapConfigForServiceName() {

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/stork/StorkGrpcChannel.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/stork/StorkGrpcChannel.java
@@ -85,7 +85,13 @@ public class StorkGrpcChannel extends Channel implements AutoCloseable {
         context.measureTime = measureTime != null && measureTime;
         context.ref = STORK_SERVICE_INSTANCE.get();
 
-        DelayedClientCall<RequestT, ResponseT> delayed = new StorkDelayedClientCall<>(executor, scheduler,
+        // The DelayedClientCall must deliver its listener callbacks on the call's
+        // own executor. Blocking stubs pass a per-call ThreadlessExecutor through
+        // CallOptions and park the calling thread draining it; if the callbacks
+        // (e.g. the close after a failed Stork resolution) are delivered on a
+        // different executor, that thread is never woken and the call hangs.
+        Executor callExecutor = callOptions.getExecutor() != null ? callOptions.getExecutor() : executor;
+        DelayedClientCall<RequestT, ResponseT> delayed = new StorkDelayedClientCall<>(callExecutor, scheduler,
                 Deadline.after(stork.deadline(), TimeUnit.MILLISECONDS));
 
         asyncCall(methodDescriptor, callOptions, context)

--- a/extensions/grpc/runtime/src/test/java/io/quarkus/grpc/runtime/stork/FlakyServiceDiscoveryConfiguration.java
+++ b/extensions/grpc/runtime/src/test/java/io/quarkus/grpc/runtime/stork/FlakyServiceDiscoveryConfiguration.java
@@ -1,0 +1,41 @@
+package io.quarkus.grpc.runtime.stork;
+
+import java.util.Collections;
+import java.util.Map;
+
+import io.smallrye.stork.api.config.ConfigWithType;
+
+/**
+ * Configuration for the {@code flaky} test {@link ServiceDiscovery} provider.
+ */
+final class FlakyServiceDiscoveryConfiguration implements ConfigWithType {
+
+    private final Map<String, String> parameters;
+
+    FlakyServiceDiscoveryConfiguration(Map<String, String> parameters) {
+        this.parameters = Collections.unmodifiableMap(parameters);
+    }
+
+    String getAddressList() {
+        return parameters.get("address-list");
+    }
+
+    long getFailureDelayMs() {
+        String delay = parameters.get("failure-delay-ms");
+        return delay == null ? 0L : Long.parseLong(delay.trim());
+    }
+
+    boolean isEmptyOnFirstLookup() {
+        return Boolean.parseBoolean(parameters.get("empty-on-first-lookup"));
+    }
+
+    @Override
+    public String type() {
+        return "flaky";
+    }
+
+    @Override
+    public Map<String, String> parameters() {
+        return parameters;
+    }
+}

--- a/extensions/grpc/runtime/src/test/java/io/quarkus/grpc/runtime/stork/FlakyServiceDiscoveryProvider.java
+++ b/extensions/grpc/runtime/src/test/java/io/quarkus/grpc/runtime/stork/FlakyServiceDiscoveryProvider.java
@@ -1,0 +1,73 @@
+package io.quarkus.grpc.runtime.stork;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.stork.api.ServiceDiscovery;
+import io.smallrye.stork.api.ServiceInstance;
+import io.smallrye.stork.api.config.ServiceConfig;
+import io.smallrye.stork.impl.DefaultServiceInstance;
+import io.smallrye.stork.spi.ServiceDiscoveryProvider;
+import io.smallrye.stork.spi.StorkInfrastructure;
+import io.smallrye.stork.utils.HostAndPort;
+import io.smallrye.stork.utils.ServiceInstanceIds;
+import io.smallrye.stork.utils.StorkAddressUtils;
+
+/**
+ * Test {@link ServiceDiscovery} that fails on the first lookup and then returns
+ * the configured static address list.
+ */
+final class FlakyServiceDiscoveryProvider implements ServiceDiscoveryProvider<FlakyServiceDiscoveryConfiguration> {
+
+    @Override
+    public ServiceDiscovery createServiceDiscovery(FlakyServiceDiscoveryConfiguration config, String serviceName,
+            ServiceConfig serviceConfig, StorkInfrastructure storkInfrastructure) {
+        HostAndPort hostAndPort = StorkAddressUtils.parseToHostAndPort(config.getAddressList(), 80, serviceName);
+        ServiceInstance instance = new DefaultServiceInstance(ServiceInstanceIds.next(), hostAndPort.host,
+                hostAndPort.port, false);
+        return new FlakyServiceDiscovery(List.of(instance), config.getFailureDelayMs(), config.isEmptyOnFirstLookup());
+    }
+
+    private static final class FlakyServiceDiscovery implements ServiceDiscovery {
+
+        private final List<ServiceInstance> instances;
+        private final long failureDelayMs;
+        private final boolean emptyOnFirstLookup;
+        private final AtomicInteger lookups = new AtomicInteger();
+
+        FlakyServiceDiscovery(List<ServiceInstance> instances, long failureDelayMs, boolean emptyOnFirstLookup) {
+            this.instances = instances;
+            this.failureDelayMs = failureDelayMs;
+            this.emptyOnFirstLookup = emptyOnFirstLookup;
+        }
+
+        @Override
+        public Uni<List<ServiceInstance>> getServiceInstances() {
+            if (lookups.getAndIncrement() == 0) {
+                if (emptyOnFirstLookup) {
+                    return delayedEmptyList();
+                }
+                Uni<List<ServiceInstance>> failure = Uni.createFrom()
+                        .failure(new IllegalStateException("simulated discovery failure"));
+                if (failureDelayMs > 0) {
+                    return Uni.createFrom().voidItem()
+                            .onItem().delayIt().by(Duration.ofMillis(failureDelayMs))
+                            .onItem().transformToUni(ignored -> failure);
+                }
+                return failure;
+            }
+            return Uni.createFrom().item(instances);
+        }
+
+        private Uni<List<ServiceInstance>> delayedEmptyList() {
+            if (failureDelayMs > 0) {
+                return Uni.createFrom().voidItem()
+                        .onItem().delayIt().by(Duration.ofMillis(failureDelayMs))
+                        .onItem().transform(ignored -> List.<ServiceInstance> of());
+            }
+            return Uni.createFrom().item(List.of());
+        }
+    }
+}

--- a/extensions/grpc/runtime/src/test/java/io/quarkus/grpc/runtime/stork/FlakyServiceDiscoveryProviderLoader.java
+++ b/extensions/grpc/runtime/src/test/java/io/quarkus/grpc/runtime/stork/FlakyServiceDiscoveryProviderLoader.java
@@ -1,0 +1,27 @@
+package io.quarkus.grpc.runtime.stork;
+
+import io.smallrye.stork.api.ServiceDiscovery;
+import io.smallrye.stork.api.config.ConfigWithType;
+import io.smallrye.stork.api.config.ServiceConfig;
+import io.smallrye.stork.spi.StorkInfrastructure;
+import io.smallrye.stork.spi.internal.ServiceDiscoveryLoader;
+
+/**
+ * ServiceDiscoveryLoader for {@link FlakyServiceDiscoveryProvider}.
+ */
+public final class FlakyServiceDiscoveryProviderLoader implements ServiceDiscoveryLoader {
+
+    private final FlakyServiceDiscoveryProvider provider = new FlakyServiceDiscoveryProvider();
+
+    @Override
+    public String type() {
+        return "flaky";
+    }
+
+    @Override
+    public ServiceDiscovery createServiceDiscovery(ConfigWithType config, String serviceName,
+            ServiceConfig serviceConfig, StorkInfrastructure storkInfrastructure) {
+        return provider.createServiceDiscovery(new FlakyServiceDiscoveryConfiguration(config.parameters()), serviceName,
+                serviceConfig, storkInfrastructure);
+    }
+}

--- a/extensions/grpc/runtime/src/test/java/io/quarkus/grpc/runtime/stork/GrpcStorkServiceDiscoveryTest.java
+++ b/extensions/grpc/runtime/src/test/java/io/quarkus/grpc/runtime/stork/GrpcStorkServiceDiscoveryTest.java
@@ -1,0 +1,190 @@
+package io.quarkus.grpc.runtime.stork;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.grpc.NameResolver;
+import io.grpc.NameResolver.ConfigOrError;
+import io.grpc.Status;
+import io.grpc.SynchronizationContext;
+import io.smallrye.stork.Stork;
+import io.smallrye.stork.api.ServiceDefinition;
+import io.smallrye.stork.api.config.ConfigWithType;
+import io.smallrye.stork.integration.DefaultStorkInfrastructure;
+
+class GrpcStorkServiceDiscoveryTest {
+
+    private static final String SERVICE_NAME = "hello-service";
+
+    private ScheduledExecutorService scheduledExecutorService;
+
+    @BeforeEach
+    void setUp() {
+        Stork.shutdown();
+        Stork.initialize(new DefaultStorkInfrastructure());
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (scheduledExecutorService != null) {
+            scheduledExecutorService.shutdownNow();
+            scheduledExecutorService = null;
+        }
+        Stork.shutdown();
+    }
+
+    @Test
+    void refreshNotifiesListenerWhenInstancesUnchanged() {
+        defineService(staticDiscovery());
+        CountingListener listener = new CountingListener();
+        NameResolver resolver = createResolver();
+
+        resolver.start(listener);
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> assertThat(listener.results.get()).isEqualTo(1));
+
+        resolver.refresh();
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> assertThat(listener.results.get()).isEqualTo(2));
+        assertThat(listener.errors.get()).isZero();
+    }
+
+    @Test
+    void refreshAfterDiscoveryFailureNotifiesListener() {
+        defineService(flakyDiscovery());
+        CountingListener listener = new CountingListener();
+        NameResolver resolver = createResolver();
+
+        resolver.start(listener);
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> assertThat(listener.errors.get()).isEqualTo(1));
+        assertThat(listener.results.get()).isZero();
+        assertThat(listener.lastError.get().getCode()).isEqualTo(Status.Code.UNAVAILABLE);
+
+        // If resolving stayed true after the async failure, refresh() would no-op.
+        resolver.refresh();
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> assertThat(listener.results.get()).isEqualTo(1));
+        assertThat(listener.errors.get()).isEqualTo(1);
+    }
+
+    @Test
+    void doesNotNotifyListenerAfterShutdownOnDiscoveryFailure() {
+        defineService(flakyDiscovery(Map.of(
+                "address-list", "localhost:9001",
+                "failure-delay-ms", "500")));
+        CountingListener listener = new CountingListener();
+        NameResolver resolver = createResolver();
+
+        resolver.start(listener);
+        resolver.shutdown();
+
+        // The delayed failure must not notify the listener once shutdown has completed.
+        await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> {
+            assertThat(listener.errors.get()).isZero();
+            assertThat(listener.results.get()).isZero();
+        });
+    }
+
+    @Test
+    void doesNotNotifyListenerAfterShutdownOnEmptyResolution() {
+        defineService(flakyDiscovery(Map.of(
+                "address-list", "localhost:9001",
+                "empty-on-first-lookup", "true",
+                "failure-delay-ms", "500")));
+        CountingListener listener = new CountingListener();
+        NameResolver resolver = createResolver();
+
+        resolver.start(listener);
+        resolver.shutdown();
+
+        // The delayed empty resolution must not notify the listener once shutdown has completed.
+        await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> {
+            assertThat(listener.errors.get()).isZero();
+            assertThat(listener.results.get()).isZero();
+        });
+    }
+
+    private void defineService(ConfigWithType discovery) {
+        Stork.getInstance().defineIfAbsent(SERVICE_NAME, ServiceDefinition.of(discovery));
+    }
+
+    private NameResolver createResolver() {
+        GrpcStorkServiceDiscovery provider = new GrpcStorkServiceDiscovery();
+        scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+        NameResolver.Args args = NameResolver.Args.newBuilder()
+                .setDefaultPort(9001)
+                .setProxyDetector(address -> null)
+                .setSynchronizationContext(new SynchronizationContext((t, e) -> {
+                    throw new RuntimeException(e);
+                }))
+                .setScheduledExecutorService(scheduledExecutorService)
+                .setServiceConfigParser(new NameResolver.ServiceConfigParser() {
+                    @Override
+                    public ConfigOrError parseServiceConfig(Map<String, ?> rawServiceConfig) {
+                        return ConfigOrError.fromConfig(Map.of());
+                    }
+                })
+                .build();
+        NameResolver resolver = provider.newNameResolver(URI.create("stork://" + SERVICE_NAME + ":9001"), args);
+        assertThat(resolver).isNotNull();
+        return resolver;
+    }
+
+    private static ConfigWithType staticDiscovery() {
+        return new ConfigWithType() {
+            @Override
+            public String type() {
+                return "static";
+            }
+
+            @Override
+            public Map<String, String> parameters() {
+                return Map.of("address-list", "localhost:9001");
+            }
+        };
+    }
+
+    private static ConfigWithType flakyDiscovery() {
+        return flakyDiscovery(Map.of("address-list", "localhost:9001"));
+    }
+
+    private static ConfigWithType flakyDiscovery(Map<String, String> parameters) {
+        return new ConfigWithType() {
+            @Override
+            public String type() {
+                return "flaky";
+            }
+
+            @Override
+            public Map<String, String> parameters() {
+                return parameters;
+            }
+        };
+    }
+
+    private static final class CountingListener extends NameResolver.Listener2 {
+        private final AtomicInteger results = new AtomicInteger();
+        private final AtomicInteger errors = new AtomicInteger();
+        private final AtomicReference<Status> lastError = new AtomicReference<>();
+
+        @Override
+        public void onResult(NameResolver.ResolutionResult resolutionResult) {
+            results.incrementAndGet();
+        }
+
+        @Override
+        public void onError(Status status) {
+            errors.incrementAndGet();
+            lastError.set(status);
+        }
+    }
+}

--- a/extensions/grpc/runtime/src/test/resources/META-INF/services/io.smallrye.stork.spi.internal.ServiceDiscoveryLoader
+++ b/extensions/grpc/runtime/src/test/resources/META-INF/services/io.smallrye.stork.spi.internal.ServiceDiscoveryLoader
@@ -1,0 +1,1 @@
+io.quarkus.grpc.runtime.stork.FlakyServiceDiscoveryProviderLoader

--- a/integration-tests/grpc-stork-recovery/pom.xml
+++ b/integration-tests/grpc-stork-recovery/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-integration-test-grpc-stork-recovery</artifactId>
+    <name>Quarkus - Integration Tests - gRPC - Stork - Recovery</name>
+    <description>Verifies a stork:// gRPC channel recovers when the service starts after the client</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-grpc</artifactId>
+            <version>${project.version}</version> <!--kept here to not pollute the BOM-->
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <!-- Generates the DelayedConfiguration class from the
+                         @ServiceDiscoveryType / @ServiceDiscoveryAttribute annotations
+                         on DelayedServiceDiscoveryProvider. -->
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.smallrye.stork</groupId>
+                            <artifactId>stork-configuration-generator</artifactId>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate-code</goal>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integration-tests/grpc-stork-recovery/src/main/java/io/quarkus/grpc/examples/stork/DelayedServiceDiscoveryProvider.java
+++ b/integration-tests/grpc-stork-recovery/src/main/java/io/quarkus/grpc/examples/stork/DelayedServiceDiscoveryProvider.java
@@ -1,0 +1,71 @@
+package io.quarkus.grpc.examples.stork;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.stork.api.ServiceDiscovery;
+import io.smallrye.stork.api.ServiceInstance;
+import io.smallrye.stork.api.config.ServiceConfig;
+import io.smallrye.stork.api.config.ServiceDiscoveryAttribute;
+import io.smallrye.stork.api.config.ServiceDiscoveryType;
+import io.smallrye.stork.impl.DefaultServiceInstance;
+import io.smallrye.stork.spi.ServiceDiscoveryProvider;
+import io.smallrye.stork.spi.StorkInfrastructure;
+import io.smallrye.stork.utils.HostAndPort;
+import io.smallrye.stork.utils.ServiceInstanceIds;
+import io.smallrye.stork.utils.StorkAddressUtils;
+
+/**
+ * A Stork service discovery that reports no instances until {@code available-after-ms}
+ * has elapsed since its first lookup, then reports the configured address.
+ * <p>
+ * It simulates a gRPC server that is started after the client - the scenario that
+ * exposed the {@code stork://} client recovery bugs in both the classic and the
+ * Vert.x gRPC clients.
+ */
+@ServiceDiscoveryType("delayed")
+@ServiceDiscoveryAttribute(name = "address-list", description = "comma-separated host:port list served once the delay elapses")
+@ServiceDiscoveryAttribute(name = "available-after-ms", description = "milliseconds after the first lookup before instances become available")
+public class DelayedServiceDiscoveryProvider implements ServiceDiscoveryProvider<DelayedConfiguration> {
+
+    @Override
+    public ServiceDiscovery createServiceDiscovery(DelayedConfiguration config, String serviceName,
+            ServiceConfig serviceConfig, StorkInfrastructure storkInfrastructure) {
+        return new DelayedServiceDiscovery(config, serviceName);
+    }
+
+    private static final class DelayedServiceDiscovery implements ServiceDiscovery {
+
+        private final List<ServiceInstance> instances;
+        private final long availableAfterMs;
+        // -1 until the first lookup; the delay window is measured from that point so the
+        // very first resolution always observes an empty instance list.
+        private final AtomicLong firstLookupAt = new AtomicLong(-1);
+
+        DelayedServiceDiscovery(DelayedConfiguration config, String serviceName) {
+            String availableAfter = config.getAvailableAfterMs();
+            this.availableAfterMs = availableAfter == null ? 2000L : Long.parseLong(availableAfter.trim());
+            // Build the instances once so their ids stay stable across lookups - gRPC
+            // requires service instance ids to be immutable.
+            List<ServiceInstance> list = new ArrayList<>();
+            for (String address : config.getAddressList().split(",")) {
+                HostAndPort hostAndPort = StorkAddressUtils.parseToHostAndPort(address.trim(), 80, serviceName);
+                list.add(new DefaultServiceInstance(ServiceInstanceIds.next(), hostAndPort.host, hostAndPort.port, false));
+            }
+            this.instances = List.copyOf(list);
+        }
+
+        @Override
+        public Uni<List<ServiceInstance>> getServiceInstances() {
+            long now = System.currentTimeMillis();
+            firstLookupAt.compareAndSet(-1, now);
+            if (now - firstLookupAt.get() < availableAfterMs) {
+                // The service has not "started" yet - report no instances.
+                return Uni.createFrom().item(List.of());
+            }
+            return Uni.createFrom().item(instances);
+        }
+    }
+}

--- a/integration-tests/grpc-stork-recovery/src/main/java/io/quarkus/grpc/examples/stork/HelloWorldService.java
+++ b/integration-tests/grpc-stork-recovery/src/main/java/io/quarkus/grpc/examples/stork/HelloWorldService.java
@@ -1,0 +1,17 @@
+package io.quarkus.grpc.examples.stork;
+
+import examples.HelloReply;
+import examples.HelloRequest;
+import examples.MutinyGreeterGrpc;
+import io.quarkus.grpc.GrpcService;
+import io.smallrye.mutiny.Uni;
+
+@GrpcService
+public class HelloWorldService extends MutinyGreeterGrpc.GreeterImplBase {
+
+    @Override
+    public Uni<HelloReply> sayHello(HelloRequest request) {
+        return Uni.createFrom().item("Hello " + request.getName())
+                .map(res -> HelloReply.newBuilder().setMessage(res).build());
+    }
+}

--- a/integration-tests/grpc-stork-recovery/src/main/proto/helloworld.proto
+++ b/integration-tests/grpc-stork-recovery/src/main/proto/helloworld.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "examples";
+option java_outer_classname = "HelloWorldProto";
+
+package helloworld;
+
+// The greeting service definition.
+service Greeter {
+    // Sends a greeting
+    rpc SayHello (HelloRequest) returns (HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+    string name = 1;
+}
+
+// The response message containing the greetings.
+message HelloReply {
+    string message = 1;
+}

--- a/integration-tests/grpc-stork-recovery/src/main/resources/application.properties
+++ b/integration-tests/grpc-stork-recovery/src/main/resources/application.properties
@@ -1,0 +1,27 @@
+quarkus.grpc.clients.hello.host=hello-service
+quarkus.grpc.clients.hello.name-resolver=stork
+quarkus.grpc.clients.hello.port=9001
+
+# 'hello-service' is resolved through the 'delayed' Stork service discovery: it
+# reports no instances for the first 5s after its first lookup, then reports the
+# in-process gRPC server. This reproduces a server that starts after the client.
+quarkus.stork."hello-service".service-discovery.type=delayed
+quarkus.stork."hello-service".service-discovery.address-list=localhost:9001
+# Long enough that the test method runs before instances appear, so we can assert
+# the first call fails and then verify recovery once the service becomes available.
+quarkus.stork."hello-service".service-discovery.available-after-ms=5000
+quarkus.stork."hello-service".load-balancer.type=round-robin
+
+quarkus.grpc.server.port=9001
+
+# Avoid clashing with the default HTTP test port (8081) when tests run in parallel.
+# See https://quarkus.io/guides/getting-started-testing#configuration-for-tests
+quarkus.http.test-port=8083
+
+# Vert.x gRPC client variant (activated by VertxGRPCTestProfile): the Vert.x
+# client shares the unified HTTP server, so the server and the address served
+# by the 'delayed' discovery both use the HTTP test port.
+%vertx.quarkus.grpc.clients.hello.use-quarkus-grpc-client=true
+%vertx.quarkus.grpc.clients.hello.port=${quarkus.http.test-port}
+%vertx.quarkus.grpc.server.use-separate-server=false
+%vertx.quarkus.stork."hello-service".service-discovery.address-list=localhost:${quarkus.http.test-port}

--- a/integration-tests/grpc-stork-recovery/src/test/java/io/quarkus/grpc/examples/stork/GrpcStorkRecoveryTest.java
+++ b/integration-tests/grpc-stork-recovery/src/test/java/io/quarkus/grpc/examples/stork/GrpcStorkRecoveryTest.java
@@ -1,0 +1,13 @@
+package io.quarkus.grpc.examples.stork;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * Recovery test for the classic Java gRPC client (the default,
+ * {@code use-quarkus-grpc-client=false}). The {@code stork://} channel is
+ * resolved by {@code GrpcStorkServiceDiscovery}.
+ */
+@QuarkusTest
+class GrpcStorkRecoveryTest extends GrpcStorkRecoveryTestBase {
+
+}

--- a/integration-tests/grpc-stork-recovery/src/test/java/io/quarkus/grpc/examples/stork/GrpcStorkRecoveryTestBase.java
+++ b/integration-tests/grpc-stork-recovery/src/test/java/io/quarkus/grpc/examples/stork/GrpcStorkRecoveryTestBase.java
@@ -1,0 +1,63 @@
+package io.quarkus.grpc.examples.stork;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import examples.GreeterGrpc;
+import examples.HelloReply;
+import examples.HelloRequest;
+import io.grpc.StatusRuntimeException;
+import io.quarkus.grpc.GrpcClient;
+
+/**
+ * Reproducer for two ways a {@code stork://} gRPC client failed to recover when
+ * the service was unavailable while the client started up.
+ * <p>
+ * The {@code delayed} Stork service discovery reports no instances for the first
+ * few seconds after its first lookup, so the client's initial resolution
+ * always sees an empty instance list. The client must then re-resolve and
+ * recover on its own once instances appear.
+ * <ul>
+ * <li>Classic Java gRPC client ({@link GrpcStorkRecoveryTest}): before the fix,
+ * {@code GrpcStorkServiceDiscovery} stayed silent on an empty resolution, so
+ * gRPC never scheduled another resolution and the channel was wedged in
+ * {@code CONNECTING} forever. The same class of bug also skipped {@code onResult}
+ * when a refresh returned an unchanged non-empty instance set (covered by
+ * {@code GrpcStorkServiceDiscoveryTest} in the gRPC runtime module).</li>
+ * <li>Vert.x gRPC client ({@link VertxGrpcStorkRecoveryTest}): before the fix,
+ * {@code StorkGrpcChannel} delivered the failed call's close callback on the
+ * wrong executor, so a blocking stub call hung instead of failing fast, and the
+ * client never got the chance to retry.</li>
+ * </ul>
+ */
+abstract class GrpcStorkRecoveryTestBase {
+
+    @GrpcClient("hello")
+    GreeterGrpc.GreeterBlockingStub hello;
+
+    @Test
+    void channelRecoversWhenServiceAppearsAfterStartup() {
+        HelloRequest request = HelloRequest.newBuilder().setName("late").build();
+
+        // While the delayed discovery reports no instances, calls must fail fast.
+        assertThatThrownBy(() -> call(request))
+                .isInstanceOf(StatusRuntimeException.class);
+
+        // Without a working re-resolution the client stays broken and this
+        // never succeeds within the timeout.
+        await().atMost(Duration.ofSeconds(30)).ignoreExceptions().untilAsserted(() -> {
+            assertThat(call(request).getMessage()).isEqualTo("Hello late");
+        });
+    }
+
+    private HelloReply call(HelloRequest request) {
+        // A deadline keeps a wedged channel from blocking the test indefinitely.
+        return hello.withDeadlineAfter(5, TimeUnit.SECONDS).sayHello(request);
+    }
+}

--- a/integration-tests/grpc-stork-recovery/src/test/java/io/quarkus/grpc/examples/stork/VertxGrpcStorkRecoveryTest.java
+++ b/integration-tests/grpc-stork-recovery/src/test/java/io/quarkus/grpc/examples/stork/VertxGrpcStorkRecoveryTest.java
@@ -1,0 +1,19 @@
+package io.quarkus.grpc.examples.stork;
+
+import io.quarkus.grpc.test.utils.VertxGRPCTestProfile;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+/**
+ * Recovery test for the Vert.x gRPC client ({@code use-quarkus-grpc-client=true}),
+ * which resolves {@code stork://} through {@code StorkGrpcChannel} instead of a
+ * gRPC {@code NameResolver}. Before the fix, {@code StorkGrpcChannel} delivered a
+ * failed call's close callback on the channel executor instead of the call's own
+ * executor, so a blocking stub call hung instead of failing fast and the client
+ * never got the chance to retry.
+ */
+@QuarkusTest
+@TestProfile(VertxGRPCTestProfile.class)
+class VertxGrpcStorkRecoveryTest extends GrpcStorkRecoveryTestBase {
+
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -427,6 +427,7 @@
                 <module>grpc-hibernate-reactive</module>
                 <module>grpc-external-proto</module>
                 <module>grpc-external-proto-test</module>
+                <module>grpc-stork-recovery</module>
                 <module>grpc-stork-response-time</module>
                 <module>grpc-stork-simple</module>
                 <module>grpc-exceptions</module>


### PR DESCRIPTION
Both Stork-backed gRPC client implementations could get permanently stuck when the target service had no instances at the time of the client's first name resolution — for example when the service is started after the client. Restarting the client was the only way to recover.

For the classic Java gRPC client, `GrpcStorkServiceDiscovery` reported neither a result nor an error to gRPC when Stork returned an empty instance list (its change-detection guard treats empty-to-empty as "nothing changed"). gRPC only re-runs a `NameResolver` after an `onResult`/`onError` callback, so the channel stayed in `CONNECTING` with no scheduled re-resolution.

For the Vert.x gRPC client, `StorkGrpcChannel` built the `DelayedClientCall` with the channel executor rather than the call's own executor. A blocking stub parks the calling thread on a per-call `ThreadlessExecutor`; the close callback after a failed Stork resolution was delivered on the wrong executor, so the call hung instead of failing fast and the client had no chance to retry.

A new `grpc-stork-recovery` integration test reproduces both scenarios (classic and Vert.x clients) using a Stork service discovery that reports no instances until shortly after startup.
