### PR TITLE
Fix wrong description for agroal.invalid.count metric

### DIFF
--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/metrics/AgroalMetricsRecorder.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/metrics/AgroalMetricsRecorder.java
@@ -83,7 +83,7 @@ public class AgroalMetricsRecorder {
                         .tag("datasource", tagValue)
                         .buildCounter(metrics::flushCount);
                 metricsFactory.builder("agroal.invalid.count")
-                        .description("Number of connections removed from the pool for being idle.")
+                        .description("Number of connections removed from the pool for being invalid.")
                         .tag("datasource", tagValue)
                         .buildCounter(metrics::invalidCount);
                 metricsFactory.builder("agroal.reap.count")


### PR DESCRIPTION
## Summary
- Fixed the `agroal.invalid.count` metric description which incorrectly said "removed from the pool for being idle" instead of "for being invalid"
- The idle description belongs to `agroal.reap.count`, not `agroal.invalid.count`
- Fixes #54497