### PR TITLE
Fix Podman CI: Start the user-level Podman socket after purge and reinstall

### DIFF
--- a/.github/workflows/podman-build.yml
+++ b/.github/workflows/podman-build.yml
@@ -79,6 +79,7 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get -qq -y install podman
           sudo bash -c "echo -e '[engine]\nservice_timeout=0' >> /etc/containers/containers.conf"
+          systemctl --user start podman.socket
       # Runs a single command using the runners shell
       - name: Check podman
         run: docker version


### PR DESCRIPTION
The Podman CI has been broken for aaaages. See, for example: https://github.com/quarkusio/quarkus/actions/runs/26549289621/job/78207836335

In the medium-term, I'd like to get that build into the normal matrix build (with some clever guards to only run when needed), so we can get feedback on podman behaviour in our normal pull request and scheduled builds. But before we can do that, it needs to even run. 

Claude says 

>  The reinstall creates systemd service/socket symlinks (system-level, under /etc/systemd/system/), but doesn't start the user-level Podman socket. The
  DOCKER_HOST points to the user-level socket at /run/user/1001/podman/podman.sock, which requires the user-level podman.socket unit to be active. After
  the purge-and-reinstall, that socket unit isn't running, so docker version gets "Cannot connect to the Docker daemon."
>
> 
>   The fix would be to start the user-level Podman socket after reinstalling, e.g.:
> 
>   systemctl --user start podman.socket
> 
>   or use podman system service --time=0 & as a fallback to activate the socket. This is a known issue with the GitHub Actions Ubuntu 24.04 runner images —
>    the pre-installed podman has the user socket running, but after a purge/reinstall it's lost and needs explicit reactivation.

I couldn't confirm it was a known problem by googling, but manually starting the socket does indeed get the build past the 'check podman' stage, to the 'all our tests fail on podman' stage: https://github.com/holly-cummins/quarkus/actions/runs/26574888168/job/78291407048