### PR TITLE
Add Maven relocations for Panache Next to Quarkus Data rename

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -6700,6 +6700,16 @@
                 <artifactId>junit5-virtual-threads</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-hibernate-panache-next</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-hibernate-panache-next-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
             <!-- End of Relocations, please put new extensions above this list -->
 
         </dependencies>

--- a/relocations/generaterelocations.java
+++ b/relocations/generaterelocations.java
@@ -40,6 +40,11 @@ public class generaterelocations implements Runnable {
         RELOCATIONS.put("quarkus-junit5-mockito", junitJupiterRelocation);
         RELOCATIONS.put("quarkus-junit5-mockito-config", junitJupiterRelocation);
         RELOCATIONS.put("quarkus-junit5-component", junitJupiterRelocation);
+
+        Function<String, Relocation> panacheNextRelocation = a -> Relocation.ofArtifactId(a,
+                a.replace("quarkus-hibernate-panache-next", "quarkus-data-hibernate"), "3.37");
+        RELOCATIONS.put("quarkus-hibernate-panache-next", panacheNextRelocation);
+        RELOCATIONS.put("quarkus-hibernate-panache-next-deployment", panacheNextRelocation);
     }
 
     private static final String RELOCATION_POM_TEMPLATE = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + //

--- a/relocations/pom.xml
+++ b/relocations/pom.xml
@@ -29,6 +29,8 @@
         <module>quarkus-junit5-mockito</module>
         <module>quarkus-junit5-mockito-config</module>
         <module>junit5-virtual-threads</module>
+        <module>quarkus-hibernate-panache-next</module>
+        <module>quarkus-hibernate-panache-next-deployment</module>
     </modules>
 
 </project>

--- a/relocations/quarkus-hibernate-panache-next-deployment/pom.xml
+++ b/relocations/quarkus-hibernate-panache-next-deployment/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-relocations-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-hibernate-panache-next-deployment</artifactId>
+    <name>Quarkus - Relocations - quarkus-hibernate-panache-next-deployment</name>
+
+    <distributionManagement>
+        <relocation>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-data-hibernate-deployment</artifactId>
+            <version>${project.version}</version>
+            <message>Update the artifactId in your project build file. Refer to https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.37 for more information.</message>
+        </relocation>
+    </distributionManagement>
+</project>

--- a/relocations/quarkus-hibernate-panache-next/pom.xml
+++ b/relocations/quarkus-hibernate-panache-next/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-relocations-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-hibernate-panache-next</artifactId>
+    <name>Quarkus - Relocations - quarkus-hibernate-panache-next</name>
+
+    <distributionManagement>
+        <relocation>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-data-hibernate</artifactId>
+            <version>${project.version}</version>
+            <message>Update the artifactId in your project build file. Refer to https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.37 for more information.</message>
+        </relocation>
+    </distributionManagement>
+</project>


### PR DESCRIPTION
## Summary

- Add relocation POMs for `quarkus-hibernate-panache-next` -> `quarkus-data-hibernate` and `quarkus-hibernate-panache-next-deployment` -> `quarkus-data-hibernate-deployment`
- Add relocation entries to the BOM
- Generated using `relocations/generaterelocations.java`

Companion PR on quarkus-updates: https://github.com/quarkusio/quarkus-updates/pull/476