### PR TITLE
Add escape hatch and improve error message in GeneratedResourceBuildItem

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/GeneratedResourceBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/GeneratedResourceBuildItem.java
@@ -27,13 +27,28 @@ public final class GeneratedResourceBuildItem extends MultiBuildItem {
     }
 
     public GeneratedResourceBuildItem(String name, byte[] data, boolean excludeFromDevCL) {
-        if (name.startsWith("META-INF/services/")) {
+        this(name, data, excludeFromDevCL, false);
+    }
+
+    private GeneratedResourceBuildItem(String name, byte[] data, boolean excludeFromDevCL,
+            boolean allowMetaInfServices) {
+        if (name.startsWith("META-INF/services/") && !allowMetaInfServices) {
             throw new IllegalArgumentException(
-                    "Use GeneratedServiceProviderBuildItem to register service providers instead of GeneratedResourceBuildItem");
+                    "Use GeneratedServiceProviderBuildItem to register service providers instead of GeneratedResourceBuildItem, or use GeneratedResourceBuildItem.allowingMetaInfServices(...) if your "
+                            + name + " resource is not a service provider");
         }
         this.name = name;
         this.data = data;
         this.excludeFromDevCL = excludeFromDevCL;
+    }
+
+    /**
+     * Use only for {@code META-INF/services/} resources with a non-standard format incompatible with
+     * {@link GeneratedServiceProviderBuildItem}. Prefer {@link GeneratedServiceProviderBuildItem} for standard
+     * Java {@link java.util.ServiceLoader} registrations.
+     */
+    public static GeneratedResourceBuildItem allowingMetaInfServices(String name, byte[] data) {
+        return new GeneratedResourceBuildItem(name, data, false, true);
     }
 
     public String getName() {

--- a/core/deployment/src/test/java/io/quarkus/deployment/builditem/GeneratedResourceBuildItemTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/builditem/GeneratedResourceBuildItemTest.java
@@ -1,7 +1,7 @@
 package io.quarkus.deployment.builditem;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
@@ -9,19 +9,37 @@ class GeneratedResourceBuildItemTest {
 
     @Test
     void throwsForServiceProviderPath() {
-        assertThrows(IllegalArgumentException.class,
-                () -> new GeneratedResourceBuildItem("META-INF/services/com.example.Foo", new byte[0]));
+        assertThatThrownBy(
+                () -> new GeneratedResourceBuildItem("META-INF/services/com.example.Foo", new byte[0]))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("META-INF/services/com.example.Foo");
     }
 
     @Test
     void throwsForServiceProviderPathWithDeprecatedConstructor() {
-        assertThrows(IllegalArgumentException.class,
-                () -> new GeneratedResourceBuildItem("META-INF/services/com.example.Foo", new byte[0], false));
+        assertThatThrownBy(
+                () -> new GeneratedResourceBuildItem("META-INF/services/com.example.Foo", new byte[0], false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("META-INF/services/com.example.Foo");
     }
 
     @Test
     void acceptsNormalPath() {
         assertDoesNotThrow(
                 () -> new GeneratedResourceBuildItem("META-INF/native-image/resource-config.json", new byte[0]));
+    }
+
+    @Test
+    void allowsMetaInfServicesWhenExplicitlyEnabled() {
+        assertDoesNotThrow(
+                () -> GeneratedResourceBuildItem.allowingMetaInfServices(
+                        "META-INF/services/org.apache.cxf.bus.factory", new byte[0]));
+    }
+
+    @Test
+    void escapeHatchWorksForNormalPaths() {
+        assertDoesNotThrow(
+                () -> GeneratedResourceBuildItem.allowingMetaInfServices(
+                        "META-INF/native-image/resource-config.json", new byte[0]));
     }
 }


### PR DESCRIPTION

● Fixes #54600
  
  The error message thrown when an extension mistakenly produces a `GeneratedResourceBuildItem` with a
  `META-INF/services/` path now includes the offending resource name, making it easier to identify the culprit.

  A static factory method `GeneratedResourceBuildItem.allowingMetaInfServices(name, data)` is also added as an
  explicit opt-in escape hatch for extensions that use `META-INF/services/` files with a non-standard format
  incompatible with `GeneratedServiceProviderBuildItem` (e.g. custom SPI mechanisms like CXF's
  `org.apache.cxf.bus.factory`). Standard Java `ServiceLoader` registrations should continue to use
  `GeneratedServiceProviderBuildItem`.
