### PR TITLE
Avoid duplicate gauge warnings for REST Client

### DIFF
--- a/extensions/resteasy-reactive/rest-client/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/RestClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/RestClientReactiveProcessor.java
@@ -23,7 +23,6 @@ import static org.jboss.resteasy.reactive.common.processor.EndpointIndexer.CDI_W
 import static org.jboss.resteasy.reactive.common.processor.JandexUtil.isImplementorOf;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.APPLICATION;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.BLOCKING;
-import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.REQUEST_SCOPED;
 import static org.jboss.resteasy.reactive.common.processor.scanning.ResteasyReactiveScanner.BUILTIN_HTTP_ANNOTATIONS_TO_METHOD;
 
 import java.lang.annotation.RetentionPolicy;
@@ -668,8 +667,7 @@ class RestClientReactiveProcessor {
                     .orElse(BuiltinScope.APPLICATION).getInfo();
 
             Optional<String> baseUri = registerRestClient.getDefaultBaseUri();
-            boolean lazyDelegate = scope.getDotName().equals(REQUEST_SCOPED)
-                    || requestedRestClientMocks.contains(jaxrsInterface.name());
+            boolean lazyDelegate = requestedRestClientMocks.contains(jaxrsInterface.name());
 
             final String configKeyValue = configKey.orElse(null);
             final String baseUriValue = baseUri.orElse("");

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientReactiveCDIWrapperBase.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientReactiveCDIWrapperBase.java
@@ -3,6 +3,7 @@ package io.quarkus.rest.client.reactive.runtime;
 import java.io.Closeable;
 import java.io.IOException;
 
+import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 
 import org.jboss.logging.Logger;
@@ -16,6 +17,7 @@ public abstract class RestClientReactiveCDIWrapperBase<T extends Closeable> impl
     private final Class<T> jaxrsInterface;
     private final String baseUriFromAnnotation;
     private final String configKey;
+    private final boolean lazyDelegate;
 
     private T delegate;
     private Object mock;
@@ -25,6 +27,12 @@ public abstract class RestClientReactiveCDIWrapperBase<T extends Closeable> impl
         this.jaxrsInterface = jaxrsInterface;
         this.baseUriFromAnnotation = baseUriFromAnnotation;
         this.configKey = configKey;
+        this.lazyDelegate = lazyDelegate;
+    }
+
+    @PostConstruct
+    @NoClassInterceptors
+    void init() {
         if (!lazyDelegate) {
             constructDelegate();
         }

--- a/integration-tests/micrometer-prometheus/pom.xml
+++ b/integration-tests/micrometer-prometheus/pom.xml
@@ -187,6 +187,11 @@
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integration-tests/micrometer-prometheus/src/test/java/io/quarkus/it/micrometer/prometheus/ClientRequestTest.java
+++ b/integration-tests/micrometer-prometheus/src/test/java/io/quarkus/it/micrometer/prometheus/ClientRequestTest.java
@@ -4,18 +4,67 @@ import static io.restassured.RestAssured.get;
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.test.junit.DisabledOnIntegrationTest;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 public class ClientRequestTest {
+
+    private static final List<LogRecord> micrometerWarnings = new CopyOnWriteArrayList<>();
+
+    private static final Handler warningHandler = new Handler() {
+        @Override
+        public void publish(LogRecord record) {
+            if (record.getLevel().intValue() >= Level.WARNING.intValue()) {
+                micrometerWarnings.add(record);
+            }
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+    };
+
+    @BeforeAll
+    static void installLogHandler() {
+        Logger micrometerLogger = LogManager.getLogManager()
+                .getLogger("io.micrometer.core.instrument.MeterRegistry");
+        if (micrometerLogger != null) {
+            micrometerLogger.addHandler(warningHandler);
+        }
+    }
+
+    @AfterAll
+    static void removeLogHandler() {
+        Logger micrometerLogger = LogManager.getLogManager()
+                .getLogger("io.micrometer.core.instrument.MeterRegistry");
+        if (micrometerLogger != null) {
+            micrometerLogger.removeHandler(warningHandler);
+        }
+    }
 
     @Test
     void testClientRequests() {
@@ -120,5 +169,16 @@ public class ClientRequestTest {
                         .when().get("/server-requests/client/count")
                         .body().as(Integer.class),
                 "Expected: http.client.requests, clientName=pingpong");
+    }
+
+    @Test
+    @DisabledOnIntegrationTest
+    void testNoDuplicateGaugeRegistrationWarning() {
+        // Trigger REST client usage to ensure gauge registration happens
+        when().get("/client/ping/test").then().statusCode(200);
+
+        assertThat(micrometerWarnings)
+                .extracting(LogRecord::getMessage)
+                .noneMatch(m -> m.contains("already registered") && m.contains("http.client"));
     }
 }


### PR DESCRIPTION
The warning was due to the CDI infrastructure: the constructor of an application scoped bean is called twice, once for the client proxy and the other for the actual bean, thus why the gauge was registered twice.

Using `@PostConstruct` seems to solve the issue - and as an added bonus it will also solve the `@RequestScoped` case in a more idiomatic way.

We have to keep the `lazyDelegate` mechanism for mocks though (tested and things didn't go well!).

- Fixes: #54482