### PR TITLE
Upgrade Oracle JDBC driver to latest version 23.26.2.0.0

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -1830,8 +1830,8 @@ jobs:
           TESTPILOT_CLIENT_ID: ""
           TESTPILOT_TOKEN: ""
           # Needed for TFO (TCP fast open)
-          LD_PRELOAD: /home/ubuntu/ojdbc_tfo/ojdbc17/23.26.0.0.0/libtfojdbc1.so
-          LD_LIBRARY_PATH: /home/ubuntu/ojdbc_tfo/ojdbc17/23.26.0.0.0
+          LD_PRELOAD: /home/ubuntu/ojdbc_tfo/ojdbc17/23.26.2.0.0/libtfojdbc1.so
+          LD_LIBRARY_PATH: /home/ubuntu/ojdbc_tfo/ojdbc17/23.26.2.0.0
           # End OTP setup
           TEST_MODULES: ${{matrix.test-modules}}
           CAPTURE_BUILD_SCAN: true
@@ -1950,8 +1950,8 @@ jobs:
           TESTPILOT_TOKEN: ""
           # Needed for TFO (TCP fast open)
           # TODO: enable after fixing https://github.com/quarkusio/quarkus/issues/54479
-          #LD_PRELOAD: /home/ubuntu/ojdbc_tfo/ojdbc17/23.26.0.0.0/libtfojdbc1.so
-          #LD_LIBRARY_PATH: /home/ubuntu/ojdbc_tfo/ojdbc17/23.26.0.0.0
+          #LD_PRELOAD: /home/ubuntu/ojdbc_tfo/ojdbc17/23.26.2.0.0/libtfojdbc1.so
+          #LD_LIBRARY_PATH: /home/ubuntu/ojdbc_tfo/ojdbc17/23.26.2.0.0
           #  -Dquarkus.native.additional-build-args='-ELD_PRELOAD,-ELD_LIBRARY_PATH' \
           # End OTP setup
           TEST_MODULES: ${{matrix.test-modules}}

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -123,7 +123,7 @@
         <mysql-jdbc.version>9.7.0</mysql-jdbc.version>
         <mssql-jdbc.version>13.4.0.jre11</mssql-jdbc.version>
         <adal4j.version>1.6.7</adal4j.version>
-        <oracle-jdbc.version>23.26.0.0.0</oracle-jdbc.version>
+        <oracle-jdbc.version>23.26.2.0.0</oracle-jdbc.version> <!-- Keep in synch. with Oracle Test Pilot CI workflow: ci-actions-incremental.yml -->
         <db2-jdbc.version>12.1.0.0</db2-jdbc.version>
         <shrinkwrap.version>1.2.6</shrinkwrap.version>
         <hamcrest.version>2.2</hamcrest.version><!-- The version needs to be compatible with both REST Assured and Awaitility -->


### PR DESCRIPTION
This PR upgrades the Oracle JDBC driver to latest version 23.26.2.0.0. It takes care about Oracle Test Pilot CI workflows as well.

* Fixes #54416
 

