### PR TITLE
Fix platform BOM and platform metadata override ordering

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateProjectCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateProjectCommandHandler.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -362,55 +361,49 @@ public class CreateProjectCommandHandler implements QuarkusCommandHandler {
         // get the recommended catalogs in the right order according to the preferences
         List<ExtensionCatalog> sortedCatalogs = recommendedCombination.getUniqueSortedCatalogs();
 
+        sortedCatalogs = normalizeCatalogs(extensionsToAdd, sortedCatalogs);
+
         if (!containsQuarkusCore(extensionsToAdd)) {
             sortedCatalogs = ensureQuarkusCorePresent(sortedCatalogs, quarkusCore);
             if (sortedCatalogs.isEmpty()) {
                 throw new QuarkusCommandException(noCompatibleQuarkusCoreVersion(extensionsToAdd));
             }
         }
+        return sortedCatalogs;
+    }
 
-        // with the introduction of offering-based filtering, some extensions may appear to be picked
-        // from a catalog with a lower preference while still having their version managed in a catalog
-        // with a higher preference.
-        // For example, an unsupported extension managed in a downstream quarkus-bom could have been picked
-        // from the upstream quarkus-bom. In this case we don't want to import both downstream and upstream
-        // quarkus-boms. The logic below is making sure there is no unnecessary BOM overlap in such cases.
-        if (sortedCatalogs.size() < 2) {
-            return sortedCatalogs;
-        }
-
+    /**
+     * With the introduction of offering-based filtering, some extensions may appear to be picked
+     * from a catalog with a lower preference while still having their version managed in a catalog
+     * with a higher preference.
+     * For example, an unsupported extension managed in a downstream quarkus-bom could have been picked
+     * from the upstream quarkus-bom. In this case we don't want to import both downstream and upstream
+     * quarkus-boms. The logic below is making sure there is no unnecessary BOM overlap in such cases.
+     *
+     * @param extensionsToAdd extensions to add
+     * @param sortedCatalogs sorted catalogs
+     * @return normalized catalog list
+     */
+    private static List<ExtensionCatalog> normalizeCatalogs(List<Extension> extensionsToAdd,
+            List<ExtensionCatalog> sortedCatalogs) {
         final List<ArtifactKey> extDeps = new ArrayList<>(extensionsToAdd.size());
         for (Extension e : extensionsToAdd) {
             extDeps.add(e.getArtifact().getKey());
         }
-        List<ExtensionCatalog> reducedCatalogs = null;
-        for (int i = 0; i < sortedCatalogs.size(); ++i) {
-            var catalog = sortedCatalogs.get(i);
-            if (reducedCatalogs != null) {
-                reducedCatalogs.add(catalog);
+        final List<ExtensionCatalog> result = new ArrayList<>(sortedCatalogs.size());
+        for (ExtensionCatalog catalog : sortedCatalogs) {
+            if (catalog.isPlatform()
+                    && catalog.getMetadata()
+                            .get(Constants.REGISTRY_CLIENT_ALL_CATALOG_EXTENSIONS) instanceof Map<?, ?> allManagedExtensionKeys
+                    && !extDeps.removeIf(allManagedExtensionKeys::containsKey)) {
+                continue;
             }
-            if (catalog.isPlatform()) {
-                var o = catalog.getMetadata().get(Constants.REGISTRY_CLIENT_ALL_CATALOG_EXTENSIONS);
-                if (o instanceof Map<?, ?> allManagedExtensionKeys) {
-                    if (extDeps.removeIf(allManagedExtensionKeys::containsKey)) {
-                        if (reducedCatalogs == null) {
-                            // if we got to the end, then we return the original catalogs
-                            if (i == sortedCatalogs.size() - 1) {
-                                break;
-                            }
-                            reducedCatalogs = new ArrayList<>(sortedCatalogs.size());
-                            for (int j = 0; j <= i; ++j) {
-                                reducedCatalogs.add(sortedCatalogs.get(j));
-                            }
-                        }
-                        if (extDeps.isEmpty()) {
-                            break;
-                        }
-                    }
-                }
+            result.add(catalog);
+            if (extDeps.isEmpty()) {
+                break;
             }
         }
-        return reducedCatalogs == null ? sortedCatalogs : reducedCatalogs;
+        return result;
     }
 
     private static List<ExtensionCatalog> ensureQuarkusCorePresent(List<ExtensionCatalog> catalogs, Extension quarkusCore) {
@@ -442,14 +435,33 @@ public class CreateProjectCommandHandler implements QuarkusCommandHandler {
         if (matchingQuarkusCoreOrigin == null) {
             return List.of();
         }
-        if (catalogContainingCoreIndex >= 0) {
-            final List<ExtensionCatalog> result = new ArrayList<>(catalogs);
-            Collections.swap(result, 0, catalogContainingCoreIndex);
-            return result;
+
+        for (int i = 0; i < catalogs.size(); ++i) {
+            ExtensionCatalog c = catalogs.get(i);
+            if (catalogContainingCoreIndex == i) {
+                // the core bom appears before the BOMs with the same groupId
+                return catalogs;
+            }
+            if (c.isPlatform() && c.getBom().getGroupId().equals(matchingQuarkusCoreOrigin.getBom().getGroupId())) {
+                List<ExtensionCatalog> result = new ArrayList<>(catalogs.size() + (catalogContainingCoreIndex < 0 ? 0 : 1));
+                int j = 0;
+                while (j < i) {
+                    result.add(catalogs.get(j++));
+                }
+                result.add(matchingQuarkusCoreOrigin);
+                while (j < catalogs.size()) {
+                    if (catalogContainingCoreIndex != j) {
+                        result.add(catalogs.get(j));
+                    }
+                    ++j;
+                }
+                return result;
+            }
         }
-        final List<ExtensionCatalog> result = new ArrayList<>(catalogs.size() + 1);
-        result.add(matchingQuarkusCoreOrigin);
+
+        List<ExtensionCatalog> result = new ArrayList<>(catalogs.size());
         result.addAll(catalogs);
+        result.add(matchingQuarkusCoreOrigin);
         return result;
     }
 

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/MixingOfferingAndNonOfferingExtensionsInTheSameBomTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/MixingOfferingAndNonOfferingExtensionsInTheSameBomTest.java
@@ -43,6 +43,9 @@ public class MixingOfferingAndNonOfferingExtensionsInTheSameBomTest extends Mult
                         Map.of("offering-a-support", List.of("supported")))
                 .addExtension("io.acme", "ext-b", "1.1.1.downstream")
                 .release()
+                .newMember("acme-b-bom")
+                .addExtension("io.acme", "ext-c", "1.1.1.downstream")
+                .release()
                 .stream().platform().registry()
                 .clientBuilder()
                 .newRegistry("upstream.registry.test")
@@ -60,6 +63,9 @@ public class MixingOfferingAndNonOfferingExtensionsInTheSameBomTest extends Mult
                 .newMember("acme-a-bom")
                 .addExtension("io.acme", "ext-a", "1.1.1")
                 .addExtension("io.acme", "ext-b", "1.1.1")
+                .release()
+                .newMember("acme-b-bom")
+                .addExtension("io.acme", "ext-c", "1.1.1")
                 .release()
                 .registry()
                 .clientBuilder()
@@ -118,6 +124,21 @@ public class MixingOfferingAndNonOfferingExtensionsInTheSameBomTest extends Mult
                         platformMemberBomCoords("acme-a-bom")),
                 List.of(ArtifactCoords.jar("io.acme", "ext-a", null),
                         ArtifactCoords.jar("io.acme", "ext-b", null)),
+                "1.1.1.downstream");
+    }
+
+    @Test
+    public void redundantUpstreamBomRemovedByNormalization() throws Exception {
+        final Path projectDir = newProjectDir("redundant-upstream-bom-removed");
+        createProject(projectDir, List.of("ext-a", "ext-b", "ext-c"));
+
+        assertModel(projectDir,
+                List.of(mainPlatformBom(),
+                        platformMemberBomCoords("acme-a-bom"),
+                        ArtifactCoords.pom("io.upstream.platform", "acme-b-bom", "1.1.1")),
+                List.of(ArtifactCoords.jar("io.acme", "ext-a", null),
+                        ArtifactCoords.jar("io.acme", "ext-b", null),
+                        ArtifactCoords.jar("io.acme", "ext-c", null)),
                 "1.1.1.downstream");
     }
 

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/PlatformWithoutQuarkusBomTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/PlatformWithoutQuarkusBomTest.java
@@ -44,7 +44,9 @@ public class PlatformWithoutQuarkusBomTest extends MultiplePlatformBomsTestBase 
                 .newMember("acme-magic-bom")
                 .addExtension("acme-magic")
                 .setPlatformProjectCodestartData("property-dump-codestart",
-                        Map.of("property", Map.of("source", Map.of("acme-platform", "acme-platform"))))
+                        Map.of("property", Map.of("source",
+                                Map.of("acme-platform", "acme-platform",
+                                        "common", "acme-platform"))))
                 .release()
                 .stream().platform()
                 .registry()
