### PR TITLE
Signals: Receivers - resolve lambda inference ambiguity

### DIFF
--- a/docs/src/main/asciidoc/signals.adoc
+++ b/docs/src/main/asciidoc/signals.adoc
@@ -344,15 +344,13 @@ The builder supports the following options:
 Registration reg = receivers.newReceiver(OrderPlaced.class)
         .setQualifiers(new Urgent.Literal())                        // <1>
         .setExecutionModel(ExecutionModel.VIRTUAL_THREAD)           // <2>
-        .setResponseType(String.class)                              // <3>
-        .notify(ctx -> {                                            // <4>
+        .notify(String.class, ctx -> {                              // <3>
             return Uni.createFrom().item("processed-" + ctx.signal().orderId());
         });
 ----
 <1> Set qualifiers for type-safe resolution.
 <2> Set the execution model (`BLOCKING`, `NON_BLOCKING`, or `VIRTUAL_THREAD`).
-<3> Set the response type for request-reply patterns.
-<4> The callback receives a `SignalContext` and returns a `Uni`.
+<3> The response type and callback; the callback receives a `SignalContext` and returns a `Uni`.
 
 For simple fire-and-forget receivers, a `Consumer`-based callback can be used:
 

--- a/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/BlockingConcurrencyLimitTest.java
+++ b/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/BlockingConcurrencyLimitTest.java
@@ -18,7 +18,6 @@ import io.quarkus.signals.Receivers.ExecutionModel;
 import io.quarkus.signals.Receivers.Registration;
 import io.quarkus.signals.Signal;
 import io.quarkus.test.QuarkusExtensionTest;
-import io.smallrye.mutiny.Uni;
 
 public class BlockingConcurrencyLimitTest extends AbstractSignalTest {
 
@@ -61,7 +60,6 @@ public class BlockingConcurrencyLimitTest extends AbstractSignalTest {
                             activeTasks.decrementAndGet();
                             allDone.countDown();
                         }
-                        return Uni.createFrom().voidItem();
                     }));
         }
 

