### PR TITLE
Jandex: order Jandex input deterministically

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/AdditionalApplicationArchiveMarkerBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/AdditionalApplicationArchiveMarkerBuildItem.java
@@ -1,5 +1,7 @@
 package io.quarkus.deployment.builditem;
 
+import java.util.Objects;
+
 import io.quarkus.builder.item.MultiBuildItem;
 
 /**
@@ -11,7 +13,7 @@ public final class AdditionalApplicationArchiveMarkerBuildItem extends MultiBuil
     private final String file;
 
     public AdditionalApplicationArchiveMarkerBuildItem(String file) {
-        this.file = file;
+        this.file = Objects.requireNonNull(file);
     }
 
     public String getFile() {

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/ApplicationArchivesBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/ApplicationArchivesBuildItem.java
@@ -1,8 +1,10 @@
 package io.quarkus.deployment.builditem;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.jboss.jandex.DotName;
@@ -10,21 +12,21 @@ import org.jboss.jandex.DotName;
 import io.quarkus.builder.item.SimpleBuildItem;
 import io.quarkus.deployment.ApplicationArchive;
 
-//temp class
 public final class ApplicationArchivesBuildItem extends SimpleBuildItem {
 
     private final ApplicationArchive root;
-    private final Collection<ApplicationArchive> applicationArchives;
-    private final Set<ApplicationArchive> allArchives;
+    private final List<ApplicationArchive> applicationArchives;
+    private final List<ApplicationArchive> allArchives;
 
-    public ApplicationArchivesBuildItem(ApplicationArchive root, Collection<ApplicationArchive> applicationArchives) {
+    public ApplicationArchivesBuildItem(ApplicationArchive root, List<ApplicationArchive> applicationArchives) {
         this.root = root;
-        this.applicationArchives = applicationArchives;
+        this.applicationArchives = Collections.unmodifiableList(applicationArchives);
 
-        HashSet<ApplicationArchive> ret = new HashSet<>(applicationArchives);
-        ret.add(root);
+        List<ApplicationArchive> all = new ArrayList<>(applicationArchives.size() + 1);
+        all.add(root);
+        all.addAll(applicationArchives);
 
-        this.allArchives = Collections.unmodifiableSet(ret);
+        this.allArchives = Collections.unmodifiableList(all);
     }
 
     /**
@@ -38,17 +40,35 @@ public final class ApplicationArchivesBuildItem extends SimpleBuildItem {
     }
 
     /**
+     * Returns a list of all application archives, excluding the root archive.
+     */
+    public List<ApplicationArchive> getArchives() {
+        return applicationArchives;
+    }
+
+    /**
+     * Returns a list of all application archives, including the root archive.
+     */
+    public List<ApplicationArchive> getAllArchives() {
+        return allArchives;
+    }
+
+    /**
+     * @deprecated use {@link #getArchives()}
      * @return A set of all application archives, excluding the root archive
      */
+    @Deprecated(since = "3.37", forRemoval = true)
     public Collection<ApplicationArchive> getApplicationArchives() {
         return applicationArchives;
     }
 
     /**
+     * @deprecated use {@link #getAllArchives()}
      * @return A set of all application archives, including the root archive
      */
+    @Deprecated(since = "3.37", forRemoval = true)
     public Set<ApplicationArchive> getAllApplicationArchives() {
-        return allArchives;
+        return new HashSet<>(allArchives);
     }
 
     /**

--- a/core/deployment/src/main/java/io/quarkus/deployment/index/ApplicationArchiveBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/index/ApplicationArchiveBuildStep.java
@@ -6,6 +6,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -156,26 +157,33 @@ public class ApplicationArchiveBuildStep {
         List<ApplicationArchive> appArchives = new ArrayList<>();
         Set<Path> indexedPaths = new HashSet<>();
 
-        //get paths that are included via marker files
-        final Set<String> markers = new HashSet<>(appMarkers.size() + 1);
+        // archives that have a marker file
+        final List<String> markers = new ArrayList<>(appMarkers.size() + 1);
         for (AdditionalApplicationArchiveMarkerBuildItem i : appMarkers) {
             final String marker = i.getFile();
             markers.add(marker.endsWith("/") ? marker.substring(0, marker.length() - 1) : marker);
         }
         markers.add(IndexingUtil.JANDEX_INDEX);
+        markers.sort(Comparator.naturalOrder());
         addMarkerFilePaths(markers, root, indexedPaths, appArchives, indexCache, removedResources);
 
-        //get paths that are included via index-dependencies
+        // archives included via index-dependencies
         addIndexDependencyPaths(indexDependencyBuildItem, root, indexedPaths, appArchives, buildCloseables,
                 indexCache, curateOutcomeBuildItem, removedResources);
 
+        // additional archives
+        List<Path> additionalPaths = new ArrayList<>();
         for (AdditionalApplicationArchiveBuildItem i : additionalApplicationArchives) {
             for (Path apPath : i.getResolvedPaths()) {
                 if (!root.getResolvedPaths().contains(apPath) && indexedPaths.add(apPath)) {
-                    appArchives.add(createApplicationArchive(buildCloseables, indexCache, apPath, null,
-                            removedResources));
+                    additionalPaths.add(apPath);
                 }
             }
+        }
+        additionalPaths.sort(Comparator.comparing(Path::toString));
+        for (Path apPath : additionalPaths) {
+            appArchives.add(createApplicationArchive(buildCloseables, indexCache, apPath, null,
+                    removedResources));
         }
 
         return appArchives;
@@ -201,10 +209,15 @@ public class ApplicationArchiveBuildStep {
                 indexGroupIds.add(indexDependencyBuildItem.getGroupId());
             }
         }
-        for (ResolvedDependency dep : curateOutcomeBuildItem.getApplicationModel().getDependencies()) {
+
+        List<ResolvedDependency> dependencies = new ArrayList<>(curateOutcomeBuildItem.getApplicationModel().getDependencies());
+        dependencies.sort(Comparator.comparing(ResolvedDependency::getKey));
+        for (ResolvedDependency dep : dependencies) {
             if (dep.isRuntimeCp()
                     && (indexDependencyKeys.contains(dep.getKey()) || indexGroupIds.contains(dep.getGroupId()))) {
-                for (Path path : dep.getContentTree().getRoots()) {
+                List<Path> roots = new ArrayList<>(dep.getContentTree().getRoots());
+                roots.sort(Comparator.comparing(Path::toString));
+                for (Path path : roots) {
                     if (!root.isExcludedFromIndexing(path)
                             && !root.getResolvedPaths().contains(path)
                             && indexedDeps.add(path)) {
@@ -238,10 +251,9 @@ public class ApplicationArchiveBuildStep {
         return new ApplicationArchiveImpl(index, openTree, resolvedDependency);
     }
 
-    private static void addMarkerFilePaths(Set<String> applicationArchiveMarkers,
+    private static void addMarkerFilePaths(List<String> applicationArchiveMarkers,
             ArchiveRootBuildItem root, Set<Path> indexedPaths, List<ApplicationArchive> appArchives,
-            IndexCache indexCache, Map<ArtifactKey, Set<String>> removed)
-            throws IOException {
+            IndexCache indexCache, Map<ArtifactKey, Set<String>> removed) {
         final QuarkusClassLoader cl = ((QuarkusClassLoader) Thread.currentThread().getContextClassLoader());
         final Set<ArtifactKey> indexedElements = new HashSet<>();
         for (String marker : applicationArchiveMarkers) {
@@ -301,8 +313,8 @@ public class ApplicationArchiveBuildStep {
         }
     }
 
-    private static Index indexPathTree(PathTree tree, Set<String> removed) throws IOException {
-        Indexer indexer = new Indexer();
+    private static Index indexPathTree(OpenPathTree tree, Set<String> removed) throws IOException {
+        List<Path> classFilesToIndex = new ArrayList<>();
         tree.walk(new PathVisitor() {
             @Override
             public void visitPath(PathVisit visit) {
@@ -314,13 +326,21 @@ public class ApplicationArchiveBuildStep {
                         || removed != null && removed.contains(visit.getRelativePath("/"))) {
                     return;
                 }
-                try (InputStream in = Files.newInputStream(path)) {
-                    indexer.index(in);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
+                classFilesToIndex.add(path);
             }
         });
+
+        // feed classes to the `Indexer` in deterministic order
+        classFilesToIndex.sort(Comparator.comparing(Path::toString));
+
+        Indexer indexer = new Indexer();
+        for (Path path : classFilesToIndex) {
+            try (InputStream in = Files.newInputStream(path)) {
+                indexer.index(in);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
         return indexer.complete();
     }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/index/IndexingUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/index/IndexingUtil.java
@@ -7,14 +7,15 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Enumeration;
+import java.util.Comparator;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
-import java.util.zip.ZipEntry;
 
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.ClassSummary;
@@ -36,16 +37,80 @@ public class IndexingUtil {
 
     private static final Logger log = Logger.getLogger("io.quarkus.deployment.index");
 
+    /**
+     * @deprecated use {@link DotName#OBJECT_NAME}
+     */
+    @Deprecated(since = "3.37", forRemoval = true)
     public static final DotName OBJECT = DotName.createSimple(Object.class.getName());
 
     public static final String JANDEX_INDEX = "META-INF/jandex.idx";
 
