### PR TITLE
Remove superfluous code in dev ui guide

### DIFF
--- a/docs/src/main/asciidoc/dev-ui.adoc
+++ b/docs/src/main/asciidoc/dev-ui.adoc
@@ -1306,8 +1306,7 @@ For example, the following Page definition will call the `devui-dev-services:dev
 cardPageBuildItem.addPage(Page.externalPageBuilder("External Page")
                 .dynamicUrlJsonRPCMethodName("devui-dev-services:devServicesConfig", // <1>
                     Map.of("name", "my-dev-service", // <2>
-                            "configKey", "url-config-key"))
-                .isHtmlContent());
+                            "configKey", "url-config-key")));
 ----
 <1> Use the `devServicesConfig` RPC method from the namespace `devui-dev-services`.
 <2> Set the parameters needed by the RPC method, `name` and `configKey`.


### PR DESCRIPTION
The `isHtmlContent()` seems to have been copy-pasta-ed in, but it doesn't add anything in this context (and probably shouldn't be in user's code even looking at a full block, because it's more intended for embedded cases).