### PR TITLE
Stabilize bytecode generated in `SchedulerProcessor`

### DIFF
--- a/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/ScheduledBusinessMethodItem.java
+++ b/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/ScheduledBusinessMethodItem.java
@@ -1,5 +1,9 @@
 package io.quarkus.scheduler.deployment;
 
+import static io.quarkus.arc.processor.Reproducibility.BEAN_COMPARATOR;
+import static io.quarkus.arc.processor.Reproducibility.METHOD_COMPARATOR;
+
+import java.util.Comparator;
 import java.util.List;
 
 import org.jboss.jandex.AnnotationInstance;
@@ -8,13 +12,17 @@ import org.jboss.jandex.MethodInfo;
 import io.quarkus.arc.processor.BeanInfo;
 import io.quarkus.builder.item.MultiBuildItem;
 
-public final class ScheduledBusinessMethodItem extends MultiBuildItem {
+public final class ScheduledBusinessMethodItem extends MultiBuildItem implements Comparable<ScheduledBusinessMethodItem> {
 
     private final BeanInfo bean;
     private final List<AnnotationInstance> schedules;
     private final MethodInfo method;
     private final boolean nonBlocking;
     private final boolean runOnVirtualThread;
+
+    private static final Comparator<ScheduledBusinessMethodItem> COMPARATOR = Comparator
+            .comparing(ScheduledBusinessMethodItem::getBean, Comparator.nullsFirst(BEAN_COMPARATOR))
+            .thenComparing(ScheduledBusinessMethodItem::getMethod, METHOD_COMPARATOR);
 
     public ScheduledBusinessMethodItem(BeanInfo bean, MethodInfo method, List<AnnotationInstance> schedules) {
         this(bean, method, schedules, false, false);
@@ -56,6 +64,11 @@ public final class ScheduledBusinessMethodItem extends MultiBuildItem {
 
     public String getMethodDescription() {
         return method.declaringClass().name() + "#" + method.name() + "()";
+    }
+
+    @Override
+    public int compareTo(ScheduledBusinessMethodItem o) {
+        return COMPARATOR.compare(this, o);
     }
 
 }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Reproducibility.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Reproducibility.java
@@ -24,7 +24,7 @@ import io.smallrye.common.annotation.SuppressForbidden;
         to establish some kind of deterministic ordering, nothing more.
         """)
 public class Reproducibility {
-    static final Comparator<BeanInfo> BEAN_COMPARATOR = Comparator.comparing(BeanInfo::getIdentifier);
+    public static final Comparator<BeanInfo> BEAN_COMPARATOR = Comparator.comparing(BeanInfo::getIdentifier);
     static final Comparator<ObserverInfo> OBSERVER_COMPARATOR = Comparator.comparing(ObserverInfo::getIdentifier);
     static final Comparator<Type> TYPE_COMPARATOR = Comparator.comparing(Type::name).thenComparing(Type::toString);
     static final Comparator<ClassInfo> CLASS_COMPARATOR = Comparator.comparing(c -> c.name().toString());
@@ -38,8 +38,9 @@ public class Reproducibility {
             .comparing(InjectionPointInfo::getType, TYPE_COMPARATOR)
             .thenComparing(InjectionPointInfo::getRequiredQualifiers,
                     setComparator(ANNOTATION_COMPARATOR, AnnotationInstance[]::new));
-    static final Comparator<MethodInfo> METHOD_COMPARATOR = Comparator
-            .comparing(MethodInfo::name)
+    public static final Comparator<MethodInfo> METHOD_COMPARATOR = Comparator
+            .comparing(MethodInfo::declaringClass, CLASS_COMPARATOR)
+            .thenComparing(MethodInfo::name)
             .thenComparing(MethodInfo::parameterTypes, listComparator(TYPE_COMPARATOR))
             .thenComparing(MethodInfo::returnType, TYPE_COMPARATOR);
 


### PR DESCRIPTION
Sorting `staticScheduledMethods` and `scheduledMethods` should improve binary reproducibility.