### PR TITLE
Reset stale Quarkus system properties on reused Gradle worker JVMs

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/BuildAotEnhancedImage.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/BuildAotEnhancedImage.java
@@ -73,6 +73,7 @@ public abstract class BuildAotEnhancedImage extends QuarkusBuildTask {
 
         workQueue.submit(BuildAotEnhancedImageWorker.class, params -> {
             params.getBuildSystemProperties().putAll(buildSystemProperties(appModel.getAppArtifact(), quarkusProperties));
+            params.getForkedSystemProperties().putAll(quarkusProperties);
             params.getBaseName().set(getExtensionView().getFinalName());
             params.getTargetDirectory().set(buildDirectory);
             params.getAppModel().set(appModel);

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildTask.java
@@ -299,6 +299,7 @@ public abstract class QuarkusBuildTask extends QuarkusTaskWithExtensionView {
 
         workQueue.submit(BuildWorker.class, params -> {
             params.getBuildSystemProperties().putAll(buildSystemProperties(appModel.getAppArtifact(), quarkusProperties));
+            params.getForkedSystemProperties().putAll(quarkusProperties);
             params.getBaseName().set(getExtensionView().getFinalName());
             params.getTargetDirectory().set(buildDir.toFile());
             params.getAppModel().set(appModel);

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
@@ -121,6 +121,7 @@ public abstract class QuarkusGenerateCode extends QuarkusTaskWithExtensionView {
 
         workQueue.submit(CodeGenWorker.class, params -> {
             params.getBuildSystemProperties().putAll(configMap);
+            params.getForkedSystemProperties().putAll(configMap);
             params.getBaseName().set(getExtensionView().getFinalName());
             params.getTargetDirectory().set(buildDir);
             params.getAppModel().set(appModel);

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/worker/QuarkusParams.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/worker/QuarkusParams.java
@@ -12,6 +12,22 @@ public interface QuarkusParams extends WorkParameters {
 
     MapProperty<String, String> getBuildSystemProperties();
 
+    /**
+     * The {@code quarkus.*} / {@code platform.quarkus.*} system properties the daemon set as
+     * fork options for this submission. Callers populate this with the same map they pass to
+     * {@code workQueue(map, ...)}, so {@link QuarkusWorker#resetQuarkusSystemProperties()} can
+     * re-establish that exact set on the worker JVM and clear any {@code quarkus.*} property
+     * left over from a previous task on the same pooled worker.
+     *
+     * <p>
+     * This map does not seed
+     * {@link io.quarkus.bootstrap.app.QuarkusBootstrap#setBuildSystemProperties};
+     * {@link #getBuildSystemProperties()} does, and so feeds the on-disk
+     * {@code build-system.properties}. Keeping the two maps separate leaves that artifact
+     * unchanged.
+     */
+    MapProperty<String, String> getForkedSystemProperties();
+
     Property<String> getBaseName();
 
     Property<ApplicationModel> getAppModel();

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/worker/QuarkusWorker.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/worker/QuarkusWorker.java
@@ -1,6 +1,8 @@
 package io.quarkus.gradle.tasks.worker;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Map;
 import java.util.Properties;
 
 import org.gradle.workers.WorkAction;
@@ -18,7 +20,50 @@ public abstract class QuarkusWorker<P extends QuarkusParams> implements WorkActi
         return props;
     }
 
+    /**
+     * Scrubs stale {@code quarkus.*} / {@code platform.quarkus.*} system properties before bootstrap.
+     *
+     * <p>
+     * Gradle pools process-isolation workers and reuses them across tasks. System properties on
+     * a reused worker JVM are fixed at startup via {@code forkOptions.systemProperty(...)} and
+     * stay put across submissions, so values set for one task remain visible to later ones.
+     * SmallRye Config's {@code SysPropConfigSource} (ordinal 400) outranks the
+     * {@code "Build system"} {@code PropertiesConfigSource} that
+     * {@code BuildTimeConfigurationReader#initConfiguration} adds (ordinal 100), so
+     * {@code quarkus.*} values from the first module's task leak into the second module's
+     * bootstrap in a multi-module build. See https://github.com/quarkusio/quarkus/issues/54095.
+     *
+     * <p>
+     * The reset aligns the worker's {@code quarkus.*} / {@code platform.quarkus.*} system
+     * properties with the daemon's intent for this submission: the same map the daemon passes
+     * to {@code forkOptions.systemProperty(...)}, exposed via
+     * {@link QuarkusParams#getForkedSystemProperties()}. Any other matching property left over
+     * from a previous task is cleared.
+     *
+     * <p>
+     * The reset is one-way by design. Each submission re-establishes the right state at the top
+     * of bootstrap; nothing is restored on exit. A symmetric tear-down would erase legitimate
+     * inter-task state, for example properties a build step set via
+     * {@link System#setProperty(String, String)} during augmentation.
+     */
+    void resetQuarkusSystemProperties() {
+        Map<String, String> intended = getParameters().getForkedSystemProperties().getOrElse(Map.of());
+        for (String key : new ArrayList<>(System.getProperties().stringPropertyNames())) {
+            if ((key.startsWith("quarkus.") || key.startsWith("platform.quarkus."))
+                    && !intended.containsKey(key)) {
+                System.clearProperty(key);
+            }
+        }
+        for (Map.Entry<String, String> entry : intended.entrySet()) {
+            String key = entry.getKey();
+            if (key.startsWith("quarkus.") || key.startsWith("platform.quarkus.")) {
+                System.setProperty(key, entry.getValue());
+            }
+        }
+    }
+
     CuratedApplication createAppCreationContext() throws BootstrapException {
+        resetQuarkusSystemProperties();
         QuarkusParams params = getParameters();
         Path buildDir = params.getTargetDirectory().getAsFile().get().toPath();
         String baseName = params.getBaseName().get();

--- a/integration-tests/gradle/pom.xml
+++ b/integration-tests/gradle/pom.xml
@@ -86,6 +86,10 @@
         <!-- START update-dependencies.sh -->
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-agroal</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
         </dependency>
         <dependency>
@@ -95,6 +99,10 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-bootstrap-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-config-yaml</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -135,6 +143,14 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jdbc-h2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-mysql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-postgresql</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -198,6 +214,19 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-agroal-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
@@ -212,6 +241,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-avro-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-config-yaml-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>
@@ -342,6 +384,32 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jdbc-h2-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-mysql-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-postgresql-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/gradle/pom.xml
+++ b/integration-tests/gradle/pom.xml
@@ -586,6 +586,7 @@
                                         </systemPropertyVariables>
                                         <includes>
                                             <include>BasicMultiModuleQuarkusBuildTest</include>
+                                            <include>MultiModuleConfigIsolationTest</include>
                                         </includes>
                                     </configuration>
                                 </execution>

--- a/integration-tests/gradle/src/main/resources/multi-module-config-isolation/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-config-isolation/build.gradle
@@ -1,0 +1,5 @@
+plugins {
+}
+
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'

--- a/integration-tests/gradle/src/main/resources/multi-module-config-isolation/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/multi-module-config-isolation/gradle.properties
@@ -1,0 +1,8 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus
+
+# Force sequential project execution and an active daemon so both modules' quarkusAppPartsBuild
+# tasks share a single pooled worker JVM. This is the JVM-reuse condition that triggers #54095;
+# without it, each invocation may start fresh workers and the leak no longer reproduces.
+org.gradle.parallel=false
+org.gradle.daemon=true

--- a/integration-tests/gradle/src/main/resources/multi-module-config-isolation/module-a/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-config-isolation/module-a/build.gradle
@@ -26,3 +26,11 @@ compileJava {
     options.encoding = 'UTF-8'
     options.compilerArgs << '-parameters'
 }
+
+// Override `quarkus.package.output-name` here, not in application.yaml. `EffectiveConfig.propagateSources`
+// only includes Gradle-side sources, so YAML values never reach the worker as system properties and
+// the leak would not reproduce. Module B does not set this property: on a reused worker it must fall
+// back to its own project base name and never inherit `module-a-only-output`.
+quarkus {
+    quarkusBuildProperties.put("quarkus.package.output-name", "module-a-only-output")
+}

--- a/integration-tests/gradle/src/main/resources/multi-module-config-isolation/module-a/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-config-isolation/module-a/build.gradle
@@ -1,0 +1,28 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+}
+
+repositories {
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
+    mavenCentral()
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-agroal'
+    implementation 'io.quarkus:quarkus-config-yaml'
+    implementation 'io.quarkus:quarkus-jdbc-postgresql'
+}
+
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
+
+compileJava {
+    options.encoding = 'UTF-8'
+    options.compilerArgs << '-parameters'
+}

--- a/integration-tests/gradle/src/main/resources/multi-module-config-isolation/module-a/src/main/resources/application.yaml
+++ b/integration-tests/gradle/src/main/resources/multi-module-config-isolation/module-a/src/main/resources/application.yaml
@@ -1,0 +1,8 @@
+quarkus:
+  application:
+    name: module-a
+  datasource:
+    "ds-a":
+      db-kind: postgresql
+      jdbc:
+        driver: org.postgresql.Driver

--- a/integration-tests/gradle/src/main/resources/multi-module-config-isolation/module-b/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-config-isolation/module-b/build.gradle
@@ -1,0 +1,28 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+}
+
+repositories {
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
+    mavenCentral()
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-agroal'
+    implementation 'io.quarkus:quarkus-config-yaml'
+    implementation 'io.quarkus:quarkus-jdbc-mysql'
+}
+
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
+
+compileJava {
+    options.encoding = 'UTF-8'
+    options.compilerArgs << '-parameters'
+}

--- a/integration-tests/gradle/src/main/resources/multi-module-config-isolation/module-b/src/main/resources/application.yaml
+++ b/integration-tests/gradle/src/main/resources/multi-module-config-isolation/module-b/src/main/resources/application.yaml
@@ -1,0 +1,8 @@
+quarkus:
+  application:
+    name: module-b
+  datasource:
+    "ds-b":
+      db-kind: mysql
+      jdbc:
+        driver: com.mysql.cj.jdbc.Driver

--- a/integration-tests/gradle/src/main/resources/multi-module-config-isolation/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-config-isolation/settings.gradle
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+        id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+
+include ':module-a', ':module-b'
+
+rootProject.name = 'multi-module-config-isolation'

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/MultiModuleConfigIsolationTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/MultiModuleConfigIsolationTest.java
@@ -1,6 +1,11 @@
 package io.quarkus.gradle;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
@@ -8,26 +13,56 @@ import org.junit.jupiter.api.Test;
  * Regression test for https://github.com/quarkusio/quarkus/issues/54095.
  *
  * <p>
- * Each module's {@code quarkusAppPartsBuild} in a multi-module Gradle build must only see its own
- * configuration. Stale system properties on a pooled worker JVM otherwise leak datasource (and
- * other extension) configuration from one module into the next module's bootstrap, making
- * {@code AgroalProcessor} try to load a driver absent from the classpath.
+ * In a multi-module Gradle build, each module's {@code quarkusAppPartsBuild} must see only its
+ * own configuration. The test catches two leak symptoms per Gradle invocation:
+ *
+ * <ul>
+ * <li><b>Crash.</b> Datasource configuration from the previous module leaks via the pooled
+ * worker JVM and {@code AgroalProcessor} fails to load a driver missing from the classpath.
+ * {@code runGradleWrapper} surfaces this as a build failure.</li>
+ * <li><b>Silent value leak.</b> Module A sets {@code quarkus.package.output-name} through
+ * its {@code quarkus { ... }} extension block. Module B leaves the property unset and falls
+ * back to its own project base name. Without the worker JVM reset, A's system property
+ * persists on the reused worker; {@code SysPropConfigSource} (ordinal 400) outranks the
+ * "Build system" {@code PropertiesConfigSource} (ordinal 100); B then emits
+ * {@code module-a-only-output.jar}. The file-name assertions below catch this.</li>
+ * </ul>
  */
 public class MultiModuleConfigIsolationTest extends QuarkusGradleWrapperTestBase {
+
+    private static final String MODULE_A_OUTPUT_NAME = "module-a-only-output";
+    private static final String MODULE_B_DEFAULT_OUTPUT_NAME = "module-b-1.0.0-SNAPSHOT";
 
     @Test
     public void testForwardOrderBuild() throws Exception {
         File projectDir = getProjectDir("multi-module-config-isolation");
-        // `clean` keeps the second test method from picking up build/ outputs left by this one.
-        // Without it, Gradle marks both quarkusAppPartsBuild tasks up-to-date and skips them,
-        // bypassing the worker JVM reuse path the test exercises. Explicit task ordering also
-        // forces module-a first.
+        // `clean` stops one test method from inheriting build/ outputs from another. Without it,
+        // Gradle marks both quarkusAppPartsBuild tasks up-to-date and skips them, sidestepping
+        // the worker JVM reuse path the test exercises. Explicit task ordering pins module-a first.
         runGradleWrapper(projectDir, "clean", ":module-a:quarkusAppPartsBuild", ":module-b:quarkusAppPartsBuild");
+        assertUserAppJarName(projectDir, "module-a", MODULE_A_OUTPUT_NAME);
+        assertUserAppJarName(projectDir, "module-b", MODULE_B_DEFAULT_OUTPUT_NAME);
     }
 
     @Test
     public void testReverseOrderBuild() throws Exception {
         File projectDir = getProjectDir("multi-module-config-isolation");
         runGradleWrapper(projectDir, "clean", ":module-b:quarkusAppPartsBuild", ":module-a:quarkusAppPartsBuild");
+        assertUserAppJarName(projectDir, "module-a", MODULE_A_OUTPUT_NAME);
+        assertUserAppJarName(projectDir, "module-b", MODULE_B_DEFAULT_OUTPUT_NAME);
+    }
+
+    private static void assertUserAppJarName(File projectDir, String module, String expectedBaseName) throws Exception {
+        // `quarkus.package.output-name` sets the `OutputTargetBuildItem` base name, which names
+        // the user-app jar in the fast-jar layout at `build/quarkus-app/app/<base-name>.jar`.
+        // Asserting on that path puts any leaked value directly into the failure message.
+        Path appDir = projectDir.toPath().resolve(module).resolve("build/quarkus-app/app");
+        assertThat(appDir).isDirectory();
+        try (Stream<Path> entries = Files.list(appDir)) {
+            assertThat(entries.map(p -> p.getFileName().toString()))
+                    .as("user-app jar in %s should be named after %s, never after another module's override", appDir,
+                            expectedBaseName)
+                    .containsExactly(expectedBaseName + ".jar");
+        }
     }
 }

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/MultiModuleConfigIsolationTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/MultiModuleConfigIsolationTest.java
@@ -1,0 +1,33 @@
+package io.quarkus.gradle;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for https://github.com/quarkusio/quarkus/issues/54095.
+ *
+ * <p>
+ * Each module's {@code quarkusAppPartsBuild} in a multi-module Gradle build must only see its own
+ * configuration. Stale system properties on a pooled worker JVM otherwise leak datasource (and
+ * other extension) configuration from one module into the next module's bootstrap, making
+ * {@code AgroalProcessor} try to load a driver absent from the classpath.
+ */
+public class MultiModuleConfigIsolationTest extends QuarkusGradleWrapperTestBase {
+
+    @Test
+    public void testForwardOrderBuild() throws Exception {
+        File projectDir = getProjectDir("multi-module-config-isolation");
+        // `clean` keeps the second test method from picking up build/ outputs left by this one.
+        // Without it, Gradle marks both quarkusAppPartsBuild tasks up-to-date and skips them,
+        // bypassing the worker JVM reuse path the test exercises. Explicit task ordering also
+        // forces module-a first.
+        runGradleWrapper(projectDir, "clean", ":module-a:quarkusAppPartsBuild", ":module-b:quarkusAppPartsBuild");
+    }
+
+    @Test
+    public void testReverseOrderBuild() throws Exception {
+        File projectDir = getProjectDir("multi-module-config-isolation");
+        runGradleWrapper(projectDir, "clean", ":module-b:quarkusAppPartsBuild", ":module-a:quarkusAppPartsBuild");
+    }
+}


### PR DESCRIPTION
This PR is an attempt to fix the above issue. Both investigation and patch developed with help from Claude Code.

Gradle pools process-isolation worker JVMs and reuses them across tasks. System properties on a reused worker are fixed at startup via `forkOptions.systemProperty(...)` and stay put across submissions. SmallRye Config's `SysPropConfigSource` (ordinal 400) outranks the per-task `"Build system"` `PropertiesConfigSource` (ordinal 100), so in a multi-module build `quarkus.*` values from the first module's task leak into the second module's bootstrap. 

For example, with distinct datasource configuration per module, `AgroalProcessor` tries to load a JDBC driver absent from the second module's classpath (that's how this issue showed in our monorepo).

The fix exposes the daemon's intended fork-option map via a new `QuarkusParams#getForkedSystemProperties()` and has each worker reset its `quarkus.*` / `platform.quarkus.*` system properties to match before bootstrap, clearing anything left over from a previous task.


- Fixes: #54095.

_N.B. Investigation and patch developed with help from Claude Code._