### PR TITLE
Align Dev UI action links with regular extension links

### DIFF
--- a/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-extension-action.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-extension-action.js
@@ -9,17 +9,19 @@ export class QwcExtensionAction extends LitElement {
         :host {
             display: flex;
             flex-direction: row;
+            justify-content: space-between;
             align-items: center;
             padding: 2px 5px;
+            gap: 5px;
         }
         .actionButton {
             display: flex;
             flex-direction: row;
-            justify-content: flex-start;
+            justify-content: space-between;
             align-items: center;
             color: var(--lumo-contrast-70pct);
             font-size: var(--lumo-font-size-s);
-            padding: 2px 5px;
+            padding: 4px 8px;
             cursor: pointer;
             gap: 5px;
             border-radius: var(--devui-radius-sm, 6px);


### PR DESCRIPTION
The action link component (`qwc-extension-action`) used different CSS layout properties than the regular link component (`qwc-extension-link`), causing misaligned rows when both appear on the same extension card. This aligns the `justify-content`, `padding`, and `gap` properties so they render consistently.

<img width="309" height="214" alt="devui-action-links-aligned" src="https://github.com/user-attachments/assets/a73755fa-09a4-463a-88da-2f2da3c0473a" />

In the test above the last 2 links are actions

Fixes #54541