### PR TITLE
Fix TestClassIndexer race causing "Not a jandex index" with forks

### DIFF
--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestClassIndexer.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestClassIndexer.java
@@ -60,11 +60,7 @@ public final class TestClassIndexer {
 
     public static void writeIndex(Index index, Path testClassLocation, Class<?> testClass) {
         // Write to a temp file in a sibling directory, then atomically rename onto the
-        // target. This avoids the truncate-then-write race where concurrent forks sharing
-        // the same test-classes/ directory each open the target with FileOutputStream
-        // (which O_TRUNCs the inode); one writer's still-open FD then continues writing at
-        // a non-zero offset, leaving a sparse-zero prefix that fails IndexReader's magic
-        // check with "Not a jandex index" (see https://github.com/quarkusio/quarkus/issues/54579).
+        // target. see https://github.com/quarkusio/quarkus/issues/54579).
         Path target = indexPath(testClassLocation);
         Path tmp = null;
         try {

--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestClassIndexer.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestClassIndexer.java
@@ -3,15 +3,17 @@ package io.quarkus.test.common;
 import static io.quarkus.test.common.PathTestHelper.getTestClassesLocation;
 
 import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.UncheckedIOException;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.FileSystem;
 import java.nio.file.FileVisitResult;
 import java.nio.file.FileVisitor;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 
@@ -57,13 +59,50 @@ public final class TestClassIndexer {
     }
 
     public static void writeIndex(Index index, Path testClassLocation, Class<?> testClass) {
-        try (FileOutputStream fos = new FileOutputStream(indexPath(testClassLocation).toFile(), false)) {
-            IndexWriter indexWriter = new IndexWriter(fos);
-            indexWriter.write(index);
+        // Write to a temp file in a sibling directory, then atomically rename onto the
+        // target. This avoids the truncate-then-write race where concurrent forks sharing
+        // the same test-classes/ directory each open the target with FileOutputStream
+        // (which O_TRUNCs the inode); one writer's still-open FD then continues writing at
+        // a non-zero offset, leaving a sparse-zero prefix that fails IndexReader's magic
+        // check with "Not a jandex index" (see https://github.com/quarkusio/quarkus/issues/54579).
+        Path target = indexPath(testClassLocation);
+        Path tmp = null;
+        try {
+            Path tmpDir = tempDirFor(testClassLocation);
+            Files.createDirectories(tmpDir);
+            tmp = Files.createTempFile(tmpDir, TEST_CLASSES_IDX + ".", ".tmp");
+            try (OutputStream os = Files.newOutputStream(tmp)) {
+                new IndexWriter(os).write(index);
+            }
+            try {
+                Files.move(tmp, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+            } catch (AtomicMoveNotSupportedException e) {
+                Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING);
+            }
+            tmp = null;
         } catch (IOException ignored) {
             // don't fail to write the index because this error is recoverable at the read site (by just recreating the index)
             // this is necessary for tests that are not part of the application itself, but instead reside in a jar (like the Quarkus Platform tests)
+        } finally {
+            if (tmp != null) {
+                try {
+                    Files.deleteIfExists(tmp);
+                } catch (IOException ignore) {
+                    // best effort
+                }
+            }
         }
+    }
+
+    /**
+     * Place the temp file in a SIBLING directory on the same filesystem as the target.
+     * Same filesystem keeps {@link StandardCopyOption#ATOMIC_MOVE} applicable, and being
+     * outside the Quarkus classpath element means {@code PathTreeClassPathElement} walkers
+     * never observe an in-progress temp.
+     */
+    private static Path tempDirFor(Path testClassLocation) {
+        Path parent = testClassLocation.getParent();
+        return parent != null ? parent.resolve(".quarkus-test-classes-idx-tmp") : testClassLocation;
     }
 
     public static Index readIndex(Class<?> testClass) {

--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestClassIndexer.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestClassIndexer.java
@@ -116,8 +116,10 @@ public final class TestClassIndexer {
                 return new IndexReader(fis).read();
             } catch (UnsupportedVersion e) {
                 throw new UnsupportedVersion("Can't read Jandex index from " + path + ": " + e.getMessage());
-            } catch (IOException e) {
-                // be lenient since the error is recoverable
+            } catch (IOException | IllegalArgumentException e) {
+                // be lenient since the error is recoverable; IllegalArgumentException covers
+                // "Not a jandex index" when the file was left corrupt by a JVM crash mid-write,
+                // an external process, or a downgrade (see https://github.com/quarkusio/quarkus/issues/54579)
                 return indexTestClasses(testClass);
             }
         } else {

--- a/test-framework/common/src/test/java/io/quarkus/test/common/TestClassIndexerTest.java
+++ b/test-framework/common/src/test/java/io/quarkus/test/common/TestClassIndexerTest.java
@@ -1,0 +1,92 @@
+package io.quarkus.test.common;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.jboss.jandex.Index;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class TestClassIndexerTest {
+
+    /**
+     * Reproduces https://github.com/quarkusio/quarkus/issues/54579.
+     *
+     * <p>
+     * Multiple writer threads invoke {@link TestClassIndexer#writeIndex} against a single
+     * target file, mirroring what happens when Gradle runs with {@code maxParallelForks > 1}
+     * and several forks share the same {@code build/classes/java/test/}. The current
+     * {@code writeIndex} opens {@code new FileOutputStream(file, false)} which truncates the
+     * shared file on every call; concurrent writers therefore leave sparse-zero prefixes
+     * (one writer's still-open file descriptor keeps writing at a non-zero offset after
+     * another writer's {@code O_TRUNC} reset the inode).
+     *
+     * <p>
+     * Reader threads exercise the production {@link TestClassIndexer#readIndex} path. When
+     * a reader catches the file with a sparse-zero prefix, {@code IndexReader.readVersion}
+     * throws {@code IllegalArgumentException("Not a jandex index")}; the current
+     * {@code readIndex} only catches {@link java.io.IOException}, so the IAE escapes —
+     * exactly the failure that kills Gradle test workers in the field.
+     */
+    @Test
+    void writeIndex_concurrentWritersAndReaders_neverObserveCorruptIndex(@TempDir Path tmpDir) throws Exception {
+        // A non-trivial index (the Jandex jar itself, always on the test classpath) keeps
+        // the write window wide enough for polling readers to observe the race quickly.
+        Path jandexJar = Path.of(Index.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+        Index index = TestClassIndexer.indexTestClasses(jandexJar);
+        TestClassIndexer.writeIndex(index, tmpDir, getClass());
+
+        int writers = 4;
+        int readers = 2;
+        int iterations = 200;
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicBoolean writersDone = new AtomicBoolean(false);
+        CountDownLatch start = new CountDownLatch(1);
+        ExecutorService pool = Executors.newFixedThreadPool(writers + readers);
+        try {
+            List<Future<?>> writerFutures = new ArrayList<>();
+            for (int w = 0; w < writers; w++) {
+                writerFutures.add(pool.submit(() -> {
+                    start.await();
+                    for (int i = 0; i < iterations && failure.get() == null; i++) {
+                        TestClassIndexer.writeIndex(index, tmpDir, getClass());
+                    }
+                    return null;
+                }));
+            }
+            for (int r = 0; r < readers; r++) {
+                pool.submit(() -> {
+                    start.await();
+                    while (!writersDone.get() && failure.get() == null) {
+                        try {
+                            TestClassIndexer.readIndex(tmpDir, getClass());
+                        } catch (RuntimeException e) {
+                            failure.compareAndSet(null, e);
+                        }
+                    }
+                    return null;
+                });
+            }
+            start.countDown();
+            for (Future<?> f : writerFutures) {
+                f.get(60, TimeUnit.SECONDS);
+            }
+            writersDone.set(true);
+        } finally {
+            pool.shutdownNow();
+            pool.awaitTermination(10, TimeUnit.SECONDS);
+        }
+
+        if (failure.get() != null) {
+            throw new AssertionError("Concurrent writeIndex caused readIndex to fail", failure.get());
+        }
+    }
+}

--- a/test-framework/common/src/test/java/io/quarkus/test/common/TestClassIndexerTest.java
+++ b/test-framework/common/src/test/java/io/quarkus/test/common/TestClassIndexerTest.java
@@ -23,22 +23,6 @@ class TestClassIndexerTest {
 
     /**
      * Reproduces https://github.com/quarkusio/quarkus/issues/54579.
-     *
-     * <p>
-     * Multiple writer threads invoke {@link TestClassIndexer#writeIndex} against a single
-     * target file, mirroring what happens when Gradle runs with {@code maxParallelForks > 1}
-     * and several forks share the same {@code build/classes/java/test/}. The current
-     * {@code writeIndex} opens {@code new FileOutputStream(file, false)} which truncates the
-     * shared file on every call; concurrent writers therefore leave sparse-zero prefixes
-     * (one writer's still-open file descriptor keeps writing at a non-zero offset after
-     * another writer's {@code O_TRUNC} reset the inode).
-     *
-     * <p>
-     * Reader threads exercise the production {@link TestClassIndexer#readIndex} path. When
-     * a reader catches the file with a sparse-zero prefix, {@code IndexReader.readVersion}
-     * throws {@code IllegalArgumentException("Not a jandex index")}; the current
-     * {@code readIndex} only catches {@link java.io.IOException}, so the IAE escapes —
-     * exactly the failure that kills Gradle test workers in the field.
      */
     @Test
     void writeIndex_concurrentWritersAndReaders_neverObserveCorruptIndex(@TempDir Path tmpDir) throws Exception {
@@ -97,14 +81,6 @@ class TestClassIndexerTest {
     /**
      * Defence-in-depth for the same race as
      * {@link #writeIndex_concurrentWritersAndReaders_neverObserveCorruptIndex}.
-     *
-     * <p>
-     * Even with the atomic-write fix, an index file may still be left corrupt by a JVM
-     * crash mid-write, an external process, or a downgrade. The current {@code readIndex}
-     * only catches {@link IOException}, so {@link IllegalArgumentException} from
-     * {@code IndexReader.readVersion("Not a jandex index")} escapes and kills the test
-     * worker. This test plants bytes that look like a corrupt jandex file and asserts
-     * {@code readIndex} recovers by re-indexing instead of throwing.
      */
     @Test
     void readIndex_recoversFromCorruptIndexFile(@TempDir Path tmpDir) throws IOException {

--- a/test-framework/common/src/test/java/io/quarkus/test/common/TestClassIndexerTest.java
+++ b/test-framework/common/src/test/java/io/quarkus/test/common/TestClassIndexerTest.java
@@ -1,5 +1,9 @@
 package io.quarkus.test.common;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -88,5 +92,32 @@ class TestClassIndexerTest {
         if (failure.get() != null) {
             throw new AssertionError("Concurrent writeIndex caused readIndex to fail", failure.get());
         }
+    }
+
+    /**
+     * Defence-in-depth for the same race as
+     * {@link #writeIndex_concurrentWritersAndReaders_neverObserveCorruptIndex}.
+     *
+     * <p>
+     * Even with the atomic-write fix, an index file may still be left corrupt by a JVM
+     * crash mid-write, an external process, or a downgrade. The current {@code readIndex}
+     * only catches {@link IOException}, so {@link IllegalArgumentException} from
+     * {@code IndexReader.readVersion("Not a jandex index")} escapes and kills the test
+     * worker. This test plants bytes that look like a corrupt jandex file and asserts
+     * {@code readIndex} recovers by re-indexing instead of throwing.
+     */
+    @Test
+    void readIndex_recoversFromCorruptIndexFile(@TempDir Path tmpDir) throws IOException {
+        Path indexFile = tmpDir.resolve(TestClassIndexer.TEST_CLASSES_IDX);
+        // Arbitrary bytes that do not start with the jandex magic; this is exactly the
+        // shape a torn write leaves behind (a sparse-zero or stale prefix).
+        Files.write(indexFile, new byte[] { 0, 1, 2, 3, 4, 5, 6, 7 });
+
+        Index index = TestClassIndexer.readIndex(tmpDir, TestClassIndexerTest.class);
+
+        assertThat(index).isNotNull();
+        assertThat(index.getClassByName(TestClassIndexerTest.class.getName()))
+                .as("fallback should re-index the test classes location")
+                .isNotNull();
     }
 }


### PR DESCRIPTION
Under Gradle `maxParallelForks > 1`, concurrent JVMs share `test-classes/` and race on the jandex index file. `writeIndex` truncated the shared file via `FileOutputStream(file, false)` while another writer's open FD kept writing at a non-zero offset, leaving a sparse-zero prefix that failed `IndexReader`'s magic check with `IllegalArgumentException: Not a jandex index`, killing the worker.

This changset updates
* `writeIndex`: write to a sibling temp file and `Files.move(..., ATOMIC_MOVE, REPLACE_EXISTING)`
*  `readIndex`: tolerate `IllegalArgumentException` as defence in depth
* Adds regression tests for the above

---

- Fixes: #54579