@@ -64,7 +66,9 @@ public class PlatformWithoutQuarkusBomTest extends MultiplePlatformBomsTestBase 
                 .addExtensionWithCodestart("quarkus-property-dump", "property-dump")
                 .addCodestartsArtifact(ArtifactCoords.jar("org.acme", "acme-codestarts", "1.0"), packageCodestart())
                 .setPlatformProjectCodestartData("property-dump-codestart",
-                        Map.of("property", Map.of("source", Map.of("quarkus-platform", "quarkus-platform"))))
+                        Map.of("property", Map.of("source",
+                                Map.of("quarkus-platform", "quarkus-platform",
+                                        "common", "quarkus-platform"))))
                 .release()
                 .newMember("quarkus-zoo-bom")
                 .addExtension("quarkus-giraffe")
@@ -163,7 +167,7 @@ public class PlatformWithoutQuarkusBomTest extends MultiplePlatformBomsTestBase 
         createProject(projectDir, List.of("acme-magic"));
 
         assertModel(projectDir,
-                List.of(mainPlatformBom(), ArtifactCoords.pom(MAIN_PLATFORM_KEY, "acme-magic-bom", "7.0.7")),
+                List.of(ArtifactCoords.pom(MAIN_PLATFORM_KEY, "acme-magic-bom", "7.0.7"), mainPlatformBom()),
                 List.of(ArtifactCoords.jar("org.acme.platform", "acme-magic", null)),
                 "2.0.4");
     }
