### PR TITLE
Fix protoc file not found

### DIFF
--- a/extensions/grpc/codegen/src/main/java/io/quarkus/grpc/codegen/GrpcCodeGen.java
+++ b/extensions/grpc/codegen/src/main/java/io/quarkus/grpc/codegen/GrpcCodeGen.java
@@ -428,24 +428,11 @@ public class GrpcCodeGen implements CodeGenProvider {
                                         .normalize().toAbsolutePath();
                                 try {
                                     Files.createDirectories(protoUnzipDir);
-                                    //                                    String relativePathStr = relativePath.toString().replace('\\', '/');
-                                    //                                    if (relativePathStr.startsWith("src/main/proto/")) {
-                                    //                                        protoDirectories.add(
-                                    //                                                protoUnzipDir.resolve("src").resolve("main").resolve("proto").toString());
-                                    //                                    } else if (relativePathStr.startsWith("src/test/proto/")) {
-                                    //                                        protoDirectories.add(
-                                    //                                                protoUnzipDir.resolve("src").resolve("test").resolve("proto").toString());
-                                    //                                    } else {
                                     protoDirectories.add(protoUnzipDir.toString());
-                                    //                                    }
                                 } catch (IOException e) {
                                     throw new GrpcCodeGenException("Failed to create directory: " + protoUnzipDir, e);
                                 }
                                 Path outPath = protoUnzipDir.resolve(relativePathStr);
-                                //                                Path outPath = protoUnzipDir;
-                                //                                for (Path part : relativePath) {
-                                //                                    outPath = outPath.resolve(part.toString());
-                                //                                }
                                 try {
                                     Files.createDirectories(outPath.getParent());
                                     if (isDependency) {

--- a/extensions/grpc/codegen/src/main/java/io/quarkus/grpc/codegen/GrpcCodeGen.java
+++ b/extensions/grpc/codegen/src/main/java/io/quarkus/grpc/codegen/GrpcCodeGen.java
@@ -408,6 +408,14 @@ public class GrpcCodeGen implements CodeGenProvider {
                                 protoDirectories.add(path.getParent().normalize().toAbsolutePath().toString());
                             } else { // archive
                                 Path relativePath = path.getRoot().relativize(path);
+                                String relativePathStr = relativePath.toString().replace('\\', '/');
+                                if (relativePathStr.startsWith("src/main/proto/")) {
+                                    relativePathStr = relativePathStr.substring("src/main/proto/".length());
+                                } else if (relativePathStr.startsWith("src/test/proto/")) {
+                                    relativePathStr = relativePathStr.substring("src/test/proto/".length());
+                                } else if (relativePathStr.startsWith("proto/")) {
+                                    relativePathStr = relativePathStr.substring("proto/".length());
+                                }
                                 String uniqueName = artifact.getGroupId() + ":" + artifact.getArtifactId();
                                 if (artifact.getVersion() != null) {
                                     uniqueName += ":" + artifact.getVersion();
@@ -420,14 +428,24 @@ public class GrpcCodeGen implements CodeGenProvider {
                                         .normalize().toAbsolutePath();
                                 try {
                                     Files.createDirectories(protoUnzipDir);
+                                    //                                    String relativePathStr = relativePath.toString().replace('\\', '/');
+                                    //                                    if (relativePathStr.startsWith("src/main/proto/")) {
+                                    //                                        protoDirectories.add(
+                                    //                                                protoUnzipDir.resolve("src").resolve("main").resolve("proto").toString());
+                                    //                                    } else if (relativePathStr.startsWith("src/test/proto/")) {
+                                    //                                        protoDirectories.add(
+                                    //                                                protoUnzipDir.resolve("src").resolve("test").resolve("proto").toString());
+                                    //                                    } else {
                                     protoDirectories.add(protoUnzipDir.toString());
+                                    //                                    }
                                 } catch (IOException e) {
                                     throw new GrpcCodeGenException("Failed to create directory: " + protoUnzipDir, e);
                                 }
-                                Path outPath = protoUnzipDir;
-                                for (Path part : relativePath) {
-                                    outPath = outPath.resolve(part.toString());
-                                }
+                                Path outPath = protoUnzipDir.resolve(relativePathStr);
+                                //                                Path outPath = protoUnzipDir;
+                                //                                for (Path part : relativePath) {
+                                //                                    outPath = outPath.resolve(part.toString());
+                                //                                }
                                 try {
                                     Files.createDirectories(outPath.getParent());
                                     if (isDependency) {

--- a/integration-tests/grpc-external-proto-test/src/main/java/io/quarkus/grpc/external/proto/BareProtoGrpcService.java
+++ b/integration-tests/grpc-external-proto-test/src/main/java/io/quarkus/grpc/external/proto/BareProtoGrpcService.java
@@ -1,0 +1,16 @@
+package io.quarkus.grpc.external.proto;
+
+import io.quarkus.grpc.GrpcService;
+import io.quarkus.grpc.external.bareproto.BareProtoMessage;
+import io.quarkus.grpc.external.bareproto.BareProtoService;
+import io.smallrye.mutiny.Uni;
+
+@GrpcService
+public class BareProtoGrpcService implements BareProtoService {
+
+    @Override
+    public Uni<BareProtoMessage> send(BareProtoMessage request) {
+        return Uni.createFrom().item(
+                BareProtoMessage.newBuilder().setContent("reply:" + request.getContent()).build());
+    }
+}

--- a/integration-tests/grpc-external-proto-test/src/main/java/io/quarkus/grpc/external/proto/NestedGrpcService.java
+++ b/integration-tests/grpc-external-proto-test/src/main/java/io/quarkus/grpc/external/proto/NestedGrpcService.java
@@ -1,0 +1,16 @@
+package io.quarkus.grpc.external.proto;
+
+import io.quarkus.grpc.GrpcService;
+import io.quarkus.grpc.external.nested.NestedMessage;
+import io.quarkus.grpc.external.nested.NestedService;
+import io.smallrye.mutiny.Uni;
+
+@GrpcService
+public class NestedGrpcService implements NestedService {
+
+    @Override
+    public Uni<NestedMessage> send(NestedMessage request) {
+        return Uni.createFrom().item(
+                NestedMessage.newBuilder().setContent("reply:" + request.getContent()).build());
+    }
+}

--- a/integration-tests/grpc-external-proto-test/src/main/java/io/quarkus/grpc/external/proto/TestScopeGrpcService.java
+++ b/integration-tests/grpc-external-proto-test/src/main/java/io/quarkus/grpc/external/proto/TestScopeGrpcService.java
@@ -1,0 +1,16 @@
+package io.quarkus.grpc.external.proto;
+
+import io.quarkus.grpc.GrpcService;
+import io.quarkus.grpc.external.testscope.TestScopeMessage;
+import io.quarkus.grpc.external.testscope.TestScopeService;
+import io.smallrye.mutiny.Uni;
+
+@GrpcService
+public class TestScopeGrpcService implements TestScopeService {
+
+    @Override
+    public Uni<TestScopeMessage> send(TestScopeMessage request) {
+        return Uni.createFrom().item(
+                TestScopeMessage.newBuilder().setContent("reply:" + request.getContent()).build());
+    }
+}

--- a/integration-tests/grpc-external-proto-test/src/main/resources/application.properties
+++ b/integration-tests/grpc-external-proto-test/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 quarkus.generate-code.grpc.scan-for-proto=io.quarkus:quarkus-integration-test-external-proto
-quarkus.generate-code.grpc.scan-for-proto-include."io.quarkus\:quarkus-integration-test-external-proto"=dir/**, invalids/invalid2.proto, protobuf/**
+quarkus.generate-code.grpc.scan-for-proto-include."io.quarkus\:quarkus-integration-test-external-proto"=dir/**, invalids/invalid2.proto, protobuf/**, src/main/proto/**, src/test/proto/**, proto/**
 quarkus.generate-code.grpc.scan-for-proto-exclude."io.quarkus\:quarkus-integration-test-external-proto"=dir/invalid.proto, invalids/invalid2.proto
 
 %vertx.quarkus.grpc.clients.hello.host=localhost

--- a/integration-tests/grpc-external-proto-test/src/test/java/io/quarkus/grpc/external/proto/ExternalProtoTestBase.java
+++ b/integration-tests/grpc-external-proto-test/src/test/java/io/quarkus/grpc/external/proto/ExternalProtoTestBase.java
@@ -10,11 +10,26 @@ import com.test.MyProto.TextContainer;
 import com.test.MyTest;
 
 import io.quarkus.grpc.GrpcClient;
+import io.quarkus.grpc.external.bareproto.BareProtoMessage;
+import io.quarkus.grpc.external.bareproto.BareProtoService;
+import io.quarkus.grpc.external.nested.NestedMessage;
+import io.quarkus.grpc.external.nested.NestedService;
+import io.quarkus.grpc.external.testscope.TestScopeMessage;
+import io.quarkus.grpc.external.testscope.TestScopeService;
 import io.smallrye.mutiny.Uni;
 
 public class ExternalProtoTestBase {
     @GrpcClient
     MyTest hello;
+
+    @GrpcClient
+    NestedService nested;
+
+    @GrpcClient
+    TestScopeService testScope;
+
+    @GrpcClient
+    BareProtoService bareProto;
 
     @Test
     void shouldWorkWithClientAndServiceFromExternalProto() {
@@ -22,5 +37,29 @@ public class ExternalProtoTestBase {
         String replyText = reply.await().atMost(Duration.ofSeconds(30))
                 .getText();
         assertThat(replyText).isEqualTo("reply_to:my-request");
+    }
+
+    @Test
+    void shouldWorkWithNestedProtoFromDependencyUnderSrcMainProto() {
+        Uni<NestedMessage> reply = nested.send(NestedMessage.newBuilder().setContent("main").build());
+        String content = reply.await().atMost(Duration.ofSeconds(30))
+                .getContent();
+        assertThat(content).isEqualTo("reply:main");
+    }
+
+    @Test
+    void shouldWorkWithNestedProtoFromDependencyUnderSrcTestProto() {
+        Uni<TestScopeMessage> reply = testScope.send(TestScopeMessage.newBuilder().setContent("test").build());
+        String content = reply.await().atMost(Duration.ofSeconds(30))
+                .getContent();
+        assertThat(content).isEqualTo("reply:test");
+    }
+
+    @Test
+    void shouldWorkWithNestedProtoFromDependencyUnderProto() {
+        Uni<BareProtoMessage> reply = bareProto.send(BareProtoMessage.newBuilder().setContent("bare").build());
+        String content = reply.await().atMost(Duration.ofSeconds(30))
+                .getContent();
+        assertThat(content).isEqualTo("reply:bare");
     }
 }

--- a/integration-tests/grpc-external-proto/pom.xml
+++ b/integration-tests/grpc-external-proto/pom.xml
@@ -13,4 +13,24 @@
     <artifactId>quarkus-integration-test-external-proto</artifactId>
     <name>Quarkus - Integration Tests - Helper project containing packaging a proto file for grpc-external-proto-test
     </name>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+            <resource>
+                <directory>src/main/proto</directory>
+                <targetPath>src/main/proto</targetPath>
+            </resource>
+            <resource>
+                <directory>src/test/proto</directory>
+                <targetPath>src/test/proto</targetPath>
+            </resource>
+            <resource>
+                <directory>proto</directory>
+                <targetPath>proto</targetPath>
+            </resource>
+        </resources>
+    </build>
 </project>

--- a/integration-tests/grpc-external-proto/proto/io/quarkus/grpc/external/bareproto/message.proto
+++ b/integration-tests/grpc-external-proto/proto/io/quarkus/grpc/external/bareproto/message.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+option java_package = "io.quarkus.grpc.external.bareproto";
+option java_multiple_files = true;
+
+package io.quarkus.grpc.external.bareproto;
+
+message BareProtoMessage {
+  string content = 1;
+}

--- a/integration-tests/grpc-external-proto/proto/io/quarkus/grpc/external/bareproto/service.proto
+++ b/integration-tests/grpc-external-proto/proto/io/quarkus/grpc/external/bareproto/service.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+option java_package = "io.quarkus.grpc.external.bareproto";
+option java_multiple_files = true;
+
+package io.quarkus.grpc.external.bareproto;
+
+import "io/quarkus/grpc/external/bareproto/message.proto";
+
+service BareProtoService {
+  rpc Send(BareProtoMessage) returns (BareProtoMessage);
+}

--- a/integration-tests/grpc-external-proto/src/main/proto/io/quarkus/grpc/external/nested/message.proto
+++ b/integration-tests/grpc-external-proto/src/main/proto/io/quarkus/grpc/external/nested/message.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+option java_package = "io.quarkus.grpc.external.nested";
+option java_multiple_files = true;
+
+package io.quarkus.grpc.external.nested;
+
+message NestedMessage {
+  string content = 1;
+}

--- a/integration-tests/grpc-external-proto/src/main/proto/io/quarkus/grpc/external/nested/service.proto
+++ b/integration-tests/grpc-external-proto/src/main/proto/io/quarkus/grpc/external/nested/service.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+option java_package = "io.quarkus.grpc.external.nested";
+option java_multiple_files = true;
+
+package io.quarkus.grpc.external.nested;
+
+import "io/quarkus/grpc/external/nested/message.proto";
+
+service NestedService {
+  rpc Send(NestedMessage) returns (NestedMessage);
+}

--- a/integration-tests/grpc-external-proto/src/test/proto/io/quarkus/grpc/external/testscope/message.proto
+++ b/integration-tests/grpc-external-proto/src/test/proto/io/quarkus/grpc/external/testscope/message.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+option java_package = "io.quarkus.grpc.external.testscope";
+option java_multiple_files = true;
+
+package io.quarkus.grpc.external.testscope;
+
+message TestScopeMessage {
+  string content = 1;
+}

--- a/integration-tests/grpc-external-proto/src/test/proto/io/quarkus/grpc/external/testscope/service.proto
+++ b/integration-tests/grpc-external-proto/src/test/proto/io/quarkus/grpc/external/testscope/service.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+option java_package = "io.quarkus.grpc.external.testscope";
+option java_multiple_files = true;
+
+package io.quarkus.grpc.external.testscope;
+
+import "io/quarkus/grpc/external/testscope/message.proto";
+
+service TestScopeService {
+  rpc Send(TestScopeMessage) returns (TestScopeMessage);
+}


### PR DESCRIPTION
Fixes #51640

When a dependency JAR stores .proto files under `src/main/proto/` (a common Maven convention for distributing proto definitions), the gRPC code generation fails because protoc cannot resolve cross-file imports.

**Root cause**
`extractProtosFromArtifact` extracts protos from a JAR preserving their full archive path (e.g., `src/main/proto/ch/example/service.proto`) but passes the extraction root as a protoc `-I` include path.

This means an import like import `ch/example/request.proto` can never resolve — protoc looks for `<root>/ch/example/request.proto`, but the file actually lives at `<root>/src/main/proto/ch/example/request.proto`.

Simply adding `<root>/src/main/proto/` as an additional `-I` doesn't work either: protoc then sees the same file through two include paths with different canonical names and reports a duplicate symbol error.

**Fix**
When proto files in the archive live under `src/main/proto/` (or `src/test/proto/`), use that subdirectory as the `-I` include path instead of the extraction root. This way protoc resolves both input files and imports consistently. JARs that store protos at the archive root (e.g., protobuf/base.proto) are unaffected.
