### PR TITLE
OIDC: Add a property enabling to use client authentication for discovery and JWKS endpoints

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-bearer-token-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-bearer-token-authentication.adoc
@@ -566,6 +566,8 @@ public class BearerGlobalTokenChainValidator implements TokenCertificateValidato
 If introspection of the Bearer token is necessary, then `OidcProviderClient` must authenticate to the OIDC provider.
 For more information about supported authentication options, see the  xref:security-oidc-code-flow-authentication.adoc#oidc-provider-client-authentication[OIDC provider client authentication] section in the Quarkus "OpenID Connect authorization code flow mechanism for protecting web applications" guide.
 
+Set `quarkus.oidc.credentials.for-all-endpoints=true` when the OIDC provider also enforces authenticated access to the discovery and JWKS endpoints, see xref:security-oidc-code-flow-authentication.adoc#authenticated-access-to-all-oidc-endpoints[Authenticated access to all OIDC endpoints].
+
 [[bearer-token-integration-testing]]
 === Testing
 

--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
@@ -220,6 +220,7 @@ quarkus.oidc.credentials.jwt.key-id=mykeyAlias
 
 Using `client_secret_jwt` or `private_key_jwt` authentication methods ensures that a client secret is not sent to the OIDC provider, thereby avoiding the risk of interception by a 'man-in-the-middle' attack.
 
+[[jwt-bearer-client-authentication]]
 .Example: Using a JWT Bearer token to authenticate a client
 
 [source,properties]
@@ -355,6 +356,17 @@ If the tokens have to be introspected and the introspection endpoint-specific au
 quarkus.oidc.introspection-credentials.name=introspection-user-name
 quarkus.oidc.introspection-credentials.secret=introspection-user-secret
 ----
+
+[[authenticated-access-to-all-oidc-endpoints]]
+==== Authenticated access to all OIDC endpoints
+
+OIDC discovery and JWKS are typically public endpoints.
+Some OIDC providers may enforce authenticated access to these endpoints.
+For example, the Kubernetes API server acts as an OIDC provider for service account tokens and requires a bearer access token to access its discovery and JWKS endpoints.
+
+To send client credentials to these endpoints, set `quarkus.oidc.credentials.for-all-endpoints=true`.
+Since the discovery and JWKS endpoints are accessed with HTTP GET requests, only authentication methods that use the HTTP `Authorization` header are effective, such as `client_secret_basic` and <<jwt-bearer-client-authentication,JWT bearer>>.
+Alternatively, you can use <<code-flow-oidc-request-filters,OidcRequestFilter>> to customize the authentication.
 
 [[code-flow-oidc-request-filters]]
 === OIDC request filters

--- a/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
+++ b/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
@@ -187,6 +187,7 @@ Have a look at the complete overview of the authentication properties below and 
 |====
 |Property name |Default |Description
 
+|quarkus.oidc.credentials.for-all-endpoints |false|Send credentials to all OIDC endpoints including the discovery and JWKS endpoints.
 |quarkus.oidc.credentials.secret ||Client secret - use it if the HTTP `Authorization: Basic` client id and secret pair is expected
 |quarkus.oidc.credentials.client-secret.value ||Client secret value
 |quarkus.oidc.credentials.client-secret.method |Basic|How client secret should be submitted or used
@@ -290,6 +291,7 @@ By default, when a client JWT authentication token must be produced, it is gener
 |====
 
 Set `quarkus.oidc.credentials.jwt.source=bearer` if the client authentication token is provided by Kubernetes, and use `quarkus.oidc.credentials.jwt.token-path` to point to the file resource containing this token.
+Set `quarkus.oidc.credentials.for-all-endpoints=true` when the OIDC provider enforces authenticated access to the discovery and JWKS endpoints. See xref:security-oidc-code-flow-authentication.adoc#authenticated-access-to-all-oidc-endpoints[Authenticated access to all OIDC endpoints] for more information.
 
 === Mutual TLS
 

--- a/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
@@ -53,7 +53,9 @@ quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus
 
 `OidcClient` will discover that the token endpoint URL is `http://localhost:8180/auth/realms/quarkus/protocol/openid-connect/tokens`.
 
-Alternatively, if the discovery endpoint is unavailable or you want to avoid an extra round-trip to it, you can disable discovery and configure the token endpoint address with a relative path.
+If the OIDC provider requires authentication to access the discovery endpoint, you can configure `OidcClient` to send credentials with the discovery request, as described in <<oidc-client-authenticated-discovery-endpoint>>.
+
+If the discovery endpoint is unavailable or you want to avoid an extra round-trip to it, you can disable discovery and configure the token endpoint address with a relative path.
 
 For example:
 
@@ -1022,6 +1024,7 @@ quarkus.oidc-client.credentials.jwt.subject=custom-subject
 quarkus.oidc-client.credentials.jwt.issuer=custom-issuer
 ----
 
+[[oidc-client-jwt-bearer]]
 ==== JWT Bearer
 
 link:https://www.rfc-editor.org/rfc/rfc7523[RFC7523] explains how JWT Bearer tokens can be used to authenticate clients.
@@ -1169,6 +1172,17 @@ quarkus.tls.oidc-client.trust-store.p12.password=${trust-store-password}
 # Add more truststore properties if needed:
 #quarkus.tls.oidc-client.trust-store.p12.alias=certAlias
 ----
