### PR TITLE
Configure protostream annotation processor in infinispan-client codestarts

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle-kotlin-dsl/base/build-layout.include.qute
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle-kotlin-dsl/base/build-layout.include.qute
@@ -33,7 +33,7 @@ dependencies {
     implementation(enforcedPlatform("{it.groupId}:{it.artifactId}:{it.version}"))
     {/if}
 {/each}
-{#if input.selected-extensions-ga.contains('io.quarkus:quarkus-data-hibernate')}
+{#if input.selected-extensions-ga.contains('io.quarkus:quarkus-data-hibernate') || input.selected-extensions-ga.contains('io.quarkus:quarkus-infinispan-client')}
     annotationProcessor(enforcedPlatform("$\{quarkusPlatformGroupId}:$\{quarkusPlatformArtifactId}:$\{quarkusPlatformVersion}"))
 {/if}
 {#for dep in dependencies}
@@ -41,6 +41,9 @@ dependencies {
 {/for}
 {#if input.selected-extensions-ga.contains('io.quarkus:quarkus-data-hibernate')}
     annotationProcessor("org.hibernate.orm:hibernate-processor")
+{/if}
+{#if input.selected-extensions-ga.contains('io.quarkus:quarkus-infinispan-client')}
+    annotationProcessor("org.infinispan.protostream:protostream-processor")
 {/if}
     testImplementation("io.quarkus:quarkus-junit")
 {#for dep in test-dependencies}

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle/base/build-layout.include.qute
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle/base/build-layout.include.qute
@@ -29,7 +29,7 @@ dependencies {
     implementation enforcedPlatform('{it.groupId}:{it.artifactId}:{it.version}')
     {/if}
 {/each}
-{#if input.selected-extensions-ga.contains('io.quarkus:quarkus-data-hibernate')}
+{#if input.selected-extensions-ga.contains('io.quarkus:quarkus-data-hibernate') || input.selected-extensions-ga.contains('io.quarkus:quarkus-infinispan-client')}
     annotationProcessor enforcedPlatform("$\{quarkusPlatformGroupId}:$\{quarkusPlatformArtifactId}:$\{quarkusPlatformVersion}")
 {/if}
 {#for dep in dependencies}
@@ -37,6 +37,9 @@ dependencies {
 {/for}
 {#if input.selected-extensions-ga.contains('io.quarkus:quarkus-data-hibernate')}
     annotationProcessor 'org.hibernate.orm:hibernate-processor'
+{/if}
+{#if input.selected-extensions-ga.contains('io.quarkus:quarkus-infinispan-client')}
+    annotationProcessor 'org.infinispan.protostream:protostream-processor'
 {/if}
 {#if quarkus.version == null || quarkus.version.compareVersionTo("3.30.999") > 0}
     testImplementation 'io.quarkus:quarkus-junit'

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/maven/base/pom.tpl.qute.xml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/maven/base/pom.tpl.qute.xml
@@ -163,17 +163,25 @@
                 <configuration>
                     <parameters>true</parameters>
                 </configuration>
-                {#if input.selected-extensions-ga.contains('io.quarkus:quarkus-data-hibernate')}
+                {#if input.selected-extensions-ga.contains('io.quarkus:quarkus-data-hibernate') || input.selected-extensions-ga.contains('io.quarkus:quarkus-infinispan-client')}
                 <executions>
                     <execution>
                         <id>default-compile</id>
                         <configuration>
                             <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
                             <annotationProcessorPaths>
+                                {#if input.selected-extensions-ga.contains('io.quarkus:quarkus-data-hibernate')}
                                 <annotationProcessorPath>
                                     <groupId>org.hibernate.orm</groupId>
                                     <artifactId>hibernate-processor</artifactId>
                                 </annotationProcessorPath>
+                                {/if}
+                                {#if input.selected-extensions-ga.contains('io.quarkus:quarkus-infinispan-client')}
+                                <annotationProcessorPath>
+                                    <groupId>org.infinispan.protostream</groupId>
+                                    <artifactId>protostream-processor</artifactId>
+                                </annotationProcessorPath>
+                                {/if}
                             </annotationProcessorPaths>
                         </configuration>
                     </execution>

--- a/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/quarkus/InfinispanClientCodestartIT.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/quarkus/InfinispanClientCodestartIT.java
@@ -1,0 +1,75 @@
+package io.quarkus.devtools.codestarts.quarkus;
+
+import static io.quarkus.devtools.codestarts.quarkus.QuarkusCodestartCatalog.Language.JAVA;
+import static io.quarkus.devtools.codestarts.quarkus.QuarkusCodestartData.QuarkusDataKey.JAVA_VERSION;
+import static io.quarkus.devtools.testing.SnapshotTesting.checkContains;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.devtools.project.BuildTool;
+import io.quarkus.devtools.testing.codestarts.QuarkusCodestartTest;
+import io.quarkus.maven.dependency.ArtifactKey;
+
+public class InfinispanClientCodestartIT {
+
+    @RegisterExtension
+    public static QuarkusCodestartTest codestartMavenTest = QuarkusCodestartTest.builder()
+            .extension(ArtifactKey.ga("io.quarkus", "quarkus-infinispan-client"))
+            .putData(JAVA_VERSION, "25")
+            .languages(JAVA)
+            .build();
+
+    @RegisterExtension
+    public static QuarkusCodestartTest codestartGradleTest = QuarkusCodestartTest.builder()
+            .extension(ArtifactKey.ga("io.quarkus", "quarkus-infinispan-client"))
+            .putData(JAVA_VERSION, "25")
+            .buildTool(BuildTool.GRADLE)
+            .languages(JAVA)
+            .build();
+
+    @RegisterExtension
+    public static QuarkusCodestartTest codestartGradleKotlinTest = QuarkusCodestartTest.builder()
+            .extension(ArtifactKey.ga("io.quarkus", "quarkus-infinispan-client"))
+            .putData(JAVA_VERSION, "25")
+            .buildTool(BuildTool.GRADLE_KOTLIN_DSL)
+            .languages(JAVA)
+            .build();
+
+    @Test
+    void testMavenContent() throws Throwable {
+        codestartMavenTest.assertThatGeneratedFile(JAVA, "pom.xml")
+                .satisfies(checkContains("<maven.compiler.release>25</maven.compiler.release>"))
+                .satisfies(checkContains("<artifactId>protostream-processor</artifactId>"))
+                .satisfies(checkContains("<annotationProcessorPaths>"));
+    }
+
+    @Test
+    void testGradleContent() throws Throwable {
+        codestartGradleTest.assertThatGeneratedFile(JAVA, "build.gradle")
+                .satisfies(checkContains("JavaVersion.VERSION_25"))
+                .satisfies(checkContains("org.infinispan.protostream:protostream-processor"));
+    }
+
+    @Test
+    void testGradleKotlinContent() throws Throwable {
+        codestartGradleKotlinTest.assertThatGeneratedFile(JAVA, "build.gradle.kts")
+                .satisfies(checkContains("JavaVersion.VERSION_25"))
+                .satisfies(checkContains("org.infinispan.protostream:protostream-processor"));
+    }
+
+    @Test
+    void testMavenBuild() throws Throwable {
+        codestartMavenTest.buildAllProjects();
+    }
+
+    @Test
+    void testGradleBuild() throws Throwable {
+        codestartGradleTest.buildAllProjects();
+    }
+
+    @Test
+    void testGradleKotlinBuild() throws Throwable {
+        codestartGradleKotlinTest.buildAllProjects();
+    }
+}


### PR DESCRIPTION
Starting with Java 24, annotation processors must be declared explicitly.
Projects generated with `quarkus-infinispan-client` were missing the `protostream-processor`
in `annotationProcessorPaths` (Maven) and `annotationProcessor` (Gradle), causing compilation
failures on Java 24+. This PR adds a codestart for `quarkus-infinispan-client` — aligned with
the existing `hibernate-panache-next` approach — and includes integration tests covering Maven,
Gradle, and Gradle Kotlin DSL on Java 25.

- Fixes: #52284