### PR TITLE
Fix gRPC streaming crash in native mode

### DIFF
--- a/.github/native-tests.json
+++ b/.github/native-tests.json
@@ -135,7 +135,7 @@
         {
             "category": "gRPC",
             "timeout": 80,
-            "test-modules": "grpc-health, grpc-encoding, grpc-interceptors, grpc-mutual-auth, grpc-plain-text-gzip, grpc-plain-text-mutiny, grpc-proto-v2, grpc-streaming, grpc-tls, grpc-tls-p12, grpc-test-random-port",
+            "test-modules": "grpc-health, grpc-encoding, grpc-interceptors, grpc-mutual-auth, grpc-plain-text-gzip, grpc-plain-text-mutiny, grpc-proto-v2, grpc-streaming, grpc-streaming-native, grpc-tls, grpc-tls-p12, grpc-test-random-port",
             "os-name": "ubuntu-latest"
         },
         {

--- a/extensions/grpc/stubs/src/main/java/io/quarkus/grpc/stubs/ClientCalls.java
+++ b/extensions/grpc/stubs/src/main/java/io/quarkus/grpc/stubs/ClientCalls.java
@@ -1,5 +1,6 @@
 package io.quarkus.grpc.stubs;
 
+import java.util.Queue;
 import java.util.concurrent.Flow;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -8,7 +9,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import org.jctools.queues.SpscChunkedArrayQueue;
+import org.jctools.queues.atomic.unpadded.SpscChunkedAtomicUnpaddedArrayQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -121,7 +122,7 @@ public class ClientCalls {
 
     private static <I> void drainLoop(ClientCallStreamObserver<I> requestFlow, Multi<I> items,
             AtomicReference<Flow.Subscription> cancellable, AtomicReference<Runnable> drainRef) {
-        SpscChunkedArrayQueue<I> queue = new SpscChunkedArrayQueue<>((int) PREFETCH, (int) PREFETCH * 2);
+        Queue<I> queue = new SpscChunkedAtomicUnpaddedArrayQueue<>((int) PREFETCH, (int) PREFETCH * 2);
         AtomicBoolean done = new AtomicBoolean(false);
         AtomicInteger wip = new AtomicInteger(0);
         long[] consumed = { 0 };

--- a/extensions/grpc/stubs/src/main/java/io/quarkus/grpc/stubs/ServerCalls.java
+++ b/extensions/grpc/stubs/src/main/java/io/quarkus/grpc/stubs/ServerCalls.java
@@ -1,5 +1,6 @@
 package io.quarkus.grpc.stubs;
 
+import java.util.Queue;
 import java.util.concurrent.Flow;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -7,7 +8,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 import org.jboss.logging.Logger;
-import org.jctools.queues.SpscChunkedArrayQueue;
+import org.jctools.queues.atomic.unpadded.SpscChunkedAtomicUnpaddedArrayQueue;
 
 import io.grpc.Status;
 import io.grpc.stub.ServerCallStreamObserver;
@@ -148,7 +149,7 @@ public class ServerCalls {
     }
 
     public static <O> void handleSubscription(Multi<O> items, ServerCallStreamObserver<O> response) {
-        SpscChunkedArrayQueue<O> queue = new SpscChunkedArrayQueue<>((int) PREFETCH, (int) PREFETCH * 2);
+        Queue<O> queue = new SpscChunkedAtomicUnpaddedArrayQueue<>((int) PREFETCH, (int) PREFETCH * 2);
         AtomicBoolean done = new AtomicBoolean(false);
         AtomicInteger wip = new AtomicInteger(0);
         long[] consumed = { 0 };

--- a/integration-tests/grpc-streaming-native/pom.xml
+++ b/integration-tests/grpc-streaming-native/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-integration-test-grpc-streaming-native</artifactId>
+    <name>Quarkus - Integration Tests - gRPC - Streaming (Native)</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate-code</goal>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/integration-tests/grpc-streaming-native/src/main/java/io/quarkus/grpc/example/streaming/StreamingEndpoint.java
+++ b/integration-tests/grpc-streaming-native/src/main/java/io/quarkus/grpc/example/streaming/StreamingEndpoint.java
@@ -1,0 +1,47 @@
+package io.quarkus.grpc.example.streaming;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.grpc.examples.streaming.Empty;
+import io.grpc.examples.streaming.Item;
+import io.grpc.examples.streaming.MutinyStreamingGrpc;
+import io.quarkus.grpc.GrpcClient;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+
+@Path("/streaming")
+public class StreamingEndpoint {
+
+    @GrpcClient
+    MutinyStreamingGrpc.MutinyStreamingStub streaming;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Multi<String> invokeSource() {
+        return streaming.source(Empty.newBuilder().build())
+                .onItem().transform(Item::getValue);
+    }
+
+    @GET
+    @Path("sink/{max}")
+    public Uni<Void> invokeSink(@PathParam("max") int max) {
+        Multi<Item> inputs = Multi.createFrom().range(0, max)
+                .map(i -> Integer.toString(i))
+                .map(i -> Item.newBuilder().setValue(i).build());
+        return streaming.sink(inputs).onItem().ignore().andContinueWithNull();
+    }
+
+    @GET
+    @Path("/{max}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Multi<String> invokePipe(@PathParam("max") int max) {
+        Multi<Item> inputs = Multi.createFrom().range(0, max)
+                .map(i -> Integer.toString(i))
+                .map(i -> Item.newBuilder().setValue(i).build());
+        return streaming.pipe(inputs).onItem().transform(Item::getValue);
+    }
+}

--- a/integration-tests/grpc-streaming-native/src/main/java/io/quarkus/grpc/example/streaming/StreamingService.java
+++ b/integration-tests/grpc-streaming-native/src/main/java/io/quarkus/grpc/example/streaming/StreamingService.java
@@ -1,0 +1,39 @@
+package io.quarkus.grpc.example.streaming;
+
+import java.time.Duration;
+
+import io.grpc.examples.streaming.Empty;
+import io.grpc.examples.streaming.Item;
+import io.grpc.examples.streaming.MutinyStreamingGrpc;
+import io.quarkus.grpc.GrpcService;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+
+@GrpcService
+public class StreamingService extends MutinyStreamingGrpc.StreamingImplBase {
+
+    @Override
+    public Multi<Item> source(Empty request) {
+        return Multi.createFrom().ticks().every(Duration.ofMillis(2))
+                .select().first(10)
+                .map(l -> Item.newBuilder().setValue(Long.toString(l)).build());
+    }
+
+    @Override
+    public Uni<Empty> sink(Multi<Item> request) {
+        return request
+                .map(Item::getValue)
+                .map(Long::parseLong)
+                .collect().last()
+                .map(l -> Empty.newBuilder().build());
+    }
+
+    @Override
+    public Multi<Item> pipe(Multi<Item> request) {
+        return request
+                .map(Item::getValue)
+                .map(Long::parseLong)
+                .onItem().scan(() -> 0L, Long::sum)
+                .onItem().transform(l -> Item.newBuilder().setValue(Long.toString(l)).build());
+    }
+}

--- a/integration-tests/grpc-streaming-native/src/main/proto/streaming.proto
+++ b/integration-tests/grpc-streaming-native/src/main/proto/streaming.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.grpc.examples.streaming";
+option java_outer_classname = "StreamingProto";
+
+package streaming;
+
+service Streaming {
+    rpc Source(Empty) returns (stream Item) {}
+    rpc Sink(stream Item) returns (Empty) {}
+    rpc Pipe(stream Item) returns (stream Item) {}
+}
+
+message Item {
+    string value = 1;
+}
+
+message Empty {
+}

--- a/integration-tests/grpc-streaming-native/src/main/resources/application.properties
+++ b/integration-tests/grpc-streaming-native/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+quarkus.grpc.server.use-separate-server=false
+quarkus.grpc.clients.streaming.host=localhost
+quarkus.grpc.clients.streaming.port=8081
+quarkus.grpc.clients.streaming.use-quarkus-grpc-client=true

--- a/integration-tests/grpc-streaming-native/src/test/java/io/quarkus/grpc/example/streaming/StreamingEndpointIT.java
+++ b/integration-tests/grpc-streaming-native/src/test/java/io/quarkus/grpc/example/streaming/StreamingEndpointIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.grpc.example.streaming;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class StreamingEndpointIT extends StreamingEndpointTestBase {
+
+}

--- a/integration-tests/grpc-streaming-native/src/test/java/io/quarkus/grpc/example/streaming/StreamingEndpointTest.java
+++ b/integration-tests/grpc-streaming-native/src/test/java/io/quarkus/grpc/example/streaming/StreamingEndpointTest.java
@@ -1,0 +1,8 @@
+package io.quarkus.grpc.example.streaming;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+class StreamingEndpointTest extends StreamingEndpointTestBase {
+
+}

--- a/integration-tests/grpc-streaming-native/src/test/java/io/quarkus/grpc/example/streaming/StreamingEndpointTestBase.java
+++ b/integration-tests/grpc-streaming-native/src/test/java/io/quarkus/grpc/example/streaming/StreamingEndpointTestBase.java
@@ -1,0 +1,35 @@
+package io.quarkus.grpc.example.streaming;
+
+import static io.restassured.RestAssured.get;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.restassured.common.mapper.TypeRef;
+
+class StreamingEndpointTestBase {
+
+    private static final TypeRef<List<String>> LIST_OF_STRING = new TypeRef<>() {
+    };
+
+    @Test
+    public void testSource() {
+        List<String> response = get("/streaming").as(LIST_OF_STRING);
+        assertThat(response).containsExactly("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
+    }
+
+    @Test
+    public void testPipe() {
+        List<String> response = get("/streaming/3").as(LIST_OF_STRING);
+        assertThat(response).containsExactly("0", "0", "1", "3");
+    }
+
+    @Test
+    public void testSink() {
+        get("/streaming/sink/3")
+                .then().statusCode(204);
+    }
+
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -420,6 +420,7 @@
                 <module>grpc-plain-text-mutiny</module>
                 <module>grpc-mutual-auth</module>
                 <module>grpc-streaming</module>
+                <module>grpc-streaming-native</module>
                 <module>grpc-interceptors</module>
                 <module>grpc-proto-v2</module>
                 <module>grpc-health</module>


### PR DESCRIPTION
Replace `SpscChunkedArrayQueue` (which relies on `sun.misc.Unsafe`) with `SpscChunkedAtomicUnpaddedArrayQueue` (uses `AtomicReferenceArray` — no Unsafe, native-safe), preserving the same `chunkSize` and `maxCapacity` parameters.

The Unsafe-based queue was introduced in PR #53313 for traffic control. It works in JVM mode but crashes the native process because the unshaded `org.jctools.*` classes lack GraalVM native image configuration (only Netty's shaded copy has substitutions registered).

- Fixes #54439