### PR TITLE
Replace deprecated Gizmo 2 method usages

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
@@ -613,7 +613,7 @@ public final class LoggingResourceProcessor {
                                         categoryMinLevelDefaults,
                                         rootMinLevel)
                                 .intValue();
-                        b0.if_(b0.objEquals(name, Const.of(category)), BlockCreator::returnTrue);
+                        b0.if_(b0.exprEquals(name, Const.of(category)), BlockCreator::returnTrue);
                         b0.if_(b0.invokeVirtual(
                                 MethodDesc.of(String.class, "startsWith", boolean.class, String.class),
                                 name, Const.of(category + ".")),

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
@@ -1323,7 +1323,7 @@ public class MessageBundleProcessor {
                 LocalVar ret = bc.localVar("ret", bc.new_(CompletableFuture.class));
 
                 // First handle dynamic messages, i.e. the "message" virtual method
-                bc.if_(bc.objEquals(name, Const.of(MESSAGE)), dynamicMessage -> {
+                bc.if_(bc.exprEquals(name, Const.of(MESSAGE)), dynamicMessage -> {
                     Expr evaluatedMessageKey = dynamicMessage.invokeStatic(Descriptors.EVALUATED_PARAMS_EVALUATE_MESSAGE_KEY,
                             evalContext);
                     Expr paramsReady = evaluatedMessageKey.field(Descriptors.EVALUATED_PARAMS_STAGE);
@@ -1412,7 +1412,7 @@ public class MessageBundleProcessor {
             Var evaluatedParams, Var ret, Var this_) {
         List<Type> methodParams = method.parameterTypes();
 
-        resolve.if_(resolve.objEquals(name, Const.of(key)), matched -> {
+        resolve.if_(resolve.exprEquals(name, Const.of(key)), matched -> {
             if (methodParams.isEmpty()) {
                 matched.invokeVirtual(Descriptors.COMPLETABLE_FUTURE_COMPLETE, ret,
                         method.isMessageBundleInterfaceMethod()

--- a/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/ExtensionMethodGenerator.java
+++ b/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/ExtensionMethodGenerator.java
@@ -346,7 +346,7 @@ public class ExtensionMethodGenerator extends AbstractGenerator {
                             bc.block(nested -> {
                                 // Test name
                                 if (!matchAny) {
-                                    nested.ifNot(nested.objEquals(name, Const.of(matchName)),
+                                    nested.ifNot(nested.exprEquals(name, Const.of(matchName)),
                                             notMatching -> notMatching.break_(nested));
                                 }
                                 // Test number of evaluated params
@@ -376,7 +376,7 @@ public class ExtensionMethodGenerator extends AbstractGenerator {
                                 // Test that any of the names matches
                                 nested.block(nested2 -> {
                                     for (String matchName : matchNames.stream().sorted().toList()) {
-                                        nested2.if_(nested2.objEquals(name, Const.of(matchName)),
+                                        nested2.if_(nested2.exprEquals(name, Const.of(matchName)),
                                                 namesMatch -> namesMatch.break_(nested2));
                                     }
                                     nested2.break_(nested);
@@ -440,7 +440,7 @@ public class ExtensionMethodGenerator extends AbstractGenerator {
                                     // Test that any of the names matches
                                     nested.block(nested2 -> {
                                         for (String matchName : em.matchNames().stream().sorted().toList()) {
-                                            nested2.if_(nested2.objEquals(name, Const.of(matchName)),
+                                            nested2.if_(nested2.exprEquals(name, Const.of(matchName)),
                                                     namesMatch -> namesMatch.break_(nested2));
                                         }
                                         nested2.break_(nested);
@@ -450,7 +450,7 @@ public class ExtensionMethodGenerator extends AbstractGenerator {
                                     boolean matchAny = matchName.equals(TemplateExtension.ANY);
                                     // Test name
                                     if (!matchAny) {
-                                        nested.ifNot(nested.objEquals(name, Const.of(matchName)),
+                                        nested.ifNot(nested.exprEquals(name, Const.of(matchName)),
                                                 notMatching -> notMatching.break_(nested));
                                     }
                                 }
@@ -872,13 +872,13 @@ public class ExtensionMethodGenerator extends AbstractGenerator {
                         // Any of the name matches
                         bc.block(nested -> {
                             for (String match : matchNames) {
-                                nested.if_(nested.objEquals(name, Const.of(match)), namesMatch -> namesMatch.break_(nested));
+                                nested.if_(nested.exprEquals(name, Const.of(match)), namesMatch -> namesMatch.break_(nested));
                             }
                             nested.returnFalse();
                         });
 
                     } else {
-                        bc.ifNot(bc.objEquals(name, Const.of(matchName)),
+                        bc.ifNot(bc.exprEquals(name, Const.of(matchName)),
                                 nameNotMatched -> nameNotMatched.returnFalse());
                     }
                 }

--- a/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/ValueResolverGenerator.java
+++ b/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/ValueResolverGenerator.java
@@ -856,16 +856,16 @@ public class ValueResolverGenerator extends AbstractGenerator {
             // Match name
             if (methodParams <= 0 && isGetterName(methodName, returnType)) {
                 // Getter found - match the property name first
-                nested.ifNot(nested.objEquals(name, Const.of(getPropertyName(methodName))), propertyNotMatched -> {
+                nested.ifNot(nested.exprEquals(name, Const.of(getPropertyName(methodName))), propertyNotMatched -> {
                     // If the property does not match then try to use the exact method name
-                    propertyNotMatched.ifNot(propertyNotMatched.objEquals(name, Const.of(methodName)),
+                    propertyNotMatched.ifNot(propertyNotMatched.exprEquals(name, Const.of(methodName)),
                             nameNotMatched -> {
                                 nameNotMatched.break_(nested);
                             });
                 });
             } else {
                 // No getter - only match the exact method name
-                nested.ifNot(nested.objEquals(name, Const.of(methodName)), notMatched -> {
+                nested.ifNot(nested.exprEquals(name, Const.of(methodName)), notMatched -> {
                     notMatched.break_(nested);
                 });
             }


### PR DESCRIPTION
## Summary
- Replace all usages of deprecated `BlockCreator.objEquals(Expr, Expr)` with the recommended `exprEquals(Expr, Expr)` across 4 files (12 call sites)

## Affected files
- `core/deployment` — `LoggingResourceProcessor.java`
- `extensions/qute/deployment` — `MessageBundleProcessor.java`
- `independent-projects/qute/generator` — `ExtensionMethodGenerator.java`, `ValueResolverGenerator.java`
