### PR TITLE
Add tests for old model dev services lifecycle

### DIFF
--- a/integration-tests/devservices/old-model-extension/deployment/src/main/java/io/quarkus/tests/oldmodelextension/deployment/OldModelDevServicesProcessor.java
+++ b/integration-tests/devservices/old-model-extension/deployment/src/main/java/io/quarkus/tests/oldmodelextension/deployment/OldModelDevServicesProcessor.java
@@ -1,7 +1,9 @@
 package io.quarkus.tests.oldmodelextension.deployment;
 
 import static io.quarkus.tests.oldmodelextension.Constants.OLD_MODEL_EXTENSION_BASE_URL;
+import static io.quarkus.tests.oldmodelextension.Constants.OLD_MODEL_EXTENSION_START_COUNT;
 import static io.quarkus.tests.oldmodelextension.Constants.OLD_MODEL_EXTENSION_STATIC_THING;
+import static io.quarkus.tests.oldmodelextension.Constants.OLD_MODEL_START_COUNT_SYSTEM_PROPERTY;
 
 import java.util.Map;
 
@@ -47,12 +49,16 @@ public class OldModelDevServicesProcessor {
 
         String baseUrl = "http://" + container.getHost() + ":" + container.getMappedPort(HTTPD_PORT);
 
+        int startCount = Integer.parseInt(System.getProperty(OLD_MODEL_START_COUNT_SYSTEM_PROPERTY, "0")) + 1;
+        System.setProperty(OLD_MODEL_START_COUNT_SYSTEM_PROPERTY, String.valueOf(startCount));
+
         devService = new RunningDevService(
                 FEATURE,
                 container.getContainerId(),
                 container::stop,
                 Map.of(OLD_MODEL_EXTENSION_BASE_URL, baseUrl,
-                        OLD_MODEL_EXTENSION_STATIC_THING, "old model value"));
+                        OLD_MODEL_EXTENSION_STATIC_THING, "old model value",
+                        OLD_MODEL_EXTENSION_START_COUNT, String.valueOf(startCount)));
 
         if (first) {
             first = false;

--- a/integration-tests/devservices/old-model-extension/runtime/src/main/java/io/quarkus/tests/oldmodelextension/Constants.java
+++ b/integration-tests/devservices/old-model-extension/runtime/src/main/java/io/quarkus/tests/oldmodelextension/Constants.java
@@ -3,4 +3,6 @@ package io.quarkus.tests.oldmodelextension;
 public class Constants {
     public static final String OLD_MODEL_EXTENSION_BASE_URL = "acme.oldmodelextension.base-url";
     public static final String OLD_MODEL_EXTENSION_STATIC_THING = "acme.oldmodelextension.static-thing";
+    public static final String OLD_MODEL_EXTENSION_START_COUNT = "acme.oldmodelextension.start-count";
+    public static final String OLD_MODEL_START_COUNT_SYSTEM_PROPERTY = "acme.oldmodel.start-count";
 }

--- a/integration-tests/devservices/tests/src/test/java/io/quarkus/devservices/test/OldModelLifecycleTest.java
+++ b/integration-tests/devservices/tests/src/test/java/io/quarkus/devservices/test/OldModelLifecycleTest.java
@@ -1,0 +1,60 @@
+package io.quarkus.devservices.test;
+
+import static io.quarkus.tests.oldmodelextension.Constants.OLD_MODEL_EXTENSION_BASE_URL;
+import static io.quarkus.tests.oldmodelextension.Constants.OLD_MODEL_START_COUNT_SYSTEM_PROPERTY;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+/**
+ * Verifies that old-model dev services get a fresh lifecycle for each test profile.
+ *
+ * Old-model processors use {@code static volatile} fields to cache running services.
+ * When the augmentation classloader is properly scoped per profile, each profile loads
+ * a fresh copy of the processor class with {@code devService == null}, triggering a
+ * fresh container start. If the classloader is incorrectly shared across profiles,
+ * the static field persists and the second profile reuses the first profile's container
+ * instead of getting its own.
+ *
+ * This test reads the JVM-wide start-count system property (which is incremented each
+ * time the processor freshly creates a container) at test execution time — after all
+ * augmentations have completed. A count greater than 1 proves that multiple profiles
+ * each received their own fresh processor instance.
+ */
+@QuarkusTest
+@TestProfile(OldModelLifecycleTest.Profile.class)
+public class OldModelLifecycleTest {
+
+    public static class Profile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of();
+        }
+    }
+
+    @ConfigProperty(name = OLD_MODEL_EXTENSION_BASE_URL, defaultValue = "unset")
+    String baseUrl;
+
+    @Test
+    public void oldModelServiceWasFreshlyStartedForThisProfile() {
+        int count = Integer.parseInt(System.getProperty(OLD_MODEL_START_COUNT_SYSTEM_PROPERTY, "0"));
+        assertTrue(count > 1,
+                "Old-model dev service should have been freshly started for each profile "
+                        + "(start-count should be > 1 indicating multiple profiles each started their own instance), "
+                        + "but start-count was " + count
+                        + ". This suggests the service was reused across profiles due to shared static state.");
+    }
+
+    @Test
+    public void oldModelServiceIsRunning() {
+        assertNotEquals("unset", baseUrl);
+    }
+}


### PR DESCRIPTION
 This is a follow-on to https://github.com/quarkusio/quarkus/pull/54405. Claude and I have added tests which exercise the lifecycle for old-model dev services a bit more. Since the lifecycle management relies on static variables, I've reproduced (ish) the problems @gsmet saw on #53656. `OldModelLifecycleTest.oldModelServiceWasFreshlyStartedForThisProfile` fails with that PR, but passes on `main`. It's a slightly artificial test since it fails based on watching variable state, rather than container identity, but for a temporary test, that should be ok. 

So once we're happy we want to remove old-model support we should remove these tests, but until then they're a useful coverage of a pattern used in the ecosystem, but not in our repo. 