### PR TITLE
[4.0] Make all Vert.x executeBlocking ordering requirement explicit

### DIFF
--- a/extensions/infinispan-cache/runtime/src/main/java/io/quarkus/cache/infinispan/runtime/InfinispanCacheImpl.java
+++ b/extensions/infinispan-cache/runtime/src/main/java/io/quarkus/cache/infinispan/runtime/InfinispanCacheImpl.java
@@ -122,7 +122,7 @@ public class InfinispanCacheImpl extends AbstractCache implements Cache {
                                     public V call() throws Exception {
                                         return valueLoader.apply(key);
                                     }
-                                }).toCompletionStage()
+                                }, false).toCompletionStage()
                                         .thenComposeAsync(newValue -> {
                                             InfinispanCacheImpl.this.putIfAbsentInInfinispan(key, newValue, resultAsync,
                                                     executor);

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -911,7 +911,7 @@ public class OidcCommonUtils {
                     }
                     return null;
                 }
-            }).flatMap(new Function<Void, Uni<? extends HttpResponse<Buffer>>>() {
+            }, false).flatMap(new Function<Void, Uni<? extends HttpResponse<Buffer>>>() {
                 @Override
                 public Uni<? extends HttpResponse<Buffer>> apply(Void unused) {
                     return request.send();

--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxHttpRequest.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxHttpRequest.java
@@ -271,7 +271,7 @@ public final class VertxHttpRequest extends BaseHttpRequest {
                         throw new RuntimeException(e);
                     }
                     return null;
-                }).onComplete(res -> {
+                }, false).onComplete(res -> {
                     if (res.succeeded())
                         ret.complete(null);
                     else

--- a/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/RequestLeakDetectionTest.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/test/java/io/quarkus/rest/client/reactive/RequestLeakDetectionTest.java
@@ -273,7 +273,7 @@ public class RequestLeakDetectionTest {
                 context.executeBlocking(() -> {
                     runnable.run();
                     return null;
-                });
+                }, true);
             } else {
                 context.runOnContext(x -> runnable.run());
             }

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/RolesAllowedServiceResource.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/RolesAllowedServiceResource.java
@@ -57,7 +57,7 @@ public class RolesAllowedServiceResource {
                     // make sure authentication is attempted on a worker thread to prevent blocking event loop
                     rolesAllowedService.receiveRolesAllowedMessage(msg.body());
                     return null;
-                }));
+                }, false));
     }
 
     void observerShutdown(@Observes ShutdownEvent shutdownEvent) {

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/BlockingHelper.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/BlockingHelper.java
@@ -43,7 +43,7 @@ public final class BlockingHelper {
                 }
             });
         } else if (vc != null) {
-            vc.executeBlocking(contextualCallable).onComplete(result);
+            vc.executeBlocking(contextualCallable, false).onComplete(result);
         } else {
             // No Vert.x context (e.g. ForkJoinPool thread after CompletableFuture.supplyAsync) —
             // already off the event loop, safe to execute directly

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/RemoteSyncHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/RemoteSyncHandler.java
@@ -89,7 +89,7 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
                     handleRequest(event);
                     return null;
                 }
-            });
+            }, false);
             return;
         }
         next.handle(event);
@@ -162,7 +162,7 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
                         }
                         return null;
                     }
-                });
+                }, false);
             }
         }).exceptionHandler(new Handler<Throwable>() {
             @Override

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/VertxHttpHotReplacementSetup.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/VertxHttpHotReplacementSetup.java
@@ -134,7 +134,7 @@ public class VertxHttpHotReplacementSetup implements HotReplacementSetup {
                             routingContext.response().end();
                             return null;
                         }
-                    }).onFailure(routingContext::fail);
+                    }, false).onFailure(routingContext::fail);
                 }
             });
             routingContext.request().resume();

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/deployment/VertxWorkerPoolShutdownTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/deployment/VertxWorkerPoolShutdownTest.java
@@ -47,7 +47,7 @@ public class VertxWorkerPoolShutdownTest {
         public void init(@Observes StartupEvent ev) {
             executorService.shutdownNow();
             ((io.vertx.core.internal.ContextInternal) vertx.getOrCreateContext()).workerPool().executor().shutdownNow();
-            Future<Boolean> ok1 = vertx.executeBlocking(() -> true);
+            Future<Boolean> ok1 = vertx.executeBlocking(() -> true, false);
             ok = ok1.toCompletionStage().toCompletableFuture().join();
         }
     }