+
+[[oidc-client-authenticated-discovery-endpoint]]
+==== Authenticated access to the discovery endpoint
+
+The OIDC discovery endpoint is typically public.
+Some OIDC providers may enforce authenticated access to this endpoint.
+For example, the Kubernetes API server acts as an OIDC provider for service account tokens and requires a bearer access token to access its discovery endpoint.
+
+To send client credentials to the discovery endpoint, set `quarkus.oidc-client.credentials.for-all-endpoints=true`.
+Since the discovery endpoint is accessed with an HTTP GET request, only authentication methods that use the HTTP `Authorization` header are effective, such as `client_secret_basic` and <<oidc-client-jwt-bearer,JWT bearer>>.
+Alternatively, you can use <<oidc-client-ref-oidc-request-filters,OidcRequestFilter>> to customize the authentication.
 
 === OIDC Client SPI
 

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientAllEndpointAuthenticationTest.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientAllEndpointAuthenticationTest.java
@@ -1,0 +1,193 @@
+package io.quarkus.oidc.client;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Base64;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.oidc.client.runtime.OidcClientConfig;
+import io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig;
+import io.quarkus.test.QuarkusExtensionTest;
+
+class OidcClientAllEndpointAuthenticationTest {
+
+    private static final String CLIENT_ID = "test-client";
+    private static final String CLIENT_SECRET = "test-secret";
+
+    private static final String JWT_HEADER = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0";
+    private static final String BEARER_TOKEN = JWT_HEADER
+            + ".eyJleHAiOjk5OTk5OTk5OTksInN1YiI6InRlc3Qtc2VydmljZSJ9.sig";
+    private static final File TOKEN_DIR = new File("target/test-tokens");
+    private static final File BEARER_TOKEN_FILE = new File(TOKEN_DIR, "bearer.jwt");
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar.addClasses(
+                    TokenResource.class,
+                    MockDiscoveryEndpoint.class,
+                    MockTokenEndpoint.class))
+            .withConfiguration("""
+                    quarkus.keycloak.devservices.enabled=false
+                    quarkus.oidc.enabled=false
+                    """)
+            .withRuntimeConfiguration("""
+                    quarkus.oidc-client.auth-server-url=http://localhost:8081/mock-oidc/basic
+                    quarkus.oidc-client.client-id=%1$s
+                    quarkus.oidc-client.credentials.secret=%2$s
+                    quarkus.oidc-client.credentials.for-all-endpoints=true
+                    quarkus.oidc-client.grant.type=client
+
+                    quarkus.oidc-client.bearer.auth-server-url=http://localhost:8081/mock-oidc/bearer
+                    quarkus.oidc-client.bearer.client-id=%1$s
+                    quarkus.oidc-client.bearer.credentials.jwt.source=bearer
+                    quarkus.oidc-client.bearer.credentials.jwt.token-path=%3$s
+                    quarkus.oidc-client.bearer.credentials.for-all-endpoints=true
+                    quarkus.oidc-client.bearer.grant.type=client
+
+                    """.formatted(CLIENT_ID, CLIENT_SECRET,
+                    BEARER_TOKEN_FILE.getAbsolutePath()))
+            .setBeforeAllCustomizer(() -> {
+                try {
+                    Files.createDirectories(TOKEN_DIR.toPath());
+                    Files.writeString(BEARER_TOKEN_FILE.toPath(), BEARER_TOKEN);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+    @Test
+    void testBasicAuth() {
+        testAuth("default");
+    }
+
+    @Test
+    void testBearerAuth() {
+        testAuth("bearer");
+    }
+
+    @Test
+    void testIncompatibleMethodThrowsValidationError() {
+        given()
+                .get("/token/invalid-post-method")
+                .then()
+                .statusCode(500)
+                .body(Matchers.containsString("Client credentials cannot be sent to all OIDC endpoints"));
+    }
+
+    private static void testAuth(String clientName) {
+        given()
+                .get("/token/" + clientName)
+                .then()
+                .statusCode(200)
+                .body(is("test-access-token"));
+    }
+
+    @Path("/token/{clientName}")
+    public static class TokenResource {
+
+        @Inject
+        OidcClients oidcClients;
+
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        public String getToken(@PathParam("clientName") String clientName) {
+            if ("invalid-post-method".equals(clientName)) {
+                return createClientWithIncompatibleMethod();
+            }
+            OidcClient client = "default".equals(clientName)
+                    ? oidcClients.getClient()
+                    : oidcClients.getClient(clientName);
+            return client.getTokens().await().indefinitely().getAccessToken();
+        }
+
+        private String createClientWithIncompatibleMethod() {
+            var config = OidcClientConfig.builder()
+                    .id("post-method-test")
+                    .authServerUrl("http://localhost:8081/mock-oidc/basic")
+                    .clientId(CLIENT_ID)
+                    .credentials()
+                    .clientSecret("secret", OidcClientCommonConfig.Credentials.Secret.Method.POST)
+                    .forAllEndpoints()
+                    .end()
+                    .grant().type(OidcClientConfig.Grant.Type.CLIENT).end()
+                    .build();
+            oidcClients.newClient(config).await().indefinitely();
+            return "wrong - config validation did not fail";
+        }
+    }
+
+    @Path("/mock-oidc/{client}/.well-known/openid-configuration")
+    public static class MockDiscoveryEndpoint {
+
+        @GET
+        @Produces(MediaType.APPLICATION_JSON)
+        public Response discover(@PathParam("client") String client,
+                @HeaderParam("Authorization") String authorization) {
+            if (isAnonymous(client, authorization)) {
+                return Response.status(401).build();
+            }
+            return Response.ok("""
+                    {
+                        "issuer": "http://localhost:8081/mock-oidc/%1$s",
+                        "token_endpoint": "http://localhost:8081/mock-oidc/%1$s/token",
+                        "subject_types_supported": ["public"]
+                    }
+                    """.formatted(client)).build();
+        }
+    }
+
+    @Path("/mock-oidc/{client}/token")
+    public static class MockTokenEndpoint {
+
+        @POST
+        @Produces(MediaType.APPLICATION_JSON)
+        public String token() {
+            return """
+                    {
+                        "access_token": "test-access-token",
+                        "token_type": "Bearer",
+                        "expires_in": 300
+                    }
+                    """;
+        }
+    }
+
+    private static boolean isAnonymous(String client, String authorization) {
+        return !switch (client) {
+            case "basic" -> isBasicAuth(authorization);
+            case "bearer" -> isBearerAuth(authorization);
+            default -> false;
+        };
+    }
+
+    private static boolean isBasicAuth(String authorization) {
+        if (authorization == null || !authorization.startsWith("Basic ")) {
+            return false;
+        }
+        String decoded = new String(Base64.getDecoder().decode(authorization.substring(6)), StandardCharsets.UTF_8);
+        return (CLIENT_ID + ":" + CLIENT_SECRET).equals(decoded);
+    }
+
+    private static boolean isBearerAuth(String authorization) {
+        return authorization != null && authorization.equals("Bearer " + BEARER_TOKEN);
+    }
+
+}

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
@@ -11,6 +11,7 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.eclipse.microprofile.jwt.Claims;
@@ -19,6 +20,7 @@ import org.jboss.logging.Logger;
 import io.quarkus.oidc.client.OidcClient;
 import io.quarkus.oidc.client.OidcClientException;
 import io.quarkus.oidc.client.Tokens;
+import io.quarkus.oidc.client.runtime.OidcClientRecorder.OidcConfigurationMetadata;
 import io.quarkus.oidc.common.OidcEndpoint;
 import io.quarkus.oidc.common.OidcRequestContextProperties;
 import io.quarkus.oidc.common.OidcRequestFilter;
@@ -28,6 +30,7 @@ import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.quarkus.oidc.common.runtime.OidcWebClient;
 import io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials.Jwt.Source;
+import io.quarkus.runtime.configuration.ConfigurationException;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.groups.UniOnItem;
 import io.vertx.core.Vertx;
@@ -93,11 +96,10 @@ public class OidcClientImpl implements OidcClient {
         this.requestFilters = requestFilters;
         this.responseFilters = responseFilters;
         this.clientSecretBasicAuthScheme = clientCredentials.clientSecretBasicAuthScheme;
-        this.jwtAssertionProvided = oidcClientConfig.credentials().jwt().source() != Source.CLIENT;
+        this.jwtAssertionProvided = clientCredentials.jwtAssertionProvided;
         this.clientJwtKey = jwtAssertionProvided ? null : clientCredentials.clientJwtKey;
         this.clientSecret = clientCredentials.clientSecret;
-        this.clientAssertionProvider = getClientAssertionProvider(vertx, oidcClientConfig.credentials(),
-                OidcClientException::new);
+        this.clientAssertionProvider = clientCredentials.clientAssertionProvider;
     }
 
     @Override
@@ -479,30 +481,42 @@ public class OidcClientImpl implements OidcClient {
         return op == Operation.REFRESH;
     }
 
-    static Uni<OidcClient> of(OidcWebClient client, String tokenRequestUri, String tokenRevokeUri, String grantType,
+    static Uni<OidcClient> of(OidcWebClient client,
+            Function<ClientCredentials, Uni<OidcConfigurationMetadata>> metadataResolver, String grantType,
             MultiMap tokenGrantParams, MultiMap commonRefreshGrantParams, OidcClientConfig oidcClientConfig,
             Map<OidcEndpoint.Type, List<OidcRequestFilter>> requestFilters,
             Map<OidcEndpoint.Type, List<OidcResponseFilter>> responseFilters, Vertx vertx) {
+        final boolean jwtAssertionProvided = oidcClientConfig.credentials().jwt().source() != Source.CLIENT;
+        final ClientAssertionProvider assertionProvider = getClientAssertionProvider(vertx, oidcClientConfig.credentials(),
+                OidcClientException::new);
         return OidcCommonUtils.clientSecret(oidcClientConfig.credentials())
                 .onItem().ifNotNull()
-                .transform(clientSecret -> new ClientCredentials(clientSecret,
-                        OidcCommonUtils.initClientSecretBasicAuth(oidcClientConfig, clientSecret)))
+                .transform(clientSecret -> new ClientCredentials(null, clientSecret,
+                        OidcCommonUtils.initClientSecretBasicAuth(oidcClientConfig, clientSecret),
+                        jwtAssertionProvided, assertionProvider))
                 .onItem().ifNull()
-                .switchTo(() -> OidcCommonUtils.initClientJwtKey(oidcClientConfig, false).map(ClientCredentials::new))
-                .onFailure().invoke(t -> LOG.error("Failed to create OidcClientImpl", t))
-                .map(clientCredentials -> new OidcClientImpl(client, tokenRequestUri, tokenRevokeUri, grantType,
-                        tokenGrantParams,
-                        commonRefreshGrantParams, oidcClientConfig, requestFilters, responseFilters, vertx, clientCredentials));
+                .switchTo(() -> OidcCommonUtils.initClientJwtKey(oidcClientConfig, false)
+                        .map(key -> new ClientCredentials(key, null, null, jwtAssertionProvided, assertionProvider)))
+                .<OidcClient> flatMap(clientCredentials -> metadataResolver.apply(clientCredentials)
+                        .map(metadata -> {
+                            if (metadata == null || metadata.tokenRequestUri == null) {
+                                throw new ConfigurationException(
+                                        "OpenId Connect Provider token endpoint URL is not configured and can not be discovered");
+                            }
+                            return new OidcClientImpl(client, metadata.tokenRequestUri, metadata.tokenRevokeUri, grantType,
+                                    tokenGrantParams,
+                                    commonRefreshGrantParams, oidcClientConfig, requestFilters, responseFilters, vertx,
+                                    clientCredentials);
+                        }))
+                .onFailure().invoke(t -> {
+                    LOG.error("Failed to create OidcClientImpl", t);
+                    if (t instanceof ConfigurationException) {
+                        client.close();
+                    }
+                });
     }
 
-    private record ClientCredentials(Key clientJwtKey, String clientSecret, String clientSecretBasicAuthScheme) {
-
-        private ClientCredentials(Key clientJwtKey) {
-            this(clientJwtKey, null, null);
-        }
-
-        private ClientCredentials(String clientSecret, String clientSecretBasicAuthScheme) {
-            this(null, clientSecret, clientSecretBasicAuthScheme);
-        }
+    record ClientCredentials(Key clientJwtKey, String clientSecret, String clientSecretBasicAuthScheme,
+            boolean jwtAssertionProvided, ClientAssertionProvider clientAssertionProvider) {
     }
 }

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
@@ -1,6 +1,7 @@
 package io.quarkus.oidc.client.runtime;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -18,6 +19,7 @@ import io.quarkus.oidc.client.OidcClientException;
 import io.quarkus.oidc.client.OidcClients;
 import io.quarkus.oidc.client.Tokens;
 import io.quarkus.oidc.client.runtime.OidcClientConfig.Grant;
+import io.quarkus.oidc.client.runtime.OidcClientImpl.ClientCredentials;
 import io.quarkus.oidc.common.OidcEndpoint;
 import io.quarkus.oidc.common.OidcRequestContextProperties;
 import io.quarkus.oidc.common.OidcRequestFilter;
@@ -26,11 +28,13 @@ import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.quarkus.oidc.common.runtime.OidcTlsSupport;
 import io.quarkus.oidc.common.runtime.OidcWebClient;
+import io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials;
 import io.quarkus.proxy.ProxyConfigurationRegistry;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpHeaders;
 import io.vertx.mutiny.core.MultiMap;
 
 @Recorder
@@ -103,6 +107,12 @@ public class OidcClientRecorder {
             return Uni.createFrom().item(new DisabledOidcClient(message));
         }
 
+        try {
+            OidcCommonUtils.validateCredentialsForAllEndpoints(oidcConfig.credentials());
+        } catch (ConfigurationException e) {
+            return Uni.createFrom().failure(e);
+        }
+
         var mutinyVertx = new io.vertx.mutiny.core.Vertx(vertx);
         OidcWebClient client = OidcWebClient.create(oidcConfig, tlsSupport, mutinyVertx, proxyConfigurationRegistry,
                 "OIDC client `" + oidcClientId + "`");
@@ -122,40 +132,33 @@ public class OidcClientRecorder {
                         OidcCommonUtils.getOidcEndpointUrl(authServerUriString, oidcConfig.tokenPath()),
                         OidcCommonUtils.getOidcEndpointUrl(authServerUriString, oidcConfig.revokePath()));
             }
-            return createOidcClientUniFromMetadata(oidcConfigurationMetadata, oidcConfig, client, oidcRequestFilters,
-                    oidcResponseFilters, vertx);
+            return createOidcClientUniFromMetadata(cc -> Uni.createFrom().item(oidcConfigurationMetadata),
+                    oidcConfig, client, oidcRequestFilters, oidcResponseFilters, vertx);
         } else {
-            final Uni<OidcConfigurationMetadata> deferredOidcConfigurationMetadata = Uni.createFrom()
-                    .deferred(() -> discoverTokenUris(client, oidcRequestFilters, oidcResponseFilters,
-                            OidcCommonUtils.getAuthServerUrl(oidcConfig), oidcConfig, mutinyVertx));
+            final Uni<OidcClient> deferredClient = Uni.createFrom().deferred(() -> createOidcClientUniFromMetadata(
+                    cc -> discoverTokenUris(client, oidcRequestFilters, oidcResponseFilters,
+                            OidcCommonUtils.getAuthServerUrl(oidcConfig), oidcConfig, cc, mutinyVertx),
+                    oidcConfig, client, oidcRequestFilters, oidcResponseFilters, vertx));
 
-            return deferredOidcConfigurationMetadata.onItemOrFailure().transformToUni((metadata, originalFailure) -> {
-                if (originalFailure != null) {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debugf(originalFailure, "OIDC metadata discovery for OIDC client '%s' failed. "
-                                + "Will try again the first time this OIDC client is used", oidcClientId);
-                    }
-                    Uni<OidcClient> deferredClient = deferredOidcConfigurationMetadata
-                            .onFailure().transform(t -> toOidcClientException(getEndpointUrl(oidcConfig), t))
-                            .flatMap(m -> createOidcClientUniFromMetadata(m, oidcConfig, client, oidcRequestFilters,
-                                    oidcResponseFilters, vertx));
-                    return Uni.createFrom().item(new DeferredOidcClient(deferredClient, oidcClientId, client));
-                }
-                return createOidcClientUniFromMetadata(metadata, oidcConfig, client, oidcRequestFilters, oidcResponseFilters,
-                        vertx);
-            });
+            return deferredClient
+                    .onFailure(f -> !(f instanceof ConfigurationException))
+                    .recoverWithItem(originalFailure -> {
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debugf(originalFailure, "OIDC metadata discovery for OIDC client '%s' failed. "
+                                    + "Will try again the first time this OIDC client is used", oidcClientId);
+                        }
+                        return new DeferredOidcClient(
+                                deferredClient.onFailure().transform(t -> toOidcClientException(getEndpointUrl(oidcConfig), t)),
+                                oidcClientId, client);
+                    });
         }
     }
 
