### PR TITLE
Stabilize bytecode from `PanacheHibernateResourceProcessor#recordEntityToPersistenceUnit`

### DIFF
--- a/extensions/data/hibernate/deployment/src/main/java/io/quarkus/hibernate/panache/deployment/EntityToPersistenceUnitBuildItem.java
+++ b/extensions/data/hibernate/deployment/src/main/java/io/quarkus/hibernate/panache/deployment/EntityToPersistenceUnitBuildItem.java
@@ -6,7 +6,8 @@ import io.quarkus.builder.item.MultiBuildItem;
 /**
  * Used to record that a specific JPA entity is associated with a specific persistence unit
  */
-public final class EntityToPersistenceUnitBuildItem extends MultiBuildItem {
+public final class EntityToPersistenceUnitBuildItem extends MultiBuildItem
+        implements Comparable<EntityToPersistenceUnitBuildItem> {
 
     private final String entityClass;
     private final String persistenceUnitName;
@@ -29,5 +30,12 @@ public final class EntityToPersistenceUnitBuildItem extends MultiBuildItem {
 
     public String getReactivePersistenceUnitName() {
         return reactivePersistenceUnitName;
+    }
+
+    @Override
+    public int compareTo(EntityToPersistenceUnitBuildItem other) {
+        // No tie-breaker is needed because Quarkus Data supports
+        // at most one persistence unit of each type per entity.
+        return entityClass.compareTo(other.entityClass);
     }
 }

--- a/extensions/data/hibernate/deployment/src/main/java/io/quarkus/hibernate/panache/deployment/PanacheHibernateResourceProcessor.java
+++ b/extensions/data/hibernate/deployment/src/main/java/io/quarkus/hibernate/panache/deployment/PanacheHibernateResourceProcessor.java
@@ -1,7 +1,6 @@
 package io.quarkus.hibernate.panache.deployment;
 
 import static io.quarkus.hibernate.panache.deployment.EntityToPersistenceUnitUtil.determineEntityPersistenceUnits;
-import static io.quarkus.security.spi.SecuredInterfaceAnnotationBuildItem.ofMethodAnnotation;
 import static io.quarkus.security.spi.SecurityTransformerBuildItem.createSecurityTransformer;
 
 import java.lang.reflect.Modifier;
@@ -215,7 +214,7 @@ public final class PanacheHibernateResourceProcessor {
             List<EntityToPersistenceUnitBuildItem> items,
             CombinedIndexBuildItem index,
             PanacheHibernateRecorder recorder,
-            Capabilities capabilities) throws ClassNotFoundException {
+            Capabilities capabilities) {
         // PU
         // FIXME: for now, this ignores the reactive PUs, but reactive PUs are not supported yet by Panache Reactive
         Map<String, String> map = new HashMap<>();
@@ -228,7 +227,7 @@ public final class PanacheHibernateResourceProcessor {
                         .orElse(false),
                 capabilities.isPresent(Capability.HIBERNATE_REACTIVE));
         // Panache 2 repos
-        Map<Class<?>, Class<?>> repositoryClassesToEntityClasses = new HashMap<>();
+        Map<String, String> repositoryClassesToEntityClasses = new HashMap<>();
         for (ClassInfo classInfo : index.getIndex().getAllKnownImplementations(DOTNAME_PANACHE_REPOSITORY_SWITCHER)) {
             // Only keep concrete classes
             if (classInfo.isInterface() || classInfo.isAbstract()) {
@@ -238,10 +237,7 @@ public final class PanacheHibernateResourceProcessor {
                     .resolveTypeParameters(classInfo.name(), DOTNAME_PANACHE_REPOSITORY_SWITCHER, index.getIndex());
             if (typeParameters.get(0).kind() == Kind.CLASS) {
                 String entityClassName = typeParameters.get(0).name().toString();
-                Class<?> entityClass = Class.forName(entityClassName, false, Thread.currentThread().getContextClassLoader());
-                Class<?> repositoryClass = Class.forName(classInfo.name().toString(), false,
-                        Thread.currentThread().getContextClassLoader());
-                repositoryClassesToEntityClasses.put(repositoryClass, entityClass);
+                repositoryClassesToEntityClasses.put(classInfo.name().toString(), entityClassName);
             } else {
                 throw new RuntimeException("Failed to find entity linked to repository: " + classInfo + ", it appears to be: "
                         + typeParameters.get(0) + " but we don't know what to do with it, it should be an entity type");

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/PanacheHibernateRecorder.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/PanacheHibernateRecorder.java
@@ -16,7 +16,7 @@ public class PanacheHibernateRecorder {
         }
     }
 
-    public void setRepositoryClassesToEntityClasses(Map<Class<?>, Class<?>> repositoryClassesToEntityClasses) {
+    public void setRepositoryClassesToEntityClasses(Map<String, String> repositoryClassesToEntityClasses) {
         AbstractJpaOperations.setRepositoryClassesToEntityClasses(repositoryClassesToEntityClasses);
     }
 }

--- a/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/AbstractJpaOperations.java
+++ b/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/AbstractJpaOperations.java
@@ -2,7 +2,10 @@ package io.quarkus.hibernate.orm.panache.common.runtime;
 
 import static io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Stream;
 
@@ -48,8 +51,20 @@ public abstract class AbstractJpaOperations<PanacheQueryType, SessionType extend
 
     private static volatile Map<Class<?>, Class<?>> repositoryClassToEntityClass = Collections.emptyMap();
 
-    public static void setRepositoryClassesToEntityClasses(Map<Class<?>, Class<?>> map) {
-        repositoryClassToEntityClass = Collections.unmodifiableMap(map);
+    public static void setRepositoryClassesToEntityClasses(Map<String, String> map) {
+        Map<Class<?>, Class<?>> converted = new HashMap<>();
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        for (Entry<String, String> entry : map.entrySet()) {
+            try {
+                Class<?> repoClass = Class.forName(entry.getKey(), false, classLoader);
+                Class<?> entityClass = Class.forName(entry.getValue(), false, classLoader);
+                converted.put(repoClass, entityClass);
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException("Unable to load repository/entity class mapping "
+                        + entry.getKey() + " -> " + entry.getValue(), e);
+            }
+        }
+        repositoryClassToEntityClass = Collections.unmodifiableMap(converted);
     }
 
     public static <Entity> Class<? extends Entity> getRepositoryEntityClass(


### PR DESCRIPTION
Make sure that `EntityToPersistenceUnitBuildItem` implements `Comparable`. Also, `repositoryClassesToEntityClasses` is now `Map<String, String>` to ensure stable iteration order, and conversion to `Map<Class<?>, Class<?>>` is pushed into `AbstractJpaOperations`.