### PR TITLE
Fix injecting `@TestSecurity` identity with `@RunOnVertxContext`

### DIFF
--- a/integration-tests/smallrye-jwt-token-propagation/pom.xml
+++ b/integration-tests/smallrye-jwt-token-propagation/pom.xml
@@ -51,6 +51,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-vertx</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy</artifactId>
         </dependency>
         <dependency>

--- a/integration-tests/smallrye-jwt-token-propagation/src/test/java/io/quarkus/it/keycloak/TestSecurityLazyAuthTest.java
+++ b/integration-tests/smallrye-jwt-token-propagation/src/test/java/io/quarkus/it/keycloak/TestSecurityLazyAuthTest.java
@@ -6,21 +6,29 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.security.Principal;
+
+import jakarta.inject.Inject;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
 import io.quarkus.test.security.jwt.Claim;
 import io.quarkus.test.security.jwt.JwtSecurity;
+import io.quarkus.test.vertx.RunOnVertxContext;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 
 @QuarkusTest
 @TestHTTPEndpoint(ProtectedJwtResource.class)
 public class TestSecurityLazyAuthTest {
+
+    @Inject
+    SecurityIdentity securityIdentity;
 
     @Test
     public void testTestSecurityAnnotationWithAugmentors_anonymousUser() {
@@ -101,6 +109,28 @@ public class TestSecurityLazyAuthTest {
     public void testJwtGetWithDummyUser() {
         RestAssured.when().get("test-security-jwt").then()
                 .body(is("userJwt:userJwt:userJwt:viewer:user@gmail.com"));
+    }
+
+    @RunOnVertxContext
+    @Test
+    @TestSecurity
+    public void testAnonymousSecurityIdentityInjectionIsNonBlocking() {
+        Principal principal = Assertions.assertDoesNotThrow(() -> securityIdentity.getPrincipal());
+        Assertions.assertNotNull(principal);
+        Assertions.assertEquals("", principal.getName());
+        boolean isAnonymous = Assertions.assertDoesNotThrow(() -> securityIdentity.isAnonymous());
+        Assertions.assertTrue(isAnonymous);
+    }
+
+    @RunOnVertxContext
+    @Test
+    @TestSecurity(user = "admin", roles = "admin")
+    public void testAdminSecurityIdentityInjectionIsNonBlocking() {
+        Principal principal = Assertions.assertDoesNotThrow(() -> securityIdentity.getPrincipal());
+        Assertions.assertNotNull(principal);
+        Assertions.assertEquals("admin", principal.getName());
+        boolean isAdmin = Assertions.assertDoesNotThrow(() -> securityIdentity.hasRole("admin"));
+        Assertions.assertTrue(isAdmin);
     }
 
     @Retention(RetentionPolicy.RUNTIME)

--- a/test-framework/security/src/main/java/io/quarkus/test/security/QuarkusSecurityTestExtension.java
+++ b/test-framework/security/src/main/java/io/quarkus/test/security/QuarkusSecurityTestExtension.java
@@ -77,6 +77,13 @@ public class QuarkusSecurityTestExtension implements QuarkusTestBeforeEachCallba
                 if (testSecurity.permissions().length != 0) {
                     throw new RuntimeException("Cannot specify permissions without a username in @TestSecurity");
                 }
+
+                if (testSecurity.authorizationEnabled()) {
+                    // test is annotated with @TestSecurity()
+                    var anonymousUser = QuarkusSecurityIdentity.builder().setAnonymous(true)
+                            .setPrincipal(new QuarkusPrincipal(""));
+                    setSecurityIdentity(context, testSecurity, anonymousUser, allAnnotations, container);
+                }
             } else {
                 QuarkusSecurityIdentity.Builder user = QuarkusSecurityIdentity.builder()
                         .setPrincipal(new QuarkusPrincipal(testSecurity.user()))
@@ -86,49 +93,54 @@ public class QuarkusSecurityTestExtension implements QuarkusTestBeforeEachCallba
                     user.addPermissionChecker(createPermissionChecker(testSecurity.permissions()));
                 }
 
-                if (testSecurity.attributes() != null) {
-                    user.addAttributes(Arrays.stream(testSecurity.attributes())
-                            .collect(Collectors.toMap(s -> s.key(), s -> s.type().convert(s.value()))));
-                }
-
-                SecurityIdentity userIdentity = augment(user.build(), allAnnotations, container);
-                container.select(TestIdentityAssociation.class).get().setTestIdentity(userIdentity);
-                if (!testSecurity.authMechanism().isEmpty()) {
-                    for (var testMechanism : container.select(AbstractTestHttpAuthenticationMechanism.class)) {
-                        testMechanism.setAuthMechanism(testSecurity.authMechanism());
-                    }
-                    container.select(TestIdentityAssociation.class).get().setPathBasedIdentity(true);
-                }
-
-                // run SecurityIdentityAugmentors when:
-                List<Instance<? extends SecurityIdentityAugmentor>> augmentors = new ArrayList<>();
-                // 1. user opted-in with @TestSecurity#augmentors, run augmentors listed by user
-                for (Class<? extends SecurityIdentityAugmentor> augmentorClass : testSecurity.augmentors()) {
-                    var augmentorInstance = container.select(augmentorClass);
-                    if (!augmentorInstance.isResolvable()) {
-                        var testMethodName = context.getTestMethod() == null ? "" : context.getTestMethod().getName();
-                        throw new RuntimeException("""
-                                SecurityIdentityAugmentor class '%s' specified with '@TestSecurity#augmentors' annotation
-                                attribute on method '%s' is not available as a CDI bean.
-                                """.formatted(augmentorClass, testMethodName));
-                    }
-                    augmentors.add(augmentorInstance);
-                }
-                // 2. @PermissionChecker is used, run the augmentor that enables this functionality
-                var quarkusPermissionAugmentor = container.select(QuarkusPermissionSecurityIdentityAugmentor.class);
-                if (quarkusPermissionAugmentor.isResolvable()) {
-                    augmentors.add(quarkusPermissionAugmentor);
-                }
-                if (!augmentors.isEmpty()) {
-                    for (var testMechanism : container.select(AbstractTestHttpAuthenticationMechanism.class)) {
-                        testMechanism.setSecurityIdentityAugmentors(augmentors);
-                    }
-                }
+                setSecurityIdentity(context, testSecurity, user, allAnnotations, container);
             }
         } catch (Exception e) {
             throw new RuntimeException("Unable to setup @TestSecurity", e);
         }
 
