### PR TITLE
Remove unused marked and dompurify libraries from Dev UI BOM

### DIFF
--- a/bom/dev-ui/pom.xml
+++ b/bom/dev-ui/pom.xml
@@ -28,7 +28,6 @@
         <shadycss.version>1.11.2</shadycss.version>
         <dedupe-mixin.version>1.4.0</dedupe-mixin.version>
         <style-observer.version>0.1.2</style-observer.version>
-        <dompurify.version>3.2.7</dompurify.version>
         <vaadin-router.version>2.0.1</vaadin-router.version>
         <lit-state.version>1.7.0</lit-state.version>
         <echarts.version>6.0.0</echarts.version>
@@ -130,12 +129,6 @@
                 <groupId>org.mvnpm</groupId>
                 <artifactId>style-observer</artifactId>
                 <version>${style-observer.version}</version>
-                <scope>runtime</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.mvnpm</groupId>
-                <artifactId>dompurify</artifactId>
-                <version>${dompurify.version}</version>
                 <scope>runtime</scope>
             </dependency>
             

--- a/bom/dev-ui/pom.xml
+++ b/bom/dev-ui/pom.xml
@@ -28,7 +28,6 @@
         <shadycss.version>1.11.2</shadycss.version>
         <dedupe-mixin.version>1.4.0</dedupe-mixin.version>
         <style-observer.version>0.1.2</style-observer.version>
-        <marked.version>17.0.5</marked.version>
         <dompurify.version>3.2.7</dompurify.version>
         <vaadin-router.version>2.0.1</vaadin-router.version>
         <lit-state.version>1.7.0</lit-state.version>
@@ -131,12 +130,6 @@
                 <groupId>org.mvnpm</groupId>
                 <artifactId>style-observer</artifactId>
                 <version>${style-observer.version}</version>
-                <scope>runtime</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.mvnpm</groupId>
-                <artifactId>marked</artifactId>
-                <version>${marked.version}</version>
                 <scope>runtime</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Both `marked` (markdown parser) and `dompurify` (HTML sanitizer) are declared in the Dev UI BOM but not used anywhere in Quarkus core or Quarkiverse. Dev UI uses `markdown-it` for markdown rendering instead.

This removes both unused dependencies and their version properties from `bom/dev-ui/pom.xml`.