### PR TITLE
Get rid of useless 1356 plugin invocations

### DIFF
--- a/independent-projects/parent/pom.xml
+++ b/independent-projects/parent/pom.xml
@@ -474,8 +474,8 @@
                         <artifactId>maven-clean-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>default-clean</id>
-                                <phase>clean</phase>
+                                <id>clean-cache</id>
+                                <phase>pre-clean</phase>
                                 <goals>
                                     <goal>clean</goal>
                                 </goals>

--- a/independent-projects/parent/pom.xml
+++ b/independent-projects/parent/pom.xml
@@ -19,7 +19,6 @@
         <!-- Plugin versions (please keep in alphabetical order) -->
         <version.archetype.plugin>3.4.1</version.archetype.plugin>
         <version.buildhelper.plugin>3.6.1</version.buildhelper.plugin>
-        <version.buildnumber.plugin>3.3.0</version.buildnumber.plugin>
         <version.clean.plugin>3.5.0</version.clean.plugin>
         <version.compiler.plugin>3.15.0</version.compiler.plugin>
         <version.dependency.plugin>3.8.1</version.dependency.plugin>
@@ -176,29 +175,10 @@
                 </executions>
             </plugin>
 
-            <!-- Set properties containing the scm revision -->
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>buildnumber-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>get-scm-revision</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>create</goal>
-                        </goals>
-                        <configuration>
-                            <doCheck>false</doCheck>
-                            <doUpdate>false</doUpdate>
-                            <revisionOnScmFailure>UNKNOWN</revisionOnScmFailure>
-                            <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <extensions>true</extensions>
                 <configuration>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
@@ -274,11 +254,6 @@
                     <version>${version.buildhelper.plugin}</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>buildnumber-maven-plugin</artifactId>
-                    <version>${version.buildnumber.plugin}</version>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
                     <version>${version.clean.plugin}</version>
@@ -318,7 +293,7 @@
                                 <Scm-Url>${project.scm.url}</Scm-Url>
                                 <Scm-Connection>${project.scm.connection}</Scm-Connection>
                                 <Bundle-License>Apache License 2.0</Bundle-License>
-                                <Scm-Revision>${buildNumber}</Scm-Revision>
+                                <Scm-Revision>${nisse.jgit.commit}</Scm-Revision>
                             </manifestEntries>
                         </archive>
                     </configuration>
@@ -499,9 +474,8 @@
                         <artifactId>maven-clean-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>clean-cache-dirs</id>
-                                <phase>pre-clean</phase>
-                                <inherited>true</inherited>
+                                <id>default-clean</id>
+                                <phase>clean</phase>
                                 <goals>
                                     <goal>clean</goal>
                                 </goals>
@@ -583,7 +557,7 @@
                                     <Java-Vendor>${java.vendor}</Java-Vendor>
                                     <Os-Name>${os.name}</Os-Name>
                                     <Os-Arch>${os.arch}</Os-Arch>
-                                    <Scm-Revision>${buildNumber}</Scm-Revision>
+                                    <Scm-Revision>${nisse.jgit.commit}</Scm-Revision>
                                 </manifestEntries>
                             </archive>
                         </configuration>
@@ -606,7 +580,7 @@
                                     <Java-Vendor>${java.vendor}</Java-Vendor>
                                     <Os-Name>${os.name}</Os-Name>
                                     <Os-Arch>${os.arch}</Os-Arch>
-                                    <Scm-Revision>${buildNumber}</Scm-Revision>
+                                    <Scm-Revision>${nisse.jgit.commit}</Scm-Revision>
                                 </manifestEntries>
                             </archive>
                         </configuration>


### PR DESCRIPTION
The buildnumber-maven-plugin is invoked per each module, that is totally useless (does nothing useful), given the needed value is already early injected by Nisse. This is 1356 plugin invocations.

The maven-clean-plugin is invoked two times per each module, but in fact is not needed. It can be merged with default execution. This is 1356 plugin invocations.

In total, ~~2712~~ 1356 plugin invocations removed.