--- a/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/ReceiverFailureTest.java
+++ b/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/ReceiverFailureTest.java
@@ -141,9 +141,8 @@ public class ReceiverFailureTest extends AbstractSignalTest {
     @Test
     public void testRequestFailureWorkerThread() {
         var reg = receivers.newReceiver(Cmd.class)
-                .setResponseType(String.class)
                 .setExecutionModel(ExecutionModel.BLOCKING)
-                .notify(new Function<SignalContext<Cmd>, Uni<String>>() {
+                .notify(String.class, new Function<SignalContext<Cmd>, Uni<String>>() {
 
                     @Override
                     public Uni<String> apply(SignalContext<Cmd> ctx) {
@@ -163,9 +162,8 @@ public class ReceiverFailureTest extends AbstractSignalTest {
     @Test
     public void testRequestFailureEventLoop() {
         var reg = receivers.newReceiver(Cmd.class)
-                .setResponseType(String.class)
                 .setExecutionModel(ExecutionModel.NON_BLOCKING)
-                .notify(new Function<SignalContext<Cmd>, Uni<String>>() {
+                .notify(String.class, new Function<SignalContext<Cmd>, Uni<String>>() {
 
                     @Override
                     public Uni<String> apply(SignalContext<Cmd> ctx) {
@@ -185,9 +183,8 @@ public class ReceiverFailureTest extends AbstractSignalTest {
     @Test
     public void testBlockingRequestFailure() {
         var reg = receivers.newReceiver(Cmd.class)
-                .setResponseType(String.class)
                 .setExecutionModel(ExecutionModel.BLOCKING)
-                .notify(new Function<SignalContext<Cmd>, Uni<String>>() {
+                .notify(String.class, new Function<SignalContext<Cmd>, Uni<String>>() {
 
                     @Override
                     public Uni<String> apply(SignalContext<Cmd> ctx) {
@@ -205,9 +202,8 @@ public class ReceiverFailureTest extends AbstractSignalTest {
     @Test
     public void testBlockingRequestCheckedExceptionWrapped() {
         var reg = receivers.newReceiver(Cmd.class)
-                .setResponseType(String.class)
                 .setExecutionModel(ExecutionModel.BLOCKING)
-                .notify(new Function<SignalContext<Cmd>, Uni<String>>() {
+                .notify(String.class, new Function<SignalContext<Cmd>, Uni<String>>() {
 
                     @Override
                     public Uni<String> apply(SignalContext<Cmd> ctx) {
@@ -299,7 +295,7 @@ public class ReceiverFailureTest extends AbstractSignalTest {
     public void testPublishUniFailure() {
         var reg = receivers.newReceiver(Cmd.class)
                 .setExecutionModel(ExecutionModel.NON_BLOCKING)
-                .notify(new Function<SignalContext<Cmd>, Uni<Void>>() {
+                .notify(Void.class, new Function<SignalContext<Cmd>, Uni<Void>>() {
                     @Override
                     public Uni<Void> apply(SignalContext<Cmd> ctx) {
                         return Uni.createFrom().failure(new IllegalStateException("publish-uni-boom"));
@@ -320,7 +316,7 @@ public class ReceiverFailureTest extends AbstractSignalTest {
     public void testSendUniFailure() {
         var reg = receivers.newReceiver(Cmd.class)
                 .setExecutionModel(ExecutionModel.NON_BLOCKING)
-                .notify(new Function<SignalContext<Cmd>, Uni<Void>>() {
+                .notify(Void.class, new Function<SignalContext<Cmd>, Uni<Void>>() {
                     @Override
                     public Uni<Void> apply(SignalContext<Cmd> ctx) {
                         return Uni.createFrom().failure(new IllegalStateException("send-uni-boom"));
@@ -339,9 +335,8 @@ public class ReceiverFailureTest extends AbstractSignalTest {
     @Test
     public void testRequestUniFailure() {
         var reg = receivers.newReceiver(Cmd.class)
-                .setResponseType(String.class)
                 .setExecutionModel(ExecutionModel.NON_BLOCKING)
-                .notify(new Function<SignalContext<Cmd>, Uni<String>>() {
+                .notify(String.class, new Function<SignalContext<Cmd>, Uni<String>>() {
                     @Override
                     public Uni<String> apply(SignalContext<Cmd> ctx) {
                         return Uni.createFrom().failure(new IllegalStateException("request-uni-boom"));

--- a/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/ReceiversTest.java
+++ b/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/ReceiversTest.java
@@ -90,8 +90,7 @@ public class ReceiversTest extends AbstractSignalTest {
     @Test
     public void testRegisterWithResponse() {
         Receivers.Registration reg = receivers.newReceiver(Order.class)
-                .setResponseType(String.class)
-                .notify(ctx -> {
+                .notify(String.class, ctx -> {
                     return Uni.createFrom().item("processed_" + ctx.signal().id());
                 });
         try {
@@ -159,8 +158,7 @@ public class ReceiversTest extends AbstractSignalTest {
         AtomicBoolean requestContextActive = new AtomicBoolean();
 
         var reg = receivers.newReceiver(Order.class)
-                .setResponseType(String.class)
-                .notify(ctx -> {
+                .notify(String.class, ctx -> {
                     requestContextActive.set(Arc.container().requestContext().isActive());
                     // Verify that a @RequestScoped bean can be used
                     requestBean.ping();
@@ -203,8 +201,7 @@ public class ReceiversTest extends AbstractSignalTest {
 
         var reg = receivers.newReceiver(Order.class)
                 .setExecutionModel(ExecutionModel.BLOCKING)
-                .setResponseType(String.class)
-                .notify(ctx -> {
+                .notify(String.class, ctx -> {
                     blockingAllowed.set(BlockingOperationControl.isBlockingAllowed());
                     return Uni.createFrom().item("done");
                 });
@@ -225,8 +222,7 @@ public class ReceiversTest extends AbstractSignalTest {
 
         var reg = receivers.newReceiver(Order.class)
                 .setExecutionModel(ExecutionModel.NON_BLOCKING)
-                .setResponseType(String.class)
-                .notify(ctx -> {
+                .notify(String.class, ctx -> {
                     blockingAllowed.set(BlockingOperationControl.isBlockingAllowed());
                     return Uni.createFrom().item("done");
                 });

--- a/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/ResolveReceiversTest.java
+++ b/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/ResolveReceiversTest.java
@@ -54,8 +54,7 @@ public class ResolveReceiversTest extends AbstractSignalTest {
         Function<SignalContext<Event>, Uni<String>> callback = ctx -> Uni.createFrom().item("ok");
         Receivers.Registration reg = receivers.newReceiver(Event.class)
                 .setExecutionModel(ExecutionModel.NON_BLOCKING)
-                .setResponseType(String.class)
-                .notify(callback);
+                .notify(String.class, callback);
         try {
             List<ReceiverInfo> infos = receivers.resolveReceivers(Event.class);
             // [onEvent, reg]

--- a/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/ResubscriptionTest.java
+++ b/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/ResubscriptionTest.java
@@ -92,8 +92,7 @@ public class ResubscriptionTest extends AbstractSignalTest {
         AtomicInteger count = new AtomicInteger();
 
         var reg = receivers.newReceiver(Ping.class)
-                .setResponseType(String.class)
-                .notify(ctx -> {
+                .notify(String.class, ctx -> {
                     return Uni.createFrom().item("reply_" + count.incrementAndGet());
                 });
         try {
@@ -160,8 +159,7 @@ public class ResubscriptionTest extends AbstractSignalTest {
         AtomicInteger count = new AtomicInteger();
 
         var reg = receivers.newReceiver(Ping.class)
-                .setResponseType(String.class)
-                .notify(ctx -> {
+                .notify(String.class, ctx -> {
                     count.incrementAndGet();
                     return Uni.createFrom().item("reply");
                 });
@@ -230,8 +228,7 @@ public class ResubscriptionTest extends AbstractSignalTest {
 
         // Register a receiver after the Uni was created
         var reg = receivers.newReceiver(Ping.class)
-                .setResponseType(String.class)
-                .notify(ctx -> {
+                .notify(String.class, ctx -> {
                     return Uni.createFrom().item("reply_" + ctx.signal().id());
                 });
         try {

--- a/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/SignalCreateTest.java
+++ b/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/SignalCreateTest.java
@@ -62,8 +62,7 @@ public class SignalCreateTest extends AbstractSignalTest {
     @Test
     public void testCreateWithClassRequest() {
         var reg = receivers.newReceiver(Ping.class)
-                .setResponseType(String.class)
-                .notify(ctx -> {
+                .notify(String.class, ctx -> {
                     return Uni.createFrom().item("reply_" + ctx.signal().id());
                 });
         try {
@@ -126,8 +125,7 @@ public class SignalCreateTest extends AbstractSignalTest {
     @Test
     public void testCreateWithTypeLiteralRequest() {
         var reg = receivers.newReceiver(Ping.class)
-                .setResponseType(String.class)
-                .notify(ctx -> {
+                .notify(String.class, ctx -> {
                     return Uni.createFrom().item("reply_" + ctx.signal().id());
                 });
         try {

--- a/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/VirtualThreadConcurrencyLimitTest.java
+++ b/extensions/signals/deployment/src/test/java/io/quarkus/signals/deployment/test/VirtualThreadConcurrencyLimitTest.java
@@ -18,7 +18,6 @@ import io.quarkus.signals.Receivers.ExecutionModel;
 import io.quarkus.signals.Receivers.Registration;
 import io.quarkus.signals.Signal;
 import io.quarkus.test.QuarkusExtensionTest;
-import io.smallrye.mutiny.Uni;
 
 public class VirtualThreadConcurrencyLimitTest extends AbstractSignalTest {
 
@@ -61,7 +60,6 @@ public class VirtualThreadConcurrencyLimitTest extends AbstractSignalTest {
                             activeTasks.decrementAndGet();
                             allDone.countDown();
                         }
-                        return Uni.createFrom().voidItem();
                     }));
         }
 

--- a/extensions/signals/deployment/src/test/java21/io/quarkus/signals/deployment/test/ReceiverFailureVirtualThreadTest.java
+++ b/extensions/signals/deployment/src/test/java21/io/quarkus/signals/deployment/test/ReceiverFailureVirtualThreadTest.java
@@ -86,9 +86,8 @@ public class ReceiverFailureVirtualThreadTest extends AbstractSignalTest {
     @Test
     public void testRequestFailureVirtualThread() {
         var reg = receivers.newReceiver(Cmd.class)
-                .setResponseType(String.class)
                 .setExecutionModel(ExecutionModel.VIRTUAL_THREAD)
-                .notify(new Function<SignalContext<Cmd>, Uni<String>>() {
+                .notify(String.class, new Function<SignalContext<Cmd>, Uni<String>>() {
 
                     @Override
                     public Uni<String> apply(SignalContext<Cmd> ctx) {

--- a/extensions/signals/runtime-api/src/main/java/io/quarkus/signals/Receivers.java
+++ b/extensions/signals/runtime-api/src/main/java/io/quarkus/signals/Receivers.java
@@ -3,7 +3,6 @@ package io.quarkus.signals;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -42,7 +41,7 @@ public interface Receivers {
      * @param signalType the received signal type
      * @return a new receiver builder
      */
-    <SIGNAL> ReceiverDefinition<SIGNAL, Void> newReceiver(Class<SIGNAL> signalType);
+    <SIGNAL> ReceiverDefinition<SIGNAL> newReceiver(Class<SIGNAL> signalType);
 
     /**
      * Returns a builder of a new receiver of the given {@code signalType}.
@@ -51,7 +50,7 @@ public interface Receivers {
      * @param signalType the received signal type
      * @return a new receiver builder
      */
-    <SIGNAL> ReceiverDefinition<SIGNAL, Void> newReceiver(TypeLiteral<SIGNAL> signalType);
+    <SIGNAL> ReceiverDefinition<SIGNAL> newReceiver(TypeLiteral<SIGNAL> signalType);
 
     /**
      * Resolves the receivers matching the given signal type and qualifiers.
@@ -115,10 +114,9 @@ public interface Receivers {
      * A builder for creating {@link Receiver} instances programmatically.
      *
      * @param <SIGNAL> the signal type
-     * @param <RESPONSE> the response type; {@code Void} by default, set by {@code setResponseType()}
      * @see Receivers#newReceiver(Class)
      */
-    interface ReceiverDefinition<SIGNAL, RESPONSE> {
+    interface ReceiverDefinition<SIGNAL> {
 
         /**
          * Sets the qualifiers of the built receiver.
@@ -127,7 +125,7 @@ public interface Receivers {
          * @param qualifiers the set of qualifiers
          * @return self
          */
-        ReceiverDefinition<SIGNAL, RESPONSE> setQualifiers(Annotation... qualifiers);
+        ReceiverDefinition<SIGNAL> setQualifiers(Annotation... qualifiers);
 
         /**
          * Sets the execution model of the receiver.
@@ -136,68 +134,50 @@ public interface Receivers {
          * @param executionModel the execution model
          * @return self
          */
-        ReceiverDefinition<SIGNAL, RESPONSE> setExecutionModel(ExecutionModel executionModel);
-
-        /**
-         * Sets the response type of the receiver.
-         * By default, {@code Void} is used.
-         *
-         * @param <R> the response type
-         * @param responseType the response type
-         * @return self
-         */
-        <R> ReceiverDefinition<SIGNAL, R> setResponseType(Class<R> responseType);
-
-        /**
-         * Sets the response type of the receiver.
-         * By default, {@code Void} is used.
-         *
-         * @param <R> the response type
-         * @param responseType the response type
-         * @return self
-         */
-        <R> ReceiverDefinition<SIGNAL, R> setResponseType(TypeLiteral<R> responseType);
+        ReceiverDefinition<SIGNAL> setExecutionModel(ExecutionModel executionModel);
 
         /**
          * Registers a new receiver.
-         * When registered through this method, the receiver always has a response type of {@code Void}.
+         * When registered through this method, the receiver always has a response type of {@code void}.
          * <p>
          * Registration is not performed atomically; concurrent emissions may or may not see the receiver while this method
          * executes. When the method returns, the receiver is fully registered.
          *
          * @param callback a consumer of the signal
-         * @return a new receiver
+         * @return a new registration handle
          */
-        default Registration notify(Consumer<SignalContext<SIGNAL>> callback) {
-            Objects.requireNonNull(callback);
-            return setResponseType(void.class).notify(new Function<SignalContext<SIGNAL>, Uni<Void>>() {
-                @Override
-                public Uni<Void> apply(SignalContext<SIGNAL> ctx) {
-                    try {
-                        callback.accept(ctx);
-                        return Uni.createFrom().voidItem();
-                    } catch (Exception e) {
-                        return Uni.createFrom().failure(e);
-                    }
-                }
-            });
-        }
+        Registration notify(Consumer<SignalContext<SIGNAL>> callback);
 
         /**
-         * Registers a new receiver.
+         * Registers a new receiver with the given response type.
          * <p>
          * Registration is not performed atomically; concurrent emissions may or may not see the receiver while this method
          * executes. When the method returns, the receiver is fully registered.
          *
+         * @param <R> the response type
+         * @param responseType the response type
          * @param callback a function from the signal to the response
-         * @return a new receiver
+         * @return a new registration handle
          */
-        Registration notify(Function<SignalContext<SIGNAL>, Uni<RESPONSE>> callback);
+        <R> Registration notify(Class<R> responseType, Function<SignalContext<SIGNAL>, Uni<R>> callback);
+
+        /**
+         * Registers a new receiver with the given response type.
+         * <p>
+         * Registration is not performed atomically; concurrent emissions may or may not see the receiver while this method
+         * executes. When the method returns, the receiver is fully registered.
+         *
+         * @param <R> the response type
+         * @param responseType the response type
+         * @param callback a function from the signal to the response
+         * @return a new registration handle
+         */
+        <R> Registration notify(TypeLiteral<R> responseType, Function<SignalContext<SIGNAL>, Uni<R>> callback);
 
     }
 
     /**
-     * A handle returned by {@link ReceiverDefinition#notify(Function)} that can be used to unregister the receiver.
+     * A handle returned by the {@code notify} methods that can be used to unregister the receiver.
      */
     interface Registration {
 

--- a/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/impl/ReceiverDefinitionImpl.java
+++ b/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/impl/ReceiverDefinitionImpl.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Type;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import jakarta.enterprise.inject.spi.BeanContainer;
@@ -18,12 +19,11 @@ import io.quarkus.signals.SignalContext;
 import io.quarkus.signals.spi.Receiver;
 import io.smallrye.mutiny.Uni;
 
-class ReceiverDefinitionImpl<SIGNAL, RESPONSE> implements Receivers.ReceiverDefinition<SIGNAL, RESPONSE> {
+class ReceiverDefinitionImpl<SIGNAL, RESPONSE> implements Receivers.ReceiverDefinition<SIGNAL> {
 
     private final Function<CallbackReceiver<SIGNAL, RESPONSE>, Receivers.Registration> registerFun;
     private final BeanContainer beanContainer;
     private final Type signalType;
-    private Type responseType = void.class;
     private Set<Annotation> qualifiers = Set.of();
     private ExecutionModel executionModel = ExecutionModel.BLOCKING;
 
@@ -31,12 +31,11 @@ class ReceiverDefinitionImpl<SIGNAL, RESPONSE> implements Receivers.ReceiverDefi
             Function<CallbackReceiver<SIGNAL, RESPONSE>, Receivers.Registration> registerFun) {
         this.signalType = signalType;
         this.beanContainer = beanContainer;
-        this.responseType = null;
         this.registerFun = registerFun;
     }
 
     @Override
-    public Receivers.ReceiverDefinition<SIGNAL, RESPONSE> setQualifiers(Annotation... qualifiers) {
+    public Receivers.ReceiverDefinition<SIGNAL> setQualifiers(Annotation... qualifiers) {
         for (Annotation qualifier : qualifiers) {
             if (!beanContainer.isQualifier(qualifier.annotationType())) {
                 throw new IllegalArgumentException("Not a qualifier: " + qualifier.annotationType().getName());
@@ -47,29 +46,49 @@ class ReceiverDefinitionImpl<SIGNAL, RESPONSE> implements Receivers.ReceiverDefi
     }
 
     @Override
-    public Receivers.ReceiverDefinition<SIGNAL, RESPONSE> setExecutionModel(ExecutionModel executionModel) {
+    public Receivers.ReceiverDefinition<SIGNAL> setExecutionModel(ExecutionModel executionModel) {
         this.executionModel = Objects.requireNonNull(executionModel);
         return this;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
-    public <R> Receivers.ReceiverDefinition<SIGNAL, R> setResponseType(Class<R> responseType) {
-        this.responseType = Objects.requireNonNull(responseType);
-        return (Receivers.ReceiverDefinition<SIGNAL, R>) this;
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public <R> Receivers.ReceiverDefinition<SIGNAL, R> setResponseType(TypeLiteral<R> responseType) {
-        this.responseType = Objects.requireNonNull(responseType.getType());
-        return (Receivers.ReceiverDefinition<SIGNAL, R>) this;
-    }
-
-    @Override
-    public Registration notify(Function<SignalContext<SIGNAL>, Uni<RESPONSE>> callback) {
+    public Registration notify(Consumer<SignalContext<SIGNAL>> callback) {
         Objects.requireNonNull(callback);
-        return registerFun.apply(new CallbackReceiver<>(signalType, qualifiers, responseType, executionModel, callback));
+        @SuppressWarnings("unchecked")
+        CallbackReceiver<SIGNAL, RESPONSE> receiver = (CallbackReceiver<SIGNAL, RESPONSE>) new CallbackReceiver<>(
+                signalType, qualifiers, void.class, executionModel,
+                new Function<SignalContext<SIGNAL>, Uni<Void>>() {
+                    @Override
+                    public Uni<Void> apply(SignalContext<SIGNAL> ctx) {
+                        try {
+                            callback.accept(ctx);
+                            return Uni.createFrom().voidItem();
+                        } catch (Exception e) {
+                            return Uni.createFrom().failure(e);
+                        }
+                    }
+                });
+        return registerFun.apply(receiver);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <R> Registration notify(Class<R> responseType, Function<SignalContext<SIGNAL>, Uni<R>> callback) {
+        Objects.requireNonNull(responseType);
+        Objects.requireNonNull(callback);
+        return registerFun.apply(
+                (CallbackReceiver<SIGNAL, RESPONSE>) new CallbackReceiver<>(signalType, qualifiers,
+                        responseType, executionModel, callback));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <R> Registration notify(TypeLiteral<R> responseType, Function<SignalContext<SIGNAL>, Uni<R>> callback) {
+        Objects.requireNonNull(responseType);
+        Objects.requireNonNull(callback);
+        return registerFun.apply(
+                (CallbackReceiver<SIGNAL, RESPONSE>) new CallbackReceiver<>(signalType, qualifiers,
+                        responseType.getType(), executionModel, callback));
     }
 
     static class CallbackReceiver<SIGNAL, RESPONSE> implements Receiver<SIGNAL, RESPONSE> {

--- a/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/impl/ReceiverManager.java
+++ b/extensions/signals/runtime/src/main/java/io/quarkus/signals/runtime/impl/ReceiverManager.java
@@ -138,12 +138,12 @@ public class ReceiverManager implements Receivers, Signals {
     }
 
     @Override
-    public <SIGNAL> ReceiverDefinition<SIGNAL, Void> newReceiver(Class<SIGNAL> signalType) {
+    public <SIGNAL> ReceiverDefinition<SIGNAL> newReceiver(Class<SIGNAL> signalType) {
         return new ReceiverDefinitionImpl<>(signalType, beanContainer, this::register);
     }
 
     @Override
-    public <SIGNAL> ReceiverDefinition<SIGNAL, Void> newReceiver(TypeLiteral<SIGNAL> signalType) {
+    public <SIGNAL> ReceiverDefinition<SIGNAL> newReceiver(TypeLiteral<SIGNAL> signalType) {
         return new ReceiverDefinitionImpl<>(signalType.getType(), beanContainer, this::register);
     }
 


### PR DESCRIPTION
- remove setResponseType() methods from ReceiverDefinition
- remove notify() Function overload from ReceiverDefinition
- add notify() methods that accept the response type to ReceiverDefinition
- update the tests and docs

Based on an idea from @manovotn (thanks a lot Matej :pray:)  about how to fix lambda inference ambiguity in the `io.quarkus.signals.Receivers.ReceiverDefinition`. Also discussed on Zulip: https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/Quarkus.20Signals.20and.20SSE/with/597851957

This is a breaking change but Signals is an experimental API.

CC @wjglerum 