### PR TITLE
Surface the application log tail when an integration test fails to boot

### DIFF
--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
@@ -19,7 +19,10 @@ import static java.util.Optional.empty;
 
 import java.io.Closeable;
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -78,6 +81,8 @@ import io.smallrye.config.SmallRyeConfigBuilder;
 public class QuarkusIntegrationTestExtension extends AbstractQuarkusTestWithContextExtension
         implements BeforeTestExecutionCallback, AfterTestExecutionCallback, BeforeEachCallback, AfterEachCallback,
         BeforeAllCallback, AfterAllCallback, TestInstancePostProcessor, ParameterResolver {
+
+    private static final int APP_LOG_TAIL_LINES = 50;
 
     private static boolean failedBoot;
 
@@ -196,6 +201,7 @@ public class QuarkusIntegrationTestExtension extends AbstractQuarkusTestWithCont
                     if (appLogFile.exists() && (appLogFile.length() > 0)) {
                         System.err.println("Failed to launch the application. The application logs can be found at: "
                                 + appLogFile.getAbsolutePath());
+                        printApplicationLogTail(appLogFile);
                     }
                 } catch (IllegalStateException ignored) {
 
@@ -206,6 +212,33 @@ public class QuarkusIntegrationTestExtension extends AbstractQuarkusTestWithCont
             }
         }
         return state;
+    }
+
+    // When the application fails to boot, the launcher only reports a generic "Unable to determine the
+    // status of the running process" error; the real cause is in the application log file. Echo the tail of
+    // that file to System.err so the cause is visible directly in the test output (e.g. in CI), not only on disk.
+    private static void printApplicationLogTail(File appLogFile) {
+        try {
+            applicationLogTail(Files.readAllLines(appLogFile.toPath()), APP_LOG_TAIL_LINES, appLogFile.getName())
+                    .forEach(System.err::println);
+        } catch (IOException ignored) {
+            // best-effort; the path to the full log was already printed above
+        }
+    }
+
+    // Formats the last `maxLines` lines of the given log content with a header, or returns an empty list
+    // when there is nothing to show. Kept package-private and pure so it can be unit-tested directly.
+    static List<String> applicationLogTail(List<String> lines, int maxLines, String fileName) {
+        if (lines.isEmpty()) {
+            return List.of();
+        }
+        int from = Math.max(0, lines.size() - maxLines);
+        List<String> tail = new ArrayList<>(lines.size() - from + 1);
+        tail.add("Last " + (lines.size() - from) + " line(s) of " + fileName + ":");
+        for (String line : lines.subList(from, lines.size())) {
+            tail.add("    " + line);
+        }
+        return tail;
     }
 
     private QuarkusTestExtensionState doProcessStart(Class<? extends QuarkusTestProfile> profile, ExtensionContext context)

--- a/test-framework/junit/src/test/java/io/quarkus/test/junit/QuarkusIntegrationTestExtensionTest.java
+++ b/test-framework/junit/src/test/java/io/quarkus/test/junit/QuarkusIntegrationTestExtensionTest.java
@@ -1,0 +1,41 @@
+package io.quarkus.test.junit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+
+public class QuarkusIntegrationTestExtensionTest {
+
+    @Test
+    public void tailReturnsLastLinesWithHeaderWhenLogExceedsLimit() {
+        List<String> lines = IntStream.rangeClosed(1, 120).mapToObj(i -> "line " + i).toList();
+
+        List<String> tail = QuarkusIntegrationTestExtension.applicationLogTail(lines, 50, "quarkus.log");
+
+        assertThat(tail).hasSize(51); // 1 header + 50 lines
+        assertThat(tail.get(0)).isEqualTo("Last 50 line(s) of quarkus.log:");
+        assertThat(tail.get(1)).isEqualTo("    line 71");
+        assertThat(tail.get(50)).isEqualTo("    line 120");
+    }
+
+    @Test
+    public void tailReturnsAllLinesWhenLogIsSmallerThanLimit() {
+        List<String> lines = List.of("first", "second", "third");
+
+        List<String> tail = QuarkusIntegrationTestExtension.applicationLogTail(lines, 50, "quarkus.log");
+
+        assertThat(tail).containsExactly(
+                "Last 3 line(s) of quarkus.log:",
+                "    first",
+                "    second",
+                "    third");
+    }
+
+    @Test
+    public void tailReturnsEmptyForEmptyLog() {
+        assertThat(QuarkusIntegrationTestExtension.applicationLogTail(List.of(), 50, "quarkus.log")).isEmpty();
+    }
+}


### PR DESCRIPTION
Hi @geoand — following up on #53799 (and thanks @GregJohnStewart for the detailed report).

### Problem
When a `@QuarkusIntegrationTest` application fails to start in packaged mode (jar/container/native), the launcher only reports:

```
java.lang.IllegalStateException: Unable to determine the status of the running process. See the above logs for details
    at io.quarkus.test.common.LauncherUtil.waitForCapturedListeningData(LauncherUtil.java:110)
```

The actual cause is written to `quarkus.log` but never echoed to the test output, so it's effectively invisible — especially in CI.

I reproduced it on both Maven and Gradle, on 3.35.2 and 3.36.0, with a genuine JDK mismatch in the container (Java 21 bytecode on a Java 17 base): the container dies with `UnsupportedClassVersionError` before listening, and that cause lands only in `quarkus.log`, never in the console or the surefire/failsafe/Gradle test reports.

### Change
`QuarkusIntegrationTestExtension` already catches the boot failure, locates `quarkus.log`, and prints a breadcrumb to its path. This additionally prints the tail (last 50 lines) of that file to `System.err`, so the real cause shows up directly in the test output — for all build tools and all launchers, which funnel through the same path. The tail formatting is extracted into a small package-private method with unit tests.

Happy to adjust the approach, the number of lines, or move the logic elsewhere (e.g. into `LauncherUtil`) if you'd prefer — just let me know.

- Fixes: #53799