### PR TITLE
Rework the native image guide.

### DIFF
--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -9,13 +9,28 @@ include::_attributes.adoc[]
 :summary: Build native executables with GraalVM or Mandrel.
 :topics: native,graalvm,mandrel
 
-This guide covers:
+Quarkus applications can be compiled to native executables, producing a standalone binary that starts in milliseconds and uses a fraction of the memory of a JVM process.
 
-* Compiling the application to a native executable
-* Packaging the native executable in a container
-* Debugging native executable
+In this guide, you will compile the application from the xref:getting-started.adoc[Getting Started Guide] to a native executable, test it, and package it in a container.
 
-This guide takes as input the application developed in the xref:getting-started.adoc[Getting Started Guide].
+== Do you need a native executable?
+
+Quarkus on the JVM is already fast, sub-second startup, low memory footprint, and optimized throughput.
+For many applications, JVM mode is the right choice.
+
+Native executables shine when:
+
+* *Startup time is critical*: serverless/FaaS, CLI tools, or scale-to-zero environments where cold starts matter.
+* *Memory is constrained*: dense container deployments or edge devices with tight RAM budgets.
+* *You want the smallest possible container image*: native binaries produce images under 50MB.
+
+JVM mode is typically better when:
+
+* *Peak throughput matters most*: the JVM's JIT compiler optimizes hot paths at runtime, which can outperform native on long-running workloads.
+* *Build time is a constraint*: native compilation takes minutes, JVM builds take seconds.
+* *You rely heavily on reflection or dynamic class loading*: these require explicit configuration for native images.
+
+TIP: Start with JVM mode. Move to native when you have a concrete need. Both modes use the same code and the same Quarkus optimizations: native just changes how the binary is produced.
 
 == Prerequisites
 
@@ -51,39 +66,14 @@ xcode-select --install
 * On Windows, you will need to install the https://aka.ms/vs/17/release/vs_buildtools.exe[Visual Studio 2022 Visual C++ Build Tools]
 ====
 
-=== Background
+=== Choosing a GraalVM distribution
 
-Building a native executable requires using a distribution of GraalVM.
-There are three distributions:
-Oracle GraalVM Community Edition (CE), Oracle GraalVM Enterprise Edition (EE) and Mandrel.
-The differences between the Oracle and Mandrel distributions are as follows:
+Building a native executable requires a GraalVM distribution. There are two main options:
 
-* Mandrel is a downstream distribution of the Oracle GraalVM CE.
-Mandrel's main goal is to provide a way to build native executables specifically designed to support Quarkus.
+* *https://www.graalvm.org[Oracle GraalVM]* — the standard distribution from Oracle. Supports Linux, macOS (both Intel and Apple Silicon), and Windows.
+* *https://github.com/graalvm/mandrel[Mandrel]* — a downstream distribution tailored for Quarkus. It excludes components not needed by Quarkus (such as polyglot support) to provide a smaller distribution.
 
-* Mandrel releases are built from a code base derived from the upstream Oracle GraalVM CE code base,
-with only minor changes but some significant exclusions that are not necessary for Quarkus native apps.
-They support the same capabilities to build native executables as Oracle GraalVM CE,
-with no significant changes to functionality.
-Notably, they do not include support for polyglot programming.
-The reason for these exclusions is to provide a better level of support for the majority of Quarkus users.
-These exclusions also mean Mandrel offers a considerable reduction in its distribution size
-when compared with Oracle GraalVM CE/EE.
-
-* Mandrel is built slightly differently to Oracle GraalVM CE, using the standard OpenJDK project.
-This means that it does not profit from a few small enhancements that Oracle have added to the version of OpenJDK used to build their own GraalVM downloads.
-These enhancements are omitted because upstream OpenJDK does not manage them, and cannot vouch for.
-This is particularly important when it comes to conformance and security.
-
-* Mandrel is recommended for building native executables that target Linux containerized environments.
-This means that Mandrel users are encouraged to use containers to build their native executables.
-If you are building native executables for macOS on amd64/x86,
-you should consider using Oracle GraalVM instead,
-because Mandrel does not currently target this platform.
-Building native executables directly on bare metal Linux, macOS (on M processors), or Windows is possible,
-with details available in the https://github.com/graalvm/mandrel/blob/default/README.md[Mandrel README]
-and https://github.com/graalvm/mandrel/releases[Mandrel releases].
-
+GraalVM {graalvm-version} is required.
 
 [[configuring-graalvm]]
 === Configuring GraalVM
@@ -97,15 +87,13 @@ For generating native executables targeting Linux, you can optionally skip this 
 [TIP]
 ====
 If you cannot install GraalVM, you can use a multi-stage Docker build to run Maven inside a Docker container that embeds GraalVM.
-There is an explanation of how to do this at <<#multistage-docker,the end of this guide>>.
+There is an explanation of how to do this in the xref:native-reference.adoc#multistage-docker[Native Reference Guide].
 ====
 
-GraalVM {graalvm-version} is required.
-
 1. Install GraalVM if you haven't already. You have a few options for this:
-** Download the appropriate archive from <https://github.com/graalvm/mandrel/releases> or <https://github.com/graalvm/graalvm-ce-builds/releases>, and unpack it like you would any other JDK.
+** Download the appropriate archive from <https://github.com/graalvm/mandrel/releases> or <https://www.graalvm.org/downloads/>, and unpack it like you would any other JDK.
 ** Use platform-specific installer tools like https://sdkman.io/jdks#graalce[sdkman], https://github.com/graalvm/homebrew-tap[homebrew], or https://github.com/ScoopInstaller/Java[scoop].
-We recommend the _community edition_ of GraalVM. For example, install it with `sdk install java 21-graalce`.
+For example, install it with `sdk install java {graalvm-flavor}`.
 2. Configure the runtime environment. Set `GRAALVM_HOME` environment variable to the GraalVM installation directory, for example:
 +
 [source,bash]
