### PR TITLE
Allow to define a Quarkus*ModeTest with a random port for parallel test executions

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/devmode/RestAssuredOverrideByRuntimePropertyPortProdModeTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/devmode/RestAssuredOverrideByRuntimePropertyPortProdModeTest.java
@@ -1,5 +1,7 @@
 package io.quarkus.vertx.http.devmode;
 
+import java.util.Map;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 
@@ -12,12 +14,13 @@ import io.quarkus.test.QuarkusProdModeTest;
 import io.restassured.RestAssured;
 import io.vertx.ext.web.Router;
 
-public class RestAssuredPortProdModeTest {
+public class RestAssuredOverrideByRuntimePropertyPortProdModeTest {
 
     @RegisterExtension
     static final QuarkusProdModeTest prodMode = new QuarkusProdModeTest()
             .withApplicationRoot((jar) -> jar
                     .addClasses(MyRoute.class))
+            .setRuntimeProperties(Map.of("quarkus.http.port", "9292"))
             .setRun(true)
             .forceRandomizedHttpPort();
 
@@ -26,9 +29,8 @@ public class RestAssuredPortProdModeTest {
         RestAssured.given().get("/hello").then()
                 .statusCode(200)
                 .body(Matchers.equalTo("hello"));
-        // should be random
-        Assertions.assertThat(prodMode.configuredHttpPort()).isNotEqualTo(8080);
-        Assertions.assertThat(prodMode.configuredHttpPort()).isNotEqualTo(8081);
+        // forceRandomizedHttpPort() take precedence
+        Assertions.assertThat(prodMode.configuredHttpPort()).isNotEqualTo(9292);
     }
 
     @ApplicationScoped

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/devmode/RestAssuredPortDevModeTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/devmode/RestAssuredPortDevModeTest.java
@@ -3,6 +3,7 @@ package io.quarkus.vertx.http.devmode;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 
+import org.assertj.core.api.Assertions;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -17,13 +18,16 @@ public class RestAssuredPortDevModeTest {
     static final QuarkusDevModeTest test = new QuarkusDevModeTest()
             .withApplicationRoot((jar) -> jar
                     .addClasses(MyRoute.class))
-            .withRandomPort();
+            .forceRandomizedHttpPort();
 
     @Test
     void restAssuredUsesConfiguredPort() {
         RestAssured.given().get("/hello").then()
                 .statusCode(200)
                 .body(Matchers.equalTo("hello"));
+        // should be random
+        Assertions.assertThat(test.configuredHttpPort()).isNotEqualTo(8080);
+        Assertions.assertThat(test.configuredHttpPort()).isNotEqualTo(8081);
     }
 
     @ApplicationScoped

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/devmode/RestAssuredPortDevModeTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/devmode/RestAssuredPortDevModeTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.vertx.http.devmode;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+import io.vertx.ext.web.Router;
+
+public class RestAssuredPortDevModeTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyRoute.class))
+            .withRandomPort();
+
+    @Test
+    void restAssuredUsesConfiguredPort() {
+        RestAssured.given().get("/hello").then()
+                .statusCode(200)
+                .body(Matchers.equalTo("hello"));
+    }
+
+    @ApplicationScoped
+    static class MyRoute {
+        public void register(@Observes Router router) {
+            router.route("/hello").handler(rc -> rc.response().end("hello"));
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/devmode/RestAssuredPortOverrideByAppPropertiesDevModeTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/devmode/RestAssuredPortOverrideByAppPropertiesDevModeTest.java
@@ -5,30 +5,32 @@ import jakarta.enterprise.event.Observes;
 
 import org.assertj.core.api.Assertions;
 import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusProdModeTest;
+import io.quarkus.test.QuarkusDevModeTest;
 import io.restassured.RestAssured;
 import io.vertx.ext.web.Router;
 
-public class RestAssuredPortProdModeTest {
+public class RestAssuredPortOverrideByAppPropertiesDevModeTest {
 
     @RegisterExtension
-    static final QuarkusProdModeTest prodMode = new QuarkusProdModeTest()
+    static final QuarkusDevModeTest devMode = new QuarkusDevModeTest()
             .withApplicationRoot((jar) -> jar
-                    .addClasses(MyRoute.class))
-            .setRun(true)
+                    .addClasses(MyRoute.class)
+                    .addAsResource(new StringAsset("""
+                            quarkus.http.port=42929
+                            """), "application.properties"))
             .forceRandomizedHttpPort();
 
     @Test
-    void restAssuredUsesRandomPort() {
+    void restAssuredUsesConfiguredPort() {
         RestAssured.given().get("/hello").then()
                 .statusCode(200)
                 .body(Matchers.equalTo("hello"));
-        // should be random
-        Assertions.assertThat(prodMode.configuredHttpPort()).isNotEqualTo(8080);
-        Assertions.assertThat(prodMode.configuredHttpPort()).isNotEqualTo(8081);
+        //        forceRandomizedHttpPort() take precedence
+        Assertions.assertThat(devMode.configuredHttpPort()).isNotEqualTo(42929);
     }
 
     @ApplicationScoped

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/devmode/RestAssuredPortProdModeTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/devmode/RestAssuredPortProdModeTest.java
@@ -1,0 +1,36 @@
+package io.quarkus.vertx.http.devmode;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusProdModeTest;
+import io.restassured.RestAssured;
+import io.vertx.ext.web.Router;
+
+public class RestAssuredPortProdModeTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest test = new QuarkusProdModeTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyRoute.class))
+            .setRun(true)
+            .withRandomPort();
+
+    @Test
+    void restAssuredUsesRandomPort() {
+        RestAssured.given().get("/hello").then()
+                .statusCode(200)
+                .body(Matchers.equalTo("hello"));
+    }
+
+    @ApplicationScoped
+    static class MyRoute {
+        public void register(@Observes Router router) {
+            router.route("/hello").handler(rc -> rc.response().end("hello"));
+        }
+    }
+}

--- a/test-framework/junit-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
+++ b/test-framework/junit-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
@@ -44,7 +44,6 @@ import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
@@ -115,6 +114,8 @@ public class QuarkusDevModeTest
     public static final OpenOption[] OPEN_OPTIONS = { StandardOpenOption.SYNC, StandardOpenOption.CREATE,
             StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE };
     private Handler[] originalRootLoggerHandlers;
+    private static final String QUARKUS_HTTP_PORT_PROPERTY = "quarkus.http.port";
+    private static final String RANDOM_PORT = "0";
 
     static {
         System.setProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager");
@@ -147,6 +148,7 @@ public class QuarkusDevModeTest
     private final Map<String, String> buildSystemProperties = new HashMap<>();
     private boolean allowFailedStart = false;
     private boolean randomPort = false;
+    private Integer configuredHttpPort;
 
     private static final List<CompilationProvider> compilationProviders;
 
@@ -317,6 +319,7 @@ public class QuarkusDevModeTest
             listeningAddress.ifPresent(address -> {
                 address.register(valueRegistry, newConfig);
                 // Configure RestAssured with the detected port
+                this.configuredHttpPort = address.port();
                 RestAssuredStateManager.setURL(address.isSsl(), address.port());
             });
 
@@ -423,10 +426,10 @@ public class QuarkusDevModeTest
             Properties properties = new Properties();
             properties.putAll(config);
             if (randomPort) {
-                properties.put("quarkus.http.port", "0");
+                // Random port takes precedence over application.properties and config
+                properties.put(QUARKUS_HTTP_PORT_PROPERTY, RANDOM_PORT);
             }
             ExportUtil.mergeCustomApplicationProperties(archive, properties);
-
             exportAndGenerateSourceTree(archive, classes, testSourceDir, deploymentSourcePath, deploymentResourcePath);
 
             // TODO: again a hack, assumes the sources dir is one dir above java sources path
@@ -445,6 +448,10 @@ public class QuarkusDevModeTest
             context.getBuildSystemProperties().put("quarkus.console.disable-input", "true"); //surefire communicates via stdin, we don't want the test to be reading input
             context.getBuildSystemProperties().putAll(buildSystemProperties);
             context.getBuildSystemProperties().putAll(config);
+            if (randomPort) {
+                // Random port takes precedence over build system properties and config
+                context.getBuildSystemProperties().put(QUARKUS_HTTP_PORT_PROPERTY, RANDOM_PORT);
+            }
             context.setCacheDir(cache.toFile());
 
             final DevModeContext.ModuleInfo.Builder moduleBuilder = new DevModeContext.ModuleInfo.Builder()
@@ -888,9 +895,33 @@ public class QuarkusDevModeTest
         return allowFailedStart;
     }
 
-    public QuarkusDevModeTest withRandomPort() {
+    /**
+     * If set, the application will use a random HTTP port (quarkus.http.port=0).
+     * The actual port is detected from the console output and configured in RestAssured.
+     * <p>
+     * This setting takes precedence over <code>quarkus.http.port</code> configured in
+     * application.properties or through build system properties.
+     */
+    public QuarkusDevModeTest forceRandomizedHttpPort() {
         this.randomPort = true;
         return this;
+    }
+
+    /**
+     * Returns the actual HTTP port the application is listening on in dev mode.
+     * <p>
+     * This is particularly useful when {@link #forceRandomizedHttpPort()} is used, as it returns
+     * the randomly assigned port number that was detected from the application startup output.
+     * <p>
+     * When a fixed port is configured (via application.properties or build system properties),
+     * this method returns that configured port.
+     * <p>
+     * Returns {@code null} if the port could not be determined or if the application hasn't started yet.
+     *
+     * @return the port number the application is listening on, or {@code null} if not available
+     */
+    public Integer configuredHttpPort() {
+        return this.configuredHttpPort;
     }
 
     public QuarkusDevModeTest setAllowFailedStart(boolean allowFailedStart) {

--- a/test-framework/junit-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
+++ b/test-framework/junit-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
@@ -73,6 +73,7 @@ import io.quarkus.test.common.GroovyClassValue;
 import io.quarkus.test.common.ListeningAddress;
 import io.quarkus.test.common.PathTestHelper;
 import io.quarkus.test.common.PropertyTestUtil;
+import io.quarkus.test.common.RestAssuredStateManager;
 import io.quarkus.test.common.TestConfigUtil;
 import io.quarkus.test.common.TestResourceManager;
 import io.quarkus.test.common.http.TestHTTPResourceManager;
@@ -145,6 +146,7 @@ public class QuarkusDevModeTest
     private String[] commandLineArgs = new String[0];
     private final Map<String, String> buildSystemProperties = new HashMap<>();
     private boolean allowFailedStart = false;
+    private boolean randomPort = false;
 
     private static final List<CompilationProvider> compilationProviders;
 
@@ -312,7 +314,11 @@ public class QuarkusDevModeTest
 
             // Capture the listening port if available and register it in ValueRegistry
             Optional<ListeningAddress> listeningAddress = listeningAddress(startupLogHandler.getRecords());
-            listeningAddress.ifPresent(address -> address.register(valueRegistry, newConfig));
+            listeningAddress.ifPresent(address -> {
+                address.register(valueRegistry, newConfig);
+                // Configure RestAssured with the detected port
+                RestAssuredStateManager.setURL(address.isSsl(), address.port());
+            });
 
             // Inject ValueRegistry and Config
             ValueRegistryInjector.inject(testInstance, valueRegistry);
@@ -393,6 +399,7 @@ public class QuarkusDevModeTest
         ConfigInjector.clear(context);
         ValueRegistryInjector.clear(context);
         inMemoryLogHandler.clearRecords();
+        RestAssuredStateManager.clearState();
     }
 
     private DevModeMain newDevModeMain(ExtensionContext extensionContext, Path deploymentDir, Path testSourceDir,
@@ -415,6 +422,9 @@ public class QuarkusDevModeTest
             // Merge TestResource configuration
             Properties properties = new Properties();
             properties.putAll(config);
+            if (randomPort) {
+                properties.put("quarkus.http.port", "0");
+            }
             ExportUtil.mergeCustomApplicationProperties(archive, properties);
 
             exportAndGenerateSourceTree(archive, classes, testSourceDir, deploymentSourcePath, deploymentResourcePath);
@@ -876,6 +886,11 @@ public class QuarkusDevModeTest
 
     public boolean isAllowFailedStart() {
         return allowFailedStart;
+    }
+
+    public QuarkusDevModeTest withRandomPort() {
+        this.randomPort = true;
+        return this;
     }
 
     public QuarkusDevModeTest setAllowFailedStart(boolean allowFailedStart) {

--- a/test-framework/junit-internal/src/main/java/io/quarkus/test/QuarkusProdModeTest.java
+++ b/test-framework/junit-internal/src/main/java/io/quarkus/test/QuarkusProdModeTest.java
@@ -135,6 +135,7 @@ public class QuarkusProdModeTest
 
     private boolean clearRestAssuredURL;
     private boolean randomPort;
+    private Integer configuredHttpPort;
 
     public QuarkusProdModeTest() {
         // If there is an application.properties resource available then load the properties
@@ -258,10 +259,30 @@ public class QuarkusProdModeTest
     /**
      * If set, the application will use a random HTTP port (quarkus.http.port=0).
      * The actual port is detected from the process output and configured in RestAssured.
+     * <p>
+     * This setting takes precedence over <code>quarkus.http.port</code> configured through
+     * {@link #setRuntimeProperties(Map)} or in application.properties.
      */
-    public QuarkusProdModeTest withRandomPort() {
+    public QuarkusProdModeTest forceRandomizedHttpPort() {
         this.randomPort = true;
         return this;
+    }
+
+    /**
+     * Returns the actual HTTP port the application is listening on.
+     * <p>
+     * This is particularly useful when {@link #forceRandomizedHttpPort()} is used, as it returns
+     * the randomly assigned port number that was detected from the application startup output.
+     * <p>
+     * When a fixed port is configured (via application.properties or {@link #setRuntimeProperties(Map)}),
+     * this method returns that configured port.
+     * <p>
+     * Returns {@code null} if the port could not be determined or if the application hasn't started yet.
+     *
+     * @return the port number the application is listening on, or {@code null} if not available
+     */
+    public Integer configuredHttpPort() {
+        return this.configuredHttpPort;
     }
 
     public QuarkusProdModeTest setLogRecordPredicate(Predicate<LogRecord> predicate) {
@@ -589,9 +610,9 @@ public class QuarkusProdModeTest
             // copy the use supplied properties since it might be an immutable map
             runtimeProperties = new HashMap<>(runtimeProperties);
         }
-        runtimeProperties.putIfAbsent(QUARKUS_HTTP_PORT_PROPERTY, DEFAULT_HTTP_PORT);
-        if (randomPort) {
-            runtimeProperties.put(QUARKUS_HTTP_PORT_PROPERTY, "0");
+
+        if (!randomPort) {
+            runtimeProperties.putIfAbsent(QUARKUS_HTTP_PORT_PROPERTY, DEFAULT_HTTP_PORT);
         }
         if (logFileName != null) {
             logfilePath = builtResultArtifactParent.resolve(logFileName);
@@ -602,6 +623,11 @@ public class QuarkusProdModeTest
         // ensure that the properties obtained from QuarkusTestResourceLifecycleManager
         // are propagated to runtime
         runtimeProperties.putAll(testResourceProperties);
+
+        if (randomPort) {
+            // Random port takes precedence over all other sources
+            runtimeProperties.put(QUARKUS_HTTP_PORT_PROPERTY, "0");
+        }
 
         List<String> systemProperties = runtimeProperties.entrySet().stream()
                 .map(e -> "-D" + e.getKey() + "=" + e.getValue()).collect(Collectors.toList());
@@ -684,7 +710,7 @@ public class QuarkusProdModeTest
                 httpPort = null;
             }
         }
-
+        this.configuredHttpPort = httpPort;
         RestAssuredStateManager.setURL(isSsl, httpPort);
     }
 

--- a/test-framework/junit-internal/src/main/java/io/quarkus/test/QuarkusProdModeTest.java
+++ b/test-framework/junit-internal/src/main/java/io/quarkus/test/QuarkusProdModeTest.java
@@ -31,6 +31,8 @@ import java.util.function.Supplier;
 import java.util.logging.Handler;
 import java.util.logging.LogManager;
 import java.util.logging.LogRecord;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import jakarta.inject.Inject;
@@ -132,6 +134,7 @@ public class QuarkusProdModeTest
     private String[] commandLineParameters = new String[0];
 
     private boolean clearRestAssuredURL;
+    private boolean randomPort;
 
     public QuarkusProdModeTest() {
         // If there is an application.properties resource available then load the properties
@@ -249,6 +252,15 @@ public class QuarkusProdModeTest
      */
     public QuarkusProdModeTest setRuntimeProperties(Map<String, String> runtimeProperties) {
         this.runtimeProperties = runtimeProperties;
+        return this;
+    }
+
+    /**
+     * If set, the application will use a random HTTP port (quarkus.http.port=0).
+     * The actual port is detected from the process output and configured in RestAssured.
+     */
+    public QuarkusProdModeTest withRandomPort() {
+        this.randomPort = true;
         return this;
     }
 
@@ -578,6 +590,9 @@ public class QuarkusProdModeTest
             runtimeProperties = new HashMap<>(runtimeProperties);
         }
         runtimeProperties.putIfAbsent(QUARKUS_HTTP_PORT_PROPERTY, DEFAULT_HTTP_PORT);
+        if (randomPort) {
+            runtimeProperties.put(QUARKUS_HTTP_PORT_PROPERTY, "0");
+        }
         if (logFileName != null) {
             logfilePath = builtResultArtifactParent.resolve(logFileName);
             runtimeProperties.put("quarkus.log.file.path", logfilePath.toAbsolutePath().toString());
@@ -647,18 +662,30 @@ public class QuarkusProdModeTest
         }
     }
 
-    private void setupRestAssured() {
-        Integer httpPort = Optional.ofNullable(runtimeProperties.get(QUARKUS_HTTP_PORT_PROPERTY))
-                .map(Integer::parseInt)
-                .orElse(DEFAULT_HTTP_PORT_INT);
+    private static final Pattern LISTENING_REGEX = Pattern.compile("Listening on:\\s+(https?)://[^:]*:(\\d+)");
 
-        // If http port is 0, then we need to set the port to null in order to use the `quarkus.http.test-ssl-port` property
-        // which is done in `RestAssuredStateManager.setURL`.
-        if (httpPort == 0) {
-            httpPort = null;
+    private void setupRestAssured() {
+        Integer httpPort = null;
+        boolean isSsl = false;
+
+        if (randomPort && startupConsoleOutput != null) {
+            Matcher matcher = LISTENING_REGEX.matcher(startupConsoleOutput);
+            if (matcher.find()) {
+                httpPort = Integer.parseInt(matcher.group(2));
+                isSsl = "https".equals(matcher.group(1));
+            }
         }
 
-        RestAssuredStateManager.setURL(false, httpPort);
+        if (httpPort == null) {
+            httpPort = Optional.ofNullable(runtimeProperties.get(QUARKUS_HTTP_PORT_PROPERTY))
+                    .map(Integer::parseInt)
+                    .orElse(DEFAULT_HTTP_PORT_INT);
+            if (httpPort == 0) {
+                httpPort = null;
+            }
+        }
+
+        RestAssuredStateManager.setURL(isSsl, httpPort);
     }
 
     private void ensureApplicationStartupOrFailure() throws IOException {


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
and the AI/LLM usage policy at https://github.com/quarkusio/quarkus/blob/main/AI_POLICY.md
-->

This pull request aims to allow the use of QuarkusProdModeTest and QuarkusDevModeTest while running parallel test executions with Maven. Furthermore, actually the RestAssured is not aware when we set a random port through `quarkus.http.port=0` which is solved by this pull request.

Closes #54519 


<!--
See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