@@ -174,8 +178,8 @@ public class PlatformWithoutQuarkusBomTest extends MultiplePlatformBomsTestBase 
         createProject(projectDir, List.of("giraffe", "acme-magic"));
 
         assertModel(projectDir,
-                List.of(mainPlatformBom(),
-                        ArtifactCoords.pom(MAIN_PLATFORM_KEY, "acme-magic-bom", "7.0.7"),
+                List.of(ArtifactCoords.pom(MAIN_PLATFORM_KEY, "acme-magic-bom", "7.0.7"),
+                        mainPlatformBom(),
                         ArtifactCoords.pom("${quarkus.platform.group-id}", "quarkus-zoo-bom", "${quarkus.platform.version}")),
                 List.of(ArtifactCoords.jar("org.acme.platform", "acme-magic", null),
                         ArtifactCoords.jar("org.quarkus.platform", "quarkus-giraffe", null)),
@@ -195,6 +199,7 @@ public class PlatformWithoutQuarkusBomTest extends MultiplePlatformBomsTestBase 
         assertPropertyDump(projectDir, Map.of(
                 "property.source.codestart", "codestart",
                 "property.source.quarkus-platform", "quarkus-platform",
+                "property.source.common", "quarkus-platform",
                 "property.source.acme-platform", "codestart"));
     }
 
@@ -204,7 +209,7 @@ public class PlatformWithoutQuarkusBomTest extends MultiplePlatformBomsTestBase 
         createProject(projectDir, List.of("quarkus-property-dump", "acme-magic"));
 
         assertModel(projectDir,
-                List.of(mainPlatformBom(), ArtifactCoords.pom(MAIN_PLATFORM_KEY, "acme-magic-bom", "7.0.7")),
+                List.of(ArtifactCoords.pom(MAIN_PLATFORM_KEY, "acme-magic-bom", "7.0.7"), mainPlatformBom()),
                 List.of(ArtifactCoords.jar("org.quarkus.platform", "quarkus-property-dump", null),
                         ArtifactCoords.jar("org.acme.platform", "acme-magic", null)),
                 "2.0.4");
@@ -212,6 +217,7 @@ public class PlatformWithoutQuarkusBomTest extends MultiplePlatformBomsTestBase 
         assertPropertyDump(projectDir, Map.of(
                 "property.source.codestart", "codestart",
                 "property.source.quarkus-platform", "quarkus-platform",
+                "property.source.common", "acme-platform",
                 "property.source.acme-platform", "acme-platform"));
     }
 

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/QuarkusPlatformBasedOnArchivedQuarkusCoreTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/QuarkusPlatformBasedOnArchivedQuarkusCoreTest.java
@@ -82,7 +82,7 @@ public class QuarkusPlatformBasedOnArchivedQuarkusCoreTest extends MultiplePlatf
         createProject(projectDir, List.of("rabbit"));
 
         assertModel(projectDir,
-                List.of(mainPlatformBom(), ArtifactCoords.pom(ACME_PLATFORM_KEY, "acme-zoo-bom", "5.0.5")),
+                List.of(ArtifactCoords.pom(ACME_PLATFORM_KEY, "acme-zoo-bom", "5.0.5"), mainPlatformBom()),
                 List.of(ArtifactCoords.jar("org.acme", "acme-rabbit", null)),
                 "3.0.5");
     }
