### PR TITLE
Use JFR events to trace the shutdown sequence

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/ShutdownContext.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ShutdownContext.java
@@ -37,5 +37,9 @@ public interface ShutdownContext {
                 log.error("Failed to close " + closeable, e);
             }
         }
+
+        public String getShutdownInfo() {
+            return closeable.getClass().getName();
+        }
     }
 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/StartupContext.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/StartupContext.java
@@ -9,6 +9,8 @@ import java.util.function.Supplier;
 
 import org.jboss.logging.Logger;
 
+import io.quarkus.runtime.shutdown.ShutdownAction;
+
 public class StartupContext implements Closeable {
 
     public static final String RAW_COMMAND_LINE_ARGS = StartupContext.class.getName() + ".raw-command-line-args";
@@ -67,16 +69,22 @@ public class StartupContext implements Closeable {
 
     @Override
     public void close() {
-        runAllAndClear(shutdownTasks);
-        runAllAndClear(lastShutdownTasks);
+        runAllAndClear(shutdownTasks, ShutdownAction.SHUTDOWN_TASK);
+        runAllAndClear(lastShutdownTasks, ShutdownAction.LAST_SHUTDOWN_TASK);
         values.clear();
     }
 
-    private void runAllAndClear(Deque<Runnable> tasks) {
+    private void runAllAndClear(Deque<Runnable> tasks, ShutdownAction action) {
         while (!tasks.isEmpty()) {
             try {
                 var runnable = tasks.remove();
-                runnable.run();
+                Object info;
+                if (runnable instanceof ShutdownContext.CloseRunnable cr) {
+                    info = cr.getShutdownInfo();
+                } else {
+                    info = runnable.getClass().getName();
+                }
+                action.run(info, runnable);
             } catch (Throwable ex) {
                 LOG.error("Running a shutdown task failed", ex);
             }

--- a/core/runtime/src/main/java/io/quarkus/runtime/shutdown/ShutdownAction.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/shutdown/ShutdownAction.java
@@ -1,0 +1,37 @@
+package io.quarkus.runtime.shutdown;
+
+/**
+ * Represents a type of action executed during the Quarkus shutdown sequence.
+ * Each action is traced with a JFR {@link ShutdownActionEvent}.
+ *
+ * @see ShutdownActionEvent
+ */
+public enum ShutdownAction {
+
+    SHUTDOWN_LISTENER_PRESHUTDOWN,
+    SHUTDOWN_LISTENER_SHUTDOWN,
+    SHUTDOWN_TASK,
+    LAST_SHUTDOWN_TASK;
+
+    /**
+     * Runs the given action and emits a JFR event with this action type and the provided info.
+     *
+     * @param info additional information about the action, e.g. the class name of the shutdown handler
+     * @param action the action to execute
+     */
+    public void run(Object info, Runnable action) {
+        ShutdownActionEvent event = new ShutdownActionEvent();
+        event.begin();
+        try {
+            action.run();
+        } finally {
+            event.end();
+            if (event.shouldCommit()) {
+                event.actionType = name();
+                event.info = info != null ? info.toString() : null;
+                event.commit();
+            }
+        }
+    }
+
+}

--- a/core/runtime/src/main/java/io/quarkus/runtime/shutdown/ShutdownActionEvent.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/shutdown/ShutdownActionEvent.java
@@ -1,0 +1,23 @@
+package io.quarkus.runtime.shutdown;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.StackTrace;
+
+@Label("Shutdown Action")
+@Category({ "Quarkus", "Shutdown" })
+@Name("quarkus.ShutdownAction")
+@Description("An action executed during Quarkus shutdown sequence")
+@StackTrace(false)
+public class ShutdownActionEvent extends Event {
+
+    @Label("Action Type")
+    public String actionType;
+
+    @Label("Info")
+    public String info;
+
+}

--- a/core/runtime/src/main/java/io/quarkus/runtime/shutdown/ShutdownRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/shutdown/ShutdownRecorder.java
@@ -48,7 +48,12 @@ public class ShutdownRecorder {
     private static void executePreShutdown() throws InterruptedException {
         CountDownLatch preShutdown = new CountDownLatch(shutdownListeners.size());
         for (ShutdownListener i : shutdownListeners) {
-            i.preShutdown(new LatchShutdownNotification(preShutdown));
+            ShutdownAction.SHUTDOWN_LISTENER_PRESHUTDOWN.run(i.getClass().getName(), new Runnable() {
+                @Override
+                public void run() {
+                    i.preShutdown(new LatchShutdownNotification(preShutdown));
+                }
+            });
         }
         preShutdown.await();
     }
@@ -66,7 +71,12 @@ public class ShutdownRecorder {
     private static void executeShutdown() throws InterruptedException {
         CountDownLatch shutdown = new CountDownLatch(shutdownListeners.size());
         for (ShutdownListener i : shutdownListeners) {
-            i.shutdown(new LatchShutdownNotification(shutdown));
+            ShutdownAction.SHUTDOWN_LISTENER_SHUTDOWN.run(i.getClass().getName(), new Runnable() {
+                @Override
+                public void run() {
+                    i.shutdown(new LatchShutdownNotification(shutdown));
+                }
+            });
         }
         if (shutdownConfig.getValue().isTimeoutEnabled()
                 && !shutdown.await(shutdownConfig.getValue().timeout().get().toMillis(), TimeUnit.MILLISECONDS)) {

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AbstractSharedContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AbstractSharedContext.java
@@ -4,6 +4,7 @@ import java.util.*;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.spi.Contextual;
 import jakarta.enterprise.context.spi.CreationalContext;
 
@@ -93,15 +94,35 @@ abstract class AbstractSharedContext implements InjectableContext, InjectableCon
         // Destroy the producers first
         for (Iterator<ContextInstanceHandle<?>> it = values.iterator(); it.hasNext();) {
             ContextInstanceHandle<?> instanceHandle = it.next();
+            InjectableBean<?> bean = instanceHandle.getBean();
             if (instanceHandle.getBean().getDeclaringBean() != null) {
-                instanceHandle.destroy();
+                String beanInfo = bean.getDeclaringBean().getBeanClass().getName();
+                actionType(bean).run(beanInfo, new Runnable() {
+                    @Override
+                    public void run() {
+                        instanceHandle.destroy();
+                    }
+                });
                 it.remove();
             }
         }
         for (ContextInstanceHandle<?> instanceHandle : values) {
-            instanceHandle.destroy();
+            InjectableBean<?> bean = instanceHandle.getBean();
+            String beanInfo = bean.getBeanClass().getName();
+            actionType(bean).run(beanInfo, new Runnable() {
+                @Override
+                public void run() {
+                    instanceHandle.destroy();
+                }
+            });
         }
         instances.removeEach(null);
+    }
+
+    private ArcShutdownAction actionType(InjectableBean<?> bean) {
+        return bean.getScope().equals(ApplicationScoped.class)
+                ? ArcShutdownAction.CDI_DESTROY_APPLICATION_BEAN
+                : ArcShutdownAction.CDI_DESTROY_SINGLETON_BEAN;
     }
 
     @Override

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
@@ -460,7 +460,9 @@ public class ArcContainerImpl implements ArcContainer {
             beforeDestroyQualifiers.add(BeforeDestroyed.Literal.APPLICATION);
             beforeDestroyQualifiers.add(Any.Literal.INSTANCE);
             try {
-                EventImpl.createNotifier(Object.class, Object.class, beforeDestroyQualifiers, this, false, null)
+                EventImpl
+                        .createShutdownNotifier(Object.class, Object.class, beforeDestroyQualifiers, this, null,
+                                ArcShutdownAction.CDI_BEFORE_DESTROYED_APPLICATION_CONTEXT)
                         .notify(toString());
             } catch (Exception e) {
                 LOGGER.warn("An error occurred during delivery of the @BeforeDestroyed(ApplicationScoped.class) event", e);
@@ -472,7 +474,8 @@ public class ArcContainerImpl implements ArcContainer {
             destroyQualifiers.add(Destroyed.Literal.APPLICATION);
             destroyQualifiers.add(Any.Literal.INSTANCE);
             try {
-                EventImpl.createNotifier(Object.class, Object.class, destroyQualifiers, this, false, null).notify(toString());
+                EventImpl.createShutdownNotifier(Object.class, Object.class, destroyQualifiers, this, null,
+                        ArcShutdownAction.CDI_DESTROYED_APPLICATION_CONTEXT).notify(toString());
             } catch (Exception e) {
                 LOGGER.warn("An error occurred during delivery of the @Destroyed(ApplicationScoped.class) event", e);
             }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcShutdownAction.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcShutdownAction.java
@@ -1,0 +1,37 @@
+package io.quarkus.arc.impl;
+
+/**
+ * Represents a type of action executed during the ArC container shutdown.
+ * Each action is traced with a JFR {@link ArcShutdownActionEvent}.
+ *
+ * @see ArcShutdownActionEvent
+ */
+enum ArcShutdownAction {
+
+    CDI_BEFORE_DESTROYED_APPLICATION_CONTEXT,
+    CDI_DESTROYED_APPLICATION_CONTEXT,
+    CDI_DESTROY_APPLICATION_BEAN,
+    CDI_DESTROY_SINGLETON_BEAN;
+
+    /**
+     * Runs the given action and emits a JFR event with this action type and the provided info.
+     *
+     * @param info additional information about the action, e.g. the bean class name
+     * @param action the action to execute
+     */
+    void run(Object info, Runnable action) {
+        ArcShutdownActionEvent event = new ArcShutdownActionEvent();
+        event.begin();
+        try {
+            action.run();
+        } finally {
+            event.end();
+            if (event.shouldCommit()) {
+                event.actionType = name();
+                event.info = info != null ? info.toString() : null;
+                event.commit();
+            }
+        }
+    }
+
+}

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcShutdownActionEvent.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcShutdownActionEvent.java
@@ -1,0 +1,23 @@
+package io.quarkus.arc.impl;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.StackTrace;
+
+@Label("Arc Shutdown Action")
+@Category({ "Quarkus", "Arc", "Shutdown" })
+@Name("quarkus.arc.ShutdownAction")
+@Description("An action executed during ArC container shutdown")
+@StackTrace(false)
+class ArcShutdownActionEvent extends Event {
+
+    @Label("Action Type")
+    public String actionType;
+
+    @Label("Info")
+    public String info;
+
+}

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/EventImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/EventImpl.java
@@ -43,6 +43,7 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.AsyncObserverExceptionHandler;
+import io.quarkus.arc.InjectableBean;
 import io.quarkus.arc.InstanceHandle;
 import io.quarkus.arc.ManagedContext;
 
@@ -178,6 +179,18 @@ class EventImpl<T> implements Event<T> {
 
     static <T> Notifier<T> createNotifier(Class<?> runtimeType, Type eventType, Set<Annotation> qualifiers,
             ArcContainerImpl container, boolean activateRequestContext, InjectionPoint injectionPoint) {
+        return doCreateNotifier(runtimeType, eventType, qualifiers, container, activateRequestContext, injectionPoint, null);
+    }
+
+    static <T> Notifier<T> createShutdownNotifier(Class<?> runtimeType, Type eventType, Set<Annotation> qualifiers,
+            ArcContainerImpl container, InjectionPoint injectionPoint, ArcShutdownAction shutdownAction) {
+        return doCreateNotifier(runtimeType, eventType, qualifiers, container, false,
+                injectionPoint, shutdownAction);
+    }
+
+    private static <T> Notifier<T> doCreateNotifier(Class<?> runtimeType, Type eventType, Set<Annotation> qualifiers,
+            ArcContainerImpl container, boolean activateRequestContext, InjectionPoint injectionPoint,
+            ArcShutdownAction shutdownAction) {
         // all events should have `@Any` qualifiers
         // if there was no other explicit qualifier added, also add @Default
         Set<Annotation> normalizedQualifiers = new HashSet<>(qualifiers);
@@ -188,6 +201,10 @@ class EventImpl<T> implements Event<T> {
         EventMetadata metadata = new EventMetadataImpl(normalizedQualifiers, eventType, injectionPoint);
         List<ObserverMethod<? super T>> notifierObserverMethods = new ArrayList<>(
                 container.resolveObserverMethods(eventType, normalizedQualifiers));
+        if (shutdownAction != null) {
+            return new ShutdownNotifier<>(runtimeType, notifierObserverMethods, metadata, activateRequestContext,
+                    shutdownAction);
+        }
         return new Notifier<>(runtimeType, notifierObserverMethods, metadata, activateRequestContext);
     }
 
@@ -258,10 +275,6 @@ class EventImpl<T> implements Event<T> {
         final EventMetadata eventMetadata;
         private final boolean hasTxObservers;
         private final boolean activateRequestContext;
-
-        Notifier(Class<?> runtimeType, List<ObserverMethod<? super T>> observerMethods, EventMetadata eventMetadata) {
-            this(runtimeType, observerMethods, eventMetadata, true);
-        }
 
         Notifier(Class<?> runtimeType, List<ObserverMethod<? super T>> observerMethods, EventMetadata eventMetadata,
                 boolean activateRequestContext) {
@@ -356,19 +369,23 @@ class EventImpl<T> implements Event<T> {
             }
         }
 
-        @SuppressWarnings({ "rawtypes", "unchecked" })
         private void notifyObservers(T event, ObserverExceptionHandler exceptionHandler,
                 Predicate<ObserverMethod<?>> predicate) {
-            EventContext eventContext = new EventContextImpl<>(event, eventMetadata);
+            EventContext<T> eventContext = new EventContextImpl<>(event, eventMetadata);
             for (ObserverMethod<?> observerMethod : observerMethods) {
                 if (predicate.test(observerMethod)) {
                     try {
-                        observerMethod.notify(eventContext);
+                        callObserverMethod(observerMethod, eventContext);
                     } catch (Throwable t) {
                         exceptionHandler.handle(t, observerMethod, eventContext);
                     }
                 }
             }
+        }
+
+        @SuppressWarnings({ "rawtypes", "unchecked" })
+        protected void callObserverMethod(ObserverMethod<?> observerMethod, EventContext eventContext) {
+            observerMethod.notify(eventContext);
         }
 
         boolean isEmpty() {
@@ -379,6 +396,30 @@ class EventImpl<T> implements Event<T> {
             return !observer.getTransactionPhase().equals(TransactionPhase.IN_PROGRESS);
         }
 
+    }
+
+    static class ShutdownNotifier<T> extends Notifier<T> {
+
+        private final ArcShutdownAction shutdownAction;
+
+        ShutdownNotifier(Class<?> runtimeType, List<ObserverMethod<? super T>> observerMethods,
+                EventMetadata eventMetadata, boolean activateRequestContext, ArcShutdownAction shutdownAction) {
+            super(runtimeType, observerMethods, eventMetadata, activateRequestContext);
+            this.shutdownAction = shutdownAction;
+        }
+
+        @Override
+        @SuppressWarnings({ "rawtypes", "unchecked" })
+        protected void callObserverMethod(ObserverMethod<?> observerMethod, EventContext eventContext) {
+            InjectableBean<?> declaringBean = (InjectableBean<?>) observerMethod.getDeclaringBean();
+            String info = declaringBean != null ? declaringBean.getBeanClass().getName() : observerMethod.toString();
+            shutdownAction.run(info, new Runnable() {
+                @Override
+                public void run() {
+                    observerMethod.notify(eventContext);
+                }
+            });
+        }
     }
 
     static class ArcSynchronization implements Synchronization {

--- a/independent-projects/arc/runtime/src/main/java/module-info.java
+++ b/independent-projects/arc/runtime/src/main/java/module-info.java
@@ -5,6 +5,8 @@ module io.quarkus.arc {
 
     requires java.logging;
 
+    requires jdk.jfr;
+
     requires jakarta.annotation;
     requires jakarta.cdi;
     requires jakarta.el;


### PR DESCRIPTION
- emit JFR events so that shutdown actions can be observed with standard profiling tools
- monitored actions include: ShutdownContext.addShutdownTask(), ShutdownContext.addLastShutdownTask(), ShutdownListener, CDI Singleton and ApplicationScoped beans, CDI Singleton and Application contexts