### PR TITLE
Bump Nisse from 0.4.4 to 0.9.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -90,6 +90,7 @@ updates:
       - dependency-name: net.revelc.code.formatter:formatter-maven-plugin
       - dependency-name: net.revelc.code:impsort-maven-plugin
       - dependency-name: eu.maveniverse.maven.njord:*
+      - dependency-name: eu.maveniverse.maven.nisse:*
       - dependency-name: io.github.gitflow-incremental-builder:*
       # Narayana
       - dependency-name: org.jboss.narayana.jta:*

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -21,8 +21,8 @@
     </extension>
     <extension>
         <groupId>eu.maveniverse.maven.nisse</groupId>
-        <artifactId>extension</artifactId>
-        <version>0.4.4</version>
+        <artifactId>extension3</artifactId>
+        <version>0.9.2</version>
     </extension>
     <extension>
         <groupId>eu.maveniverse.maven.njord</groupId>


### PR DESCRIPTION
Nisse at 0.5.0 got a GAV change, to make room for Maven 4 extension.


