### PR TITLE
Bump proposed Maven version to 3.9.16

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -61,7 +61,7 @@
         <supported-maven-versions>[3.9.0,)</supported-maven-versions>
 
         <!-- These 2 properties are used by CreateProjectMojo to add the Maven Wrapper -->
-        <proposed-maven-version>3.9.15</proposed-maven-version>
+        <proposed-maven-version>3.9.16</proposed-maven-version>
         <maven-wrapper.version>3.3.4</maven-wrapper.version>
         <gradle-wrapper.version>9.5.1</gradle-wrapper.version>
         <quarkus-gradle-plugin.version>${project.version}</quarkus-gradle-plugin.version>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -47,7 +47,7 @@
         <jandex.version>3.5.3</jandex.version>
         <bytebuddy.version>1.17.6</bytebuddy.version>
         <junit.version>6.1.0</junit.version>
-        <maven.version>3.9.15</maven.version>
+        <maven.version>3.9.16</maven.version>
         <assertj.version>3.27.7</assertj.version>
         <jboss-logging.version>3.6.3.Final</jboss-logging.version>
         <jboss-logmanager.version>3.2.2.Final</jboss-logmanager.version>

--- a/independent-projects/tools/devtools-testing/src/main/resources/fake-catalog.json
+++ b/independent-projects/tools/devtools-testing/src/main/resources/fake-catalog.json
@@ -451,7 +451,7 @@
         "supported-maven-versions": "[3.6.2,)",
         "minimum-java-version": "11",
         "recommended-java-version": "17",
-        "proposed-maven-version": "3.9.15",
+        "proposed-maven-version": "3.9.16",
         "maven-wrapper-version": "3.3.4",
         "gradle-wrapper-version": "9.5.1"
       }

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -36,7 +36,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- These properties are used by CreateProjectMojo to add the Maven Wrapper -->
-        <proposed-maven-version>3.9.15</proposed-maven-version>
+        <proposed-maven-version>3.9.16</proposed-maven-version>
         <maven-wrapper.version>3.3.4</maven-wrapper.version>
         <!-- When updating gradle-wrapper.version, make sure to also update files in
              independent-projects/tools/base-codestarts/src/main/resources/codestarts


### PR DESCRIPTION
## Summary

  - Bump the proposed Maven version from 3.9.15 to 3.9.16

  ## Why

  Maven 3.9.16 fixes a plugin prefix resolution regression (apache/maven#12019) introduced in 3.9.12. Since that version, `mvn quarkus:dev` can resolve to the wrong plugin when the POM declares a `quarkus-maven-plugin` with a different groupId than what's in `settings.xml`
   `<pluginGroup>` entries (e.g. `com.redhat.quarkus.platform` vs `io.quarkus`). This directly affects Red Hat product builds.