### PR TITLE
Allow Dev UI to work with Amazon Lambda HTTP extensions in dev mode

### DIFF
--- a/extensions/amazon-lambda-http/deployment/pom.xml
+++ b/extensions/amazon-lambda-http/deployment/pom.xml
@@ -43,6 +43,17 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-server-spi-deployment</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
       <resources>

--- a/extensions/amazon-lambda-http/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
+++ b/extensions/amazon-lambda-http/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
@@ -25,11 +25,13 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.AdditionalIndexedClassesBuildItem;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
 import io.quarkus.resteasy.reactive.server.spi.ContextTypeBuildItem;
+import io.quarkus.runtime.LaunchMode;
 import io.quarkus.vertx.http.deployment.RequireVirtualHttpBuildItem;
 
 public class AmazonLambdaHttpProcessor {
@@ -67,8 +69,12 @@ public class AmazonLambdaHttpProcessor {
     }
 
     @BuildStep
-    public RequireVirtualHttpBuildItem requestVirtualHttp() {
-        return RequireVirtualHttpBuildItem.ALWAYS_VIRTUAL;
+    public RequireVirtualHttpBuildItem requestVirtualHttp(LaunchModeBuildItem launchMode) {
+        // In dev mode, allow the real HTTP socket to start alongside the virtual channel
+        // so that Dev UI and other non-application routes are accessible
+        return launchMode.getLaunchMode() == LaunchMode.DEVELOPMENT
+                ? RequireVirtualHttpBuildItem.MARKER
+                : RequireVirtualHttpBuildItem.ALWAYS_VIRTUAL;
     }
 
     @BuildStep

--- a/extensions/amazon-lambda-http/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/DevServicesHttpLambdaProcessor.java
+++ b/extensions/amazon-lambda-http/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/DevServicesHttpLambdaProcessor.java
@@ -1,8 +1,12 @@
 package io.quarkus.amazon.lambda.http.deployment;
 
 import io.quarkus.amazon.lambda.deployment.EventServerOverrideBuildItem;
+import io.quarkus.amazon.lambda.deployment.EventServerPortOverrideBuildItem;
 import io.quarkus.amazon.lambda.runtime.MockHttpEventServer;
+import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.runtime.LaunchMode;
 
 public class DevServicesHttpLambdaProcessor {
 
@@ -10,5 +14,15 @@ public class DevServicesHttpLambdaProcessor {
     public EventServerOverrideBuildItem overrideEventServer() {
         return new EventServerOverrideBuildItem(
                 () -> new MockHttpEventServer());
+    }
+
+    @BuildStep
+    void adjustEventServerPortForDevMode(LaunchModeBuildItem launchMode,
+            BuildProducer<EventServerPortOverrideBuildItem> portOverride) {
+        if (launchMode.getLaunchMode() == LaunchMode.DEVELOPMENT) {
+            // In dev mode, the real Vert.x HTTP server starts on the default port (for Dev UI),
+            // so the mock event server must use an ephemeral port to avoid conflict
+            portOverride.produce(new EventServerPortOverrideBuildItem(0));
+        }
     }
 }

--- a/extensions/amazon-lambda-http/deployment/src/test/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessorTest.java
+++ b/extensions/amazon-lambda-http/deployment/src/test/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessorTest.java
@@ -1,0 +1,50 @@
+package io.quarkus.amazon.lambda.http.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.runtime.LaunchMode;
+import io.quarkus.vertx.http.deployment.RequireVirtualHttpBuildItem;
+
+class AmazonLambdaHttpProcessorTest {
+
+    @Test
+    void devModeShouldReturnMarkerToAllowRealHttpSocket() {
+        AmazonLambdaHttpProcessor processor = new AmazonLambdaHttpProcessor();
+        LaunchModeBuildItem devMode = new LaunchModeBuildItem(
+                LaunchMode.DEVELOPMENT, Optional.empty(), false, Optional.empty(), false);
+
+        RequireVirtualHttpBuildItem result = processor.requestVirtualHttp(devMode);
+
+        assertThat(result).isSameAs(RequireVirtualHttpBuildItem.MARKER);
+        assertThat(result.isAlwaysVirtual()).isFalse();
+    }
+
+    @Test
+    void testModeShouldReturnAlwaysVirtual() {
+        AmazonLambdaHttpProcessor processor = new AmazonLambdaHttpProcessor();
+        LaunchModeBuildItem testMode = new LaunchModeBuildItem(
+                LaunchMode.TEST, Optional.empty(), false, Optional.empty(), true);
+
+        RequireVirtualHttpBuildItem result = processor.requestVirtualHttp(testMode);
+
+        assertThat(result).isSameAs(RequireVirtualHttpBuildItem.ALWAYS_VIRTUAL);
+        assertThat(result.isAlwaysVirtual()).isTrue();
+    }
+
+    @Test
+    void productionModeShouldReturnAlwaysVirtual() {
+        AmazonLambdaHttpProcessor processor = new AmazonLambdaHttpProcessor();
+        LaunchModeBuildItem prodMode = new LaunchModeBuildItem(
+                LaunchMode.NORMAL, Optional.empty(), false, Optional.empty(), false);
+
+        RequireVirtualHttpBuildItem result = processor.requestVirtualHttp(prodMode);
+
+        assertThat(result).isSameAs(RequireVirtualHttpBuildItem.ALWAYS_VIRTUAL);
+        assertThat(result.isAlwaysVirtual()).isTrue();
+    }
+}

--- a/extensions/amazon-lambda-rest/deployment/pom.xml
+++ b/extensions/amazon-lambda-rest/deployment/pom.xml
@@ -43,6 +43,17 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-server-spi-deployment</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
       <resources>

--- a/extensions/amazon-lambda-rest/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
+++ b/extensions/amazon-lambda-rest/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
@@ -29,11 +29,13 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.AdditionalIndexedClassesBuildItem;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
 import io.quarkus.resteasy.reactive.server.spi.ContextTypeBuildItem;
+import io.quarkus.runtime.LaunchMode;
 import io.quarkus.vertx.http.deployment.RequireVirtualHttpBuildItem;
 
 public class AmazonLambdaHttpProcessor {
@@ -67,8 +69,12 @@ public class AmazonLambdaHttpProcessor {
     }
 
     @BuildStep
-    public RequireVirtualHttpBuildItem requestVirtualHttp() {
-        return RequireVirtualHttpBuildItem.ALWAYS_VIRTUAL;
+    public RequireVirtualHttpBuildItem requestVirtualHttp(LaunchModeBuildItem launchMode) {
+        // In dev mode, allow the real HTTP socket to start alongside the virtual channel
+        // so that Dev UI and other non-application routes are accessible
+        return launchMode.getLaunchMode() == LaunchMode.DEVELOPMENT
+                ? RequireVirtualHttpBuildItem.MARKER
+                : RequireVirtualHttpBuildItem.ALWAYS_VIRTUAL;
     }
 
     @BuildStep

--- a/extensions/amazon-lambda-rest/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/DevServicesRestLambdaProcessor.java
+++ b/extensions/amazon-lambda-rest/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/DevServicesRestLambdaProcessor.java
@@ -1,8 +1,12 @@
 package io.quarkus.amazon.lambda.http.deployment;
 
 import io.quarkus.amazon.lambda.deployment.EventServerOverrideBuildItem;
+import io.quarkus.amazon.lambda.deployment.EventServerPortOverrideBuildItem;
 import io.quarkus.amazon.lambda.runtime.MockRestEventServer;
+import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.runtime.LaunchMode;
 
 public class DevServicesRestLambdaProcessor {
 
@@ -10,5 +14,15 @@ public class DevServicesRestLambdaProcessor {
     public EventServerOverrideBuildItem overrideEventServer() {
         return new EventServerOverrideBuildItem(
                 () -> new MockRestEventServer());
+    }
+
+    @BuildStep
+    void adjustEventServerPortForDevMode(LaunchModeBuildItem launchMode,
+            BuildProducer<EventServerPortOverrideBuildItem> portOverride) {
+        if (launchMode.getLaunchMode() == LaunchMode.DEVELOPMENT) {
+            // In dev mode, the real Vert.x HTTP server starts on the default port (for Dev UI),
+            // so the mock event server must use an ephemeral port to avoid conflict
+            portOverride.produce(new EventServerPortOverrideBuildItem(0));
+        }
     }
 }

--- a/extensions/amazon-lambda-rest/deployment/src/test/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessorTest.java
+++ b/extensions/amazon-lambda-rest/deployment/src/test/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessorTest.java
@@ -1,0 +1,50 @@
+package io.quarkus.amazon.lambda.http.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.runtime.LaunchMode;
+import io.quarkus.vertx.http.deployment.RequireVirtualHttpBuildItem;
+
+class AmazonLambdaHttpProcessorTest {
+
+    @Test
+    void devModeShouldReturnMarkerToAllowRealHttpSocket() {
+        AmazonLambdaHttpProcessor processor = new AmazonLambdaHttpProcessor();
+        LaunchModeBuildItem devMode = new LaunchModeBuildItem(
+                LaunchMode.DEVELOPMENT, Optional.empty(), false, Optional.empty(), false);
+
+        RequireVirtualHttpBuildItem result = processor.requestVirtualHttp(devMode);
+
+        assertThat(result).isSameAs(RequireVirtualHttpBuildItem.MARKER);
+        assertThat(result.isAlwaysVirtual()).isFalse();
+    }
+
+    @Test
+    void testModeShouldReturnAlwaysVirtual() {
+        AmazonLambdaHttpProcessor processor = new AmazonLambdaHttpProcessor();
+        LaunchModeBuildItem testMode = new LaunchModeBuildItem(
+                LaunchMode.TEST, Optional.empty(), false, Optional.empty(), true);
+
+        RequireVirtualHttpBuildItem result = processor.requestVirtualHttp(testMode);
+
+        assertThat(result).isSameAs(RequireVirtualHttpBuildItem.ALWAYS_VIRTUAL);
+        assertThat(result.isAlwaysVirtual()).isTrue();
+    }
+
+    @Test
+    void productionModeShouldReturnAlwaysVirtual() {
+        AmazonLambdaHttpProcessor processor = new AmazonLambdaHttpProcessor();
+        LaunchModeBuildItem prodMode = new LaunchModeBuildItem(
+                LaunchMode.NORMAL, Optional.empty(), false, Optional.empty(), false);
+
+        RequireVirtualHttpBuildItem result = processor.requestVirtualHttp(prodMode);
+
+        assertThat(result).isSameAs(RequireVirtualHttpBuildItem.ALWAYS_VIRTUAL);
+        assertThat(result.isAlwaysVirtual()).isTrue();
+    }
+}

--- a/extensions/amazon-lambda/common-deployment/src/main/java/io/quarkus/amazon/lambda/deployment/DevServicesLambdaProcessor.java
+++ b/extensions/amazon-lambda/common-deployment/src/main/java/io/quarkus/amazon/lambda/deployment/DevServicesLambdaProcessor.java
@@ -56,6 +56,7 @@ public class DevServicesLambdaProcessor {
     public void startEventServer(LaunchModeBuildItem launchModeBuildItem,
             LambdaBuildConfig config,
             Optional<EventServerOverrideBuildItem> override,
+            Optional<EventServerPortOverrideBuildItem> portOverride,
             BuildProducer<DevServicesResultBuildItem> devServicePropertiesProducer) {
         LaunchMode launchMode = launchModeBuildItem.getLaunchMode();
         if (!launchMode.isDevOrTest())
@@ -77,12 +78,14 @@ public class DevServicesLambdaProcessor {
         String portPropertySuffix = isTest ? "test-port" : "dev-port";
         String propName = "quarkus.lambda.mock-event-server." + portPropertySuffix;
 
+        int overridePort = portOverride.map(EventServerPortOverrideBuildItem::getPort).orElse(Integer.MIN_VALUE);
+
         // No compose support, and no using of external services, so no need to discover existing services
 
         DevServicesResultBuildItem buildItem = DevServicesResultBuildItem.owned().feature(Feature.AMAZON_LAMBDA)
                 .serviceName(Feature.AMAZON_LAMBDA.getName())
                 .serviceConfig(config)
-                .startable(() -> new StartableEventServer(server, propName, isTest))
+                .startable(() -> new StartableEventServer(server, propName, isTest, overridePort))
                 .highPriorityConfig(Set.of(propName)) // Pass through the external config for the port, so that it can be overridden if it's an ephemeral port
                 .configProvider(
                         Map.of(propName, s -> String.valueOf(s.getExposedPort()),
@@ -98,25 +101,32 @@ public class DevServicesLambdaProcessor {
         private final MockEventServer server;
         private final String propName;
         private final boolean isTest;
+        private final int overridePort;
 
-        public StartableEventServer(MockEventServer server, String propName, boolean isTest) {
+        public StartableEventServer(MockEventServer server, String propName, boolean isTest, int overridePort) {
             this.server = server;
             this.propName = propName;
             this.isTest = isTest;
+            this.overridePort = overridePort;
         }
 
         @Override
         public void start() {
             // Technically, we shouldn't peek at the runtime config, but every dev service does it
             // However, we won't get defaults, so we need to fill our own in
-            int port = isTest ? Integer.parseInt(MockEventServerConfig.TEST_PORT)
-                    : Integer.parseInt(MockEventServerConfig.DEV_PORT);
+            int port;
+            if (overridePort >= 0) {
+                port = overridePort;
+            } else {
+                port = isTest ? Integer.parseInt(MockEventServerConfig.TEST_PORT)
+                        : Integer.parseInt(MockEventServerConfig.DEV_PORT);
+            }
             int configuredPort = ConfigProvider.getConfig().getOptionalValue(propName, Integer.class)
                     .or(() -> Optional.of(port))
                     .get();
 
             server.start(configuredPort);
-            log.debugf("Starting event server on port %d", configuredPort);
+            log.debugf("Started event server on port %d", server.getPort());
         }
 
         public int getExposedPort() {

--- a/extensions/amazon-lambda/common-deployment/src/main/java/io/quarkus/amazon/lambda/deployment/EventServerPortOverrideBuildItem.java
+++ b/extensions/amazon-lambda/common-deployment/src/main/java/io/quarkus/amazon/lambda/deployment/EventServerPortOverrideBuildItem.java
@@ -1,0 +1,21 @@
+package io.quarkus.amazon.lambda.deployment;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * Allows extensions to override the default mock event server port.
+ * Used by amazon-lambda-http and amazon-lambda-rest to avoid port conflicts
+ * when the real Vert.x HTTP server also starts in dev mode.
+ */
+public final class EventServerPortOverrideBuildItem extends SimpleBuildItem {
+
+    private final int port;
+
+    public EventServerPortOverrideBuildItem(int port) {
+        this.port = port;
+    }
+
+    public int getPort() {
+        return port;
+    }
+}


### PR DESCRIPTION
Both `amazon-lambda-http` and `amazon-lambda-rest` unconditionally returned `RequireVirtualHttpBuildItem.ALWAYS_VIRTUAL`, which prevented the real Vert.x HTTP server from starting — even in dev mode. Since Dev UI is served by the Vert.x HTTP server, it was completely inaccessible. Worse, attempting to load Dev UI would jam the Lambda event queue and break all subsequent REST requests.

In dev mode, the `requestVirtualHttp()` build step now returns `MARKER` instead of `ALWAYS_VIRTUAL`. This starts both the virtual HTTP channel (needed by the Lambda handler) and the real Vert.x HTTP socket (needed by Dev UI). To avoid a port conflict between the Vert.x server and the mock Lambda event server (both defaulting to port 8080), a new `EventServerPortOverrideBuildItem` tells the event server to use an ephemeral port in dev mode. Test mode and production mode are unchanged.

This is the same pattern already used by the Google Cloud Functions HTTP and Azure Functions HTTP extensions, which conditionally return `MARKER` (or `null`) in non-production modes — see `GoogleCloudFunctionsHttpProcessor.requestVirtualHttp()` and `AzureFunctionsHttpProcessor.requestVirtualHttp()`.

Dev mode after the fix:
- Vert.x HTTP server on port 8080 — serves Dev UI, REST endpoints, and all non-application routes
- Mock event server on an auto-assigned port — serves the `/_lambda_` test API

------

- Fixes: #34285