### PR TITLE
Clear stale annotation processor output after code generation

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/CodeGenerator.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/CodeGenerator.java
@@ -10,6 +10,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -19,6 +20,7 @@ import java.util.ServiceLoader;
 import java.util.StringJoiner;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 import org.eclipse.microprofile.config.Config;
 import org.jboss.logging.Logger;
@@ -79,6 +81,7 @@ public class CodeGenerator {
             generator.setRedirectIO(true);
             trigger(classLoader, generator, appModel, config, test);
         }
+        clearAnnotationProcessorOutputDir(generatedSourcesDir);
     }
 
     private static List<CodeGenData> init(
@@ -411,6 +414,40 @@ public class CodeGenerator {
         } catch (IOException e) {
             throw new CodeGenException(
                     "Failed to create output directory for generated sources: " + outputDir.toAbsolutePath(), e);
+        }
+    }
+
+    /**
+     * Removes stale annotation-processor-generated sources left over from a
+     * previous compilation. When code generation (e.g.&nbsp;protoc) rewrites
+     * its output the {@code maven-compiler-plugin} detects "changed source
+     * code", adds the previously generated annotation sources to the
+     * {@code javac} source list, then clears the annotation output directory
+     * — leaving {@code javac} with references to files that no longer exist.
+     * <p>
+     * Clearing the directory here, between code generation and compilation,
+     * prevents the compiler from ever picking up those stale files; the
+     * annotation processor will regenerate them during the next compile
+     * because the code generation changes will trigger a full recompilation.
+     */
+    private static void clearAnnotationProcessorOutputDir(Path generatedSourcesDir) {
+        Path annotationOutputDir = generatedSourcesDir.resolve("annotations");
+        if (!Files.isDirectory(annotationOutputDir)) {
+            return;
+        }
+        try (Stream<Path> walk = Files.walk(annotationOutputDir)) {
+            walk.sorted(Comparator.reverseOrder())
+                    .filter(p -> !p.equals(annotationOutputDir))
+                    .forEach(p -> {
+                        try {
+                            Files.delete(p);
+                        } catch (IOException e) {
+                            // best-effort
+                        }
+                    });
+        } catch (IOException e) {
+            // best-effort — if we cannot clean up, the compiler may still fail
+            // on stale annotation sources, which is the pre-existing behavior
         }
     }
 


### PR DESCRIPTION
## Summary

- Fixes incremental compilation failure when a project combines Quarkus code generation (e.g. gRPC/protoc) with annotation processors that generate sources into `target/generated-sources/annotations/`
- After all code generation providers run, clears the annotation processor output directory so the `maven-compiler-plugin` does not pick up stale files from a previous compilation

## Problem

When running `mvn compile` (without `clean`) on a module that uses both Quarkus code generation and annotation processing, the build fails with:

```
18:41:02 [INFO] --- compiler:3.15.0:compile (default-compile) @ quarkus-integration-test-grpc-stork-recovery ---
18:41:02 [INFO] Recompiling the module because of changed dependency.
18:41:02 [INFO] Compiling 14 source files with javac [debug deprecation parameters release 17] to target/classes
18:41:02 [INFO] -------------------------------------------------------------
18:41:02 [ERROR] COMPILATION ERROR : 
18:41:02 [INFO] -------------------------------------------------------------
18:41:02 [ERROR] /home/hudson/hudson_workspace/workspace/utils-deploy-quarkus-main-artifacts-to-internal-repository/integration-tests/grpc-stork-recovery/target/generated-sources/annotations/io/quarkus/grpc/examples/stork/DelayedConfiguration.java: error reading ...DelayedConfiguration.java; ...DelayedConfiguration.java
18:41:02 [ERROR] /home/hudson/hudson_workspace/workspace/utils-deploy-quarkus-main-artifacts-to-internal-repository/integration-tests/grpc-stork-recovery/target/generated-sources/annotations/io/quarkus/grpc/examples/stork/DelayedServiceDiscoveryProviderLoader.java: error reading ...DelayedServiceDiscoveryProviderLoader.java; ...DelayedServiceDiscoveryProviderLoader.java
```

The same failure can be reproduced locally:

```
18:41:02 [INFO] --- compiler:3.15.0:compile (default-compile) @ quarkus-integration-test-grpc-stork-recovery ---
18:41:02 [INFO] Recompiling the module because of changed source code.
18:41:02 [INFO] Compiling 14 source files with javac [debug deprecation parameters release 17] to target/classes
18:41:02 [ERROR] COMPILATION ERROR :
18:41:02 [ERROR] .../target/generated-sources/annotations/.../DelayedConfiguration.java: error reading .../DelayedConfiguration.java
18:41:02 [ERROR] .../target/generated-sources/annotations/.../DelayedServiceDiscoveryProviderLoader.java: error reading .../DelayedServiceDiscoveryProviderLoader.java
```

### Root cause

1. A first `mvn compile` succeeds — code generation produces proto sources in `target/generated-sources/grpc/` and annotation processing produces files in `target/generated-sources/annotations/`
2. On a subsequent `mvn compile` (without `clean`), the `maven-compiler-plugin` detects a reason to recompile (changed source code from code generation, or a changed dependency in CI)
3. The compiler scans all source roots including `target/generated-sources/annotations/` and adds the previously annotation-generated files to the `javac` source list (14 files instead of 12)
4. The compiler then clears the `target/generated-sources/annotations/` directory before invoking `javac`
5. `javac` fails because it tries to read files that were just deleted

In CI the trigger is "changed dependency" (upstream modules were rebuilt in the same run); locally the trigger is "changed source code" (code generation rewrites proto files). The end result is identical — stale annotation files are added to the source list, then deleted, then `javac` cannot read them.

### How the fix works

After all code generation providers have executed in `CodeGenerator.initAndRun()`, clear the contents of `target/generated-sources/annotations/`. This prevents the `maven-compiler-plugin` from ever picking up stale annotation-generated files from a previous compilation. The annotation processor regenerates them during the next `javac` invocation — this is safe because the presence of code generation providers causes the compiler to trigger a full recompilation.

### How to reproduce locally

```bash
cd integration-tests/grpc-stork-recovery
mvn clean compile -DskipTests   # succeeds
mvn compile -DskipTests          # fails without this fix, succeeds with it
```

## Test plan

- [x] `mvn clean compile -DskipTests` followed by `mvn compile -DskipTests` succeeds on `integration-tests/grpc-stork-recovery`
- [x] Repeated `mvn compile -DskipTests` runs succeed consistently
- [x] Annotation-generated files (`DelayedConfiguration.java`, `DelayedServiceDiscoveryProviderLoader.java`) are properly regenerated after each compile
- [ ] CI passes