-    private static final String META_INF_VERSIONS = "META-INF/versions/";
-
-    private static final int JAVA_VERSION = Runtime.version().feature();
-
     // At least Jandex 3.0 is needed
     private static final int REQUIRED_INDEX_VERSION = 11;
+
+    public static Index indexTree(OpenPathTree tree, Set<String> removed) throws IOException {
+        if (removed == null) {
+            Index index = tree.apply(JANDEX_INDEX, new Function<PathVisit, Index>() {
+                @Override
+                public Index apply(PathVisit visit) {
+                    if (visit == null) {
+                        return null;
+                    }
+                    try (InputStream in = Files.newInputStream(visit.getPath())) {
+                        IndexReader reader = new IndexReader(in);
+                        try {
+                            int indexVersion = reader.getIndexVersion();
+                            if (indexVersion < REQUIRED_INDEX_VERSION) {
+                                log.warnf("Reindexing %s, at least Jandex 3.0 must be used"
+                                        + " to index an application dependency (index version is %s)",
+                                        tree.toString(), indexVersion);
+                                return null;
+                            }
+                            return reader.read();
+                        } catch (UnsupportedVersion e) {
+                            log.warnf("Reindexing %s, the index format is too new for the Jandex version"
+                                    + " used by your application. Please report it to the author of this JAR (%s)",
+                                    tree.toString(), e.getMessage());
+                            return null;
+                        }
+                    } catch (IOException e) {
+                        throw new UncheckedIOException("Can't read Jandex index from " + tree, e);
+                    }
+                }
+            });
+            if (index != null) {
+                return index;
+            }
+        }
+
+        List<Path> classFilesToIndex = new ArrayList<>();
+        tree.walk(new PathVisitor() {
+            @Override
+            public void visitPath(PathVisit visit) {
+                Path fileName = visit.getPath().getFileName();
+                if (fileName == null
+                        || !fileName.toString().endsWith(".class")
+                        || Files.isDirectory(visit.getPath())
+                        || removed != null && removed.contains(visit.getRelativePath("/"))) {
+                    return;
+                }
+                classFilesToIndex.add(visit.getPath());
+            }
+        });
+
+        // feed classes to the `Indexer` in deterministic order
+        classFilesToIndex.sort(Comparator.comparing(Path::toString));
+
+        final Indexer indexer = new Indexer();
+        for (Path classFile : classFilesToIndex) {
+            try (InputStream inputStream = Files.newInputStream(classFile)) {
+                indexer.index(inputStream);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+        return indexer.complete();
+    }
 
     public static Index indexJar(Path path) throws IOException {
         return indexJar(path.toFile(), Collections.emptySet());
@@ -59,22 +124,9 @@ public class IndexingUtil {
         return indexJar(path.toFile(), removed);
     }
 
-    public static Index indexTree(OpenPathTree tree, Set<String> removed) throws IOException {
-        if (removed == null) {
-            final Index i = tree.apply(JANDEX_INDEX, new MetaInfJandexReader(tree.toString()));
-            if (i != null) {
-                return i;
-            }
-        }
-        final Indexer indexer = new Indexer();
-        final PathTreeIndexer treeIndexer = new PathTreeIndexer(indexer, removed);
-        tree.walk(treeIndexer);
-        return indexer.complete();
-    }
-
     public static Index indexJar(File file, Set<String> removed) throws IOException {
-        try (JarFile jarFile = new JarFile(file)) {
-            ZipEntry existing = jarFile.getEntry(JANDEX_INDEX);
+        try (JarFile jarFile = JarFiles.create(file)) {
+            JarEntry existing = jarFile.getJarEntry(JANDEX_INDEX);
             if (existing != null && removed == null) {
                 try (InputStream in = jarFile.getInputStream(existing)) {
                     IndexReader reader = new IndexReader(in);
@@ -99,45 +151,41 @@ public class IndexingUtil {
     }
 
     private static Index indexJar(JarFile file, Set<String> removed) throws IOException {
-        Indexer indexer = new Indexer();
-        Enumeration<JarEntry> e = file.entries();
-        boolean multiRelease = JarFiles.isMultiRelease(file);
-        while (e.hasMoreElements()) {
-            JarEntry entry = e.nextElement();
-            if (removed != null && removed.contains(entry.getName())) {
+        List<JarEntry> entriesToIndex = new ArrayList<>();
+        for (JarEntry entry : file.versionedStream().toList()) {
+            if (removed != null && removed.contains(entry.getRealName())) {
                 continue;
             }
             if (entry.getName().endsWith(".class")) {
-                if (multiRelease && entry.getName().startsWith(META_INF_VERSIONS)) {
-                    String part = entry.getName().substring(META_INF_VERSIONS.length());
-                    int slash = part.indexOf("/");
-                    if (slash != -1) {
-                        try {
-                            int ver = Integer.parseInt(part.substring(0, slash));
-                            if (ver <= JAVA_VERSION) {
-                                try (InputStream inputStream = file.getInputStream(entry)) {
-                                    indexer.index(inputStream);
-                                }
-                            }
-                        } catch (NumberFormatException ex) {
-                            log.debug("Failed to parse META-INF/versions entry", ex);
-                        }
-                    }
-                } else {
-                    try (InputStream inputStream = file.getInputStream(entry)) {
-                        indexer.index(inputStream);
-                    }
-                }
+                entriesToIndex.add(entry);
+            }
+        }
+
+        // feed classes to the `Indexer` in deterministic order
+        entriesToIndex.sort(Comparator.comparing(JarEntry::getRealName));
+
+        Indexer indexer = new Indexer();
+        for (JarEntry entry : entriesToIndex) {
+            try (InputStream inputStream = file.getInputStream(entry)) {
+                indexer.index(inputStream);
             }
         }
         return indexer.complete();
     }
 
+    /**
+     * @deprecated use {@link LazyIndexer}
+     */
+    @Deprecated(since = "3.37", forRemoval = true)
     public static void indexClass(String className, Indexer indexer, IndexView quarkusIndex,
             Set<DotName> additionalIndex, ClassLoader classLoader) {
         indexClass(className, indexer, quarkusIndex, additionalIndex, new HashSet<>(), classLoader);
     }
 
+    /**
+     * @deprecated use {@link LazyIndexer}
+     */
+    @Deprecated(since = "3.37", forRemoval = true)
     public static void indexClass(String className, Indexer indexer, IndexView quarkusIndex,
             Set<DotName> additionalIndex, Set<DotName> knownMissingClasses, ClassLoader classLoader) {
         DotName classDotName = DotName.createSimple(className);
@@ -187,16 +235,24 @@ public class IndexingUtil {
                 }
             }
         }
-        if (superclassName != null && !superclassName.equals(OBJECT)) {
+        if (superclassName != null && !superclassName.equals(DotName.OBJECT_NAME)) {
             indexClass(superclassName.toString(), indexer, quarkusIndex, additionalIndex, knownMissingClasses, classLoader);
         }
     }
 
+    /**
+     * @deprecated use {@link LazyIndexer}
+     */
+    @Deprecated(since = "3.37", forRemoval = true)
     public static void indexClass(String className, Indexer indexer,
             IndexView quarkusIndex, Set<DotName> additionalIndex, ClassLoader classLoader, byte[] beanData) {
         indexClass(className, indexer, quarkusIndex, additionalIndex, new HashSet<>(), classLoader, beanData);
     }
 
+    /**
+     * @deprecated use {@link LazyIndexer}
+     */
+    @Deprecated(since = "3.37", forRemoval = true)
     public static void indexClass(String className, Indexer indexer,
             IndexView quarkusIndex, Set<DotName> additionalIndex, Set<DotName> knownMissingClasses,
             ClassLoader classLoader, byte[] beanData) {
@@ -238,68 +294,6 @@ public class IndexingUtil {
                 } catch (IOException e) {
                     throw new IllegalStateException("Failed to index: " + className, e);
                 }
-            }
-        }
-    }
-
-    private static class PathTreeIndexer implements PathVisitor {
-
-        final Indexer indexer;
-        final Set<String> removed;
-
-        PathTreeIndexer(Indexer indexer, Set<String> removed) {
-            this.indexer = indexer;
-            this.removed = removed;
-        }
-
-        @Override
-        public void visitPath(PathVisit visit) {
-            final Path fileName = visit.getPath().getFileName();
-            if (fileName == null ||
-                    !fileName.toString().endsWith(".class") ||
-                    Files.isDirectory(visit.getPath()) ||
-                    removed != null && removed.contains(visit.getRelativePath("/"))) {
-                return;
-            }
-            try (InputStream inputStream = Files.newInputStream(visit.getPath())) {
-                indexer.index(inputStream);
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
-        }
-    }
-
-    private static class MetaInfJandexReader implements Function<PathVisit, Index> {
-        private final String treeDescription;
-
-        MetaInfJandexReader(String treeDescription) {
-            this.treeDescription = treeDescription;
-        }
-
-        @Override
-        public Index apply(PathVisit visit) {
-            if (visit == null) {
-                return null;
-            }
-            try (InputStream in = Files.newInputStream(visit.getPath())) {
-                IndexReader reader = new IndexReader(in);
-                try {
-                    int indexVersion = reader.getIndexVersion();
-                    if (indexVersion < REQUIRED_INDEX_VERSION) {
-                        log.warnf("Reindexing %s, at least Jandex 3.0 must be used"
-                                + " to index an application dependency (index version is %s)",
-                                treeDescription, indexVersion);
-                        return null;
-                    }
-                    return reader.read();
-                } catch (UnsupportedVersion e) {
-                    log.warnf("Reindexing %s, the index format is too new for the Jandex version"
-                            + " used by your application. Please report it to the author of this JAR (%s)",
-                            treeDescription, e.getMessage());
-                    return null;
-                }
-            } catch (IOException e) {
-                throw new UncheckedIOException("Can't read Jandex index from " + treeDescription, e);
             }
         }
     }

--- a/core/deployment/src/main/java/io/quarkus/deployment/index/LazyIndexer.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/index/LazyIndexer.java
@@ -1,0 +1,188 @@
+package io.quarkus.deployment.index;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.ClassSummary;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.Indexer;
+
+import io.quarkus.deployment.util.IoUtil;
+
+/**
+ * A lazy creator of a Jandex {@link Index}. It reads class data from a given class loader
+ * and skips classes that are present in the given existing Jandex index.
+ * <p>
+ * Expected usage:
+ * <ol>
+ * <li>Create an instance: {@code new LazyIndexer(classLoader, existingIndex)}</li>
+ * <li>Add class names to be indexed lazily: {@code add(className)}, {@code addAll(classNames)}</li>
+ * <li>Run the indexing process: {@code var result = indexer.complete()}</li>
+ * </ol>
+ * After calling {@code complete()}, the instance should be thrown away.
+ * The resulting index is expected to be combined with the given existing index using
+ * a {@link org.jboss.jandex.CompositeIndex CompositeIndex} or {@link org.jboss.jandex.StackedIndex StackedIndex}.
+ */
+public class LazyIndexer {
+    /**
+     * A result of lazy indexing process. Contains mainly a Jandex {@link Index},
+     * but also a set of annotation types whose classes were not found. It is perfectly
+     * normal for an annotation class to be missing, so this is <em>not</em> an error.
+     */
+    public record Result(Index index, Set<DotName> missingAnnotations) {
+    }
+
+    private final ClassLoader classLoader;
+    private final IndexView existingIndex;
+
+    private final Set<String> classNames = new HashSet<>();
+    private final Map<String, byte[]> classesData = new HashMap<>();
+
+    public LazyIndexer(ClassLoader classLoader, IndexView existingIndex) {
+        this.classLoader = Objects.requireNonNull(classLoader);
+        this.existingIndex = Objects.requireNonNull(existingIndex);
+    }
+
+    /**
+     * Adds the given {@code className} to the set of classes to be indexed lazily.
+     * <p>
+     * The given class, all its superclasses, and all annotations found on the class
+     * and its superclasses will be indexed.
+     */
+    public void add(String className) {
+        classNames.add(Objects.requireNonNull(className));
+    }
+
+    /**
+     * Adds all given {@code classNames} to the set of classes to be indexed lazily.
+     * <p>
+     * The given classes, all their superclasses, and all annotations found on the classes
+     * and their superclasses will be indexed.
+     */
+    public void addAll(Collection<String> classNames) {
+        this.classNames.addAll(Objects.requireNonNull(classNames));
+    }
+
+    /**
+     * Adds the given {@code className} to the set of classes to be indexed lazily.
+     * The class data will not be obtained from the class loader; instead, the given
+     * {@code classData} will be used.
+     * <p>
+     * The given class and all annotations found on it will be indexed.
+     * Unlike the other {@code add} methods, superclasses will <em>not</em> be indexed.
+     * <p>
+     * If the same class name has already been added with <em>different</em> class data,
+     * an exception is thrown.
+     */
+    public void add(String className, byte[] classData) {
+        Objects.requireNonNull(className);
+        Objects.requireNonNull(classData);
+
+        // this shouldn't happen very often (hopefully...), but there is code out there
+        // that suggests a class name passed here may be an internal name, not a binary name
+        className = className.replace('/', '.');
+
+        byte[] existingData = classesData.get(className);
+        if (existingData != null && !Arrays.equals(existingData, classData)) {
+            throw new IllegalArgumentException("Class " + className + " already present with different class data");
+        }
+
+        classNames.add(className);
+        classesData.put(className, classData);
+    }
+
+    /**
+     * Runs the indexing process. All classes added via {@code add()} are indexed
+     * and the {@link Result} is returned. If a class is not found in the class loader,
+     * an exception is thrown, unless it is a class of an annotation that is present
+     * on one of the previously indexed classes.
+     */
+    public Result complete() {
+        Indexer indexer = new Indexer();
+        Set<DotName> missingAnnotations = new HashSet<>();
+
+        Set<String> alreadySeen = new HashSet<>();
+
+        List<String> current = null;
+        List<String> next = new ArrayList<>(classNames);
+
+        while (!next.isEmpty()) {
+            current = next;
+            next = new ArrayList<>();
+
+            // feed classes to the `Indexer` in deterministic order
+            Collections.sort(current);
+
+            for (String className : current) {
+                if (alreadySeen.contains(className)) {
+                    continue;
+                }
+
+                byte[] classData = classesData.get(className);
+
+                DotName superclassName;
+                Set<DotName> annotationNames;
+
+                ClassInfo classInfo = existingIndex.getClassByName(className);
+                if (classInfo == null) {
+                    try (InputStream stream = classData != null
+                            ? new ByteArrayInputStream(classData)
+                            : IoUtil.readClass(classLoader, className)) {
+                        if (stream == null) {
+                            throw new IllegalStateException("Failed to index: " + className
+                                    + ", class not present in class loader: " + classLoader);
+                        }
+
+                        ClassSummary summary = indexer.indexWithSummary(stream);
+                        alreadySeen.add(summary.name().toString());
+                        superclassName = summary.superclassName();
+                        annotationNames = summary.annotations();
+                    } catch (Exception e) {
+                        throw new IllegalStateException("Failed to index: " + className, e);
+                    }
+                } else {
+                    alreadySeen.add(className);
+                    superclassName = classInfo.superName();
+                    annotationNames = classInfo.annotationsMap().keySet();
+                }
+
+                for (DotName annotationDotName : annotationNames) {
+                    String annotationName = annotationDotName.toString();
+                    if (!alreadySeen.contains(annotationName) && existingIndex.getClassByName(annotationDotName) == null) {
+                        try (InputStream annotationStream = IoUtil.readClass(classLoader, annotationName)) {
+                            if (annotationStream == null) {
+                                missingAnnotations.add(annotationDotName);
+                            } else {
+                                next.add(annotationName);
+                            }
+                        } catch (IOException e) {
+                            throw new IllegalStateException("Failed to index: " + className, e);
+                        }
+                    }
+                }
+                if (classData == null && superclassName != null && !superclassName.equals(DotName.OBJECT_NAME)) {
+                    next.add(superclassName.toString());
+                }
+            }
+        }
+
+        classNames.clear();
+        classesData.clear();
+
+        return new Result(indexer.complete(), missingAnnotations);
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
@@ -414,7 +414,7 @@ public final class LoggingResourceProcessor {
             LogBuildTimeConfig logBuildTimeConfig,
             BuildProducer<LoggingDecorateBuildItem> loggingDecorateProducer) {
         List<IndexView> indexList = new ArrayList<>();
-        for (ApplicationArchive i : item.getAllApplicationArchives()) {
+        for (ApplicationArchive i : item.getAllArchives()) {
             if (i.getResolvedPaths().isSinglePath() && Files.isDirectory(i.getResolvedPaths().getSinglePath())) {
                 indexList.add(i.getIndex());
             }

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ApplicationIndexBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ApplicationIndexBuildStep.java
@@ -7,7 +7,10 @@ import java.nio.file.FileVisitor;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Set;
 
 import org.jboss.jandex.Index;
@@ -28,55 +31,49 @@ public class ApplicationIndexBuildStep {
     @BuildStep
     ApplicationIndexBuildItem build(ArchiveRootBuildItem root, CurateOutcomeBuildItem curation,
             ClassLoadingConfig classLoadingConfig) throws IOException {
-        Indexer indexer = new Indexer();
-        Set<String> removedApplicationClasses = removedApplicationClasses(curation, classLoadingConfig);
+        List<Path> classFilesToIndex = new ArrayList<>();
         for (Path p : root.getRootDirectories()) {
-            Files.walkFileTree(p, new FileVisitor<Path>() {
+            Files.walkFileTree(p, new FileVisitor<>() {
                 @Override
-                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
                     return FileVisitResult.CONTINUE;
                 }
 
                 @Override
-                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
                     if (file.getFileName().toString().endsWith(".class")) {
-                        if (isRemovedApplicationClass(file, removedApplicationClasses)) {
-                            log.debugf("File %s will not be indexed because the class has been configured as part of '%s'",
-                                    file, "quarkus.class-loading.removed-resources");
-                        } else {
-                            log.debugf("Indexing %s", file);
-                            try (InputStream stream = Files.newInputStream(file)) {
-                                indexer.index(stream);
-                            }
-                        }
+                        classFilesToIndex.add(file);
                     }
                     return FileVisitResult.CONTINUE;
                 }
 
-                private boolean isRemovedApplicationClass(Path file, Set<String> removedApplicationClasses) {
-                    if (removedApplicationClasses.isEmpty()) {
-                        return false;
-                    }
-                    String fileName = file.toString().replace('\\', '/');
-                    String sanitizedFileName = (fileName.startsWith("/") ? fileName.substring(1) : fileName);
-                    for (String removedApplicationClass : removedApplicationClasses) {
-                        if (sanitizedFileName.endsWith(removedApplicationClass)) {
-                            return true;
-                        }
-                    }
-                    return false;
-                }
-
                 @Override
-                public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+                public FileVisitResult visitFileFailed(Path file, IOException exc) {
                     return FileVisitResult.CONTINUE;
                 }
 
                 @Override
-                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                public FileVisitResult postVisitDirectory(Path dir, IOException exc) {
                     return FileVisitResult.CONTINUE;
                 }
             });
+        }
+
+        // feed classes to the `Indexer` in deterministic order
+        classFilesToIndex.sort(Comparator.comparing(Path::toString));
+
+        Indexer indexer = new Indexer();
+        Set<String> removedApplicationClasses = removedApplicationClasses(curation, classLoadingConfig);
+        for (Path file : classFilesToIndex) {
+            if (isRemovedApplicationClass(file, removedApplicationClasses)) {
+                log.debugf("File %s will not be indexed because the class has been configured as part of '%s'",
+                        file, "quarkus.class-loading.removed-resources");
+            } else {
+                log.debugf("Indexing %s", file);
+                try (InputStream stream = Files.newInputStream(file)) {
+                    indexer.index(stream);
+                }
+            }
         }
         Index appIndex = indexer.complete();
         return new ApplicationIndexBuildItem(appIndex);
@@ -87,6 +84,20 @@ public class ApplicationIndexBuildStep {
         Set<String> entry = classLoadingConfig.removedResources()
                 .get(appArtifact.getGroupId() + ":" + appArtifact.getArtifactId());
         return entry != null ? entry : Collections.emptySet();
+    }
+
+    private boolean isRemovedApplicationClass(Path file, Set<String> removedApplicationClasses) {
+        if (removedApplicationClasses.isEmpty()) {
+            return false;
+        }
+        String fileName = file.toString().replace('\\', '/');
+        String sanitizedFileName = (fileName.startsWith("/") ? fileName.substring(1) : fileName);
+        for (String removedApplicationClass : removedApplicationClasses) {
+            if (sanitizedFileName.endsWith(removedApplicationClass)) {
+                return true;
+            }
+        }
+        return false;
     }
 
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/CombinedIndexBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/CombinedIndexBuildStep.java
@@ -1,17 +1,14 @@
 package io.quarkus.deployment.steps;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.CompositeIndex;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
-import org.jboss.jandex.Indexer;
 
 import io.quarkus.deployment.ApplicationArchive;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -21,7 +18,7 @@ import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.deployment.dev.RuntimeUpdatesProcessor;
 import io.quarkus.deployment.index.IndexWrapper;
-import io.quarkus.deployment.index.IndexingUtil;
+import io.quarkus.deployment.index.LazyIndexer;
 import io.quarkus.deployment.index.PersistentClassIndex;
 
 public class CombinedIndexBuildStep {
@@ -32,22 +29,17 @@ public class CombinedIndexBuildStep {
             LiveReloadBuildItem liveReloadBuildItem) {
         List<IndexView> archiveIndexes = new ArrayList<>();
 
-        for (ApplicationArchive i : archives.getAllApplicationArchives()) {
+        for (ApplicationArchive i : archives.getAllArchives()) {
             archiveIndexes.add(i.getIndex());
         }
 
         CompositeIndex archivesIndex = CompositeIndex.create(archiveIndexes);
 
-        Indexer indexer = new Indexer();
-        Set<DotName> additionalIndex = new HashSet<>();
-        Set<DotName> knownMissingClasses = new HashSet<>();
-
+        LazyIndexer indexer = new LazyIndexer(Thread.currentThread().getContextClassLoader(), archivesIndex);
         for (AdditionalIndexedClassesBuildItem additionalIndexedClasses : additionalIndexedClassesItems) {
-            for (String classToIndex : additionalIndexedClasses.getClassesToIndex()) {
-                IndexingUtil.indexClass(classToIndex, indexer, archivesIndex, additionalIndex,
-                        knownMissingClasses, Thread.currentThread().getContextClassLoader());
-            }
+            indexer.addAll(additionalIndexedClasses.getClassesToIndex());
         }
+        LazyIndexer.Result result = indexer.complete();
 
         PersistentClassIndex index = liveReloadBuildItem.getContextObject(PersistentClassIndex.class);
         if (index == null) {
@@ -56,11 +48,11 @@ public class CombinedIndexBuildStep {
         }
 
         Map<DotName, Optional<ClassInfo>> additionalClasses = index.getAdditionalClasses();
-        for (DotName knownMissingClass : knownMissingClasses) {
+        for (DotName knownMissingClass : result.missingAnnotations()) {
             additionalClasses.put(knownMissingClass, Optional.empty());
         }
 
-        CompositeIndex compositeIndex = CompositeIndex.create(archivesIndex, indexer.complete());
+        CompositeIndex compositeIndex = CompositeIndex.create(archivesIndex, result.index());
         RuntimeUpdatesProcessor.setLastStartIndex(compositeIndex);
         return new CombinedIndexBuildItem(compositeIndex,
                 new IndexWrapper(compositeIndex, Thread.currentThread().getContextClassLoader(), index));

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BeanArchiveProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BeanArchiveProcessor.java
@@ -18,14 +18,13 @@ import jakarta.enterprise.inject.spi.DefinitionException;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.AnnotationTarget.Kind;
+import org.jboss.jandex.AnnotationTransformation;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.CompositeIndex;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
-import org.jboss.jandex.Indexer;
 import org.jboss.logging.Logger;
 
-import io.quarkus.arc.processor.AnnotationsTransformer;
 import io.quarkus.arc.processor.BeanArchives;
 import io.quarkus.arc.processor.BeanDefiningAnnotation;
 import io.quarkus.arc.processor.BeanDeployment;
@@ -39,7 +38,7 @@ import io.quarkus.deployment.builditem.ExcludeDependencyBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.deployment.index.IndexDependencyConfig;
-import io.quarkus.deployment.index.IndexingUtil;
+import io.quarkus.deployment.index.LazyIndexer;
 import io.quarkus.deployment.index.PersistentClassIndex;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.ArtifactKey;
@@ -66,7 +65,6 @@ public class BeanArchiveProcessor {
                 new KnownCompatibleBeanArchives(knownCompatibleBeanArchives));
 
         // Then build additional index for beans added by extensions
-        Indexer additionalBeanIndexer = new Indexer();
         List<String> additionalBeanClasses = new ArrayList<>();
         for (AdditionalBeanBuildItem i : additionalBeans) {
             additionalBeanClasses.addAll(i.getBeanClasses());
@@ -75,37 +73,24 @@ public class BeanArchiveProcessor {
         Set<String> additionalBeansFromExtensions = new HashSet<>();
         buildCompatibleExtensions.entrypoint.runDiscovery(applicationIndex, additionalBeansFromExtensions);
         additionalBeanClasses.addAll(additionalBeansFromExtensions);
-        annotationsTransformations.produce(new AnnotationsTransformerBuildItem(new AnnotationsTransformer() {
-            @Override
-            public boolean appliesTo(Kind kind) {
-                return kind == Kind.CLASS;
-            }
-
-            @Override
-            public void transform(TransformationContext ctx) {
-                if (additionalBeansFromExtensions.contains(ctx.getTarget().asClass().name().toString())) {
-                    // make all the `@Discovery`-registered classes beans
-                    ctx.transform().add(AdditionalBean.class).done();
-                }
-            }
-        }));
+        annotationsTransformations.produce(new AnnotationsTransformerBuildItem(
+                // make all the `@Discovery`-registered classes beans
+                AnnotationTransformation.forClasses()
+                        .whenClass(cl -> additionalBeansFromExtensions.contains(cl.name().toString()))
+                        .transform(ctx -> ctx.add(AdditionalBean.class))));
 
         // Build the index for additional beans and generated bean classes
-        Set<DotName> additionalIndex = new HashSet<>();
-        Set<DotName> knownMissingClasses = new HashSet<>();
-        for (String beanClass : additionalBeanClasses) {
-            IndexingUtil.indexClass(beanClass, additionalBeanIndexer, applicationIndex, additionalIndex,
-                    knownMissingClasses, Thread.currentThread().getContextClassLoader());
-        }
+        LazyIndexer indexer = new LazyIndexer(Thread.currentThread().getContextClassLoader(), applicationIndex);
+        indexer.addAll(additionalBeanClasses);
         Set<DotName> generatedClassNames = new HashSet<>();
         for (GeneratedBeanBuildItem generatedBean : generatedBeans) {
-            IndexingUtil.indexClass(generatedBean.getName(), additionalBeanIndexer, applicationIndex, additionalIndex,
-                    knownMissingClasses, Thread.currentThread().getContextClassLoader(), generatedBean.getData());
+            indexer.add(generatedBean.getName(), generatedBean.getData());
             generatedClassNames.add(DotName.createSimple(generatedBean.getName().replace('/', '.')));
             generatedClass.produce(new GeneratedClassBuildItem(generatedBean.isApplicationClass(), generatedBean.getName(),
                     generatedBean.getData(),
                     generatedBean.getSource()));
         }
+        LazyIndexer.Result result = indexer.complete();
 
         PersistentClassIndex index = liveReloadBuildItem.getContextObject(PersistentClassIndex.class);
         if (index == null) {
@@ -114,12 +99,12 @@ public class BeanArchiveProcessor {
         }
 
         Map<DotName, Optional<ClassInfo>> additionalClasses = index.getAdditionalClasses();
-        for (DotName knownMissingClass : knownMissingClasses) {
+        for (DotName knownMissingClass : result.missingAnnotations()) {
             additionalClasses.put(knownMissingClass, Optional.empty());
         }
 
         IndexView immutableBeanArchiveIndex = BeanArchives.buildImmutableBeanArchiveIndex(applicationIndex,
-                additionalBeanIndexer.complete());
+                result.index());
         IndexView computingBeanArchiveIndex = BeanArchives.buildComputingBeanArchiveIndex(
                 Thread.currentThread().getContextClassLoader(),
                 additionalClasses, immutableBeanArchiveIndex);
@@ -132,7 +117,7 @@ public class BeanArchiveProcessor {
             List<BeanArchivePredicateBuildItem> beanArchivePredicates,
             KnownCompatibleBeanArchives knownCompatibleBeanArchives) {
 
-        Set<ApplicationArchive> archives = applicationArchivesBuildItem.getAllApplicationArchives();
+        List<ApplicationArchive> archives = applicationArchivesBuildItem.getAllArchives();
 
         // We need to collect all stereotype annotations first
         Set<DotName> stereotypes = new HashSet<>();
@@ -162,11 +147,9 @@ public class BeanArchiveProcessor {
         beanDefiningAnnotations.add(DotNames.INTERCEPTOR);
 
         boolean rootIsAlwaysBeanArchive = !config.strictCompatibility();
-        Collection<ApplicationArchive> candidateArchives = applicationArchivesBuildItem.getApplicationArchives();
-        if (!rootIsAlwaysBeanArchive) {
-            candidateArchives = new ArrayList<>(candidateArchives);
-            candidateArchives.add(applicationArchivesBuildItem.getRootArchive());
-        }
+        List<ApplicationArchive> candidateArchives = rootIsAlwaysBeanArchive
+                ? applicationArchivesBuildItem.getArchives()
+                : applicationArchivesBuildItem.getAllArchives();
 
         List<IndexView> indexes = new ArrayList<>();
 

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/SplitPackageProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/SplitPackageProcessor.java
@@ -68,10 +68,10 @@ public class SplitPackageProcessor {
         }
 
         // for all app archives
-        for (ApplicationArchive archive : archivesBuildItem.getAllApplicationArchives()) {
+        for (ApplicationArchive archive : archivesBuildItem.getAllArchives()) {
             // and for each known class in each archive
             for (ClassInfo classInfo : archive.getIndex().getKnownClasses()) {
-                String packageName = DotNames.packageName(classInfo.name());
+                String packageName = DotNames.packagePrefix(classInfo.name());
                 packageToArchiveMap.compute(packageName, (key, val) -> {
                     Set<ApplicationArchive> returnValue = val == null ? new HashSet<>() : val;
                     boolean add = true;

--- a/extensions/devui/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/NotFoundProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/NotFoundProcessor.java
@@ -57,7 +57,7 @@ public class NotFoundProcessor {
         }
 
         // Static files
-        Set<String> staticRoots = applicationArchivesBuildItem.getAllApplicationArchives().stream()
+        Set<String> staticRoots = applicationArchivesBuildItem.getAllArchives().stream()
                 .map(i -> i.apply(t -> {
                     var p = t.getPath(META_INF_RESOURCES);
                     return p == null ? null : p.toAbsolutePath().toString();

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -65,7 +65,6 @@ import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.CompositeIndex;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
-import org.jboss.jandex.Indexer;
 import org.jboss.logging.Logger;
 import org.jboss.logmanager.Level;
 
@@ -120,7 +119,7 @@ import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveMethodBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
-import io.quarkus.deployment.index.IndexingUtil;
+import io.quarkus.deployment.index.LazyIndexer;
 import io.quarkus.deployment.pkg.AotJarEnabled;
 import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.deployment.recording.RecorderContext;
@@ -444,21 +443,16 @@ public final class HibernateOrmProcessor {
             CombinedIndexBuildItem index,
             List<AdditionalJpaModelBuildItem> additionalJpaModelBuildItems,
             List<io.quarkus.hibernate.orm.deployment.AdditionalJpaModelBuildItem> deprecatedAdditionalJpaModelBuildItems) {
-        Set<String> additionalClassNames = new HashSet<>();
+        // build a composite index with additional jpa model classes
+        LazyIndexer indexer = new LazyIndexer(HibernateOrmProcessor.class.getClassLoader(), index.getIndex());
         for (AdditionalJpaModelBuildItem jpaModel : additionalJpaModelBuildItems) {
-            additionalClassNames.add(jpaModel.getClassName());
+            indexer.add(jpaModel.getClassName());
         }
         for (io.quarkus.hibernate.orm.deployment.AdditionalJpaModelBuildItem jpaModel : deprecatedAdditionalJpaModelBuildItems) {
-            additionalClassNames.add(jpaModel.getClassName());
+            indexer.add(jpaModel.getClassName());
         }
-        // build a composite index with additional jpa model classes
-        Indexer indexer = new Indexer();
-        Set<DotName> additionalIndex = new HashSet<>();
-        for (String className : additionalClassNames) {
-            IndexingUtil.indexClass(className, indexer, index.getIndex(), additionalIndex,
-                    HibernateOrmProcessor.class.getClassLoader());
-        }
-        CompositeIndex compositeIndex = CompositeIndex.create(index.getComputingIndex(), indexer.complete());
+        LazyIndexer.Result result = indexer.complete();
+        CompositeIndex compositeIndex = CompositeIndex.create(index.getComputingIndex(), result.index());
         return new JpaModelIndexBuildItem(compositeIndex);
     }
 

--- a/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/MethodValidatedAnnotationsTransformer.java
+++ b/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/MethodValidatedAnnotationsTransformer.java
@@ -12,7 +12,6 @@ import org.jboss.logging.Logger;
 import org.objectweb.asm.Opcodes;
 
 import io.quarkus.arc.processor.AnnotationsTransformer;
-import io.quarkus.deployment.index.IndexingUtil;
 import io.quarkus.hibernate.validator.runtime.interceptor.MethodValidated;
 import io.quarkus.hibernate.validator.runtime.jaxrs.JaxrsEndPointValidated;
 
@@ -100,7 +99,7 @@ public class MethodValidatedAnnotationsTransformer implements AnnotationsTransfo
 
         // check superclass, but only the direct one since we do not (yet) have the entire ClassInfo hierarchy here
         DotName superClass = clazz.superName();
-        if (!superClass.equals(IndexingUtil.OBJECT)) {
+        if (!superClass.equals(DotName.OBJECT_NAME)) {
             if (isJaxrsMethod(signatureKey, superClass)) {
                 return true;
             }

--- a/extensions/hibernate-validator/spi/src/main/java/io/quarkus/hibernate/validator/spi/AdditionalConstrainedClassBuildItem.java
+++ b/extensions/hibernate-validator/spi/src/main/java/io/quarkus/hibernate/validator/spi/AdditionalConstrainedClassBuildItem.java
@@ -2,7 +2,8 @@ package io.quarkus.hibernate.validator.spi;
 
 import io.quarkus.builder.item.MultiBuildItem;
 
-public final class AdditionalConstrainedClassBuildItem extends MultiBuildItem {
+public final class AdditionalConstrainedClassBuildItem extends MultiBuildItem
+        implements Comparable<AdditionalConstrainedClassBuildItem> {
 
     private static final byte[] EMPTY = new byte[0];
 
@@ -44,5 +45,10 @@ public final class AdditionalConstrainedClassBuildItem extends MultiBuildItem {
 
     public boolean isGenerated() {
         return clazz == null;
+    }
+
+    @Override
+    public int compareTo(AdditionalConstrainedClassBuildItem that) {
+        return name.compareTo(that.name);
     }
 }

--- a/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/InfinispanClientProcessor.java
+++ b/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/InfinispanClientProcessor.java
@@ -220,7 +220,7 @@ class InfinispanClientProcessor {
             Object marshaller = properties.get(ConfigurationProperties.MARSHALLER);
 
             if (marshaller instanceof ProtoStreamMarshaller) {
-                for (ApplicationArchive applicationArchive : applicationArchivesBuildItem.getAllApplicationArchives()) {
+                for (ApplicationArchive applicationArchive : applicationArchivesBuildItem.getAllArchives()) {
                     // If we have properties file we may have to care about
                     Path metaPath = applicationArchive.getChildPath(META_INF);
 

--- a/extensions/jaxb/deployment/src/main/java/io/quarkus/jaxb/deployment/JaxbProcessor.java
+++ b/extensions/jaxb/deployment/src/main/java/io/quarkus/jaxb/deployment/JaxbProcessor.java
@@ -439,7 +439,7 @@ public class JaxbProcessor {
     private void iterateResources(ApplicationArchivesBuildItem applicationArchivesBuildItem, String path,
             BuildProducer<NativeImageResourceBuildItem> resource, BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             List<String> classesToBeBound) {
-        for (ApplicationArchive archive : applicationArchivesBuildItem.getAllApplicationArchives()) {
+        for (ApplicationArchive archive : applicationArchivesBuildItem.getAllArchives()) {
             archive.accept(tree -> {
                 var arch = tree.getPath(path);
                 if (arch != null && Files.isDirectory(arch)) {

--- a/extensions/oidc-client/deployment/src/main/java/io/quarkus/oidc/client/deployment/OidcClientBuildStep.java
+++ b/extensions/oidc-client/deployment/src/main/java/io/quarkus/oidc/client/deployment/OidcClientBuildStep.java
@@ -86,7 +86,7 @@ public class OidcClientBuildStep {
     }
 
     private Set<String> oidcClientNamesOf(ApplicationArchivesBuildItem beanArchiveIndex) {
-        return beanArchiveIndex.getAllApplicationArchives().stream()
+        return beanArchiveIndex.getAllArchives().stream()
                 .map(ApplicationArchive::getIndex)
                 .flatMap(archive -> archive.getAnnotations(DotName.createSimple(NamedOidcClient.class.getName())).stream())
                 .map(annotation -> annotation.value().asString())

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
@@ -1596,7 +1596,7 @@ public class MessageBundleProcessor {
         List<MessageFile> messageFiles = new ArrayList<>();
 
         addMessageFiles(applicationArchives.getRootArchive(), 10, messageFiles);
-        for (ApplicationArchive archive : applicationArchives.getApplicationArchives()) {
+        for (ApplicationArchive archive : applicationArchives.getArchives()) {
             addMessageFiles(archive, 1, messageFiles);
         }
 

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
@@ -2282,7 +2282,7 @@ public class QuteProcessor {
 
         final boolean tryLocateSource = launchMode.getLaunchMode().isDev()
                 && DevModeType.LOCAL == launchMode.getDevModeType().orElse(null);
-        final Set<ApplicationArchive> allApplicationArchives = applicationArchives.getAllApplicationArchives();
+        final List<ApplicationArchive> allApplicationArchives = applicationArchives.getAllArchives();
         final Set<ArtifactKey> appArtifactKeys = new HashSet<>(allApplicationArchives.size());
         for (var archive : allApplicationArchives) {
             appArtifactKeys.add(archive.getKey());
@@ -2295,7 +2295,7 @@ public class QuteProcessor {
                         config, excludePatterns, TemplatePathBuildItem.APP_ARCHIVE_PRIORITY, null, tryLocateSource, null);
             }
         }
-        for (ApplicationArchive archive : applicationArchives.getApplicationArchives()) {
+        for (ApplicationArchive archive : applicationArchives.getArchives()) {
             archive.accept(
                     tree -> scanPathTree(tree, templateRoots, watchedPaths, templatePaths, nativeImageResources, config,
                             excludePatterns, TemplatePathBuildItem.APP_ARCHIVE_PRIORITY, null, tryLocateSource, null));

--- a/extensions/resteasy-reactive/rest-client/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/RestClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/RestClientReactiveProcessor.java
@@ -54,7 +54,6 @@ import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
-import org.jboss.jandex.CompositeIndex;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
@@ -240,7 +239,7 @@ class RestClientReactiveProcessor {
         enrichers.produce(new JaxrsClientReactiveEnricherBuildItem(new MicroProfileRestClientEnricher()));
     }
 
-    private void searchForJaxRsMethods(List<MethodInfo> listOfKnownMethods, ClassInfo startingInterface, CompositeIndex index) {
+    private void searchForJaxRsMethods(List<MethodInfo> listOfKnownMethods, ClassInfo startingInterface, IndexView index) {
         for (MethodInfo method : startingInterface.methods()) {
             if (isRestMethod(method)) {
                 listOfKnownMethods.add(method);
@@ -548,10 +547,10 @@ class RestClientReactiveProcessor {
             CombinedIndexBuildItem combinedIndexBuildItem,
             RestClientsBuildTimeConfig clientsConfig,
             BuildProducer<RegisteredRestClientBuildItem> producer) {
-        CompositeIndex index = CompositeIndex.create(combinedIndexBuildItem.getIndex());
+        IndexView index = combinedIndexBuildItem.getIndex();
         Set<DotName> seen = new HashSet<>();
 
-        List<AnnotationInstance> actualInstances = index.getAnnotations(REGISTER_REST_CLIENT);
+        Collection<AnnotationInstance> actualInstances = index.getAnnotations(REGISTER_REST_CLIENT);
         for (AnnotationInstance instance : actualInstances) {
             AnnotationTarget annotationTarget = instance.target();
             ClassInfo classInfo = annotationTarget.asClass();
@@ -616,7 +615,7 @@ class RestClientReactiveProcessor {
             RestClientRecorder recorder,
             ShutdownContextBuildItem shutdown) {
 
-        CompositeIndex index = CompositeIndex.create(combinedIndexBuildItem.getIndex());
+        IndexView index = combinedIndexBuildItem.getIndex();
 
         Set<DotName> requestedRestClientMocks = Collections.emptySet();
         if (launchMode.getLaunchMode() == LaunchMode.TEST) {

--- a/extensions/resteasy-reactive/rest-common/spi-deployment/src/main/java/io/quarkus/resteasy/reactive/spi/GeneratedJaxRsResourceBuildItem.java
+++ b/extensions/resteasy-reactive/rest-common/spi-deployment/src/main/java/io/quarkus/resteasy/reactive/spi/GeneratedJaxRsResourceBuildItem.java
@@ -6,7 +6,8 @@ import io.quarkus.builder.item.MultiBuildItem;
  * Represents a JAX-RS resource that is generated.
  * Meant to be used by extension that generate JAX-RS resources as part of their build time processing
  */
-public final class GeneratedJaxRsResourceBuildItem extends MultiBuildItem {
+public final class GeneratedJaxRsResourceBuildItem extends MultiBuildItem
+        implements Comparable<GeneratedJaxRsResourceBuildItem> {
 
     private final String binaryName;
     private final String internalName;
@@ -44,5 +45,10 @@ public final class GeneratedJaxRsResourceBuildItem extends MultiBuildItem {
 
     public byte[] getData() {
         return data;
+    }
+
+    @Override
+    public int compareTo(GeneratedJaxRsResourceBuildItem o) {
+        return binaryName.compareTo(o.binaryName());
     }
 }

--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveScanningProcessor.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveScanningProcessor.java
@@ -25,7 +25,6 @@ import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.CompositeIndex;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
-import org.jboss.jandex.Indexer;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
 import org.jboss.resteasy.reactive.common.core.BlockingNotAllowedException;
@@ -63,7 +62,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
-import io.quarkus.deployment.index.IndexingUtil;
+import io.quarkus.deployment.index.LazyIndexer;
 import io.quarkus.resteasy.reactive.common.deployment.ApplicationResultBuildItem;
 import io.quarkus.resteasy.reactive.common.deployment.ResourceInterceptorsContributorBuildItem;
 import io.quarkus.resteasy.reactive.common.deployment.ResourceScanningResultBuildItem;
@@ -395,23 +394,21 @@ public class ResteasyReactiveScanningProcessor {
         // if we have custom filters, we need to index these classes
         if (!customContainerRequestFilters.isEmpty() || !customContainerResponseFilters.isEmpty()
                 || !customExceptionMappers.isEmpty()) {
-            Indexer indexer = new Indexer();
-            Set<DotName> additionalIndex = new HashSet<>();
             //we have to use the non-computing index here
             //the logic checks if the bean is already indexed, so the computing one breaks this
+            LazyIndexer indexer = new LazyIndexer(Thread.currentThread().getContextClassLoader(),
+                    combinedIndexBuildItem.getIndex());
             for (CustomContainerRequestFilterBuildItem filter : customContainerRequestFilters) {
-                IndexingUtil.indexClass(filter.getClassName(), indexer, combinedIndexBuildItem.getIndex(), additionalIndex,
-                        Thread.currentThread().getContextClassLoader());
+                indexer.add(filter.getClassName());
             }
             for (CustomContainerResponseFilterBuildItem filter : customContainerResponseFilters) {
-                IndexingUtil.indexClass(filter.getClassName(), indexer, combinedIndexBuildItem.getIndex(), additionalIndex,
-                        Thread.currentThread().getContextClassLoader());
+                indexer.add(filter.getClassName());
             }
             for (CustomExceptionMapperBuildItem mapper : customExceptionMappers) {
-                IndexingUtil.indexClass(mapper.getClassName(), indexer, combinedIndexBuildItem.getIndex(), additionalIndex,
-                        Thread.currentThread().getContextClassLoader());
+                indexer.add(mapper.getClassName());
             }
-            index = CompositeIndex.create(index, indexer.complete());
+            LazyIndexer.Result result = indexer.complete();
+            index = CompositeIndex.create(index, result.index());
         }
 
         List<FilterGeneration.GeneratedFilter> generatedFilters = FilterGeneration.generate(index,

--- a/extensions/security/spi/src/main/java/io/quarkus/security/spi/SecurityTransformerBuildItem.java
+++ b/extensions/security/spi/src/main/java/io/quarkus/security/spi/SecurityTransformerBuildItem.java
@@ -1,6 +1,5 @@
 package io.quarkus.security.spi;
 
-import static io.quarkus.deployment.index.IndexingUtil.OBJECT;
 import static java.util.stream.Collectors.toSet;
 import static org.jboss.jandex.AnnotationTarget.Kind.CLASS;
 import static org.jboss.jandex.AnnotationTarget.Kind.METHOD;
@@ -262,7 +261,7 @@ public final class SecurityTransformerBuildItem extends SimpleBuildItem {
                 .map(ClassInfo::interfaceNames)
                 .flatMap(Collection::stream)
                 .filter(Objects::nonNull)
-                .filter(n -> !OBJECT.equals(n))
+                .filter(n -> !DotName.OBJECT_NAME.equals(n))
                 .filter(n -> !ignoredPackages.contains(n.packagePrefix()))
                 .map(index::getClassByName)
                 .filter(Objects::nonNull)

--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -286,16 +287,23 @@ public class SmallRyeGraphQLProcessor {
             SmallRyeGraphQLModifiedClasesBuildItem graphQLIndexBuildItem,
             List<SmallRyeGraphQLFinalIndexModifierBuildItem> indexModifiers) {
 
-        Indexer indexer = new Indexer();
-        Map<String, byte[]> modifiedClases = graphQLIndexBuildItem.getModifiedClases();
+        List<Map.Entry<String, byte[]>> list = new ArrayList<>();
+        for (Map.Entry<String, byte[]> entry : graphQLIndexBuildItem.getModifiedClases().entrySet()) {
+            if (entry.getKey() != null && entry.getValue() != null) {
+                list.add(entry);
+            }
+        }
 
-        for (Map.Entry<String, byte[]> kv : modifiedClases.entrySet()) {
-            if (kv.getKey() != null && kv.getValue() != null) {
-                try (ByteArrayInputStream bais = new ByteArrayInputStream(kv.getValue())) {
-                    indexer.index(bais);
-                } catch (IOException ex) {
-                    LOG.warn("Could not index [" + kv.getKey() + "] - " + ex.getMessage());
-                }
+        // feed classes to the `Indexer` in deterministic order
+        list.sort(Map.Entry.comparingByKey());
+
+        Indexer indexer = new Indexer();
+
+        for (Map.Entry<String, byte[]> kv : list) {
+            try (ByteArrayInputStream bais = new ByteArrayInputStream(kv.getValue())) {
+                indexer.index(bais);
+            } catch (IOException ex) {
+                LOG.warn("Could not index [" + kv.getKey() + "] - " + ex.getMessage());
             }
         }
 

--- a/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/WebXmlParsingBuildStep.java
+++ b/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/WebXmlParsingBuildStep.java
@@ -118,7 +118,7 @@ public class WebXmlParsingBuildStep {
      */
     private List<WebFragmentMetaData> parseWebFragments(ApplicationArchivesBuildItem applicationArchivesBuildItem) {
         List<WebFragmentMetaData> webFragments = new ArrayList<>();
-        for (ApplicationArchive archive : applicationArchivesBuildItem.getAllApplicationArchives()) {
+        for (ApplicationArchive archive : applicationArchivesBuildItem.getAllArchives()) {
             archive.accept(tree -> {
                 Path webFragment = tree.getPath(WEB_FRAGMENT_XML);
                 if (webFragment != null && Files.isRegularFile(webFragment)) {

--- a/extensions/undertow/spi/src/main/java/io/quarkus/undertow/deployment/UndertowStaticResourcesBuildStep.java
+++ b/extensions/undertow/spi/src/main/java/io/quarkus/undertow/deployment/UndertowStaticResourcesBuildStep.java
@@ -60,7 +60,7 @@ public class UndertowStaticResourcesBuildStep {
         //this kinda sucks
         final Set<String> knownFiles = new HashSet<>();
         final Set<String> knownDirectories = new HashSet<>();
-        for (ApplicationArchive i : applicationArchivesBuildItem.getAllApplicationArchives()) {
+        for (ApplicationArchive i : applicationArchivesBuildItem.getAllArchives()) {
             i.accept(tree -> {
                 Path resource = tree.getPath(META_INF_RESOURCES);
                 if (resource != null && Files.exists(resource)) {

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ArtifactKey.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ArtifactKey.java
@@ -1,6 +1,6 @@
 package io.quarkus.maven.dependency;
 
-public interface ArtifactKey {
+public interface ArtifactKey extends Comparable<ArtifactKey> {
 
     static ArtifactKey fromString(String s) {
         return GACT.fromString(s);
@@ -70,4 +70,35 @@ public interface ArtifactKey {
         return buf.toString();
     }
 
+    default int compareTo(ArtifactKey that) {
+        // `groupId`, `artifactId` and `classifier` are never `null`
+        // `type` is nullable
+
+        int result = getGroupId().compareTo(that.getGroupId());
+        if (result != 0) {
+            return result;
+        }
+
+        result = getArtifactId().compareTo(that.getArtifactId());
+        if (result != 0) {
+            return result;
+        }
+
+        result = getClassifier().compareTo(that.getClassifier());
+        if (result != 0) {
+            return result;
+        }
+
+        String thisType = getType();
+        String thatType = that.getType();
+        if (thisType != null && thatType != null) {
+            return thisType.compareTo(thatType);
+        } else if (thisType != null) {
+            return -1;
+        } else if (thatType != null) {
+            return 1;
+        } else {
+            return 0;
+        }
+    }
 }

--- a/independent-projects/extension-maven-plugin/src/main/java/io/quarkus/maven/AggregateSkillsMojo.java
+++ b/independent-projects/extension-maven-plugin/src/main/java/io/quarkus/maven/AggregateSkillsMojo.java
@@ -11,6 +11,7 @@ import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -364,16 +365,22 @@ public class AggregateSkillsMojo extends AbstractMojo {
         }
 
         // Fall back to on-the-fly indexing
-        Indexer indexer = new Indexer();
+        List<Path> classFilesToIndex = new ArrayList<>();
         try (var stream = Files.walk(classesDir)) {
             stream.filter(p -> p.toString().endsWith(".class"))
-                    .forEach(p -> {
-                        try (InputStream is = Files.newInputStream(p)) {
-                            indexer.index(is);
-                        } catch (IOException e) {
-                            getLog().debug("Failed to index " + p + ": " + e.getMessage());
-                        }
-                    });
+                    .forEach(classFilesToIndex::add);
+        }
+
+        // feed classes to the `Indexer` in deterministic order
+        classFilesToIndex.sort(Comparator.comparing(Path::toString));
+
+        Indexer indexer = new Indexer();
+        for (Path file : classFilesToIndex) {
+            try (InputStream is = Files.newInputStream(file)) {
+                indexer.index(is);
+            } catch (IOException e) {
+                getLog().debug("Failed to index " + file + ": " + e.getMessage());
+            }
         }
         return indexer.complete();
     }

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/JandexUtil.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/JandexUtil.java
@@ -8,6 +8,7 @@ import java.nio.file.Path;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -44,22 +45,30 @@ public final class JandexUtil {
     }
 
     public static Index createIndex(Path path) {
-        Indexer indexer = new Indexer();
+        List<Path> classFilesToIndex = new ArrayList<>();
         try (Stream<Path> files = Files.walk(path)) {
             files.forEach(new Consumer<Path>() {
                 @Override
                 public void accept(Path path) {
                     if (path.toString().endsWith(".class")) {
-                        try (InputStream in = Files.newInputStream(path)) {
-                            indexer.index(in);
-                        } catch (IOException e) {
-                            throw new RuntimeException(e);
-                        }
+                        classFilesToIndex.add(path);
                     }
                 }
             });
         } catch (IOException e) {
             throw new RuntimeException(e);
+        }
+
+        // feed classes to the `Indexer` in deterministic order
+        classFilesToIndex.sort(Comparator.comparing(Path::toString));
+
+        Indexer indexer = new Indexer();
+        for (Path file : classFilesToIndex) {
+            try (InputStream in = Files.newInputStream(file)) {
+                indexer.index(in);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
         }
         return indexer.complete();
     }

--- a/test-framework/jacoco/deployment/src/main/java/io/quarkus/jacoco/deployment/JacocoProcessor.java
+++ b/test-framework/jacoco/deployment/src/main/java/io/quarkus/jacoco/deployment/JacocoProcessor.java
@@ -8,6 +8,7 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -93,7 +94,7 @@ public class JacocoProcessor {
         System.setProperty("jacoco-agent.jmx", "true");
 
         // Use offline instrumentation to modify the bytecode of classes that should be analyzed
-        Set<ApplicationArchive> appArchives = applicationArchivesBuildItem.getAllApplicationArchives();
+        List<ApplicationArchive> appArchives = applicationArchivesBuildItem.getAllArchives();
         ApplicationModel appModel = curateOutcomeBuildItem.getApplicationModel();
         Instrumenter instrumenter = new Instrumenter(new OfflineInstrumentationAccessGenerator());
         Set<String> transformed = new HashSet<>();


### PR DESCRIPTION
This commit attempts to fix all places that contribute to production application (i.e. not testing, not dev mode) and create a Jandex index such that the index is constructed in a deterministic order. This applies both to places that use an `Indexer` and places that use `CompositeIndex`. Both require their input to be deterministically ordered in order to produce output that is also deterministically ordered.

This commit also deprecated (for removal) a few methods in `IndexingUtil` that were used to index classes based on class data obtained from a class loader. The primary reason for deprecation is that the API was needlessly complex. The replacement, `LazyIndexer`, allows for the same usage, yet with much cleaner and smaller API.

Further, this commit adds an implementation of `Comparable` to a small set of build items that I could determine are directly used when creating a Jandex index. There's very likely more build items that should implement `Comparable`, for example because they affect bytecode generation, but that's for another time.

Finally, the `ApplicationArchivesBuildItem` methods that declare a return type of `Collection` or `Set` are now deprecated, with the replacements declaring a return type of `List`. The application archives are fed to this build item in a deterministic order (hopefully!), so the consumers should consume them in deterministic order as well.