### PR TITLE
Introduce ability to get response metadata in streamed response

### DIFF
--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -1065,6 +1065,55 @@ public interface SseClient {
 ----
 ====
 
+==== Accessing response metadata from a stream
+
+When consuming a streaming response (SSE, newline-delimited JSON, or chunked), you may need access to the HTTP status code or response headers alongside the streamed items.
+Using `RestMultiResponse<T>` instead of `Multi<T>` as the return type gives you non-blocking access to this metadata via the `response()` method, which returns a `Uni<BasicRestResponse>`.
+
+[source, java]
+----
+package org.acme.rest.client;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.jboss.resteasy.reactive.client.BasicRestResponse;
+import org.jboss.resteasy.reactive.client.RestMultiResponse;
+import org.jboss.resteasy.reactive.client.SseEvent;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/sse")
+@RegisterRestClient(configKey = "some-api")
+public interface SseClient {
+     @GET
+     @Produces(MediaType.SERVER_SENT_EVENTS)
+     RestMultiResponse<SseEvent<Long>> get();
+}
+----
+
+The `BasicRestResponse` is available as soon as the HTTP response headers arrive, before any stream items are emitted:
+
+[source, java]
+----
+RestMultiResponse<SseEvent<Long>> stream = sseClient.get();
+
+// non-blocking access to response metadata
+stream.response().subscribe().with(response -> {
+    int status = response.status();
+    String correlationId = response.headers().getFirst("X-Correlation-Id");
+});
+
+// consume the stream items
+stream.subscribe().with(event -> {
+    // process each event
+});
+----
+
+`RestMultiResponse<T>` extends `Multi<T>`, so it can be used anywhere a `Multi` is expected.
+It works with any streaming media type, not just SSE.
+
 ==== Filtering out events
 
 On occasion, the stream of SSE events may contain some events that should not be returned by the client - an example of this is having the server send heartbeat events in order to keep the underlying TCP connection open.

--- a/extensions/resteasy-reactive/rest-client-jackson/deployment/src/test/java/io/quarkus/rest/client/reactive/jackson/test/RestMultiResponseTest.java
+++ b/extensions/resteasy-reactive/rest-client-jackson/deployment/src/test/java/io/quarkus/rest/client/reactive/jackson/test/RestMultiResponseTest.java
@@ -1,0 +1,182 @@
+package io.quarkus.rest.client.reactive.jackson.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.net.URI;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.sse.Sse;
+import jakarta.ws.rs.sse.SseEventSink;
+
+import org.jboss.resteasy.reactive.client.BasicRestResponse;
+import org.jboss.resteasy.reactive.client.RestMultiResponse;
+import org.jboss.resteasy.reactive.client.SseEvent;
+import org.jboss.resteasy.reactive.server.jackson.JacksonBasicMessageBodyReader;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+
+public class RestMultiResponseTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest TEST = new QuarkusExtensionTest()
+            .withEmptyApplication();
+
+    @TestHTTPResource
+    URI uri;
+
+    @Test
+    void shouldConsumeStreamAndAccessResponseMetadata() {
+        RestMultiResponse<SseEvent<Dto>> stream = createClient().stream();
+
+        var response = new AtomicReference<BasicRestResponse>();
+        stream.response().subscribe().with(response::set);
+
+        var resultList = new CopyOnWriteArrayList<Dto>();
+        stream.subscribe().with(event -> resultList.add(event.data()));
+
+        await().atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    assertThat(response.get()).isNotNull();
+                    assertThat(response.get().status()).isEqualTo(200);
+                    assertThat(response.get().headers()).isNotNull();
+                    assertThat(resultList).containsExactly(
+                            new Dto("foo", "1"),
+                            new Dto("bar", "2"));
+                });
+    }
+
+    @Test
+    void shouldWorkWithoutProducesAnnotation() {
+        RestMultiResponse<SseEvent<Dto>> stream = createClient().streamNoProduces();
+
+        var response = new AtomicReference<BasicRestResponse>();
+        stream.response().subscribe().with(response::set);
+
+        var resultList = new CopyOnWriteArrayList<Dto>();
+        stream.subscribe().with(event -> resultList.add(event.data()));
+
+        await().atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    assertThat(response.get()).isNotNull();
+                    assertThat(response.get().status()).isEqualTo(200);
+                    assertThat(resultList).containsExactly(
+                            new Dto("foo", "1"),
+                            new Dto("bar", "2"));
+                });
+    }
+
+    @Test
+    void shouldConsumeSimpleTypeStream() {
+        RestMultiResponse<String> stream = createClient().streamStrings();
+
+        var response = new AtomicReference<BasicRestResponse>();
+        stream.response().subscribe().with(response::set);
+
+        var resultList = new CopyOnWriteArrayList<String>();
+        stream.subscribe().with(resultList::add);
+
+        await().atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    assertThat(response.get()).isNotNull();
+                    assertThat(response.get().status()).isEqualTo(200);
+                    assertThat(resultList).containsExactly("hello", "world");
+                });
+    }
+
+    private StreamClient createClient() {
+        return QuarkusRestClientBuilder.newBuilder()
+                .baseUri(uri)
+                .register(new JacksonBasicMessageBodyReader(new ObjectMapper()))
+                .build(StreamClient.class);
+    }
+
+    @Path("/sse-stream")
+    public interface StreamClient {
+        @GET
+        @Path("/event")
+        @Produces(MediaType.SERVER_SENT_EVENTS)
+        RestMultiResponse<SseEvent<Dto>> stream();
+
+        @GET
+        @Path("/event")
+        RestMultiResponse<SseEvent<Dto>> streamNoProduces();
+
+        @GET
+        @Path("/string")
+        RestMultiResponse<String> streamStrings();
+    }
+
+    @Path("/sse-stream")
+    public static class SseStreamResource {
+
+        @GET
+        @Path("/event")
+        @Produces(MediaType.SERVER_SENT_EVENTS)
+        public void event(@Context SseEventSink sink, @Context Sse sse) {
+            try (sink) {
+                sink.send(sse.newEventBuilder()
+                        .id("1")
+                        .mediaType(MediaType.APPLICATION_JSON_TYPE)
+                        .data(Dto.class, new Dto("foo", "1"))
+                        .name("event1")
+                        .build());
+                sink.send(sse.newEventBuilder()
+                        .id("2")
+                        .mediaType(MediaType.APPLICATION_JSON_TYPE)
+                        .data(Dto.class, new Dto("bar", "2"))
+                        .name("event2")
+                        .build());
+            }
+        }
+
+        @GET
+        @Path("/string")
+        @Produces(MediaType.SERVER_SENT_EVENTS)
+        public io.smallrye.mutiny.Multi<String> strings() {
+            return io.smallrye.mutiny.Multi.createFrom().items("hello", "world");
+        }
+    }
+
+    public static class Dto {
+        public String name;
+        public String value;
+
+        public Dto(String name, String value) {
+            this.name = name;
+            this.value = value;
+        }
+
+        public Dto() {
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
+            Dto dto = (Dto) o;
+            return Objects.equals(name, dto.name) && Objects.equals(value, dto.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, value);
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
@@ -22,6 +22,7 @@ import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNa
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.PART_TYPE_NAME;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.REST_FORM_PARAM;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.REST_MULTI;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.REST_MULTI_RESPONSE;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.STRING;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.UNI;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.URI;
@@ -91,7 +92,6 @@ import org.jboss.jandex.TypeVariable;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.client.api.ClientMultipartForm;
 import org.jboss.resteasy.reactive.client.handlers.ClientObservabilityHandler;
-import org.jboss.resteasy.reactive.client.impl.AbstractRxInvoker;
 import org.jboss.resteasy.reactive.client.impl.AsyncInvokerImpl;
 import org.jboss.resteasy.reactive.client.impl.ClientBuilderImpl;
 import org.jboss.resteasy.reactive.client.impl.ClientImpl;
@@ -233,7 +233,8 @@ public class JaxrsClientReactiveProcessor {
     private static final DotName URL = DotName.createSimple("io.quarkus.rest.client.reactive.Url");
     private static final DotName WEB_TARGET = DotName.createSimple(WebTarget.class);
 
-    private static final Set<DotName> ASYNC_RETURN_TYPES = Set.of(COMPLETION_STAGE, UNI, MULTI, REST_MULTI);
+    private static final Set<DotName> ASYNC_RETURN_TYPES = Set.of(COMPLETION_STAGE, UNI, MULTI, REST_MULTI,
+            REST_MULTI_RESPONSE);
     public static final DotName BYTE = DotName.createSimple(Byte.class.getName());
     public static final MethodDescriptor MULTIPART_RESPONSE_DATA_ADD_FILLER = MethodDescriptor
             .ofMethod(MultipartResponseDataBase.class, "addFiller", void.class, FieldFiller.class);
@@ -2562,7 +2563,9 @@ public class JaxrsClientReactiveProcessor {
                         ? ReturnCategory.COMPLETION_STAGE
                         : paramType.name().equals(MULTI) || paramType.name().equals(REST_MULTI)
                                 ? ReturnCategory.MULTI
-                                : ReturnCategory.UNI;
+                                : paramType.name().equals(REST_MULTI_RESPONSE)
+                                        ? ReturnCategory.REST_MULTI_RESPONSE
+                                        : ReturnCategory.UNI;
 
                 // the async types have one type argument:
                 if (paramType.arguments().isEmpty()) {
@@ -2739,26 +2742,30 @@ public class JaxrsClientReactiveProcessor {
                                     CONTINUATION.toString()),
                             result, tryBlock.getMethodParam(continuationIndex));
                 }
-            } else if (returnCategory == ReturnCategory.MULTI) {
+            } else if (returnCategory == ReturnCategory.MULTI
+                    || returnCategory == ReturnCategory.REST_MULTI_RESPONSE) {
                 ResultHandle rx = tryBlock.invokeInterfaceMethod(
                         MethodDescriptor.ofMethod(Invocation.Builder.class, "rx", RxInvoker.class, Class.class),
                         builder, tryBlock.loadClassFromTCCL(MultiInvoker.class));
                 ResultHandle multiInvoker = tryBlock.checkCast(rx, MultiInvoker.class);
-                // with entity
+                boolean wrapResponse = returnCategory == ReturnCategory.REST_MULTI_RESPONSE;
                 if (genericReturnType != null) {
                     result = tryBlock.invokeVirtualMethod(
                             MethodDescriptor.ofMethod(MultiInvoker.class, "method",
                                     Multi.class, String.class,
-                                    Entity.class, GenericType.class),
+                                    Entity.class, GenericType.class, boolean.class),
                             multiInvoker, tryBlock.load(httpMethod), entity,
-                            genericReturnType);
+                            genericReturnType, tryBlock.load(wrapResponse));
                 } else {
                     result = tryBlock.invokeVirtualMethod(
-                            MethodDescriptor.ofMethod(AbstractRxInvoker.class, "method",
-                                    Object.class, String.class,
-                                    Entity.class, Class.class),
+                            MethodDescriptor.ofMethod(MultiInvoker.class, "method",
+                                    Multi.class, String.class,
+                                    Entity.class, GenericType.class, boolean.class),
                             multiInvoker, tryBlock.load(httpMethod), entity,
-                            tryBlock.loadClassFromTCCL(simpleReturnType));
+                            tryBlock.newInstance(
+                                    MethodDescriptor.ofConstructor(GenericType.class, java.lang.reflect.Type.class),
+                                    tryBlock.loadClassFromTCCL(simpleReturnType)),
+                            tryBlock.load(wrapResponse));
                 }
             } else {
                 if (genericReturnType != null) {
@@ -2820,24 +2827,31 @@ public class JaxrsClientReactiveProcessor {
                                     CONTINUATION.toString()),
                             result, tryBlock.getMethodParam(continuationIndex));
                 }
