### PR TITLE
Fix: quarkus.rest-client-oidc-filter.refresh-on-unauthorized not respected with multiple @RegisterProvider annotations

### DIFF
--- a/extensions/oidc-client-filter/deployment/src/main/java/io/quarkus/oidc/client/filter/deployment/OidcClientFilterBuildStep.java
+++ b/extensions/oidc-client-filter/deployment/src/main/java/io/quarkus/oidc/client/filter/deployment/OidcClientFilterBuildStep.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProviders;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
@@ -139,7 +140,8 @@ public class OidcClientFilterBuildStep {
     void registerDetectUnauthorizedResponseFilterForCustomFilters(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<RestClientPredicateProviderBuildItem> restPredicateProvider, CombinedIndexBuildItem indexBuildItem) {
         var annotatedRestClientNames = detectCustomFiltersThatRequireResponseFilter(AbstractOidcClientRequestFilter.class,
-                RegisterProvider.class, indexBuildItem.getIndex()).stream().map(ClassInfo::name).toList();
+                RegisterProvider.class, RegisterProviders.class, indexBuildItem.getIndex()).stream().map(ClassInfo::name)
+                .toList();
         boolean detectionEnabledForCustomFilters = !annotatedRestClientNames.isEmpty();
         if (detectionEnabledForCustomFilters) {
             // test whether the provider should be added restClientClassInfo

--- a/extensions/oidc-client-reactive-filter/deployment/src/main/java/io/quarkus/oidc/client/reactive/filter/deployment/OidcClientReactiveFilterBuildStep.java
+++ b/extensions/oidc-client-reactive-filter/deployment/src/main/java/io/quarkus/oidc/client/reactive/filter/deployment/OidcClientReactiveFilterBuildStep.java
@@ -10,6 +10,7 @@ import java.util.List;
 import jakarta.ws.rs.Priorities;
 
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProviders;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.DotName;
@@ -99,7 +100,8 @@ public class OidcClientReactiveFilterBuildStep {
     void registerDetectUnauthorizedResponseFilterForCustomFilters(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<RegisterProviderAnnotationInstanceBuildItem> producer, CombinedIndexBuildItem indexBuildItem) {
         var annotatedRestClientNames = detectCustomFiltersThatRequireResponseFilter(
-                AbstractOidcClientRequestReactiveFilter.class, RegisterProvider.class, indexBuildItem.getIndex());
+                AbstractOidcClientRequestReactiveFilter.class, RegisterProvider.class, RegisterProviders.class,
+                indexBuildItem.getIndex());
         boolean detectionEnabledForCustomFilters = !annotatedRestClientNames.isEmpty();
         if (detectionEnabledForCustomFilters) {
             // client filter responsibility must be the other way around for response because

--- a/extensions/oidc-client-reactive-filter/deployment/src/test/java/io/quarkus/oidc/client/reactive/filter/AbstractRevokedAccessTokenDevModeTest.java
+++ b/extensions/oidc-client-reactive-filter/deployment/src/test/java/io/quarkus/oidc/client/reactive/filter/AbstractRevokedAccessTokenDevModeTest.java
@@ -174,6 +174,8 @@ public abstract class AbstractRevokedAccessTokenDevModeTest {
                 case DEFAULT_CLIENT -> myDefaultClient().revokeAccessTokenAndRespond(named);
                 case DEFAULT_CLIENT_WITHOUT_REFRESH -> myDefaultClientWithoutRefresh().revokeAccessTokenAndRespond(named);
                 case NAMED_CLIENT_WITHOUT_REFRESH -> myNamedClientWithoutRefresh().revokeAccessTokenAndRespond(named);
+                case DEFAULT_CLIENT_MULTIPLE_PROVIDERS -> myDefaultClientMultipleProviders().revokeAccessTokenAndRespond(named);
+                case NAMED_CLIENT_MULTIPLE_PROVIDERS -> myNamedClientMultipleProviders().revokeAccessTokenAndRespond(named);
                 // calls the same endpoint as ones above, however with filter applied on individual RESTEasy client methods
                 case NAMED_CLIENT_ANNOTATION_ON_METHOD -> myNamedClient_AnnotationOnMethod(named);
                 case DEFAULT_CLIENT_ANNOTATION_ON_METHOD -> myDefaultClient_AnnotationOnMethod(named);
@@ -190,6 +192,14 @@ public abstract class AbstractRevokedAccessTokenDevModeTest {
         protected abstract MyClient myDefaultClientWithoutRefresh();
 
         protected abstract MyClient myNamedClientWithoutRefresh();
+
+        protected MyClient myDefaultClientMultipleProviders() {
+            return null;
+        }
+
+        protected MyClient myNamedClientMultipleProviders() {
+            return null;
+        }
 
         protected String myDefaultClient_AnnotationOnMethod(String named) {
             return null;
@@ -234,6 +244,8 @@ public abstract class AbstractRevokedAccessTokenDevModeTest {
         NAMED_CLIENT_ANNOTATION_ON_METHOD(true),
         NAMED_CLIENT_MULTIPLE_METHODS(true),
         DEFAULT_CLIENT_MULTIPLE_METHODS(false),
+        DEFAULT_CLIENT_MULTIPLE_PROVIDERS(true),
+        NAMED_CLIENT_MULTIPLE_PROVIDERS(true),
         NO_ACCESS_TOKEN(false);
 
         public final boolean named;

--- a/extensions/oidc-client-reactive-filter/deployment/src/test/java/io/quarkus/oidc/client/reactive/filter/OidcClientRequestFilterRevokedTokenDevModeTest.java
+++ b/extensions/oidc-client-reactive-filter/deployment/src/test/java/io/quarkus/oidc/client/reactive/filter/OidcClientRequestFilterRevokedTokenDevModeTest.java
@@ -5,8 +5,11 @@ import java.util.Optional;
 import jakarta.annotation.Priority;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
 
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.jupiter.api.Test;
@@ -21,19 +24,28 @@ import io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManager;
 public class OidcClientRequestFilterRevokedTokenDevModeTest extends AbstractRevokedAccessTokenDevModeTest {
 
     @RegisterExtension
-    static final QuarkusDevModeTest test = createQuarkusDevModeTest("", MyDefaultClient.class, MyNamedClient.class,
+    static final QuarkusDevModeTest test = createQuarkusDevModeTest(
+            """
+                    %s/mp-rest/url=http://localhost:${quarkus.http.port}
+                    %s/mp-rest/url=http://localhost:${quarkus.http.port}
+                    """.formatted(MyDefaultClientMultipleProviders.class.getName(),
+                    MyNamedClientMultipleProviders.class.getName()),
+            MyDefaultClient.class, MyNamedClient.class,
             MyNamedClientWithoutRefresh.class, MyDefaultClientWithoutRefresh.class, MyClientResourceImpl.class,
             DefaultClientRefreshEnabled.class, NamedClientRefreshEnabled.class, DefaultClientRefreshDisabled.class,
-            NamedClientRefreshDisabled.class);
+            NamedClientRefreshDisabled.class, MyClientExceptionMapper.class, MyDefaultClientMultipleProviders.class,
+            MyNamedClientMultipleProviders.class);
 
     @Test
     void verifyDefaultClientHasTokenRefreshedOn401() {
         verifyTokenRefreshedOn401(MyClientCategory.DEFAULT_CLIENT);
+        verifyTokenRefreshedOn401(MyClientCategory.DEFAULT_CLIENT_MULTIPLE_PROVIDERS);
     }
 
     @Test
     void verifyNamedClientHasTokenRefreshedOn401() {
         verifyTokenRefreshedOn401(MyClientCategory.NAMED_CLIENT);
+        verifyTokenRefreshedOn401(MyClientCategory.NAMED_CLIENT_MULTIPLE_PROVIDERS);
     }
 
     @RegisterRestClient
@@ -97,6 +109,32 @@ public class OidcClientRequestFilterRevokedTokenDevModeTest extends AbstractRevo
         }
     }
 
+    @RegisterRestClient
+    @RegisterProvider(value = DefaultClientRefreshEnabled.class)
+    @RegisterProvider(value = MyClientExceptionMapper.class)
+    @Path(MY_SERVER_RESOURCE_PATH)
+    public interface MyDefaultClientMultipleProviders extends MyClient {
+    }
+
+    @RegisterRestClient
+    @RegisterProvider(value = NamedClientRefreshEnabled.class)
+    @RegisterProvider(value = MyClientExceptionMapper.class)
+    @Path(MY_SERVER_RESOURCE_PATH)
+    public interface MyNamedClientMultipleProviders extends MyClient {
+    }
+
+    public static class MyClientExceptionMapper implements ResponseExceptionMapper<RuntimeException> {
+        @Override
+        public boolean handles(int status, MultivaluedMap<String, Object> headers) {
+            return status == 500;
+        }
+
+        @Override
+        public RuntimeException toThrowable(Response response) {
+            return new RuntimeException("Error");
+        }
+    }
+
     @Path(MY_CLIENT_RESOURCE_PATH)
     public static class MyClientResourceImpl extends MyClientResource {
 
@@ -104,14 +142,20 @@ public class OidcClientRequestFilterRevokedTokenDevModeTest extends AbstractRevo
         private final MyNamedClient myNamedClient;
         private final MyDefaultClientWithoutRefresh myDefaultClientWithoutRefresh;
         private final MyNamedClientWithoutRefresh myNamedClientWithoutRefresh;
+        private final MyDefaultClientMultipleProviders myDefaultClientMultipleProviders;
+        private final MyNamedClientMultipleProviders myNamedClientMultipleProviders;
 
         public MyClientResourceImpl(@RestClient MyDefaultClient myDefaultClient, @RestClient MyNamedClient myNamedClient,
                 @RestClient MyDefaultClientWithoutRefresh myDefaultClientWithoutRefresh,
-                @RestClient MyNamedClientWithoutRefresh myNamedClientWithoutRefresh) {
+                @RestClient MyNamedClientWithoutRefresh myNamedClientWithoutRefresh,
+                @RestClient MyDefaultClientMultipleProviders myDefaultClientMultipleProviders,
+                @RestClient MyNamedClientMultipleProviders myNamedClientMultipleProviders) {
             this.myDefaultClient = myDefaultClient;
             this.myNamedClient = myNamedClient;
             this.myDefaultClientWithoutRefresh = myDefaultClientWithoutRefresh;
             this.myNamedClientWithoutRefresh = myNamedClientWithoutRefresh;
+            this.myDefaultClientMultipleProviders = myDefaultClientMultipleProviders;
+            this.myNamedClientMultipleProviders = myNamedClientMultipleProviders;
         }
 
         @Override
@@ -132,6 +176,16 @@ public class OidcClientRequestFilterRevokedTokenDevModeTest extends AbstractRevo
         @Override
         protected MyClient myNamedClientWithoutRefresh() {
             return myNamedClientWithoutRefresh;
+        }
+
+        @Override
+        protected MyClient myDefaultClientMultipleProviders() {
+            return myDefaultClientMultipleProviders;
+        }
+
+        @Override
+        protected MyClient myNamedClientMultipleProviders() {
+            return myNamedClientMultipleProviders;
         }
     }
 

--- a/extensions/oidc-client/deployment/src/main/java/io/quarkus/oidc/client/deployment/OidcClientFilterDeploymentHelper.java
+++ b/extensions/oidc-client/deployment/src/main/java/io/quarkus/oidc/client/deployment/OidcClientFilterDeploymentHelper.java
@@ -3,6 +3,7 @@ package io.quarkus.oidc.client.deployment;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -208,7 +209,7 @@ public class OidcClientFilterDeploymentHelper<T extends AbstractTokensProducer> 
     }
 
     public static List<ClassInfo> detectCustomFiltersThatRequireResponseFilter(Class<?> abstractFilterClass,
-            Class<?> registerProviderClass, IndexView index) {
+            Class<?> registerProviderClass, Class<?> registerProvidersClass, IndexView index) {
         List<ClassInfo> result = new ArrayList<>();
         for (ClassInfo subClass : index.getKnownDirectSubclasses(abstractFilterClass)) {
             if (!subClass.isInterface() && !subClass.isAbstract()) {
@@ -224,6 +225,13 @@ public class OidcClientFilterDeploymentHelper<T extends AbstractTokensProducer> 
                                 .filter(ai -> ai.target().kind() == AnnotationTarget.Kind.CLASS)
                                 .map(ai -> ai.target().asClass())
                                 .toList());
+                        result.addAll(index
+                                .getAnnotations(registerProvidersClass).stream()
+                                .filter(ai -> ai.value() != null)
+                                .filter(ai -> registersDeclaringClass(ai, declaringClassName))
+                                .filter(ai -> ai.target().kind() == AnnotationTarget.Kind.CLASS)
+                                .map(ai -> ai.target().asClass())
+                                .toList());
                     }
                 }
             }
@@ -234,5 +242,10 @@ public class OidcClientFilterDeploymentHelper<T extends AbstractTokensProducer> 
     private static void throwBothMethodAndClassAnnotated(AnnotationInstance instance) {
         throw new RuntimeException(OidcClientFilter.class.getName() + " annotation can be applied either on class "
                 + getTargetRestClient(instance) + " or its methods");
+    }
+
+    private static boolean registersDeclaringClass(AnnotationInstance ai, DotName declaringClassName) {
+        return Arrays.stream(ai.value().asNestedArray())
+                .anyMatch(nestedAi -> nestedAi.value().asClass().name().equals(declaringClassName));
     }
 }


### PR DESCRIPTION
When multiple `@RegisterProvider `annotations are added to a rest client, they are indexed as a `@RegisterProviders` annotation instead of a `@RegisterProvider `annotation instance. This PR also considers the `@RegisterProviders` annotation instances so the `quarkus.rest-client-oidc-filter.refresh-on-unauthorized` property would be respected on clients with multiple `@RegisterProvider` annotations.

* Fixes #54281 

