### PR TITLE
Separate Stork AP from compile in grpc-stork-recovery IT

### DIFF
--- a/integration-tests/grpc-stork-recovery/pom.xml
+++ b/integration-tests/grpc-stork-recovery/pom.xml
@@ -62,17 +62,61 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <!-- Generates the DelayedConfiguration class from the
-                         @ServiceDiscoveryType / @ServiceDiscoveryAttribute annotations
-                         on DelayedServiceDiscoveryProvider. -->
-                    <annotationProcessorPaths>
-                        <path>
-                            <groupId>io.smallrye.stork</groupId>
-                            <artifactId>stork-configuration-generator</artifactId>
-                        </path>
-                    </annotationProcessorPaths>
-                </configuration>
+                <executions>
+                    <!-- Generate DelayedConfiguration and *ProviderLoader in a dedicated
+                         phase so javac compile does not read AP output while it is written
+                         (avoids intermittent "error reading" failures in parallel builds). -->
+                    <execution>
+                        <id>generate-stork-configuration</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <proc>only</proc>
+                            <!-- Only the Stork registrar: gRPC stubs are generated later by quarkus:generate-code. -->
+                            <includes>
+                                <include>**/DelayedServiceDiscoveryProvider.java</include>
+                            </includes>
+                            <!-- Outside generated-sources/annotations so default-compile cleanup does not delete these files. -->
+                            <generatedSourcesDirectory>${project.build.directory}/generated-stork-sources</generatedSourcesDirectory>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.smallrye.stork</groupId>
+                                    <artifactId>stork-configuration-generator</artifactId>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <proc>none</proc>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-stork-generated-sources</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.build.directory}/generated-stork-sources</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>io.quarkus</groupId>


### PR DESCRIPTION
This pull request updates the build configuration in the `integration-tests/grpc-stork-recovery/pom.xml` file to improve the reliability and separation of generated sources during the Maven build process, especially when running parallel builds. The changes ensure that Stork configuration classes are generated in a dedicated phase and directory, and that these sources are properly included in the project.

Build process improvements:

* Configured the `maven-compiler-plugin` to generate Stork configuration sources (`DelayedConfiguration` and `*ProviderLoader`) in a separate `generate-sources` phase and output them to a dedicated `generated-stork-sources` directory, preventing conflicts and intermittent errors during parallel builds.
* Added a second execution of the `maven-compiler-plugin` for the regular `compile` phase, explicitly disabling annotation processing to avoid reprocessing.

Source inclusion:

* Added the `build-helper-maven-plugin` to include the `generated-stork-sources` directory as a source folder, ensuring the generated sources are compiled.
