### PR TITLE
Attempt to fix the flakiness of testPrices

### DIFF
--- a/integration-tests/reactive-messaging-kafka/src/test/java/io/quarkus/it/kafka/KafkaConnectorTest.java
+++ b/integration-tests/reactive-messaging-kafka/src/test/java/io/quarkus/it/kafka/KafkaConnectorTest.java
@@ -75,7 +75,7 @@ public class KafkaConnectorTest {
     @Order(4)
     public void testPrices() {
         KafkaRepeatableReceivers repeatableReceivers = Arc.container().instance(KafkaRepeatableReceivers.class).get();
-        await().untilAsserted(() -> Assertions.assertEquals(repeatableReceivers.getPrices().size(), 6));
+        await().untilAsserted(() -> Assertions.assertEquals(6, new HashSet<>(repeatableReceivers.getPrices()).size()));
     }
 
     @Test


### PR DESCRIPTION
The idea is to deduplicate the list's content, since additional items can be added if the app is restarted or during rebalancing.

