### PR TITLE
Use native MongoDB operations to handle parameters in MongoDB Panache

### DIFF
--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/binder/CommonQueryBinder.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/binder/CommonQueryBinder.java
@@ -1,88 +1,19 @@
 package io.quarkus.mongodb.panache.common.binder;
 
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Date;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-import org.bson.types.ObjectId;
-
 final class CommonQueryBinder {
-
-    private static final String ISO_DATE_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
-    // the default DateTimeFormatter.ISO_LOCAL_DATE_TIME format with too many nano fraction (up to 9) for MongoDB (only 3)
-    private static final DateTimeFormatter ISO_DATE_FORMATTER = DateTimeFormatter.ofPattern(ISO_DATE_PATTERN);
 
     private CommonQueryBinder() {
     }
 
-    static String replace(String query, String oldChars, Object value) {
-        return query.replace(oldChars, escape(value));
-    }
-
-    static String escape(Object value) {
-        if (value == null) {
-            return "null";
-        }
-        if (value.getClass().isArray() || Collection.class.isAssignableFrom(value.getClass())) {
-            return "[" + arrayAsString(value) + "]";
-        }
-        if (Number.class.isAssignableFrom(value.getClass()) || value instanceof Boolean) {
-            return value.toString();
-        }
-        if (value.getClass().isEnum()) {
-            return "'" + ((Enum<?>) value).name() + "'";
-        }
-        if (value instanceof Date) {
-            ZonedDateTime zonedDateTime = ((Date) value).toInstant().atZone(ZoneOffset.UTC);
-            return "{\"$date\": \"" + ISO_DATE_FORMATTER.format(zonedDateTime) + "\"} ";
-        }
-        if (value instanceof LocalDate) {
-            ZonedDateTime zonedDateTime = ((LocalDate) value).atStartOfDay(ZoneOffset.UTC);
-            return "{\"$date\": \"" + ISO_DATE_FORMATTER.format(zonedDateTime) + "\"} ";
-        }
-        if (value instanceof LocalDateTime) {
-            ZonedDateTime zonedDateTime = ((LocalDateTime) value).atZone(ZoneOffset.UTC);
-            return "{\"$date\": \"" + ISO_DATE_FORMATTER.format(zonedDateTime) + "\"} ";
-        }
-        if (value instanceof Instant) {
-            ZonedDateTime zonedDateTime = ((Instant) value).atZone(ZoneOffset.UTC);
-            return "{\"$date\": \"" + ISO_DATE_FORMATTER.format(zonedDateTime) + "\"} ";
-        }
-        if (value instanceof UUID) {
-            return "UUID('" + value.toString() + "')";
-        }
-        if (value instanceof ObjectId) {
-            ObjectId objectId = (ObjectId) value;
-            return "ObjectId('" + objectId.toHexString() + "')";
-        }
-        return "'" + value.toString().replace("\\", "\\\\").replace("'", "\\'") + "'";
-    }
-
     /**
-     * Converts Collection or Array to a String separated for ','. Used in $in operators
+     * Converts parameter values that need special handling before being passed to the MongoDB driver.
+     * Enums are converted to their {@link Enum#name()} since the driver has no built-in enum codec.
+     * All other values are returned as-is — the driver's CodecRegistry handles encoding.
      */
-    private static String arrayAsString(Object value) {
-        Object[] valueArray = convertToArray(value);
-
-        return Arrays.stream(valueArray)
-                .map(CommonQueryBinder::escape)
-                .collect(Collectors.joining(", "));
-    }
-
-    private static Object[] convertToArray(Object value) {
-        if (value.getClass().isArray()) {
-            return (Object[]) value;
+    static Object paramValue(Object value) {
+        if (value != null && value.getClass().isEnum()) {
+            return ((Enum<?>) value).name();
         }
-
-        Collection collection = (Collection) value;
-        return collection.toArray(new Object[collection.size()]);
+        return value;
     }
 }

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/binder/MongoParserVisitor.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/binder/MongoParserVisitor.java
@@ -1,6 +1,12 @@
 package io.quarkus.mongodb.panache.common.binder;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+
+import org.bson.conversions.Bson;
+
+import com.mongodb.client.model.Filters;
 
 import io.quarkus.panacheql.internal.HqlParser;
 import io.quarkus.panacheql.internal.HqlParser.ComparisonPredicateContext;
@@ -12,7 +18,7 @@ import io.quarkus.panacheql.internal.HqlParser.PositionalParameterContext;
 import io.quarkus.panacheql.internal.HqlParser.StandardFunctionContext;
 import io.quarkus.panacheql.internal.HqlParserBaseVisitor;
 
-class MongoParserVisitor extends HqlParserBaseVisitor<String> {
+class MongoParserVisitor extends HqlParserBaseVisitor<Object> {
     private Map<String, String> replacementMap;
     private Map<String, Object> parameterMaps;
 
@@ -22,110 +28,112 @@ class MongoParserVisitor extends HqlParserBaseVisitor<String> {
     }
 
     @Override
-    public String visitAndPredicate(HqlParser.AndPredicateContext ctx) {
-        StringBuilder sb = new StringBuilder();
+    public Object visitAndPredicate(HqlParser.AndPredicateContext ctx) {
+        List<Bson> filters = new ArrayList<>();
         for (HqlParser.PredicateContext predicate : ctx.predicate()) {
-            if (sb.length() > 0)
-                sb.append(",");
-            sb.append(predicate.accept(this));
+            filters.add((Bson) predicate.accept(this));
         }
-        return sb.toString();
+        return Filters.and(filters);
     }
 
     @Override
-    public String visitOrPredicate(HqlParser.OrPredicateContext ctx) {
-        StringBuilder sb = new StringBuilder("'$or':[");
+    public Object visitOrPredicate(HqlParser.OrPredicateContext ctx) {
+        List<Bson> filters = new ArrayList<>();
         for (HqlParser.PredicateContext predicate : ctx.predicate()) {
-            if (sb.length() > 7)
-                sb.append(",");
-            sb.append('{').append(predicate.accept(this)).append('}');
+            filters.add((Bson) predicate.accept(this));
         }
-        sb.append("]");
-        return sb.toString();
+        return Filters.or(filters);
     }
 
     @Override
-    public String visitComparisonPredicate(ComparisonPredicateContext ctx) {
-        String lhs = ctx.expression(0).accept(this);
-        String rhs = ctx.expression(1).accept(this);
+    public Object visitComparisonPredicate(ComparisonPredicateContext ctx) {
+        String field = (String) ctx.expression(0).accept(this);
+        Object value = ctx.expression(1).accept(this);
         if (ctx.comparisonOperator().EQUAL() != null) {
-            return lhs + ":" + rhs;
+            return Filters.eq(field, value);
         }
         if (ctx.comparisonOperator().NOT_EQUAL() != null) {
-            return lhs + ":{'$ne':" + rhs + "}";
+            return Filters.ne(field, value);
         }
         if (ctx.comparisonOperator().GREATER() != null) {
-            return lhs + ":{'$gt':" + rhs + "}";
+            return Filters.gt(field, value);
         }
         if (ctx.comparisonOperator().GREATER_EQUAL() != null) {
-            return lhs + ":{'$gte':" + rhs + "}";
+            return Filters.gte(field, value);
         }
         if (ctx.comparisonOperator().LESS() != null) {
-            return lhs + ":{'$lt':" + rhs + "}";
+            return Filters.lt(field, value);
         }
         if (ctx.comparisonOperator().LESS_EQUAL() != null) {
-            return lhs + ":{'$lte':" + rhs + "}";
+            return Filters.lte(field, value);
         }
         return super.visitComparisonPredicate(ctx);
     }
 
     @Override
-    public String visitLikePredicate(HqlParser.LikePredicateContext ctx) {
-        String parameter = ctx.expression(1).accept(this);
-        if (parameter.indexOf('/') == 1 && parameter.lastIndexOf('/') > 1) {
-            // In case we have something like '/.*/.*' we are in a JavaScript regex, so we must unescape the parameter.
-            // We do this here instead of inside visitParameterExpression to avoid unescaping for non-regex parameters.
-            parameter = parameter.substring(1, parameter.length() - 1);
+    public Object visitLikePredicate(HqlParser.LikePredicateContext ctx) {
+        String field = (String) ctx.expression(0).accept(this);
+        Object parameter = ctx.expression(1).accept(this);
+        String pattern = parameter.toString();
+        // In case we have something like '/.*/.*' we are in a JavaScript regex, so we must unescape the parameter.
+        // We do this here instead of inside visitParameterExpression to avoid unescaping for non-regex parameters.
+        if (pattern.startsWith("/") && pattern.lastIndexOf('/') > 0) {
+            int lastSlash = pattern.lastIndexOf('/');
+            String options = pattern.substring(lastSlash + 1);
+            pattern = pattern.substring(1, lastSlash);
+            if (!options.isEmpty()) {
+                return Filters.regex(field, pattern, options);
+            }
         }
-        return ctx.expression(0).accept(this) + ":{'$regex':" + parameter + "}";
+        return Filters.regex(field, pattern);
     }
 
     @Override
-    public String visitIsNullPredicate(HqlParser.IsNullPredicateContext ctx) {
+    public Object visitIsNullPredicate(HqlParser.IsNullPredicateContext ctx) {
+        String field = (String) ctx.expression().accept(this);
         boolean exists = ctx.NOT() != null;
-        return ctx.expression().accept(this) + ":{'$exists':" + exists + "}";
+        return Filters.exists(field, exists);
     }
 
     @Override
-    public String visitLiteralExpression(HqlParser.LiteralExpressionContext ctx) {
-        String text = ctx.getText();
+    public Object visitLiteralExpression(HqlParser.LiteralExpressionContext ctx) {
         // FIXME: this only really supports text literals
+        String text = ctx.getText();
         if (ctx.literal().STRING_LITERAL() != null) {
             text = text.substring(1, text.length() - 1);
         }
-        return CommonQueryBinder.escape(text);
+        return text;
     }
 
     @Override
-    public String visitNamedParameter(NamedParameterContext ctx) {
+    public Object visitNamedParameter(NamedParameterContext ctx) {
         return visitParameter(ctx);
     }
 
     @Override
-    public String visitPositionalParameter(PositionalParameterContext ctx) {
+    public Object visitPositionalParameter(PositionalParameterContext ctx) {
         return visitParameter(ctx);
     }
 
     @Override
-    public String visitParameterExpression(HqlParser.ParameterExpressionContext ctx) {
+    public Object visitParameterExpression(HqlParser.ParameterExpressionContext ctx) {
         return visitParameter(ctx.parameter());
     }
 
     @Override
-    public String visitGroupedExpression(GroupedExpressionContext ctx) {
+    public Object visitGroupedExpression(GroupedExpressionContext ctx) {
         return ctx.expression().accept(this);
     }
 
     @Override
-    public String visitGroupedPredicate(GroupedPredicateContext ctx) {
+    public Object visitGroupedPredicate(GroupedPredicateContext ctx) {
         return ctx.predicate().accept(this);
     }
 
-    private String visitParameter(ParameterContext ctx) {
+    private Object visitParameter(ParameterContext ctx) {
         // this will match parameters used by PanacheQL : '?1' for index based or ':key' for named one.
         if (parameterMaps.containsKey(ctx.getText())) {
-            Object value = parameterMaps.get(ctx.getText());
-            return CommonQueryBinder.escape(value);
+            return CommonQueryBinder.paramValue(parameterMaps.get(ctx.getText()));
         } else {
             // we return the parameter to avoid an exception but the query will be invalid
             return ctx.getText();
@@ -133,10 +141,10 @@ class MongoParserVisitor extends HqlParserBaseVisitor<String> {
     }
 
     @Override
-    public String visitGeneralPathExpression(HqlParser.GeneralPathExpressionContext ctx) {
+    public Object visitGeneralPathExpression(HqlParser.GeneralPathExpressionContext ctx) {
+        // this is the name of the field, we apply replacement
         String identifier = unquote(ctx.getText());
-        // this is the name of the field, we apply replacement and escape with '
-        return "'" + replacementMap.getOrDefault(identifier, identifier) + "'";
+        return replacementMap.getOrDefault(identifier, identifier);
     }
 
     /**
@@ -150,17 +158,20 @@ class MongoParserVisitor extends HqlParserBaseVisitor<String> {
     }
 
     @Override
-    public String visitInPredicate(HqlParser.InPredicateContext ctx) {
-        StringBuilder sb = new StringBuilder(ctx.expression().accept(this))
-                .append(":{'$in':")
-                .append(ctx.inList().accept(this))
-                .append("}");
-        return sb.toString();
+    public Object visitInPredicate(HqlParser.InPredicateContext ctx) {
+        String field = (String) ctx.expression().accept(this);
+        Object inValue = ctx.inList().accept(this);
+        if (inValue instanceof Iterable) {
+            return Filters.in(field, (Iterable<?>) inValue);
+        } else if (inValue != null && inValue.getClass().isArray()) {
+            return Filters.in(field, (Object[]) inValue);
+        }
+        return Filters.in(field, inValue);
     }
 
     // Turn new date functions such as instant into regular fields, to not break existing queries
     @Override
-    public String visitStandardFunction(StandardFunctionContext ctx) {
-        return "'" + ctx.getText() + "'";
+    public Object visitStandardFunction(StandardFunctionContext ctx) {
+        return ctx.getText();
     }
 }

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/binder/NativeQueryBinder.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/binder/NativeQueryBinder.java
@@ -1,26 +1,76 @@
 package io.quarkus.mongodb.panache.common.binder;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+
+import org.bson.Document;
+import org.bson.conversions.Bson;
 
 public class NativeQueryBinder {
 
-    public static String bindQuery(String query, Object[] params) {
-        String bindQuery = query;
+    private static final String PLACEHOLDER_PREFIX = "__PANACHE_PARAM_";
+    private static final String PLACEHOLDER_SUFFIX = "__";
+
+    public static Bson bindQuery(String query, Object[] params) {
+        Map<String, Object> placeholderValues = new HashMap<>();
+        String boundQuery = query;
         for (int i = 1; i <= params.length; i++) {
             String bindParamsKey = "?" + i;
-            bindQuery = CommonQueryBinder.replace(bindQuery, bindParamsKey, params[i - 1]);
+            String placeholder = toPlaceholder(bindParamsKey);
+            placeholderValues.put(placeholder, CommonQueryBinder.paramValue(params[i - 1]));
+            boundQuery = boundQuery.replace(bindParamsKey, "'" + placeholder + "'");
         }
 
-        return bindQuery;
+        Document document = Document.parse(boundQuery);
+        replacePlaceholders(document, placeholderValues);
+        return document;
     }
 
-    public static String bindQuery(String query, Map<String, Object> params) {
-        String bindQuery = query;
-        for (Map.Entry entry : params.entrySet()) {
+    public static Bson bindQuery(String query, Map<String, Object> params) {
+        Map<String, Object> placeholderValues = new HashMap<>();
+        String boundQuery = query;
+        for (Map.Entry<String, Object> entry : params.entrySet()) {
             String bindParamsKey = ":" + entry.getKey();
-            bindQuery = CommonQueryBinder.replace(bindQuery, bindParamsKey, entry.getValue());
+            String placeholder = toPlaceholder(bindParamsKey);
+            placeholderValues.put(placeholder, CommonQueryBinder.paramValue(entry.getValue()));
+            boundQuery = boundQuery.replace(bindParamsKey, "'" + placeholder + "'");
         }
 
-        return bindQuery;
+        Document document = Document.parse(boundQuery);
+        replacePlaceholders(document, placeholderValues);
+        return document;
+    }
+
+    private static String toPlaceholder(String key) {
+        return PLACEHOLDER_PREFIX + key + PLACEHOLDER_SUFFIX;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void replacePlaceholders(Document document, Map<String, Object> placeholderValues) {
+        for (Map.Entry<String, Object> entry : document.entrySet()) {
+            Object value = entry.getValue();
+            if (value instanceof String && placeholderValues.containsKey(value)) {
+                document.put(entry.getKey(), placeholderValues.get(value));
+            } else if (value instanceof Document) {
+                replacePlaceholders((Document) value, placeholderValues);
+            } else if (value instanceof List) {
+                replaceInList((List<Object>) value, placeholderValues);
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void replaceInList(List<Object> list, Map<String, Object> placeholderValues) {
+        for (int i = 0; i < list.size(); i++) {
+            Object item = list.get(i);
+            if (item instanceof String && placeholderValues.containsKey(item)) {
+                list.set(i, placeholderValues.get(item));
+            } else if (item instanceof Document) {
+                replacePlaceholders((Document) item, placeholderValues);
+            } else if (item instanceof List) {
+                replaceInList((List<Object>) item, placeholderValues);
+            }
+        }
     }
 }

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/binder/PanacheQlQueryBinder.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/binder/PanacheQlQueryBinder.java
@@ -5,6 +5,8 @@ import java.util.Map;
 
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
+import org.bson.Document;
+import org.bson.conversions.Bson;
 
 import io.quarkus.mongodb.panache.common.runtime.MongoPropertyUtil;
 import io.quarkus.panacheql.internal.HqlLexer;
@@ -13,12 +15,13 @@ import io.quarkus.panacheql.internal.HqlParserBaseVisitor;
 
 public class PanacheQlQueryBinder {
 
-    public static String bindQuery(Class<?> clazz, String query, Object[] params) {
+    public static Bson bindQuery(Class<?> clazz, String query, Object[] params) {
         Map<String, String> replacementMap = MongoPropertyUtil.getReplacementMap(clazz);
 
         //shorthand query
         if (params.length == 1 && query.indexOf('?') == -1) {
-            return "{'" + replaceField(query, replacementMap) + "':" + CommonQueryBinder.escape(params[0]) + "}";
+            String field = replaceField(query, replacementMap);
+            return new Document(field, CommonQueryBinder.paramValue(params[0]));
         }
 
         //classic query
@@ -31,7 +34,7 @@ public class PanacheQlQueryBinder {
         return prepareQuery(query, replacementMap, parameterMaps);
     }
 
-    public static String bindQuery(Class<?> clazz, String query, Map<String, Object> params) {
+    public static Bson bindQuery(Class<?> clazz, String query, Map<String, Object> params) {
         Map<String, String> replacementMap = MongoPropertyUtil.getReplacementMap(clazz);
 
         Map<String, Object> parameterMaps = new HashMap<>();
@@ -47,12 +50,12 @@ public class PanacheQlQueryBinder {
         return replacementMap.getOrDefault(field, field);
     }
 
-    private static String prepareQuery(String query, Map<String, String> replacementMap, Map<String, Object> parameterMaps) {
+    private static Bson prepareQuery(String query, Map<String, String> replacementMap, Map<String, Object> parameterMaps) {
         HqlLexer lexer = new HqlLexer(CharStreams.fromString(query));
         CommonTokenStream tokens = new CommonTokenStream(lexer);
         HqlParser parser = new HqlParser(tokens);
         HqlParser.PredicateContext predicate = parser.predicate();
-        HqlParserBaseVisitor<String> visitor = new MongoParserVisitor(replacementMap, parameterMaps);
-        return "{" + predicate.accept(visitor) + "}";
+        HqlParserBaseVisitor<Object> visitor = new MongoParserVisitor(replacementMap, parameterMaps);
+        return (Bson) predicate.accept(visitor);
     }
 }

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/reactive/runtime/ReactiveMongoOperations.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/reactive/runtime/ReactiveMongoOperations.java
@@ -399,8 +399,7 @@ public abstract class ReactiveMongoOperations<QueryType, UpdateType> {
     }
 
     public QueryType find(Class<?> entityClass, String query, Sort sort, Object... params) {
-        String bindQuery = bindFilter(entityClass, query, params);
-        Bson docQuery = Document.parse(bindQuery);
+        Bson docQuery = bindFilter(entityClass, query, params);
         Bson docSort = sortToDocument(sort);
         ReactiveMongoCollection collection = mongoCollection(entityClass);
         return createQuery(collection, docQuery, docSort);
@@ -410,8 +409,8 @@ public abstract class ReactiveMongoOperations<QueryType, UpdateType> {
      * We should have a query like <code>{'firstname': ?1, 'lastname': ?2}</code> for native one
      * and like <code>firstname = ?1</code> for PanacheQL one.
      */
-    public String bindFilter(Class<?> clazz, String query, Object[] params) {
-        String bindQuery = bindQuery(clazz, query, params);
+    public Bson bindFilter(Class<?> clazz, String query, Object[] params) {
+        Bson bindQuery = bindQuery(clazz, query, params);
         LOGGER.debug(bindQuery);
         return bindQuery;
     }
@@ -420,8 +419,8 @@ public abstract class ReactiveMongoOperations<QueryType, UpdateType> {
      * We should have a query like <code>{'firstname': :firstname, 'lastname': :lastname}</code> for native one
      * and like <code>firstname = :firstname and lastname = :lastname</code> for PanacheQL one.
      */
-    public String bindFilter(Class<?> clazz, String query, Map<String, Object> params) {
-        String bindQuery = bindQuery(clazz, query, params);
+    public Bson bindFilter(Class<?> clazz, String query, Map<String, Object> params) {
+        Bson bindQuery = bindQuery(clazz, query, params);
         LOGGER.debug(bindQuery);
         return bindQuery;
     }
@@ -431,10 +430,10 @@ public abstract class ReactiveMongoOperations<QueryType, UpdateType> {
      * and like <code>firstname = ?1 and lastname = ?2</code> for PanacheQL one.
      * As update document needs an update operator, we add <code>$set</code> if none is provided.
      */
-    String bindUpdate(Class<?> clazz, String query, Object[] params) {
-        String bindUpdate = bindQuery(clazz, query, params);
+    Bson bindUpdate(Class<?> clazz, String query, Object[] params) {
+        Bson bindUpdate = bindQuery(clazz, query, params);
         if (!containsUpdateOperator(query)) {
-            bindUpdate = "{'$set':" + bindUpdate + "}";
+            bindUpdate = new Document("$set", bindUpdate);
         }
         LOGGER.debug(bindUpdate);
         return bindUpdate;
@@ -445,10 +444,10 @@ public abstract class ReactiveMongoOperations<QueryType, UpdateType> {
      * and like <code>firstname = :firstname and lastname = :lastname</code> for PanacheQL one.
      * As update document needs an update operator, we add <code>$set</code> if none is provided.
      */
-    String bindUpdate(Class<?> clazz, String query, Map<String, Object> params) {
-        String bindUpdate = bindQuery(clazz, query, params);
+    Bson bindUpdate(Class<?> clazz, String query, Map<String, Object> params) {
+        Bson bindUpdate = bindQuery(clazz, query, params);
         if (!containsUpdateOperator(query)) {
-            bindUpdate = "{'$set':" + bindUpdate + "}";
+            bindUpdate = new Document("$set", bindUpdate);
         }
         LOGGER.debug(bindUpdate);
         return bindUpdate;
@@ -463,34 +462,26 @@ public abstract class ReactiveMongoOperations<QueryType, UpdateType> {
         return false;
     }
 
-    String bindQuery(Class<?> clazz, String query, Object[] params) {
-        String bindQuery = null;
-
+    Bson bindQuery(Class<?> clazz, String query, Object[] params) {
         //determine the type of the query
         if (query.charAt(0) == '{') {
             //this is a native query
-            bindQuery = NativeQueryBinder.bindQuery(query, params);
+            return NativeQueryBinder.bindQuery(query, params);
         } else {
             //this is a PanacheQL query
-            bindQuery = PanacheQlQueryBinder.bindQuery(clazz, query, params);
+            return PanacheQlQueryBinder.bindQuery(clazz, query, params);
         }
-
-        return bindQuery;
     }
 
-    String bindQuery(Class<?> clazz, String query, Map<String, Object> params) {
-        String bindQuery = null;
-
+    Bson bindQuery(Class<?> clazz, String query, Map<String, Object> params) {
         //determine the type of the query
         if (query.charAt(0) == '{') {
             //this is a native query
-            bindQuery = NativeQueryBinder.bindQuery(query, params);
+            return NativeQueryBinder.bindQuery(query, params);
         } else {
             //this is a PanacheQL query
-            bindQuery = PanacheQlQueryBinder.bindQuery(clazz, query, params);
+            return PanacheQlQueryBinder.bindQuery(clazz, query, params);
         }
-
-        return bindQuery;
     }
 
     public QueryType find(Class<?> entityClass, String query, Map<String, Object> params) {
@@ -498,8 +489,7 @@ public abstract class ReactiveMongoOperations<QueryType, UpdateType> {
     }
 
     public QueryType find(Class<?> entityClass, String query, Sort sort, Map<String, Object> params) {
-        String bindQuery = bindFilter(entityClass, query, params);
-        Bson docQuery = Document.parse(bindQuery);
+        Bson docQuery = bindFilter(entityClass, query, params);
         Bson docSort = sortToDocument(sort);
         ReactiveMongoCollection collection = mongoCollection(entityClass);
         return createQuery(collection, docQuery, docSort);
@@ -647,8 +637,7 @@ public abstract class ReactiveMongoOperations<QueryType, UpdateType> {
     }
 
     public Uni<Long> count(Class<?> entityClass, String query, Object... params) {
-        String bindQuery = bindFilter(entityClass, query, params);
-        BsonDocument docQuery = BsonDocument.parse(bindQuery);
+        Bson docQuery = bindFilter(entityClass, query, params);
         ReactiveMongoCollection collection = mongoCollection(entityClass);
         if (Panache.getCurrentSession() != null) {
             return collection.countDocuments(Panache.getCurrentSession(), docQuery);
@@ -657,8 +646,7 @@ public abstract class ReactiveMongoOperations<QueryType, UpdateType> {
     }
 
     public Uni<Long> count(Class<?> entityClass, String query, Map<String, Object> params) {
-        String bindQuery = bindFilter(entityClass, query, params);
-        BsonDocument docQuery = BsonDocument.parse(bindQuery);
+        Bson docQuery = bindFilter(entityClass, query, params);
         ReactiveMongoCollection collection = mongoCollection(entityClass);
         if (Panache.getCurrentSession() != null) {
             return collection.countDocuments(Panache.getCurrentSession(), docQuery);
@@ -697,8 +685,7 @@ public abstract class ReactiveMongoOperations<QueryType, UpdateType> {
     }
 
     public Uni<Long> delete(Class<?> entityClass, String query, Object... params) {
-        String bindQuery = bindFilter(entityClass, query, params);
-        BsonDocument docQuery = BsonDocument.parse(bindQuery);
+        Bson docQuery = bindFilter(entityClass, query, params);
         ReactiveMongoCollection<?> collection = mongoCollection(entityClass);
         if (Panache.getCurrentSession() != null) {
             return collection.deleteMany(Panache.getCurrentSession(), docQuery).map(DeleteResult::getDeletedCount);
@@ -707,8 +694,7 @@ public abstract class ReactiveMongoOperations<QueryType, UpdateType> {
     }
 
     public Uni<Long> delete(Class<?> entityClass, String query, Map<String, Object> params) {
-        String bindQuery = bindFilter(entityClass, query, params);
-        BsonDocument docQuery = BsonDocument.parse(bindQuery);
+        Bson docQuery = bindFilter(entityClass, query, params);
         ReactiveMongoCollection<?> collection = mongoCollection(entityClass);
         if (Panache.getCurrentSession() != null) {
             return collection.deleteMany(Panache.getCurrentSession(), docQuery).map(DeleteResult::getDeletedCount);
@@ -746,15 +732,13 @@ public abstract class ReactiveMongoOperations<QueryType, UpdateType> {
     }
 
     private UpdateType executeUpdate(Class<?> entityClass, String update, Object... params) {
-        String bindUpdate = bindUpdate(entityClass, update, params);
-        Bson docUpdate = Document.parse(bindUpdate);
+        Bson docUpdate = bindUpdate(entityClass, update, params);
         ReactiveMongoCollection<?> collection = mongoCollection(entityClass);
         return createUpdate(collection, entityClass, docUpdate);
     }
 
     private UpdateType executeUpdate(Class<?> entityClass, String update, Map<String, Object> params) {
-        String bindUpdate = bindUpdate(entityClass, update, params);
-        Bson docUpdate = Document.parse(bindUpdate);
+        Bson docUpdate = bindUpdate(entityClass, update, params);
         ReactiveMongoCollection<?> collection = mongoCollection(entityClass);
         return createUpdate(collection, entityClass, docUpdate);
     }

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/reactive/runtime/ReactivePanacheUpdateImpl.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/reactive/runtime/ReactivePanacheUpdateImpl.java
@@ -28,15 +28,13 @@ public class ReactivePanacheUpdateImpl implements ReactivePanacheUpdate {
 
     @Override
     public Uni<Long> where(String query, Object... params) {
-        String bindQuery = operations.bindFilter(entityClass, query, params);
-        BsonDocument docQuery = BsonDocument.parse(bindQuery);
+        Bson docQuery = operations.bindFilter(entityClass, query, params);
         return executeUpdate(docQuery);
     }
 
     @Override
     public Uni<Long> where(String query, Map<String, Object> params) {
-        String bindQuery = operations.bindFilter(entityClass, query, params);
-        BsonDocument docQuery = BsonDocument.parse(bindQuery);
+        Bson docQuery = operations.bindFilter(entityClass, query, params);
         return executeUpdate(docQuery);
     }
 

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/runtime/MongoOperations.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/runtime/MongoOperations.java
@@ -436,8 +436,7 @@ public abstract class MongoOperations<QueryType, UpdateType> {
     }
 
     public QueryType find(Class<?> entityClass, String query, Sort sort, Object... params) {
-        String bindQuery = bindFilter(entityClass, query, params);
-        Bson docQuery = Document.parse(bindQuery);
+        Bson docQuery = bindFilter(entityClass, query, params);
         Bson docSort = sortToDocument(sort);
         MongoCollection collection = mongoCollection(entityClass);
         ClientSession session = getSession(entityClass);
@@ -448,8 +447,8 @@ public abstract class MongoOperations<QueryType, UpdateType> {
      * We should have a query like <code>{'firstname': ?1, 'lastname': ?2}</code> for native one
      * and like <code>firstname = ?1</code> for PanacheQL one.
      */
-    public String bindFilter(Class<?> clazz, String query, Object[] params) {
-        String bindQuery = bindQuery(clazz, query, params);
+    public Bson bindFilter(Class<?> clazz, String query, Object[] params) {
+        Bson bindQuery = bindQuery(clazz, query, params);
         LOGGER.debug(bindQuery);
         return bindQuery;
     }
@@ -458,8 +457,8 @@ public abstract class MongoOperations<QueryType, UpdateType> {
      * We should have a query like <code>{'firstname': :firstname, 'lastname': :lastname}</code> for native one
      * and like <code>firstname = :firstname and lastname = :lastname</code> for PanacheQL one.
      */
-    public String bindFilter(Class<?> clazz, String query, Map<String, Object> params) {
-        String bindQuery = bindQuery(clazz, query, params);
+    public Bson bindFilter(Class<?> clazz, String query, Map<String, Object> params) {
+        Bson bindQuery = bindQuery(clazz, query, params);
         LOGGER.debug(bindQuery);
         return bindQuery;
     }
@@ -469,10 +468,10 @@ public abstract class MongoOperations<QueryType, UpdateType> {
      * and like <code>firstname = ?1 and lastname = ?2</code> for PanacheQL one.
      * As update document needs an update operator, we add <code>$set</code> if none is provided.
      */
-    String bindUpdate(Class<?> clazz, String query, Object[] params) {
-        String bindUpdate = bindQuery(clazz, query, params);
+    Bson bindUpdate(Class<?> clazz, String query, Object[] params) {
+        Bson bindUpdate = bindQuery(clazz, query, params);
         if (!containsUpdateOperator(query)) {
-            bindUpdate = "{'$set':" + bindUpdate + "}";
+            bindUpdate = new Document("$set", bindUpdate);
         }
         LOGGER.debug(bindUpdate);
         return bindUpdate;
@@ -483,10 +482,10 @@ public abstract class MongoOperations<QueryType, UpdateType> {
      * and like <code>firstname = :firstname and lastname = :lastname</code> for PanacheQL one.
      * As update document needs an update operator, we add <code>$set</code> if none is provided.
      */
-    String bindUpdate(Class<?> clazz, String query, Map<String, Object> params) {
-        String bindUpdate = bindQuery(clazz, query, params);
+    Bson bindUpdate(Class<?> clazz, String query, Map<String, Object> params) {
+        Bson bindUpdate = bindQuery(clazz, query, params);
         if (!containsUpdateOperator(query)) {
-            bindUpdate = "{'$set':" + bindUpdate + "}";
+            bindUpdate = new Document("$set", bindUpdate);
         }
         LOGGER.debug(bindUpdate);
         return bindUpdate;
@@ -501,30 +500,26 @@ public abstract class MongoOperations<QueryType, UpdateType> {
         return false;
     }
 
-    private String bindQuery(Class<?> clazz, String query, Object[] params) {
-        String bindQuery = null;
+    private Bson bindQuery(Class<?> clazz, String query, Object[] params) {
         //determine the type of the query
         if (query.charAt(0) == '{') {
             //this is a native query
-            bindQuery = NativeQueryBinder.bindQuery(query, params);
+            return NativeQueryBinder.bindQuery(query, params);
         } else {
             //this is a PanacheQL query
-            bindQuery = PanacheQlQueryBinder.bindQuery(clazz, query, params);
+            return PanacheQlQueryBinder.bindQuery(clazz, query, params);
         }
-        return bindQuery;
     }
 
-    private String bindQuery(Class<?> clazz, String query, Map<String, Object> params) {
-        String bindQuery = null;
+    private Bson bindQuery(Class<?> clazz, String query, Map<String, Object> params) {
         //determine the type of the query
         if (query.charAt(0) == '{') {
             //this is a native query
-            bindQuery = NativeQueryBinder.bindQuery(query, params);
+            return NativeQueryBinder.bindQuery(query, params);
         } else {
             //this is a PanacheQL query
-            bindQuery = PanacheQlQueryBinder.bindQuery(clazz, query, params);
+            return PanacheQlQueryBinder.bindQuery(clazz, query, params);
         }
-        return bindQuery;
     }
 
     public QueryType find(Class<?> entityClass, String query, Map<String, Object> params) {
@@ -532,8 +527,7 @@ public abstract class MongoOperations<QueryType, UpdateType> {
     }
 
     public QueryType find(Class<?> entityClass, String query, Sort sort, Map<String, Object> params) {
-        String bindQuery = bindFilter(entityClass, query, params);
-        Bson docQuery = Document.parse(bindQuery);
+        Bson docQuery = bindFilter(entityClass, query, params);
         Bson docSort = sortToDocument(sort);
         MongoCollection collection = mongoCollection(entityClass);
         ClientSession session = getSession(entityClass);
@@ -684,8 +678,7 @@ public abstract class MongoOperations<QueryType, UpdateType> {
     }
 
     public long count(Class<?> entityClass, String query, Object... params) {
-        String bindQuery = bindFilter(entityClass, query, params);
-        BsonDocument docQuery = BsonDocument.parse(bindQuery);
+        Bson docQuery = bindFilter(entityClass, query, params);
         MongoCollection collection = mongoCollection(entityClass);
 
         ClientSession session = getSession(entityClass);
@@ -693,8 +686,7 @@ public abstract class MongoOperations<QueryType, UpdateType> {
     }
 
     public long count(Class<?> entityClass, String query, Map<String, Object> params) {
-        String bindQuery = bindFilter(entityClass, query, params);
-        BsonDocument docQuery = BsonDocument.parse(bindQuery);
+        Bson docQuery = bindFilter(entityClass, query, params);
         MongoCollection collection = mongoCollection(entityClass);
 
         ClientSession session = getSession(entityClass);
@@ -728,8 +720,7 @@ public abstract class MongoOperations<QueryType, UpdateType> {
     }
 
     public long delete(Class<?> entityClass, String query, Object... params) {
-        String bindQuery = bindFilter(entityClass, query, params);
-        BsonDocument docQuery = BsonDocument.parse(bindQuery);
+        Bson docQuery = bindFilter(entityClass, query, params);
         MongoCollection collection = mongoCollection(entityClass);
         ClientSession session = getSession(entityClass);
         return session == null ? collection.deleteMany(docQuery).getDeletedCount()
@@ -737,8 +728,7 @@ public abstract class MongoOperations<QueryType, UpdateType> {
     }
 
     public long delete(Class<?> entityClass, String query, Map<String, Object> params) {
-        String bindQuery = bindFilter(entityClass, query, params);
-        BsonDocument docQuery = BsonDocument.parse(bindQuery);
+        Bson docQuery = bindFilter(entityClass, query, params);
         MongoCollection collection = mongoCollection(entityClass);
         ClientSession session = getSession(entityClass);
         return session == null ? collection.deleteMany(docQuery).getDeletedCount()
@@ -774,14 +764,12 @@ public abstract class MongoOperations<QueryType, UpdateType> {
     }
 
     private UpdateType executeUpdate(Class<?> entityClass, String update, Object... params) {
-        String bindUpdate = bindUpdate(entityClass, update, params);
-        Bson docUpdate = Document.parse(bindUpdate);
+        Bson docUpdate = bindUpdate(entityClass, update, params);
         return createUpdate(mongoCollection(entityClass), entityClass, docUpdate);
     }
 
     private UpdateType executeUpdate(Class<?> entityClass, String update, Map<String, Object> params) {
-        String bindUpdate = bindUpdate(entityClass, update, params);
-        Bson docUpdate = Document.parse(bindUpdate);
+        Bson docUpdate = bindUpdate(entityClass, update, params);
         return createUpdate(mongoCollection(entityClass), entityClass, docUpdate);
     }
 

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/runtime/PanacheUpdateImpl.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/runtime/PanacheUpdateImpl.java
@@ -28,15 +28,13 @@ public class PanacheUpdateImpl implements PanacheUpdate {
 
     @Override
     public long where(String query, Object... params) {
-        String bindQuery = operations.bindFilter(entityClass, query, params);
-        BsonDocument docQuery = BsonDocument.parse(bindQuery);
+        Bson docQuery = operations.bindFilter(entityClass, query, params);
         return executeUpdate(docQuery);
     }
 
     @Override
     public long where(String query, Map<String, Object> params) {
-        String bindQuery = operations.bindFilter(entityClass, query, params);
-        BsonDocument docQuery = BsonDocument.parse(bindQuery);
+        Bson docQuery = operations.bindFilter(entityClass, query, params);
         return executeUpdate(docQuery);
     }
 

--- a/extensions/panache/mongodb-panache-common/runtime/src/test/java/io/quarkus/mongodb/panache/common/runtime/MongoOperationsTest.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/test/java/io/quarkus/mongodb/panache/common/runtime/MongoOperationsTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.mongodb.panache.common.runtime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -15,13 +16,27 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Stream;
 
+import org.bson.BsonDocument;
+import org.bson.BsonReader;
+import org.bson.BsonWriter;
+import org.bson.UuidRepresentation;
+import org.bson.codecs.Codec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.EncoderContext;
+import org.bson.codecs.StringCodec;
+import org.bson.codecs.UuidCodec;
+import org.bson.codecs.configuration.CodecRegistries;
+import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.codecs.pojo.annotations.BsonProperty;
 import org.bson.conversions.Bson;
+import org.bson.types.ObjectId;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import com.mongodb.MongoClientSettings;
 import com.mongodb.client.ClientSession;
 import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Filters;
 
 import io.quarkus.mongodb.panache.common.PanacheUpdate;
 import io.quarkus.panache.common.Parameters;
@@ -57,6 +72,47 @@ class MongoOperationsTest {
         public String property;
     }
 
+    private enum TestEnum {
+        VALUE_A,
+        VALUE_B
+    }
+
+    private static class CustomType {
+        private final String inner;
+
+        CustomType(String inner) {
+            this.inner = inner;
+        }
+
+        public String getInner() {
+            return inner;
+        }
+
+        @Override
+        public String toString() {
+            return "CustomType{" + inner + "}";
+        }
+    }
+
+    private static class CustomTypeCodec implements Codec<CustomType> {
+        private final StringCodec stringCodec = new StringCodec();
+
+        @Override
+        public void encode(BsonWriter writer, CustomType value, EncoderContext encoderContext) {
+            stringCodec.encode(writer, value.getInner(), encoderContext);
+        }
+
+        @Override
+        public CustomType decode(BsonReader reader, DecoderContext decoderContext) {
+            return new CustomType(stringCodec.decode(reader, decoderContext));
+        }
+
+        @Override
+        public Class<CustomType> getEncoderClass() {
+            return CustomType.class;
+        }
+    }
+
     @BeforeAll
     static void setupFieldReplacement() {
         Map<String, Map<String, String>> replacementCache = new HashMap<>();
@@ -67,43 +123,80 @@ class MongoOperationsTest {
         MongoPropertyUtil.setReplacementCache(replacementCache);
     }
 
+    private static final CodecRegistry CODEC_REGISTRY = CodecRegistries.fromRegistries(
+            CodecRegistries.fromCodecs(new UuidCodec(UuidRepresentation.STANDARD), new CustomTypeCodec()),
+            MongoClientSettings.getDefaultCodecRegistry());
+
+    private static BsonDocument toBsonDoc(Bson bson) {
+        return bson.toBsonDocument(BsonDocument.class, CODEC_REGISTRY);
+    }
+
+    private static void assertBsonEquals(Bson expected, Bson actual) {
+        assertEquals(toBsonDoc(expected), toBsonDoc(actual));
+    }
+
     @Test
     public void testBindShorthandFilter() {
-        String query = operations.bindFilter(Object.class, "field", new Object[] { "a value" });
-        assertEquals("{'field':'a value'}", query);
+        Bson result = operations.bindFilter(Object.class, "field", new Object[] { "a value" });
+        assertBsonEquals(Filters.eq("field", "a value"), result);
 
-        query = operations.bindFilter(Object.class, "field", new Object[] { true });
-        assertEquals("{'field':true}", query);
+        result = operations.bindFilter(Object.class, "field", new Object[] { true });
+        assertBsonEquals(Filters.eq("field", true), result);
 
-        query = operations.bindFilter(Object.class, "field", new Object[] { LocalDate.of(2019, 3, 4) });
-        assertEquals("{'field':{\"$date\": \"2019-03-04T00:00:00.000Z\"} }", query);
+        result = operations.bindFilter(Object.class, "field", new Object[] { LocalDate.of(2019, 3, 4) });
+        assertBsonEquals(Filters.eq("field", LocalDate.of(2019, 3, 4)), result);
 
-        query = operations.bindFilter(Object.class, "field", new Object[] { LocalDateTime.of(2019, 3, 4, 1, 1, 1) });
-        assertEquals("{'field':{\"$date\": \"2019-03-04T01:01:01.000Z\"} }", query);
+        result = operations.bindFilter(Object.class, "field", new Object[] { LocalDateTime.of(2019, 3, 4, 1, 1, 1) });
+        assertBsonEquals(Filters.eq("field", LocalDateTime.of(2019, 3, 4, 1, 1, 1)), result);
 
-        query = operations.bindFilter(Object.class, "field",
+        result = operations.bindFilter(Object.class, "field",
                 new Object[] { LocalDateTime.of(2019, 3, 4, 1, 1, 1).toInstant(ZoneOffset.UTC) });
-        assertEquals("{'field':{\"$date\": \"2019-03-04T01:01:01.000Z\"} }", query);
+        assertBsonEquals(Filters.eq("field", LocalDateTime.of(2019, 3, 4, 1, 1, 1).toInstant(ZoneOffset.UTC)), result);
 
-        query = operations.bindFilter(Object.class, "field",
+        result = operations.bindFilter(Object.class, "field",
                 new Object[] { toDate(LocalDateTime.of(2019, 3, 4, 1, 1, 1)) });
-        assertEquals("{'field':{\"$date\": \"2019-03-04T01:01:01.000Z\"} }", query);
+        assertBsonEquals(Filters.eq("field", toDate(LocalDateTime.of(2019, 3, 4, 1, 1, 1))), result);
 
-        query = operations.bindFilter(Object.class, "field",
+        result = operations.bindFilter(Object.class, "field",
                 new Object[] { UUID.fromString("7f000101-7370-1f68-8173-70afa71b0000") });
-        assertEquals("{'field':UUID('7f000101-7370-1f68-8173-70afa71b0000')}", query);
+        assertBsonEquals(Filters.eq("field", UUID.fromString("7f000101-7370-1f68-8173-70afa71b0000")), result);
 
-        //test field replacement
-        query = operations.bindFilter(DemoObj.class, "property", new Object[] { "a value" });
-        assertEquals("{'value':'a value'}", query);
+        // test field replacement
+        result = operations.bindFilter(DemoObj.class, "property", new Object[] { "a value" });
+        assertBsonEquals(Filters.eq("value", "a value"), result);
 
         // keywords (quoted)
-        query = operations.bindFilter(Object.class, "`instant` = ?1", new Object[] { "a value" });
-        assertEquals("{'instant':'a value'}", query);
+        result = operations.bindFilter(Object.class, "`instant` = ?1", new Object[] { "a value" });
+        assertBsonEquals(Filters.eq("instant", "a value"), result);
 
         // keywords (unquoted)
-        query = operations.bindFilter(Object.class, "instant = ?1", new Object[] { "a value" });
-        assertEquals("{'instant':'a value'}", query);
+        result = operations.bindFilter(Object.class, "instant = ?1", new Object[] { "a value" });
+        assertBsonEquals(Filters.eq("instant", "a value"), result);
+
+        // null value
+        result = operations.bindFilter(Object.class, "field", new Object[] { null });
+        assertBsonEquals(Filters.eq("field", null), result);
+    }
+
+    @Test
+    public void testBindShorthandFilterWithCustomType() {
+        CustomType custom = new CustomType("test");
+        Bson result = operations.bindFilter(Object.class, "field", new Object[] { custom });
+        // the raw CustomType object is preserved, and the codec encodes it as "test" (not toString())
+        assertBsonEquals(Filters.eq("field", custom), result);
+    }
+
+    @Test
+    public void testBindShorthandFilterWithEnum() {
+        Bson result = operations.bindFilter(Object.class, "field", new Object[] { TestEnum.VALUE_A });
+        assertBsonEquals(Filters.eq("field", "VALUE_A"), result);
+    }
+
+    @Test
+    public void testBindShorthandFilterWithObjectId() {
+        ObjectId objectId = new ObjectId("507f1f77bcf86cd799439011");
+        Bson result = operations.bindFilter(Object.class, "field", new Object[] { objectId });
+        assertBsonEquals(Filters.eq("field", objectId), result);
     }
 
     private Object toDate(LocalDateTime of) {
@@ -112,321 +205,507 @@ class MongoOperationsTest {
 
     @Test
     public void testBindNativeFilterByIndex() {
-        String query = operations.bindFilter(DemoObj.class, "{'field': ?1}", new Object[] { "a value" });
-        assertEquals("{'field': 'a value'}", query);
+        Bson result = operations.bindFilter(DemoObj.class, "{'field': ?1}", new Object[] { "a value" });
+        assertBsonEquals(Filters.eq("field", "a value"), result);
 
-        query = operations.bindFilter(DemoObj.class, "{'field.sub': ?1}", new Object[] { "a value" });
-        assertEquals("{'field.sub': 'a value'}", query);
+        result = operations.bindFilter(DemoObj.class, "{'field.sub': ?1}", new Object[] { "a value" });
+        assertBsonEquals(Filters.eq("field.sub", "a value"), result);
 
-        //test that there are no field replacement for native queries
-        query = operations.bindFilter(DemoObj.class, "{'property': ?1}", new Object[] { "a value" });
-        assertEquals("{'property': 'a value'}", query);
+        // test that there are no field replacement for native queries
+        result = operations.bindFilter(DemoObj.class, "{'property': ?1}", new Object[] { "a value" });
+        assertBsonEquals(Filters.eq("property", "a value"), result);
 
-        query = operations.bindFilter(Object.class, "{'field': ?1}",
+        result = operations.bindFilter(Object.class, "{'field': ?1}",
                 new Object[] { LocalDate.of(2019, 3, 4) });
-        assertEquals("{'field': {\"$date\": \"2019-03-04T00:00:00.000Z\"} }", query);
+        assertBsonEquals(Filters.eq("field", LocalDate.of(2019, 3, 4)), result);
 
-        query = operations.bindFilter(Object.class, "{'field': ?1}",
+        result = operations.bindFilter(Object.class, "{'field': ?1}",
                 new Object[] { LocalDateTime.of(2019, 3, 4, 1, 1, 1) });
-        assertEquals("{'field': {\"$date\": \"2019-03-04T01:01:01.000Z\"} }", query);
+        assertBsonEquals(Filters.eq("field", LocalDateTime.of(2019, 3, 4, 1, 1, 1)), result);
 
-        query = operations.bindFilter(Object.class, "{'field': ?1}",
+        result = operations.bindFilter(Object.class, "{'field': ?1}",
                 new Object[] { LocalDateTime.of(2019, 3, 4, 1, 1, 1).toInstant(ZoneOffset.UTC) });
-        assertEquals("{'field': {\"$date\": \"2019-03-04T01:01:01.000Z\"} }", query);
+        assertBsonEquals(Filters.eq("field", LocalDateTime.of(2019, 3, 4, 1, 1, 1).toInstant(ZoneOffset.UTC)), result);
 
-        query = operations.bindFilter(Object.class, "{'field': ?1}",
+        result = operations.bindFilter(Object.class, "{'field': ?1}",
                 new Object[] { toDate(LocalDateTime.of(2019, 3, 4, 1, 1, 1)) });
-        assertEquals("{'field': {\"$date\": \"2019-03-04T01:01:01.000Z\"} }", query);
+        assertBsonEquals(Filters.eq("field", toDate(LocalDateTime.of(2019, 3, 4, 1, 1, 1))), result);
 
-        query = operations.bindFilter(Object.class, "{'field': ?1}",
+        result = operations.bindFilter(Object.class, "{'field': ?1}",
                 new Object[] { UUID.fromString("7f000101-7370-1f68-8173-70afa71b0000") });
-        assertEquals("{'field': UUID('7f000101-7370-1f68-8173-70afa71b0000')}", query);
+        assertBsonEquals(Filters.eq("field", UUID.fromString("7f000101-7370-1f68-8173-70afa71b0000")), result);
 
-        query = operations.bindFilter(Object.class, "{'field': ?1, 'isOk': ?2}", new Object[] { "a value", true });
-        assertEquals("{'field': 'a value', 'isOk': true}", query);
+        result = operations.bindFilter(Object.class, "{'field': ?1, 'isOk': ?2}", new Object[] { "a value", true });
+        assertInstanceOf(org.bson.Document.class, result);
+        org.bson.Document doc = (org.bson.Document) result;
+        assertEquals("a value", doc.get("field"));
+        assertEquals(true, doc.get("isOk"));
 
-        //queries related to '$in' operator
+        // queries related to '$in' operator
         List<Object> list = Arrays.asList("f1", "f2");
-        query = operations.bindFilter(DemoObj.class, "{ field: { '$in': ?1 } }", new Object[] { list });
-        assertEquals("{ field: { '$in': ['f1', 'f2'] } }", query);
+        result = operations.bindFilter(DemoObj.class, "{ field: { '$in': ?1 } }", new Object[] { list });
+        assertInstanceOf(org.bson.Document.class, result);
+        doc = (org.bson.Document) result;
+        org.bson.Document inDoc = (org.bson.Document) doc.get("field");
+        assertEquals(list, inDoc.get("$in"));
 
-        query = operations.bindFilter(DemoObj.class, "{ field: { '$in': ?1 }, isOk: ?2 }", new Object[] { list, true });
-        assertEquals("{ field: { '$in': ['f1', 'f2'] }, isOk: true }", query);
+        result = operations.bindFilter(DemoObj.class, "{ field: { '$in': ?1 }, isOk: ?2 }", new Object[] { list, true });
+        assertInstanceOf(org.bson.Document.class, result);
+        doc = (org.bson.Document) result;
+        inDoc = (org.bson.Document) doc.get("field");
+        assertEquals(list, inDoc.get("$in"));
+        assertEquals(true, doc.get("isOk"));
 
-        query = operations.bindFilter(DemoObj.class,
+        result = operations.bindFilter(DemoObj.class,
                 "{ field: { '$in': ?1 }, $or: [ {'property': ?2}, {'property': ?3} ] }",
                 new Object[] { list, "jpg", "gif" });
-        assertEquals("{ field: { '$in': ['f1', 'f2'] }, $or: [ {'property': 'jpg'}, {'property': 'gif'} ] }", query);
+        assertInstanceOf(org.bson.Document.class, result);
+        doc = (org.bson.Document) result;
+        inDoc = (org.bson.Document) doc.get("field");
+        assertEquals(list, inDoc.get("$in"));
+        List<?> orList = (List<?>) doc.get("$or");
+        assertEquals(2, orList.size());
+        assertEquals("jpg", ((org.bson.Document) orList.get(0)).get("property"));
+        assertEquals("gif", ((org.bson.Document) orList.get(1)).get("property"));
 
-        query = operations.bindFilter(DemoObj.class,
+        result = operations.bindFilter(DemoObj.class,
                 "{ field: { '$in': ?1 }, isOk: ?2, $or: [ {'property': ?3}, {'property': ?4} ] }",
                 new Object[] { list, true, "jpg", "gif" });
-        assertEquals("{ field: { '$in': ['f1', 'f2'] }, isOk: true, $or: [ {'property': 'jpg'}, {'property': 'gif'} ] }",
-                query);
+        assertInstanceOf(org.bson.Document.class, result);
+        doc = (org.bson.Document) result;
+        inDoc = (org.bson.Document) doc.get("field");
+        assertEquals(list, inDoc.get("$in"));
+        assertEquals(true, doc.get("isOk"));
+        orList = (List<?>) doc.get("$or");
+        assertEquals(2, orList.size());
+        assertEquals("jpg", ((org.bson.Document) orList.get(0)).get("property"));
+        assertEquals("gif", ((org.bson.Document) orList.get(1)).get("property"));
+    }
+
+    @Test
+    public void testBindNativeFilterByIndexWithCustomType() {
+        CustomType custom = new CustomType("test");
+        Bson result = operations.bindFilter(DemoObj.class, "{'field': ?1}", new Object[] { custom });
+        assertBsonEquals(Filters.eq("field", custom), result);
+    }
+
+    @Test
+    public void testBindNativeFilterByIndexWithEnum() {
+        Bson result = operations.bindFilter(DemoObj.class, "{'field': ?1}", new Object[] { TestEnum.VALUE_A });
+        assertBsonEquals(Filters.eq("field", "VALUE_A"), result);
     }
 
     @Test
     public void testBindNativeFilterByName() {
-        String query = operations.bindFilter(Object.class, "{'field': :field}",
+        Bson result = operations.bindFilter(Object.class, "{'field': :field}",
                 Parameters.with("field", "a value").map());
-        assertEquals("{'field': 'a value'}", query);
+        assertBsonEquals(Filters.eq("field", "a value"), result);
 
-        query = operations.bindFilter(Object.class, "{'field.sub': :field}",
+        result = operations.bindFilter(Object.class, "{'field.sub': :field}",
                 Parameters.with("field", "a value").map());
-        assertEquals("{'field.sub': 'a value'}", query);
+        assertBsonEquals(Filters.eq("field.sub", "a value"), result);
 
-        //test that there are no field replacement for native queries
-        query = operations.bindFilter(DemoObj.class, "{'property': :field}",
+        // test that there are no field replacement for native queries
+        result = operations.bindFilter(DemoObj.class, "{'property': :field}",
                 Parameters.with("field", "a value").map());
-        assertEquals("{'property': 'a value'}", query);
+        assertBsonEquals(Filters.eq("property", "a value"), result);
 
-        query = operations.bindFilter(Object.class, "{'field': :field}",
+        result = operations.bindFilter(Object.class, "{'field': :field}",
                 Parameters.with("field", LocalDate.of(2019, 3, 4)).map());
-        assertEquals("{'field': {\"$date\": \"2019-03-04T00:00:00.000Z\"} }", query);
+        assertBsonEquals(Filters.eq("field", LocalDate.of(2019, 3, 4)), result);
 
-        query = operations.bindFilter(Object.class, "{'field': :field}",
+        result = operations.bindFilter(Object.class, "{'field': :field}",
                 Parameters.with("field", LocalDateTime.of(2019, 3, 4, 1, 1, 1)).map());
-        assertEquals("{'field': {\"$date\": \"2019-03-04T01:01:01.000Z\"} }", query);
+        assertBsonEquals(Filters.eq("field", LocalDateTime.of(2019, 3, 4, 1, 1, 1)), result);
 
-        query = operations.bindFilter(Object.class, "{'field': :field}",
+        result = operations.bindFilter(Object.class, "{'field': :field}",
                 Parameters.with("field", LocalDateTime.of(2019, 3, 4, 1, 1, 1).toInstant(ZoneOffset.UTC)).map());
-        assertEquals("{'field': {\"$date\": \"2019-03-04T01:01:01.000Z\"} }", query);
+        assertBsonEquals(Filters.eq("field", LocalDateTime.of(2019, 3, 4, 1, 1, 1).toInstant(ZoneOffset.UTC)), result);
 
-        query = operations.bindFilter(Object.class, "{'field': :field}",
+        result = operations.bindFilter(Object.class, "{'field': :field}",
                 Parameters.with("field", toDate(LocalDateTime.of(2019, 3, 4, 1, 1, 1))).map());
-        assertEquals("{'field': {\"$date\": \"2019-03-04T01:01:01.000Z\"} }", query);
+        assertBsonEquals(Filters.eq("field", toDate(LocalDateTime.of(2019, 3, 4, 1, 1, 1))), result);
 
-        query = operations.bindFilter(Object.class, "{'field': :field}",
+        result = operations.bindFilter(Object.class, "{'field': :field}",
                 Parameters.with("field", UUID.fromString("7f000101-7370-1f68-8173-70afa71b0000")).map());
-        assertEquals("{'field': UUID('7f000101-7370-1f68-8173-70afa71b0000')}", query);
+        assertBsonEquals(Filters.eq("field", UUID.fromString("7f000101-7370-1f68-8173-70afa71b0000")), result);
 
-        query = operations.bindFilter(Object.class, "{'field': :field, 'isOk': :isOk}",
+        result = operations.bindFilter(Object.class, "{'field': :field, 'isOk': :isOk}",
                 Parameters.with("field", "a value").and("isOk", true).map());
-        assertEquals("{'field': 'a value', 'isOk': true}", query);
+        assertInstanceOf(org.bson.Document.class, result);
+        org.bson.Document doc = (org.bson.Document) result;
+        assertEquals("a value", doc.get("field"));
+        assertEquals(true, doc.get("isOk"));
 
-        //queries related to '$in' operator
+        // queries related to '$in' operator
         List<Object> ids = Arrays.asList("f1", "f2");
-        query = operations.bindFilter(DemoObj.class, "{ field: { '$in': :fields } }",
+        result = operations.bindFilter(DemoObj.class, "{ field: { '$in': :fields } }",
                 Parameters.with("fields", ids).map());
-        assertEquals("{ field: { '$in': ['f1', 'f2'] } }", query);
+        assertInstanceOf(org.bson.Document.class, result);
+        doc = (org.bson.Document) result;
+        org.bson.Document inDoc = (org.bson.Document) doc.get("field");
+        assertEquals(ids, inDoc.get("$in"));
 
-        query = operations.bindFilter(DemoObj.class, "{ field: { '$in': :fields }, isOk: :isOk }",
+        result = operations.bindFilter(DemoObj.class, "{ field: { '$in': :fields }, isOk: :isOk }",
                 Parameters.with("fields", ids).and("isOk", true).map());
-        assertEquals("{ field: { '$in': ['f1', 'f2'] }, isOk: true }", query);
+        assertInstanceOf(org.bson.Document.class, result);
+        doc = (org.bson.Document) result;
+        inDoc = (org.bson.Document) doc.get("field");
+        assertEquals(ids, inDoc.get("$in"));
+        assertEquals(true, doc.get("isOk"));
 
-        query = operations.bindFilter(DemoObj.class,
+        result = operations.bindFilter(DemoObj.class,
                 "{ field: { '$in': :fields }, $or: [ {'property': :p1}, {'property': :p2} ] }",
                 Parameters.with("fields", ids).and("p1", "jpg").and("p2", "gif").map());
-        assertEquals("{ field: { '$in': ['f1', 'f2'] }, $or: [ {'property': 'jpg'}, {'property': 'gif'} ] }", query);
+        assertInstanceOf(org.bson.Document.class, result);
+        doc = (org.bson.Document) result;
+        inDoc = (org.bson.Document) doc.get("field");
+        assertEquals(ids, inDoc.get("$in"));
+        List<?> orList = (List<?>) doc.get("$or");
+        assertEquals(2, orList.size());
+        assertEquals("jpg", ((org.bson.Document) orList.get(0)).get("property"));
+        assertEquals("gif", ((org.bson.Document) orList.get(1)).get("property"));
 
-        query = operations.bindFilter(DemoObj.class,
+        result = operations.bindFilter(DemoObj.class,
                 "{ field: { '$in': :fields }, isOk: :isOk, $or: [ {'property': :p1}, {'property': :p2} ] }",
                 Parameters.with("fields", ids)
                         .and("isOk", true)
                         .and("p1", "jpg")
                         .and("p2", "gif").map());
-        assertEquals("{ field: { '$in': ['f1', 'f2'] }, isOk: true, $or: [ {'property': 'jpg'}, {'property': 'gif'} ] }",
-                query);
+        assertInstanceOf(org.bson.Document.class, result);
+        doc = (org.bson.Document) result;
+        inDoc = (org.bson.Document) doc.get("field");
+        assertEquals(ids, inDoc.get("$in"));
+        assertEquals(true, doc.get("isOk"));
+        orList = (List<?>) doc.get("$or");
+        assertEquals(2, orList.size());
+        assertEquals("jpg", ((org.bson.Document) orList.get(0)).get("property"));
+        assertEquals("gif", ((org.bson.Document) orList.get(1)).get("property"));
+    }
+
+    @Test
+    public void testBindNativeFilterByNameWithCustomType() {
+        CustomType custom = new CustomType("test");
+        Bson result = operations.bindFilter(DemoObj.class, "{'field': :field}",
+                Parameters.with("field", custom).map());
+        assertBsonEquals(Filters.eq("field", custom), result);
     }
 
     @Test
     public void testBindEnhancedFilterByIndex() {
-        String query = operations.bindFilter(Object.class, "field = ?1", new Object[] { "a value" });
-        assertEquals("{'field':'a value'}", query);
+        Bson result = operations.bindFilter(Object.class, "field = ?1", new Object[] { "a value" });
+        assertBsonEquals(Filters.eq("field", "a value"), result);
 
-        query = operations.bindFilter(Object.class, "{'field.sub': :field}",
+        result = operations.bindFilter(Object.class, "{'field.sub': :field}",
                 Parameters.with("field", "a value").map());
-        assertEquals("{'field.sub': 'a value'}", query);
+        assertBsonEquals(Filters.eq("field.sub", "a value"), result);
 
-        //test field replacement
-        query = operations.bindFilter(DemoObj.class, "property = ?1", new Object[] { "a value" });
-        assertEquals("{'value':'a value'}", query);
+        // test field replacement
+        result = operations.bindFilter(DemoObj.class, "property = ?1", new Object[] { "a value" });
+        assertBsonEquals(Filters.eq("value", "a value"), result);
 
-        query = operations.bindFilter(Object.class, "field = ?1", new Object[] { LocalDate.of(2019, 3, 4) });
-        assertEquals("{'field':{\"$date\": \"2019-03-04T00:00:00.000Z\"} }", query);
+        result = operations.bindFilter(Object.class, "field = ?1", new Object[] { LocalDate.of(2019, 3, 4) });
+        assertBsonEquals(Filters.eq("field", LocalDate.of(2019, 3, 4)), result);
 
-        query = operations.bindFilter(Object.class, "field = ?1", new Object[] { LocalDateTime.of(2019, 3, 4, 1, 1, 1) });
-        assertEquals("{'field':{\"$date\": \"2019-03-04T01:01:01.000Z\"} }", query);
+        result = operations.bindFilter(Object.class, "field = ?1", new Object[] { LocalDateTime.of(2019, 3, 4, 1, 1, 1) });
+        assertBsonEquals(Filters.eq("field", LocalDateTime.of(2019, 3, 4, 1, 1, 1)), result);
 
-        query = operations.bindFilter(Object.class, "field = ?1",
+        result = operations.bindFilter(Object.class, "field = ?1",
                 new Object[] { LocalDateTime.of(2019, 3, 4, 1, 1, 1).toInstant(ZoneOffset.UTC) });
-        assertEquals("{'field':{\"$date\": \"2019-03-04T01:01:01.000Z\"} }", query);
+        assertBsonEquals(Filters.eq("field", LocalDateTime.of(2019, 3, 4, 1, 1, 1).toInstant(ZoneOffset.UTC)), result);
 
-        query = operations.bindFilter(Object.class, "field = ?1",
+        result = operations.bindFilter(Object.class, "field = ?1",
                 new Object[] { toDate(LocalDateTime.of(2019, 3, 4, 1, 1, 1)) });
-        assertEquals("{'field':{\"$date\": \"2019-03-04T01:01:01.000Z\"} }", query);
+        assertBsonEquals(Filters.eq("field", toDate(LocalDateTime.of(2019, 3, 4, 1, 1, 1))), result);
 
-        query = operations.bindFilter(Object.class, "field = ?1",
+        result = operations.bindFilter(Object.class, "field = ?1",
                 new Object[] { UUID.fromString("7f000101-7370-1f68-8173-70afa71b0000") });
-        assertEquals("{'field':UUID('7f000101-7370-1f68-8173-70afa71b0000')}", query);
+        assertBsonEquals(Filters.eq("field", UUID.fromString("7f000101-7370-1f68-8173-70afa71b0000")), result);
 
-        query = operations.bindFilter(Object.class, "field = ?1 and isOk = ?2", new Object[] { "a value", true });
-        assertEquals("{'field':'a value','isOk':true}", query);
+        result = operations.bindFilter(Object.class, "field = ?1 and isOk = ?2", new Object[] { "a value", true });
+        assertBsonEquals(Filters.and(Filters.eq("field", "a value"), Filters.eq("isOk", true)), result);
 
-        query = operations.bindFilter(Object.class, "field = ?1 or isOk = ?2", new Object[] { "a value", true });
-        assertEquals("{'$or':[{'field':'a value'},{'isOk':true}]}", query);
+        result = operations.bindFilter(Object.class, "field = ?1 or isOk = ?2", new Object[] { "a value", true });
+        assertBsonEquals(Filters.or(Filters.eq("field", "a value"), Filters.eq("isOk", true)), result);
 
-        query = operations.bindFilter(Object.class, "count >= ?1 and count < ?2", new Object[] { 5, 10 });
-        assertEquals("{'count':{'$gte':5},'count':{'$lt':10}}", query);
+        result = operations.bindFilter(Object.class, "count >= ?1 and count < ?2", new Object[] { 5, 10 });
+        assertBsonEquals(Filters.and(Filters.gte("count", 5), Filters.lt("count", 10)), result);
 
-        query = operations.bindFilter(Object.class, "field != ?1", new Object[] { "a value" });
-        assertEquals("{'field':{'$ne':'a value'}}", query);
+        result = operations.bindFilter(Object.class, "field != ?1", new Object[] { "a value" });
+        assertBsonEquals(Filters.ne("field", "a value"), result);
 
-        query = operations.bindFilter(Object.class, "field like ?1", new Object[] { "a value" });
-        assertEquals("{'field':{'$regex':'a value'}}", query);
+        result = operations.bindFilter(Object.class, "field like ?1", new Object[] { "a value" });
+        assertBsonEquals(Filters.regex("field", "a value"), result);
 
-        query = operations.bindFilter(Object.class, "field is not null", new Object[] {});
-        assertEquals("{'field':{'$exists':true}}", query);
+        // regex with JavaScript syntax
+        result = operations.bindFilter(Object.class, "field like ?1", new Object[] { "/uppercase.*/i" });
+        assertBsonEquals(Filters.regex("field", "uppercase.*", "i"), result);
 
-        query = operations.bindFilter(Object.class, "field is null", new Object[] {});
-        assertEquals("{'field':{'$exists':false}}", query);
+        result = operations.bindFilter(Object.class, "field is not null", new Object[] {});
+        assertBsonEquals(Filters.exists("field", true), result);
+
+        result = operations.bindFilter(Object.class, "field is null", new Object[] {});
+        assertBsonEquals(Filters.exists("field", false), result);
 
         // test with hardcoded value
-        query = operations.bindFilter(Object.class, "field = 'some hardcoded value'", new Object[] {});
-        assertEquals("{'field':'some hardcoded value'}", query);
+        result = operations.bindFilter(Object.class, "field = 'some hardcoded value'", new Object[] {});
+        assertBsonEquals(Filters.eq("field", "some hardcoded value"), result);
 
-        //queries related to '$in' operator
+        // queries related to '$in' operator
         List<Object> list = Arrays.asList("f1", "f2");
-        query = operations.bindFilter(DemoObj.class, "field in ?1", new Object[] { list });
-        assertEquals("{'field':{'$in':['f1', 'f2']}}", query);
+        result = operations.bindFilter(DemoObj.class, "field in ?1", new Object[] { list });
+        assertBsonEquals(Filters.in("field", list), result);
 
-        query = operations.bindFilter(DemoObj.class, "field in ?1 and isOk = ?2", new Object[] { list, true });
-        assertEquals("{'field':{'$in':['f1', 'f2']},'isOk':true}", query);
+        result = operations.bindFilter(DemoObj.class, "field in ?1 and isOk = ?2", new Object[] { list, true });
+        assertBsonEquals(Filters.and(Filters.in("field", list), Filters.eq("isOk", true)), result);
 
-        query = operations.bindFilter(DemoObj.class,
+        result = operations.bindFilter(DemoObj.class,
                 "field in ?1 and (property = ?2 or property = ?3)",
                 new Object[] { list, "jpg", "gif" });
-        assertEquals("{'field':{'$in':['f1', 'f2']},'$or':[{'value':'jpg'},{'value':'gif'}]}", query);
+        assertBsonEquals(Filters.and(
+                Filters.in("field", list),
+                Filters.or(Filters.eq("value", "jpg"), Filters.eq("value", "gif"))), result);
 
-        query = operations.bindFilter(DemoObj.class,
+        result = operations.bindFilter(DemoObj.class,
                 "field in ?1 and isOk = ?2 and (property = ?3 or property = ?4)",
                 new Object[] { list, true, "jpg", "gif" });
-        assertEquals("{'field':{'$in':['f1', 'f2']},'isOk':true,'$or':[{'value':'jpg'},{'value':'gif'}]}", query);
+        assertBsonEquals(Filters.and(
+                Filters.and(Filters.in("field", list), Filters.eq("isOk", true)),
+                Filters.or(Filters.eq("value", "jpg"), Filters.eq("value", "gif"))), result);
+    }
+
+    @Test
+    public void testBindEnhancedFilterByIndexWithCustomType() {
+        CustomType custom = new CustomType("test");
+        Bson result = operations.bindFilter(Object.class, "field = ?1", new Object[] { custom });
+        assertBsonEquals(Filters.eq("field", custom), result);
+    }
+
+    @Test
+    public void testBindEnhancedFilterByIndexWithEnum() {
+        Bson result = operations.bindFilter(Object.class, "field = ?1", new Object[] { TestEnum.VALUE_A });
+        assertBsonEquals(Filters.eq("field", "VALUE_A"), result);
     }
 
     @Test
     public void testBindEnhancedFilterByName() {
-        String query = operations.bindFilter(Object.class, "field = :field",
+        Bson result = operations.bindFilter(Object.class, "field = :field",
                 Parameters.with("field", "a value").map());
-        assertEquals("{'field':'a value'}", query);
+        assertBsonEquals(Filters.eq("field", "a value"), result);
 
-        query = operations.bindFilter(Object.class, "field.sub = :field",
+        result = operations.bindFilter(Object.class, "field.sub = :field",
                 Parameters.with("field", "a value").map());
-        assertEquals("{'field.sub':'a value'}", query);
+        assertBsonEquals(Filters.eq("field.sub", "a value"), result);
 
-        //test field replacement
-        query = operations.bindFilter(DemoObj.class, "property = :field",
+        // test field replacement
+        result = operations.bindFilter(DemoObj.class, "property = :field",
                 Parameters.with("field", "a value").map());
-        assertEquals("{'value':'a value'}", query);
+        assertBsonEquals(Filters.eq("value", "a value"), result);
 
-        query = operations.bindFilter(Object.class, "field = :field",
+        result = operations.bindFilter(Object.class, "field = :field",
                 Parameters.with("field", LocalDate.of(2019, 3, 4)).map());
-        assertEquals("{'field':{\"$date\": \"2019-03-04T00:00:00.000Z\"} }", query);
+        assertBsonEquals(Filters.eq("field", LocalDate.of(2019, 3, 4)), result);
 
-        query = operations.bindFilter(Object.class, "field = :field",
+        result = operations.bindFilter(Object.class, "field = :field",
                 Parameters.with("field", LocalDateTime.of(2019, 3, 4, 1, 1, 1)).map());
-        assertEquals("{'field':{\"$date\": \"2019-03-04T01:01:01.000Z\"} }", query);
+        assertBsonEquals(Filters.eq("field", LocalDateTime.of(2019, 3, 4, 1, 1, 1)), result);
 
-        query = operations.bindFilter(Object.class, "field = :field",
+        result = operations.bindFilter(Object.class, "field = :field",
                 Parameters.with("field", LocalDateTime.of(2019, 3, 4, 1, 1, 1).toInstant(ZoneOffset.UTC)).map());
-        assertEquals("{'field':{\"$date\": \"2019-03-04T01:01:01.000Z\"} }", query);
+        assertBsonEquals(Filters.eq("field", LocalDateTime.of(2019, 3, 4, 1, 1, 1).toInstant(ZoneOffset.UTC)), result);
 
-        query = operations.bindFilter(Object.class, "field = :field",
+        result = operations.bindFilter(Object.class, "field = :field",
                 Parameters.with("field", toDate(LocalDateTime.of(2019, 3, 4, 1, 1, 1))).map());
-        assertEquals("{'field':{\"$date\": \"2019-03-04T01:01:01.000Z\"} }", query);
+        assertBsonEquals(Filters.eq("field", toDate(LocalDateTime.of(2019, 3, 4, 1, 1, 1))), result);
 
-        query = operations.bindFilter(Object.class, "field = :field",
+        result = operations.bindFilter(Object.class, "field = :field",
                 Parameters.with("field", UUID.fromString("7f000101-7370-1f68-8173-70afa71b0000")).map());
-        assertEquals("{'field':UUID('7f000101-7370-1f68-8173-70afa71b0000')}", query);
+        assertBsonEquals(Filters.eq("field", UUID.fromString("7f000101-7370-1f68-8173-70afa71b0000")), result);
 
-        query = operations.bindFilter(Object.class, "field = :field and isOk = :isOk",
+        result = operations.bindFilter(Object.class, "field = :field and isOk = :isOk",
                 Parameters.with("field", "a value").and("isOk", true).map());
-        assertEquals("{'field':'a value','isOk':true}", query);
+        assertBsonEquals(Filters.and(Filters.eq("field", "a value"), Filters.eq("isOk", true)), result);
 
-        query = operations.bindFilter(Object.class, "field = :field or isOk = :isOk",
+        result = operations.bindFilter(Object.class, "field = :field or isOk = :isOk",
                 Parameters.with("field", "a value").and("isOk", true).map());
-        assertEquals("{'$or':[{'field':'a value'},{'isOk':true}]}", query);
+        assertBsonEquals(Filters.or(Filters.eq("field", "a value"), Filters.eq("isOk", true)), result);
 
-        query = operations.bindFilter(Object.class, "count > :lower and count <= :upper",
+        result = operations.bindFilter(Object.class, "count > :lower and count <= :upper",
                 Parameters.with("lower", 5).and("upper", 10).map());
-        assertEquals("{'count':{'$gt':5},'count':{'$lte':10}}", query);
+        assertBsonEquals(Filters.and(Filters.gt("count", 5), Filters.lte("count", 10)), result);
 
-        query = operations.bindFilter(Object.class, "field != :field",
+        result = operations.bindFilter(Object.class, "field != :field",
                 Parameters.with("field", "a value").map());
-        assertEquals("{'field':{'$ne':'a value'}}", query);
+        assertBsonEquals(Filters.ne("field", "a value"), result);
 
-        query = operations.bindFilter(Object.class, "field like :field",
+        result = operations.bindFilter(Object.class, "field like :field",
                 Parameters.with("field", "a value").map());
-        assertEquals("{'field':{'$regex':'a value'}}", query);
+        assertBsonEquals(Filters.regex("field", "a value"), result);
 
-        //queries related to '$in' operator
+        // queries related to '$in' operator
         List<Object> list = Arrays.asList("f1", "f2");
-        query = operations.bindFilter(DemoObj.class, "field in :fields",
+        result = operations.bindFilter(DemoObj.class, "field in :fields",
                 Parameters.with("fields", list).map());
-        assertEquals("{'field':{'$in':['f1', 'f2']}}", query);
+        assertBsonEquals(Filters.in("field", list), result);
 
-        query = operations.bindFilter(DemoObj.class, "field in :fields and isOk = :isOk",
+        result = operations.bindFilter(DemoObj.class, "field in :fields and isOk = :isOk",
                 Parameters.with("fields", list).and("isOk", true).map());
-        assertEquals("{'field':{'$in':['f1', 'f2']},'isOk':true}", query);
+        assertBsonEquals(Filters.and(Filters.in("field", list), Filters.eq("isOk", true)), result);
 
-        query = operations.bindFilter(DemoObj.class,
+        result = operations.bindFilter(DemoObj.class,
                 "field in :fields and (property = :p1 or property = :p2)",
                 Parameters.with("fields", list).and("p1", "jpg").and("p2", "gif").map());
-        assertEquals("{'field':{'$in':['f1', 'f2']},'$or':[{'value':'jpg'},{'value':'gif'}]}", query);
+        assertBsonEquals(Filters.and(
+                Filters.in("field", list),
+                Filters.or(Filters.eq("value", "jpg"), Filters.eq("value", "gif"))), result);
 
-        query = operations.bindFilter(DemoObj.class,
+        result = operations.bindFilter(DemoObj.class,
                 "field in :fields and isOk = :isOk and (property = :p1 or property = :p2)",
                 Parameters.with("fields", list)
                         .and("isOk", true)
                         .and("p1", "jpg")
                         .and("p2", "gif").map());
-        assertEquals("{'field':{'$in':['f1', 'f2']},'isOk':true,'$or':[{'value':'jpg'},{'value':'gif'}]}", query);
+        assertBsonEquals(Filters.and(
+                Filters.and(Filters.in("field", list), Filters.eq("isOk", true)),
+                Filters.or(Filters.eq("value", "jpg"), Filters.eq("value", "gif"))), result);
+    }
+
+    @Test
+    public void testBindEnhancedFilterByNameWithCustomType() {
+        CustomType custom = new CustomType("test");
+        Bson result = operations.bindFilter(Object.class, "field = :field",
+                Parameters.with("field", custom).map());
+        assertBsonEquals(Filters.eq("field", custom), result);
     }
 
     @Test
     public void testBindUpdate() {
         // native update by index without $set
-        String update = operations.bindUpdate(DemoObj.class, "{'field': ?1}", new Object[] { "a value" });
-        assertEquals("{'$set':{'field': 'a value'}}", update);
+        Bson update = operations.bindUpdate(DemoObj.class, "{'field': ?1}", new Object[] { "a value" });
+        assertInstanceOf(org.bson.Document.class, update);
+        org.bson.Document updateDoc = (org.bson.Document) update;
+        org.bson.Document setDoc = (org.bson.Document) updateDoc.get("$set");
+        assertEquals("a value", setDoc.get("field"));
 
-        // native update by index without $set
+        // native update by index without $set (list value)
         update = operations.bindUpdate(DemoObj.class, "{'listField': ?1}", new Object[] { List.of("value1", "value2") });
-        assertEquals("{'$set':{'listField': ['value1', 'value2']}}", update);
+        assertInstanceOf(org.bson.Document.class, update);
+        updateDoc = (org.bson.Document) update;
+        setDoc = (org.bson.Document) updateDoc.get("$set");
+        assertEquals(List.of("value1", "value2"), setDoc.get("listField"));
 
         // native update by name without $set
         update = operations.bindUpdate(Object.class, "{'field': :field}",
                 Parameters.with("field", "a value").map());
-        assertEquals("{'$set':{'field': 'a value'}}", update);
+        assertInstanceOf(org.bson.Document.class, update);
+        updateDoc = (org.bson.Document) update;
+        setDoc = (org.bson.Document) updateDoc.get("$set");
+        assertEquals("a value", setDoc.get("field"));
 
         // native update by index with $set
         update = operations.bindUpdate(DemoObj.class, "{'$set':{'field': ?1}}", new Object[] { "a value" });
-        assertEquals("{'$set':{'field': 'a value'}}", update);
+        assertInstanceOf(org.bson.Document.class, update);
+        updateDoc = (org.bson.Document) update;
+        setDoc = (org.bson.Document) updateDoc.get("$set");
+        assertEquals("a value", setDoc.get("field"));
 
         // native update by name with $set
         update = operations.bindUpdate(Object.class, "{'$set':{'field': :field}}",
                 Parameters.with("field", "a value").map());
-        assertEquals("{'$set':{'field': 'a value'}}", update);
+        assertInstanceOf(org.bson.Document.class, update);
+        updateDoc = (org.bson.Document) update;
+        setDoc = (org.bson.Document) updateDoc.get("$set");
+        assertEquals("a value", setDoc.get("field"));
 
         // native update by index with $inc
         update = operations.bindUpdate(DemoObj.class, "{'$inc':{'field': ?1}}", new Object[] { "a value" });
-        assertEquals("{'$inc':{'field': 'a value'}}", update);
+        assertInstanceOf(org.bson.Document.class, update);
+        updateDoc = (org.bson.Document) update;
+        org.bson.Document incDoc = (org.bson.Document) updateDoc.get("$inc");
+        assertEquals("a value", incDoc.get("field"));
 
         // native update by name with $inc
         update = operations.bindUpdate(Object.class, "{'$inc':{'field': :field}}",
                 Parameters.with("field", "a value").map());
-        assertEquals("{'$inc':{'field': 'a value'}}", update);
+        assertInstanceOf(org.bson.Document.class, update);
+        updateDoc = (org.bson.Document) update;
+        incDoc = (org.bson.Document) updateDoc.get("$inc");
+        assertEquals("a value", incDoc.get("field"));
 
-        // shortand update
+        // shorthand update
         update = operations.bindUpdate(Object.class, "field", new Object[] { "a value" });
-        assertEquals("{'$set':{'field':'a value'}}", update);
+        assertInstanceOf(org.bson.Document.class, update);
+        updateDoc = (org.bson.Document) update;
+        org.bson.Document innerDoc = (org.bson.Document) updateDoc.get("$set");
+        assertEquals("a value", innerDoc.get("field"));
 
         // enhanced update by index
         update = operations.bindUpdate(Object.class, "field = ?1", new Object[] { "a value" });
-        assertEquals("{'$set':{'field':'a value'}}", update);
+        assertBsonEquals(
+                new org.bson.Document("$set", Filters.eq("field", "a value")),
+                update);
 
         // enhanced update by name
         update = operations.bindUpdate(Object.class, "field = :field",
                 Parameters.with("field", "a value").map());
-        assertEquals("{'$set':{'field':'a value'}}", update);
+        assertBsonEquals(
+                new org.bson.Document("$set", Filters.eq("field", "a value")),
+                update);
+    }
+
+    @Test
+    public void testBindUpdateWithCustomType() {
+        CustomType custom = new CustomType("test");
+        Bson update = operations.bindUpdate(Object.class, "field", new Object[] { custom });
+        assertBsonEquals(
+                new org.bson.Document("$set", Filters.eq("field", custom)),
+                update);
+    }
+
+    @Test
+    public void testBindInWithCustomTypes() {
+        // PanacheQL IN with custom types
+        List<CustomType> customList = Arrays.asList(new CustomType("a"), new CustomType("b"));
+        Bson result = operations.bindFilter(Object.class, "field in ?1", new Object[] { customList });
+        assertBsonEquals(Filters.in("field", customList), result);
+
+        // PanacheQL IN with custom types by name
+        result = operations.bindFilter(Object.class, "field in :values",
+                Parameters.with("values", customList).map());
+        assertBsonEquals(Filters.in("field", customList), result);
+
+        // native query IN with custom types
+        result = operations.bindFilter(Object.class, "{ field: { '$in': ?1 } }", new Object[] { customList });
+        assertInstanceOf(org.bson.Document.class, result);
+        org.bson.Document doc = (org.bson.Document) result;
+        org.bson.Document inDoc = (org.bson.Document) doc.get("field");
+        assertEquals(customList, inDoc.get("$in"));
+
+        // PanacheQL IN with a single value (not a collection)
+        result = operations.bindFilter(Object.class, "field in ?1", new Object[] { "single" });
+        assertBsonEquals(Filters.in("field", "single"), result);
+    }
+
+    @Test
+    public void testBindStringEscaping() {
+        // test string with single quotes
+        Bson result = operations.bindFilter(Object.class, "field", new Object[] { "it's a value" });
+        assertBsonEquals(Filters.eq("field", "it's a value"), result);
+
+        // test string with backslashes
+        result = operations.bindFilter(Object.class, "field", new Object[] { "path\\to\\file" });
+        assertBsonEquals(Filters.eq("field", "path\\to\\file"), result);
+
+        // test string with double quotes
+        result = operations.bindFilter(Object.class, "field", new Object[] { "say \"hello\"" });
+        assertBsonEquals(Filters.eq("field", "say \"hello\""), result);
+
+        // enhanced query with special characters
+        result = operations.bindFilter(Object.class, "field = ?1", new Object[] { "it's a value" });
+        assertBsonEquals(Filters.eq("field", "it's a value"), result);
+
+        // native query with special characters
+        result = operations.bindFilter(Object.class, "{'field': ?1}", new Object[] { "it's a value" });
+        assertBsonEquals(Filters.eq("field", "it's a value"), result);
     }
 }

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/bugs/Bug54526Entity.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/bugs/Bug54526Entity.java
@@ -1,0 +1,11 @@
+package io.quarkus.it.mongodb.panache.bugs;
+
+import io.quarkus.mongodb.panache.PanacheMongoEntity;
+import io.quarkus.mongodb.panache.common.MongoEntity;
+
+@MongoEntity(collection = "bug54526")
+public class Bug54526Entity extends PanacheMongoEntity {
+
+    public Isbn isbn;
+    public String title;
+}

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/bugs/BugResource.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/bugs/BugResource.java
@@ -151,4 +151,37 @@ public class BugResource {
 
         return Response.ok().build();
     }
+
+    @GET
+    @Path("54526")
+    public String testBug54526() {
+        Bug54526Entity entity = new Bug54526Entity();
+        entity.isbn = Isbn.of("978-3-86680-192-9");
+        entity.title = "Test Book";
+        entity.persist();
+
+        try {
+            // shorthand query — this was the original reported bug
+            long shorthand = Bug54526Entity.count("isbn", entity.isbn);
+            if (shorthand != 1) {
+                return "FAIL: shorthand query returned " + shorthand;
+            }
+
+            // PanacheQL query
+            long panacheQl = Bug54526Entity.count("isbn = ?1", entity.isbn);
+            if (panacheQl != 1) {
+                return "FAIL: PanacheQL query returned " + panacheQl;
+            }
+
+            // native query
+            long nativeQuery = Bug54526Entity.count("{'isbn': ?1}", entity.isbn);
+            if (nativeQuery != 1) {
+                return "FAIL: native query returned " + nativeQuery;
+            }
+
+            return "OK";
+        } finally {
+            entity.delete();
+        }
+    }
 }

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/bugs/Isbn.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/bugs/Isbn.java
@@ -1,0 +1,40 @@
+package io.quarkus.it.mongodb.panache.bugs;
+
+import java.util.Objects;
+
+public final class Isbn {
+
+    private final String value;
+
+    private Isbn(String value) {
+        Objects.requireNonNull(value);
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public static Isbn of(String value) {
+        return new Isbn(value);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        return value.equals(((Isbn) o).value);
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "ISBN{" + value + "}";
+    }
+}

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/bugs/IsbnCodecProvider.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/bugs/IsbnCodecProvider.java
@@ -1,0 +1,56 @@
+package io.quarkus.it.mongodb.panache.bugs;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.bson.BsonReader;
+import org.bson.BsonType;
+import org.bson.BsonWriter;
+import org.bson.codecs.Codec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.EncoderContext;
+import org.bson.codecs.configuration.CodecProvider;
+import org.bson.codecs.configuration.CodecRegistry;
+
+@ApplicationScoped
+public class IsbnCodecProvider implements CodecProvider {
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> Codec<T> get(Class<T> clazz, CodecRegistry registry) {
+        if (clazz == Isbn.class) {
+            return (Codec<T>) new IsbnCodec(registry.get(String.class));
+        }
+        return null;
+    }
+
+    private static class IsbnCodec implements Codec<Isbn> {
+        private final Codec<String> stringCodec;
+
+        IsbnCodec(Codec<String> stringCodec) {
+            this.stringCodec = stringCodec;
+        }
+
+        @Override
+        public void encode(BsonWriter writer, Isbn value, EncoderContext encoderContext) {
+            if (value == null) {
+                writer.writeNull();
+                return;
+            }
+            stringCodec.encode(writer, value.value(), encoderContext);
+        }
+
+        @Override
+        public Isbn decode(BsonReader reader, DecoderContext decoderContext) {
+            if (reader.getCurrentBsonType() == BsonType.NULL) {
+                reader.readNull();
+                return null;
+            }
+            return Isbn.of(stringCodec.decode(reader, decoderContext));
+        }
+
+        @Override
+        public Class<Isbn> getEncoderClass() {
+            return Isbn.class;
+        }
+    }
+}

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheResourceTest.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheResourceTest.java
@@ -432,4 +432,9 @@ class MongodbPanacheResourceTest {
         get("/bugs/23813").then().statusCode(200);
     }
 
+    @Test
+    public void testBug54526() {
+        get("/bugs/54526").then().body(is("OK"));
+    }
+
 }


### PR DESCRIPTION
We used to manipulate strings which was quite brittle and led to some bugs.

Idea by me, most of the coding by Claude guided by me, carefully reviewed by me.

Fixes #54526