+    }
+
+    private void setSecurityIdentity(QuarkusTestMethodContext context, TestSecurity testSecurity,
+            QuarkusSecurityIdentity.Builder user, Annotation[] allAnnotations, ArcContainer container) {
+        if (testSecurity.attributes() != null) {
+            user.addAttributes(Arrays.stream(testSecurity.attributes())
+                    .collect(Collectors.toMap(s -> s.key(), s -> s.type().convert(s.value()))));
+        }
+
+        SecurityIdentity userIdentity = augment(user.build(), allAnnotations, container);
+        container.select(TestIdentityAssociation.class).get().setTestIdentity(userIdentity);
+        if (!testSecurity.authMechanism().isEmpty()) {
+            for (var testMechanism : container.select(AbstractTestHttpAuthenticationMechanism.class)) {
+                testMechanism.setAuthMechanism(testSecurity.authMechanism());
+            }
+            container.select(TestIdentityAssociation.class).get().setPathBasedIdentity(true);
+        }
+
+        // run SecurityIdentityAugmentors when:
+        List<Instance<? extends SecurityIdentityAugmentor>> augmentors = new ArrayList<>();
+        // 1. user opted-in with @TestSecurity#augmentors, run augmentors listed by user
+        for (Class<? extends SecurityIdentityAugmentor> augmentorClass : testSecurity.augmentors()) {
+            var augmentorInstance = container.select(augmentorClass);
+            if (!augmentorInstance.isResolvable()) {
+                var testMethodName = context.getTestMethod() == null ? "" : context.getTestMethod().getName();
+                throw new RuntimeException("""
+                        SecurityIdentityAugmentor class '%s' specified with '@TestSecurity#augmentors' annotation
+                        attribute on method '%s' is not available as a CDI bean.
+                        """.formatted(augmentorClass, testMethodName));
+            }
+            augmentors.add(augmentorInstance);
+        }
+        // 2. @PermissionChecker is used, run the augmentor that enables this functionality
+        var quarkusPermissionAugmentor = container.select(QuarkusPermissionSecurityIdentityAugmentor.class);
+        if (quarkusPermissionAugmentor.isResolvable()) {
+            augmentors.add(quarkusPermissionAugmentor);
+        }
+        if (!augmentors.isEmpty()) {
+            for (var testMechanism : container.select(AbstractTestHttpAuthenticationMechanism.class)) {
+                testMechanism.setSecurityIdentityAugmentors(augmentors);
+            }
+        }
     }
 
     private static Function<Permission, Uni<Boolean>> createPermissionChecker(String[] permissions) {

--- a/test-framework/security/src/main/java/io/quarkus/test/security/TestIdentityAssociation.java
+++ b/test-framework/security/src/main/java/io/quarkus/test/security/TestIdentityAssociation.java
@@ -1,5 +1,7 @@
 package io.quarkus.test.security;
 
+import static io.quarkus.test.security.TestIdentityAssociation.determineDelegate;
+
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -38,10 +40,10 @@ public class TestIdentityAssociation implements CurrentIdentityAssociation {
      * A request scoped delegate that allows the system to function as normal when
      * the user has not been explicitly overridden
      */
-    private final CurrentIdentityAssociation delegate;
+    private final DelegatingSecurityIdentityAssociation delegate;
 
-    TestIdentityAssociation(DelegateSecurityIdentityAssociation defaultDelegate) {
-        this.delegate = determineDelegate(defaultDelegate);
+    TestIdentityAssociation(DelegatingSecurityIdentityAssociation delegate) {
+        this.delegate = delegate;
     }
 
     @PostConstruct
@@ -82,6 +84,12 @@ public class TestIdentityAssociation implements CurrentIdentityAssociation {
 
     @Override
     public SecurityIdentity getIdentity() {
+        // if we can determine that delegate's identity is not set, we can avoid blocking when resolving anonymous
+        // identity on IO thread
+        if (delegate.isIdentityNotSet() && testIdentity != null && !isPathBasedIdentity) {
+            return testIdentity;
+        }
+
         //we check the underlying identity first
         //in most cases this will have been set by the TestHttpAuthenticationMechanism
         //this means that all the usual auth process will run, including augmentors and
@@ -100,7 +108,7 @@ public class TestIdentityAssociation implements CurrentIdentityAssociation {
     }
 
     @SuppressWarnings("unchecked")
-    private static CurrentIdentityAssociation determineDelegate(DelegateSecurityIdentityAssociation defaultDelegate) {
+    static CurrentIdentityAssociation determineDelegate(DelegateSecurityIdentityAssociation defaultDelegate) {
         String delegateIdentityAssociationClassName = System.getProperty(DELEGATE_IDENTITY_ASSOCIATION_KEY);
         if (delegateIdentityAssociationClassName != null) {
             final Class<? extends CurrentIdentityAssociation> delegateClass;
@@ -130,5 +138,39 @@ class DelegateSecurityIdentityAssociation extends AbstractSecurityIdentityAssoci
     @Override
     protected IdentityProviderManager getIdentityProviderManager() {
         return identityProviderManager;
+    }
+}
+
+@RequestScoped
+class DelegatingSecurityIdentityAssociation {
+
+    private final CurrentIdentityAssociation delegate;
+    private volatile boolean isIdentitySet = false;
+
+    @Inject
+    DelegatingSecurityIdentityAssociation(DelegateSecurityIdentityAssociation defaultDelegate) {
+        this.delegate = determineDelegate(defaultDelegate);
+    }
+
+    void setIdentity(SecurityIdentity identity) {
+        isIdentitySet = identity != null;
+        delegate.setIdentity(identity);
+    }
+
+    void setIdentity(Uni<SecurityIdentity> identity) {
+        isIdentitySet = identity != null;
+        delegate.setIdentity(identity);
+    }
+
+    SecurityIdentity getIdentity() {
+        return delegate.getIdentity();
+    }
+
+    Uni<SecurityIdentity> getDeferredIdentity() {
+        return delegate.getDeferredIdentity();
+    }
+
+    boolean isIdentityNotSet() {
+        return !isIdentitySet;
     }
 }

--- a/test-framework/security/src/test/java/io/quarkus/test/security/TestIdentityAssociationTest.java
+++ b/test-framework/security/src/test/java/io/quarkus/test/security/TestIdentityAssociationTest.java
@@ -18,7 +18,7 @@ public class TestIdentityAssociationTest {
 
     @BeforeEach
     void init() {
-        sut = new TestIdentityAssociation(new DelegateSecurityIdentityAssociation());
+        sut = new TestIdentityAssociation(new DelegatingSecurityIdentityAssociation(new DelegateSecurityIdentityAssociation()));
 
         BlockingOperationControl.setIoThreadDetector(new IOThreadDetector[0]);
     }


### PR DESCRIPTION
* Closes: https://github.com/quarkusio/quarkus/issues/54426
* When users apply `@TestSecurity` we already know they probably want to set user (either some specific or anonymous) and it does not make sense to block on resolving anonymous identity