### PR TITLE
Avoid starting @QuarkusTest resources for tests excluded by JUnit   filtering

### DIFF
--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -81,6 +81,7 @@ import io.quarkus.test.config.ValueRegistryInjector;
 import io.quarkus.test.junit.callback.QuarkusTestContext;
 import io.quarkus.test.junit.callback.QuarkusTestMethodContext;
 import io.quarkus.test.junit.common.ClearCache;
+import io.quarkus.test.junit.launcher.SelectedTestsIndex;
 import io.quarkus.value.registry.ValueRegistry;
 import io.smallrye.config.Config;
 import io.smallrye.config.SmallRyeConfigProviderResolver;
@@ -585,6 +586,10 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
         return false;
     }
 
+    private boolean shouldBootstrap(ExtensionContext context) {
+        return SelectedTestsIndex.shouldStart(context.getRequiredTestClass());
+    }
+
     private QuarkusTestExtensionState ensureStarted(ExtensionContext extensionContext) {
         QuarkusTestExtensionState state = getState(extensionContext);
 
@@ -680,7 +685,7 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
         currentTestClassStack.push(requiredTestClass);
         //set the right launch mode in the outer CL, used by the HTTP host config source
         LaunchMode.set(LaunchMode.TEST);
-        if (isNativeOrIntegrationTest(requiredTestClass)) {
+        if (isNativeOrIntegrationTest(requiredTestClass) || !shouldBootstrap(context)) {
             return;
         }
         resetHangTimeout();
@@ -725,7 +730,7 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
     @Override
     public void interceptBeforeAllMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext,
             ExtensionContext extensionContext) throws Throwable {
-        if (isNativeOrIntegrationTest(extensionContext.getRequiredTestClass())) {
+        if (isNativeOrIntegrationTest(extensionContext.getRequiredTestClass()) || !shouldBootstrap(extensionContext)) {
             invocation.proceed();
             return;
         }
@@ -744,7 +749,7 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
     public <T> T interceptTestClassConstructor(Invocation<T> invocation,
             ReflectiveInvocationContext<Constructor<T>> invocationContext, ExtensionContext extensionContext) throws Throwable {
         Class<?> requiredTestClass = extensionContext.getRequiredTestClass();
-        if (isNativeOrIntegrationTest(requiredTestClass)) {
+        if (isNativeOrIntegrationTest(requiredTestClass) || !shouldBootstrap(extensionContext)) {
             return invocation.proceed();
         }
 

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/launcher/CustomLauncherInterceptor.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/launcher/CustomLauncherInterceptor.java
@@ -211,7 +211,7 @@ public class CustomLauncherInterceptor
      */
     @Override
     public void testPlanExecutionStarted(TestPlan testPlan) {
-        // Do nothing, but have the method here for symmetry :)
+        SelectedTestsIndex.initialize(testPlan);
     }
 
     /**
@@ -231,6 +231,7 @@ public class CustomLauncherInterceptor
      */
     @Override
     public void testPlanExecutionFinished(TestPlan testPlan) {
+        SelectedTestsIndex.clear();
         clearContextClassloader();
     }
 }

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/launcher/SelectedTestsIndex.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/launcher/SelectedTestsIndex.java
@@ -1,0 +1,61 @@
+package io.quarkus.test.junit.launcher;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.junit.platform.engine.TestSource;
+import org.junit.platform.engine.support.descriptor.ClassSource;
+import org.junit.platform.engine.support.descriptor.MethodSource;
+import org.junit.platform.launcher.TestIdentifier;
+import org.junit.platform.launcher.TestPlan;
+
+public final class SelectedTestsIndex {
+
+    private static final Set<String> SELECTED_CLASSES = ConcurrentHashMap.newKeySet();
+    private static volatile boolean initialized;
+
+    private SelectedTestsIndex() {
+    }
+
+    public static void initialize(TestPlan testPlan) {
+        initialized = true;
+        SELECTED_CLASSES.clear();
+        for (TestIdentifier root : testPlan.getRoots()) {
+            visit(testPlan, root);
+        }
+    }
+
+    public static void clear() {
+        initialized = false;
+        SELECTED_CLASSES.clear();
+    }
+
+    public static boolean shouldStart(Class<?> testClass) {
+        if (!initialized) {
+            return true;
+        }
+        Class<?> current = testClass;
+        while ((current != null) && (current != Object.class)) {
+            if (SELECTED_CLASSES.contains(current.getName())) {
+                return true;
+            }
+            current = current.getEnclosingClass();
+        }
+        return false;
+    }
+
+    private static void visit(TestPlan testPlan, TestIdentifier identifier) {
+        identifier.getSource().ifPresent(SelectedTestsIndex::record);
+        for (TestIdentifier child : testPlan.getChildren(identifier)) {
+            visit(testPlan, child);
+        }
+    }
+
+    private static void record(TestSource source) {
+        if (source instanceof ClassSource classSource) {
+            SELECTED_CLASSES.add(classSource.getClassName());
+        } else if (source instanceof MethodSource methodSource) {
+            SELECTED_CLASSES.add(methodSource.getClassName());
+        }
+    }
+}


### PR DESCRIPTION
Fix #54435

 ## Summary

  When `@QuarkusTest` classes are excluded by standard JUnit filtering
  such as tags, Quarkus could still bootstrap the test runtime and
  start test resources before the tests were effectively skipped.

  This change makes `@QuarkusTest` consult the filtered JUnit
  `TestPlan` before bootstrapping. If the current test class is not
  part of the selected plan, Quarkus no longer test resources.