### PR TITLE
Stop leaking jprotoc V3 protobuf classes from grpc-protoc-plugin main artifact

### DIFF
--- a/extensions/grpc/protoc/pom.xml
+++ b/extensions/grpc/protoc/pom.xml
@@ -44,7 +44,38 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <executions>
+                    <!--
+                      Shade only jprotoc into the main artifact so the published POM can drop
+                      jprotoc as a transitive dependency (it bundles V3 protobuf classes that
+                      conflict with the V4 protobuf-java declared above). See #53044.
+                    -->
                     <execution>
+                        <id>shade-main</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                            <createSourcesJar>false</createSourcesJar>
+                            <shadedArtifactAttached>false</shadedArtifactAttached>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.salesforce.servicelibs:jprotoc</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>com.salesforce.servicelibs:jprotoc</artifact>
+                                    <excludes>
+                                        <exclude>com/google/protobuf/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>shaded-classifier</id>
                         <phase>package</phase>
                         <goals>
                             <goal>shade</goal>


### PR DESCRIPTION
Fixes #53044.

## Why

The published main artifact `io.quarkus:quarkus-grpc-protoc-plugin` declares `com.salesforce.servicelibs:jprotoc:1.2.2` as a compile-scope dependency. `jprotoc` is itself a shaded uber-jar that bundles ~732 old `com.google.protobuf.*` V3 class files. Any downstream consumer of the main artifact ends up with V3 (from `jprotoc`) AND V4 (from the sibling `protobuf-java:4.33.2`) on the same classpath. V3 and V4 are ABI-incompatible, so first-loaded-wins on the classloader → `NoSuchMethodError` / `ClassCastException` at runtime.

The existing `maven-shade-plugin` execution stripped V3 from the `-shaded` classifier but left the main artifact's POM untouched, so anyone depending on the default coordinates hit the leak. The longer-term Mutiny generator + protobuf V4 migration (Option A on the issue thread) is being tracked separately for Quarkus 4 per the discussion with @cescoffier and @andreaTP.

## What changes

Only `extensions/grpc/protoc/pom.xml` is touched. +31 lines, no deletions.

A second `maven-shade-plugin` execution `<id>shade-main</id>` is added that:

- bundles **only** `com.salesforce.servicelibs:jprotoc` into the main artifact via `<artifactSet><includes>` — `protobuf-java` and `smallrye-common-annotation` remain regular declared deps so downstream callers of `MutinyGrpcGenerator` still receive them at compile time;
- writes a dependency-reduced POM that drops `jprotoc` from the published `<dependencies>` while preserving `protobuf-java` and `smallrye-common-annotation`;
- uses the recursive filter `com/google/protobuf/**` so the `com/google/protobuf/util/*` subpackage (~46 classes) is also stripped from the main artifact — the original `com/google/protobuf/*` + `com/google/protobuf/compiler/*` patterns matched only direct children.

The existing execution gets `<id>shaded-classifier</id>` for clarity (no behavior change — same `Main-Class`, same filter pattern, same shape). The `-shaded.jar` remains byte-structurally identical for BOM-managed consumers and for `GrpcCodeGen.java` which loads the `-shaded` classifier at runtime.

## Execution ordering caveat

`shade-main` is declared **before** `shaded-classifier` in document order. With `maven-shade-plugin:3.6.2`, running the attached-classifier execution before the replace-main execution in the same `package` phase silently deletes the classifier jar from `target/` before `install` runs — the attached-artifact metadata survives but the file path becomes stale, and `install` fails with "Could not find artifact". Reverse order works cleanly: replace-main runs first, classifier-attach runs second, both outputs land.

## Verification

**Consumer `mvn dependency:tree`**

Before:

```
\- io.quarkus:quarkus-grpc-protoc-plugin:jar:999-SNAPSHOT:compile
   +- com.google.protobuf:protobuf-java:jar:4.33.2:compile
   +- io.smallrye.common:smallrye-common-annotation:jar:2.18.1:compile
   \- com.salesforce.servicelibs:jprotoc:jar:1.2.2:compile     (V3 leak)
```

After:

```
\- io.quarkus:quarkus-grpc-protoc-plugin:jar:999-SNAPSHOT:compile
   +- com.google.protobuf:protobuf-java:jar:4.33.2:compile
   \- io.smallrye.common:smallrye-common-annotation:jar:2.18.1:compile
```

**Main jar contents**

| | Before | After |
|---|---|---|
| Size | 20 KB | 3.6 MB |
| In-tree generator classes | 3 | 3 |
| `com/google/protobuf/*` (V3, transitively leaked via jprotoc) | 732 on classpath via jprotoc.jar | 0 |
| `com/salesforce/jprotoc/*` (API needed by `MutinyGrpcGenerator`) | transitive via jprotoc | 13 embedded |
| `com/google/common/*` (guava, used by `MutinyGrpcGenerator`) | transitive inside jprotoc.jar | 2042 embedded |
| `Main-Class` | absent | absent (library, not executable) |

**`-shaded` classifier**: 5.6 MB, `Main-Class: io.quarkus.grpc.protoc.plugin.MutinyGrpcGenerator`, same filter applied as before. No behavior change.

**Internal `<protocPlugin>` consumers** (`extensions/grpc/{deployment,stubs}/`, `extensions/opentelemetry/deployment/`, `integration-tests/devmode/`) use the identical configuration shape — same `mainClass`, no classifier — so they all resolve the new main artifact + the dep-reduced POM's transitives and invoke `MutinyGrpcGenerator` the same way. I built `extensions/grpc/stubs` locally end-to-end against the new main: it emits the expected `MutinyHealthGrpc.java`, `MutinyServerReflectionGrpc.java` etc. with the `value = "by Mutiny Grpc generator"` header from `health.proto`, `reflection/v1/reflection.proto`, and `reflection/v1alpha/reflection.proto`. CI of course covers the other three under the same pattern.

## Risks / call-outs

1. **Main artifact grows from 20 KB → ~3.6 MB.** The growth is the embedded jprotoc API + guava + grpc-stub + javax.annotation that previously came in as a transitive `jprotoc.jar`. Build-time artifact, not shipped to production; one-time ~3.5 MB extra download cost, cached thereafter. Accepted tradeoff for POM hygiene as discussed on the issue thread.
2. **SBOM visibility.** `dependency:tree` and POM-scanning SBOM tools no longer surface `jprotoc` as a transitive dep. The filtered classes are still inside the JAR, so JAR-content SBOM tools (e.g. CycloneDX with `inputFormat=container`) still attribute them. Worth a release-note line for downstream security teams who scan POMs.
3. **`-shaded` classifier unchanged.** Consumers explicitly using `<classifier>shaded</classifier>` (BOM-managed users; `GrpcCodeGen.java` at runtime; the `bom/application/pom.xml` entry) are not affected.

## Follow-up

A separate issue tracks the longer-term V4 Mutiny generator migration (Option A from #53044), scoped to Quarkus 4 per @cescoffier's call.

cc @cescoffier @andreaTP @alesj