--- a/extensions/virtual-threads/runtime/src/test/java/io/quarkus/virtual/threads/VirtualThreadExecutorSupplierTest.java
+++ b/extensions/virtual-threads/runtime/src/test/java/io/quarkus/virtual/threads/VirtualThreadExecutorSupplierTest.java
@@ -74,7 +74,7 @@ class VirtualThreadExecutorSupplierTest {
                 future.complete(Vertx.currentContext());
             });
             return null;
-        }).toCompletionStage().toCompletableFuture().get();
+        }, false).toCompletionStage().toCompletableFuture().get();
         assertThat(future.get()).isNotNull();
     }
 
@@ -87,7 +87,7 @@ class VirtualThreadExecutorSupplierTest {
                 .runSubscriptionOn(command -> vertx.executeBlocking(() -> {
                     command.run();
                     return null;
-                }))
+                }, false))
                 .emitOn(executorService)
                 .map(x -> {
                     assertThatItRunsOnVirtualThread();
@@ -107,7 +107,7 @@ class VirtualThreadExecutorSupplierTest {
             executorService.submit(() -> {
                 assertThatItRunsOnVirtualThread();
                 future.complete(Vertx.currentContext());
-            });
+            }, false);
             return null;
         }).toCompletionStage().toCompletableFuture().get();
         assertThat(future.get()).isNotNull();
@@ -126,7 +126,7 @@ class VirtualThreadExecutorSupplierTest {
                 assertThatItRunsOnVirtualThread();
                 return Vertx.currentContext();
             }));
-        }).toCompletionStage().toCompletableFuture().get();
+        }, false).toCompletionStage().toCompletableFuture().get();
         assertThat(futures).allSatisfy(contextFuture -> assertThat(contextFuture.get()).isNotNull());
     }
 

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/InputStreamReadStream.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/InputStreamReadStream.java
@@ -117,7 +117,7 @@ public class InputStreamReadStream implements ReadStream<Buffer> {
                         VertxByteBufAllocator.DEFAULT.heapBuffer(amount, Integer.MAX_VALUE).writeBytes(bytes, 0,
                                 amount));
             }
-        });
+        }, true);
         fut.onComplete(new Handler<>() {
             @Override
             public void handle(AsyncResult<Buffer> ar) {

--- a/integration-tests/vertx/src/main/java/io/quarkus/it/vertx/verticles/MdcVerticle.java
+++ b/integration-tests/vertx/src/main/java/io/quarkus/it/vertx/verticles/MdcVerticle.java
@@ -22,7 +22,7 @@ public class MdcVerticle extends AbstractVerticle {
                         vertx.executeBlocking(() -> {
                             LOGGER.warn("Blocking task executed ### " + MDC.get(MDC_KEY));
                             return null;
-                        }).onComplete(bar -> message.reply("OK-" + MDC.get(MDC_KEY)));
+                        }, false).onComplete(bar -> message.reply("OK-" + MDC.get(MDC_KEY)));
                     });
                 })
                 .completion().onComplete(promise);

--- a/test-framework/vertx/src/main/java/io/quarkus/test/vertx/RunOnVertxContextTestMethodInvoker.java
+++ b/test-framework/vertx/src/main/java/io/quarkus/test/vertx/RunOnVertxContextTestMethodInvoker.java
@@ -106,7 +106,7 @@ public class RunOnVertxContextTestMethodInvoker implements TestMethodInvoker {
         } else {
             var handler = new RunTestMethodOnVertxBlockingContextHandler(actualTestInstance, actualTestMethod,
                     actualTestMethodArgs, uniAsserter);
-            Future<Object> future = context.executeBlocking(handler::execute);
+            Future<Object> future = context.executeBlocking(handler::execute, false);
             return future.await(30, TimeUnit.SECONDS);
         }
     }


### PR DESCRIPTION
This ensures each call to executeBlocking defines its ordering needs
instead of inadvertently falling back to strict ordering.

See #54088
