### PR TITLE
Produce both quoted and unquoted variants of schema management config

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/dev/HibernateOrmDevServicesProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/dev/HibernateOrmDevServicesProcessor.java
@@ -1,7 +1,7 @@
 package io.quarkus.hibernate.orm.deployment.dev;
 
 import java.util.Collection;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -44,29 +44,32 @@ public class HibernateOrmDevServicesProcessor {
                     .dataSourcePropertyKeys(dataSourceName.orElse(null), "username");
 
             if (!managedSources.contains(dataSourceName.orElse(DataSourceUtil.DEFAULT_DATASOURCE_NAME))) {
-                String schemaManagementStrategyPropertyKey = HibernateOrmRuntimeConfig.puPropertyKey(entry.getKey(),
+                List<String> schemaManagementStrategyPropertyKeys = HibernateOrmRuntimeConfig.puPropertyKeys(entry.getKey(),
                         "schema-management.strategy");
-                String legacyDatabaseGenerationPropertyKey = HibernateOrmRuntimeConfig.puPropertyKey(entry.getKey(),
+                List<String> legacyDatabaseGenerationPropertyKeys = HibernateOrmRuntimeConfig.puPropertyKeys(entry.getKey(),
                         "database.generation");
                 if (!ConfigUtils.isAnyPropertyPresent(propertyKeysIndicatingDataSourceConfigured)
-                        && !ConfigUtils.isPropertyNonEmpty(schemaManagementStrategyPropertyKey)
-                        && !ConfigUtils.isPropertyNonEmpty(legacyDatabaseGenerationPropertyKey)) {
+                        && !ConfigUtils.isAnyPropertyPresent(schemaManagementStrategyPropertyKeys)
+                        && !ConfigUtils.isAnyPropertyPresent(legacyDatabaseGenerationPropertyKeys)) {
                     devServicesAdditionalConfigProducer
                             .produce(new DevServicesAdditionalConfigBuildItem(devServicesConfig -> {
                                 // Only force DB generation if the datasource is configured through dev services
                                 if (propertyKeysIndicatingDataSourceConfigured.stream()
                                         .anyMatch(devServicesConfig::containsKey)) {
-                                    String offlineStartKey = HibernateOrmRuntimeConfig.puPropertyKey(entry.getKey(),
+                                    List<String> offlineStartKeys = HibernateOrmRuntimeConfig.puPropertyKeys(entry.getKey(),
                                             "database.start-offline");
                                     Optional<Boolean> offlineStart = ConfigUtils
-                                            .getFirstOptionalValue(Collections.singletonList(offlineStartKey), Boolean.class);
+                                            .getFirstOptionalValue(offlineStartKeys, Boolean.class);
 
-                                    String forcedValue;
                                     if (offlineStart.isEmpty() || !offlineStart.get()) {
-                                        forcedValue = "drop-and-create";
+                                        String forcedValue = "drop-and-create";
+                                        Map<String, String> result = new HashMap<>();
+                                        for (String key : schemaManagementStrategyPropertyKeys) {
+                                            result.put(key, forcedValue);
+                                        }
                                         LOG.infof("Setting %s=%s to initialize Dev Services managed database",
-                                                schemaManagementStrategyPropertyKey, forcedValue);
-                                        return Map.of(schemaManagementStrategyPropertyKey, forcedValue);
+                                                schemaManagementStrategyPropertyKeys, forcedValue);
+                                        return result;
                                     } else {
                                         return Map.of();
                                     }

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/DevServicesSchemaManagementStrategyNamedPUQuotedTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/DevServicesSchemaManagementStrategyNamedPUQuotedTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.hibernate.orm.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.config.namedpu.MyEntity;
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * Verifies that Dev Services automatically sets schema-management.strategy=drop-and-create
+ * for a named persistence unit configured with quoted keys.
+ */
+public class DevServicesSchemaManagementStrategyNamedPUQuotedTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addPackage(MyEntity.class.getPackage().getName()))
+            .overrideConfigKey("quarkus.hibernate-orm.\"pu-1\".datasource", "<default>")
+            .overrideConfigKey("quarkus.hibernate-orm.\"pu-1\".packages", MyEntity.class.getPackageName());
+
+    @Test
+    public void testDevServicesSchemaManagementStrategy() {
+        assertThat(ConfigProvider.getConfig()
+                .getValue("quarkus.hibernate-orm.pu-1.schema-management.strategy", String.class))
+                .isEqualTo("drop-and-create");
+        assertThat(ConfigProvider.getConfig()
+                .getValue("quarkus.hibernate-orm.\"pu-1\".schema-management.strategy", String.class))
+                .isEqualTo("drop-and-create");
+    }
+
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/DevServicesSchemaManagementStrategyNamedPUUnquotedTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/DevServicesSchemaManagementStrategyNamedPUUnquotedTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.hibernate.orm.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.config.namedpu.MyEntity;
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * Verifies that Dev Services automatically sets schema-management.strategy=drop-and-create
+ * for a named persistence unit configured with unquoted keys.
+ */
+public class DevServicesSchemaManagementStrategyNamedPUUnquotedTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addPackage(MyEntity.class.getPackage().getName()))
+            .overrideConfigKey("quarkus.hibernate-orm.pu-1.datasource", "<default>")
+            .overrideConfigKey("quarkus.hibernate-orm.pu-1.packages", MyEntity.class.getPackageName());
+
+    @Test
+    public void testDevServicesSchemaManagementStrategy() {
+        assertThat(ConfigProvider.getConfig()
+                .getValue("quarkus.hibernate-orm.pu-1.schema-management.strategy", String.class))
+                .isEqualTo("drop-and-create");
+        assertThat(ConfigProvider.getConfig()
+                .getValue("quarkus.hibernate-orm.\"pu-1\".schema-management.strategy", String.class))
+                .isEqualTo("drop-and-create");
+    }
+
+}

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfig.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfig.java
@@ -1,5 +1,6 @@
 package io.quarkus.hibernate.orm.runtime;
 
+import java.util.List;
 import java.util.Map;
 
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
@@ -47,5 +48,23 @@ public interface HibernateOrmRuntimeConfig {
                 ? "quarkus.hibernate-orm."
                 : "quarkus.hibernate-orm.\"" + puName + "\".";
         return prefix + radical;
+    }
+
+    /**
+     * Returns both the quoted and unquoted property key variants for a persistence unit property.
+     * <p>
+     * SmallRye Config treats {@code quarkus.hibernate-orm."pu-name".x} and
+     * {@code quarkus.hibernate-orm.pu-name.x} as two completely independent properties
+     * with no cross-resolution: setting one does not make the other visible.
+     * Both forms must therefore be set when producing config defaults programmatically,
+     * and both must be checked when looking up user-supplied config.
+     */
+    static List<String> puPropertyKeys(String puName, String radical) {
+        if (PersistenceUnitUtil.isDefaultPersistenceUnit(puName)) {
+            return List.of("quarkus.hibernate-orm." + radical);
+        }
+        return List.of(
+                "quarkus.hibernate-orm.\"" + puName + "\"." + radical,
+                "quarkus.hibernate-orm." + puName + "." + radical);
     }
 }

--- a/integration-tests/hibernate-reactive-panache/src/main/resources/application.properties
+++ b/integration-tests/hibernate-reactive-panache/src/main/resources/application.properties
@@ -9,7 +9,4 @@ quarkus.datasource.secondary.db-kind=postgresql
 
 quarkus.hibernate-orm.secondary.datasource=secondary
 quarkus.hibernate-orm.secondary.packages=io.quarkus.it.panache.secondary
-# Workaround for https://github.com/quarkusio/quarkus/issues/52699
-# This should not be necessary, but it is.
-quarkus.hibernate-orm.secondary.schema-management.strategy=drop-and-create
 

--- a/integration-tests/jpa-mapping-xml/modern-app/src/main/resources/application.properties
+++ b/integration-tests/jpa-mapping-xml/modern-app/src/main/resources/application.properties
@@ -9,37 +9,22 @@ quarkus.datasource.libraryA.db-kind=h2
 quarkus.datasource.libraryB.db-kind=h2
 
 quarkus.hibernate-orm.xml-mapping-only-dirty-checking.datasource=xml-mapping-only-dirty-checking
-# Workaround for https://github.com/quarkusio/quarkus/issues/52699
-# This should not be necessary, but it is.
-quarkus.hibernate-orm.xml-mapping-only-dirty-checking.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.xml-mapping-only-dirty-checking.packages=io.quarkus.it.jpa.mapping.xml.modern.app.xmlmappingonly.dirtychecking
 quarkus.hibernate-orm.xml-mapping-only-dirty-checking.mapping-files=xml-mapping-only-dirty-checking.orm.xml
 
 quarkus.hibernate-orm.xml-mapping-only-attribute-converter.datasource=xml-mapping-only-attribute-converter
-# Workaround for https://github.com/quarkusio/quarkus/issues/52699
-# This should not be necessary, but it is.
-quarkus.hibernate-orm.xml-mapping-only-attribute-converter.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.xml-mapping-only-attribute-converter.packages=io.quarkus.it.jpa.mapping.xml.modern.app.xmlmappingonly.attributeconverter
 quarkus.hibernate-orm.xml-mapping-only-attribute-converter.mapping-files=xml-mapping-only-attribute-converter.orm.xml
 
 quarkus.hibernate-orm.xml-mapping-only-entity-listener.datasource=xml-mapping-only-entity-listener
-# Workaround for https://github.com/quarkusio/quarkus/issues/52699
-# This should not be necessary, but it is.
-quarkus.hibernate-orm.xml-mapping-only-entity-listener.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.xml-mapping-only-entity-listener.packages=io.quarkus.it.jpa.mapping.xml.modern.app.xmlmappingonly.entitylistener
 quarkus.hibernate-orm.xml-mapping-only-entity-listener.mapping-files=xml-mapping-only-entity-listener.orm.xml
 
 quarkus.hibernate-orm.libraryA.datasource=libraryA
-# Workaround for https://github.com/quarkusio/quarkus/issues/52699
-# This should not be necessary, but it is.
-quarkus.hibernate-orm.libraryA.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.libraryA.packages=io.quarkus.it.jpa.mapping.xml.modern.library_a
 quarkus.hibernate-orm.libraryA.mapping-files=META-INF/library-a.orm.xml
 
 quarkus.hibernate-orm.libraryB.datasource=libraryB
-# Workaround for https://github.com/quarkusio/quarkus/issues/52699
-# This should not be necessary, but it is.
-quarkus.hibernate-orm.libraryB.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.libraryB.packages=io.quarkus.it.jpa.mapping.xml.modern.library_b
 quarkus.hibernate-orm.libraryB.mapping-files=META-INF/library-b.orm.xml
 


### PR DESCRIPTION
Basically, we have to be consistent with the form the user chose, and
given we have no idea which it is, we need to create both variants.

This is once again a sign that being too flexible with map keys is the
source of some evil (if not all!).

Fixes https://github.com/quarkusio/quarkus/issues/52699

/cc @yrodiere 
/cc @holly-cummins for awareness
/cc @radcortez as I would really us to start this conversation about finding a path to fix this ambiguity once and for all
