### PR TITLE
Fix log cleanup filters not being applied in @QuarkusTest

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
@@ -313,6 +313,7 @@ public final class LoggingResourceProcessor {
 
             context.registerSubstitution(InheritableLevel.ActualLevel.class, String.class, InheritableLevel.Substitution.class);
             context.registerSubstitution(InheritableLevel.Inherited.class, String.class, InheritableLevel.Substitution.class);
+            context.registerSubstitution(Level.class, String.class, LogCleanupFilterElement.LevelSubstitution.class);
 
             DiscoveredLogComponents discoveredLogComponents = discoverLogComponents(combinedIndexBuildItem.getIndex());
             if (!discoveredLogComponents.getNameToFilterClass().isEmpty()) {
@@ -323,14 +324,6 @@ public final class LoggingResourceProcessor {
                         .produce(ServiceProviderBuildItem.allProvidersFromClassPath(LogFilterFactory.class.getName()));
             }
 
-            shutdownListenerBuildItemBuildProducer.produce(new ShutdownListenerBuildItem(
-                    recorder.initializeLogging(discoveredLogComponents,
-                            categoryMinLevelDefaults.content, alwaysEnableLogStream,
-                            streamingDevUiLogHandler, handlers, namedHandlers,
-                            possibleConsoleFormatters, possibleFileFormatters, possibleSyslogFormatters,
-                            possibleSocketFormatters, namedHandlerFormatters,
-                            possibleSupplier, launchModeBuildItem.getLaunchMode(), true)));
-
             List<LogCleanupFilterElement> additionalLogCleanupFilters = new ArrayList<>(logCleanupFilters.size());
             for (LogCleanupFilterBuildItem i : logCleanupFilters) {
                 LogCleanupFilterElement filterElement = i.getFilterElement();
@@ -340,6 +333,15 @@ public final class LoggingResourceProcessor {
                                 : filterElement.getTargetLevel(),
                         filterElement.getMessageStarts()));
             }
+
+            shutdownListenerBuildItemBuildProducer.produce(new ShutdownListenerBuildItem(
+                    recorder.initializeLogging(discoveredLogComponents,
+                            categoryMinLevelDefaults.content, alwaysEnableLogStream,
+                            streamingDevUiLogHandler, handlers, namedHandlers,
+                            possibleConsoleFormatters, possibleFileFormatters, possibleSyslogFormatters,
+                            possibleSocketFormatters, namedHandlerFormatters,
+                            possibleSupplier, launchModeBuildItem.getLaunchMode(), true,
+                            additionalLogCleanupFilters)));
 
             SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
             LogBuildTimeConfig logBuildTimeConfig = config.getConfigMapping(LogBuildTimeConfig.class);

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LogCleanupFilter.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LogCleanupFilter.java
@@ -27,7 +27,6 @@ public class LogCleanupFilter implements Filter {
 
     @Override
     public boolean isLoggable(LogRecord record) {
-
         //we also use this filter to add a warning about errors generated after shutdown
         if (record.getLevel().intValue() >= org.jboss.logmanager.Level.ERROR.intValue() && shutdownNotifier.shutdown) {
             if (!record.getMessage().endsWith(SHUTDOWN_MESSAGE)) {

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LogCleanupFilterElement.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LogCleanupFilterElement.java
@@ -1,7 +1,12 @@
 package io.quarkus.runtime.logging;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.logging.Level;
+
+import org.jboss.logmanager.LogContext;
+
+import io.quarkus.runtime.ObjectSubstitution;
 
 public class LogCleanupFilterElement {
     private String loggerName;
@@ -46,5 +51,17 @@ public class LogCleanupFilterElement {
 
     public void setTargetLevel(Level targetLevel) {
         this.targetLevel = targetLevel;
+    }
+
+    public static class LevelSubstitution implements ObjectSubstitution<Level, String> {
+        @Override
+        public String serialize(Level obj) {
+            return obj.getName();
+        }
+
+        @Override
+        public Level deserialize(String obj) {
+            return LogContext.getLogContext().getLevelForName(obj.toUpperCase(Locale.ROOT));
+        }
     }
 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
@@ -128,7 +128,8 @@ public class LoggingSetupRecorder {
                 new RuntimeValue<>(consoleRuntimeConfig)).initializeLogging(
                         DiscoveredLogComponents.ofEmpty(), emptyMap(), false, null, emptyList(), emptyList(), emptyList(),
                         emptyList(),
-                        emptyList(), emptyList(), emptyList(), banner, LaunchMode.DEVELOPMENT, false);
+                        emptyList(), emptyList(), emptyList(), banner, LaunchMode.DEVELOPMENT, false,
+                        emptyList());
     }
 
     public ShutdownListener initializeLogging(
@@ -145,7 +146,8 @@ public class LoggingSetupRecorder {
             final List<RuntimeValue<Map<NamedHandlerType, Map<String, Optional<Formatter>>>>> namedHandlerFormatters,
             final RuntimeValue<Optional<Supplier<String>>> possibleBannerSupplier,
             final LaunchMode launchMode,
-            final boolean includeFilters) {
+            final boolean includeFilters,
+            final List<LogCleanupFilterElement> additionalLogCleanupFilters) {
 
         LogBuildTimeConfig buildConfig = logBuildTimeConfig;
         LogRuntimeConfig config = logRuntimeConfig.getValue();
@@ -166,17 +168,16 @@ public class LoggingSetupRecorder {
 
         ErrorManager errorManager = new OnlyOnceErrorManager();
         Map<String, CleanupFilterConfig> filters = config.filters();
-        List<LogCleanupFilterElement> filterElements;
-        if (filters.isEmpty()) {
-            filterElements = emptyList();
-        } else {
-            filterElements = new ArrayList<>(filters.size());
-            filters.forEach(new BiConsumer<>() {
-                @Override
-                public void accept(String loggerName, CleanupFilterConfig config) {
-                    filterElements.add(new LogCleanupFilterElement(loggerName, config.targetLevel(), config.ifStartsWith()));
-                }
-            });
+        List<LogCleanupFilterElement> filterElements = new ArrayList<>(filters.size() + additionalLogCleanupFilters.size());
+        filters.forEach(new BiConsumer<>() {
+            @Override
+            public void accept(String loggerName, CleanupFilterConfig config) {
+                filterElements.add(new LogCleanupFilterElement(loggerName, config.targetLevel(), config.ifStartsWith()));
+            }
+        });
+        for (LogCleanupFilterElement additionalLogCleanupFilter : additionalLogCleanupFilters) {
+            filterElements.add(new LogCleanupFilterElement(additionalLogCleanupFilter.getLoggerName(),
+                    additionalLogCleanupFilter.getTargetLevel(), additionalLogCleanupFilter.getMessageStarts()));
         }
         LogCleanupFilter cleanupFiler = new LogCleanupFilter(filterElements, shutdownNotifier);
         for (Handler handler : LogManager.getLogManager().getLogger("").getHandlers()) {

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/QuarkusBootstrapLogFilters.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/QuarkusBootstrapLogFilters.java
@@ -1,0 +1,29 @@
+package io.quarkus.runtime.logging;
+
+import java.util.List;
+
+/**
+ * Service provider interface for declaring log cleanup filters that must be active
+ * <em>before</em> the Quarkus augmentation phase starts.
+ *
+ * <p>
+ * Extensions that produce {@link io.quarkus.deployment.logging.LogCleanupFilterBuildItem}s to silence
+ * known-noisy library log messages should also implement this interface and register it via the standard
+ * {@link java.util.ServiceLoader} mechanism (i.e. a
+ * {@code META-INF/services/io.quarkus.runtime.logging.QuarkusBootstrapLogFilters} file in the
+ * <em>deployment</em> module). This ensures those same filters are applied during {@code @QuarkusTest}
+ * runs, where augmentation-phase logs would otherwise bypass the recorder-configured cleanup filters.
+ *
+ * <p>
+ * The service is loaded by {@code QuarkusTestExtension} using the augmentation classloader, so the
+ * implementation class must be in the extension's deployment JAR.
+ */
+public interface QuarkusBootstrapLogFilters {
+
+    /**
+     * Returns the list of log cleanup filter elements that should be installed before augmentation.
+     *
+     * @return non-null list of filter elements; may be empty
+     */
+    List<LogCleanupFilterElement> getLogCleanupFilters();
+}

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateBootstrapLogFilters.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateBootstrapLogFilters.java
@@ -1,0 +1,38 @@
+package io.quarkus.hibernate.orm.deployment;
+
+import java.util.List;
+
+import org.jboss.logmanager.Level;
+
+import io.quarkus.runtime.logging.LogCleanupFilterElement;
+import io.quarkus.runtime.logging.QuarkusBootstrapLogFilters;
+
+/**
+ * Declares the Hibernate ORM log cleanup filters that must be active before augmentation in
+ * {@code @QuarkusTest} runs. These filters mirror the ones produced by
+ * {@link HibernateLogFilterBuildStep}, ensuring they are applied even before the Quarkus recorder
+ * has had a chance to register them through the normal build-step mechanism.
+ *
+ * @see QuarkusBootstrapLogFilters
+ */
+public class HibernateBootstrapLogFilters implements QuarkusBootstrapLogFilters {
+
+    @Override
+    public List<LogCleanupFilterElement> getLogCleanupFilters() {
+        return List.of(
+                new LogCleanupFilterElement("org.hibernate.orm.core", Level.DEBUG,
+                        List.of("HHH000001")),
+                new LogCleanupFilterElement("org.hibernate.orm.jpa", Level.DEBUG,
+                        List.of("HHH008540")),
+                new LogCleanupFilterElement("org.hibernate.statistics", Level.DEBUG,
+                        List.of("HHH000400")),
+                new LogCleanupFilterElement("org.hibernate.orm.beans", Level.DEBUG,
+                        List.of("HHH10005002", "HHH10005004")),
+                new LogCleanupFilterElement("org.hibernate.orm.incubating", Level.DEBUG,
+                        List.of("HHH90006001")),
+                new LogCleanupFilterElement("org.hibernate.orm.connections.pooling", Level.DEBUG,
+                        List.of("HHH10001005")),
+                new LogCleanupFilterElement("org.hibernate.orm.deprecation", Level.DEBUG,
+                        List.of("HHH90000025")));
+    }
+}

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -200,6 +200,12 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
             startupAction.applyModuleConfigurationToClassloader(curatedApplication.getAugmentClassLoader());
             startupAction.applyModuleConfigurationToClassloader(curatedApplication.getBaseRuntimeClassLoader());
 
+            // Install per-logger log cleanup filters declared by extensions before the application
+            // starts. This ensures that noisy library messages (e.g. from Hibernate) are suppressed
+            // during the augmentation phase, before the Quarkus recorder installs the handler-level
+            // LogCleanupFilter through the normal initializeLogging() path.
+            installBootstrapLogFilters(curatedApplication.getAugmentClassLoader());
+
             Path testClassLocation = getTestClassesLocation(requiredTestClass, curatedApplication);
             TestProfileAndProperties testProfileAndProperties = TestProfileAndProperties.ofNullable(profileClass, NORMAL);
             Optional<QuarkusTestProfile> profileInstance = testProfileAndProperties.testProfile();
@@ -302,6 +308,69 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
             throw effectiveException;
         }
 
+    }
+
+    /**
+     * Uses the {@link java.util.ServiceLoader} mechanism to discover {@code QuarkusBootstrapLogFilters}
+     * providers in the given {@code classLoader} (typically the augmentation classloader) and installs
+     * a per-logger {@link java.util.logging.Filter} for each declared cleanup filter element.
+     *
+     * <p>
+     * Installing these filters directly on the JBoss LogManager loggers guarantees that the
+     * suppression is in effect before {@link StartupAction#run} triggers library initialization
+     * (e.g., Hibernate ORM), regardless of whether the handler-level {@code LogCleanupFilter}
+     * has been configured yet.
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private static void installBootstrapLogFilters(ClassLoader classLoader) {
+        try {
+            // Load the interface class from the augment classloader. quarkus-core-runtime is
+            // parent-first in all child classloaders, so this is the same Class object that the
+            // provider implementations were compiled against.
+            Class filterInterface = classLoader.loadClass("io.quarkus.runtime.logging.QuarkusBootstrapLogFilters");
+            Method getFiltersMethod = filterInterface.getMethod("getLogCleanupFilters");
+            for (Object provider : ServiceLoader.load(filterInterface, classLoader)) {
+                List<?> elements = (List<?>) getFiltersMethod.invoke(provider);
+                for (Object element : elements) {
+                    String loggerName = (String) element.getClass().getMethod("getLoggerName").invoke(element);
+                    List<String> messageStarts = (List<String>) element.getClass().getMethod("getMessageStarts")
+                            .invoke(element);
+                    if (loggerName != null && messageStarts != null && !messageStarts.isEmpty()) {
+                        installBootstrapLogFilter(loggerName, List.copyOf(messageStarts));
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Failed to install bootstrap log cleanup filters from service providers", e);
+        }
+    }
+
+    /**
+     * Installs a per-logger {@link java.util.logging.Filter} on the JBoss LogManager logger
+     * identified by {@code loggerName}. Any log record whose message starts with one of
+     * {@code messageStartPrefixes} and whose level is {@code WARNING} or below is downgraded to
+     * {@code DEBUG}; since {@code DEBUG} is typically below the effective minimum level the record
+     * is then suppressed.
+     */
+    private static void installBootstrapLogFilter(String loggerName, List<String> messageStartPrefixes) {
+        org.jboss.logmanager.Logger logger = org.jboss.logmanager.LogContext.getLogContext().getLogger(loggerName);
+        java.util.logging.Filter existing = logger.getFilter();
+        logger.setFilter(record -> {
+            if (existing != null && !existing.isLoggable(record)) {
+                return false;
+            }
+            // Only apply prefix-based downgrading for WARNING level and below (same contract as LogCleanupFilter)
+            if (record.getLevel().intValue() <= java.util.logging.Level.WARNING.intValue()) {
+                for (String prefix : messageStartPrefixes) {
+                    if (record.getMessage() != null && record.getMessage().startsWith(prefix)) {
+                        record.setLevel(org.jboss.logmanager.Level.DEBUG);
+                        return org.jboss.logmanager.LogContext.getLogContext().getLogger(record.getLoggerName())
+                                .isLoggable(org.jboss.logmanager.Level.DEBUG);
+                    }
+                }
+            }
+            return true;
+        });
     }
 
     private static QuarkusClassLoader getClassLoaderFromTestClass(Class<?> requiredTestClass) {


### PR DESCRIPTION
Fix #48346

Log cleanup filters registered by extensions via `LogCleanupFilterBuildItem`
were silently ineffective in `@QuarkusTest`. The handler-level
`LogCleanupFilter` is installed by the Quarkus recorder during
`initializeLogging()`, but library initialization (e.g. Hibernate ORM) can
happen before that recorder call completes, so the noisy INFO messages
escape unfiltered.

This PR introduces a `QuarkusBootstrapLogFilters` SPI (in
`quarkus-core-runtime`) that extensions can implement and register via the
standard `ServiceLoader` mechanism in their deployment JAR.
`QuarkusTestExtension` reads these providers through the augmentation
classloader before calling `startupAction.run()`, and installs a per-logger
`java.util.logging.Filter` for each declared filter element. Per-logger
filters are evaluated before any handler, so they suppress the matching
records regardless of handler configuration state.

Hibernate ORM is the first extension to provide an implementation,
covering the same message prefixes already declared in
`HibernateLogFilterBuildStep`.

Release note: Log cleanup filters registered by extensions via `LogCleanupFilterBuildItem` now work correctly in `@QuarkusTest`, suppressing noisy library messages (such as Hibernate ORM's `HHH*` version and connection-pool INFO lines) during test runs.