### PR TITLE
Add icon when dynamic urls are set in the dev ui

### DIFF
--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/page/ExternalPageBuilder.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/page/ExternalPageBuilder.java
@@ -48,6 +48,10 @@ public class ExternalPageBuilder extends PageBuilder<ExternalPageBuilder> {
             throw new RuntimeException("Invalid dynamic URL Method name, can not be empty");
         }
         super.metadata.put(DYNAMIC_URL, methodName);
+        if (methodName != null) {
+            return staticLabel(
+                    "<div style='color: var(--lumo-contrast-80pct);'  target='_blank'><vaadin-icon class='icon' icon='font-awesome-solid:up-right-from-square'></vaadin-icon></div>");
+        }
         return this;
     }
 
@@ -60,6 +64,10 @@ public class ExternalPageBuilder extends PageBuilder<ExternalPageBuilder> {
                             + URLEncoder.encode(e.getValue(), StandardCharsets.UTF_8))
                     .reduce((a, b) -> a + "&" + b)
                     .orElse(""));
+        }
+        if (methodName != null) {
+            return staticLabel(
+                    "<div style='color: var(--lumo-contrast-80pct);'  target='_blank'><vaadin-icon class='icon' icon='font-awesome-solid:up-right-from-square'></vaadin-icon></div>");
         }
         return this;
     }


### PR DESCRIPTION
Opening for discussion, because I'm not totally sure what the best behaviour is. 

I noticed when converting otel to the new dev services model (https://github.com/quarkusio/quarkus/pull/54388), we lost the little 
<img width="52" height="48" alt="image" src="https://github.com/user-attachments/assets/73bedbcb-ea78-41a8-83b4-ecdee7832c4a" />
icon on the link. 

I checked, and it's because the `.url()` method will add it, but the dynamic url method won't. The complexity happens because the `.url()` method only adds it on the two-argument option. I think the intention is to have one url on the left and a different url on the right, or, I guess, an 'open in external tab' option on the right, and an in-tab option on the left. About half the usages have a `?embed=true` option on one link, and the other half just use the exact same link for both sides. More generally, about half the usages are of the one-argument variant, and half are of the two-argument variant. 

I can't get exact parity with the static-url behaviour (or at least, not trivially) because of how the dynamic urls are handled. Instead, what I did is put a non-live icon in the same place. 

So I have a few questions: 

- Is a non-live icon worse than no icon (people click it, and nothing happens), or better (it indicates the thing to the left is a link that opens an external page)?
- There's no enforcement that in the `url()` case, the behaviour of the left and right links is different. Or is it supposed to be enforced that it's the same? I'm not totally sure what the intention is, and the docs only cover the one-link case. 
- From a user perspective, some external links get the icon, and some don't. I think more consistency would help; my expectation as a user would be that every external link gets the icon, and the icon is indicating that the link leads to an external page. 
- Should there be some connection between calling `doNotEmbed()` and the icon, like if you add `doNotEmbed() on the externalPageBuilder, you get the icon, and otherwise you don't? That would be my expectation as a user, I think. 

I haven't implemented it in my first version of this PR, but I'd suggest:

- Drop or deprecate the two-argument `url()` option
- Make `doNotEmbed()` default to false on ExternalPageBuilder (sort of orthogonal, but saves people typing)
- Make `doNotEmbed()` control whether an icon appears; icon appears if `embed` is false, so both `url()` and the dynamic url method will optionally add the icon 
- Have the icon be an anchor where we can, and not an anchor in other cases, to prioritise doing-what-people-want over consistency 

cc @phillip-kruger 