### PR TITLE
REST: share CDI request context between @RouteFilter and JAX-RS resource

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/RouteFilterRequestContextPropagationTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/RouteFilterRequestContextPropagationTest.java
@@ -1,0 +1,86 @@
+package io.quarkus.resteasy.reactive.server.test;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.is;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.vertx.web.RouteFilter;
+import io.smallrye.common.annotation.NonBlocking;
+import io.vertx.ext.web.RoutingContext;
+
+public class RouteFilterRequestContextPropagationTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot(root -> root.addClasses(RequestFoo.class, MyFilter.class, MyResource.class));
+
+    @Test
+    void testBlockingEndpoint() {
+        when().get("/hello/blocking")
+                .then()
+                .statusCode(200)
+                .body(is("route-filter-value"));
+    }
+
+    @Test
+    void testNonBlockingEndpoint() {
+        when().get("/hello/non-blocking")
+                .then()
+                .statusCode(200)
+                .body(is("route-filter-value"));
+    }
+
+    @RequestScoped
+    public static class RequestFoo {
+
+        private volatile String value;
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+
+    public static class MyFilter {
+
+        @Inject
+        RequestFoo foo;
+
+        @RouteFilter
+        void filter(RoutingContext rc) {
+            foo.setValue("route-filter-value");
+            rc.next();
+        }
+    }
+
+    @Path("hello")
+    public static class MyResource {
+
+        @Inject
+        RequestFoo foo;
+
+        @GET
+        @Path("blocking")
+        public String blocking() {
+            return foo.getValue();
+        }
+
+        @GET
+        @Path("non-blocking")
+        @NonBlocking
+        public String nonBlocking() {
+            return foo.getValue();
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/QuarkusResteasyReactiveRequestContext.java
+++ b/extensions/resteasy-reactive/rest/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/QuarkusResteasyReactiveRequestContext.java
@@ -37,6 +37,11 @@ public class QuarkusResteasyReactiveRequestContext extends VertxResteasyReactive
         if (VertxContext.isOnDuplicatedContext()) {
             VertxContextSafetyToggle.setCurrentContextSafe(true);
         }
+        // If a CDI request context is already active (e.g. activated by a @RouteFilter),
+        // capture it so that it can be reused when the handler chain resumes on a worker thread
+        if (requestContext.isRequestContextActive()) {
+            captureCDIRequestScope();
+        }
     }
 
     protected void handleRequestScopeActivation() {


### PR DESCRIPTION
- fixes #54465

Note that the worker executor propagates the Vert.x duplicated context but strips the CDI context keys to prevent cross-request leakage. As a result, RESTEasy Reactive creates a new CDI request context. The fix captures the existing CDI request context in the QuarkusResteasyReactiveRequestContext constructor. When the handler chain resumes on a worker thread, the captured state is reused.

