### PR TITLE
Reworked paging in Quarkus Data

### DIFF
--- a/extensions/data/hibernate/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/PagingTest.java
+++ b/extensions/data/hibernate/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/PagingTest.java
@@ -2,6 +2,8 @@ package io.quarkus.hibernate.panache.deployment.test;
 
 import java.util.List;
 
+import jakarta.data.Order;
+import jakarta.data.Sort;
 import jakarta.transaction.Transactional;
 
 import org.junit.jupiter.api.Test;
@@ -33,7 +35,7 @@ public class PagingTest {
     void cursorPage() {
         PanacheBlockingQuery<MyEntity> query = MyEntity_.managedBlocking().findAll();
 
-        List<MyEntity> list = query.paging().cursored(0, 10).list();
+        List<MyEntity> list = query.paging().cursored(0, 10, Order.by(Sort.asc("foo"))).list();
         while (query.paging().hasNext()) {
             list = query.paging().next().list();
         }

--- a/extensions/data/hibernate/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/PagingTest.java
+++ b/extensions/data/hibernate/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/PagingTest.java
@@ -330,7 +330,7 @@ public class PagingTest {
 
     @Transactional
     void noPaging() {
-        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+        PanacheBlockingQuery<MyEntity> query = repo.findAll(_MyEntity.foo.asc());
 
         List<MyEntity> all = query.list();
         assertThat(all).hasSize(25);

--- a/extensions/data/hibernate/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/PagingTest.java
+++ b/extensions/data/hibernate/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/PagingTest.java
@@ -33,9 +33,9 @@ public class PagingTest {
 
     @Transactional
     void cursorPage() {
-        PanacheBlockingQuery<MyEntity> query = MyEntity_.managedBlocking().findAll();
+        PanacheBlockingQuery<MyEntity> query = MyEntity_.managedBlocking().findAll(Order.by(Sort.asc("foo")));
 
-        List<MyEntity> list = query.paging().cursored(0, 10, Order.by(Sort.asc("foo"))).list();
+        List<MyEntity> list = query.paging().cursored(0, 10).list();
         while (query.paging().hasNext()) {
             list = query.paging().next().list();
         }

--- a/extensions/data/hibernate/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/PagingTest.java
+++ b/extensions/data/hibernate/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/PagingTest.java
@@ -1,9 +1,14 @@
 package io.quarkus.hibernate.panache.deployment.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.util.List;
 
+import jakarta.data.Limit;
 import jakarta.data.Order;
-import jakarta.data.Sort;
+import jakarta.data.page.PageRequest;
+import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 
 import org.junit.jupiter.api.Test;
@@ -18,38 +23,365 @@ public class PagingTest {
     static QuarkusExtensionTest runner = new QuarkusExtensionTest()
             .withApplicationRoot((jar) -> jar
                     .addAsResource("application-test.properties", "application.properties")
-                    .addClasses(MyEntity.class, MyEntity_.class, MyEntity_.ManagedBlockingQueries_.class,
-                            MyEntity_.FindOnlyRepo_.class));
+                    .addClasses(MyEntity.class, MyEntity_.class, _MyEntity.class,
+                            MyEntity_.ManagedBlockingQueries_.class, MyEntity_.FindOnlyRepo_.class));
+
+    @Inject
+    MyEntity.ManagedBlockingQueries repo;
 
     @Transactional
-    void offsetPage() {
-        PanacheBlockingQuery<MyEntity> query = MyEntity_.managedBlocking().findAll();
-
-        List<MyEntity> list = query.paging().offset(0, 10).list();
-        while (query.paging().hasNext()) {
-            list = query.paging().next().list();
+    void createEntities() {
+        repo.deleteAll();
+        for (int i = 0; i < 25; i++) {
+            MyEntity entity = new MyEntity();
+            entity.foo = "foo" + String.format("%02d", i);
+            entity.bar = "bar" + (24 - i);
+            entity.persist();
         }
     }
 
-    @Transactional
-    void cursorPage() {
-        PanacheBlockingQuery<MyEntity> query = MyEntity_.managedBlocking().findAll(Order.by(Sort.asc("foo")));
+    // Offset-based paging
 
-        List<MyEntity> list = query.paging().cursored(0, 10).list();
-        while (query.paging().hasNext()) {
-            list = query.paging().next().list();
-        }
+    @Transactional
+    void offsetPageBasic() {
+        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+
+        List<MyEntity> page0 = query.pages().page(0, 10).list();
+        assertThat(page0).hasSize(10);
+        assertThat(page0.get(0).foo).isEqualTo("foo00");
+        assertThat(page0.get(9).foo).isEqualTo("foo09");
+
+        List<MyEntity> page1 = query.pages().page(1, 10).list();
+        assertThat(page1).hasSize(10);
+        assertThat(page1.get(0).foo).isEqualTo("foo10");
+
+        List<MyEntity> page2 = query.pages().page(2, 10).list();
+        assertThat(page2).hasSize(5);
+        assertThat(page2.get(0).foo).isEqualTo("foo20");
     }
 
     @Transactional
-    void limitPage() {
-        PanacheBlockingQuery<MyEntity> query = MyEntity_.managedBlocking().findAll();
+    void offsetPageNavigation() {
+        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
 
-        List<MyEntity> list = query.limiting().limit(10).list();
+        query.pages().page(0, 10);
+        List<MyEntity> page0 = query.list();
+        assertThat(page0).hasSize(10);
+        assertThat(query.pages().hasNext()).isTrue();
+        assertThat(query.pages().hasPrevious()).isFalse();
+
+        query.pages().next();
+        List<MyEntity> page1 = query.list();
+        assertThat(page1).hasSize(10);
+        assertThat(page1.get(0).foo).isEqualTo("foo10");
+        assertThat(query.pages().hasNext()).isTrue();
+        assertThat(query.pages().hasPrevious()).isTrue();
+
+        query.pages().next();
+        List<MyEntity> page2 = query.list();
+        assertThat(page2).hasSize(5);
+        assertThat(query.pages().hasNext()).isFalse();
+        assertThat(query.pages().hasPrevious()).isTrue();
+
+        query.pages().previous();
+        List<MyEntity> back = query.list();
+        assertThat(back).hasSize(10);
+        assertThat(back.get(0).foo).isEqualTo("foo10");
+
+        query.pages().first();
+        List<MyEntity> first = query.list();
+        assertThat(first.get(0).foo).isEqualTo("foo00");
+
+        query.pages().last();
+        List<MyEntity> last = query.list();
+        assertThat(last.get(0).foo).isEqualTo("foo20");
+        assertThat(last).hasSize(5);
+    }
+
+    @Transactional
+    void offsetPageCount() {
+        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+
+        query.pages().page(0, 10);
+        assertThat(query.pages().count()).isEqualTo(3L);
+        assertThat(query.count()).isEqualTo(25L);
+    }
+
+    @Transactional
+    void offsetPageIterateAll() {
+        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+
+        int totalResults = 0;
+        List<MyEntity> list = query.pages().page(0, 10).list();
+        totalResults += list.size();
+        while (query.pages().hasNext()) {
+            list = query.pages().next().list();
+            totalResults += list.size();
+        }
+        assertThat(totalResults).isEqualTo(25);
+    }
+
+    // Cursor-based paging
+
+    @Transactional
+    void cursorPageBasic() {
+        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+
+        List<MyEntity> page0 = query.pages().cursor(0, 10).list();
+        assertThat(page0).hasSize(10);
+        assertThat(page0.get(0).foo).isEqualTo("foo00");
+        assertThat(page0.get(9).foo).isEqualTo("foo09");
+    }
+
+    @Transactional
+    void cursorPageNavigation() {
+        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+
+        List<MyEntity> page0 = query.pages().cursor(0, 10).list();
+        assertThat(page0).hasSize(10);
+        assertThat(query.pages().hasNext()).isTrue();
+        assertThat(query.pages().hasPrevious()).isFalse();
+
+        List<MyEntity> page1 = query.pages().next().list();
+        assertThat(page1).hasSize(10);
+        assertThat(page1.get(0).foo).isEqualTo("foo10");
+        assertThat(query.pages().hasNext()).isTrue();
+        assertThat(query.pages().hasPrevious()).isTrue();
+
+        List<MyEntity> page2 = query.pages().next().list();
+        assertThat(page2).hasSize(5);
+        assertThat(query.pages().hasNext()).isFalse();
+        assertThat(query.pages().hasPrevious()).isTrue();
+
+        List<MyEntity> backToPage1 = query.pages().previous().list();
+        assertThat(backToPage1).hasSize(10);
+        assertThat(backToPage1.get(0).foo).isEqualTo("foo10");
+
+        List<MyEntity> first = query.pages().first().list();
+        assertThat(first).hasSize(10);
+        assertThat(first.get(0).foo).isEqualTo("foo00");
+    }
+
+    @Transactional
+    void cursorPageIterateAll() {
+        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+
+        int totalResults = 0;
+        List<MyEntity> list = query.pages().cursor(0, 10).list();
+        totalResults += list.size();
+        while (query.pages().hasNext()) {
+            list = query.pages().next().list();
+            totalResults += list.size();
+        }
+        assertThat(totalResults).isEqualTo(25);
+    }
+
+    @Transactional
+    void cursorPageWithoutSortThrows() {
+        PanacheBlockingQuery<MyEntity> query = repo.findAll();
+
+        assertThatThrownBy(() -> query.pages().cursor(0, 10))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("sort");
+    }
+
+    @Transactional
+    void cursorPageLastThrows() {
+        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+
+        query.pages().cursor(0, 10).list();
+        assertThatThrownBy(() -> query.pages().last())
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    // Limiting
+
+    @Transactional
+    void limitBasic() {
+        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+
+        List<MyEntity> list = query.limits().limit(10).list();
+        assertThat(list).hasSize(10);
+        assertThat(list.get(0).foo).isEqualTo("foo00");
+        assertThat(list.get(9).foo).isEqualTo("foo09");
+    }
+
+    @Transactional
+    void limitWithStartOffset() {
+        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+
+        List<MyEntity> list = query.limits().limit(5, 10).list();
+        assertThat(list).hasSize(10);
+        assertThat(list.get(0).foo).isEqualTo("foo05");
+    }
+
+    @Transactional
+    void limitRange() {
+        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+
+        List<MyEntity> list = query.limits().range(5, 14).list();
+        assertThat(list).hasSize(10);
+        assertThat(list.get(0).foo).isEqualTo("foo05");
+        assertThat(list.get(9).foo).isEqualTo("foo14");
+    }
+
+    @Transactional
+    void limitAll() {
+        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+
+        List<MyEntity> list = query.limits().limit(100).list();
+        assertThat(list).hasSize(25);
+    }
+
+    @Transactional
+    void limitZeroThrows() {
+        PanacheBlockingQuery<MyEntity> query = repo.findAll();
+
+        assertThatThrownBy(() -> query.limits().limit(0))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Transactional
+    void limitFrom() {
+        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+
+        List<MyEntity> list = query.limits().limitFrom(5).list();
+        assertThat(list).hasSize(10);
+        assertThat(list.get(0).foo).isEqualTo("foo05");
+        assertThat(list.get(9).foo).isEqualTo("foo14");
+    }
+
+    @Transactional
+    void limitFromBeyondEnd() {
+        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+
+        List<MyEntity> list = query.limits().limitFrom(20).list();
+        assertThat(list).hasSize(5);
+        assertThat(list.get(0).foo).isEqualTo("foo20");
+    }
+
+    @Transactional
+    void limitWithJakartaLimit() {
+        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+
+        List<MyEntity> list = query.limits().limit(Limit.of(10)).list();
+        assertThat(list).hasSize(10);
+        assertThat(list.get(0).foo).isEqualTo("foo00");
+        assertThat(list.get(9).foo).isEqualTo("foo09");
+    }
+
+    @Transactional
+    void limitWithJakartaLimitRange() {
+        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+
+        List<MyEntity> list = query.limits().limit(Limit.range(6, 15)).list();
+        assertThat(list).hasSize(10);
+        assertThat(list.get(0).foo).isEqualTo("foo05");
+        assertThat(list.get(9).foo).isEqualTo("foo14");
+    }
+
+    @Transactional
+    void requestWithPageRequest() {
+        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+
+        List<MyEntity> page0 = query.pages().request(PageRequest.ofPage(1, 10, false)).list();
+        assertThat(page0).hasSize(10);
+        assertThat(page0.get(0).foo).isEqualTo("foo00");
+        assertThat(page0.get(9).foo).isEqualTo("foo09");
+
+        List<MyEntity> page1 = query.pages().request(PageRequest.ofPage(2, 10, false)).list();
+        assertThat(page1).hasSize(10);
+        assertThat(page1.get(0).foo).isEqualTo("foo10");
+
+        List<MyEntity> page2 = query.pages().request(PageRequest.ofPage(3, 10, false)).list();
+        assertThat(page2).hasSize(5);
+        assertThat(page2.get(0).foo).isEqualTo("foo20");
+    }
+
+    // Switching between paging modes
+
+    @Transactional
+    void switchFromOffsetToLimit() {
+        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+
+        query.pages().page(0, 10);
+        List<MyEntity> paged = query.list();
+        assertThat(paged).hasSize(10);
+
+        List<MyEntity> limited = query.limits().limit(5).list();
+        assertThat(limited).hasSize(5);
+        assertThat(limited.get(0).foo).isEqualTo("foo00");
+    }
+
+    @Transactional
+    void switchFromLimitToOffset() {
+        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+
+        query.limits().limit(5);
+        List<MyEntity> limited = query.list();
+        assertThat(limited).hasSize(5);
+
+        List<MyEntity> paged = query.pages().page(1, 10).list();
+        assertThat(paged).hasSize(10);
+        assertThat(paged.get(0).foo).isEqualTo("foo10");
+    }
+
+    // No paging/limiting (all results)
+
+    @Transactional
+    void noPaging() {
+        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+
+        List<MyEntity> all = query.list();
+        assertThat(all).hasSize(25);
+        assertThat(all.get(0).foo).isEqualTo("foo00");
+        assertThat(all.get(24).foo).isEqualTo("foo24");
+    }
+
+    @Transactional
+    void clear() {
+        repo.deleteAll();
     }
 
     @Test
-    void testRepositories() {
+    void testPaging() {
+        createEntities();
+
+        // No paging
+        noPaging();
+
+        // Offset-based paging
+        offsetPageBasic();
+        offsetPageNavigation();
+        offsetPageCount();
+        offsetPageIterateAll();
+
+        // Cursor-based paging
+        cursorPageBasic();
+        cursorPageNavigation();
+        cursorPageIterateAll();
+        cursorPageWithoutSortThrows();
+        cursorPageLastThrows();
+
+        // Limiting
+        limitBasic();
+        limitWithStartOffset();
+        limitRange();
+        limitAll();
+        limitZeroThrows();
+        limitFrom();
+        limitFromBeyondEnd();
+        limitWithJakartaLimit();
+        limitWithJakartaLimitRange();
+
+        // PageRequest
+        requestWithPageRequest();
+
+        // Switching modes
+        switchFromOffsetToLimit();
+        switchFromLimitToOffset();
+
+        clear();
     }
 
 }

--- a/extensions/data/hibernate/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/PagingTest.java
+++ b/extensions/data/hibernate/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/PagingTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.hibernate.panache.deployment.test;
+
+import java.util.List;
+
+import jakarta.transaction.Transactional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.panache.blocking.PanacheBlockingQuery;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class PagingTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("application-test.properties", "application.properties")
+                    .addClasses(MyEntity.class, MyEntity_.class, MyEntity_.ManagedBlockingQueries_.class,
+                            MyEntity_.FindOnlyRepo_.class));
+
+    @Transactional
+    void offsetPage() {
+        PanacheBlockingQuery<MyEntity> query = MyEntity_.managedBlocking().findAll();
+
+        List<MyEntity> list = query.paging().offset(0, 10).list();
+        while (query.paging().hasNext()) {
+            list = query.paging().next().list();
+        }
+    }
+
+    @Transactional
+    void cursorPage() {
+        PanacheBlockingQuery<MyEntity> query = MyEntity_.managedBlocking().findAll();
+
+        List<MyEntity> list = query.paging().cursored(0, 10).list();
+        while (query.paging().hasNext()) {
+            list = query.paging().next().list();
+        }
+    }
+
+    @Transactional
+    void limitPage() {
+        PanacheBlockingQuery<MyEntity> query = MyEntity_.managedBlocking().findAll();
+
+        List<MyEntity> list = query.limiting().limit(10).list();
+    }
+
+    @Test
+    void testRepositories() {
+    }
+
+}

--- a/extensions/data/hibernate/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/ReactivePagingTest.java
+++ b/extensions/data/hibernate/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/ReactivePagingTest.java
@@ -1,0 +1,386 @@
+package io.quarkus.hibernate.panache.deployment.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import jakarta.data.Limit;
+import jakarta.data.Order;
+import jakarta.data.page.PageRequest;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.panache.reactive.PanacheReactiveQuery;
+import io.quarkus.hibernate.reactive.panache.common.WithTransaction;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.vertx.RunOnVertxContext;
+import io.quarkus.test.vertx.UniAsserter;
+import io.smallrye.mutiny.Uni;
+
+public class ReactivePagingTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("application-test.properties", "application.properties")
+                    .addClasses(MyReactiveEntity.class, MyReactiveEntity_.class, _MyReactiveEntity.class,
+                            MyReactiveEntity_.ManagedReactiveQueries_.class));
+
+    @Inject
+    MyReactiveEntity.ManagedReactiveQueries repo;
+
+    @WithTransaction
+    Uni<Void> createEntities() {
+        return repo.deleteAll().flatMap(v -> {
+            Uni<Void> chain = Uni.createFrom().voidItem();
+            for (int i = 0; i < 25; i++) {
+                MyReactiveEntity entity = new MyReactiveEntity();
+                entity.foo = "foo" + String.format("%02d", i);
+                entity.bar = "bar" + (24 - i);
+                chain = chain.flatMap(ignored -> entity.persist().replaceWithVoid());
+            }
+            return chain;
+        });
+    }
+
+    @WithTransaction
+    Uni<Void> clear() {
+        return repo.deleteAll().replaceWithVoid();
+    }
+
+    // Offset-based paging
+
+    @WithTransaction
+    Uni<Void> offsetPageBasic() {
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(Order.by(_MyReactiveEntity.foo.asc()));
+
+        return query.pages().page(0, 10).list().flatMap(page0 -> {
+            assertThat(page0).hasSize(10);
+            assertThat(page0.get(0).foo).isEqualTo("foo00");
+            assertThat(page0.get(9).foo).isEqualTo("foo09");
+
+            return query.pages().page(1, 10).list();
+        }).flatMap(page1 -> {
+            assertThat(page1).hasSize(10);
+            assertThat(page1.get(0).foo).isEqualTo("foo10");
+
+            return query.pages().page(2, 10).list();
+        }).map(page2 -> {
+            assertThat(page2).hasSize(5);
+            assertThat(page2.get(0).foo).isEqualTo("foo20");
+            return null;
+        });
+    }
+
+    @WithTransaction
+    Uni<Void> offsetPageNavigation() {
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(Order.by(_MyReactiveEntity.foo.asc()));
+
+        query.pages().page(0, 10);
+        return query.list().flatMap(page0 -> {
+            assertThat(page0).hasSize(10);
+            return query.pages().hasNext();
+        }).flatMap(hasNext -> {
+            assertThat(hasNext).isTrue();
+            return query.pages().hasPrevious();
+        }).flatMap(hasPrev -> {
+            assertThat(hasPrev).isFalse();
+
+            query.pages().next();
+            return query.list();
+        }).flatMap(page1 -> {
+            assertThat(page1).hasSize(10);
+            assertThat(page1.get(0).foo).isEqualTo("foo10");
+
+            query.pages().next();
+            return query.list();
+        }).flatMap(page2 -> {
+            assertThat(page2).hasSize(5);
+            return query.pages().hasNext();
+        }).flatMap(hasNext -> {
+            assertThat(hasNext).isFalse();
+
+            query.pages().previous();
+            return query.list();
+        }).flatMap(back -> {
+            assertThat(back).hasSize(10);
+            assertThat(back.get(0).foo).isEqualTo("foo10");
+
+            query.pages().first();
+            return query.list();
+        }).flatMap(first -> {
+            assertThat(first.get(0).foo).isEqualTo("foo00");
+
+            return query.pages().last();
+        }).flatMap(q -> q.list()).map(last -> {
+            assertThat(last.get(0).foo).isEqualTo("foo20");
+            assertThat(last).hasSize(5);
+            return null;
+        });
+    }
+
+    @WithTransaction
+    Uni<Void> offsetPageCount() {
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(Order.by(_MyReactiveEntity.foo.asc()));
+
+        query.pages().page(0, 10);
+        return query.pages().count().flatMap(pageCount -> {
+            assertThat(pageCount).isEqualTo(3L);
+            return query.count();
+        }).map(totalCount -> {
+            assertThat(totalCount).isEqualTo(25L);
+            return null;
+        });
+    }
+
+    @WithTransaction
+    Uni<Void> offsetPageIterateAll() {
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(Order.by(_MyReactiveEntity.foo.asc()));
+
+        int[] totalResults = { 0 };
+        return query.pages().page(0, 10).list().flatMap(list -> {
+            totalResults[0] += list.size();
+            return iteratePages(query, totalResults);
+        }).map(v -> {
+            assertThat(totalResults[0]).isEqualTo(25);
+            return null;
+        });
+    }
+
+    private Uni<Void> iteratePages(PanacheReactiveQuery<MyReactiveEntity> query, int[] totalResults) {
+        return query.pages().hasNext().flatMap(hasNext -> {
+            if (!hasNext) {
+                return Uni.createFrom().voidItem();
+            }
+            query.pages().next();
+            return query.list().flatMap(list -> {
+                totalResults[0] += list.size();
+                return iteratePages(query, totalResults);
+            });
+        });
+    }
+
+    // Cursor-based paging (unsupported in Hibernate Reactive)
+
+    @WithTransaction
+    Uni<Void> cursorPageThrows() {
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(Order.by(_MyReactiveEntity.foo.asc()));
+
+        assertThatThrownBy(() -> query.pages().cursor(0, 10))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("Hibernate Reactive");
+        return Uni.createFrom().voidItem();
+    }
+
+    // Limiting
+
+    @WithTransaction
+    Uni<Void> limitBasic() {
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(Order.by(_MyReactiveEntity.foo.asc()));
+
+        return query.limits().limit(10).list().map(list -> {
+            assertThat(list).hasSize(10);
+            assertThat(list.get(0).foo).isEqualTo("foo00");
+            assertThat(list.get(9).foo).isEqualTo("foo09");
+            return null;
+        });
+    }
+
+    @WithTransaction
+    Uni<Void> limitWithStartOffset() {
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(Order.by(_MyReactiveEntity.foo.asc()));
+
+        return query.limits().limit(5, 10).list().map(list -> {
+            assertThat(list).hasSize(10);
+            assertThat(list.get(0).foo).isEqualTo("foo05");
+            return null;
+        });
+    }
+
+    @WithTransaction
+    Uni<Void> limitRange() {
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(Order.by(_MyReactiveEntity.foo.asc()));
+
+        return query.limits().range(5, 14).list().map(list -> {
+            assertThat(list).hasSize(10);
+            assertThat(list.get(0).foo).isEqualTo("foo05");
+            assertThat(list.get(9).foo).isEqualTo("foo14");
+            return null;
+        });
+    }
+
+    @WithTransaction
+    Uni<Void> limitAll() {
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(Order.by(_MyReactiveEntity.foo.asc()));
+
+        return query.limits().limit(100).list().map(list -> {
+            assertThat(list).hasSize(25);
+            return null;
+        });
+    }
+
+    @WithTransaction
+    Uni<Void> limitZeroThrows() {
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll();
+
+        assertThatThrownBy(() -> query.limits().limit(0))
+                .isInstanceOf(IllegalArgumentException.class);
+        return Uni.createFrom().voidItem();
+    }
+
+    @WithTransaction
+    Uni<Void> limitFrom() {
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(Order.by(_MyReactiveEntity.foo.asc()));
+
+        return query.limits().limitFrom(5).list().map(list -> {
+            assertThat(list).hasSize(10);
+            assertThat(list.get(0).foo).isEqualTo("foo05");
+            assertThat(list.get(9).foo).isEqualTo("foo14");
+            return null;
+        });
+    }
+
+    @WithTransaction
+    Uni<Void> limitFromBeyondEnd() {
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(Order.by(_MyReactiveEntity.foo.asc()));
+
+        return query.limits().limitFrom(20).list().map(list -> {
+            assertThat(list).hasSize(5);
+            assertThat(list.get(0).foo).isEqualTo("foo20");
+            return null;
+        });
+    }
+
+    @WithTransaction
+    Uni<Void> limitWithJakartaLimit() {
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(Order.by(_MyReactiveEntity.foo.asc()));
+
+        return query.limits().limit(Limit.of(10)).list().map(list -> {
+            assertThat(list).hasSize(10);
+            assertThat(list.get(0).foo).isEqualTo("foo00");
+            assertThat(list.get(9).foo).isEqualTo("foo09");
+            return null;
+        });
+    }
+
+    @WithTransaction
+    Uni<Void> limitWithJakartaLimitRange() {
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(Order.by(_MyReactiveEntity.foo.asc()));
+
+        return query.limits().limit(Limit.range(6, 15)).list().map(list -> {
+            assertThat(list).hasSize(10);
+            assertThat(list.get(0).foo).isEqualTo("foo05");
+            assertThat(list.get(9).foo).isEqualTo("foo14");
+            return null;
+        });
+    }
+
+    @WithTransaction
+    Uni<Void> requestWithPageRequest() {
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(Order.by(_MyReactiveEntity.foo.asc()));
+
+        return query.pages().request(PageRequest.ofPage(1, 10, false)).list().flatMap(page0 -> {
+            assertThat(page0).hasSize(10);
+            assertThat(page0.get(0).foo).isEqualTo("foo00");
+            assertThat(page0.get(9).foo).isEqualTo("foo09");
+
+            return query.pages().request(PageRequest.ofPage(2, 10, false)).list();
+        }).flatMap(page1 -> {
+            assertThat(page1).hasSize(10);
+            assertThat(page1.get(0).foo).isEqualTo("foo10");
+
+            return query.pages().request(PageRequest.ofPage(3, 10, false)).list();
+        }).map(page2 -> {
+            assertThat(page2).hasSize(5);
+            assertThat(page2.get(0).foo).isEqualTo("foo20");
+            return null;
+        });
+    }
+
+    // Switching between paging modes
+
+    @WithTransaction
+    Uni<Void> switchFromOffsetToLimit() {
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(Order.by(_MyReactiveEntity.foo.asc()));
+
+        query.pages().page(0, 10);
+        return query.list().flatMap(paged -> {
+            assertThat(paged).hasSize(10);
+
+            return query.limits().limit(5).list();
+        }).map(limited -> {
+            assertThat(limited).hasSize(5);
+            assertThat(limited.get(0).foo).isEqualTo("foo00");
+            return null;
+        });
+    }
+
+    @WithTransaction
+    Uni<Void> switchFromLimitToOffset() {
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(Order.by(_MyReactiveEntity.foo.asc()));
+
+        return query.limits().limit(5).list().flatMap(limited -> {
+            assertThat(limited).hasSize(5);
+
+            return query.pages().page(1, 10).list();
+        }).map(paged -> {
+            assertThat(paged).hasSize(10);
+            assertThat(paged.get(0).foo).isEqualTo("foo10");
+            return null;
+        });
+    }
+
+    // No paging/limiting (all results)
+
+    @WithTransaction
+    Uni<Void> noPaging() {
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(Order.by(_MyReactiveEntity.foo.asc()));
+
+        return query.list().map(all -> {
+            assertThat(all).hasSize(25);
+            assertThat(all.get(0).foo).isEqualTo("foo00");
+            assertThat(all.get(24).foo).isEqualTo("foo24");
+            return null;
+        });
+    }
+
+    @RunOnVertxContext
+    @Test
+    void testPaging(UniAsserter asserter) {
+        asserter.execute(() -> createEntities());
+
+        // No paging
+        asserter.execute(() -> noPaging());
+
+        // Offset-based paging
+        asserter.execute(() -> offsetPageBasic());
+        asserter.execute(() -> offsetPageNavigation());
+        asserter.execute(() -> offsetPageCount());
+        asserter.execute(() -> offsetPageIterateAll());
+
+        // Cursor-based paging (unsupported in Hibernate Reactive)
+        asserter.execute(() -> cursorPageThrows());
+
+        // Limiting
+        asserter.execute(() -> limitBasic());
+        asserter.execute(() -> limitWithStartOffset());
+        asserter.execute(() -> limitRange());
+        asserter.execute(() -> limitAll());
+        asserter.execute(() -> limitZeroThrows());
+        asserter.execute(() -> limitFrom());
+        asserter.execute(() -> limitFromBeyondEnd());
+        asserter.execute(() -> limitWithJakartaLimit());
+        asserter.execute(() -> limitWithJakartaLimitRange());
+
+        // PageRequest
+        asserter.execute(() -> requestWithPageRequest());
+
+        // Switching modes
+        asserter.execute(() -> switchFromOffsetToLimit());
+        asserter.execute(() -> switchFromLimitToOffset());
+
+        asserter.execute(() -> clear());
+    }
+
+}

--- a/extensions/data/hibernate/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/ReactivePagingTest.java
+++ b/extensions/data/hibernate/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/ReactivePagingTest.java
@@ -335,7 +335,7 @@ public class ReactivePagingTest {
 
     @WithTransaction
     Uni<Void> noPaging() {
-        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(Order.by(_MyReactiveEntity.foo.asc()));
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(_MyReactiveEntity.foo.asc());
 
         return query.list().map(all -> {
             assertThat(all).hasSize(25);

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/PanacheQuery.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/PanacheQuery.java
@@ -140,15 +140,15 @@ public interface PanacheQuery<Query extends PanacheQuery<Query, Entity, EntityLi
 
         /**
          * Sets the current page using cursor-based pagination (keyset pagination).
-         * The provided {@link jakarta.data.Order} specifies the sort criteria used to define
-         * the keyset columns.
+         * The sort criteria from the original query (via {@code find()} or {@code findAll()})
+         * are used to define the keyset columns.
          *
          * @param pageIndex the 0-based page index
          * @param pageSize the number of results per page
-         * @param order the sort criteria for keyset pagination
          * @return this query, modified
+         * @throws UnsupportedOperationException if no sort criteria were provided when creating the query
          */
-        Query cursor(long pageIndex, int pageSize, jakarta.data.Order<?> order);
+        Query cursor(long pageIndex, int pageSize);
 
         /**
          * Moves to the next page.

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/PanacheQuery.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/PanacheQuery.java
@@ -139,13 +139,16 @@ public interface PanacheQuery<Query extends PanacheQuery<Query, Entity, EntityLi
         Query page(long pageIndex, int pageSize);
 
         /**
-         * Sets the current page using cursor-based pagination.
+         * Sets the current page using cursor-based pagination (keyset pagination).
+         * The provided {@link jakarta.data.Order} specifies the sort criteria used to define
+         * the keyset columns.
          *
          * @param pageIndex the 0-based page index
          * @param pageSize the number of results per page
+         * @param order the sort criteria for keyset pagination
          * @return this query, modified
          */
-        Query cursor(long pageIndex, int pageSize);
+        Query cursor(long pageIndex, int pageSize, jakarta.data.Order<?> order);
 
         /**
          * Moves to the next page.

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/PanacheQuery.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/PanacheQuery.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import jakarta.data.Limit;
+import jakarta.data.page.PageRequest;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.NoResultException;
 import jakarta.persistence.NonUniqueResultException;
@@ -26,116 +28,206 @@ import org.hibernate.query.Page;
  * @author Stéphane Épardaud
  * @param <Entity> The entity type being queried
  */
-public interface PanacheQuery<Entity, EntityList, Confirmation, Count> {
+public interface PanacheQuery<Query extends PanacheQuery<Query, Entity, EntityList, QueryAfterCount, Confirmation, Count>, Entity, EntityList, QueryAfterCount, Confirmation, Count> {
+
+    /**
+     * Provides operations for limiting the number of results returned by a query using absolute row indices.
+     * <p>
+     * Limiting and paging are mutually exclusive: setting a limit clears any current page, and vice versa.
+     * Use {@link Pages} if you need page-based navigation instead.
+     *
+     * @param <Query> the query type, so that fluent methods return the correct query type
+     */
+    public interface Limits<Query extends PanacheQuery<?, ?, ?, ?, ?, ?>> {
+
+        /**
+         * Returns the current limit as a Jakarta Data {@link Limit}.
+         *
+         * @return the current limit
+         * @throws UnsupportedOperationException if no limit or range has been set
+         */
+        // FIXME: do we group these appart in a Ranging interface?
+        Limit limit();
+
+        /**
+         * Sets the current limit from a Jakarta Data {@link Limit}.
+         *
+         * @param limit the limit to apply
+         * @return this query, modified
+         */
+        Query limit(Limit limit);
+
+        /**
+         * Limits the query to return at most {@code max} results, starting from the first result (index 0).
+         *
+         * @param max the maximum number of results to return
+         * @return this query, modified
+         * @throws IllegalArgumentException if {@code max} is 0
+         */
+        // FIXME: do we add these shortcuts or rely on Limit?
+        Query limit(int max);
+
+        /**
+         * Limits the query to return at most {@code max} results, starting from the given row index.
+         *
+         * @param start the 0-based index of the first result to return
+         * @param max the maximum number of results to return
+         * @return this query, modified
+         */
+        Query limit(long start, int max);
+
+        /**
+         * Limits the query to start at the given row index, using a default maximum number of results.
+         *
+         * @param start the 0-based index of the first result to return
+         * @return this query, modified
+         */
+        Query limitFrom(long start);
+
+        /**
+         * Sets a fixed range of results to return, using inclusive start and end row indices.
+         * Unlike paging, a range is fixed and does not support subsequent navigation.
+         *
+         * @param start the 0-based index of the first result to return (inclusive)
+         * @param end the 0-based index of the last result to return (inclusive)
+         * @return this query, modified
+         */
+        Query range(long start, long end);
+    }
+
+    /**
+     * Provides operations for page-based navigation over query results.
+     * <p>
+     * Paging supports both offset-based and cursor-based pagination modes.
+     * Paging and limiting are mutually exclusive: setting a page clears any current limit, and vice versa.
+     * <p>
+     * A page must be set (via {@link #request(PageRequest)}, {@link #page(long, int)}, or
+     * {@link #cursor(long, int)}) before calling navigation or inspection methods.
+     *
+     * @param <Query> the query type, so that fluent methods return the correct query type
+     * @param <QueryAfterCount> the return type for operations that require a count query (may be async)
+     * @param <Confirmation> the return type for boolean checks (may be async)
+     * @param <Count> the return type for count values (may be async)
+     */
+    public interface Pages<Query extends PanacheQuery<?, ?, ?, ?, ?, ?>, QueryAfterCount, Confirmation, Count> {
+
+        /**
+         * Returns the current page as a Jakarta Data {@link PageRequest}.
+         *
+         * @return the current page request
+         * @throws UnsupportedOperationException if no page has been set
+         */
+        // FIXME: or page()?
+        PageRequest request();
+
+        /**
+         * Sets the current page from a Jakarta Data {@link PageRequest}.
+         *
+         * @param request the page request to apply
+         * @return this query, modified
+         */
+        Query request(PageRequest request);
+
+        /**
+         * Sets the current page using offset-based pagination.
+         *
+         * @param pageIndex the 0-based page index
+         * @param pageSize the number of results per page
+         * @return this query, modified
+         */
+        // FIXME: same question about shortcut methods
+        Query page(long pageIndex, int pageSize);
+
+        /**
+         * Sets the current page using cursor-based pagination.
+         *
+         * @param pageIndex the 0-based page index
+         * @param pageSize the number of results per page
+         * @return this query, modified
+         */
+        Query cursor(long pageIndex, int pageSize);
+
+        /**
+         * Moves to the next page.
+         *
+         * @return this query, modified
+         * @throws UnsupportedOperationException if no page has been set
+         */
+        // FIXME: harmonize with PageRequest?
+        Query next();
+
+        /**
+         * Moves to the previous page, or stays on the first page if already there.
+         *
+         * @return this query, modified
+         * @throws UnsupportedOperationException if no page has been set
+         */
+        Query previous();
+
+        /**
+         * Moves to the first page.
+         *
+         * @return this query, modified
+         * @throws UnsupportedOperationException if no page has been set
+         */
+        Query first();
+
+        /**
+         * Moves to the last page. This requires reading the entity count.
+         *
+         * @return this query, modified (may be async if the query is reactive)
+         * @throws UnsupportedOperationException if no page has been set
+         * @see #count()
+         */
+        QueryAfterCount last();
+
+        /**
+         * Returns true if there is another page to read after the current one.
+         * This requires reading the entity count.
+         *
+         * @return true if there is a next page (may be async if the query is reactive)
+         * @throws UnsupportedOperationException if no page has been set
+         * @see #hasPrevious()
+         * @see #count()
+         */
+        Confirmation hasNext();
+
+        /**
+         * Returns true if there is a page before the current one.
+         *
+         * @return true if there is a previous page (may be async if the query is reactive)
+         * @throws UnsupportedOperationException if no page has been set
+         * @see #hasNext()
+         */
+        Confirmation hasPrevious();
+
+        /**
+         * Returns the total number of pages, based on the current page size.
+         * This requires reading the entity count.
+         *
+         * @return the total number of pages (may be async if the query is reactive)
+         * @throws UnsupportedOperationException if no page has been set
+         */
+        Count count();
+    }
+
+    /**
+     * Returns the {@link Limits} interface for this query, which provides operations to
+     * restrict results using absolute row indices and ranges.
+     *
+     * @return the limiting interface for this query
+     */
+    Limits<Query> limits();
+
+    /**
+     * Returns the {@link Pages} interface for this query, which provides operations for
+     * page-based navigation over query results.
+     *
+     * @return the paging interface for this query
+     */
+    Pages<Query, QueryAfterCount, Confirmation, Count> pages();
 
     // Builder
-
-    /**
-     * Sets the current page.
-     *
-     * @param page the new page
-     * @return this query, modified
-     * @see #page(int, int)
-     * @see #page()
-     */
-    public PanacheQuery<Entity, EntityList, Confirmation, Count> page(Page page);
-
-    /**
-     * Sets the current page.
-     *
-     * @param pageIndex the page index (0-based)
-     * @param pageSize the page size
-     * @return this query, modified
-     * @see #page(Page)
-     * @see #page()
-     */
-    public PanacheQuery<Entity, EntityList, Confirmation, Count> page(int pageIndex, int pageSize);
-
-    /**
-     * Sets the current page to the next page
-     *
-     * @return this query, modified
-     * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
-     * @see #previousPage()
-     */
-    public PanacheQuery<Entity, EntityList, Confirmation, Count> nextPage();
-
-    /**
-     * Sets the current page to the previous page (or the first page if there is no previous page)
-     *
-     * @return this query, modified
-     * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
-     * @see #nextPage()
-     */
-    public PanacheQuery<Entity, EntityList, Confirmation, Count> previousPage();
-
-    /**
-     * Sets the current page to the first page
-     *
-     * @return this query, modified
-     * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
-     * @see #lastPage()
-     */
-    public PanacheQuery<Entity, EntityList, Confirmation, Count> firstPage();
-
-    /**
-     * Sets the current page to the last page. This will cause reading of the entity count.
-     *
-     * @return this query, modified
-     * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
-     * @see #firstPage()
-     * @see #count()
-     */
-    public PanacheQuery<Entity, EntityList, Confirmation, Count> lastPage();
-
-    /**
-     * Returns true if there is another page to read after the current one.
-     * This will cause reading of the entity count.
-     *
-     * @return true if there is another page to read
-     * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
-     * @see #hasPreviousPage()
-     * @see #count()
-     */
-    public Confirmation hasNextPage();
-
-    /**
-     * Returns true if there is a page to read before the current one.
-     *
-     * @return true if there is a previous page to read
-     * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
-     * @see #hasNextPage()
-     */
-    public Confirmation hasPreviousPage();
-
-    /**
-     * Returns the total number of pages to be read using the current page size.
-     * This will cause reading of the entity count.
-     *
-     * @return the total number of pages to be read using the current page size.
-     * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
-     */
-    public Count pageCount();
-
-    /**
-     * Returns the current page.
-     *
-     * @return the current page
-     * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
-     * @see #page(Page)
-     * @see #page(int,int)
-     */
-    public Page page();
-
-    /**
-     * Switch the query to use a fixed range (start index - last index) instead of a page.
-     * As the range is fixed, subsequent pagination of the query is not possible.
-     *
-     * @param startIndex the index of the first element, starting at 0
-     * @param lastIndex the index of the last element
-     * @return this query, modified
-     */
-    public PanacheQuery<Entity, EntityList, Confirmation, Count> range(int startIndex, int lastIndex);
 
     /**
      * Define the locking strategy used for this query.
@@ -143,7 +235,7 @@ public interface PanacheQuery<Entity, EntityList, Confirmation, Count> {
      * @param lockModeType the locking strategy to be used for this query.
      * @return this query, modified
      */
-    public PanacheQuery<Entity, EntityList, Confirmation, Count> withLock(LockModeType lockModeType);
+    public Query withLock(LockModeType lockModeType);
 
     /**
      * Set a query property or hint on the underlying JPA Query.
@@ -152,7 +244,7 @@ public interface PanacheQuery<Entity, EntityList, Confirmation, Count> {
      * @param value value for the property or hint.
      * @return this query, modified
      */
-    public PanacheQuery<Entity, EntityList, Confirmation, Count> withHint(String hintName, Object value);
+    public Query withHint(String hintName, Object value);
 
     /**
      * <p>
@@ -168,7 +260,8 @@ public interface PanacheQuery<Entity, EntityList, Confirmation, Count> {
      * @param parameters The set of parameters for the filter, if the filter requires parameters
      * @return this query, modified
      */
-    public PanacheQuery<Entity, EntityList, Confirmation, Count> filter(String filterName, Map<String, Object> parameters);
+    public Query filter(String filterName,
+            Map<String, Object> parameters);
 
     /**
      * <p>
@@ -183,7 +276,7 @@ public interface PanacheQuery<Entity, EntityList, Confirmation, Count> {
      * @param filterName The name of the filter to enable
      * @return this query, modified
      */
-    public PanacheQuery<Entity, EntityList, Confirmation, Count> filter(String filterName);
+    public Query filter(String filterName);
 
     // Results
 

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/PanacheRepositoryQueries.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/PanacheRepositoryQueries.java
@@ -3,6 +3,7 @@ package io.quarkus.hibernate.panache;
 import java.util.Map;
 
 import jakarta.data.Order;
+import jakarta.data.Sort;
 import jakarta.persistence.LockModeType;
 
 public interface PanacheRepositoryQueries<EntityResult, EntityList, Query extends PanacheQuery<?, ?, ?, ?, ?, ?>, Count, Confirmation, Id> {
@@ -54,6 +55,19 @@ public interface PanacheRepositoryQueries<EntityResult, EntityList, Query extend
     Query find(String query, Order<?> order, Object... params);
 
     /**
+     * Find entities using a query and the given sort option, with optional indexed parameters.
+     * This is a shortcut for <code>find(query, Order.by(sort), params)</code>.
+     *
+     * @param query a {@link io.quarkus.hibernate.panache query string}
+     * @param sort the sort strategy to use
+     * @param params optional sequence of indexed parameters
+     * @return a new {@link PanacheQuery} instance for the given query
+     */
+    default Query find(String query, Sort<?> sort, Object... params) {
+        return find(query, Order.by(sort), params);
+    }
+
+    /**
      * Find entities using a query, with named parameters.
      *
      * @param query a {@link io.quarkus.hibernate.panache query string}
@@ -81,6 +95,19 @@ public interface PanacheRepositoryQueries<EntityResult, EntityList, Query extend
     Query find(String query, Order<?> order, Map<String, Object> params);
 
     /**
+     * Find entities using a query and the given sort option, with named parameters.
+     * This is a shortcut for <code>find(query, Order.by(sort), params)</code>.
+     *
+     * @param query a {@link io.quarkus.hibernate.panache query string}
+     * @param sort the sort strategy to use
+     * @param params {@link Map} of named parameters
+     * @return a new {@link PanacheQuery} instance for the given query
+     */
+    default Query find(String query, Sort<?> sort, Map<String, Object> params) {
+        return find(query, Order.by(sort), params);
+    }
+
+    /**
      * Find all entities of this type.
      *
      * @return a new {@link PanacheQuery} instance to find all entities of this type.
@@ -100,6 +127,17 @@ public interface PanacheRepositoryQueries<EntityResult, EntityList, Query extend
      * @see #streamAll(Order)
      */
     Query findAll(Order<?> order);
+
+    /**
+     * Find all entities of this type, in the given order.
+     * This is a shortcut for <code>findAll(Order.by(sort))</code>.
+     *
+     * @param sort the sort order to use
+     * @return a new {@link PanacheQuery} instance to find all entities of this type.
+     */
+    default Query findAll(Sort<?> sort) {
+        return findAll(Order.by(sort));
+    }
 
     /**
      * Find entities matching a query, with optional indexed parameters.
@@ -131,6 +169,19 @@ public interface PanacheRepositoryQueries<EntityResult, EntityList, Query extend
     EntityList list(String query, Order<?> order, Object... params);
 
     /**
+     * Find entities matching a query and the given sort option, with optional indexed parameters.
+     * This is a shortcut for <code>list(query, Order.by(sort), params)</code>.
+     *
+     * @param query a {@link io.quarkus.hibernate.panache query string}
+     * @param sort the sort strategy to use
+     * @param params optional sequence of indexed parameters
+     * @return a {@link List} containing all results, without paging
+     */
+    default EntityList list(String query, Sort<?> sort, Object... params) {
+        return list(query, Order.by(sort), params);
+    }
+
+    /**
      * Find entities matching a query, with named parameters.
      * This method is a shortcut for <code>find(query, params).list()</code>.
      *
@@ -160,6 +211,19 @@ public interface PanacheRepositoryQueries<EntityResult, EntityList, Query extend
     EntityList list(String query, Order<?> order, Map<String, Object> params);
 
     /**
+     * Find entities matching a query and the given sort option, with named parameters.
+     * This is a shortcut for <code>list(query, Order.by(sort), params)</code>.
+     *
+     * @param query a {@link io.quarkus.hibernate.panache query string}
+     * @param sort the sort strategy to use
+     * @param params {@link Map} of named parameters
+     * @return a {@link List} containing all results, without paging
+     */
+    default EntityList list(String query, Sort<?> sort, Map<String, Object> params) {
+        return list(query, Order.by(sort), params);
+    }
+
+    /**
      * Find all entities of this type.
      * This method is a shortcut for <code>findAll().list()</code>.
      *
@@ -181,6 +245,17 @@ public interface PanacheRepositoryQueries<EntityResult, EntityList, Query extend
      * @see #streamAll(Order)
      */
     EntityList listAll(Order<?> order);
+
+    /**
+     * Find all entities of this type, in the given order.
+     * This is a shortcut for <code>listAll(Order.by(sort))</code>.
+     *
+     * @param sort the sort order to use
+     * @return a {@link List} containing all results, without paging
+     */
+    default EntityList listAll(Sort<?> sort) {
+        return listAll(Order.by(sort));
+    }
 
     /**
      * Counts the number of this type of entity in the database.

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/PanacheRepositoryQueries.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/PanacheRepositoryQueries.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import jakarta.data.Order;
 import jakarta.persistence.LockModeType;
 
-public interface PanacheRepositoryQueries<EntityResult, EntityList, Query extends PanacheQuery<?, ?, ?, ?>, Count, Confirmation, Id> {
+public interface PanacheRepositoryQueries<EntityResult, EntityList, Query extends PanacheQuery<?, ?, ?, ?, ?, ?>, Count, Confirmation, Id> {
 
     // Queries
 

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/blocking/PanacheBlockingQuery.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/blocking/PanacheBlockingQuery.java
@@ -8,7 +8,8 @@ import jakarta.persistence.NonUniqueResultException;
 
 import io.quarkus.hibernate.panache.PanacheQuery;
 
-public interface PanacheBlockingQuery<Entity> extends PanacheQuery<Entity, List<Entity>, Boolean, Long> {
+public interface PanacheBlockingQuery<Entity>
+        extends PanacheQuery<PanacheBlockingQuery<Entity>, Entity, List<Entity>, PanacheBlockingQuery<Entity>, Boolean, Long> {
 
     /**
      * Defines a projection class. This will transform the returned values into instances of the given type using the following
@@ -34,7 +35,7 @@ public interface PanacheBlockingQuery<Entity> extends PanacheQuery<Entity, List<
      *         <code>type</code>
      * @throws PanacheQueryException if this represents an already-projected query
      */
-    public <T> PanacheQuery<T, List<T>, Boolean, Long> project(Class<T> type);
+    public <T> PanacheBlockingQuery<T> project(Class<T> type);
 
     /**
      * Returns the current page of results as a {@link Stream}.

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/blocking/PanacheRepositoryBlockingQueries.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/blocking/PanacheRepositoryBlockingQueries.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import jakarta.data.Order;
+import jakarta.data.Sort;
 import jakarta.persistence.LockModeType;
 
 import io.quarkus.hibernate.panache.PanacheRepositoryQueries;
@@ -65,6 +66,19 @@ public interface PanacheRepositoryBlockingQueries<Entity, Id>
     Stream<Entity> stream(String query, Order<?> order, Object... params);
 
     /**
+     * Find entities matching a query and the given sort option, with optional indexed parameters.
+     * This is a shortcut for <code>stream(query, Order.by(sort), params)</code>.
+     *
+     * @param query a {@link io.quarkus.hibernate.panache query string}
+     * @param sort the sort strategy to use
+     * @param params optional sequence of indexed parameters
+     * @return a {@link Stream} containing all results, without paging
+     */
+    default Stream<Entity> stream(String query, Sort<?> sort, Object... params) {
+        return stream(query, Order.by(sort), params);
+    }
+
+    /**
      * Find entities matching a query, with named parameters.
      * This method is a shortcut for <code>find(query, params).stream()</code>.
      * It requires a transaction to work.
@@ -98,6 +112,19 @@ public interface PanacheRepositoryBlockingQueries<Entity, Id>
     Stream<Entity> stream(String query, Order<?> order, Map<String, Object> params);
 
     /**
+     * Find entities matching a query and the given sort option, with named parameters.
+     * This is a shortcut for <code>stream(query, Order.by(sort), params)</code>.
+     *
+     * @param query a {@link io.quarkus.hibernate.panache query string}
+     * @param sort the sort strategy to use
+     * @param params {@link Map} of named parameters
+     * @return a {@link Stream} containing all results, without paging
+     */
+    default Stream<Entity> stream(String query, Sort<?> sort, Map<String, Object> params) {
+        return stream(query, Order.by(sort), params);
+    }
+
+    /**
      * Find all entities of this type.
      * This method is a shortcut for <code>findAll().stream()</code>.
      * It requires a transaction to work.
@@ -109,6 +136,17 @@ public interface PanacheRepositoryBlockingQueries<Entity, Id>
      * @see #listAll()
      */
     Stream<Entity> streamAll(Order<?> order);
+
+    /**
+     * Find all entities of this type, in the given order.
+     * This is a shortcut for <code>streamAll(Order.by(sort))</code>.
+     *
+     * @param sort the sort order to use
+     * @return a {@link Stream} containing all results, without paging
+     */
+    default Stream<Entity> streamAll(Sort<?> sort) {
+        return streamAll(Order.by(sort));
+    }
 
     /**
      * Find all entities of this type, in the given order.

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/reactive/PanacheReactiveQuery.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/reactive/PanacheReactiveQuery.java
@@ -7,7 +7,9 @@ import io.quarkus.hibernate.panache.PanacheQuery;
 import io.quarkus.panache.common.exception.PanacheQueryException;
 import io.smallrye.mutiny.Uni;
 
-public interface PanacheReactiveQuery<Entity> extends PanacheQuery<Uni<Entity>, Uni<List<Entity>>, Uni<Boolean>, Uni<Long>> {
+public interface PanacheReactiveQuery<Entity>
+        extends
+        PanacheQuery<PanacheReactiveQuery<Entity>, Uni<Entity>, Uni<List<Entity>>, Uni<PanacheReactiveQuery<Entity>>, Uni<Boolean>, Uni<Long>> {
 
     /**
      * Defines a projection class. This will transform the returned values into instances of the given type using the following
@@ -33,5 +35,5 @@ public interface PanacheReactiveQuery<Entity> extends PanacheQuery<Uni<Entity>, 
      *         <code>type</code>
      * @throws PanacheQueryException if this represents an already-projected query
      */
-    public <T> PanacheQuery<Uni<T>, Uni<List<T>>, Boolean, Long> project(Class<T> type);
+    public <T> PanacheReactiveQuery<T> project(Class<T> type);
 }

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/hr/ManagedReactiveJpaOperations.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/hr/ManagedReactiveJpaOperations.java
@@ -11,9 +11,10 @@ import io.smallrye.mutiny.Uni;
 public class ManagedReactiveJpaOperations extends AbstractManagedJpaOperations<PanacheReactiveQuery<?>> {
 
     @Override
-    protected PanacheReactiveQuery<?> createPanacheQuery(Uni<Mutiny.Session> session, String query, String originalQuery,
+    protected PanacheReactiveQuery<?> createPanacheQuery(Uni<Mutiny.Session> session, Class<?> entityClass, String query,
+            String originalQuery,
             String orderBy, Object paramsArrayOrMap) {
-        return new PanacheManagedReactiveQueryImpl<>(session, query, originalQuery, orderBy, paramsArrayOrMap);
+        return new PanacheManagedReactiveQueryImpl<>(session, entityClass, query, originalQuery, orderBy, paramsArrayOrMap);
     }
 
     @Override

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/hr/ManagedReactiveJpaOperations.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/hr/ManagedReactiveJpaOperations.java
@@ -6,6 +6,7 @@ import org.hibernate.reactive.mutiny.Mutiny;
 
 import io.quarkus.hibernate.panache.reactive.PanacheReactiveQuery;
 import io.quarkus.hibernate.reactive.panache.common.runtime.AbstractManagedJpaOperations;
+import io.quarkus.panache.common.Sort;
 import io.smallrye.mutiny.Uni;
 
 public class ManagedReactiveJpaOperations extends AbstractManagedJpaOperations<PanacheReactiveQuery<?>> {
@@ -13,8 +14,8 @@ public class ManagedReactiveJpaOperations extends AbstractManagedJpaOperations<P
     @Override
     protected PanacheReactiveQuery<?> createPanacheQuery(Uni<Mutiny.Session> session, Class<?> entityClass, String query,
             String originalQuery,
-            String orderBy, Object paramsArrayOrMap) {
-        return new PanacheManagedReactiveQueryImpl<>(session, entityClass, query, originalQuery, orderBy, paramsArrayOrMap);
+            Sort sort, Object paramsArrayOrMap) {
+        return new PanacheManagedReactiveQueryImpl<>(session, entityClass, query, originalQuery, sort, paramsArrayOrMap);
     }
 
     @Override

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/hr/PanacheManagedReactiveQueryImpl.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/hr/PanacheManagedReactiveQueryImpl.java
@@ -4,18 +4,130 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import jakarta.data.Limit;
+import jakarta.data.page.PageRequest;
 import jakarta.persistence.LockModeType;
 
-import org.hibernate.query.Page;
 import org.hibernate.reactive.mutiny.Mutiny;
 
 import io.quarkus.hibernate.panache.reactive.PanacheReactiveQuery;
 import io.quarkus.hibernate.reactive.panache.common.runtime.CommonManagedPanacheQueryImpl;
+import io.quarkus.panache.common.Page;
 import io.smallrye.mutiny.Uni;
 
 public class PanacheManagedReactiveQueryImpl<Entity> implements PanacheReactiveQuery<Entity> {
 
     final CommonManagedPanacheQueryImpl<Entity> delegate;
+    final Limits<PanacheReactiveQuery<Entity>> limitingDelegate = new Limits<PanacheReactiveQuery<Entity>>() {
+        @Override
+        public Limit limit() {
+            io.quarkus.panache.common.Range range = delegate.range();
+            // convert 0-based range to 1-based Jakarta Data Limit
+            return Limit.range(range.getStartIndex() + 1, range.getLastIndex() + 1);
+        }
+
+        @Override
+        public PanacheReactiveQuery<Entity> limit(Limit limit) {
+            // startAt is 1-based in Jakarta Data, convert to 0-based; end is inclusive, hence -1 on size
+            delegate.range((int) (limit.startAt() - 1), (int) (limit.startAt() + limit.maxResults() - 2));
+            return PanacheManagedReactiveQueryImpl.this;
+        }
+
+        @Override
+        public PanacheReactiveQuery<Entity> limit(int max) {
+            if (max == 0) {
+                throw new IllegalArgumentException("Limiting to 0 values is not supported");
+            }
+            // end is inclusive, hence -1 on size
+            delegate.range(0, max - 1);
+            return PanacheManagedReactiveQueryImpl.this;
+        }
+
+        @Override
+        public PanacheReactiveQuery<Entity> limit(long start, int max) {
+            // end is inclusive, hence -1 on size
+            delegate.range((int) start, (int) (start + max - 1));
+            return PanacheManagedReactiveQueryImpl.this;
+        }
+
+        @Override
+        public PanacheReactiveQuery<Entity> limitFrom(long start) {
+            // end is inclusive, hence -1 on size
+            // default page size of Jakarta Data is 10 (see PageRequest)
+            delegate.range((int) start, (int) (start + 10 - 1));
+            return PanacheManagedReactiveQueryImpl.this;
+        }
+
+        @Override
+        public PanacheReactiveQuery<Entity> range(long start, long end) {
+            delegate.range((int) start, (int) end);
+            return PanacheManagedReactiveQueryImpl.this;
+        }
+    };
+    final Pages<PanacheReactiveQuery<Entity>, Uni<PanacheReactiveQuery<Entity>>, Uni<Boolean>, Uni<Long>> pagesDelegate = new Pages<PanacheReactiveQuery<Entity>, Uni<PanacheReactiveQuery<Entity>>, Uni<Boolean>, Uni<Long>>() {
+        @Override
+        public PageRequest request() {
+            Page page = delegate.page();
+            // FIXME: let's hope they fix their page indices to 0-based
+            return PageRequest.ofPage(page.index + 1, page.size, false);
+        }
+
+        @Override
+        public PanacheReactiveQuery<Entity> request(PageRequest request) {
+            // FIXME: let's hope they fix their page indices to 0-based
+            delegate.page((int) (request.page() - 1), request.size());
+            return PanacheManagedReactiveQueryImpl.this;
+        }
+
+        @Override
+        public PanacheReactiveQuery<Entity> page(long pageIndex, int pageSize) {
+            delegate.page((int) pageIndex, pageSize);
+            return PanacheManagedReactiveQueryImpl.this;
+        }
+
+        @Override
+        public PanacheReactiveQuery<Entity> cursor(long pageIndex, int pageSize) {
+            throw new UnsupportedOperationException("Cursor-based pagination is not supported by Hibernate Reactive");
+        }
+
+        @Override
+        public PanacheReactiveQuery<Entity> next() {
+            delegate.nextPage();
+            return PanacheManagedReactiveQueryImpl.this;
+        }
+
+        @Override
+        public PanacheReactiveQuery<Entity> previous() {
+            delegate.previousPage();
+            return PanacheManagedReactiveQueryImpl.this;
+        }
+
+        @Override
+        public PanacheReactiveQuery<Entity> first() {
+            delegate.firstPage();
+            return PanacheManagedReactiveQueryImpl.this;
+        }
+
+        @Override
+        public Uni<PanacheReactiveQuery<Entity>> last() {
+            return delegate.lastPage().map(v -> PanacheManagedReactiveQueryImpl.this);
+        }
+
+        @Override
+        public Uni<Boolean> hasNext() {
+            return delegate.hasNextPage();
+        }
+
+        @Override
+        public Uni<Boolean> hasPrevious() {
+            return Uni.createFrom().item(delegate.hasPreviousPage());
+        }
+
+        @Override
+        public Uni<Long> count() {
+            return delegate.pageCount().map(i -> (long) i);
+        }
+    };
 
     PanacheManagedReactiveQueryImpl(Uni<Mutiny.Session> session, String query, String originalQuery, String orderBy,
             Object paramsArrayOrMap) {
@@ -24,68 +136,6 @@ public class PanacheManagedReactiveQueryImpl<Entity> implements PanacheReactiveQ
 
     PanacheManagedReactiveQueryImpl(CommonManagedPanacheQueryImpl<Entity> delegate) {
         this.delegate = delegate;
-    }
-
-    @Override
-    public PanacheManagedReactiveQueryImpl<Entity> page(Page page) {
-        delegate.page(page.getNumber(), page.getSize());
-        return this;
-    }
-
-    @Override
-    public PanacheManagedReactiveQueryImpl<Entity> page(int pageIndex, int pageSize) {
-        delegate.page(pageIndex, pageSize);
-        return this;
-    }
-
-    @Override
-    public PanacheManagedReactiveQueryImpl<Entity> nextPage() {
-        delegate.nextPage();
-        return this;
-    }
-
-    @Override
-    public PanacheManagedReactiveQueryImpl<Entity> previousPage() {
-        delegate.previousPage();
-        return this;
-    }
-
-    @Override
-    public PanacheManagedReactiveQueryImpl<Entity> firstPage() {
-        delegate.firstPage();
-        return this;
-    }
-
-    @Override
-    public PanacheManagedReactiveQueryImpl<Entity> lastPage() {
-        delegate.lastPage();
-        return this;
-    }
-
-    @Override
-    public Uni<Boolean> hasNextPage() {
-        return delegate.hasNextPage();
-    }
-
-    @Override
-    public Uni<Boolean> hasPreviousPage() {
-        return Uni.createFrom().item(delegate.hasPreviousPage());
-    }
-
-    @Override
-    public Uni<Long> pageCount() {
-        return delegate.pageCount().map(i -> i.longValue());
-    }
-
-    @Override
-    public Page page() {
-        return Page.page(delegate.page().size, delegate.page().index);
-    }
-
-    @Override
-    public PanacheManagedReactiveQueryImpl<Entity> range(int startIndex, int lastIndex) {
-        delegate.range(startIndex, lastIndex);
-        return this;
     }
 
     @Override
@@ -130,6 +180,16 @@ public class PanacheManagedReactiveQueryImpl<Entity> implements PanacheReactiveQ
     @Override
     public Uni<Entity> singleResult() {
         return delegate.singleResult();
+    }
+
+    @Override
+    public Limits<PanacheReactiveQuery<Entity>> limits() {
+        return limitingDelegate;
+    }
+
+    @Override
+    public Pages<PanacheReactiveQuery<Entity>, Uni<PanacheReactiveQuery<Entity>>, Uni<Boolean>, Uni<Long>> pages() {
+        return pagesDelegate;
     }
 
     @Override

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/hr/PanacheManagedReactiveQueryImpl.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/hr/PanacheManagedReactiveQueryImpl.java
@@ -86,7 +86,7 @@ public class PanacheManagedReactiveQueryImpl<Entity> implements PanacheReactiveQ
         }
 
         @Override
-        public PanacheReactiveQuery<Entity> cursor(long pageIndex, int pageSize) {
+        public PanacheReactiveQuery<Entity> cursor(long pageIndex, int pageSize, jakarta.data.Order<?> order) {
             throw new UnsupportedOperationException("Cursor-based pagination is not supported by Hibernate Reactive");
         }
 
@@ -129,9 +129,11 @@ public class PanacheManagedReactiveQueryImpl<Entity> implements PanacheReactiveQ
         }
     };
 
-    PanacheManagedReactiveQueryImpl(Uni<Mutiny.Session> session, String query, String originalQuery, String orderBy,
+    PanacheManagedReactiveQueryImpl(Uni<Mutiny.Session> session, Class<?> entityClass, String query, String originalQuery,
+            String orderBy,
             Object paramsArrayOrMap) {
-        delegate = new CommonManagedPanacheQueryImpl<Entity>(session, query, originalQuery, orderBy, paramsArrayOrMap);
+        delegate = new CommonManagedPanacheQueryImpl<Entity>(session, entityClass, query, originalQuery, orderBy,
+                paramsArrayOrMap);
     }
 
     PanacheManagedReactiveQueryImpl(CommonManagedPanacheQueryImpl<Entity> delegate) {

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/hr/PanacheManagedReactiveQueryImpl.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/hr/PanacheManagedReactiveQueryImpl.java
@@ -13,6 +13,7 @@ import org.hibernate.reactive.mutiny.Mutiny;
 import io.quarkus.hibernate.panache.reactive.PanacheReactiveQuery;
 import io.quarkus.hibernate.reactive.panache.common.runtime.CommonManagedPanacheQueryImpl;
 import io.quarkus.panache.common.Page;
+import io.quarkus.panache.common.Sort;
 import io.smallrye.mutiny.Uni;
 
 public class PanacheManagedReactiveQueryImpl<Entity> implements PanacheReactiveQuery<Entity> {
@@ -86,7 +87,7 @@ public class PanacheManagedReactiveQueryImpl<Entity> implements PanacheReactiveQ
         }
 
         @Override
-        public PanacheReactiveQuery<Entity> cursor(long pageIndex, int pageSize, jakarta.data.Order<?> order) {
+        public PanacheReactiveQuery<Entity> cursor(long pageIndex, int pageSize) {
             throw new UnsupportedOperationException("Cursor-based pagination is not supported by Hibernate Reactive");
         }
 
@@ -130,9 +131,9 @@ public class PanacheManagedReactiveQueryImpl<Entity> implements PanacheReactiveQ
     };
 
     PanacheManagedReactiveQueryImpl(Uni<Mutiny.Session> session, Class<?> entityClass, String query, String originalQuery,
-            String orderBy,
+            Sort sort,
             Object paramsArrayOrMap) {
-        delegate = new CommonManagedPanacheQueryImpl<Entity>(session, entityClass, query, originalQuery, orderBy,
+        delegate = new CommonManagedPanacheQueryImpl<Entity>(session, entityClass, query, originalQuery, sort,
                 paramsArrayOrMap);
     }
 

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/hr/PanacheStatelessReactiveQueryImpl.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/hr/PanacheStatelessReactiveQueryImpl.java
@@ -86,7 +86,7 @@ public class PanacheStatelessReactiveQueryImpl<Entity> implements PanacheReactiv
         }
 
         @Override
-        public PanacheReactiveQuery<Entity> cursor(long pageIndex, int pageSize) {
+        public PanacheReactiveQuery<Entity> cursor(long pageIndex, int pageSize, jakarta.data.Order<?> order) {
             throw new UnsupportedOperationException("Cursor-based pagination is not supported by Hibernate Reactive");
         }
 
@@ -129,9 +129,11 @@ public class PanacheStatelessReactiveQueryImpl<Entity> implements PanacheReactiv
         }
     };
 
-    PanacheStatelessReactiveQueryImpl(Uni<Mutiny.StatelessSession> session, String query, String originalQuery, String orderBy,
+    PanacheStatelessReactiveQueryImpl(Uni<Mutiny.StatelessSession> session, Class<?> entityClass, String query,
+            String originalQuery, String orderBy,
             Object paramsArrayOrMap) {
-        delegate = new CommonStatelessPanacheQueryImpl<Entity>(session, query, originalQuery, orderBy, paramsArrayOrMap);
+        delegate = new CommonStatelessPanacheQueryImpl<Entity>(session, entityClass, query, originalQuery, orderBy,
+                paramsArrayOrMap);
     }
 
     PanacheStatelessReactiveQueryImpl(CommonStatelessPanacheQueryImpl<Entity> delegate) {

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/hr/PanacheStatelessReactiveQueryImpl.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/hr/PanacheStatelessReactiveQueryImpl.java
@@ -4,18 +4,130 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import jakarta.data.Limit;
+import jakarta.data.page.PageRequest;
 import jakarta.persistence.LockModeType;
 
-import org.hibernate.query.Page;
 import org.hibernate.reactive.mutiny.Mutiny;
 
 import io.quarkus.hibernate.panache.reactive.PanacheReactiveQuery;
 import io.quarkus.hibernate.reactive.panache.common.runtime.CommonStatelessPanacheQueryImpl;
+import io.quarkus.panache.common.Page;
 import io.smallrye.mutiny.Uni;
 
 public class PanacheStatelessReactiveQueryImpl<Entity> implements PanacheReactiveQuery<Entity> {
 
     final CommonStatelessPanacheQueryImpl<Entity> delegate;
+    final Limits<PanacheReactiveQuery<Entity>> limitingDelegate = new Limits<PanacheReactiveQuery<Entity>>() {
+        @Override
+        public Limit limit() {
+            io.quarkus.panache.common.Range range = delegate.range();
+            // convert 0-based range to 1-based Jakarta Data Limit
+            return Limit.range(range.getStartIndex() + 1, range.getLastIndex() + 1);
+        }
+
+        @Override
+        public PanacheReactiveQuery<Entity> limit(Limit limit) {
+            // startAt is 1-based in Jakarta Data, convert to 0-based; end is inclusive, hence -1 on size
+            delegate.range((int) (limit.startAt() - 1), (int) (limit.startAt() + limit.maxResults() - 2));
+            return PanacheStatelessReactiveQueryImpl.this;
+        }
+
+        @Override
+        public PanacheReactiveQuery<Entity> limit(int max) {
+            if (max == 0) {
+                throw new IllegalArgumentException("Limiting to 0 values is not supported");
+            }
+            // end is inclusive, hence -1 on size
+            delegate.range(0, max - 1);
+            return PanacheStatelessReactiveQueryImpl.this;
+        }
+
+        @Override
+        public PanacheReactiveQuery<Entity> limit(long start, int max) {
+            // end is inclusive, hence -1 on size
+            delegate.range((int) start, (int) (start + max - 1));
+            return PanacheStatelessReactiveQueryImpl.this;
+        }
+
+        @Override
+        public PanacheReactiveQuery<Entity> limitFrom(long start) {
+            // end is inclusive, hence -1 on size
+            // default page size of Jakarta Data is 10 (see PageRequest)
+            delegate.range((int) start, (int) (start + 10 - 1));
+            return PanacheStatelessReactiveQueryImpl.this;
+        }
+
+        @Override
+        public PanacheReactiveQuery<Entity> range(long start, long end) {
+            delegate.range((int) start, (int) end);
+            return PanacheStatelessReactiveQueryImpl.this;
+        }
+    };
+    final Pages<PanacheReactiveQuery<Entity>, Uni<PanacheReactiveQuery<Entity>>, Uni<Boolean>, Uni<Long>> pagesDelegate = new Pages<PanacheReactiveQuery<Entity>, Uni<PanacheReactiveQuery<Entity>>, Uni<Boolean>, Uni<Long>>() {
+        @Override
+        public PageRequest request() {
+            Page page = delegate.page();
+            // FIXME: let's hope they fix their page indices to 0-based
+            return PageRequest.ofPage(page.index + 1, page.size, false);
+        }
+
+        @Override
+        public PanacheReactiveQuery<Entity> request(PageRequest request) {
+            // FIXME: let's hope they fix their page indices to 0-based
+            delegate.page((int) (request.page() - 1), request.size());
+            return PanacheStatelessReactiveQueryImpl.this;
+        }
+
+        @Override
+        public PanacheReactiveQuery<Entity> page(long pageIndex, int pageSize) {
+            delegate.page((int) pageIndex, pageSize);
+            return PanacheStatelessReactiveQueryImpl.this;
+        }
+
+        @Override
+        public PanacheReactiveQuery<Entity> cursor(long pageIndex, int pageSize) {
+            throw new UnsupportedOperationException("Cursor-based pagination is not supported by Hibernate Reactive");
+        }
+
+        @Override
+        public PanacheReactiveQuery<Entity> next() {
+            delegate.nextPage();
+            return PanacheStatelessReactiveQueryImpl.this;
+        }
+
+        @Override
+        public PanacheReactiveQuery<Entity> previous() {
+            delegate.previousPage();
+            return PanacheStatelessReactiveQueryImpl.this;
+        }
+
+        @Override
+        public PanacheReactiveQuery<Entity> first() {
+            delegate.firstPage();
+            return PanacheStatelessReactiveQueryImpl.this;
+        }
+
+        @Override
+        public Uni<PanacheReactiveQuery<Entity>> last() {
+            return delegate.lastPage().map(v -> PanacheStatelessReactiveQueryImpl.this);
+        }
+
+        @Override
+        public Uni<Boolean> hasNext() {
+            return delegate.hasNextPage();
+        }
+
+        @Override
+        public Uni<Boolean> hasPrevious() {
+            return Uni.createFrom().item(delegate.hasPreviousPage());
+        }
+
+        @Override
+        public Uni<Long> count() {
+            return delegate.pageCount().map(i -> (long) i);
+        }
+    };
 
     PanacheStatelessReactiveQueryImpl(Uni<Mutiny.StatelessSession> session, String query, String originalQuery, String orderBy,
             Object paramsArrayOrMap) {
@@ -24,68 +136,6 @@ public class PanacheStatelessReactiveQueryImpl<Entity> implements PanacheReactiv
 
     PanacheStatelessReactiveQueryImpl(CommonStatelessPanacheQueryImpl<Entity> delegate) {
         this.delegate = delegate;
-    }
-
-    @Override
-    public PanacheStatelessReactiveQueryImpl<Entity> page(Page page) {
-        delegate.page(page.getNumber(), page.getSize());
-        return this;
-    }
-
-    @Override
-    public PanacheStatelessReactiveQueryImpl<Entity> page(int pageIndex, int pageSize) {
-        delegate.page(pageIndex, pageSize);
-        return this;
-    }
-
-    @Override
-    public PanacheStatelessReactiveQueryImpl<Entity> nextPage() {
-        delegate.nextPage();
-        return this;
-    }
-
-    @Override
-    public PanacheStatelessReactiveQueryImpl<Entity> previousPage() {
-        delegate.previousPage();
-        return this;
-    }
-
-    @Override
-    public PanacheStatelessReactiveQueryImpl<Entity> firstPage() {
-        delegate.firstPage();
-        return this;
-    }
-
-    @Override
-    public PanacheStatelessReactiveQueryImpl<Entity> lastPage() {
-        delegate.lastPage();
-        return this;
-    }
-
-    @Override
-    public Uni<Boolean> hasNextPage() {
-        return delegate.hasNextPage();
-    }
-
-    @Override
-    public Uni<Boolean> hasPreviousPage() {
-        return Uni.createFrom().item(delegate.hasPreviousPage());
-    }
-
-    @Override
-    public Uni<Long> pageCount() {
-        return delegate.pageCount().map(i -> i.longValue());
-    }
-
-    @Override
-    public Page page() {
-        return Page.page(delegate.page().size, delegate.page().index);
-    }
-
-    @Override
-    public PanacheStatelessReactiveQueryImpl<Entity> range(int startIndex, int lastIndex) {
-        delegate.range(startIndex, lastIndex);
-        return this;
     }
 
     @Override
@@ -130,6 +180,16 @@ public class PanacheStatelessReactiveQueryImpl<Entity> implements PanacheReactiv
     @Override
     public Uni<Entity> singleResult() {
         return delegate.singleResult();
+    }
+
+    @Override
+    public Limits<PanacheReactiveQuery<Entity>> limits() {
+        return limitingDelegate;
+    }
+
+    @Override
+    public Pages<PanacheReactiveQuery<Entity>, Uni<PanacheReactiveQuery<Entity>>, Uni<Boolean>, Uni<Long>> pages() {
+        return pagesDelegate;
     }
 
     @Override

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/hr/PanacheStatelessReactiveQueryImpl.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/hr/PanacheStatelessReactiveQueryImpl.java
@@ -13,6 +13,7 @@ import org.hibernate.reactive.mutiny.Mutiny;
 import io.quarkus.hibernate.panache.reactive.PanacheReactiveQuery;
 import io.quarkus.hibernate.reactive.panache.common.runtime.CommonStatelessPanacheQueryImpl;
 import io.quarkus.panache.common.Page;
+import io.quarkus.panache.common.Sort;
 import io.smallrye.mutiny.Uni;
 
 public class PanacheStatelessReactiveQueryImpl<Entity> implements PanacheReactiveQuery<Entity> {
@@ -86,7 +87,7 @@ public class PanacheStatelessReactiveQueryImpl<Entity> implements PanacheReactiv
         }
 
         @Override
-        public PanacheReactiveQuery<Entity> cursor(long pageIndex, int pageSize, jakarta.data.Order<?> order) {
+        public PanacheReactiveQuery<Entity> cursor(long pageIndex, int pageSize) {
             throw new UnsupportedOperationException("Cursor-based pagination is not supported by Hibernate Reactive");
         }
 
@@ -130,9 +131,9 @@ public class PanacheStatelessReactiveQueryImpl<Entity> implements PanacheReactiv
     };
 
     PanacheStatelessReactiveQueryImpl(Uni<Mutiny.StatelessSession> session, Class<?> entityClass, String query,
-            String originalQuery, String orderBy,
+            String originalQuery, Sort sort,
             Object paramsArrayOrMap) {
-        delegate = new CommonStatelessPanacheQueryImpl<Entity>(session, entityClass, query, originalQuery, orderBy,
+        delegate = new CommonStatelessPanacheQueryImpl<Entity>(session, entityClass, query, originalQuery, sort,
                 paramsArrayOrMap);
     }
 

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/hr/StatelessReactiveJpaOperations.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/hr/StatelessReactiveJpaOperations.java
@@ -6,6 +6,7 @@ import org.hibernate.reactive.mutiny.Mutiny;
 
 import io.quarkus.hibernate.panache.reactive.PanacheReactiveQuery;
 import io.quarkus.hibernate.reactive.panache.common.runtime.AbstractStatelessJpaOperations;
+import io.quarkus.panache.common.Sort;
 import io.smallrye.mutiny.Uni;
 
 public class StatelessReactiveJpaOperations extends AbstractStatelessJpaOperations<PanacheReactiveQuery<?>> {
@@ -14,8 +15,8 @@ public class StatelessReactiveJpaOperations extends AbstractStatelessJpaOperatio
     protected PanacheReactiveQuery<?> createPanacheQuery(Uni<Mutiny.StatelessSession> session, Class<?> entityClass,
             String query,
             String originalQuery,
-            String orderBy, Object paramsArrayOrMap) {
-        return new PanacheStatelessReactiveQueryImpl<>(session, entityClass, query, originalQuery, orderBy, paramsArrayOrMap);
+            Sort sort, Object paramsArrayOrMap) {
+        return new PanacheStatelessReactiveQueryImpl<>(session, entityClass, query, originalQuery, sort, paramsArrayOrMap);
     }
 
     @Override

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/hr/StatelessReactiveJpaOperations.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/hr/StatelessReactiveJpaOperations.java
@@ -11,10 +11,11 @@ import io.smallrye.mutiny.Uni;
 public class StatelessReactiveJpaOperations extends AbstractStatelessJpaOperations<PanacheReactiveQuery<?>> {
 
     @Override
-    protected PanacheReactiveQuery<?> createPanacheQuery(Uni<Mutiny.StatelessSession> session, String query,
+    protected PanacheReactiveQuery<?> createPanacheQuery(Uni<Mutiny.StatelessSession> session, Class<?> entityClass,
+            String query,
             String originalQuery,
             String orderBy, Object paramsArrayOrMap) {
-        return new PanacheStatelessReactiveQueryImpl<>(session, query, originalQuery, orderBy, paramsArrayOrMap);
+        return new PanacheStatelessReactiveQueryImpl<>(session, entityClass, query, originalQuery, orderBy, paramsArrayOrMap);
     }
 
     @Override

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/orm/ManagedBlockingJpaOperations.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/orm/ManagedBlockingJpaOperations.java
@@ -7,14 +7,15 @@ import org.hibernate.Session;
 
 import io.quarkus.hibernate.orm.panache.common.runtime.AbstractManagedJpaOperations;
 import io.quarkus.hibernate.panache.blocking.PanacheBlockingQuery;
+import io.quarkus.panache.common.Sort;
 
 public class ManagedBlockingJpaOperations extends AbstractManagedJpaOperations<PanacheBlockingQuery<?>> {
 
     @Override
     protected PanacheBlockingQuery<?> createPanacheQuery(Session session, Class<?> entityClass, String query,
             String originalQuery,
-            String orderBy, Object paramsArrayOrMap) {
-        return new PanacheBlockingQueryImpl<>(session, entityClass, query, originalQuery, orderBy, paramsArrayOrMap);
+            Sort sort, Object paramsArrayOrMap) {
+        return new PanacheBlockingQueryImpl<>(session, entityClass, query, originalQuery, sort, paramsArrayOrMap);
     }
 
     @Override

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/orm/ManagedBlockingJpaOperations.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/orm/ManagedBlockingJpaOperations.java
@@ -11,9 +11,10 @@ import io.quarkus.hibernate.panache.blocking.PanacheBlockingQuery;
 public class ManagedBlockingJpaOperations extends AbstractManagedJpaOperations<PanacheBlockingQuery<?>> {
 
     @Override
-    protected PanacheBlockingQuery<?> createPanacheQuery(Session session, String query, String originalQuery,
+    protected PanacheBlockingQuery<?> createPanacheQuery(Session session, Class<?> entityClass, String query,
+            String originalQuery,
             String orderBy, Object paramsArrayOrMap) {
-        return new PanacheBlockingQueryImpl<>(session, query, originalQuery, orderBy, paramsArrayOrMap);
+        return new PanacheBlockingQueryImpl<>(session, entityClass, query, originalQuery, orderBy, paramsArrayOrMap);
     }
 
     @Override

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/orm/PanacheBlockingQueryImpl.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/orm/PanacheBlockingQueryImpl.java
@@ -6,17 +6,131 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import jakarta.data.Limit;
+import jakarta.data.page.PageRequest;
 import jakarta.persistence.LockModeType;
 
 import org.hibernate.SharedSessionContract;
-import org.hibernate.query.Page;
 
 import io.quarkus.hibernate.orm.panache.common.runtime.CommonPanacheQueryImpl;
 import io.quarkus.hibernate.panache.blocking.PanacheBlockingQuery;
+import io.quarkus.panache.common.Page;
 
 public class PanacheBlockingQueryImpl<Entity> implements PanacheBlockingQuery<Entity> {
 
     final CommonPanacheQueryImpl<Entity> delegate;
+    final Limits<PanacheBlockingQuery<Entity>> limitingDelegate = new Limits<PanacheBlockingQuery<Entity>>() {
+        @Override
+        public Limit limit() {
+            io.quarkus.panache.common.Range range = delegate.range();
+            // convert 0-based range to 1-based Jakarta Data Limit
+            return Limit.range(range.getStartIndex() + 1, range.getLastIndex() + 1);
+        }
+
+        @Override
+        public PanacheBlockingQuery<Entity> limit(Limit limit) {
+            // startAt is 1-based in Jakarta Data, convert to 0-based; end is inclusive, hence -1 on size
+            delegate.range((int) (limit.startAt() - 1), (int) (limit.startAt() + limit.maxResults() - 2));
+            return PanacheBlockingQueryImpl.this;
+        }
+
+        @Override
+        public PanacheBlockingQuery<Entity> limit(int max) {
+            if (max == 0) {
+                throw new IllegalArgumentException("Limiting to 0 values is not supported");
+            }
+            // end is inclusive, hence -1 on size
+            delegate.range(0, max - 1);
+            return PanacheBlockingQueryImpl.this;
+        }
+
+        @Override
+        public PanacheBlockingQuery<Entity> limit(long start, int max) {
+            // end is inclusive, hence -1 on size
+            delegate.range((int) start, (int) (start + max - 1));
+            return PanacheBlockingQueryImpl.this;
+        }
+
+        @Override
+        public PanacheBlockingQuery<Entity> limitFrom(long start) {
+            // end is inclusive, hence -1 on size
+            // default page size of Jakarta Data is 10 (see PageRequest)
+            delegate.range((int) start, (int) (start + 10 - 1));
+            return PanacheBlockingQueryImpl.this;
+        }
+
+        @Override
+        public PanacheBlockingQuery<Entity> range(long start, long end) {
+            delegate.range((int) start, (int) end);
+            return PanacheBlockingQueryImpl.this;
+        }
+    };
+    final Pages<PanacheBlockingQuery<Entity>, PanacheBlockingQuery<Entity>, Boolean, Long> pagesDelegate = new Pages<PanacheBlockingQuery<Entity>, PanacheBlockingQuery<Entity>, Boolean, Long>() {
+        @Override
+        public PageRequest request() {
+            Page page = delegate.page();
+            // FIXME: let's hope they fix their page indices to 0-based
+            return PageRequest.ofPage(page.index + 1, page.size, false);
+        }
+
+        @Override
+        public PanacheBlockingQuery<Entity> request(PageRequest request) {
+            // FIXME: let's hope they fix their page indices to 0-based
+            delegate.page((int) (request.page() - 1), request.size());
+            return PanacheBlockingQueryImpl.this;
+        }
+
+        @Override
+        public PanacheBlockingQuery<Entity> page(long pageIndex, int pageSize) {
+            delegate.page((int) pageIndex, pageSize);
+            return PanacheBlockingQueryImpl.this;
+        }
+
+        @Override
+        public PanacheBlockingQuery<Entity> cursor(long pageIndex, int pageSize) {
+            // FIXME: not supported yet
+            return null;
+        }
+
+        @Override
+        public PanacheBlockingQuery<Entity> next() {
+            delegate.nextPage();
+            return PanacheBlockingQueryImpl.this;
+        }
+
+        @Override
+        public PanacheBlockingQuery<Entity> previous() {
+            delegate.previousPage();
+            return PanacheBlockingQueryImpl.this;
+        }
+
+        @Override
+        public PanacheBlockingQuery<Entity> first() {
+            delegate.firstPage();
+            return PanacheBlockingQueryImpl.this;
+        }
+
+        @Override
+        public PanacheBlockingQuery<Entity> last() {
+            delegate.lastPage();
+            return PanacheBlockingQueryImpl.this;
+        }
+
+        @Override
+        public Boolean hasNext() {
+            return delegate.hasNextPage();
+        }
+
+        @Override
+        public Boolean hasPrevious() {
+            return delegate.hasPreviousPage();
+        }
+
+        @Override
+        public Long count() {
+            return (long) delegate.pageCount();
+        }
+    };
 
     PanacheBlockingQueryImpl(SharedSessionContract session, String query, String originalQuery, String orderBy,
             Object paramsArrayOrMap) {
@@ -25,68 +139,6 @@ public class PanacheBlockingQueryImpl<Entity> implements PanacheBlockingQuery<En
 
     PanacheBlockingQueryImpl(CommonPanacheQueryImpl<Entity> delegate) {
         this.delegate = delegate;
-    }
-
-    @Override
-    public PanacheBlockingQueryImpl<Entity> page(Page page) {
-        delegate.page(page.getNumber(), page.getSize());
-        return this;
-    }
-
-    @Override
-    public PanacheBlockingQueryImpl<Entity> page(int pageIndex, int pageSize) {
-        delegate.page(pageIndex, pageSize);
-        return this;
-    }
-
-    @Override
-    public PanacheBlockingQueryImpl<Entity> nextPage() {
-        delegate.nextPage();
-        return this;
-    }
-
-    @Override
-    public PanacheBlockingQueryImpl<Entity> previousPage() {
-        delegate.previousPage();
-        return this;
-    }
-
-    @Override
-    public PanacheBlockingQueryImpl<Entity> firstPage() {
-        delegate.firstPage();
-        return this;
-    }
-
-    @Override
-    public PanacheBlockingQueryImpl<Entity> lastPage() {
-        delegate.lastPage();
-        return this;
-    }
-
-    @Override
-    public Boolean hasNextPage() {
-        return delegate.hasNextPage();
-    }
-
-    @Override
-    public Boolean hasPreviousPage() {
-        return delegate.hasPreviousPage();
-    }
-
-    @Override
-    public Long pageCount() {
-        return (long) delegate.pageCount();
-    }
-
-    @Override
-    public Page page() {
-        return Page.page(delegate.page().size, delegate.page().index);
-    }
-
-    @Override
-    public PanacheBlockingQueryImpl<Entity> range(int startIndex, int lastIndex) {
-        delegate.range(startIndex, lastIndex);
-        return this;
     }
 
     @Override
@@ -134,6 +186,16 @@ public class PanacheBlockingQueryImpl<Entity> implements PanacheBlockingQuery<En
     }
 
     @Override
+    public Limits<PanacheBlockingQuery<Entity>> limits() {
+        return limitingDelegate;
+    }
+
+    @Override
+    public Pages<PanacheBlockingQuery<Entity>, PanacheBlockingQuery<Entity>, Boolean, Long> pages() {
+        return pagesDelegate;
+    }
+
+    @Override
     public <NewEntity> PanacheBlockingQueryImpl<NewEntity> project(Class<NewEntity> type) {
         return new PanacheBlockingQueryImpl<>(delegate.project(type));
     }
@@ -152,5 +214,4 @@ public class PanacheBlockingQueryImpl<Entity> implements PanacheBlockingQuery<En
     public Optional<Entity> singleResultOptional() {
         return delegate.singleResultOptional();
     }
-
 }

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/orm/PanacheBlockingQueryImpl.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/orm/PanacheBlockingQueryImpl.java
@@ -87,9 +87,18 @@ public class PanacheBlockingQueryImpl<Entity> implements PanacheBlockingQuery<En
         }
 
         @Override
-        public PanacheBlockingQuery<Entity> cursor(long pageIndex, int pageSize) {
-            // FIXME: not supported yet
-            return null;
+        public PanacheBlockingQuery<Entity> cursor(long pageIndex, int pageSize, jakarta.data.Order<?> order) {
+            List<org.hibernate.query.Order<?>> hibernateOrders = new java.util.ArrayList<>();
+            for (jakarta.data.Sort<?> sort : order.sorts()) {
+                org.hibernate.query.SortDirection direction = sort.isAscending()
+                        ? org.hibernate.query.SortDirection.ASCENDING
+                        : org.hibernate.query.SortDirection.DESCENDING;
+                org.hibernate.query.Order<?> hibernateOrder = org.hibernate.query.Order
+                        .by((Class) delegate.entityClass(), sort.property(), direction, sort.ignoreCase());
+                hibernateOrders.add(hibernateOrder);
+            }
+            delegate.cursored((int) pageIndex, pageSize, hibernateOrders);
+            return PanacheBlockingQueryImpl.this;
         }
 
         @Override
@@ -132,9 +141,10 @@ public class PanacheBlockingQueryImpl<Entity> implements PanacheBlockingQuery<En
         }
     };
 
-    PanacheBlockingQueryImpl(SharedSessionContract session, String query, String originalQuery, String orderBy,
+    PanacheBlockingQueryImpl(SharedSessionContract session, Class<?> entityClass, String query, String originalQuery,
+            String orderBy,
             Object paramsArrayOrMap) {
-        delegate = new CommonPanacheQueryImpl<Entity>(session, query, originalQuery, orderBy, paramsArrayOrMap);
+        delegate = new CommonPanacheQueryImpl<Entity>(session, entityClass, query, originalQuery, orderBy, paramsArrayOrMap);
     }
 
     PanacheBlockingQueryImpl(CommonPanacheQueryImpl<Entity> delegate) {

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/orm/PanacheBlockingQueryImpl.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/orm/PanacheBlockingQueryImpl.java
@@ -15,6 +15,7 @@ import org.hibernate.SharedSessionContract;
 import io.quarkus.hibernate.orm.panache.common.runtime.CommonPanacheQueryImpl;
 import io.quarkus.hibernate.panache.blocking.PanacheBlockingQuery;
 import io.quarkus.panache.common.Page;
+import io.quarkus.panache.common.Sort;
 
 public class PanacheBlockingQueryImpl<Entity> implements PanacheBlockingQuery<Entity> {
 
@@ -87,17 +88,8 @@ public class PanacheBlockingQueryImpl<Entity> implements PanacheBlockingQuery<En
         }
 
         @Override
-        public PanacheBlockingQuery<Entity> cursor(long pageIndex, int pageSize, jakarta.data.Order<?> order) {
-            List<org.hibernate.query.Order<?>> hibernateOrders = new java.util.ArrayList<>();
-            for (jakarta.data.Sort<?> sort : order.sorts()) {
-                org.hibernate.query.SortDirection direction = sort.isAscending()
-                        ? org.hibernate.query.SortDirection.ASCENDING
-                        : org.hibernate.query.SortDirection.DESCENDING;
-                org.hibernate.query.Order<?> hibernateOrder = org.hibernate.query.Order
-                        .by((Class) delegate.entityClass(), sort.property(), direction, sort.ignoreCase());
-                hibernateOrders.add(hibernateOrder);
-            }
-            delegate.cursored((int) pageIndex, pageSize, hibernateOrders);
+        public PanacheBlockingQuery<Entity> cursor(long pageIndex, int pageSize) {
+            delegate.cursor((int) pageIndex, pageSize);
             return PanacheBlockingQueryImpl.this;
         }
 
@@ -142,9 +134,9 @@ public class PanacheBlockingQueryImpl<Entity> implements PanacheBlockingQuery<En
     };
 
     PanacheBlockingQueryImpl(SharedSessionContract session, Class<?> entityClass, String query, String originalQuery,
-            String orderBy,
+            Sort sort,
             Object paramsArrayOrMap) {
-        delegate = new CommonPanacheQueryImpl<Entity>(session, entityClass, query, originalQuery, orderBy, paramsArrayOrMap);
+        delegate = new CommonPanacheQueryImpl<Entity>(session, entityClass, query, originalQuery, sort, paramsArrayOrMap);
     }
 
     PanacheBlockingQueryImpl(CommonPanacheQueryImpl<Entity> delegate) {

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/orm/StatelessBlockingJpaOperations.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/orm/StatelessBlockingJpaOperations.java
@@ -7,14 +7,15 @@ import org.hibernate.StatelessSession;
 
 import io.quarkus.hibernate.orm.panache.common.runtime.AbstractStatelessJpaOperations;
 import io.quarkus.hibernate.panache.blocking.PanacheBlockingQuery;
+import io.quarkus.panache.common.Sort;
 
 public class StatelessBlockingJpaOperations extends AbstractStatelessJpaOperations<PanacheBlockingQuery<?>> {
 
     @Override
     protected PanacheBlockingQuery<?> createPanacheQuery(StatelessSession session, Class<?> entityClass, String query,
             String originalQuery,
-            String orderBy, Object paramsArrayOrMap) {
-        return new PanacheBlockingQueryImpl<>(session, entityClass, query, originalQuery, orderBy, paramsArrayOrMap);
+            Sort sort, Object paramsArrayOrMap) {
+        return new PanacheBlockingQueryImpl<>(session, entityClass, query, originalQuery, sort, paramsArrayOrMap);
     }
 
     @Override

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/orm/StatelessBlockingJpaOperations.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/orm/StatelessBlockingJpaOperations.java
@@ -11,9 +11,10 @@ import io.quarkus.hibernate.panache.blocking.PanacheBlockingQuery;
 public class StatelessBlockingJpaOperations extends AbstractStatelessJpaOperations<PanacheBlockingQuery<?>> {
 
     @Override
-    protected PanacheBlockingQuery<?> createPanacheQuery(StatelessSession session, String query, String originalQuery,
+    protected PanacheBlockingQuery<?> createPanacheQuery(StatelessSession session, Class<?> entityClass, String query,
+            String originalQuery,
             String orderBy, Object paramsArrayOrMap) {
-        return new PanacheBlockingQueryImpl<>(session, query, originalQuery, orderBy, paramsArrayOrMap);
+        return new PanacheBlockingQueryImpl<>(session, entityClass, query, originalQuery, orderBy, paramsArrayOrMap);
     }
 
     @Override

--- a/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/AbstractJpaOperations.java
+++ b/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/AbstractJpaOperations.java
@@ -87,7 +87,8 @@ public abstract class AbstractJpaOperations<PanacheQueryType, SessionType extend
         this.sessionType = sessionType;
     }
 
-    protected abstract PanacheQueryType createPanacheQuery(SessionType session, String query, String originalQuery,
+    protected abstract PanacheQueryType createPanacheQuery(SessionType session, Class<?> entityClass, String query,
+            String originalQuery,
             String orderBy,
             Object paramsArrayOrMap);
 
@@ -189,11 +190,12 @@ public abstract class AbstractJpaOperations<PanacheQueryType, SessionType extend
                                 + "\" instead");
             }
             NamedQueryUtil.checkNamedQuery(entityClass, namedQuery);
-            return createPanacheQuery(session, panacheQuery, panacheQuery, null, params);
+            return createPanacheQuery(session, entityClass, panacheQuery, panacheQuery, null, params);
         }
 
         String translatedHqlQuery = PanacheJpaUtil.createFindQuery(entityClass, panacheQuery, paramCount(params));
-        return createPanacheQuery(session, translatedHqlQuery, panacheQuery, PanacheJpaUtil.toOrderBy(sort), params);
+        return createPanacheQuery(session, entityClass, translatedHqlQuery, panacheQuery, PanacheJpaUtil.toOrderBy(sort),
+                params);
     }
 
     public PanacheQueryType find(Class<?> entityClass, String panacheQuery, Map<String, Object> params) {
@@ -210,11 +212,12 @@ public abstract class AbstractJpaOperations<PanacheQueryType, SessionType extend
                                 + "\" instead");
             }
             NamedQueryUtil.checkNamedQuery(entityClass, namedQuery);
-            return createPanacheQuery(session, panacheQuery, panacheQuery, null, params);
+            return createPanacheQuery(session, entityClass, panacheQuery, panacheQuery, null, params);
         }
 
         String translatedHqlQuery = PanacheJpaUtil.createFindQuery(entityClass, panacheQuery, paramCount(params));
-        return createPanacheQuery(session, translatedHqlQuery, panacheQuery, PanacheJpaUtil.toOrderBy(sort), params);
+        return createPanacheQuery(session, entityClass, translatedHqlQuery, panacheQuery, PanacheJpaUtil.toOrderBy(sort),
+                params);
     }
 
     public PanacheQueryType find(Class<?> entityClass, String panacheQuery, Parameters params) {
@@ -276,13 +279,13 @@ public abstract class AbstractJpaOperations<PanacheQueryType, SessionType extend
     public PanacheQueryType findAll(Class<?> entityClass) {
         String query = "FROM " + PanacheJpaUtil.getEntityName(entityClass);
         SessionType session = getSession(entityClass);
-        return createPanacheQuery(session, query, null, null, null);
+        return createPanacheQuery(session, entityClass, query, null, null, null);
     }
 
     public PanacheQueryType findAll(Class<?> entityClass, Sort sort) {
         String query = "FROM " + PanacheJpaUtil.getEntityName(entityClass);
         SessionType session = getSession(entityClass);
-        return createPanacheQuery(session, query, null, PanacheJpaUtil.toOrderBy(sort), null);
+        return createPanacheQuery(session, entityClass, query, null, PanacheJpaUtil.toOrderBy(sort), null);
     }
 
     public List<?> listAll(Class<?> entityClass) {

--- a/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/AbstractJpaOperations.java
+++ b/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/AbstractJpaOperations.java
@@ -89,7 +89,7 @@ public abstract class AbstractJpaOperations<PanacheQueryType, SessionType extend
 
     protected abstract PanacheQueryType createPanacheQuery(SessionType session, Class<?> entityClass, String query,
             String originalQuery,
-            String orderBy,
+            Sort sort,
             Object paramsArrayOrMap);
 
     public abstract List<?> list(PanacheQueryType query);
@@ -194,8 +194,7 @@ public abstract class AbstractJpaOperations<PanacheQueryType, SessionType extend
         }
 
         String translatedHqlQuery = PanacheJpaUtil.createFindQuery(entityClass, panacheQuery, paramCount(params));
-        return createPanacheQuery(session, entityClass, translatedHqlQuery, panacheQuery, PanacheJpaUtil.toOrderBy(sort),
-                params);
+        return createPanacheQuery(session, entityClass, translatedHqlQuery, panacheQuery, sort, params);
     }
 
     public PanacheQueryType find(Class<?> entityClass, String panacheQuery, Map<String, Object> params) {
@@ -216,8 +215,7 @@ public abstract class AbstractJpaOperations<PanacheQueryType, SessionType extend
         }
 
         String translatedHqlQuery = PanacheJpaUtil.createFindQuery(entityClass, panacheQuery, paramCount(params));
-        return createPanacheQuery(session, entityClass, translatedHqlQuery, panacheQuery, PanacheJpaUtil.toOrderBy(sort),
-                params);
+        return createPanacheQuery(session, entityClass, translatedHqlQuery, panacheQuery, sort, params);
     }
 
     public PanacheQueryType find(Class<?> entityClass, String panacheQuery, Parameters params) {
@@ -285,7 +283,7 @@ public abstract class AbstractJpaOperations<PanacheQueryType, SessionType extend
     public PanacheQueryType findAll(Class<?> entityClass, Sort sort) {
         String query = "FROM " + PanacheJpaUtil.getEntityName(entityClass);
         SessionType session = getSession(entityClass);
-        return createPanacheQuery(session, entityClass, query, null, PanacheJpaUtil.toOrderBy(sort), null);
+        return createPanacheQuery(session, entityClass, query, null, sort, null);
     }
 
     public List<?> listAll(Class<?> entityClass) {

--- a/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/CommonPanacheQueryImpl.java
+++ b/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/CommonPanacheQueryImpl.java
@@ -20,7 +20,6 @@ import org.hibernate.Filter;
 import org.hibernate.SharedSessionContract;
 import org.hibernate.query.KeyedPage;
 import org.hibernate.query.KeyedResultList;
-import org.hibernate.query.Order;
 import org.hibernate.query.SelectionQuery;
 import org.hibernate.query.spi.SqmQuery;
 
@@ -29,6 +28,7 @@ import io.quarkus.hibernate.orm.panache.common.ProjectedConstructor;
 import io.quarkus.hibernate.orm.panache.common.ProjectedFieldName;
 import io.quarkus.panache.common.Page;
 import io.quarkus.panache.common.Range;
+import io.quarkus.panache.common.Sort;
 import io.quarkus.panache.common.exception.PanacheQueryException;
 import io.quarkus.panache.hibernate.common.runtime.PanacheJpaUtil;
 
@@ -75,7 +75,7 @@ public class CommonPanacheQueryImpl<Entity> {
      * Otherwise we do not use this, and rely on ORM to generate count queries
      */
     protected String customCountQueryForSpring;
-    private String orderBy;
+    private Sort sort;
     private SharedSessionContract session;
     private Class<?> entityClass;
 
@@ -94,13 +94,13 @@ public class CommonPanacheQueryImpl<Entity> {
     private Class<?> projectionType;
 
     public CommonPanacheQueryImpl(SharedSessionContract session, Class<?> entityClass, String query, String originalQuery,
-            String orderBy,
+            Sort sort,
             Object paramsArrayOrMap) {
         this.session = session;
         this.entityClass = entityClass;
         this.query = query;
         this.originalQuery = originalQuery;
-        this.orderBy = orderBy;
+        this.sort = sort;
         this.paramsArrayOrMap = paramsArrayOrMap;
     }
 
@@ -111,7 +111,7 @@ public class CommonPanacheQueryImpl<Entity> {
         this.entityClass = previousQuery.entityClass;
         this.query = newQueryString;
         this.customCountQueryForSpring = customCountQueryForSpring;
-        this.orderBy = previousQuery.orderBy;
+        this.sort = previousQuery.sort;
         this.paramsArrayOrMap = previousQuery.paramsArrayOrMap;
         this.page = previousQuery.page;
         this.count = previousQuery.count;
@@ -263,8 +263,13 @@ public class CommonPanacheQueryImpl<Entity> {
     }
 
     @SuppressWarnings("unchecked")
-    public void cursored(int pageIndex, int pageSize, List<Order<?>> orders) {
-        this.keyedPage = org.hibernate.query.Page.page(pageSize, pageIndex).keyedBy((List) orders);
+    public void cursor(int pageIndex, int pageSize) {
+        if (sort == null || sort.getColumns().isEmpty()) {
+            throw new UnsupportedOperationException(
+                    "Cannot use cursor-based pagination without sort criteria: use find(entityClass, query, sort) or findAll(entityClass, sort)");
+        }
+        List orders = PanacheJpaUtil.toHibernateOrders(entityClass, sort);
+        this.keyedPage = org.hibernate.query.Page.page(pageSize, pageIndex).keyedBy(orders);
         this.lastKeyedResult = null;
         this.page = null;
         this.range = null;
@@ -529,6 +534,7 @@ public class CommonPanacheQueryImpl<Entity> {
             hibernateQuery = session.createNamedSelectionQuery(namedQuery, projectionType);
         } else {
             try {
+                String orderBy = PanacheJpaUtil.toOrderBy(sort);
                 hibernateQuery = session.createSelectionQuery(orderBy != null ? query + orderBy : query, projectionType);
             } catch (RuntimeException x) {
                 throw NamedQueryUtil.checkForNamedQueryMistake(x, originalQuery);

--- a/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/CommonPanacheQueryImpl.java
+++ b/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/CommonPanacheQueryImpl.java
@@ -18,6 +18,9 @@ import jakarta.persistence.LockModeType;
 
 import org.hibernate.Filter;
 import org.hibernate.SharedSessionContract;
+import org.hibernate.query.KeyedPage;
+import org.hibernate.query.KeyedResultList;
+import org.hibernate.query.Order;
 import org.hibernate.query.SelectionQuery;
 import org.hibernate.query.spi.SqmQuery;
 
@@ -74,11 +77,15 @@ public class CommonPanacheQueryImpl<Entity> {
     protected String customCountQueryForSpring;
     private String orderBy;
     private SharedSessionContract session;
+    private Class<?> entityClass;
 
-    private Page page;
     private Long count;
 
+    // We can only have one of page|range|keyedPage set at the same time, they're mutually exclusive
+    private Page page;
     private Range range;
+    private KeyedPage<?> keyedPage;
+    private KeyedResultList<?> lastKeyedResult;
 
     private LockModeType lockModeType;
     private Map<String, Object> hints;
@@ -86,9 +93,11 @@ public class CommonPanacheQueryImpl<Entity> {
     private Map<String, Map<String, Object>> filters;
     private Class<?> projectionType;
 
-    public CommonPanacheQueryImpl(SharedSessionContract session, String query, String originalQuery, String orderBy,
+    public CommonPanacheQueryImpl(SharedSessionContract session, Class<?> entityClass, String query, String originalQuery,
+            String orderBy,
             Object paramsArrayOrMap) {
         this.session = session;
+        this.entityClass = entityClass;
         this.query = query;
         this.originalQuery = originalQuery;
         this.orderBy = orderBy;
@@ -99,6 +108,7 @@ public class CommonPanacheQueryImpl<Entity> {
             String customCountQueryForSpring,
             Class<?> projectionType) {
         this.session = previousQuery.session;
+        this.entityClass = previousQuery.entityClass;
         this.query = newQueryString;
         this.customCountQueryForSpring = customCountQueryForSpring;
         this.orderBy = previousQuery.orderBy;
@@ -106,6 +116,8 @@ public class CommonPanacheQueryImpl<Entity> {
         this.page = previousQuery.page;
         this.count = previousQuery.count;
         this.range = previousQuery.range;
+        this.keyedPage = previousQuery.keyedPage;
+        this.lastKeyedResult = previousQuery.lastKeyedResult;
         this.lockModeType = previousQuery.lockModeType;
         this.hints = previousQuery.hints;
         this.filters = previousQuery.filters;
@@ -241,40 +253,95 @@ public class CommonPanacheQueryImpl<Entity> {
 
     public void page(Page page) {
         this.page = page;
-        this.range = null; // reset the range to be able to switch from range to page
+        this.range = null;
+        this.keyedPage = null;
+        this.lastKeyedResult = null;
     }
 
     public void page(int pageIndex, int pageSize) {
         page(Page.of(pageIndex, pageSize));
     }
 
+    @SuppressWarnings("unchecked")
+    public void cursored(int pageIndex, int pageSize, List<Order<?>> orders) {
+        this.keyedPage = org.hibernate.query.Page.page(pageSize, pageIndex).keyedBy((List) orders);
+        this.lastKeyedResult = null;
+        this.page = null;
+        this.range = null;
+    }
+
     public void nextPage() {
         checkPagination();
-        page(page.next());
+        if (keyedPage != null) {
+            if (lastKeyedResult == null) {
+                throw new UnsupportedOperationException(
+                        "Cannot call nextPage() before fetching results with list()");
+            }
+            keyedPage = lastKeyedResult.getNextPage();
+            lastKeyedResult = null;
+        } else {
+            page(page.next());
+        }
     }
 
     public void previousPage() {
         checkPagination();
-        page(page.previous());
+        if (keyedPage != null) {
+            if (lastKeyedResult == null) {
+                throw new UnsupportedOperationException(
+                        "Cannot call previousPage() before fetching results with list()");
+            }
+            KeyedPage<?> prev = lastKeyedResult.getPreviousPage();
+            if (prev != null) {
+                keyedPage = prev;
+            }
+            lastKeyedResult = null;
+        } else {
+            page(page.previous());
+        }
     }
 
+    @SuppressWarnings("unchecked")
     public void firstPage() {
         checkPagination();
-        page(page.first());
+        if (keyedPage != null) {
+            keyedPage = keyedPage.getPage().first().keyedBy((List) keyedPage.getKeyDefinition());
+            lastKeyedResult = null;
+        } else {
+            page(page.first());
+        }
     }
 
     public void lastPage() {
         checkPagination();
+        if (keyedPage != null) {
+            throw new UnsupportedOperationException(
+                    "Cannot navigate to last page in cursor-based pagination");
+        }
         page(page.index(pageCount() - 1));
     }
 
     public boolean hasNextPage() {
         checkPagination();
+        if (keyedPage != null) {
+            if (lastKeyedResult == null) {
+                throw new UnsupportedOperationException(
+                        "Cannot call hasNextPage() before fetching results with list()");
+            }
+            return !lastKeyedResult.isLastPage();
+        }
         return page.index < (pageCount() - 1);
     }
 
     public boolean hasPreviousPage() {
         checkPagination();
+        if (keyedPage != null) {
+            if (lastKeyedResult == null) {
+                throw new UnsupportedOperationException(
+                        "Cannot call hasPreviousPage() before fetching results with list()");
+            }
+            return !lastKeyedResult.isFirstPage();
+        }
         return page.index > 0;
     }
 
@@ -283,7 +350,8 @@ public class CommonPanacheQueryImpl<Entity> {
         long count = count();
         if (count == 0)
             return 1; // a single page of zero results
-        return (int) Math.ceil((double) count / (double) page.size);
+        int pageSize = keyedPage != null ? keyedPage.getPage().getSize() : page.size;
+        return (int) Math.ceil((double) count / (double) pageSize);
     }
 
     public Page page() {
@@ -292,7 +360,7 @@ public class CommonPanacheQueryImpl<Entity> {
     }
 
     private void checkPagination() {
-        if (page == null) {
+        if (page == null && keyedPage == null) {
             throw new UnsupportedOperationException("Cannot call a page related method, " +
                     "call page(Page) or page(int, int) to initiate pagination first");
         }
@@ -320,8 +388,9 @@ public class CommonPanacheQueryImpl<Entity> {
 
     public void range(int startIndex, int lastIndex) {
         this.range = Range.of(startIndex, lastIndex);
-        // reset the page to its default to be able to switch from page to range
         this.page = null;
+        this.keyedPage = null;
+        this.lastKeyedResult = null;
     }
 
     public void withLock(LockModeType lockModeType) {
@@ -360,14 +429,28 @@ public class CommonPanacheQueryImpl<Entity> {
 
     @SuppressWarnings("unchecked")
     public <T extends Entity> List<T> list() {
+        if (keyedPage != null) {
+            SelectionQuery hibernateQuery = createBaseQuery();
+            try (NonThrowingCloseable c = applyFilters()) {
+                lastKeyedResult = hibernateQuery.getKeyedResultList((KeyedPage) keyedPage);
+                return (List<T>) lastKeyedResult.getResultList();
+            }
+        }
         SelectionQuery hibernateQuery = createQuery();
         try (NonThrowingCloseable c = applyFilters()) {
             return hibernateQuery.getResultList();
         }
     }
 
-    @SuppressWarnings("unchecked")
     public <T extends Entity> Stream<T> stream() {
+        if (keyedPage != null) {
+            SelectionQuery hibernateQuery = createBaseQuery();
+            try (NonThrowingCloseable c = applyFilters()) {
+                lastKeyedResult = hibernateQuery.getKeyedResultList((KeyedPage) keyedPage);
+                // there's no support for getKeyedResultStream() yet in ORM
+                return (Stream<T>) lastKeyedResult.getResultList().stream();
+            }
+        }
         SelectionQuery hibernateQuery = createQuery();
         try (NonThrowingCloseable c = applyFilters()) {
             return hibernateQuery.getResultStream();

--- a/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/CommonPanacheQueryImpl.java
+++ b/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/CommonPanacheQueryImpl.java
@@ -302,6 +302,22 @@ public class CommonPanacheQueryImpl<Entity> {
         }
     }
 
+    private void checkRange() {
+        if (range == null) {
+            throw new UnsupportedOperationException("Cannot call a range related method, " +
+                    "call range(int, int) to initiate range first");
+        }
+        if (page != null) {
+            throw new UnsupportedOperationException("Cannot call a range related method in a paged query, " +
+                    "call range(int, int) to initiate range first");
+        }
+    }
+
+    public Range range() {
+        checkRange();
+        return range;
+    }
+
     public void range(int startIndex, int lastIndex) {
         this.range = Range.of(startIndex, lastIndex);
         // reset the page to its default to be able to switch from page to range

--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/runtime/KotlinJpaOperations.kt
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/runtime/KotlinJpaOperations.kt
@@ -6,11 +6,20 @@ import org.hibernate.Session
 class KotlinJpaOperations : AbstractManagedJpaOperations<PanacheQueryImpl<*>>() {
     override fun createPanacheQuery(
         session: Session,
+        entityClass: Class<*>,
         hqlQuery: String,
         originalQuery: String?,
         orderBy: String?,
         paramsArrayOrMap: Any?,
-    ) = PanacheQueryImpl<Any>(session, hqlQuery, originalQuery, orderBy, paramsArrayOrMap)
+    ) =
+        PanacheQueryImpl<Any>(
+            session,
+            entityClass,
+            hqlQuery,
+            originalQuery,
+            orderBy,
+            paramsArrayOrMap,
+        )
 
     override fun list(query: PanacheQueryImpl<*>) = query.list()
 

--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/runtime/KotlinJpaOperations.kt
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/runtime/KotlinJpaOperations.kt
@@ -1,6 +1,7 @@
 package io.quarkus.hibernate.orm.panache.kotlin.runtime
 
 import io.quarkus.hibernate.orm.panache.common.runtime.AbstractManagedJpaOperations
+import io.quarkus.panache.common.Sort
 import org.hibernate.Session
 
 class KotlinJpaOperations : AbstractManagedJpaOperations<PanacheQueryImpl<*>>() {
@@ -9,17 +10,9 @@ class KotlinJpaOperations : AbstractManagedJpaOperations<PanacheQueryImpl<*>>() 
         entityClass: Class<*>,
         hqlQuery: String,
         originalQuery: String?,
-        orderBy: String?,
+        sort: Sort?,
         paramsArrayOrMap: Any?,
-    ) =
-        PanacheQueryImpl<Any>(
-            session,
-            entityClass,
-            hqlQuery,
-            originalQuery,
-            orderBy,
-            paramsArrayOrMap,
-        )
+    ) = PanacheQueryImpl<Any>(session, entityClass, hqlQuery, originalQuery, sort, paramsArrayOrMap)
 
     override fun list(query: PanacheQueryImpl<*>) = query.list()
 

--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/runtime/PanacheQueryImpl.kt
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/runtime/PanacheQueryImpl.kt
@@ -4,6 +4,7 @@ import io.quarkus.hibernate.orm.panache.common.runtime.CommonPanacheQueryImpl
 import io.quarkus.hibernate.orm.panache.kotlin.PanacheQuery
 import io.quarkus.panache.common.Page
 import io.quarkus.panache.common.Parameters
+import io.quarkus.panache.common.Sort
 import jakarta.persistence.LockModeType
 import java.util.stream.Stream
 import org.hibernate.Session
@@ -16,7 +17,7 @@ class PanacheQueryImpl<Entity : Any> : PanacheQuery<Entity> {
         entityClass: Class<*>?,
         hqlQuery: String?,
         originalQuery: String?,
-        orderBy: String?,
+        sort: Sort?,
         paramsArrayOrMap: Any?,
     ) {
         delegate =
@@ -25,7 +26,7 @@ class PanacheQueryImpl<Entity : Any> : PanacheQuery<Entity> {
                 entityClass,
                 hqlQuery,
                 originalQuery,
-                orderBy,
+                sort,
                 paramsArrayOrMap,
             )
     }

--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/runtime/PanacheQueryImpl.kt
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/runtime/PanacheQueryImpl.kt
@@ -13,13 +13,21 @@ class PanacheQueryImpl<Entity : Any> : PanacheQuery<Entity> {
 
     internal constructor(
         session: Session?,
+        entityClass: Class<*>?,
         hqlQuery: String?,
         originalQuery: String?,
         orderBy: String?,
         paramsArrayOrMap: Any?,
     ) {
         delegate =
-            CommonPanacheQueryImpl(session, hqlQuery, originalQuery, orderBy, paramsArrayOrMap)
+            CommonPanacheQueryImpl(
+                session,
+                entityClass,
+                hqlQuery,
+                originalQuery,
+                orderBy,
+                paramsArrayOrMap,
+            )
     }
 
     private constructor(delegate: CommonPanacheQueryImpl<Entity>) {

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/CustomCountPanacheQuery.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/CustomCountPanacheQuery.java
@@ -11,7 +11,7 @@ public class CustomCountPanacheQuery<Entity> extends PanacheQueryImpl<Entity> {
 
     public CustomCountPanacheQuery(Session session, SelectionQuery hibernateQuery, String customCountQuery,
             Object paramsArrayOrMap) {
-        super(new CommonPanacheQueryImpl<>(session, CommonPanacheQueryImpl.getQueryString(hibernateQuery),
+        super(new CommonPanacheQueryImpl<>(session, null, CommonPanacheQueryImpl.getQueryString(hibernateQuery),
                 null, null, paramsArrayOrMap) {
             {
                 this.customCountQueryForSpring = customCountQuery;

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/JpaOperations.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/JpaOperations.java
@@ -14,9 +14,11 @@ public class JpaOperations extends AbstractManagedJpaOperations<PanacheQueryImpl
     public static final JpaOperations INSTANCE = new JpaOperations();
 
     @Override
-    protected PanacheQueryImpl<?> createPanacheQuery(Session session, String query, String originalQuery, String orderBy,
+    protected PanacheQueryImpl<?> createPanacheQuery(Session session, Class<?> entityClass, String query,
+            String originalQuery,
+            String orderBy,
             Object paramsArrayOrMap) {
-        return new PanacheQueryImpl<>(session, query, originalQuery, orderBy, paramsArrayOrMap);
+        return new PanacheQueryImpl<>(session, entityClass, query, originalQuery, orderBy, paramsArrayOrMap);
     }
 
     @Override

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/JpaOperations.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/JpaOperations.java
@@ -6,6 +6,7 @@ import java.util.stream.Stream;
 import org.hibernate.Session;
 
 import io.quarkus.hibernate.orm.panache.common.runtime.AbstractManagedJpaOperations;
+import io.quarkus.panache.common.Sort;
 
 public class JpaOperations extends AbstractManagedJpaOperations<PanacheQueryImpl<?>> {
     /**
@@ -16,9 +17,9 @@ public class JpaOperations extends AbstractManagedJpaOperations<PanacheQueryImpl
     @Override
     protected PanacheQueryImpl<?> createPanacheQuery(Session session, Class<?> entityClass, String query,
             String originalQuery,
-            String orderBy,
+            Sort sort,
             Object paramsArrayOrMap) {
-        return new PanacheQueryImpl<>(session, entityClass, query, originalQuery, orderBy, paramsArrayOrMap);
+        return new PanacheQueryImpl<>(session, entityClass, query, originalQuery, sort, paramsArrayOrMap);
     }
 
     @Override

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/JpaStatelessOperations.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/JpaStatelessOperations.java
@@ -14,10 +14,11 @@ public class JpaStatelessOperations extends AbstractStatelessJpaOperations<Panac
     public static final JpaStatelessOperations INSTANCE = new JpaStatelessOperations();
 
     @Override
-    protected PanacheQueryImpl<?> createPanacheQuery(StatelessSession session, String query, String originalQuery,
+    protected PanacheQueryImpl<?> createPanacheQuery(StatelessSession session, Class<?> entityClass, String query,
+            String originalQuery,
             String orderBy,
             Object paramsArrayOrMap) {
-        return new PanacheQueryImpl<>(session, query, originalQuery, orderBy, paramsArrayOrMap);
+        return new PanacheQueryImpl<>(session, entityClass, query, originalQuery, orderBy, paramsArrayOrMap);
     }
 
     @Override

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/JpaStatelessOperations.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/JpaStatelessOperations.java
@@ -6,6 +6,7 @@ import java.util.stream.Stream;
 import org.hibernate.StatelessSession;
 
 import io.quarkus.hibernate.orm.panache.common.runtime.AbstractStatelessJpaOperations;
+import io.quarkus.panache.common.Sort;
 
 public class JpaStatelessOperations extends AbstractStatelessJpaOperations<PanacheQueryImpl<?>> {
     /**
@@ -16,9 +17,9 @@ public class JpaStatelessOperations extends AbstractStatelessJpaOperations<Panac
     @Override
     protected PanacheQueryImpl<?> createPanacheQuery(StatelessSession session, Class<?> entityClass, String query,
             String originalQuery,
-            String orderBy,
+            Sort sort,
             Object paramsArrayOrMap) {
-        return new PanacheQueryImpl<>(session, entityClass, query, originalQuery, orderBy, paramsArrayOrMap);
+        return new PanacheQueryImpl<>(session, entityClass, query, originalQuery, sort, paramsArrayOrMap);
     }
 
     @Override

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/PanacheQueryImpl.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/PanacheQueryImpl.java
@@ -14,14 +14,15 @@ import io.quarkus.hibernate.orm.panache.PanacheQuery;
 import io.quarkus.hibernate.orm.panache.common.runtime.CommonPanacheQueryImpl;
 import io.quarkus.panache.common.Page;
 import io.quarkus.panache.common.Parameters;
+import io.quarkus.panache.common.Sort;
 
 public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
 
     private CommonPanacheQueryImpl<Entity> delegate;
 
-    PanacheQueryImpl(SharedSessionContract session, Class<?> entityClass, String query, String originalQuery, String orderBy,
+    PanacheQueryImpl(SharedSessionContract session, Class<?> entityClass, String query, String originalQuery, Sort sort,
             Object paramsArrayOrMap) {
-        this.delegate = new CommonPanacheQueryImpl<>(session, entityClass, query, originalQuery, orderBy, paramsArrayOrMap);
+        this.delegate = new CommonPanacheQueryImpl<>(session, entityClass, query, originalQuery, sort, paramsArrayOrMap);
     }
 
     protected PanacheQueryImpl(CommonPanacheQueryImpl<Entity> delegate) {

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/PanacheQueryImpl.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/PanacheQueryImpl.java
@@ -19,9 +19,9 @@ public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
 
     private CommonPanacheQueryImpl<Entity> delegate;
 
-    PanacheQueryImpl(SharedSessionContract session, String query, String originalQuery, String orderBy,
+    PanacheQueryImpl(SharedSessionContract session, Class<?> entityClass, String query, String originalQuery, String orderBy,
             Object paramsArrayOrMap) {
-        this.delegate = new CommonPanacheQueryImpl<>(session, query, originalQuery, orderBy, paramsArrayOrMap);
+        this.delegate = new CommonPanacheQueryImpl<>(session, entityClass, query, originalQuery, orderBy, paramsArrayOrMap);
     }
 
     protected PanacheQueryImpl(CommonPanacheQueryImpl<Entity> delegate) {

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/AbstractJpaOperations.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/AbstractJpaOperations.java
@@ -35,7 +35,8 @@ public abstract class AbstractJpaOperations<PanacheQueryType, SessionType> {
     static final long TIMEOUT_MS = 5000;
     protected static final Object[] EMPTY_OBJECT_ARRAY = new Object[0];
 
-    protected abstract PanacheQueryType createPanacheQuery(Uni<SessionType> session, String query, String originalQuery,
+    protected abstract PanacheQueryType createPanacheQuery(Uni<SessionType> session, Class<?> entityClass, String query,
+            String originalQuery,
             String orderBy,
             Object paramsArrayOrMap);
 
@@ -100,10 +101,10 @@ public abstract class AbstractJpaOperations<PanacheQueryType, SessionType> {
                                 + "\" instead");
             }
             NamedQueryUtil.checkNamedQuery(entityClass, namedQuery);
-            return createPanacheQuery(session, panacheQuery, panacheQuery, PanacheJpaUtil.toOrderBy(sort), params);
+            return createPanacheQuery(session, entityClass, panacheQuery, panacheQuery, PanacheJpaUtil.toOrderBy(sort), params);
         }
         String hqlQuery = PanacheJpaUtil.createFindQuery(entityClass, panacheQuery, paramCount(params));
-        return createPanacheQuery(session, hqlQuery, panacheQuery, PanacheJpaUtil.toOrderBy(sort), params);
+        return createPanacheQuery(session, entityClass, hqlQuery, panacheQuery, PanacheJpaUtil.toOrderBy(sort), params);
     }
 
     public PanacheQueryType find(Class<?> entityClass, String panacheQuery, Map<String, Object> params) {
@@ -120,10 +121,10 @@ public abstract class AbstractJpaOperations<PanacheQueryType, SessionType> {
                                 + "\" instead");
             }
             NamedQueryUtil.checkNamedQuery(entityClass, namedQuery);
-            return createPanacheQuery(session, panacheQuery, panacheQuery, PanacheJpaUtil.toOrderBy(sort), params);
+            return createPanacheQuery(session, entityClass, panacheQuery, panacheQuery, PanacheJpaUtil.toOrderBy(sort), params);
         }
         String hqlQuery = PanacheJpaUtil.createFindQuery(entityClass, panacheQuery, paramCount(params));
-        return createPanacheQuery(session, hqlQuery, panacheQuery, PanacheJpaUtil.toOrderBy(sort), params);
+        return createPanacheQuery(session, entityClass, hqlQuery, panacheQuery, PanacheJpaUtil.toOrderBy(sort), params);
     }
 
     public PanacheQueryType find(Class<?> entityClass, String query, Parameters params) {
@@ -161,13 +162,13 @@ public abstract class AbstractJpaOperations<PanacheQueryType, SessionType> {
     public PanacheQueryType findAll(Class<?> entityClass) {
         String query = "FROM " + PanacheJpaUtil.getEntityName(entityClass);
         Uni<SessionType> session = getSession(entityClass);
-        return createPanacheQuery(session, query, null, null, null);
+        return createPanacheQuery(session, entityClass, query, null, null, null);
     }
 
     public PanacheQueryType findAll(Class<?> entityClass, Sort sort) {
         String query = "FROM " + PanacheJpaUtil.getEntityName(entityClass);
         Uni<SessionType> session = getSession(entityClass);
-        return createPanacheQuery(session, query, null, PanacheJpaUtil.toOrderBy(sort), null);
+        return createPanacheQuery(session, entityClass, query, null, PanacheJpaUtil.toOrderBy(sort), null);
     }
 
     public Uni<List<?>> listAll(Class<?> entityClass) {

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/AbstractJpaOperations.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/AbstractJpaOperations.java
@@ -37,7 +37,7 @@ public abstract class AbstractJpaOperations<PanacheQueryType, SessionType> {
 
     protected abstract PanacheQueryType createPanacheQuery(Uni<SessionType> session, Class<?> entityClass, String query,
             String originalQuery,
-            String orderBy,
+            Sort sort,
             Object paramsArrayOrMap);
 
     protected abstract Uni<List<?>> list(PanacheQueryType query);
@@ -101,10 +101,10 @@ public abstract class AbstractJpaOperations<PanacheQueryType, SessionType> {
                                 + "\" instead");
             }
             NamedQueryUtil.checkNamedQuery(entityClass, namedQuery);
-            return createPanacheQuery(session, entityClass, panacheQuery, panacheQuery, PanacheJpaUtil.toOrderBy(sort), params);
+            return createPanacheQuery(session, entityClass, panacheQuery, panacheQuery, sort, params);
         }
         String hqlQuery = PanacheJpaUtil.createFindQuery(entityClass, panacheQuery, paramCount(params));
-        return createPanacheQuery(session, entityClass, hqlQuery, panacheQuery, PanacheJpaUtil.toOrderBy(sort), params);
+        return createPanacheQuery(session, entityClass, hqlQuery, panacheQuery, sort, params);
     }
 
     public PanacheQueryType find(Class<?> entityClass, String panacheQuery, Map<String, Object> params) {
@@ -121,10 +121,10 @@ public abstract class AbstractJpaOperations<PanacheQueryType, SessionType> {
                                 + "\" instead");
             }
             NamedQueryUtil.checkNamedQuery(entityClass, namedQuery);
-            return createPanacheQuery(session, entityClass, panacheQuery, panacheQuery, PanacheJpaUtil.toOrderBy(sort), params);
+            return createPanacheQuery(session, entityClass, panacheQuery, panacheQuery, sort, params);
         }
         String hqlQuery = PanacheJpaUtil.createFindQuery(entityClass, panacheQuery, paramCount(params));
-        return createPanacheQuery(session, entityClass, hqlQuery, panacheQuery, PanacheJpaUtil.toOrderBy(sort), params);
+        return createPanacheQuery(session, entityClass, hqlQuery, panacheQuery, sort, params);
     }
 
     public PanacheQueryType find(Class<?> entityClass, String query, Parameters params) {
@@ -168,7 +168,7 @@ public abstract class AbstractJpaOperations<PanacheQueryType, SessionType> {
     public PanacheQueryType findAll(Class<?> entityClass, Sort sort) {
         String query = "FROM " + PanacheJpaUtil.getEntityName(entityClass);
         Uni<SessionType> session = getSession(entityClass);
-        return createPanacheQuery(session, entityClass, query, null, PanacheJpaUtil.toOrderBy(sort), null);
+        return createPanacheQuery(session, entityClass, query, null, sort, null);
     }
 
     public Uni<List<?>> listAll(Class<?> entityClass) {

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/CommonAbstractPanacheQueryImpl.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/CommonAbstractPanacheQueryImpl.java
@@ -59,10 +59,13 @@ public abstract class CommonAbstractPanacheQueryImpl<Entity, SessionType extends
     private Class<?> projectionType;
 
     protected Uni<SessionType> em;
+    private Class<?> entityClass;
 
-    public CommonAbstractPanacheQueryImpl(Uni<SessionType> em, String query, String originalQuery, String orderBy,
+    public CommonAbstractPanacheQueryImpl(Uni<SessionType> em, Class<?> entityClass, String query, String originalQuery,
+            String orderBy,
             Object paramsArrayOrMap) {
         this.em = em;
+        this.entityClass = entityClass;
         this.query = query;
         this.originalQuery = originalQuery;
         this.orderBy = orderBy;
@@ -74,6 +77,7 @@ public abstract class CommonAbstractPanacheQueryImpl<Entity, SessionType extends
             String customCountQueryForSpring,
             Class<?> projectionType) {
         this.em = previousQuery.em;
+        this.entityClass = previousQuery.entityClass;
         this.query = newQueryString;
         this.customCountQueryForSpring = customCountQueryForSpring;
         this.orderBy = previousQuery.orderBy;

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/CommonAbstractPanacheQueryImpl.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/CommonAbstractPanacheQueryImpl.java
@@ -284,10 +284,26 @@ public abstract class CommonAbstractPanacheQueryImpl<Entity, SessionType extends
         }
     }
 
+    public Range range() {
+        checkRange();
+        return range;
+    }
+
     public void range(int startIndex, int lastIndex) {
         this.range = Range.of(startIndex, lastIndex);
         // reset the page to its default to be able to switch from page to range
         this.page = null;
+    }
+
+    private void checkRange() {
+        if (range == null) {
+            throw new UnsupportedOperationException("Cannot call a range related method, " +
+                    "call range(int, int) to initiate range first");
+        }
+        if (page != null) {
+            throw new UnsupportedOperationException("Cannot call a range related method in a paged query, " +
+                    "call range(int, int) to initiate range first");
+        }
     }
 
     public void withLock(LockModeType lockModeType) {

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/CommonAbstractPanacheQueryImpl.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/CommonAbstractPanacheQueryImpl.java
@@ -23,6 +23,7 @@ import io.quarkus.hibernate.reactive.panache.common.ProjectedConstructor;
 import io.quarkus.hibernate.reactive.panache.common.ProjectedFieldName;
 import io.quarkus.panache.common.Page;
 import io.quarkus.panache.common.Range;
+import io.quarkus.panache.common.Sort;
 import io.quarkus.panache.common.exception.PanacheQueryException;
 import io.quarkus.panache.hibernate.common.runtime.PanacheJpaUtil;
 import io.smallrye.mutiny.Multi;
@@ -45,7 +46,7 @@ public abstract class CommonAbstractPanacheQueryImpl<Entity, SessionType extends
      * Otherwise we do not use this, and rely on ORM to generate count queries
      */
     protected String customCountQueryForSpring;
-    private String orderBy;
+    private Sort sort;
 
     private Page page;
     private Uni<Long> count;
@@ -62,13 +63,13 @@ public abstract class CommonAbstractPanacheQueryImpl<Entity, SessionType extends
     private Class<?> entityClass;
 
     public CommonAbstractPanacheQueryImpl(Uni<SessionType> em, Class<?> entityClass, String query, String originalQuery,
-            String orderBy,
+            Sort sort,
             Object paramsArrayOrMap) {
         this.em = em;
         this.entityClass = entityClass;
         this.query = query;
         this.originalQuery = originalQuery;
-        this.orderBy = orderBy;
+        this.sort = sort;
         this.paramsArrayOrMap = paramsArrayOrMap;
     }
 
@@ -80,7 +81,7 @@ public abstract class CommonAbstractPanacheQueryImpl<Entity, SessionType extends
         this.entityClass = previousQuery.entityClass;
         this.query = newQueryString;
         this.customCountQueryForSpring = customCountQueryForSpring;
-        this.orderBy = previousQuery.orderBy;
+        this.sort = previousQuery.sort;
         this.paramsArrayOrMap = previousQuery.paramsArrayOrMap;
         this.page = previousQuery.page;
         this.count = previousQuery.count;
@@ -437,6 +438,7 @@ public abstract class CommonAbstractPanacheQueryImpl<Entity, SessionType extends
                     : em.createNamedQuery(namedQuery, projectionType);
         } else {
             try {
+                String orderBy = PanacheJpaUtil.toOrderBy(sort);
                 hibernateQuery = em.createSelectionQuery(orderBy != null ? query + orderBy : query, projectionType);
             } catch (RuntimeException x) {
                 throw NamedQueryUtil.checkForNamedQueryMistake(x, originalQuery);

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/CommonManagedPanacheQueryImpl.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/CommonManagedPanacheQueryImpl.java
@@ -3,14 +3,15 @@ package io.quarkus.hibernate.reactive.panache.common.runtime;
 import org.hibernate.Filter;
 import org.hibernate.reactive.mutiny.Mutiny;
 
+import io.quarkus.panache.common.Sort;
 import io.smallrye.mutiny.Uni;
 
 public class CommonManagedPanacheQueryImpl<Entity> extends CommonAbstractPanacheQueryImpl<Entity, Mutiny.Session> {
 
     public CommonManagedPanacheQueryImpl(Uni<Mutiny.Session> em, Class<?> entityClass, String query, String originalQuery,
-            String orderBy,
+            Sort sort,
             Object paramsArrayOrMap) {
-        super(em, entityClass, query, originalQuery, orderBy, paramsArrayOrMap);
+        super(em, entityClass, query, originalQuery, sort, paramsArrayOrMap);
     }
 
     protected CommonManagedPanacheQueryImpl(CommonManagedPanacheQueryImpl<?> previousQuery, String newQueryString,

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/CommonManagedPanacheQueryImpl.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/CommonManagedPanacheQueryImpl.java
@@ -7,9 +7,10 @@ import io.smallrye.mutiny.Uni;
 
 public class CommonManagedPanacheQueryImpl<Entity> extends CommonAbstractPanacheQueryImpl<Entity, Mutiny.Session> {
 
-    public CommonManagedPanacheQueryImpl(Uni<Mutiny.Session> em, String query, String originalQuery, String orderBy,
+    public CommonManagedPanacheQueryImpl(Uni<Mutiny.Session> em, Class<?> entityClass, String query, String originalQuery,
+            String orderBy,
             Object paramsArrayOrMap) {
-        super(em, query, originalQuery, orderBy, paramsArrayOrMap);
+        super(em, entityClass, query, originalQuery, orderBy, paramsArrayOrMap);
     }
 
     protected CommonManagedPanacheQueryImpl(CommonManagedPanacheQueryImpl<?> previousQuery, String newQueryString,

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/CommonStatelessPanacheQueryImpl.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/CommonStatelessPanacheQueryImpl.java
@@ -3,6 +3,7 @@ package io.quarkus.hibernate.reactive.panache.common.runtime;
 import org.hibernate.Filter;
 import org.hibernate.reactive.mutiny.Mutiny;
 
+import io.quarkus.panache.common.Sort;
 import io.smallrye.mutiny.Uni;
 
 public class CommonStatelessPanacheQueryImpl<Entity> extends CommonAbstractPanacheQueryImpl<Entity, Mutiny.StatelessSession> {
@@ -10,9 +11,9 @@ public class CommonStatelessPanacheQueryImpl<Entity> extends CommonAbstractPanac
     protected Uni<Mutiny.StatelessSession> em;
 
     public CommonStatelessPanacheQueryImpl(Uni<Mutiny.StatelessSession> em, Class<?> entityClass, String query,
-            String originalQuery, String orderBy,
+            String originalQuery, Sort sort,
             Object paramsArrayOrMap) {
-        super(em, entityClass, query, originalQuery, orderBy, paramsArrayOrMap);
+        super(em, entityClass, query, originalQuery, sort, paramsArrayOrMap);
     }
 
     protected CommonStatelessPanacheQueryImpl(CommonStatelessPanacheQueryImpl<?> previousQuery, String newQueryString,

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/CommonStatelessPanacheQueryImpl.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/CommonStatelessPanacheQueryImpl.java
@@ -9,9 +9,10 @@ public class CommonStatelessPanacheQueryImpl<Entity> extends CommonAbstractPanac
 
     protected Uni<Mutiny.StatelessSession> em;
 
-    public CommonStatelessPanacheQueryImpl(Uni<Mutiny.StatelessSession> em, String query, String originalQuery, String orderBy,
+    public CommonStatelessPanacheQueryImpl(Uni<Mutiny.StatelessSession> em, Class<?> entityClass, String query,
+            String originalQuery, String orderBy,
             Object paramsArrayOrMap) {
-        super(em, query, originalQuery, orderBy, paramsArrayOrMap);
+        super(em, entityClass, query, originalQuery, orderBy, paramsArrayOrMap);
     }
 
     protected CommonStatelessPanacheQueryImpl(CommonStatelessPanacheQueryImpl<?> previousQuery, String newQueryString,

--- a/extensions/panache/hibernate-reactive-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/reactive/panache/kotlin/runtime/KotlinJpaOperations.kt
+++ b/extensions/panache/hibernate-reactive-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/reactive/panache/kotlin/runtime/KotlinJpaOperations.kt
@@ -1,6 +1,7 @@
 package io.quarkus.hibernate.reactive.panache.kotlin.runtime
 
 import io.quarkus.hibernate.reactive.panache.common.runtime.AbstractManagedJpaOperations
+import io.quarkus.panache.common.Sort
 import io.smallrye.mutiny.Uni
 import org.hibernate.reactive.mutiny.Mutiny
 
@@ -10,9 +11,9 @@ class KotlinJpaOperations : AbstractManagedJpaOperations<PanacheQueryImpl<*>>() 
         entityClass: Class<*>,
         query: String,
         originalQuery: String?,
-        orderBy: String?,
+        sort: Sort?,
         paramsArrayOrMap: Any?,
-    ) = PanacheQueryImpl<Any>(session, entityClass, query, originalQuery, orderBy, paramsArrayOrMap)
+    ) = PanacheQueryImpl<Any>(session, entityClass, query, originalQuery, sort, paramsArrayOrMap)
 
     override fun list(query: PanacheQueryImpl<*>): Uni<MutableList<*>> =
         query.list() as Uni<MutableList<*>>

--- a/extensions/panache/hibernate-reactive-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/reactive/panache/kotlin/runtime/KotlinJpaOperations.kt
+++ b/extensions/panache/hibernate-reactive-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/reactive/panache/kotlin/runtime/KotlinJpaOperations.kt
@@ -7,11 +7,12 @@ import org.hibernate.reactive.mutiny.Mutiny
 class KotlinJpaOperations : AbstractManagedJpaOperations<PanacheQueryImpl<*>>() {
     override fun createPanacheQuery(
         session: Uni<Mutiny.Session>,
+        entityClass: Class<*>,
         query: String,
         originalQuery: String?,
         orderBy: String?,
         paramsArrayOrMap: Any?,
-    ) = PanacheQueryImpl<Any>(session, query, originalQuery, orderBy, paramsArrayOrMap)
+    ) = PanacheQueryImpl<Any>(session, entityClass, query, originalQuery, orderBy, paramsArrayOrMap)
 
     override fun list(query: PanacheQueryImpl<*>): Uni<MutableList<*>> =
         query.list() as Uni<MutableList<*>>

--- a/extensions/panache/hibernate-reactive-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/reactive/panache/kotlin/runtime/PanacheQueryImpl.kt
+++ b/extensions/panache/hibernate-reactive-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/reactive/panache/kotlin/runtime/PanacheQueryImpl.kt
@@ -13,13 +13,21 @@ class PanacheQueryImpl<Entity : Any> : PanacheQuery<Entity> {
 
     internal constructor(
         em: Uni<Mutiny.Session>,
+        entityClass: Class<*>?,
         query: String?,
         originalQuery: String?,
         orderBy: String?,
         paramsArrayOrMap: Any?,
     ) {
         delegate =
-            CommonManagedPanacheQueryImpl(em, query, originalQuery, orderBy, paramsArrayOrMap)
+            CommonManagedPanacheQueryImpl(
+                em,
+                entityClass,
+                query,
+                originalQuery,
+                orderBy,
+                paramsArrayOrMap,
+            )
     }
 
     private constructor(delegate: CommonManagedPanacheQueryImpl<Entity>) {

--- a/extensions/panache/hibernate-reactive-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/reactive/panache/kotlin/runtime/PanacheQueryImpl.kt
+++ b/extensions/panache/hibernate-reactive-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/reactive/panache/kotlin/runtime/PanacheQueryImpl.kt
@@ -4,6 +4,7 @@ import io.quarkus.hibernate.reactive.panache.common.runtime.CommonManagedPanache
 import io.quarkus.hibernate.reactive.panache.kotlin.PanacheQuery
 import io.quarkus.panache.common.Page
 import io.quarkus.panache.common.Parameters
+import io.quarkus.panache.common.Sort
 import io.smallrye.mutiny.Uni
 import jakarta.persistence.LockModeType
 import org.hibernate.reactive.mutiny.Mutiny
@@ -16,7 +17,7 @@ class PanacheQueryImpl<Entity : Any> : PanacheQuery<Entity> {
         entityClass: Class<*>?,
         query: String?,
         originalQuery: String?,
-        orderBy: String?,
+        sort: Sort?,
         paramsArrayOrMap: Any?,
     ) {
         delegate =
@@ -25,7 +26,7 @@ class PanacheQueryImpl<Entity : Any> : PanacheQuery<Entity> {
                 entityClass,
                 query,
                 originalQuery,
-                orderBy,
+                sort,
                 paramsArrayOrMap,
             )
     }

--- a/extensions/panache/hibernate-reactive-panache/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/runtime/CustomCountPanacheQuery.java
+++ b/extensions/panache/hibernate-reactive-panache/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/runtime/CustomCountPanacheQuery.java
@@ -11,7 +11,7 @@ public class CustomCountPanacheQuery<Entity> extends PanacheQueryImpl<Entity> {
 
     public CustomCountPanacheQuery(Uni<Mutiny.Session> em, String query, String customCountQuery,
             Object paramsArrayOrMap) {
-        super(new CommonManagedPanacheQueryImpl<Entity>(em, query, null, null, paramsArrayOrMap) {
+        super(new CommonManagedPanacheQueryImpl<Entity>(em, null, query, null, null, paramsArrayOrMap) {
             {
                 this.customCountQueryForSpring = customCountQuery;
             }

--- a/extensions/panache/hibernate-reactive-panache/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/runtime/JpaOperations.java
+++ b/extensions/panache/hibernate-reactive-panache/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/runtime/JpaOperations.java
@@ -12,10 +12,11 @@ public class JpaOperations extends AbstractManagedJpaOperations<PanacheQueryImpl
     public static final JpaOperations INSTANCE = new JpaOperations();
 
     @Override
-    protected PanacheQueryImpl<?> createPanacheQuery(Uni<Mutiny.Session> session, String query, String originalQuery,
+    protected PanacheQueryImpl<?> createPanacheQuery(Uni<Mutiny.Session> session, Class<?> entityClass, String query,
+            String originalQuery,
             String orderBy,
             Object paramsArrayOrMap) {
-        return new PanacheQueryImpl<>(session, query, originalQuery, orderBy, paramsArrayOrMap);
+        return new PanacheQueryImpl<>(session, entityClass, query, originalQuery, orderBy, paramsArrayOrMap);
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/extensions/panache/hibernate-reactive-panache/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/runtime/JpaOperations.java
+++ b/extensions/panache/hibernate-reactive-panache/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/runtime/JpaOperations.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.hibernate.reactive.mutiny.Mutiny;
 
 import io.quarkus.hibernate.reactive.panache.common.runtime.AbstractManagedJpaOperations;
+import io.quarkus.panache.common.Sort;
 import io.smallrye.mutiny.Uni;
 
 public class JpaOperations extends AbstractManagedJpaOperations<PanacheQueryImpl<?>> {
@@ -14,9 +15,9 @@ public class JpaOperations extends AbstractManagedJpaOperations<PanacheQueryImpl
     @Override
     protected PanacheQueryImpl<?> createPanacheQuery(Uni<Mutiny.Session> session, Class<?> entityClass, String query,
             String originalQuery,
-            String orderBy,
+            Sort sort,
             Object paramsArrayOrMap) {
-        return new PanacheQueryImpl<>(session, entityClass, query, originalQuery, orderBy, paramsArrayOrMap);
+        return new PanacheQueryImpl<>(session, entityClass, query, originalQuery, sort, paramsArrayOrMap);
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/extensions/panache/hibernate-reactive-panache/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/runtime/PanacheQueryImpl.java
+++ b/extensions/panache/hibernate-reactive-panache/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/runtime/PanacheQueryImpl.java
@@ -12,15 +12,16 @@ import io.quarkus.hibernate.reactive.panache.PanacheQuery;
 import io.quarkus.hibernate.reactive.panache.common.runtime.CommonManagedPanacheQueryImpl;
 import io.quarkus.panache.common.Page;
 import io.quarkus.panache.common.Parameters;
+import io.quarkus.panache.common.Sort;
 import io.smallrye.mutiny.Uni;
 
 public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
 
     private CommonManagedPanacheQueryImpl<Entity> delegate;
 
-    PanacheQueryImpl(Uni<Mutiny.Session> em, Class<?> entityClass, String query, String originalQuery, String orderBy,
+    PanacheQueryImpl(Uni<Mutiny.Session> em, Class<?> entityClass, String query, String originalQuery, Sort sort,
             Object paramsArrayOrMap) {
-        this.delegate = new CommonManagedPanacheQueryImpl<Entity>(em, entityClass, query, originalQuery, orderBy,
+        this.delegate = new CommonManagedPanacheQueryImpl<Entity>(em, entityClass, query, originalQuery, sort,
                 paramsArrayOrMap);
     }
 

--- a/extensions/panache/hibernate-reactive-panache/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/runtime/PanacheQueryImpl.java
+++ b/extensions/panache/hibernate-reactive-panache/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/runtime/PanacheQueryImpl.java
@@ -18,8 +18,10 @@ public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
 
     private CommonManagedPanacheQueryImpl<Entity> delegate;
 
-    PanacheQueryImpl(Uni<Mutiny.Session> em, String query, String originalQuery, String orderBy, Object paramsArrayOrMap) {
-        this.delegate = new CommonManagedPanacheQueryImpl<Entity>(em, query, originalQuery, orderBy, paramsArrayOrMap);
+    PanacheQueryImpl(Uni<Mutiny.Session> em, Class<?> entityClass, String query, String originalQuery, String orderBy,
+            Object paramsArrayOrMap) {
+        this.delegate = new CommonManagedPanacheQueryImpl<Entity>(em, entityClass, query, originalQuery, orderBy,
+                paramsArrayOrMap);
     }
 
     protected PanacheQueryImpl(CommonManagedPanacheQueryImpl<Entity> delegate) {

--- a/extensions/panache/panache-common/runtime/src/main/java/io/quarkus/panache/common/Range.java
+++ b/extensions/panache/panache-common/runtime/src/main/java/io/quarkus/panache/common/Range.java
@@ -12,24 +12,52 @@ package io.quarkus.panache.common;
  * <code><pre>
  * Range range = Range.of(0, 5);
  * </pre></code>
+ *
+ * Note that due to the end index being inclusive, it's impossible to write empty ranges.
  */
 public class Range {
+    // FIXME: bump to long? Jakarta Data uses longs for its Limit type
     private final int startIndex;
     private final int lastIndex;
 
+    /**
+     * Creates a new range
+     *
+     * @param startIndex the start index to include, 0-based
+     * @param lastIndex the end index to include, 0-based
+     */
     public Range(int startIndex, int lastIndex) {
+        if (startIndex < 0)
+            throw new IllegalArgumentException("Start index must be >= 0: " + startIndex);
+        if (lastIndex < 0)
+            throw new IllegalArgumentException("Last index must be >= 0: " + lastIndex);
+        if (lastIndex < startIndex)
+            throw new IllegalArgumentException(
+                    "Last index must be >= start index: " + lastIndex + " is not larger or equal to " + startIndex);
         this.startIndex = startIndex;
         this.lastIndex = lastIndex;
     }
 
+    /**
+     * Creates a new range
+     *
+     * @param startIndex the start index to include, 0-based
+     * @param lastIndex the end index to include, 0-based
+     */
     public static Range of(int startIndex, int lastIndex) {
         return new Range(startIndex, lastIndex);
     }
 
+    /**
+     * @return the start index to include, 0-based
+     */
     public int getStartIndex() {
         return startIndex;
     }
 
+    /**
+     * @return the last index to include, 0-based
+     */
     public int getLastIndex() {
         return lastIndex;
     }

--- a/extensions/panache/panache-hibernate-common/runtime/src/main/java/io/quarkus/panache/hibernate/common/runtime/PanacheJpaUtil.java
+++ b/extensions/panache/panache-hibernate-common/runtime/src/main/java/io/quarkus/panache/hibernate/common/runtime/PanacheJpaUtil.java
@@ -1,7 +1,12 @@
 package io.quarkus.panache.hibernate.common.runtime;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.regex.Pattern;
+
+import org.hibernate.query.Order;
+import org.hibernate.query.SortDirection;
 
 import io.quarkus.panache.common.Sort;
 import io.quarkus.panache.common.exception.PanacheQueryException;
@@ -237,6 +242,27 @@ public class PanacheJpaUtil {
         }
 
         return result;
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public static List<Order<?>> toHibernateOrders(Class<?> entityClass, Sort sort) {
+        if (sort == null || sort.getColumns().isEmpty()) {
+            return List.of();
+        }
+        List<Order<?>> orders = new ArrayList<>();
+        for (Sort.Column column : sort.getColumns()) {
+            SortDirection direction = column.getDirection() == Sort.Direction.Ascending
+                    ? SortDirection.ASCENDING
+                    : SortDirection.DESCENDING;
+            Order<?> order = Order.by((Class) entityClass, column.getName(), direction, column.isIgnoreCase());
+            if (column.getNullPrecedence() == Sort.NullPrecedence.NULLS_FIRST) {
+                order = order.withNullsFirst();
+            } else if (column.getNullPrecedence() == Sort.NullPrecedence.NULLS_LAST) {
+                order = order.withNullsLast();
+            }
+            orders.add(order);
+        }
+        return orders;
     }
 
     private static StringBuilder escapeColumnName(String columnName) {


### PR DESCRIPTION
- Moved all paging methods to a new type `PanacheQuery.Paging`, for a Mutiny-style API, freeing `PanacheQuery` from clutter
- Moved all range methods to a new type `PanacheQuery.Limits`
- Added support for cursored paging
- Switched to `PageRequest` from Jakarta Data
- Added overloads to support `Sort` (single column) as well as `Order` (multi column)
- Added paging tests

There are still some questions about the API, but it looks better than before, I think.
Also needs some docs.

Fixes #53431