### PR TITLE
Fix Dev UI Workspace scroll not working

### DIFF
--- a/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-workspace.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-workspace.js
@@ -48,12 +48,21 @@ export class QwcWorkspace extends observeState(QwcHotReloadElement) {
     
         .split vaadin-split-layout {
             width: 100%;
+            height: 100%;
+            flex: 1 1 0;
+            min-height: 0;
         }
-    
+
         .files {
             height: 100%;
             display: flex;
             padding-left: 10px;
+            overflow-y: auto;
+        }
+
+        .mainPart {
+            height: 100%;
+            overflow-y: auto;
         }
         .nothing {
             display: flex;
@@ -278,7 +287,7 @@ export class QwcWorkspace extends observeState(QwcHotReloadElement) {
     
     _renderResultSplitView(){
         if(this._actionResult && this._actionResult.content && this._actionResult.display === "split"){
-            return html`<detail-content style="width: 50%;">
+            return html`<detail-content style="width: 50%;overflow-y: auto;">
                 <div class="actionSplitScreen">
                     <div class="actionButtonBar">
                         <vaadin-button theme="icon" aria-label="Close" @click="${this._clearActionResult}">


### PR DESCRIPTION
Vaadin's `vaadin-split-layout` component applies `overflow: clip` to all slotted children via its internal `::slotted(:not(vaadin-split-layout))` CSS rule. This prevented both the file tree and code editor panels in the Dev UI Workspace screen from scrolling when their content exceeded the visible area.

The fix constrains the split layouts to their parent heights and adds `overflow-y: auto` to the file tree, code panel, and action result containers so they scroll within their clipped boundaries.

Fixes #54522