### PR TITLE
Upgrade Pulsar client to 4.2.3

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -216,7 +216,7 @@
         <sshd-common.version>2.19.0</sshd-common.version>
         <mime4j.version>0.8.12</mime4j.version>
         <mutiny-zero.version>1.2.1</mutiny-zero.version>
-        <pulsar-client.version>4.2.1</pulsar-client.version>
+        <pulsar-client.version>4.2.3</pulsar-client.version>
         <async-http-client.version>2.15.0</async-http-client.version>
         <!-- keep in-sync, if possible, with Micrometer registry Prometheus -->
         <prometheus.version>0.16.0</prometheus.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -212,7 +212,7 @@
         <sshd-common.version>2.18.0</sshd-common.version>
         <mime4j.version>0.8.12</mime4j.version>
         <mutiny-zero.version>1.2.1</mutiny-zero.version>
-        <pulsar-client.version>4.2.1</pulsar-client.version>
+        <pulsar-client.version>4.2.3</pulsar-client.version>
         <async-http-client.version>2.15.0</async-http-client.version>
         <!-- keep in-sync, if possible, with Micrometer registry Prometheus -->
         <prometheus.version>0.16.0</prometheus.version>

--- a/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/SmallRyeReactiveMessagingPulsarProcessor.java
+++ b/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/SmallRyeReactiveMessagingPulsarProcessor.java
@@ -188,13 +188,13 @@ public class SmallRyeReactiveMessagingPulsarProcessor {
         }
 
         Collection<ClassInfo> authPluginClasses = combinedIndex.getIndex()
-                .getAllKnownImplementations(DotNames.PULSAR_AUTHENTICATION);
+                .getAllKnownImplementors(DotNames.PULSAR_AUTHENTICATION);
         for (ClassInfo authPluginClass : authPluginClasses) {
             reflectiveClass.produce(ReflectiveClassBuildItem.builder(authPluginClass.name().toString())
                     .constructors().build());
         }
         Collection<ClassInfo> sslFactoryClasses = combinedIndex.getIndex()
-                .getAllKnownImplementations(DotNames.PULSAR_SSL_FACTORY);
+                .getAllKnownImplementors(DotNames.PULSAR_SSL_FACTORY);
         for (ClassInfo sslFactoryClass : sslFactoryClasses) {
             reflectiveClass.produce(ReflectiveClassBuildItem.builder(sslFactoryClass.name().toString())
                     .constructors().build());

--- a/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/SmallRyeReactiveMessagingPulsarProcessor.java
+++ b/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/SmallRyeReactiveMessagingPulsarProcessor.java
@@ -169,16 +169,23 @@ public class SmallRyeReactiveMessagingPulsarProcessor {
         // ReflectiveChannelFactory against the platform SocketChannel returned by
         // EventLoopUtil. quarkus-netty registers only the NIO variants; register
         // Epoll/KQueue/IOUring here so native image can find their no-arg
-        // constructors at runtime. Revisit when bumping pulsar-client — if Pulsar
-        // moves to non-reflective ChannelFactory factories, these can be removed.
-        reflectiveClass.produce(ReflectiveClassBuildItem
-                .builder("io.netty.channel.epoll.EpollSocketChannel",
-                        "io.netty.channel.epoll.EpollDatagramChannel",
-                        "io.netty.channel.kqueue.KQueueSocketChannel",
-                        "io.netty.channel.kqueue.KQueueDatagramChannel",
-                        "io.netty.incubator.channel.uring.IOUringSocketChannel",
-                        "io.netty.incubator.channel.uring.IOUringDatagramChannel")
-                .constructors().build());
+        // constructors at runtime. These native transports are platform-specific
+        // and optional, so only register the ones actually on the classpath.
+        // Revisit when bumping pulsar-client — if Pulsar moves to non-reflective
+        // ChannelFactory factories, these can be removed.
+        String[] nettyTransportChannels = {
+                "io.netty.channel.epoll.EpollSocketChannel",
+                "io.netty.channel.epoll.EpollDatagramChannel",
+                "io.netty.channel.kqueue.KQueueSocketChannel",
+                "io.netty.channel.kqueue.KQueueDatagramChannel",
+                "io.netty.incubator.channel.uring.IOUringSocketChannel",
+                "io.netty.incubator.channel.uring.IOUringDatagramChannel"
+        };
+        for (String channel : nettyTransportChannels) {
+            if (QuarkusClassLoader.isClassPresentAtRuntime(channel)) {
+                reflectiveClass.produce(ReflectiveClassBuildItem.builder(channel).constructors().build());
+            }
+        }
 
         Collection<ClassInfo> authPluginClasses = combinedIndex.getIndex()
                 .getAllKnownImplementations(DotNames.PULSAR_AUTHENTICATION);


### PR DESCRIPTION

Bumps the Apache Pulsar client from 3.3.0 to 4.2.1.

The 3.3.0 release is no longer covered by Apache Pulsar's security
support policy, and applications that override `pulsar-client.version`
to a 4.x release fail to build a native image with:

    java.lang.ClassNotFoundException: org.apache.pulsar.client.util.WithSNISslEngineFactory

`WithSNISslEngineFactory` was removed from the Pulsar client in 4.x
(SNI is now applied directly in `PulsarChannelInitializer`); removing
the dangling `addRuntimeInitializedClass(...)` registration makes the
extension compatible with 4.x.

The rest of the native-image configuration in `SmallRyeReactiveMessagingPulsarProcessor` was reviewed against the
Pulsar 4.2.1 source and remains correct: `MessageCryptoBc`, `SecretsSerializer`, the OAuth2 protocol classes, the async-http-client hints, and the Protobuf hints are all still present in 4.2.1 with the same package layout. The `@Substitute` for `ClientCredentialsFlow.loadPrivateKey` in `io.quarkus.pulsar.runtime.graal.Substitutions` replaces the entire method body, so the small upstream tweak inside that method (`getInputStream()` → `getContent()`) does not affect us.

Validated by running `./mvnw verify -f integration-tests/reactive-messaging-pulsar/ -Dnative` —
all six native-image builds in that module compile cleanly against Pulsar 4.2.1. Could not run the resulting binaries locally on macOS arm64 because the container build produced Linux binaries; runtime smoke tests are left to CI.

Fixes #48776