-    private static Uni<OidcClient> createOidcClientUniFromMetadata(OidcConfigurationMetadata metadata,
+    private static Uni<OidcClient> createOidcClientUniFromMetadata(
+            Function<ClientCredentials, Uni<OidcConfigurationMetadata>> metadataResolver,
             OidcClientConfig oidcConfig, OidcWebClient client,
             Map<OidcEndpoint.Type, List<OidcRequestFilter>> oidcRequestFilters,
             Map<OidcEndpoint.Type, List<OidcResponseFilter>> oidcResponseFilters, Vertx vertx) {
-        if (metadata.tokenRequestUri == null) {
-            client.close();
-            throw new ConfigurationException(
-                    "OpenId Connect Provider token endpoint URL is not configured and can not be discovered");
-        }
         String grantType = oidcConfig.grant().type().getGrantType();
 
         MultiMap tokenGrantParams = null;
@@ -204,7 +207,7 @@ public class OidcClientRecorder {
         MultiMap commonRefreshGrantParams = new MultiMap(io.vertx.core.MultiMap.caseInsensitiveMultiMap());
         setGrantClientParams(oidcConfig, commonRefreshGrantParams, OidcConstants.REFRESH_TOKEN_GRANT);
 
-        return OidcClientImpl.of(client, metadata.tokenRequestUri, metadata.tokenRevokeUri, grantType,
+        return OidcClientImpl.of(client, metadataResolver, grantType,
                 tokenGrantParams, commonRefreshGrantParams, oidcConfig, oidcRequestFilters,
                 oidcResponseFilters, vertx);
     }
@@ -226,12 +229,40 @@ public class OidcClientRecorder {
     private static Uni<OidcConfigurationMetadata> discoverTokenUris(OidcWebClient client,
             Map<OidcEndpoint.Type, List<OidcRequestFilter>> oidcRequestFilters,
             Map<OidcEndpoint.Type, List<OidcResponseFilter>> oidcResponseFilters,
-            String authServerUrl, OidcClientConfig oidcConfig, io.vertx.mutiny.core.Vertx vertx) {
+            String authServerUrl, OidcClientConfig oidcConfig, ClientCredentials clientCredentials,
+            io.vertx.mutiny.core.Vertx vertx) {
         final long connectionDelayInMillisecs = OidcCommonUtils.getConnectionDelayInMillis(oidcConfig);
         OidcRequestContextProperties contextProps = new OidcRequestContextProperties(
                 Map.of(CLIENT_ID_ATTRIBUTE, oidcConfig.id().orElse(DEFAULT_OIDC_CLIENT_ID)));
         final String discoveryUrl = OidcCommonUtils.getDiscoveryUri(authServerUrl, oidcConfig.discoveryPath());
-        return OidcCommonUtils.discoverMetadata(client, oidcRequestFilters, contextProps, oidcResponseFilters,
+        final Map<OidcEndpoint.Type, List<OidcRequestFilter>> discoveryFilters;
+        if (oidcConfig.credentials().forAllEndpoints()) {
+            discoveryFilters = new HashMap<>(oidcRequestFilters);
+            OidcRequestFilter authFilter = new OidcRequestFilter() {
+                @Override
+                public Uni<Void> filter(OidcRequestFilterContext context) {
+                    if (clientCredentials.clientSecretBasicAuthScheme() != null) {
+                        context.request().putHeader(String.valueOf(HttpHeaders.AUTHORIZATION),
+                                clientCredentials.clientSecretBasicAuthScheme());
+                    } else if (clientCredentials.jwtAssertionProvided()
+                            && clientCredentials.clientAssertionProvider() != null
+                            && oidcConfig.credentials().jwt().source() == Credentials.Jwt.Source.BEARER) {
+                        String assertion = clientCredentials.clientAssertionProvider().getClientAssertion();
+                        if (assertion == null) {
+                            throw new OidcClientException(
+                                    "Cannot access discovery endpoint because a JWT bearer client_assertion is not available");
+                        }
+                        context.request().putHeader(String.valueOf(HttpHeaders.AUTHORIZATION),
+                                OidcConstants.BEARER_SCHEME + " " + assertion);
+                    }
+                    return Uni.createFrom().voidItem();
+                }
+            };
+            discoveryFilters.computeIfAbsent(OidcEndpoint.Type.DISCOVERY, k -> new ArrayList<>()).add(authFilter);
+        } else {
+            discoveryFilters = oidcRequestFilters;
+        }
+        return OidcCommonUtils.discoverMetadata(client, discoveryFilters, contextProps, oidcResponseFilters,
                 discoveryUrl, connectionDelayInMillisecs, vertx, oidcConfig.useBlockingDnsLookup())
                 .onItem().transform(json -> new OidcConfigurationMetadata(json.getString("token_endpoint"),
                         json.getString("revocation_endpoint")));
@@ -282,9 +313,9 @@ public class OidcClientRecorder {
 
     }
 
-    private static class OidcConfigurationMetadata {
-        private final String tokenRequestUri;
-        private final String tokenRevokeUri;
+    static final class OidcConfigurationMetadata {
+        final String tokenRequestUri;
+        final String tokenRevokeUri;
 
         OidcConfigurationMetadata(String tokenRequestUri, String tokenRevokeUri) {
             this.tokenRequestUri = tokenRequestUri;

--- a/extensions/oidc-client/runtime/src/test/java/io/quarkus/oidc/client/OidcClientConfigBuilderTest.java
+++ b/extensions/oidc-client/runtime/src/test/java/io/quarkus/oidc/client/OidcClientConfigBuilderTest.java
@@ -91,6 +91,7 @@ public class OidcClientConfigBuilderTest {
         assertEquals(10, jwt.lifespan());
         assertFalse(jwt.assertion());
         assertFalse(jwt.tokenPath().isPresent());
+        assertFalse(credentials.forAllEndpoints());
 
         // OidcCommonConfig methods
         assertTrue(config.authServerUrl().isEmpty());
@@ -183,7 +184,9 @@ public class OidcClientConfigBuilderTest {
                 .signatureAlgorithm("ES512")
                 .lifespan(852)
                 .assertion(true)
-                .endCredentials()
+                .end()
+                .forAllEndpoints()
+                .end()
                 // OidcCommonConfig methods
                 .authServerUrl("we")
                 .discoveryEnabled(false)
@@ -284,6 +287,7 @@ public class OidcClientConfigBuilderTest {
         assertEquals("ES512", jwt.signatureAlgorithm().orElse(null));
         assertEquals(852, jwt.lifespan());
         assertTrue(jwt.assertion());
+        assertTrue(credentials.forAllEndpoints());
 
         // OidcCommonConfig methods
         assertEquals("we", config.authServerUrl().orElse(null));

--- a/extensions/oidc-client/runtime/src/test/java/io/quarkus/oidc/client/OidcClientConfigImpl.java
+++ b/extensions/oidc-client/runtime/src/test/java/io/quarkus/oidc/client/OidcClientConfigImpl.java
@@ -91,6 +91,7 @@ final class OidcClientConfigImpl implements OidcClientConfig {
         CREDENTIALS_JWT_SIGNATURE_ALGORITHM,
         CREDENTIALS_JWT_LIFESPAN,
         CREDENTIALS_JWT_ASSERTION,
+        CREDENTIALS_FOR_ALL_ENDPOINTS,
         CREDENTIALS_JWT_AUDIENCE,
         CREDENTIALS_JWT_KEEP_AUDIENCE_TRAILING_SLASH,
         CREDENTIALS_JWT_TOKEN_ID,
@@ -316,6 +317,12 @@ final class OidcClientConfigImpl implements OidcClientConfig {
                         return false;
                     }
                 };
+            }
+
+            @Override
+            public boolean forAllEndpoints() {
+                invocationsRecorder.put(ConfigMappingMethods.CREDENTIALS_FOR_ALL_ENDPOINTS, true);
+                return false;
             }
         };
     }

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcClientCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcClientCommonConfig.java
@@ -118,6 +118,8 @@ public abstract class OidcClientCommonConfig extends OidcCommonConfig
          */
         public Jwt jwt = new Jwt();
 
+        private boolean forAllEndpoints = false;
+
         public Optional<String> getSecret() {
             return secret;
         }
@@ -146,6 +148,7 @@ public abstract class OidcClientCommonConfig extends OidcCommonConfig
             secret = mapping.secret();
             clientSecret.addConfigMappingValues(mapping.clientSecret());
             jwt.addConfigMappingValues(mapping.jwt());
+            forAllEndpoints = mapping.forAllEndpoints();
         }
 
         @Override
@@ -161,6 +164,11 @@ public abstract class OidcClientCommonConfig extends OidcCommonConfig
         @Override
         public io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials.Jwt jwt() {
             return jwt;
+        }
+
+        @Override
+        public boolean forAllEndpoints() {
+            return forAllEndpoints;
         }
 
         /**

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -458,6 +458,21 @@ public class OidcCommonUtils {
         return clientSecretMethod(creds) == Secret.Method.POST_JWT;
     }
 
+    public static void validateCredentialsForAllEndpoints(Credentials creds) {
+        if (!creds.forAllEndpoints()) {
+            return;
+        }
+        if (isClientSecretBasicAuthRequired(creds)) {
+            return;
+        }
+        if (creds.jwt().source() == Source.BEARER && creds.jwt().tokenPath().isPresent()) {
+            return;
+        }
+        throw new ConfigurationException(
+                "Client credentials cannot be sent to all OIDC endpoints because only "
+                        + "'client_secret_basic' or JWT bearer ('jwt.source=bearer') authentication methods are supported");
+    }
+
     public static boolean isJwtAssertion(Credentials creds) {
         return creds.jwt().assertion();
     }

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/config/OidcClientCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/config/OidcClientCommonConfig.java
@@ -69,6 +69,20 @@ public interface OidcClientCommonConfig extends OidcCommonConfig {
         Jwt jwt();
 
         /**
+         * If true, client credentials are also sent to OIDC discovery and JWKS endpoints, which normally
+         * do not require authentication.
+         * Enable this when the OIDC provider enforces authenticated access to these endpoints.
+         * <p>
+         * One of the following authentication methods must be used when this property is enabled:
+         * <ul>
+         * <li>{@code client_secret_basic} — {@code Authorization: Basic} header</li>
+         * <li>JWT bearer ({@code jwt.source=bearer}) — {@code Authorization: Bearer} header</li>
+         * </ul>
+         */
+        @WithDefault("false")
+        boolean forAllEndpoints();
+
+        /**
          * Supports the client authentication methods that involve sending a client secret.
          *
          * @see <a href=

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/config/OidcClientCommonConfigBuilder.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/config/OidcClientCommonConfigBuilder.java
@@ -161,13 +161,15 @@ public abstract class OidcClientCommonConfigBuilder<T> extends OidcCommonConfigB
      */
     public static final class CredentialsBuilder<T> {
 
-        private record CredentialsImpl(Optional<String> secret, Secret clientSecret, Jwt jwt) implements Credentials {
+        private record CredentialsImpl(Optional<String> secret, Secret clientSecret, Jwt jwt,
+                boolean forAllEndpoints) implements Credentials {
         }
 
         private final OidcClientCommonConfigBuilder<T> builder;
         private Optional<String> secret;
         private Secret clientSecret;
         private Jwt jwt;
+        private boolean forAllEndpoints;
 
         public CredentialsBuilder() {
             this(getConfigBuilderWithDefaults());
@@ -178,6 +180,7 @@ public abstract class OidcClientCommonConfigBuilder<T> extends OidcCommonConfigB
             this.secret = builder.credentials.secret();
             this.clientSecret = builder.credentials.clientSecret();
             this.jwt = builder.credentials.jwt();
+            this.forAllEndpoints = builder.credentials.forAllEndpoints();
         }
 
         /**
@@ -251,6 +254,17 @@ public abstract class OidcClientCommonConfigBuilder<T> extends OidcCommonConfigB
         }
 
         /**
+         * Enables sending client credentials to all OIDC endpoints, including the discovery and JWKS endpoints.
+         *
+         * @return this builder
+         * @see Credentials#forAllEndpoints()
+         */
+        public CredentialsBuilder<T> forAllEndpoints() {
+            this.forAllEndpoints = true;
+            return this;
+        }
+
+        /**
          * Builds {@link Credentials} and returns the builder.
          *
          * @return T builder
@@ -264,7 +278,7 @@ public abstract class OidcClientCommonConfigBuilder<T> extends OidcCommonConfigB
          * @return Credentials
          */
         public Credentials build() {
-            return new CredentialsImpl(secret, clientSecret, jwt);
+            return new CredentialsImpl(secret, clientSecret, jwt, forAllEndpoints);
         }
 
         private static <T> OidcClientCommonConfigBuilder<T> getConfigBuilderWithDefaults() {

--- a/extensions/oidc-common/runtime/src/test/java/io/quarkus/oidc/common/runtime/OidcClientCommonConfigBuilderTest.java
+++ b/extensions/oidc-common/runtime/src/test/java/io/quarkus/oidc/common/runtime/OidcClientCommonConfigBuilderTest.java
@@ -51,6 +51,13 @@ public class OidcClientCommonConfigBuilderTest {
         assertEquals(10, jwt.lifespan());
         assertFalse(jwt.assertion());
         assertFalse(jwt.tokenPath().isPresent());
+        assertFalse(credentials.forAllEndpoints());
+    }
+
+    @Test
+    void testRequiredForAllEndpoints() {
+        Credentials credentials = new CredentialsBuilder<>().forAllEndpoints().build();
+        assertTrue(credentials.forAllEndpoints());
     }
 
 }

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/OidcAllEndpointAuthenticationTest.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/OidcAllEndpointAuthenticationTest.java
@@ -1,0 +1,211 @@
+package io.quarkus.oidc.test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Base64;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.oidc.OidcRequestContext;
+import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.TenantConfigResolver;
+import io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig;
+import io.quarkus.security.Authenticated;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+
+class OidcAllEndpointAuthenticationTest {
+
+    private static final String CLIENT_ID = "test-client";
+    private static final String CLIENT_SECRET = "test-secret";
+
+    private static final String JWT_HEADER = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0";
+    private static final String BEARER_TOKEN = JWT_HEADER
+            + ".eyJleHAiOjk5OTk5OTk5OTksInN1YiI6InRlc3Qtc2VydmljZSJ9.sig";
+    private static final File TOKEN_DIR = new File("target/test-tokens");
+    private static final File BEARER_TOKEN_FILE = new File(TOKEN_DIR, "bearer.jwt");
+
+    @RegisterExtension
+    static final QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar.addClasses(
+                    ProtectedResource.class,
+                    IncompatibleMethodTenantConfigResolver.class,
+                    MockDiscoveryEndpoint.class,
+                    MockJwksEndpoint.class,
+                    MockIntrospectionEndpoint.class))
+            .withConfiguration("""
+                    quarkus.keycloak.devservices.enabled=false
+                    quarkus.http.auth.proactive=false
+                    """)
+            .withRuntimeConfiguration("""
+                    quarkus.oidc.auth-server-url=http://localhost:8081/mock-oidc/basic
+                    quarkus.oidc.client-id=%1$s
+                    quarkus.oidc.credentials.secret=%2$s
+                    quarkus.oidc.credentials.for-all-endpoints=true
+                    quarkus.oidc.tenant-paths=/basic/*
+
+                    quarkus.oidc.bearer.auth-server-url=http://localhost:8081/mock-oidc/bearer
+                    quarkus.oidc.bearer.client-id=%1$s
+                    quarkus.oidc.bearer.credentials.jwt.source=bearer
+                    quarkus.oidc.bearer.credentials.jwt.token-path=%3$s
+                    quarkus.oidc.bearer.credentials.for-all-endpoints=true
+                    quarkus.oidc.bearer.tenant-paths=/bearer/*
+
+                    """.formatted(CLIENT_ID, CLIENT_SECRET,
+                    BEARER_TOKEN_FILE.getAbsolutePath()))
+            .setBeforeAllCustomizer(() -> {
+                try {
+                    Files.createDirectories(TOKEN_DIR.toPath());
+                    Files.writeString(BEARER_TOKEN_FILE.toPath(), BEARER_TOKEN);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+    @Test
+    void testBasicAuth() {
+        testAuth("basic");
+    }
+
+    @Test
+    void testBearerAuth() {
+        testAuth("bearer");
+    }
+
+    @Test
+    void testIncompatibleMethodThrowsValidationError() {
+        given()
+                .auth().oauth2("any-token")
+                .get("/post-method/protected")
+                .then()
+                .statusCode(500)
+                .body(Matchers.containsString("Client credentials cannot be sent to all OIDC endpoints"));
+    }
+
+    private static void testAuth(String tenant) {
+        given()
+                .auth().oauth2("any-token")
+                .get("/" + tenant + "/protected")
+                .then()
+                .statusCode(200)
+                .body(is("OK"));
+    }
+
+    @Path("/{tenant}/protected")
+    @Authenticated
+    public static class ProtectedResource {
+
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        public String get() {
+            return "OK";
+        }
+    }
+
+    @Path("/mock-oidc/{tenant}/.well-known/openid-configuration")
+    public static class MockDiscoveryEndpoint {
+
+        @GET
+        @Produces(MediaType.APPLICATION_JSON)
+        public Response discover(@PathParam("tenant") String tenant,
+                @HeaderParam("Authorization") String authorization) {
+            if (isAnonymous(tenant, authorization)) {
+                return Response.status(401).build();
+            }
+            String json = """
+                    {
+                        "issuer": "http://localhost:8081/mock-oidc/%1$s",
+                        "jwks_uri": "http://localhost:8081/mock-oidc/%1$s/protocol/openid-connect/certs",
+                        "token_endpoint": "http://localhost:8081/mock-oidc/%1$s/token",
+                        "introspection_endpoint": "http://localhost:8081/mock-oidc/%1$s/introspect",
+                        "authorization_endpoint": "http://localhost:8081/mock-oidc/%1$s/authorize",
+                        "subject_types_supported": ["public"]
+                    }
+                    """.formatted(tenant);
+            return Response.ok(json).build();
+        }
+    }
+
+    @Path("/mock-oidc/{tenant}/protocol/openid-connect/certs")
+    public static class MockJwksEndpoint {
+
+        @GET
+        @Produces(MediaType.APPLICATION_JSON)
+        public Response jwks(@PathParam("tenant") String tenant,
+                @HeaderParam("Authorization") String authorization) {
+            if (isAnonymous(tenant, authorization)) {
+                return Response.status(401).build();
+            }
+            return Response.ok("{\"keys\":[]}").build();
+        }
+    }
+
+    @Path("/mock-oidc/{tenant}/introspect")
+    public static class MockIntrospectionEndpoint {
+
+        @POST
+        @Produces(MediaType.APPLICATION_JSON)
+        public String introspect() {
+            return "{\"active\":true,\"sub\":\"test-user\",\"username\":\"test-user\"}";
+        }
+    }
+
+    private static boolean isAnonymous(String tenant, String authorization) {
+        return !switch (tenant) {
+            case "basic" -> isBasicAuth(authorization);
+            case "bearer" -> isBearerAuth(authorization, BEARER_TOKEN);
+            default -> false;
+        };
+    }
+
+    private static boolean isBasicAuth(String authorization) {
+        if (authorization == null || !authorization.startsWith("Basic ")) {
+            return false;
+        }
+        String decoded = new String(Base64.getDecoder().decode(authorization.substring(6)), StandardCharsets.UTF_8);
+        return (CLIENT_ID + ":" + CLIENT_SECRET).equals(decoded);
+    }
+
+    private static boolean isBearerAuth(String authorization, String expectedToken) {
+        return authorization != null && authorization.equals("Bearer " + expectedToken);
+    }
+
+    @ApplicationScoped
+    public static class IncompatibleMethodTenantConfigResolver implements TenantConfigResolver {
+
+        @Override
+        public Uni<OidcTenantConfig> resolve(RoutingContext routingContext,
+                OidcRequestContext<OidcTenantConfig> requestContext) {
+            if (routingContext.normalizedPath().startsWith("/post-method/")) {
+                return Uni.createFrom().item(OidcTenantConfig.builder()
+                        .tenantId("post-method")
+                        .authServerUrl("http://localhost:8081/mock-oidc/basic")
+                        .clientId(CLIENT_ID)
+                        .credentials()
+                        .clientSecret(CLIENT_SECRET, OidcClientCommonConfig.Credentials.Secret.Method.POST)
+                        .forAllEndpoints()
+                        .end()
+                        .build());
+            }
+            return Uni.createFrom().nullItem();
+        }
+    }
+}

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClientImpl.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClientImpl.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.jboss.logging.Logger;
 import org.jose4j.lang.UnresolvableKeyException;
@@ -53,9 +54,24 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
         REVOKE("Revoke"),
         PAR("Pushed Authorization Request");
 
-        String op;
+        final String op;
 
         TokenOperation(String op) {
+            this.op = op;
+        }
+
+        String operation() {
+            return op;
+        }
+    }
+
+    private enum MetadataOperation {
+        DISCOVERY("Discovery"),
+        JWKS("JWKS");
+
+        final String op;
+
+        MetadataOperation(String op) {
             this.op = op;
         }
 
@@ -99,14 +115,13 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
         this.metadata = metadata;
         this.oidcConfig = oidcConfig;
         this.clientSecretBasicAuthScheme = clientCredentials.clientSecretBasicAuthScheme;
-        this.jwtAssertionProvided = oidcConfig.credentials().jwt()
-                .source() != OidcClientCommonConfig.Credentials.Jwt.Source.CLIENT;
-        this.clientAssertionProvider = getClientAssertionProvider(vertx, oidcConfig.credentials(), OIDCException::new);
+        this.jwtAssertionProvided = clientCredentials.jwtAssertionProvided;
+        this.clientAssertionProvider = clientCredentials.clientAssertionProvider;
         this.clientJwtKey = jwtAssertionProvided ? null : clientCredentials.clientJwtKey;
         this.introspectionBasicAuthScheme = initIntrospectionBasicAuthScheme(oidcConfig);
         this.requestFilters = requestFilters;
         this.responseFilters = responseFilters;
-        this.clientSecretQueryAuthentication = oidcConfig.credentials().clientSecret().method().orElse(null) == Method.QUERY;
+        this.clientSecretQueryAuthentication = clientCredentials.clientSecretQueryAuthentication;
         this.clientSecret = clientCredentials.clientSecret;
         this.jwtSecret = clientCredentials.jwtSecret;
         this.refreshTokenToTokensUni = new ConcurrentHashMap<>();
@@ -150,11 +165,35 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
         if (!cookies.isEmpty()) {
             request.putHeader(OidcCommonUtils.COOKIE_REQUEST_HEADER, cookies);
         }
-        return filterHttpRequest(requestProps, OidcEndpoint.Type.JWKS, request, null)
-                .flatMap(httpRequest -> OidcCommonUtils
-                        .sendRequest(vertx, httpRequest, oidcConfig.useBlockingDnsLookup()))
-                .onItem()
-                .transformToUni(resp -> getJsonWebKeySet(requestProps, resp));
+        final UniOnItem<HttpResponse<Buffer>> httpResponse;
+        if (oidcConfig.credentials().forAllEndpoints()) {
+            var requestPropsCopy = requestProps != null ? new OidcRequestContextProperties(requestProps.getAll()) : null;
+            var preparedRequest = prepareGetJsonWebKeySetRequest(requestProps, cookies, true);
+            httpResponse = withCredentialsRetry(preparedRequest,
+                    () -> prepareGetJsonWebKeySetRequest(requestPropsCopy, cookies, true));
+        } else {
+            httpResponse = prepareGetJsonWebKeySetRequest(requestProps, cookies, false).httpRequestUni.onItem();
+        }
+        return httpResponse.transformToUni(resp -> getJsonWebKeySet(requestProps, resp));
+    }
+
+    private PreparedHttpRequest prepareGetJsonWebKeySetRequest(OidcRequestContextProperties requestProps, List<String> cookies,
+            boolean addCredentials) {
+        LOG.debugf("Get verification JWT Key Set at %s", metadata.getJsonWebKeySetUri());
+        HttpRequest<Buffer> request = client.getAbs(metadata.getJsonWebKeySetUri());
+        if (!cookies.isEmpty()) {
+            request.putHeader(OidcCommonUtils.COOKIE_REQUEST_HEADER, cookies);
+        }
+        PreparedHttpRequest.CredentialsToRetry credentialsToRetry = null;
+        if (addCredentials) {
+            credentialsToRetry = setHttpAuthorizationForJwks(request,
+                    new ClientCredentials(null, clientSecret, null, clientSecretBasicAuthScheme,
+                            jwtAssertionProvided, clientAssertionProvider, clientSecretQueryAuthentication),
+                    oidcConfig);
+        }
+        var filteredRequest = filterHttpRequest(requestProps, OidcEndpoint.Type.JWKS, request, null)
+                .flatMap(httpRequest -> OidcCommonUtils.sendRequest(vertx, httpRequest, oidcConfig.useBlockingDnsLookup()));
+        return new PreparedHttpRequest(filteredRequest, credentialsToRetry);
     }
 
     public Uni<UserInfo> getUserInfo(final String accessToken) {
@@ -467,44 +506,8 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
 
         var preparedRequest = prepareHttpRequest(requestProps, uri, newFormBody, op, endpointType, bodyBuffer);
         if (hasClientSecretProvider && preparedRequest.credentialsToRetry != null) {
-            return preparedRequest.httpRequestUni.flatMap(httpResponse -> {
-                if (httpResponse.statusCode() == 401) {
-                    // here we need to deal with error responses (like unauthorized_client) possibly caused by
-                    // invalid credentialsToRetry; if credentialsToRetry provider updated credentialsToRetry, we should retry
-                    var credentialsRefresh = switch (preparedRequest.credentialsToRetry) {
-                        case CLIENT_SECRET -> OidcCommonUtils.clientSecret(oidcConfig.credentials())
-                                .map(newClientSecret -> {
-                                    if (newClientSecret != null && !newClientSecret.equals(clientSecret)) {
-                                        this.clientSecret = newClientSecret;
-                                        return true;
-                                    }
-                                    return false;
-                                });
-                        case CLIENT_SECRET_BASIC_AUTH_SCHEME -> OidcCommonUtils.clientSecret(oidcConfig.credentials())
-                                .map(newClientSecret -> {
-                                    var newClientSecretBasicAuthScheme = OidcCommonUtils.initClientSecretBasicAuth(oidcConfig,
-                                            newClientSecret);
-                                    if (newClientSecretBasicAuthScheme != null
-                                            && !newClientSecretBasicAuthScheme.equals(clientSecretBasicAuthScheme)) {
-                                        this.clientSecret = newClientSecret;
-                                        this.clientSecretBasicAuthScheme = newClientSecretBasicAuthScheme;
-                                        return true;
-                                    }
-                                    return false;
-                                });
-                    };
-
-                    return credentialsRefresh.flatMap(credentialsRefreshed -> {
-                        if (Boolean.TRUE.equals(credentialsRefreshed)) {
-                            LOG.debug("HTTP request failed with response status code 401 and the CredentialsProvider"
-                                    + " provided new credentials, retrying the request with new credentials");
-                            return prepareHttpRequest(requestProps, uri, formBody, op, endpointType, bodyBuffer).httpRequestUni;
-                        }
-                        return Uni.createFrom().item(httpResponse);
-                    });
-                }
-                return Uni.createFrom().item(httpResponse);
-            }).onItem();
+            return withCredentialsRetry(preparedRequest,
+                    () -> prepareHttpRequest(requestProps, uri, formBody, op, endpointType, bodyBuffer));
         }
         return preparedRequest.httpRequestUni.onItem();
     }
@@ -655,25 +658,110 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
     record UserInfoResponse(String contentType, String data) {
     }
 
+    static void setHttpAuthorizationForDiscovery(HttpRequest<Buffer> request,
+            ClientCredentials clientCredentials, OidcClientCommonConfig oidcConfig) {
+        setHttpAuthorization(request, clientCredentials, oidcConfig, MetadataOperation.DISCOVERY);
+    }
+
+    static PreparedHttpRequest.CredentialsToRetry setHttpAuthorizationForJwks(HttpRequest<Buffer> request,
+            ClientCredentials clientCredentials, OidcClientCommonConfig oidcConfig) {
+        return setHttpAuthorization(request, clientCredentials, oidcConfig, MetadataOperation.JWKS);
+    }
+
+    private static PreparedHttpRequest.CredentialsToRetry setHttpAuthorization(HttpRequest<Buffer> request,
+            ClientCredentials clientCredentials, OidcClientCommonConfig oidcConfig, MetadataOperation op) {
+        if (clientCredentials.clientSecretBasicAuthScheme != null) {
+            request.putHeader(AUTHORIZATION_HEADER, clientCredentials.clientSecretBasicAuthScheme);
+            return PreparedHttpRequest.CredentialsToRetry.CLIENT_SECRET_BASIC_AUTH_SCHEME;
+        } else if (clientCredentials.jwtAssertionProvided && clientCredentials.clientAssertionProvider != null
+                && oidcConfig.credentials().jwt().source() == OidcClientCommonConfig.Credentials.Jwt.Source.BEARER) {
+            final String clientAssertion = clientCredentials.clientAssertionProvider.getClientAssertion();
+            if (clientAssertion == null) {
+                throw new OIDCException(String.format(
+                        "Cannot access the %s endpoint for client '%s' because a JWT bearer client_assertion is not available",
+                        op.operation(), oidcConfig.clientId().orElse(null)));
+            }
+            request.putHeader(AUTHORIZATION_HEADER, OidcConstants.BEARER_SCHEME + " " + clientAssertion);
+        }
+        return null;
+    }
+
+    private UniOnItem<HttpResponse<Buffer>> withCredentialsRetry(PreparedHttpRequest preparedRequest,
+            Supplier<PreparedHttpRequest> refreshRequestSupplier) {
+        return preparedRequest.httpRequestUni.flatMap(httpResponse -> {
+            if (httpResponse.statusCode() == 401) {
+                // here we need to deal with error responses (like unauthorized_client) possibly caused by
+                // invalid credentialsToRetry; if credentialsToRetry provider updated credentialsToRetry, we should retry
+                var credentialsRefresh = switch (preparedRequest.credentialsToRetry) {
+                    case CLIENT_SECRET -> OidcCommonUtils.clientSecret(oidcConfig.credentials())
+                            .map(newClientSecret -> {
+                                if (newClientSecret != null && !newClientSecret.equals(clientSecret)) {
+                                    this.clientSecret = newClientSecret;
+                                    return true;
+                                }
+                                return false;
+                            });
+                    case CLIENT_SECRET_BASIC_AUTH_SCHEME -> OidcCommonUtils.clientSecret(oidcConfig.credentials())
+                            .map(newClientSecret -> {
+                                var newClientSecretBasicAuthScheme = OidcCommonUtils.initClientSecretBasicAuth(oidcConfig,
+                                        newClientSecret);
+                                if (newClientSecretBasicAuthScheme != null
+                                        && !newClientSecretBasicAuthScheme.equals(clientSecretBasicAuthScheme)) {
+                                    this.clientSecret = newClientSecret;
+                                    this.clientSecretBasicAuthScheme = newClientSecretBasicAuthScheme;
+                                    return true;
+                                }
+                                return false;
+                            });
+                };
+
+                return credentialsRefresh.flatMap(credentialsRefreshed -> {
+                    if (Boolean.TRUE.equals(credentialsRefreshed)) {
+                        LOG.debug("HTTP request failed with response status code 401 and the CredentialsProvider"
+                                + " provided new credentials, retrying the request with new credentials");
+                        return refreshRequestSupplier.get().httpRequestUni;
+                    }
+                    return Uni.createFrom().item(httpResponse);
+                });
+            }
+            return Uni.createFrom().item(httpResponse);
+        }).onItem();
+    }
+
     static boolean isIntrospection(TokenOperation op) {
         return op == TokenOperation.INTROSPECT;
     }
 
-    static Uni<OidcProviderClientImpl> of(OidcWebClient client, Vertx vertx, OidcConfigurationMetadata metadata,
+    static Uni<OidcProviderClientImpl> of(OidcWebClient client, Vertx vertx,
+            Function<ClientCredentials, Uni<OidcConfigurationMetadata>> metadataResolver,
             OidcTenantConfig oidcConfig,
             Map<OidcEndpoint.Type, List<OidcRequestFilter>> requestFilters,
             Map<OidcEndpoint.Type, List<OidcResponseFilter>> responseFilters) {
+        final boolean jwtAssertionProvided = oidcConfig.credentials().jwt()
+                .source() != OidcClientCommonConfig.Credentials.Jwt.Source.CLIENT;
+        final ClientAssertionProvider assertionProvider = getClientAssertionProvider(vertx, oidcConfig.credentials(),
+                OIDCException::new);
+        final boolean queryAuth = oidcConfig.credentials().clientSecret().method().orElse(null) == Method.QUERY;
         return OidcCommonUtils.clientSecret(oidcConfig.credentials())
                 .onItem().ifNotNull()
-                .transform(clientSecret -> new ClientCredentials(clientSecret,
-                        OidcCommonUtils.initClientSecretBasicAuth(oidcConfig, clientSecret)))
+                .transform(clientSecret -> new ClientCredentials(null, clientSecret, null,
+                        OidcCommonUtils.initClientSecretBasicAuth(oidcConfig, clientSecret),
+                        jwtAssertionProvided, assertionProvider, queryAuth))
                 .onItem().ifNull().switchTo(() -> OidcCommonUtils.initClientJwtKey(oidcConfig, true)
-                        .onItem().ifNotNull().transform(ClientCredentials::new)
+                        .onItem().ifNotNull()
+                        .transform(key -> new ClientCredentials(key, null, null, null,
+                                jwtAssertionProvided, assertionProvider, queryAuth))
                         .onItem().ifNull()
-                        .switchTo(() -> OidcCommonUtils.jwtSecret(oidcConfig.credentials()).map(ClientCredentials::new)))
-                .onFailure().invoke(t -> LOG.error("Failed to create OidcProviderClientImpl", t))
-                .map(clientCredentials -> new OidcProviderClientImpl(client, vertx, metadata, oidcConfig,
-                        clientCredentials, requestFilters, responseFilters));
+                        .switchTo(() -> OidcCommonUtils.jwtSecret(oidcConfig.credentials())
+                                .map(secret -> new ClientCredentials(null, null, secret, null,
+                                        jwtAssertionProvided, assertionProvider, queryAuth))))
+                .flatMap(cc -> metadataResolver.apply(cc)
+                        .map(metadata -> new OidcProviderClientImpl(client, vertx, metadata, oidcConfig,
+                                cc, requestFilters, responseFilters)))
+                .onFailure().invoke(t -> {
+                    LOG.error("Failed to create OidcProviderClientImpl", t);
+                    client.close();
+                });
     }
 
     String getClientOrJwtSecret() {
@@ -687,19 +775,9 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
         return null;
     }
 
-    private record ClientCredentials(Key clientJwtKey, String clientSecret, String jwtSecret,
-            String clientSecretBasicAuthScheme) {
-
-        private ClientCredentials(Key clientJwtKey) {
-            this(clientJwtKey, null, null, null);
-        }
-
-        private ClientCredentials(String jwtSecret) {
-            this(null, null, jwtSecret, null);
-        }
-
-        private ClientCredentials(String clientSecret, String clientSecretBasicAuthScheme) {
-            this(null, clientSecret, null, clientSecretBasicAuthScheme);
-        }
+    record ClientCredentials(Key clientJwtKey, String clientSecret, String jwtSecret,
+            String clientSecretBasicAuthScheme,
+            boolean jwtAssertionProvided, ClientAssertionProvider clientAssertionProvider,
+            boolean clientSecretQueryAuthentication) {
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantContextFactory.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantContextFactory.java
@@ -6,6 +6,7 @@ import static io.quarkus.oidc.SecurityEvent.Type.OIDC_SERVER_NOT_AVAILABLE;
 import static io.quarkus.oidc.runtime.OidcRecorder.LOG;
 import static io.quarkus.oidc.runtime.OidcUtils.DEFAULT_TENANT_ID;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -450,7 +451,11 @@ final class TenantContextFactory {
 
     private Uni<OidcProviderClientImpl> createOidcClientUni(OidcTenantConfig oidcConfig) {
 
-        String authServerUriString = OidcCommonUtils.getAuthServerUrl(oidcConfig);
+        try {
+            OidcCommonUtils.validateCredentialsForAllEndpoints(oidcConfig.credentials());
+        } catch (ConfigurationException e) {
+            return Uni.createFrom().failure(e);
+        }
 
         var mutinyVertx = new io.vertx.mutiny.core.Vertx(vertx);
         OidcWebClient client = OidcWebClient.create(oidcConfig, tlsSupport, mutinyVertx, proxyConfigurationRegistry,
@@ -458,6 +463,20 @@ final class TenantContextFactory {
 
         Map<OidcEndpoint.Type, List<OidcRequestFilter>> oidcRequestFilters = OidcUtils.getOidcRequestFilters(oidcConfig);
         Map<OidcEndpoint.Type, List<OidcResponseFilter>> oidcResponseFilters = OidcUtils.getOidcResponseFilters(oidcConfig);
+
+        return OidcProviderClientImpl.of(client, vertx,
+                clientCredentials -> createOidcConfigurationMetadata(oidcConfig, client, oidcRequestFilters,
+                        oidcResponseFilters, clientCredentials, mutinyVertx),
+                oidcConfig, oidcRequestFilters, oidcResponseFilters);
+    }
+
+    private Uni<OidcConfigurationMetadata> createOidcConfigurationMetadata(OidcTenantConfig oidcConfig, OidcWebClient client,
+            Map<OidcEndpoint.Type, List<OidcRequestFilter>> oidcRequestFilters,
+            Map<OidcEndpoint.Type, List<OidcResponseFilter>> oidcResponseFilters,
+            OidcProviderClientImpl.ClientCredentials clientCredentials,
+            io.vertx.mutiny.core.Vertx mutinyVertx) {
+
+        String authServerUriString = OidcCommonUtils.getAuthServerUrl(oidcConfig);
 
         final Uni<OidcConfigurationMetadata> metadataUni;
         if (!oidcConfig.discoveryEnabled().orElse(true)) {
@@ -467,8 +486,23 @@ final class TenantContextFactory {
             final String discoveryUri = OidcCommonUtils.getDiscoveryUri(authServerUriString, oidcConfig.discoveryPath());
             OidcRequestContextProperties contextProps = new OidcRequestContextProperties(
                     Map.of(OidcUtils.TENANT_ID_ATTRIBUTE, oidcConfig.tenantId().orElse(OidcUtils.DEFAULT_TENANT_ID)));
+            final Map<OidcEndpoint.Type, List<OidcRequestFilter>> discoveryFilters;
+            if (oidcConfig.credentials().forAllEndpoints()) {
+                discoveryFilters = new HashMap<>(oidcRequestFilters);
+                OidcRequestFilter authFilter = new OidcRequestFilter() {
+                    @Override
+                    public Uni<Void> filter(OidcRequestFilterContext context) {
+                        OidcProviderClientImpl.setHttpAuthorizationForDiscovery(context.request(),
+                                clientCredentials, oidcConfig);
+                        return Uni.createFrom().voidItem();
+                    }
+                };
+                discoveryFilters.computeIfAbsent(OidcEndpoint.Type.DISCOVERY, k -> new ArrayList<>()).add(authFilter);
+            } else {
+                discoveryFilters = oidcRequestFilters;
+            }
             metadataUni = OidcCommonUtils
-                    .discoverMetadata(client, oidcRequestFilters, contextProps, oidcResponseFilters, discoveryUri,
+                    .discoverMetadata(client, discoveryFilters, contextProps, oidcResponseFilters, discoveryUri,
                             connectionDelayInMillisecs,
                             mutinyVertx,
                             oidcConfig.useBlockingDnsLookup())
@@ -482,72 +516,68 @@ final class TenantContextFactory {
                     });
         }
         return metadataUni.onItemOrFailure()
-                .transformToUni(new BiFunction<OidcConfigurationMetadata, Throwable, Uni<? extends OidcProviderClientImpl>>() {
+                .transformToUni(
+                        new BiFunction<OidcConfigurationMetadata, Throwable, Uni<? extends OidcConfigurationMetadata>>() {
 
-                    @Override
-                    public Uni<OidcProviderClientImpl> apply(OidcConfigurationMetadata metadata, Throwable t) {
-                        String tenantId = oidcConfig.tenantId().orElse(DEFAULT_TENANT_ID);
-                        if (t != null) {
-                            client.close();
-                            return Uni.createFrom().failure(toOidcException(t, authServerUriString, tenantId));
-                        }
-                        if (shouldFireOidcServerAvailableEvent(tenantId)) {
-                            fireOidcServerAvailableEvent(authServerUriString, tenantId);
-                        }
-                        if (metadata == null) {
-                            client.close();
-                            return Uni.createFrom().failure(new ConfigurationException(
-                                    "OpenId Connect Provider configuration metadata is not configured and can not be discovered"));
-                        }
-                        if (oidcConfig.logout().path().isPresent()) {
-                            if (oidcConfig.endSessionPath().isEmpty() && metadata.getEndSessionUri() == null) {
-                                client.close();
-                                return Uni.createFrom().failure(new ConfigurationException(
-                                        "The application supports RP-Initiated Logout but the OpenID Provider does not advertise the end_session_endpoint"));
-                            }
-                        }
-                        if (userInfoInjectionPointDetected && metadata.getUserInfoUri() != null) {
-                            enableUserInfo(oidcConfig);
-                        }
-                        if (oidcConfig.authentication().userInfoRequired().orElse(false) && metadata.getUserInfoUri() == null) {
-                            client.close();
-                            return Uni.createFrom().failure(new ConfigurationException(
-                                    "UserInfo is required but the OpenID Provider UserInfo endpoint is not configured."
-                                            + " Use '%s' if the discovery is disabled."
-                                                    .formatted(getConfigPropertyForTenant(tenantId, "user-info-path"))));
-                        }
-                        if (OidcUtils.isParEnabled(oidcConfig.authentication(), metadata)) {
-                            if (metadata.getPushedAuthorizationRequestUri() == null) {
-                                client.close();
-                                String exceptionMessage = ("OIDC tenant '%s' has enabled the pushed authorization requests, but "
-                                        + "the OpenID Provider PAR endpoint is not configured. Use '%s' if the discovery is disabled.")
-                                        .formatted(tenantId,
-                                                getConfigPropertyForTenant(tenantId, "authentication.par.path"));
-                                return Uni.createFrom().failure(new ConfigurationException(exceptionMessage));
-                            }
-                            if (!LaunchMode.current().isDevOrTest()
-                                    && !"https".startsWith(metadata.getPushedAuthorizationRequestUri().toLowerCase())) {
-                                LOG.debugf("OIDC tenant '%s' has the OpenID Provider PAR endpoint '%s', " +
-                                        "however the HTTPS scheme is required by the specification. Proceeding" +
-                                        " with HTTP assuming a secure internal network or proxy.", tenantId,
-                                        metadata.getPushedAuthorizationRequestUri());
+                            @Override
+                            public Uni<OidcConfigurationMetadata> apply(OidcConfigurationMetadata metadata, Throwable t) {
+                                String tenantId = oidcConfig.tenantId().orElse(DEFAULT_TENANT_ID);
+                                if (t != null) {
+                                    return Uni.createFrom().failure(toOidcException(t, authServerUriString, tenantId));
+                                }
+                                if (shouldFireOidcServerAvailableEvent(tenantId)) {
+                                    fireOidcServerAvailableEvent(authServerUriString, tenantId);
+                                }
+                                if (metadata == null) {
+                                    return Uni.createFrom().failure(new ConfigurationException(
+                                            "OpenId Connect Provider configuration metadata is not configured and can not be discovered"));
+                                }
+                                if (oidcConfig.logout().path().isPresent()) {
+                                    if (oidcConfig.endSessionPath().isEmpty() && metadata.getEndSessionUri() == null) {
+                                        return Uni.createFrom().failure(new ConfigurationException(
+                                                "The application supports RP-Initiated Logout but the OpenID Provider does not advertise the end_session_endpoint"));
+                                    }
+                                }
+                                if (userInfoInjectionPointDetected && metadata.getUserInfoUri() != null) {
+                                    enableUserInfo(oidcConfig);
+                                }
+                                if (oidcConfig.authentication().userInfoRequired().orElse(false)
+                                        && metadata.getUserInfoUri() == null) {
+                                    return Uni.createFrom().failure(new ConfigurationException(
+                                            "UserInfo is required but the OpenID Provider UserInfo endpoint is not configured."
+                                                    + " Use '%s' if the discovery is disabled."
+                                                            .formatted(
+                                                                    getConfigPropertyForTenant(tenantId, "user-info-path"))));
+                                }
+                                if (OidcUtils.isParEnabled(oidcConfig.authentication(), metadata)) {
+                                    if (metadata.getPushedAuthorizationRequestUri() == null) {
+                                        String exceptionMessage = ("OIDC tenant '%s' has enabled the pushed authorization requests, but "
+                                                + "the OpenID Provider PAR endpoint is not configured. Use '%s' if the discovery is disabled.")
+                                                .formatted(tenantId,
+                                                        getConfigPropertyForTenant(tenantId, "authentication.par.path"));
+                                        return Uni.createFrom().failure(new ConfigurationException(exceptionMessage));
+                                    }
+                                    if (!LaunchMode.current().isDevOrTest()
+                                            && !"https".startsWith(metadata.getPushedAuthorizationRequestUri().toLowerCase())) {
+                                        LOG.debugf("OIDC tenant '%s' has the OpenID Provider PAR endpoint '%s', " +
+                                                "however the HTTPS scheme is required by the specification. Proceeding" +
+                                                " with HTTP assuming a secure internal network or proxy.", tenantId,
+                                                metadata.getPushedAuthorizationRequestUri());
+                                    }
+
+                                    boolean clientSecretQueryAuthentication = oidcConfig.credentials().clientSecret().method()
+                                            .orElse(null) == OidcClientCommonConfig.Credentials.Secret.Method.QUERY;
+                                    if (clientSecretQueryAuthentication) {
+                                        String exceptionMessage = ("OIDC tenant '%s' has enabled the pushed authorization requests, "
+                                                + "and uses the client authentication method 'query'. Please set different"
+                                                + " client authentication method").formatted(tenantId);
+                                        return Uni.createFrom().failure(new ConfigurationException(exceptionMessage));
+                                    }
+                                }
+                                return Uni.createFrom().item(metadata);
                             }
 
-                            boolean clientSecretQueryAuthentication = oidcConfig.credentials().clientSecret().method()
-                                    .orElse(null) == OidcClientCommonConfig.Credentials.Secret.Method.QUERY;
-                            if (clientSecretQueryAuthentication) {
-                                client.close();
-                                String exceptionMessage = ("OIDC tenant '%s' has enabled the pushed authorization requests, "
-                                        + "and uses the client authentication method 'query'. Please set different"
-                                        + " client authentication method").formatted(tenantId);
-                                return Uni.createFrom().failure(new ConfigurationException(exceptionMessage));
-                            }
-                        }
-                        return OidcProviderClientImpl.of(client, vertx, metadata, oidcConfig, oidcRequestFilters,
-                                oidcResponseFilters);
-                    }
-
-                });
+                        });
     }
 
     private OidcConfigurationMetadata createLocalMetadata(OidcTenantConfig oidcConfig, String authServerUriString) {

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
@@ -86,6 +86,7 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
         CREDENTIALS_JWT_SIGNATURE_ALGORITHM,
         CREDENTIALS_JWT_LIFESPAN,
         CREDENTIALS_JWT_ASSERTION,
+        CREDENTIALS_FOR_ALL_ENDPOINTS,
         CREDENTIALS_JWT_AUDIENCE,
         CREDENTIALS_JWT_KEEP_AUDIENCE_TRAILING_SLASH,
         CREDENTIALS_JWT_TOKEN_ID,
@@ -1235,6 +1236,12 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
                         return false;
                     }
                 };
+            }
+
+            @Override
+            public boolean forAllEndpoints() {
+                invocationsRecorder.put(ConfigMappingMethods.CREDENTIALS_FOR_ALL_ENDPOINTS, true);
+                return false;
             }
         };
     }


### PR DESCRIPTION
* Closes: https://github.com/quarkusio/quarkus/issues/53943
* [Kubernetes Service Account Issuer Discovery](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-issuer-discovery) and JWKs endpoints are only accessible using tokens mounted to pod or SA tokens from external traffic. Some users just relax these rules, but we can support users that want to keep discovery/jwks secured.