@@ -93,7 +93,7 @@ public class QuarkusPlatformBasedOnArchivedQuarkusCoreTest extends MultiplePlatf
         createProject(projectDir, List.of("rabbit", "quarkus-rest", "quarkus-magic"));
 
         assertModel(projectDir,
-                List.of(mainPlatformBom(), ArtifactCoords.pom(ACME_PLATFORM_KEY, "acme-zoo-bom", "5.0.5")),
+                List.of(ArtifactCoords.pom(ACME_PLATFORM_KEY, "acme-zoo-bom", "5.0.5"), mainPlatformBom()),
                 List.of(ArtifactCoords.jar("org.acme", "acme-rabbit", null),
                         ArtifactCoords.jar(OTHER_PLATFORM_KEY, "quarkus-rest", null),
                         ArtifactCoords.jar(OTHER_PLATFORM_KEY, "quarkus-magic", null)),

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/ReversedRegistryOrderPropertyDumpTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/ReversedRegistryOrderPropertyDumpTest.java
@@ -1,0 +1,170 @@
+package io.quarkus.devtools.project.create;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.devtools.testing.registry.client.TestRegistryClientBuilder;
+import io.quarkus.fs.util.ZipUtils;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.paths.PathTree;
+
+/**
+ * Same platforms and extensions as {@link PlatformWithoutQuarkusBomTest} but with
+ * the registry order reversed: the Quarkus registry is registered first (higher preference)
+ * and the ACME registry second (lower preference). This affects BOM import order and
+ * which platform's codestart data wins for overlapping keys.
+ */
+public class ReversedRegistryOrderPropertyDumpTest extends MultiplePlatformBomsTestBase {
+
+    private static final String ACME_PLATFORM_KEY = "org.acme.platform";
+
+    private static String prevMavenRepoLocalTail;
+
+    @BeforeAll
+    public static void setup() throws Exception {
+        TestRegistryClientBuilder.newInstance()
+                //.debug()
+                .baseDir(configDir())
+                // Main Quarkus registry (FIRST → higher preference)
+                .newRegistry("registry.quarkus.org")
+                .newPlatform("org.quarkus.platform")
+                .newStream("2.0")
+                .newRelease("2.0.4")
+                .quarkusVersion("2.2.2")
+                .addCoreMember()
+                .addExtension("quarkus-magic")
+                .addExtensionWithCodestart("quarkus-property-dump", "property-dump")
+                .addCodestartsArtifact(ArtifactCoords.jar("org.acme", "acme-codestarts", "1.0"), packageCodestart())
+                .setPlatformProjectCodestartData("property-dump-codestart",
+                        Map.of("property", Map.of("source",
+                                Map.of("quarkus-platform", "quarkus-platform",
+                                        "common", "quarkus-platform"))))
+                .release()
+                .newMember("quarkus-zoo-bom")
+                .addExtension("quarkus-giraffe")
+                .release()
+                .registry()
+                .clientBuilder()
+                // ACME registry (SECOND → lower preference)
+                .newRegistry("registry.acme.org")
+                .newPlatform(ACME_PLATFORM_KEY)
+                .newStream("7.0")
+                .newRelease("7.0.7")
+                .quarkusVersion("2.2.2")
+                .newMember("acme-magic-bom")
+                .addExtension("acme-magic")
+                .setPlatformProjectCodestartData("property-dump-codestart",
+                        Map.of("property", Map.of("source",
+                                Map.of("acme-platform", "acme-platform",
+                                        "common", "acme-platform"))))
+                .release()
+                .stream().platform()
+                .registry()
+                .clientBuilder()
+                .build();
+
+        prevMavenRepoLocalTail = System.setProperty("maven.repo.local.tail",
+                TestRegistryClientBuilder.getMavenRepoDir(configDir()).toString());
+        enableRegistryClient();
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        if (prevMavenRepoLocalTail == null) {
+            System.clearProperty("maven.repo.local.tail");
+        } else {
+            System.setProperty("maven.repo.local.tail", prevMavenRepoLocalTail);
+        }
+    }
+
+    protected String getMainPlatformKey() {
+        return "org.quarkus.platform";
+    }
+
+    @Test
+    public void testAcmePropertyDump() throws Exception {
+        final Path projectDir = newProjectDir("reversed-registry-order-acme-property-dump");
+        createProject(projectDir, List.of("quarkus-property-dump", "acme-magic"));
+
+        assertModel(projectDir,
+                List.of(mainPlatformBom(), ArtifactCoords.pom(ACME_PLATFORM_KEY, "acme-magic-bom", "7.0.7")),
+                List.of(ArtifactCoords.jar("org.quarkus.platform", "quarkus-property-dump", null),
+                        ArtifactCoords.jar("org.acme.platform", "acme-magic", null)),
+                "2.0.4");
+
+        assertPropertyDump(projectDir, Map.of(
+                "property.source.codestart", "codestart",
+                "property.source.quarkus-platform", "quarkus-platform",
+                "property.source.common", "quarkus-platform",
+                "property.source.acme-platform", "acme-platform"));
+    }
+
+    private static void assertPropertyDump(Path projectDir, Map<String, String> expectedProps) throws IOException {
+        Path propDump = projectDir.resolve("property-dump.txt");
+        assertThat(propDump).exists();
+        Properties props = new Properties();
+        try (BufferedReader reader = Files.newBufferedReader(propDump)) {
+            props.load(reader);
+        }
+        assertThat(props).containsExactlyInAnyOrderEntriesOf(expectedProps);
+    }
+
+    private static Path packageCodestart() {
+        var url = Thread.currentThread().getContextClassLoader().getResource("codestarts");
+        if (url == null) {
+            throw new RuntimeException("Failed to locate codestarts directory on the classpath");
+        }
+        var dir = toLocalPath(url);
+        if (!Files.isDirectory(dir)) {
+            throw new RuntimeException(dir + " is not a directory");
+        }
+
+        var codestartsJar = Path.of("target").resolve("test-codestarts.jar");
+        try {
+            Files.deleteIfExists(codestartsJar);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        try (FileSystem fs = ZipUtils.newZip(codestartsJar)) {
+            var codestartsDir = fs.getPath("codestarts");
+            Files.createDirectories(codestartsDir);
+            PathTree.ofDirectoryOrArchive(dir).walk(visit -> {
+                final String relativePath = visit.getResourceName();
+                if (relativePath.isEmpty()) {
+                    return;
+                }
+                try {
+                    Files.copy(visit.getPath(), codestartsDir.resolve(visit.getResourceName()));
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return codestartsJar;
+    }
+
+    private static Path toLocalPath(final URL url) {
+        try {
+            return Path.of(url.toURI());
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Failed to translate " + url + " to local path", e);
+        }
+    }
+}

--- a/independent-projects/tools/devtools-testing/src/test/resources/codestarts/quarkus/property-dump-codestart/base/property-dump.tpl.qute.txt
+++ b/independent-projects/tools/devtools-testing/src/test/resources/codestarts/quarkus/property-dump-codestart/base/property-dump.tpl.qute.txt
@@ -1,3 +1,4 @@
 property.source.codestart={property.source.codestart}
 property.source.quarkus-platform={property.source.quarkus-platform}
 property.source.acme-platform={property.source.acme-platform}
+property.source.common={property.source.common}

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/CatalogMergeUtility.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/CatalogMergeUtility.java
@@ -117,12 +117,12 @@ public class CatalogMergeUtility {
                 return currentValue;
             }
             for (var e : ((Map<?, ?>) value).entrySet()) {
-                if (e.getKey() instanceof String) {
+                if (e.getKey() instanceof String eKey) {
                     try {
-                        putIfAbscentRecursively(e.getKey().toString(), e.getValue(), currentMap);
+                        putIfAbscentRecursively(eKey, e.getValue(), currentMap);
                     } catch (UnsupportedOperationException ex) {
                         currentMap = new HashMap(currentMap);
-                        putIfAbscentRecursively(e.getKey().toString(), e.getValue(), currentMap);
+                        putIfAbscentRecursively(eKey, e.getValue(), currentMap);
                     }
                 }
             }


### PR DESCRIPTION
This change makes sure the core Quarkus platform metadata does not override a platform metadata that is layered on top of it, respecting the registry ordering in the configuration file.

It also fixes another issue I found while fixing this one, which is related to filtering out redundant platform BOMs when creating a project with configured offerings and an extension being found in more than one platform BOM. A test was added.

The issue was reported in [#users > codestart catalog overrides regression](https://quarkusio.zulipchat.com/#narrow/channel/187030-users/topic/codestart.20catalog.20overrides.20regression/with/596228780)

FYI @vsevel 