### PR TITLE
Bump Agroal to 3.2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -98,7 +98,7 @@
              hibernate-search.version, antlr.version, bytebuddy.version -->
         <narayana.version>7.3.4.Final</narayana.version>
         <narayana-lra.version>1.2.0.Final</narayana-lra.version>
-        <agroal.version>3.1.2</agroal.version>
+        <agroal.version>3.2</agroal.version>
         <jboss-transaction-spi.version>8.0.0.Final</jboss-transaction-spi.version>
         <elasticsearch-opensource-components.version>9.3.4</elasticsearch-opensource-components.version>
         <rxjava.version>2.2.21</rxjava.version>


### PR DESCRIPTION
Bumps Agroal from 3.1.2 to 3.2

The minor version bump was because of a [minor API change in the Spring integration](https://github.com/agroal/agroal/commit/f1ad878c0e68ef7efa0d8cf427307a24250923ea) (which is not used in Quarkus) 

- Fixes #54558