@@ -113,7 +101,7 @@ We recommend the _community edition_ of GraalVM. For example, install it with `s
 export GRAALVM_HOME=$HOME/Development/mandrel/
 ----
 +
-On macOS (amd64/x86 based Macs not supported), point the variable to the `Home` sub-directory:
+On macOS, point the variable to the `Home` sub-directory:
 +
 [source,bash]
 ----
@@ -143,11 +131,12 @@ export PATH=${GRAALVM_HOME}/bin:$PATH
 .Issues using GraalVM with macOS
 [NOTE]
 ====
-GraalVM binaries are not (yet) notarized for macOS as reported in this https://github.com/oracle/graal/issues/1724[GraalVM issue]. This means that you may see the following error when using `native-image`:
+GraalVM binaries are not (yet) notarized for macOS as reported in this https://github.com/oracle/graal/issues/1724[GraalVM issue].
+This means that you may see the following error when using `native-image`:
 
 [source,bash]
 ----
-“native-image” cannot be opened because the developer cannot be verified
+"native-image" cannot be opened because the developer cannot be verified
 ----
 
 Use the following command to recursively delete the `com.apple.quarantine` extended attribute on the GraalVM install directory as a workaround:
@@ -158,55 +147,22 @@ xattr -r -d com.apple.quarantine ${GRAALVM_HOME}/../..
 -----
 ====
 
-== Solution
-
-We recommend that you follow the instructions in the next sections and package the application step by step. However, you can go right to the completed example.
-
-Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {quickstarts-archive-url}[archive].
-
-The solution is located in the `getting-started` directory.
-
 == Producing a native executable
 
-The native executable for our application will contain the application code, required libraries, Java APIs, and a reduced version of a VM. The smaller VM base improves the startup time of the application and produces a minimal disk footprint.
+The native executable for your application will contain the application code, required libraries, Java APIs, and a reduced version of a VM.
+The smaller VM base improves the startup time of the application and produces a minimal disk footprint.
 
 image:native-executable-process.png[Creating a native executable]
-
-If you have generated the application from the previous tutorial, you can find in the `pom.xml` the following Maven profile section:
-
-[source,xml]
-----
-<profiles>
-    <profile>
-        <id>native</id>
-        <activation>
-            <property>
-                <name>native</name>
-            </property>
-        </activation>
-        <properties>
-            <skipITs>false</skipITs>
-            <quarkus.native.enabled>true</quarkus.native.enabled>
-        </properties>
-    </profile>
-</profiles>
-----
 
 [TIP]
 ====
 You can provide custom options for the `native-image` command using the `quarkus.native.additional-build-args` and `quarkus.native.additional-build-args-append` properties.
 Multiple options may be separated by a comma.
 
-By convention `quarkus.native.additional-build-args-append` is meant to be defined at the command line (e.g. `-Dquarkus.native.additional-build-args-append=--verbose`), while `quarkus.native.additional-build-args` may be defined either at the command line or in your `application.properties`. Note that, any arguments included in `quarkus.native.additional-build-args-append` may override those included in `quarkus.native.additional-build-args`.
-
 You can find more information about how to configure the native image building process in the <<configuration-reference>> section below.
 ====
 
-We use a profile because, you will see very soon, packaging the native executable takes a _few_ minutes. You could
-just pass -Dquarkus.native.enabled=true as a property on the command line, however it is better to use a profile as
-this allows native image tests to also be run.
-
-Create a native executable using:
+Native compilation takes significantly longer than a regular JVM build. Create a native executable using:
 
 include::{includes}/devtools/build-native.adoc[]
 
@@ -217,65 +173,46 @@ include::{includes}/devtools/build-native.adoc[]
 The Microsoft Native Tools for Visual Studio must first be initialized before packaging.
 You can do this by starting the `x64 Native Tools Command Prompt` that was installed with the Visual Studio Build Tools.
 At the `x64 Native Tools Command Prompt`, you can navigate to your project folder and run `./mvnw package -Dnative`.
+====
 
-Another solution is to write a script to do this for you:
+The build produces `target/getting-started-1.0.0-SNAPSHOT-runner`.
+You can run it directly:
 
 [source,bash]
 ----
-cmd /c 'call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat" && mvn package -Dnative'
+./target/getting-started-1.0.0-SNAPSHOT-runner
 ----
-====
 
-In addition to the regular files, the build also produces `target/getting-started-1.0.0-SNAPSHOT-runner`.
-You can run it using: `./target/getting-started-1.0.0-SNAPSHOT-runner`.
-
-[[graal-package-preview]]
-[NOTE]
-.Java preview features
-====
-Java code that relies on preview features requires special attention.
-To produce a native executable, this means that the `--enable-preview` flag needs to be passed to the underlying native image invocation.
-You can do so by prepending the flag with `-J` and passing it as additional native build argument: `-Dquarkus.native.additional-build-args=-J--enable-preview`.
-====
-
-=== Build fully static native executables
-
-IMPORTANT: Fully static native executables support is experimental.
-
-On Linux it's possible to package a native executable that doesn't depend on any system shared library.
-There are link:https://www.graalvm.org/{graalvm-docs-version}/reference-manual/native-image/guides/build-static-executables/#prerequisites-and-preparation[some system requirements] to be fulfilled and additional build arguments to be used along with the `native-image` invocation, a minimum is `-Dquarkus.native.additional-build-args="--static","--libc=musl"`.
-
-Compiling fully static binaries is done by statically linking https://musl.libc.org/[musl] instead of `glibc` and should not be used in production without rigorous testing.
+[source,shell]
+----
+__  ____  __  _____   ___  __ ____  ______
+ --/ __ \/ / / / _ | / _ \/ //_/ / / / __/
+ -/ /_/ / /_/ / __ |/ , _/ ,< / /_/ /\ \
+--\___\_\____/_/ |_/_/|_/_/|_|\____/___/
+INFO  [io.quarkus] (main) getting-started 1.0.0-SNAPSHOT native (powered by Quarkus {quarkus-version}) started in 0.012s. Listening on: http://0.0.0.0:8080
+INFO  [io.quarkus] (main) Profile prod activated.
+INFO  [io.quarkus] (main) Installed features: [cdi, rest, smallrye-context-propagation, vertx]
+----
 
 == Testing the native executable
 
-Producing a native executable can lead to a few issues, and so it's also a good idea to run some tests against the application running in the native file. The reasoning is explained in the link:getting-started-testing#quarkus-integration-test[Testing Guide].
+Producing a native executable can lead to a few issues, and so it's also a good idea to run some tests against the application running in the native file.
+The reasoning is explained in the xref:getting-started-testing.adoc#quarkus-integration-test[Testing Guide].
 
 To see the `GreetingResourceIT` run against the native executable, use `./mvnw verify -Dnative`:
 [source,shell,subs=attributes+]
 ----
 $ ./mvnw verify -Dnative
 ...
-Finished generating 'getting-started-1.0.0-SNAPSHOT-runner' in 22.0s.
-[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildRunner] docker run --env LANG=C --rm --user 1000:1000 -v /home/zakkak/code/quarkus-quickstarts/getting-started/target/getting-started-1.0.0-SNAPSHOT-native-image-source-jar:/project:z --entrypoint /bin/bash quay.io/quarkus/ubi10-quarkus-mandrel-builder-image:{mandrel-flavor} -c objcopy --strip-debug getting-started-1.0.0-SNAPSHOT-runner
-[INFO] [io.quarkus.deployment.QuarkusAugmentor] Quarkus augmentation completed in 70686ms
-[INFO]
-[INFO] --- maven-failsafe-plugin:3.0.0-M7:integration-test (default) @ getting-started ---
-[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
-[INFO]
 [INFO] -------------------------------------------------------
 [INFO]  T E S T S
 [INFO] -------------------------------------------------------
 [INFO] Running org.acme.getting.started.GreetingResourceIT
-Executing "/home/zakkak/code/quarkus-quickstarts/getting-started/target/getting-started-1.0.0-SNAPSHOT-runner -Dquarkus.http.port=8081 -Dquarkus.http.ssl-port=8444 -Dquarkus.log.file.path=/home/zakkak/code/quarkus-quickstarts/getting-started/target/quarkus.log -Dquarkus.log.file.enable=true -Dquarkus.log.category."io.quarkus".level=INFO"
-__  ____  __  _____   ___  __ ____  ______
- --/ __ \/ / / / _ | / _ \/ //_/ / / / __/
- -/ /_/ / /_/ / __ |/ , _/ ,< / /_/ /\ \
---\___\_\____/_/ |_/_/|_/_/|_|\____/___/
-2023-05-05 10:55:52,068 INFO  [io.quarkus] (main) getting-started 1.0.0-SNAPSHOT native (powered by Quarkus 3.0.2.Final) started in 0.009s. Listening on: http://0.0.0.0:8081
-2023-05-05 10:55:52,069 INFO  [io.quarkus] (main) Profile prod activated.
-2023-05-05 10:55:52,069 INFO  [io.quarkus] (main) Installed features: [cdi, rest, smallrye-context-propagation, vertx]
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.99 s - in org.acme.getting.started.GreetingResourceIT
+...
+INFO  [io.quarkus] (main) getting-started 1.0.0-SNAPSHOT native (powered by Quarkus {quarkus-version}) started in 0.012s. Listening on: http://0.0.0.0:8081
+INFO  [io.quarkus] (main) Profile prod activated.
+INFO  [io.quarkus] (main) Installed features: [cdi, rest, smallrye-context-propagation, vertx]
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
 ...
 ----
 
@@ -286,112 +223,13 @@ duration can be changed using the `quarkus.test.wait-time` system property. For 
 to 300 seconds, use: `./mvnw verify -Dnative -Dquarkus.test.wait-time=300`.
 ====
 
-[WARNING]
-====
-This procedure was formerly accomplished using the `@NativeImageTest` annotation. `@NativeImageTest` was replaced by `@QuarkusIntegrationTest` which provides a superset of the testing
-capabilities of `@NativeImageTest`. More information about `@QuarkusIntegrationTest` can be found in the xref:getting-started-testing.adoc#quarkus-integration-test[Testing Guide].
-====
-
-=== Profiles
-By default, integration tests both *build* and *run* the native executable using the `prod` profile.
-
-You can override the profile the executable *runs* with during the test using the `quarkus.test.integration-test-profile` property.
-Either by adding it to `application.properties` or by appending it to the command line:
-`./mvnw verify -Dnative -Dquarkus.test.integration-test-profile=test`.
-Your `%test.` prefixed properties will be used at the test runtime.
-
-
-You can override the profile the executable is *built* with and *runs* with using the `quarkus.profile=test` property, e.g.
-`./mvnw clean verify -Dnative -Dquarkus.profile=test`. This might come handy if there are test specific resources to be processed,
-such as importing test data into the database.
-
-[source,properties]
-----
-quarkus.native.resources.includes=version.txt
-%test.quarkus.native.resources.includes=version.txt,import-dev.sql
-%test.quarkus.hibernate-orm.schema-management.strategy=drop-and-create
-%test.quarkus.hibernate-orm.sql-load-script=import-dev.sql
-----
-
-With the aforementioned example in your `application.properties`, your Hibernate ORM managed database will be populated with test
-data both during the JVM mode test run and during the native mode test run. The production
-executable will contain only the `version.txt` resource, no superfluous test data.
-
-[WARNING]
-====
-The executable built with `-Dquarkus.profile=test` is not suitable for production deployment.
-It contains your test resources files and settings. Once the testing is done, the executable would have to be built again,
-using the default, `prod` profile.
-
-Alternatively, if you need to specify specific properties when running tests against the native executable
-built using the `prod` profile, an option is to put those properties in file `src/test/resources/application-nativeit.yaml`, and refer to it from the `failsafe` plugin configuration using the `QUARKUS_CONFIG_LOCATIONS` environment variable. For instance:
-
-[source,xml]
-----
-<plugin>
-  <artifactId>maven-failsafe-plugin</artifactId>
-  <version>${surefire-plugin.version}</version>
-  <executions>
-    <execution>
-      <goals>
-        <goal>integration-test</goal>
-        <goal>verify</goal>
-      </goals>
-      <configuration>
-        <systemPropertyVariables>
-          <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-          <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-          <maven.home>${maven.home}</maven.home>
-        </systemPropertyVariables>
-        <environmentVariables>
-          <QUARKUS_CONFIG_LOCATIONS>./src/test/resources/application-nativeit.yaml</QUARKUS_CONFIG_LOCATIONS>
-        </environmentVariables>
-      </configuration>
-    </execution>
-  </executions>
-</plugin>
-----
-====
-
-=== Java preview features
-
-[[graal-test-preview]]
-[NOTE]
-.Java preview features
-====
-Java code that relies on preview features requires special attention.
-To test a native executable, this means that the `--enable-preview` flag needs to be passed to the Surefire plugin.
-Adding `<argLine>--enable-preview</argLine>` to its `configuration` section is one way to do so.
-====
-
-=== Excluding tests when running as a native executable
-
-When running tests this way, the only things that actually run natively are your application endpoints, which
-you can only test via HTTP calls. Your test code does not actually run natively, so if you are testing code
-that does not call your HTTP endpoints, it's probably not a good idea to run them as part of native tests.
-
-If you share your test class between JVM and native executions like we advise above, you can mark certain tests
-with the `@DisabledOnIntegrationTest` annotation in order to skip them when testing against a native image.
-
-[NOTE]
-====
-Using `@DisabledOnIntegrationTest` will also disable the test in all integration test instances, including
-testing the application in JVM mode, in a container image, and native image.
-====
-
-=== Testing an existing native executable
-
-It is also possible to re-run the tests against a native executable that has already been built. To do this run
-`./mvnw test-compile failsafe:integration-test -Dnative`. This will discover the existing native image and run the tests against it using failsafe.
-
-If the process cannot find the native image for some reason, or you want to test a native image that is no longer in the
-target directory you can specify the executable with the `-Dnative.image.path=` system property.
+For advanced testing scenarios, test profiles, excluding tests from native runs, or testing an existing binary, see the xref:native-reference.adoc#native-testing[Native Reference Guide].
 
 [[container-runtime]]
 == Creating a Linux executable without GraalVM installed
 
-IMPORTANT: Before going further, be sure to have a working container runtime (Docker, podman) environment. If you use Docker
-on Windows you should share your project's drive at Docker Desktop file share settings and restart Docker Desktop.
+IMPORTANT: Before going further, be sure to have a working container runtime (Docker, podman) environment.
+If you use Docker on Windows you should share your project's drive at Docker Desktop file share settings and restart Docker Desktop.
 
 Quite often one only needs to create a native Linux executable for their Quarkus application (for example in order to run in a containerized environment) and would like to avoid
 the trouble of installing the proper GraalVM version in order to accomplish this task (for example, in CI environments it's common practice
@@ -501,20 +339,10 @@ See <<tip-quarkus-native-remote-container-build,Creating a Linux executable with
 
 See the xref:container-image.adoc[Container Image guide] for more details.
 
-=== Manually using the micro base image
+=== Using the micro base image
 
-You can run the application in a container using the JAR produced by the Quarkus Maven Plugin.
-However, in this section, we focus on creating a container image using the produced native executable.
-
-image:containerization-process.png[Containerization Process]
-
-When using a local GraalVM installation, the native executable targets your local operating system (Linux, macOS, Windows etc).
-However, as a container may not use the same _executable_ format as the one produced by your operating system,
-we will instruct the Maven build to produce an executable by leveraging a container runtime (as described in <<#container-runtime,this section>>):
-
-The produced executable will be a 64-bit Linux executable, so depending on your operating system, it may no longer be runnable.
-However, it's not an issue as we are going to copy it to a container.
-The project generation has provided a `Dockerfile.native-micro` in the `src/main/docker` directory with the following content:
+You can also build a container manually using the generated Dockerfile.
+The project generation provides a `Dockerfile.native-micro` in the `src/main/docker` directory with the following content:
 
 [source,dockerfile]
 ----
@@ -536,491 +364,21 @@ ENTRYPOINT ["./application", "-Dquarkus.http.host=0.0.0.0"]
 ====
 The Quarkus Micro Image is a small container image providing the right set of dependencies to run your native application.
 It is based on https://catalog.redhat.com/en/software/containers/ubi10-micro/66f16b145db83414cddcfcb3?container-tabs=overview[UBI Micro].
-This base image has been tailored to work perfectly in containers.
-
-You can read more about UBI images on:
-
-* https://www.redhat.com/en/blog/introducing-red-hat-universal-base-image[Introduction to Universal Base Image]
-* https://catalog.redhat.com/en/software/containers/ubi10/ubi/66f16b555db83414cddcfcbe[Red Hat Universal Base Image 10]
-
-UBI images can be used without any limitations.
 
 xref:quarkus-runtime-base-image.adoc[This page] explains how to extend the `quarkus-micro` image when your application has specific requirements.
 ====
 
-Then, if you didn't delete the generated native executable, you can build the docker image with:
+Build and run the container:
 
 [source,bash]
 ----
 docker build -f src/main/docker/Dockerfile.native-micro -t quarkus-quickstart/getting-started .
-----
-
-And finally, run it with:
-
-[source,bash]
-----
 docker run -i --rm -p 8080:8080 quarkus-quickstart/getting-started
 ----
 
-=== Manually using the minimal base image
-
-The project generation has also provided a `Dockerfile.native` in the `src/main/docker` directory with the following content:
-
-[source,dockerfile]
-----
-FROM registry.access.redhat.com/ubi10/ubi-minimal:10.2
-WORKDIR /work/
-RUN chown 1001 /work \
-    && chmod "g+rwX" /work \
-    && chown 1001:root /work
-COPY --chown=1001:root --chmod=0755 target/*-runner /work/application
-
-EXPOSE 8080
-USER 1001
-
-CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
-----
-
-The UBI minimal image is bigger than the micro one mentioned above.
-It contains more utilities such as the `microdnf` package manager.
-
-[[multistage-docker]]
-=== Using a multi-stage Docker build
-
-The previous section showed you how to build a native executable using Maven or Gradle, but it requires you to have created the native executable first.
-In addition, this native executable must be a Linux 64 bits executable.
-
-You may want to build the native executable directly in a container without having a final container containing the build tools.
-That approach is possible with a multi-stage Docker build:
-
-1. The first stage builds the native executable using Maven or Gradle
-2. The second stage is a minimal image copying the produced native executable
-
-
-[WARNING]
-====
-Before building a container image from the Dockerfiles shown below, you need to update the default `.dockerignore` file, as it filters everything except the `target` directory. In order to build inside a container, you need to copy the `src` directory. Thus, edit your `.dockerignore` and remove the `*` line.
-====
-
-Such a multi-stage build can be achieved as follows:
-
-Sample Dockerfile for building with Maven:
-[source,dockerfile,subs=attributes+]
-----
-## Stage 1 : build with maven builder image with native capabilities
-FROM quay.io/quarkus/ubi10-quarkus-mandrel-builder-image:{mandrel-flavor} AS build
-COPY --chown=quarkus:quarkus --chmod=0755 mvnw /code/mvnw
-COPY --chown=quarkus:quarkus .mvn /code/.mvn
-COPY --chown=quarkus:quarkus pom.xml /code/
-USER quarkus
-WORKDIR /code
-RUN ./mvnw -B org.apache.maven.plugins:maven-dependency-plugin:3.8.1:go-offline
-COPY src /code/src
-RUN ./mvnw package -Dnative
-
-## Stage 2 : create the docker final image
-FROM quay.io/quarkus/ubi10-quarkus-micro-image:2.0
-WORKDIR /work/
-COPY --from=build /code/target/*-runner /work/application
-
-# set up permissions for user `1001`
-RUN chmod 775 /work /work/application \
-  && chown -R 1001 /work \
-  && chmod -R "g+rwX" /work \
-  && chown -R 1001:root /work
-
-EXPOSE 8080
-USER 1001
-
-CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
-----
-
-NOTE: This multi-stage Docker build copies the Maven wrapper from the host machine.
-The Maven wrapper (or the Gradle wrapper) is a convenient way to provide a specific version of Maven/Gradle.
-It avoids having to create a base image with Maven and Gradle.
-To provision the Maven Wrapper in your project, use: `mvn wrapper:wrapper`.
-
-Save this file in `src/main/docker/Dockerfile.multistage` as it is not included in the getting started quickstart.
-
-Sample Dockerfile for building with Gradle:
-[source,dockerfile,subs=attributes+]
-----
-## Stage 1 : build with maven builder image with native capabilities
-FROM quay.io/quarkus/ubi10-quarkus-mandrel-builder-image:{mandrel-flavor} AS build
-USER root
-RUN microdnf install findutils -y
-COPY --chown=quarkus:quarkus gradlew /code/gradlew
-COPY --chown=quarkus:quarkus gradle /code/gradle
-COPY --chown=quarkus:quarkus build.gradle /code/
-COPY --chown=quarkus:quarkus settings.gradle /code/
-COPY --chown=quarkus:quarkus gradle.properties /code/
-USER quarkus
-WORKDIR /code
-COPY src /code/src
-RUN ./gradlew build -Dquarkus.native.enabled=true
-
-## Stage 2 : create the docker final image
-FROM quay.io/quarkus/ubi10-quarkus-micro-image:2.0
-WORKDIR /work/
-COPY --from=build /code/build/*-runner /work/application
-RUN chmod 775 /work
-EXPOSE 8080
-CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
-----
-
-If you are using Gradle in your project, you can use this sample Dockerfile.  Save it in `src/main/docker/Dockerfile.multistage`.
-
-[source,bash]
-----
-docker build -f src/main/docker/Dockerfile.multistage -t quarkus-quickstart/getting-started .
-----
-
-And, finally, run it with:
-
-[source,bash]
-----
-docker run -i --rm -p 8080:8080 quarkus-quickstart/getting-started
-----
-
-[TIP]
-====
-If you need SSL support in your native executable, you can easily include the necessary libraries in your Docker image.
-
-Please see xref:native-and-ssl.adoc#working-with-containers[our Using SSL With Native Executables guide] for more information.
-====
-
-[NOTE,subs=attributes+]
-====
-To use GraalVM CE instead of Mandrel, update the `FROM` clause to: `FROM quay.io/quarkus/ubi10-quarkus-graalvmce-builder-image:{graalvm-flavor} AS build`.
-====
-
-=== Using a Distroless base image
-
-IMPORTANT: Distroless image support is experimental.
-
-If you are looking for small container images, the https://github.com/GoogleContainerTools/distroless[distroless] approach reduces the size of the base layer.
-The idea behind _distroless_ is the usage of a single and minimal base image containing all the requirements, and sometimes even the application itself.
-
-Quarkus provides a distroless base image that you can use in your `Dockerfile`.
-You only need to copy your application, and you are done:
-
-[source, dockerfile]
-----
-FROM quay.io/quarkus/quarkus-distroless-image:2.0
-COPY target/*-runner /application
-
-EXPOSE 8080
-USER nonroot
-
-CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
-----
-
-Quarkus provides the `quay.io/quarkus/quarkus-distroless-image:2.0` image.
-It contains the required packages to run a native executable and is only **9Mb**.
-Just add your application on top of this image, and you will get a tiny container image.
-
-Distroless images should not be used in production without rigorous testing.
-
-=== Build a container image from scratch
-
-IMPORTANT: Scratch image support is experimental.
-
-Building fully statically linked binaries enables the usage of a https://hub.docker.com/_/scratch[scratch image] containing solely the resulting native executable.
-
-Sample multistage Dockerfile for building an image from `scratch`:
-
-[source,dockerfile,subs=attributes+]
-----
-## Stage 1 : build with maven builder image with native capabilities
-FROM quay.io/quarkus/ubi10-quarkus-graalvmce-builder-image:{graalvm-flavor} AS build
-USER root
-RUN microdnf install make gcc -y
-COPY --chown=quarkus:quarkus mvnw /code/mvnw
-COPY --chown=quarkus:quarkus .mvn /code/.mvn
-COPY --chown=quarkus:quarkus pom.xml /code/
-RUN mkdir /musl && \
-    curl -L -o musl.tar.gz https://more.musl.cc/11.2.1/x86_64-linux-musl/x86_64-linux-musl-native.tgz && \
-    tar -xvzf musl.tar.gz -C /musl --strip-components 1 && \
-    curl -L -o zlib.tar.gz https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz && \
-    mkdir zlib && tar -xvzf zlib.tar.gz -C zlib --strip-components 1 && \
-    cd zlib && ./configure --static --prefix=/musl && \
-    make && make install && \
-    cd .. && rm -rf zlib && rm -f zlib.tar.gz && rm -f musl.tar.gz
-ENV PATH="/musl/bin:${PATH}"
-USER quarkus
-WORKDIR /code
-RUN ./mvnw -B org.apache.maven.plugins:maven-dependency-plugin:3.8.1:go-offline
-COPY src /code/src
-RUN ./mvnw package -Dnative -DskipTests -Dquarkus.native.additional-build-args="--static","--libc=musl"
-
-## Stage 2 : create the final image
-FROM scratch
-COPY --from=build /code/target/*-runner /application
-EXPOSE 8080
-ENTRYPOINT [ "/application" ]
-----
-
-Scratch images should not be used in production without rigorous testing.
-
-NOTE: The versions of musl and zlib may need to be updated to meet the native-image executable requirements (and UPX if you use native image compression).
-
-=== Compress native images
-
-Quarkus can compress the produced native executable using UPX.
-More details on xref:./upx.adoc[UPX Compression documentation].
-
-=== Separating Java and native image compilation
-
-In certain circumstances, you may want to build the native image in a separate step.
-For example, in a CI/CD pipeline, you may want to have one step to generate the source that will be used for the native image generation and another step to use these sources to actually build the native executable.
-For this use case, you can set the additional flag `quarkus.native.sources-only=true`.
-This will execute the java compilation as if you had started native compilation (`-Dnative`), but stops before triggering the actual call to GraalVM's `native-image`.
-
-[source,bash]
-----
-$ ./mvnw clean package -Dnative -Dquarkus.native.sources-only=true
-----
-
-After compilation has finished, you find the build artifact in `target/native-sources`:
-
-[source,bash]
-----
-$ cd target/native-sources
-$ ls
-getting-started-1.0.0-SNAPSHOT-runner.jar  graalvm.version  lib  native-image.args
-----
-
-From the output above one can see that, in addition to the produced jar file and the associated lib directory, a text file named `native-image.args` was created.
-This file holds all parameters (including the name of the JAR to compile) to pass along to GraalVM's `native-image` command.
-A text file named `graalvm.version` was also created and holds the GraalVM version that should be used.
-If you have GraalVM installed and it matches this version, you can start the native compilation by executing:
-
-[source,bash]
-----
-$ cd target/native-sources
-$ native-image $(cat native-image.args)
-...
-$ ls
-native-image.args
-getting-started-1.0.0-SNAPSHOT-runner
-getting-started-1.0.0-SNAPSHOT-runner.build_artifacts.txt
-getting-started-1.0.0-SNAPSHOT-runner.jar
-----
-
-The process for Gradle is analogous.
-
-Running the build process in a container is also possible:
-
-[source,bash]
-----
-$ ./mvnw clean package -Dquarkus.native.enabled=true -Dquarkus.native.sources-only=true -Dquarkus.native.container-build=true
-----
-
-`-Dquarkus.native.container-build=true` will produce an additional text file named `native-builder.image` holding the docker image name to be used to build the native image.
-
-[source,bash,subs=attributes+]
-----
-cd target/native-sources
-docker run \
-  -it \
-  --user $(id -ur):$(id -gr) \
-  --rm \
-  -v $(pwd):/work \# <1>
-  -w /work \# <2>
-  --entrypoint /bin/sh \
-  $(cat native-builder.image) \# <3>
-  -c "native-image $(cat native-image.args) -J-Xmx4g"# <4>
-----
-
-<1> Mount the host's directory `target/native-image` to the container's `/work`. Thus, the generated binary will also be written to this directory.
-<2> Switch the working directory to `/work`, which we have mounted in <1>.
-<3> Use the docker image from the file `native-builder.image`.
-<4> Call `native-image` with the content of file `native-image.args` as arguments. We also supply an additional argument to limit the process's maximum memory to 4 Gigabytes (this may vary depending on the project being built and the machine building it).
-
-[WARNING]
-====
-If you are running on a Windows machine, please keep in mind that the binary was created within a Linux docker container.
-Hence, the binary will not be executable on the host Windows machine.
-====
-
-A high level overview of what the various steps of a CI/CD pipeline would look is the following:
-
-1. Register the output of the step executing `./mvnw ...` command (i.e. directory `target/native-image`) as a build artifact,
-2. Require this artifact in the step executing the `native-image ...` command, and
-3. Register the output of the step executing the `native-image ...` command (i.e. files matching `target/*runner`) as build artifact.
-
-The environment executing step `1` only needs Java and Maven (or Gradle) installed, while the environment executing step `3` only needs a GraalVM installation (including the `native-image` feature).
-
-Depending on what the final desired output of the CI/CD pipeline is, the generated binary might then be used to create a container image.
-
-== Debugging native executable
-
-Native executables can be debugged using tools such as `gdb`.
-For this to be possible native executables need to be generated with debug symbols.
-
-[NOTE]
-====
-Debug symbol generation is only supported on Linux.
-Windows support is still under development, while macOS is not supported.
-====
-
-To generate debug symbols,
-add `-Dquarkus.native.debug.enabled=true` flag when generating the native executable.
-You will find the debug symbols for the native executable in a `.debug` file next to the native executable.
-
-[NOTE]
-====
-The generation of the `.debug` file depends on `objcopy`.
-As a result, when using a local GraalVM installation on common Linux distributions, you will need to install the `binutils` package:
-
-[source,bash]
-----
-# dnf (rpm-based)
-sudo dnf install binutils
-# Debian-based distributions
-sudo apt-get install binutils
-----
-
-When `objcopy` is not available, debug symbols are embedded in the executable.
-====
-
-Aside from debug symbols,
-setting `-Dquarkus.native.debug.enabled=true` flag generates a cache of source files
-for any JDK runtime classes, GraalVM classes, and application classes resolved during native executable generation.
-This source cache is useful for native debugging tools,
-to establish the link between the symbols and the matching source code.
-It provides a convenient way of making just the necessary sources available to the debugger/IDE when debugging a native executable.
-
-Sources for third party jar dependencies, including Quarkus source code,
-are not added to the source cache by default.
-To include those, make sure you invoke `mvn dependency:sources` first.
-This step is required in order to pull the sources for these dependencies,
-and get them included in the source cache.
-
-The source cache is located in the `target/sources` folder.
-
-[TIP]
-====
-If running `gdb` from a different directory than `target`, then the sources can be loaded by running:
-
-[source,bash]
-----
-directory path/to/target
-----
-
-in the `gdb` prompt.
-
-Or start `gdb` with:
-
-[source,bash]
-----
-gdb -ex 'directory path/to/target' path/to/target/{project.name}-{project.version}-runner
-----
-
-e.g.,
-[source,bash]
-----
-gdb -ex 'directory ./target' ./target/getting-started-1.0.0-SNAPSHOT-runner
-----
-====
-
-For a more detailed guide about debugging native images please refer to the xref:native-reference.adoc[Native Reference Guide].
-
-== Using Monitoring Options
-
-Monitoring options such as JDK flight recorder, jvmstat, heap dumps, NMT (starting with Mandrel 24.1 for JDK 23), and remote JMX
-can be added to the native executable build. Simply supply a comma separated list of the monitoring options you wish to
-include at build time.
-[source,bash]
-----
--Dquarkus.native.monitoring=<comma separated list of options>
-----
-
-|===
-|Monitoring Option |Description |Availability As Of
-
-|jcmd
-|Include JCMD support
-|GraalVM CE for JDK 24 Mandrel 24.2
-
-|jfr
-|Include JDK Flight Recorder support
-|GraalVM CE 21.3 Mandrel 21.3
-
-|jvmstat
-|Adds jvmstat support
-|GraalVM 22.3, GraalVM CE 17.0.7 Mandrel 22.3 Mandrel 23.0 (17.0.7)
-
-|heapdump
-|Adds support for generating heap dumps
-|GraalVM 22.3, GraalVM CE 17.0.7 Mandrel 22.3 Mandrel 23.0 (17.0.7)
-
-|jmxclient
-|Adds support for connections to JMX servers.
-|GraalVM for JDK 17/20 Mandrel 23.0
-
-|jmxserver
-|Adds support for accepting connections from JMX clients.
-|GraalVM for JDK 17/20 Mandrel 23.0 (17.0.7)
-
-|nmt
-|Adds support for native memory tracking.
-|GraalVM for JDK 23 Mandrel 24.1
-
-|threaddump
-|Adds support for dumping thread stacks on SIGQUIT/SIGBREAK.
-|GraalVM for JDK 22 Mandrel 24.0
-
-|none
-|Disables support for all monitoring options that would be enabled by default in Quarkus
-|Pseudo option used by Quarkus
-
-|all
-|Adds all monitoring options.
-|GraalVM 22.3, GraalVM CE 17.0.7 Mandrel 22.3 Mandrel 23.0 (17.0.7)
-|===
-
-Please see the Quarkus Native Reference Guide for more detailed information on these monitoring options.
+For advanced container options — multi-stage builds, distroless images, scratch images, or UPX compression — see the xref:native-reference.adoc#native-container-options[Native Reference Guide].
 
 [[configuration-reference]]
-
-== Creating a Native Image Bundle
-
-A native image bundle containing everything required to build a native image can be generated.
-This is useful to inspect the build inputs and configuration.
-
-The generation of the bundle can be activated by setting any of the following parameters:
-
-|===
-|Parameter |Description |Default
-
-|quarkus.native.bundle.enabled
-|Enables the native-image bundle generation
-|`false`
-
-|quarkus.native.bundle.dry-run
-|Generates the bundle without building the native executable
-|`false`
-
-|quarkus.native.bundle.name
-|Sets the name of the bundle
-|
-|===
-
-To use this feature, run:
-
-[source,bash]
-----
-./mvnw package -Dnative -Dquarkus.native.bundle.enabled=true
-----
-
-This command will generate all the files and configuration needed for the native image build in `target/{project.name}-{project.version}-runner.nib`.
-
-[NOTE]
-====
-More details on the GraalVM native-image bundle are available in the link:https://www.graalvm.org/{graalvm-docs-version}/reference-manual/native-image/overview/Bundles[GraalVM documentation].
-====
-
 == Configuring the Native Executable
 
 There are a lot of different configuration options that can affect how the native executable is generated.
@@ -1034,6 +392,7 @@ include::{generated-dir}/config/quarkus-core_quarkus.native.adoc[opts=optional]
 
 This guide covered the creation of a native (binary) executable for your application.
 It provides an application exhibiting a swift startup time and consuming less memory.
-However, there is much more.
 
-We recommend continuing the journey with the xref:deploying-to-kubernetes.adoc[deployment to Kubernetes and OpenShift].
+* xref:native-reference.adoc[Native Reference Guide] — advanced topics: memory management, debugging, monitoring, testing profiles, and more
+* xref:deploying-to-kubernetes.adoc[Deploying to Kubernetes and OpenShift]
+* xref:container-image.adoc[Container Image Guide] — Jib, Docker, and Buildpack integrations

--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -32,6 +32,52 @@ JVM mode is typically better when:
 
 TIP: Start with JVM mode. Move to native when you have a concrete need. Both modes use the same code and the same Quarkus optimizations: native just changes how the binary is produced.
 
+=== Comparing JVM, Leyden AOT, and native modes
+
+Native is one of three runtime options Quarkus supports.
+JVM fast-jar, JVM with xref:aot.adoc[Project Leyden AOT caching] (JDK 24+), and native (Mandrel) each trade cold-start speed, peak throughput, memory footprint, and build cost differently.
+The table below compares them.
+Pick the mode that matches your workload's most important constraint.
+
+[cols="1,1,1,1,1,1,1,2",options="header"]
+|===
+| Mode | Cold start | Time to first request | Peak throughput | Memory (RSS) | Container image size | Build cost | When to choose
+
+| JVM fast-jar
+| ~0.4 s (small REST) to ~3 s (large CRUD)
+| 4,417 ms
+| 13,265 tps (baseline)
+| 304 MiB
+| 517 MB
+| ~30 s build; no special workflow
+| Long-running services, throughput-critical workloads; teams on pre-JDK-24 runtimes
+
+| xref:aot.adoc[JVM + Leyden AOT cache]
+| ~80 ms (small) to ~900 ms (large)
+| 1,859 ms
+| 12,389 tps (~7% below JVM)
+| 240 MiB
+| 715 MB (AOT cache adds ~198 MB)
+| Standard build plus a training run on a representative workload
+| Cold-start-sensitive but not millisecond-critical; requires JDK 24+; keeps full JVM tooling (debuggers, profilers, JFR)
+
+| Native (Mandrel)
+| ~17 ms (small) to ~240 ms (large)
+| 581 ms
+| 5,411 tps (~59% below JVM)
+| 95 MiB
+| 244 MB
+| 3-10 min build; 4-8 GB build-host RAM
+| Extreme cold start (serverless, scale-to-zero); edge deployments; high-density container hosts where memory is the binding constraint
+|===
+
+Time to first request, peak throughput, and memory (RSS) come from the https://raw.githubusercontent.com/quarkusio/benchmarks/main/images/spring-quarkus-perf-comparison/2026-04-21_09-26-13/metrics-tuned-composite-for-quarkus-light.svg[2026-04-21 perf-lab tuned benchmark] (Quarkus 3.34.3, JDK 25.0.2, GraalVM 25.0.2-graalce, 4 CPUs, `-Xmx512m`).
+Cold-start ranges and container image sizes come from the https://quarkus.io/blog/leyden-2/[Leyden integration benchmarks] and the https://quarkus.io/blog/new-benchmarks/[Mar 2026 performance post].
+For the latest numbers, see the https://github.com/quarkusio/benchmarks#chart-reference[Quarkus benchmarks chart reference].
+
+For the Leyden AOT cache path, see xref:aot.adoc[the AOT caching guide].
+If native is the right fit for your workload, read on. The next sections walk you through prerequisites, compilation, testing, and container packaging.
+
 == Prerequisites
 
 :prerequisites-docker:
@@ -239,6 +285,18 @@ To this end, Quarkus provides a very convenient way of creating a native Linux e
 The easiest way of accomplishing this task is to execute:
 
 include::{includes}/devtools/build-native-container.adoc[]
+
+.What to expect
+[NOTE]
+====
+Your first container-based native build typically takes 3-10 minutes and uses 4-8 GB of RAM on the build host.
+Fan spin-up is normal; the build is still running, just working hard.
+A build that runs past 15 minutes without output usually means the container runtime is short on memory; raise its CPU and memory allocation and retry.
+
+The output is a Linux binary produced inside the builder image.
+Its architecture matches the builder image you pulled: typically `x86_64` unless you explicitly selected an `arm64` variant or are running on an `arm64` host.
+Run the binary in a Linux container that matches that architecture, not directly on your host OS.
+====
 
 [TIP]
 ====

--- a/docs/src/main/asciidoc/native-reference.adoc
+++ b/docs/src/main/asciidoc/native-reference.adoc
@@ -19,7 +19,13 @@ increase the reliability and improve the runtime performance of native executabl
 These are the high level sections to be found in this guide:
 
 * <<native-memory-management,Native Memory Management>>
+* <<native-image-agent-integration,Native Image Tracing Agent Integration>>
 * <<inspecting-and-debugging,Inspecting and Debugging Native Executables>>
+* <<native-testing,Advanced Native Testing>>
+* <<native-container-options,Advanced Container Image Options>>
+* <<native-ci-cd,CI/CD and Build Pipeline Options>>
+* <<native-monitoring,Monitoring Options>>
+* <<native-bundles,Native Image Bundles>>
 * <<native-faq,Frequently Asked Questions>>
 
 [[native-memory-management]]
@@ -2119,6 +2125,571 @@ We can now examine line `169` and get a first hint of what might be wrong
 or walk up the stack using `gdb`’s `up` command to see what part of our code led to this situation.
 For more information about using `gdb` to debug native executables, see the
 link:https://www.graalvm.org/{graalvm-docs-version}/reference-manual/native-image/debugging-and-diagnostics/DebugInfo/[GraalVM Debug Info Feature] guide.
+
+[[native-testing]]
+== Advanced Native Testing
+
+The xref:building-native-image.adoc[Building a Native Executable] guide covers the basics of testing native executables.
+This section covers advanced testing topics: test profiles, Java preview features, excluding tests, and testing a pre-built binary.
+
+=== Profiles
+By default, integration tests both *build* and *run* the native executable using the `prod` profile.
+
+You can override the profile the executable *runs* with during the test using the `quarkus.test.integration-test-profile` property.
+Either by adding it to `application.properties` or by appending it to the command line:
+`./mvnw verify -Dnative -Dquarkus.test.integration-test-profile=test`.
+Your `%test.` prefixed properties will be used at the test runtime.
+
+
+You can override the profile the executable is *built* with and *runs* with using the `quarkus.profile=test` property, e.g.
+`./mvnw clean verify -Dnative -Dquarkus.profile=test`. This might come handy if there are test specific resources to be processed,
+such as importing test data into the database.
+
+[source,properties]
+----
+quarkus.native.resources.includes=version.txt
+%test.quarkus.native.resources.includes=version.txt,import-dev.sql
+%test.quarkus.hibernate-orm.schema-management.strategy=drop-and-create
+%test.quarkus.hibernate-orm.sql-load-script=import-dev.sql
+----
+
+With the aforementioned example in your `application.properties`, your Hibernate ORM managed database will be populated with test
+data both during the JVM mode test run and during the native mode test run. The production
+executable will contain only the `version.txt` resource, no superfluous test data.
+
+[WARNING]
+====
+The executable built with `-Dquarkus.profile=test` is not suitable for production deployment.
+It contains your test resources files and settings. Once the testing is done, the executable would have to be built again,
+using the default, `prod` profile.
+
+Alternatively, if you need to specify specific properties when running tests against the native executable
+built using the `prod` profile, an option is to put those properties in file `src/test/resources/application-nativeit.yaml`, and refer to it from the `failsafe` plugin configuration using the `QUARKUS_CONFIG_LOCATIONS` environment variable. For instance:
+
+[source,xml]
+----
+<plugin>
+  <artifactId>maven-failsafe-plugin</artifactId>
+  <version>${surefire-plugin.version}</version>
+  <executions>
+    <execution>
+      <goals>
+        <goal>integration-test</goal>
+        <goal>verify</goal>
+      </goals>
+      <configuration>
+        <systemPropertyVariables>
+          <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+          <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+          <maven.home>${maven.home}</maven.home>
+        </systemPropertyVariables>
+        <environmentVariables>
+          <QUARKUS_CONFIG_LOCATIONS>./src/test/resources/application-nativeit.yaml</QUARKUS_CONFIG_LOCATIONS>
+        </environmentVariables>
+      </configuration>
+    </execution>
+  </executions>
+</plugin>
+----
+====
+
+=== Java preview features
+
+[[graal-test-preview]]
+Java code that relies on preview features requires special attention.
+To test a native executable, this means that the `--enable-preview` flag needs to be passed to the Surefire plugin.
+Adding `<argLine>--enable-preview</argLine>` to its `configuration` section is one way to do so.
+
+=== Excluding tests when running as a native executable
+
+When running tests this way, the only things that actually run natively are your application endpoints, which
+you can only test via HTTP calls. Your test code does not actually run natively, so if you are testing code
+that does not call your HTTP endpoints, it's probably not a good idea to run them as part of native tests.
+
+If you share your test class between JVM and native executions like we advise above, you can mark certain tests
+with the `@DisabledOnIntegrationTest` annotation in order to skip them when testing against a native image.
+
+[NOTE]
+====
+Using `@DisabledOnIntegrationTest` will also disable the test in all integration test instances, including
+testing the application in JVM mode, in a container image, and native image.
+====
+
+=== Testing an existing native executable
+
+It is also possible to re-run the tests against a native executable that has already been built. To do this run
+`./mvnw test-compile failsafe:integration-test -Dnative`. This will discover the existing native image and run the tests against it using failsafe.
+
+If the process cannot find the native image for some reason, or you want to test a native image that is no longer in the
+target directory you can specify the executable with the `-Dnative.image.path=` system property.
+
+[[native-container-options]]
+== Advanced Container Image Options
+
+The xref:building-native-image.adoc[Building a Native Executable] guide covers the basics of creating containers with the micro base image and the container-image extensions.
+This section covers additional container strategies: the minimal (UBI) base image, multi-stage Docker builds, distroless images, scratch images, static linking, and UPX compression.
+
+=== Using the minimal base image
+
+The project generation provides a `Dockerfile.native` in the `src/main/docker` directory with the following content:
+
+[source,dockerfile]
+----
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.2
+WORKDIR /work/
+RUN chown 1001 /work \
+    && chmod "g+rwX" /work \
+    && chown 1001:root /work
+COPY --chown=1001:root --chmod=0755 target/*-runner /work/application
+
+EXPOSE 8080
+USER 1001
+
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
+----
+
+The UBI minimal image is bigger than the micro image mentioned in the xref:building-native-image.adoc[Building a Native Executable] guide.
+It contains more utilities such as the `microdnf` package manager.
+
+[[multistage-docker]]
+=== Using a multi-stage Docker build
+
+You may want to build the native executable directly in a container without having a final container containing the build tools.
+That approach is possible with a multi-stage Docker build:
+
+1. The first stage builds the native executable using Maven or Gradle
+2. The second stage is a minimal image copying the produced native executable
+
+
+[WARNING]
+====
+Before building a container image from the Dockerfiles shown below, you need to update the default `.dockerignore` file, as it filters everything except the `target` directory. In order to build inside a container, you need to copy the `src` directory. Thus, edit your `.dockerignore` and remove the `*` line.
+====
+
+Such a multi-stage build can be achieved as follows:
+
+Sample Dockerfile for building with Maven:
+[source,dockerfile,subs=attributes+]
+----
+## Stage 1 : build with maven builder image with native capabilities
+FROM quay.io/quarkus/ubi10-quarkus-mandrel-builder-image:{mandrel-flavor} AS build
+COPY --chown=quarkus:quarkus --chmod=0755 mvnw /code/mvnw
+COPY --chown=quarkus:quarkus .mvn /code/.mvn
+COPY --chown=quarkus:quarkus pom.xml /code/
+USER quarkus
+WORKDIR /code
+RUN ./mvnw -B org.apache.maven.plugins:maven-dependency-plugin:3.8.1:go-offline
+COPY src /code/src
+RUN ./mvnw package -Dnative
+
+## Stage 2 : create the docker final image
+FROM quay.io/quarkus/ubi10-quarkus-micro-image:2.0
+WORKDIR /work/
+COPY --from=build /code/target/*-runner /work/application
+
+# set up permissions for user `1001`
+RUN chmod 775 /work /work/application \
+  && chown -R 1001 /work \
+  && chmod -R "g+rwX" /work \
+  && chown -R 1001:root /work
+
+EXPOSE 8080
+USER 1001
+
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
+----
+
+NOTE: This multi-stage Docker build copies the Maven wrapper from the host machine.
+The Maven wrapper (or the Gradle wrapper) is a convenient way to provide a specific version of Maven/Gradle.
+It avoids having to create a base image with Maven and Gradle.
+To provision the Maven Wrapper in your project, use: `mvn wrapper:wrapper`.
+
+Save this file in `src/main/docker/Dockerfile.multistage` as it is not included in the getting started quickstart.
+
+Sample Dockerfile for building with Gradle:
+[source,dockerfile,subs=attributes+]
+----
+## Stage 1 : build with maven builder image with native capabilities
+FROM quay.io/quarkus/ubi10-quarkus-mandrel-builder-image:{mandrel-flavor} AS build
+USER root
+RUN microdnf install findutils -y
+COPY --chown=quarkus:quarkus gradlew /code/gradlew
+COPY --chown=quarkus:quarkus gradle /code/gradle
+COPY --chown=quarkus:quarkus build.gradle /code/
+COPY --chown=quarkus:quarkus settings.gradle /code/
+COPY --chown=quarkus:quarkus gradle.properties /code/
+USER quarkus
+WORKDIR /code
+COPY src /code/src
+RUN ./gradlew build -Dquarkus.native.enabled=true
+
+## Stage 2 : create the docker final image
+FROM quay.io/quarkus/ubi10-quarkus-micro-image:2.0
+WORKDIR /work/
+COPY --from=build /code/build/*-runner /work/application
+RUN chmod 775 /work
+EXPOSE 8080
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
+----
+
+If you are using Gradle in your project, you can use this sample Dockerfile.  Save it in `src/main/docker/Dockerfile.multistage`.
+
+[source,bash]
+----
+docker build -f src/main/docker/Dockerfile.multistage -t quarkus-quickstart/getting-started .
+----
+
+And, finally, run it with:
+
+[source,bash]
+----
+docker run -i --rm -p 8080:8080 quarkus-quickstart/getting-started
+----
+
+[TIP]
+====
+If you need SSL support in your native executable, you can easily include the necessary libraries in your Docker image.
+
+Please see xref:native-and-ssl.adoc#working-with-containers[our Using SSL With Native Executables guide] for more information.
+====
+
+[NOTE,subs=attributes+]
+====
+To use GraalVM CE instead of Mandrel, update the `FROM` clause to: `FROM quay.io/quarkus/ubi10-quarkus-graalvmce-builder-image:{graalvm-flavor} AS build`.
+====
+
+=== Using a Distroless base image
+
+IMPORTANT: Distroless image support is experimental.
+
+If you are looking for small container images, the https://github.com/GoogleContainerTools/distroless[distroless] approach reduces the size of the base layer.
+The idea behind _distroless_ is the usage of a single and minimal base image containing all the requirements, and sometimes even the application itself.
+
+Quarkus provides a distroless base image that you can use in your `Dockerfile`.
+You only need to copy your application, and you are done:
+
+[source, dockerfile]
+----
+FROM quay.io/quarkus/quarkus-distroless-image:2.0
+COPY target/*-runner /application
+
+EXPOSE 8080
+USER nonroot
+
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
+----
+
+Quarkus provides the `quay.io/quarkus/quarkus-distroless-image:2.0` image.
+It contains the required packages to run a native executable and is only **9Mb**.
+Just add your application on top of this image, and you will get a tiny container image.
+
+Distroless images should not be used in production without rigorous testing.
+
+=== Building fully static native executables
+
+IMPORTANT: Fully static native executables support is experimental.
+
+On Linux it's possible to package a native executable that doesn't depend on any system shared library.
+There are link:https://www.graalvm.org/{graalvm-docs-version}/reference-manual/native-image/guides/build-static-executables/#prerequisites-and-preparation[some system requirements] to be fulfilled and additional build arguments to be used along with the `native-image` invocation, a minimum is `-Dquarkus.native.additional-build-args="--static","--libc=musl"`.
+
+Compiling fully static binaries is done by statically linking https://musl.libc.org/[musl] instead of `glibc` and should not be used in production without rigorous testing.
+
+=== Building a container image from scratch
+
+IMPORTANT: Scratch image support is experimental.
+
+Building fully statically linked binaries enables the usage of a https://hub.docker.com/_/scratch[scratch image] containing solely the resulting native executable.
+
+Sample multistage Dockerfile for building an image from `scratch`:
+
+[source,dockerfile,subs=attributes+]
+----
+## Stage 1 : build with maven builder image with native capabilities
+FROM quay.io/quarkus/ubi10-quarkus-graalvmce-builder-image:{graalvm-flavor} AS build
+USER root
+RUN microdnf install make gcc -y
+COPY --chown=quarkus:quarkus mvnw /code/mvnw
+COPY --chown=quarkus:quarkus .mvn /code/.mvn
+COPY --chown=quarkus:quarkus pom.xml /code/
+RUN mkdir /musl && \
+    curl -L -o musl.tar.gz https://more.musl.cc/11.2.1/x86_64-linux-musl/x86_64-linux-musl-native.tgz && \
+    tar -xvzf musl.tar.gz -C /musl --strip-components 1 && \
+    curl -L -o zlib.tar.gz https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz && \
+    mkdir zlib && tar -xvzf zlib.tar.gz -C zlib --strip-components 1 && \
+    cd zlib && ./configure --static --prefix=/musl && \
+    make && make install && \
+    cd .. && rm -rf zlib && rm -f zlib.tar.gz && rm -f musl.tar.gz
+ENV PATH="/musl/bin:${PATH}"
+USER quarkus
+WORKDIR /code
+RUN ./mvnw -B org.apache.maven.plugins:maven-dependency-plugin:3.8.1:go-offline
+COPY src /code/src
+RUN ./mvnw package -Dnative -DskipTests -Dquarkus.native.additional-build-args="--static","--libc=musl"
+
+## Stage 2 : create the final image
+FROM scratch
+COPY --from=build /code/target/*-runner /application
+EXPOSE 8080
+ENTRYPOINT [ "/application" ]
+----
+
+Scratch images should not be used in production without rigorous testing.
+
+=== Compressing native executables
+
+Quarkus can compress the produced native executable using UPX.
+More details on xref:./upx.adoc[UPX Compression documentation].
+
+[[native-ci-cd]]
+== CI/CD and Build Pipeline Options
+
+=== Separating Java and native image compilation
+
+In certain circumstances, you may want to build the native image in a separate step.
+For example, in a CI/CD pipeline, you may want to have one step to generate the source that will be used for the native image generation and another step to use these sources to actually build the native executable.
+For this use case, you can set the additional flag `quarkus.native.sources-only=true`.
+This will execute the java compilation as if you had started native compilation (`-Dnative`), but stops before triggering the actual call to GraalVM's `native-image`.
+
+[source,bash]
+----
+$ ./mvnw clean package -Dnative -Dquarkus.native.sources-only=true
+----
+
+After compilation has finished, you find the build artifact in `target/native-sources`:
+
+[source,bash]
+----
+$ cd target/native-sources
+$ ls
+getting-started-1.0.0-SNAPSHOT-runner.jar  graalvm.version  lib  native-image.args
+----
+
+From the output above one can see that, in addition to the produced jar file and the associated lib directory, a text file named `native-image.args` was created.
+This file holds all parameters (including the name of the JAR to compile) to pass along to GraalVM's `native-image` command.
+A text file named `graalvm.version` was also created and holds the GraalVM version that should be used.
+If you have GraalVM installed and it matches this version, you can start the native compilation by executing:
+
+[source,bash]
+----
+$ cd target/native-sources
+$ native-image $(cat native-image.args)
+...
+$ ls
+native-image.args
+getting-started-1.0.0-SNAPSHOT-runner
+getting-started-1.0.0-SNAPSHOT-runner.build_artifacts.txt
+getting-started-1.0.0-SNAPSHOT-runner.jar
+----
+
+The process for Gradle is analogous.
+
+Running the build process in a container is also possible:
+
+[source,bash]
+----
+$ ./mvnw clean package -Dquarkus.native.enabled=true -Dquarkus.native.sources-only=true -Dquarkus.native.container-build=true
+----
+
+`-Dquarkus.native.container-build=true` will produce an additional text file named `native-builder.image` holding the docker image name to be used to build the native image.
+
+[source,bash,subs=attributes+]
+----
+cd target/native-sources
+docker run \
+  -it \
+  --user $(id -ur):$(id -gr) \
+  --rm \
+  -v $(pwd):/work \# <1>
+  -w /work \# <2>
+  --entrypoint /bin/sh \
+  $(cat native-builder.image) \# <3>
+  -c "native-image $(cat native-image.args) -J-Xmx4g"# <4>
+----
+
+<1> Mount the host's directory `target/native-image` to the container's `/work`. Thus, the generated binary will also be written to this directory.
+<2> Switch the working directory to `/work`, which we have mounted in <1>.
+<3> Use the docker image from the file `native-builder.image`.
+<4> Call `native-image` with the content of file `native-image.args` as arguments. We also supply an additional argument to limit the process's maximum memory to 4 Gigabytes (this may vary depending on the project being built and the machine building it).
+
+[WARNING]
+====
+If you are running on a Windows machine, please keep in mind that the binary was created within a Linux docker container.
+Hence, the binary will not be executable on the host Windows machine.
+====
+
+A high level overview of what the various steps of a CI/CD pipeline would look is the following:
+
+1. Register the output of the step executing `./mvnw ...` command (i.e. directory `target/native-image`) as a build artifact,
+2. Require this artifact in the step executing the `native-image ...` command, and
+3. Register the output of the step executing the `native-image ...` command (i.e. files matching `target/*runner`) as build artifact.
+
+The environment executing step `1` only needs Java and Maven (or Gradle) installed, while the environment executing step `3` only needs a GraalVM installation (including the `native-image` feature).
+
+Depending on what the final desired output of the CI/CD pipeline is, the generated binary might then be used to create a container image.
+
+=== Debugging native executables
+
+Native executables can be debugged using tools such as `gdb`.
+For this to be possible native executables need to be generated with debug symbols.
+
+[NOTE]
+Debug symbol generation is only supported on Linux.
+Windows support is still under development, while macOS is not supported.
+
+To generate debug symbols,
+add `-Dquarkus.native.debug.enabled=true` flag when generating the native executable.
+You will find the debug symbols for the native executable in a `.debug` file next to the native executable.
+
+[NOTE]
+====
+The generation of the `.debug` file depends on `objcopy`.
+As a result, when using a local GraalVM installation on common Linux distributions, you will need to install the `binutils` package:
+
+[source,bash]
+----
+# dnf (rpm-based)
+sudo dnf install binutils
+# Debian-based distributions
+sudo apt-get install binutils
+----
+
+When `objcopy` is not available, debug symbols are embedded in the executable.
+====
+
+Aside from debug symbols,
+setting `-Dquarkus.native.debug.enabled=true` flag generates a cache of source files
+for any JDK runtime classes, GraalVM classes, and application classes resolved during native executable generation.
+This source cache is useful for native debugging tools,
+to establish the link between the symbols and the matching source code.
+It provides a convenient way of making just the necessary sources available to the debugger/IDE when debugging a native executable.
+
+Sources for third party jar dependencies, including Quarkus source code,
+are not added to the source cache by default.
+To include those, make sure you invoke `mvn dependency:sources` first.
+This step is required in order to pull the sources for these dependencies,
+and get them included in the source cache.
+
+The source cache is located in the `target/sources` folder.
+
+[TIP]
+====
+If running `gdb` from a different directory than `target`, then the sources can be loaded by running:
+
+[source,bash]
+----
+directory path/to/target
+----
+
+in the `gdb` prompt.
+
+Or start `gdb` with:
+
+[source,bash]
+----
+gdb -ex 'directory path/to/target' path/to/target/{project.name}-{project.version}-runner
+----
+
+e.g.,
+[source,bash]
+----
+gdb -ex 'directory ./target' ./target/getting-started-1.0.0-SNAPSHOT-runner
+----
+====
+
+For more in-depth debugging and inspection techniques, see the <<inspecting-and-debugging>> section above.
+
+[[native-monitoring]]
+== Monitoring Options
+
+Monitoring options such as JDK flight recorder, jvmstat, heap dumps, NMT (starting with Mandrel 24.1 for JDK 23), and remote JMX
+can be added to the native executable build. Simply supply a comma separated list of the monitoring options you wish to
+include at build time.
+[source,bash]
+----
+-Dquarkus.native.monitoring=<comma separated list of options>
+----
+
+|===
+|Monitoring Option |Description |Availability As Of
+
+|jcmd
+|Include JCMD support
+|GraalVM CE for JDK 24 Mandrel 24.2
+
+|jfr
+|Include JDK Flight Recorder support
+|GraalVM CE 21.3 Mandrel 21.3
+
+|jvmstat
+|Adds jvmstat support
+|GraalVM 22.3, GraalVM CE 17.0.7 Mandrel 22.3 Mandrel 23.0 (17.0.7)
+
+|heapdump
+|Adds support for generating heap dumps
+|GraalVM 22.3, GraalVM CE 17.0.7 Mandrel 22.3 Mandrel 23.0 (17.0.7)
+
+|jmxclient
+|Adds support for connections to JMX servers.
+|GraalVM for JDK 17/20 Mandrel 23.0
+
+|jmxserver
+|Adds support for accepting connections from JMX clients.
+|GraalVM for JDK 17/20 Mandrel 23.0 (17.0.7)
+
+|nmt
+|Adds support for native memory tracking.
+|GraalVM for JDK 23 Mandrel 24.1
+
+|threaddump
+|Adds support for dumping thread stacks on SIGQUIT/SIGBREAK.
+|GraalVM for JDK 22 Mandrel 24.0
+
+|none
+|Disables support for all monitoring options that would be enabled by default in Quarkus
+|Pseudo option used by Quarkus
+
+|all
+|Adds all monitoring options.
+|GraalVM 22.3, GraalVM CE 17.0.7 Mandrel 22.3 Mandrel 23.0 (17.0.7)
+|===
+
+[[native-bundles]]
+== Native Image Bundles
+
+A native image bundle containing everything required to build a native image can be generated.
+This is useful to inspect the build inputs and configuration.
+
+The generation of the bundle can be activated by setting any of the following parameters:
+
+|===
+|Parameter |Description |Default
+
+|quarkus.native.bundle.enabled
+|Enables the native-image bundle generation
+|`false`
+
+|quarkus.native.bundle.dry-run
+|Generates the bundle without building the native executable
+|`false`
+
+|quarkus.native.bundle.name
+|Sets the name of the bundle
+|
+|===
+
+To use this feature, run:
+
+[source,bash]
+----
+./mvnw package -Dnative -Dquarkus.native.bundle.enabled=true
+----
+
+This command will generate all the files and configuration needed for the native image build in `target/{project.name}-{project.version}-runner.nib`.
+
+[NOTE]
+====
+More details on the GraalVM native-image bundle are available in the link:https://www.graalvm.org/{graalvm-docs-version}/reference-manual/native-image/overview/Bundles[GraalVM documentation].
+====
 
 [[native-faq]]
 == Frequently Asked Questions


### PR DESCRIPTION
Restructure the native image guide to move "reference" content into the native reference guide and keep the "getting started with native guide" as focused as possible. 

This new guide contains a preliminary section explaining when you need native. It also includes the table from @rolfedh comparing JVM, AOT, and native. 

This was initially part of #54398.