-            } else if (returnCategory == ReturnCategory.MULTI) {
+            } else if (returnCategory == ReturnCategory.MULTI
+                    || returnCategory == ReturnCategory.REST_MULTI_RESPONSE) {
                 ResultHandle rx = tryBlock.invokeInterfaceMethod(
                         MethodDescriptor.ofMethod(Invocation.Builder.class, "rx", RxInvoker.class, Class.class),
                         builder, tryBlock.loadClassFromTCCL(MultiInvoker.class));
                 ResultHandle multiInvoker = tryBlock.checkCast(rx, MultiInvoker.class);
+                boolean wrapResponse = returnCategory == ReturnCategory.REST_MULTI_RESPONSE;
                 if (genericReturnType != null) {
                     result = tryBlock.invokeVirtualMethod(
-                            MethodDescriptor.ofMethod(AbstractRxInvoker.class, "method",
-                                    Object.class, String.class,
-                                    GenericType.class),
-                            multiInvoker, tryBlock.load(httpMethod), genericReturnType);
+                            MethodDescriptor.ofMethod(MultiInvoker.class, "method",
+                                    Multi.class, String.class,
+                                    Entity.class, GenericType.class, boolean.class),
+                            multiInvoker, tryBlock.load(httpMethod),
+                            tryBlock.loadNull(), genericReturnType, tryBlock.load(wrapResponse));
                 } else {
                     result = tryBlock.invokeVirtualMethod(
-                            MethodDescriptor.ofMethod(AbstractRxInvoker.class, "method",
-                                    Object.class, String.class,
-                                    Class.class),
+                            MethodDescriptor.ofMethod(MultiInvoker.class, "method",
+                                    Multi.class, String.class,
+                                    Entity.class, GenericType.class, boolean.class),
                             multiInvoker, tryBlock.load(httpMethod),
-                            tryBlock.loadClassFromTCCL(simpleReturnType));
+                            tryBlock.loadNull(),
+                            tryBlock.newInstance(
+                                    MethodDescriptor.ofConstructor(GenericType.class, java.lang.reflect.Type.class),
+                                    tryBlock.loadClassFromTCCL(simpleReturnType)),
+                            tryBlock.load(wrapResponse));
                 }
             } else {
                 if (genericReturnType != null) {
@@ -3595,7 +3609,8 @@ public class JaxrsClientReactiveProcessor {
         UNI,
         MULTI,
         REST_MULTI,
-        COROUTINE
+        COROUTINE,
+        REST_MULTI_RESPONSE
     }
 
     private static class SubResourceParameter {

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/BasicRestResponse.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/BasicRestResponse.java
@@ -1,0 +1,14 @@
+package org.jboss.resteasy.reactive.client;
+
+import jakarta.ws.rs.core.MultivaluedMap;
+
+/**
+ * Provides access to HTTP response metadata (status code and headers)
+ * when consuming a streaming response via {@link RestMultiResponse}.
+ */
+public interface BasicRestResponse {
+
+    int status();
+
+    MultivaluedMap<String, String> headers();
+}

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/RestMultiResponse.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/RestMultiResponse.java
@@ -1,0 +1,20 @@
+package org.jboss.resteasy.reactive.client;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * A {@link Multi} that also provides non-blocking access to the HTTP response
+ * metadata (status code, headers) via {@link #response()}.
+ * <p>
+ * Returned by REST Client methods that consume streaming responses (SSE, newline-delimited JSON,
+ * or chunked) when response metadata is needed alongside the event stream.
+ */
+public interface RestMultiResponse<T> extends Multi<T> {
+
+    /**
+     * Returns a {@link Uni} that completes when the HTTP response is received,
+     * before any stream items are emitted
+     */
+    Uni<BasicRestResponse> response();
+}

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/BasicRestResponseImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/BasicRestResponseImpl.java
@@ -1,0 +1,9 @@
+package org.jboss.resteasy.reactive.client.impl;
+
+import jakarta.ws.rs.core.MultivaluedMap;
+
+import org.jboss.resteasy.reactive.client.BasicRestResponse;
+
+record BasicRestResponseImpl(int status, MultivaluedMap<String, String> headers) implements BasicRestResponse {
+
+}

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/MultiInvoker.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/MultiInvoker.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
@@ -13,12 +14,14 @@ import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.MediaType;
 
+import org.jboss.resteasy.reactive.client.BasicRestResponse;
 import org.jboss.resteasy.reactive.client.SseEvent;
 import org.jboss.resteasy.reactive.client.SseEventFilter;
 import org.jboss.resteasy.reactive.common.jaxrs.ResponseImpl;
 import org.jboss.resteasy.reactive.common.util.RestMediaType;
 
 import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.subscription.MultiEmitter;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
@@ -119,17 +122,30 @@ public class MultiInvoker extends AbstractRxInvoker<Multi<?>> {
 
     @Override
     public <R> Multi<R> method(String name, Entity<?> entity, GenericType<R> responseType) {
+        return method(name, entity, responseType, false);
+    }
+
+    public <R> Multi<R> method(String name, Entity<?> entity, GenericType<R> responseType,
+            boolean wrapAsRestMultiResponse) {
         AsyncInvokerImpl invoker = (AsyncInvokerImpl) invocationBuilder.rx();
+        CompletableFuture<BasicRestResponse> restResponseFuture = wrapAsRestMultiResponse ? new CompletableFuture<>() : null;
         // FIXME: backpressure setting?
-        return Multi.createFrom().emitter(emitter -> {
+        Multi<R> multi = Multi.createFrom().emitter(emitter -> {
             MultiRequest<R> multiRequest = new MultiRequest<>(emitter);
             RestClientRequestContext restClientRequestContext = invoker.performRequestInternal(name, entity, responseType,
                     false);
             restClientRequestContext.getResult().handle((response, connectionError) -> {
                 if (connectionError != null) {
                     emitter.fail(connectionError);
+                    if (restResponseFuture != null) {
+                        restResponseFuture.completeExceptionally(connectionError);
+                    }
                 } else {
                     HttpClientResponse vertxResponse = restClientRequestContext.getVertxClientResponse();
+                    if (restResponseFuture != null) {
+                        restResponseFuture.complete(
+                                new BasicRestResponseImpl(response.getStatus(), response.getStringHeaders()));
+                    }
                     if (!emitter.isCancelled()) {
                         if (response.getStatus() == 200
                                 && MediaType.SERVER_SENT_EVENTS_TYPE.isCompatible(response.getMediaType())) {
@@ -142,9 +158,7 @@ public class MultiInvoker extends AbstractRxInvoker<Multi<?>> {
                                 && isNewlineDelimited(response)) {
                             registerForJsonStream(multiRequest, restClientRequestContext, responseType, response,
                                     vertxResponse);
-
                         } else {
-                            // read stuff in chunks
                             registerForChunks(multiRequest, restClientRequestContext, responseType, response, vertxResponse);
                         }
                         vertxResponse.resume();
@@ -155,6 +169,11 @@ public class MultiInvoker extends AbstractRxInvoker<Multi<?>> {
                 return null;
             });
         });
+        if (restResponseFuture != null) {
+            Uni<BasicRestResponse> responseUni = Uni.createFrom().completionStage(restResponseFuture);
+            return new RestMultiResponseImpl<>(multi, responseUni);
+        }
+        return multi;
     }
 
     private boolean isNewlineDelimited(ResponseImpl response) {

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/RestMultiResponseImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/RestMultiResponseImpl.java
@@ -1,0 +1,30 @@
+package org.jboss.resteasy.reactive.client.impl;
+
+import org.jboss.resteasy.reactive.client.BasicRestResponse;
+import org.jboss.resteasy.reactive.client.RestMultiResponse;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.operators.AbstractMulti;
+import io.smallrye.mutiny.subscription.MultiSubscriber;
+
+class RestMultiResponseImpl<T> extends AbstractMulti<T> implements RestMultiResponse<T> {
+
+    private final Multi<T> delegate;
+    private final Uni<BasicRestResponse> responseUni;
+
+    RestMultiResponseImpl(Multi<T> delegate, Uni<BasicRestResponse> responseUni) {
+        this.delegate = delegate;
+        this.responseUni = responseUni;
+    }
+
+    @Override
+    public Uni<BasicRestResponse> response() {
+        return responseUni;
+    }
+
+    @Override
+    public void subscribe(MultiSubscriber<? super T> subscriber) {
+        delegate.subscribe(subscriber);
+    }
+}

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/ResteasyReactiveDotNames.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/ResteasyReactiveDotNames.java
@@ -213,6 +213,8 @@ public final class ResteasyReactiveDotNames {
     public static final DotName UNI = DotName.createSimple(Uni.class.getName());
     public static final DotName MULTI = DotName.createSimple(Multi.class.getName());
     public static final DotName REST_MULTI = DotName.createSimple(RestMulti.class.getName());
+    public static final DotName REST_MULTI_RESPONSE = DotName
+            .createSimple("org.jboss.resteasy.reactive.client.RestMultiResponse");
     public static final DotName COMPLETION_STAGE = DotName.createSimple(CompletionStage.class.getName());
     public static final DotName COMPLETABLE_FUTURE = DotName.createSimple(CompletableFuture.class.getName());
     public static final DotName PUBLISHER = DotName.createSimple(Publisher.class.getName());


### PR DESCRIPTION
With the introduction of `RestMultiResponse` in the REST Client, 
we can now extract the status code and the HTTP headers from a streamed response.

I first ran into this in Quarkus LangChain4j were
because of the lack of this feature, I needed to
resort to using the Vert.x HTTP Client