### PR TITLE
Add `quarkus-rest-data-hibernate-types`  extension

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -2936,6 +2936,16 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-rest-data-hibernate-json-types</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-rest-data-hibernate-json-types-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-rest-kotlin</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/devtools/bom-descriptor-json/pom.xml
+++ b/devtools/bom-descriptor-json/pom.xml
@@ -2379,6 +2379,19 @@
                 </dependency>
                 <dependency>
                     <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-rest-data-hibernate-json-types</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-rest-data-panache</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -2343,6 +2343,19 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-data-hibernate-json-types-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-data-panache-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>

--- a/docs/src/main/asciidoc/quarkus-data-hibernate.adoc
+++ b/docs/src/main/asciidoc/quarkus-data-hibernate.adoc
@@ -1173,6 +1173,110 @@ types of repositories in your entity to support managed entities.
 TIP: You can also use <<Use stateless sessions,Panache Stateless repositories>> or
 <<Reactive and stateless,Panache Stateless Reactive repositories>>.
 
+== REST integration
+
+When your application uses both `quarkus-data-hibernate` and `quarkus-rest-jackson`, Quarkus automatically
+adds REST support for common Jakarta Data parameter types. This lets you declare Jakarta Data types directly as
+REST endpoint parameters, and they will be populated from HTTP query parameters without any manual parsing.
+
+=== Supported parameter types
+
+The following Jakarta Data types are automatically mapped from query parameters:
+
+[cols="1,2,1,2"]
+|===
+|Jakarta Data type|Query parameters|Defaults|Example URL
+
+|`PageRequest`
+|`page`, `size`, `requestTotal`
+|`page=1`, `size=10`, `requestTotal=true`
+|`?page=2&size=25`
+
+|`Sort<?>`
+|`sort`
+|`null`
+|`?sort=name` (asc) or `?sort=-name` (desc)
+
+|`Order<?>`
+|`sort` (repeating)
+|`null`
+|`?sort=name&sort=-salary`
+
+|`Limit`
+|`limit`, `startAt`, `endAt`
+|`null` (no limit), `startAt=1`
+|`?limit=10` or `?limit=10&startAt=51` or `?startAt=51&endAt=60`
+
+|`Direction`
+|`direction`
+|`null`
+|`?direction=ASC` or `?direction=desc`
+
+|===
+
+For `Sort` and `Order`, prefix the property name with `-` to indicate descending order.
+
+NOTE: Cursor-based pagination (`PageRequest.Mode.CURSOR_NEXT` / `CURSOR_PREVIOUS`) is not currently supported
+by this REST integration. Only offset-based pagination is available via query parameters.
+
+=== Page serialization
+
+When a REST endpoint returns a `jakarta.data.page.Page`, it is serialized as a JSON object with pagination
+metadata, rather than as a plain array:
+
+[source,json]
+----
+{
+  "content": [ ... ],
+  "hasNext": true,
+  "hasPrevious": false,
+  "totalElements": 100,
+  "totalPages": 34
+}
+----
+
+The `totalElements` and `totalPages` fields are only included when the `PageRequest` was created with
+`requestTotal=true`.
+
+=== Example endpoint
+
+Here is an example of a REST endpoint that uses `PageRequest` and `Order` to return a paginated, sorted
+list of cats. `PanacheRepository` already provides a `findAll(PageRequest, Order)` method, so you can use
+the entity and repository we defined earlier directly:
+
+[source,java]
+----
+import jakarta.data.Order;
+import jakarta.data.page.Page;
+import jakarta.data.page.PageRequest;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@Path("cats")
+public class CatResource {
+
+    @Inject
+    Cat.Repo repo;
+
+    @GET
+    public Page<Cat> list(PageRequest pageRequest, Order<Cat> order) { // <1>
+        return repo.findAll(pageRequest, order);
+    }
+}
+----
+<1> `PageRequest` is populated from `page`, `size`, and `requestTotal` query parameters.
+`Order` is populated from repeating `sort` query parameters.
+
+A client can then call:
+
+[source]
+----
+GET /cats?page=1&size=20&sort=name&sort=-birth
+----
+
+This produces a `PageRequest.ofPage(1, 20, true)` and `Order.by(Sort.asc("name"), Sort.desc("birth"))`.
+
 == HQL, JD-QL, Jakarta-QL, Panache-QL
 
 There are different query languages used in this API:

--- a/extensions/resteasy-reactive/pom.xml
+++ b/extensions/resteasy-reactive/pom.xml
@@ -24,6 +24,7 @@
         <module>rest-qute</module>
         <module>rest-servlet</module>
         <module>rest-links</module>
+        <module>rest-data-hibernate-json-types</module>
         <module>rest-kotlin</module>
         <module>rest-kotlin-serialization-common</module>
         <module>rest-kotlin-serialization</module>

--- a/extensions/resteasy-reactive/rest-data-hibernate-json-types/deployment/pom.xml
+++ b/extensions/resteasy-reactive/rest-data-hibernate-json-types/deployment/pom.xml
@@ -1,46 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>quarkus-rest-jackson-parent</artifactId>
+        <artifactId>quarkus-rest-data-hibernate-json-types-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
     </parent>
+    <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>quarkus-rest-jackson</artifactId>
-    <name>Quarkus - REST - Jackson - Runtime</name>
-    <description>Jackson serialization support for Quarkus REST. This extension is not compatible with the quarkus-resteasy extension, or any of the extensions that depend on it</description>
+    <artifactId>quarkus-rest-data-hibernate-json-types-deployment</artifactId>
+    <name>Quarkus - REST - Data Hibernate JSON Types - Deployment</name>
 
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest</artifactId>
+            <artifactId>quarkus-rest-server-spi-deployment</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-jackson-common</artifactId>
+            <artifactId>quarkus-rest-common-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson-deployment</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-data-hibernate-json-types</artifactId>
-            <optional>true</optional> <!-- conditional dependency -->
         </dependency>
     </dependencies>
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-extension-maven-plugin</artifactId>
-                <configuration>
-                    <capabilities>
-                        <provides>io.quarkus.rest.jackson</provides>
-                        <provides>io.quarkus.resteasy.reactive.json.jackson</provides>
-                    </capabilities>
-                </configuration>
-            </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <executions>
@@ -60,6 +52,4 @@
             </plugin>
         </plugins>
     </build>
-
-
 </project>

--- a/extensions/resteasy-reactive/rest-data-hibernate-json-types/deployment/src/main/java/io/quarkus/resteasy/reactive/data/hibernate/deployment/RestDataHibernateProcessor.java
+++ b/extensions/resteasy-reactive/rest-data-hibernate-json-types/deployment/src/main/java/io/quarkus/resteasy/reactive/data/hibernate/deployment/RestDataHibernateProcessor.java
@@ -1,0 +1,66 @@
+package io.quarkus.resteasy.reactive.data.hibernate.deployment;
+
+import java.util.Map;
+
+import jakarta.data.Direction;
+import jakarta.data.Limit;
+import jakarta.data.Order;
+import jakarta.data.Sort;
+import jakarta.data.page.PageRequest;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Type;
+import org.jboss.resteasy.reactive.server.core.parameters.ParameterExtractor;
+import org.jboss.resteasy.reactive.server.processor.scanning.MethodScanner;
+
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.resteasy.reactive.data.hibernate.runtime.DirectionParamExtractor;
+import io.quarkus.resteasy.reactive.data.hibernate.runtime.JakartaDataObjectMapperCustomizer;
+import io.quarkus.resteasy.reactive.data.hibernate.runtime.LimitParamExtractor;
+import io.quarkus.resteasy.reactive.data.hibernate.runtime.OrderParamExtractor;
+import io.quarkus.resteasy.reactive.data.hibernate.runtime.PageRequestParamExtractor;
+import io.quarkus.resteasy.reactive.data.hibernate.runtime.SortParamExtractor;
+import io.quarkus.resteasy.reactive.server.spi.MethodScannerBuildItem;
+
+public class RestDataHibernateProcessor {
+
+    private static final DotName PAGE_REQUEST = DotName.createSimple(PageRequest.class);
+    private static final DotName SORT = DotName.createSimple(Sort.class);
+    private static final DotName ORDER = DotName.createSimple(Order.class);
+    private static final DotName LIMIT = DotName.createSimple(Limit.class);
+    private static final DotName DIRECTION = DotName.createSimple(Direction.class);
+
+    @BuildStep
+    AdditionalBeanBuildItem registerJacksonCustomizer() {
+        return AdditionalBeanBuildItem.unremovableOf(JakartaDataObjectMapperCustomizer.class);
+    }
+
+    @BuildStep
+    MethodScannerBuildItem jakartaDataParamScanner() {
+        return new MethodScannerBuildItem(new MethodScanner() {
+            @Override
+            public ParameterExtractor handleCustomParameter(Type paramType, Map<DotName, AnnotationInstance> annotations,
+                    boolean field, Map<String, Object> methodContext) {
+                DotName name = paramType.name();
+                if (name.equals(PAGE_REQUEST)) {
+                    return new PageRequestParamExtractor();
+                }
+                if (name.equals(SORT)) {
+                    return new SortParamExtractor();
+                }
+                if (name.equals(ORDER)) {
+                    return new OrderParamExtractor();
+                }
+                if (name.equals(LIMIT)) {
+                    return new LimitParamExtractor();
+                }
+                if (name.equals(DIRECTION)) {
+                    return new DirectionParamExtractor();
+                }
+                return null;
+            }
+        });
+    }
+}

--- a/extensions/resteasy-reactive/rest-data-hibernate-json-types/pom.xml
+++ b/extensions/resteasy-reactive/rest-data-hibernate-json-types/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-rest-parent-aggregator</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-rest-data-hibernate-json-types-parent</artifactId>
+    <name>Quarkus - REST - Data Hibernate JSON Types</name>
+    <packaging>pom</packaging>
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+
+</project>

--- a/extensions/resteasy-reactive/rest-data-hibernate-json-types/runtime/pom.xml
+++ b/extensions/resteasy-reactive/rest-data-hibernate-json-types/runtime/pom.xml
@@ -1,31 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>quarkus-rest-jackson-parent</artifactId>
         <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-rest-data-hibernate-json-types-parent</artifactId>
         <version>999-SNAPSHOT</version>
     </parent>
+    <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>quarkus-rest-jackson</artifactId>
-    <name>Quarkus - REST - Jackson - Runtime</name>
-    <description>Jackson serialization support for Quarkus REST. This extension is not compatible with the quarkus-resteasy extension, or any of the extensions that depend on it</description>
+    <artifactId>quarkus-rest-data-hibernate-json-types</artifactId>
+    <name>Quarkus - REST - Data Hibernate JSON Types - Runtime</name>
+    <description>Provides Jakarta Data support for Quarkus REST</description>
 
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest</artifactId>
+            <artifactId>quarkus-rest-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.resteasy.reactive</groupId>
+            <artifactId>resteasy-reactive</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.data</groupId>
+            <artifactId>jakarta.data-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-jackson-common</artifactId>
+            <artifactId>quarkus-jackson</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-data-hibernate-json-types</artifactId>
-            <optional>true</optional> <!-- conditional dependency -->
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
     </dependencies>
 
@@ -35,10 +42,9 @@
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-extension-maven-plugin</artifactId>
                 <configuration>
-                    <capabilities>
-                        <provides>io.quarkus.rest.jackson</provides>
-                        <provides>io.quarkus.resteasy.reactive.json.jackson</provides>
-                    </capabilities>
+                    <dependencyCondition>
+                        <artifact>io.quarkus:quarkus-data-hibernate</artifact>
+                    </dependencyCondition>
                 </configuration>
             </plugin>
             <plugin>
@@ -60,6 +66,4 @@
             </plugin>
         </plugins>
     </build>
-
-
 </project>

--- a/extensions/resteasy-reactive/rest-data-hibernate-json-types/runtime/src/main/java/io/quarkus/resteasy/reactive/data/hibernate/runtime/DirectionParamExtractor.java
+++ b/extensions/resteasy-reactive/rest-data-hibernate-json-types/runtime/src/main/java/io/quarkus/resteasy/reactive/data/hibernate/runtime/DirectionParamExtractor.java
@@ -1,0 +1,28 @@
+package io.quarkus.resteasy.reactive.data.hibernate.runtime;
+
+import java.util.Locale;
+
+import jakarta.data.Direction;
+
+import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
+import org.jboss.resteasy.reactive.server.core.parameters.ParameterExtractor;
+
+/**
+ * Extracts a {@link Direction} from the HTTP query parameter {@code direction}.
+ * <ul>
+ * <li>{@code direction} — sort direction, either {@code ASC} or {@code DESC}, case-insensitive
+ * (default: {@code null})</li>
+ * </ul>
+ * Example: {@code ?direction=desc} produces {@code Direction.DESC}.
+ */
+public class DirectionParamExtractor implements ParameterExtractor {
+
+    @Override
+    public Object extractParameter(ResteasyReactiveRequestContext context) {
+        String value = (String) context.getQueryParameter("direction", true, false);
+        if (value == null) {
+            return null;
+        }
+        return Direction.valueOf(value.toUpperCase(Locale.ROOT));
+    }
+}

--- a/extensions/resteasy-reactive/rest-data-hibernate-json-types/runtime/src/main/java/io/quarkus/resteasy/reactive/data/hibernate/runtime/JakartaDataObjectMapperCustomizer.java
+++ b/extensions/resteasy-reactive/rest-data-hibernate-json-types/runtime/src/main/java/io/quarkus/resteasy/reactive/data/hibernate/runtime/JakartaDataObjectMapperCustomizer.java
@@ -1,0 +1,19 @@
+package io.quarkus.resteasy.reactive.data.hibernate.runtime;
+
+import jakarta.inject.Singleton;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import io.quarkus.jackson.ObjectMapperCustomizer;
+
+@Singleton
+public class JakartaDataObjectMapperCustomizer implements ObjectMapperCustomizer {
+
+    @Override
+    public void customize(ObjectMapper objectMapper) {
+        SimpleModule module = new SimpleModule("quarkus-rest-data-hibernate-json-types");
+        module.addSerializer(new PageSerializer());
+        objectMapper.registerModule(module);
+    }
+}

--- a/extensions/resteasy-reactive/rest-data-hibernate-json-types/runtime/src/main/java/io/quarkus/resteasy/reactive/data/hibernate/runtime/LimitParamExtractor.java
+++ b/extensions/resteasy-reactive/rest-data-hibernate-json-types/runtime/src/main/java/io/quarkus/resteasy/reactive/data/hibernate/runtime/LimitParamExtractor.java
@@ -1,0 +1,47 @@
+package io.quarkus.resteasy.reactive.data.hibernate.runtime;
+
+import jakarta.data.Limit;
+
+import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
+import org.jboss.resteasy.reactive.server.core.parameters.ParameterExtractor;
+
+/**
+ * Extracts a {@link Limit} from HTTP query parameters.
+ * <p>
+ * Supports two modes:
+ * <ul>
+ * <li><b>Count mode:</b> {@code ?limit=N} optionally with {@code &startAt=M} —
+ * produces {@code Limit.of(N)} or {@code Limit.range(M, M+N-1)}</li>
+ * <li><b>Range mode:</b> {@code ?startAt=M&endAt=N} —
+ * produces {@code Limit.range(M, N)}</li>
+ * </ul>
+ * <p>
+ * Defaults: {@code startAt=1}. Returns {@code null} when neither {@code limit}
+ * nor {@code endAt} is provided.
+ */
+public class LimitParamExtractor implements ParameterExtractor {
+
+    @Override
+    public Object extractParameter(ResteasyReactiveRequestContext context) {
+        String limitStr = (String) context.getQueryParameter("limit", true, false);
+        String startAtStr = (String) context.getQueryParameter("startAt", true, false);
+        String endAtStr = (String) context.getQueryParameter("endAt", true, false);
+
+        if (limitStr == null && endAtStr == null) {
+            return null;
+        }
+
+        if (endAtStr != null) {
+            long startAt = startAtStr != null ? Long.parseLong(startAtStr) : 1;
+            long endAt = Long.parseLong(endAtStr);
+            return Limit.range(startAt, endAt);
+        }
+
+        int limit = Integer.parseInt(limitStr);
+        if (startAtStr != null) {
+            long startAt = Long.parseLong(startAtStr);
+            return Limit.range(startAt, startAt + limit - 1);
+        }
+        return Limit.of(limit);
+    }
+}

--- a/extensions/resteasy-reactive/rest-data-hibernate-json-types/runtime/src/main/java/io/quarkus/resteasy/reactive/data/hibernate/runtime/OrderParamExtractor.java
+++ b/extensions/resteasy-reactive/rest-data-hibernate-json-types/runtime/src/main/java/io/quarkus/resteasy/reactive/data/hibernate/runtime/OrderParamExtractor.java
@@ -1,0 +1,31 @@
+package io.quarkus.resteasy.reactive.data.hibernate.runtime;
+
+import java.util.List;
+
+import jakarta.data.Order;
+import jakarta.data.Sort;
+
+import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
+import org.jboss.resteasy.reactive.server.core.parameters.ParameterExtractor;
+
+/**
+ * Extracts an {@link Order} (multiple sort criteria) from repeating HTTP query parameter {@code sort}.
+ * <ul>
+ * <li>{@code sort} — property name to sort by; prefix with {@code -} for descending.
+ * Repeat for multiple criteria. (default: empty {@code Order})</li>
+ * </ul>
+ * Example: {@code ?sort=name&sort=-salary} produces
+ * {@code Order.by(Sort.asc("name"), Sort.desc("salary"))}.
+ */
+public class OrderParamExtractor implements ParameterExtractor {
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Override
+    public Object extractParameter(ResteasyReactiveRequestContext context) {
+        List<String> values = (List<String>) context.getQueryParameter("sort", false, false);
+        if (values == null || values.isEmpty()) {
+            return Order.by();
+        }
+        return Order.by((List) SortParamExtractor.parseSorts(values));
+    }
+}

--- a/extensions/resteasy-reactive/rest-data-hibernate-json-types/runtime/src/main/java/io/quarkus/resteasy/reactive/data/hibernate/runtime/PageRequestParamExtractor.java
+++ b/extensions/resteasy-reactive/rest-data-hibernate-json-types/runtime/src/main/java/io/quarkus/resteasy/reactive/data/hibernate/runtime/PageRequestParamExtractor.java
@@ -1,0 +1,44 @@
+package io.quarkus.resteasy.reactive.data.hibernate.runtime;
+
+import jakarta.data.page.PageRequest;
+
+import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
+import org.jboss.resteasy.reactive.server.core.parameters.ParameterExtractor;
+
+/**
+ * Extracts a {@link PageRequest} from HTTP query parameters.
+ * <ul>
+ * <li>{@code page} — 1-based page number (default: {@value #DEFAULT_PAGE_NUMBER})</li>
+ * <li>{@code size} — maximum number of results per page (default: {@value #DEFAULT_PAGE_SIZE})</li>
+ * <li>{@code requestTotal} — whether to request the total number of elements (default: {@code true})</li>
+ * </ul>
+ */
+public class PageRequestParamExtractor implements ParameterExtractor {
+
+    private static final int DEFAULT_PAGE_NUMBER = 1;
+    private static final int DEFAULT_PAGE_SIZE = 10;
+
+    @Override
+    public Object extractParameter(ResteasyReactiveRequestContext context) {
+        long page = DEFAULT_PAGE_NUMBER;
+        int size = DEFAULT_PAGE_SIZE;
+        boolean requestTotal = true;
+
+        String pageStr = (String) context.getQueryParameter("page", true, false);
+        if (pageStr != null) {
+            page = Long.parseLong(pageStr);
+        }
+
+        String sizeStr = (String) context.getQueryParameter("size", true, false);
+        if (sizeStr != null) {
+            size = Integer.parseInt(sizeStr);
+        }
+
+        String requestTotalStr = (String) context.getQueryParameter("requestTotal", true, false);
+        if (requestTotalStr != null) {
+            requestTotal = Boolean.parseBoolean(requestTotalStr);
+        }
+
+        return PageRequest.ofPage(page, size, requestTotal);
+    }
+}

--- a/extensions/resteasy-reactive/rest-data-hibernate-json-types/runtime/src/main/java/io/quarkus/resteasy/reactive/data/hibernate/runtime/PageSerializer.java
+++ b/extensions/resteasy-reactive/rest-data-hibernate-json-types/runtime/src/main/java/io/quarkus/resteasy/reactive/data/hibernate/runtime/PageSerializer.java
@@ -1,0 +1,38 @@
+package io.quarkus.resteasy.reactive.data.hibernate.runtime;
+
+import java.io.IOException;
+
+import jakarta.data.page.Page;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+/**
+ * Jackson serializer for {@link Page} that includes pagination metadata
+ * instead of serializing as a plain array (which is the default because
+ * {@link Page} extends {@link Iterable}).
+ */
+@SuppressWarnings("rawtypes")
+public class PageSerializer extends StdSerializer<Page> {
+
+    public PageSerializer() {
+        super(Page.class);
+    }
+
+    @Override
+    public void serialize(Page page, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        gen.writeStartObject();
+
+        gen.writeObjectField("content", page.content());
+        gen.writeBooleanField("hasNext", page.hasNext());
+        gen.writeBooleanField("hasPrevious", page.hasPrevious());
+
+        if (page.hasTotals()) {
+            gen.writeNumberField("totalElements", page.totalElements());
+            gen.writeNumberField("totalPages", page.totalPages());
+        }
+
+        gen.writeEndObject();
+    }
+}

--- a/extensions/resteasy-reactive/rest-data-hibernate-json-types/runtime/src/main/java/io/quarkus/resteasy/reactive/data/hibernate/runtime/SortParamExtractor.java
+++ b/extensions/resteasy-reactive/rest-data-hibernate-json-types/runtime/src/main/java/io/quarkus/resteasy/reactive/data/hibernate/runtime/SortParamExtractor.java
@@ -1,0 +1,48 @@
+package io.quarkus.resteasy.reactive.data.hibernate.runtime;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import jakarta.data.Sort;
+
+import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
+import org.jboss.resteasy.reactive.server.core.parameters.ParameterExtractor;
+
+/**
+ * Extracts a single {@link Sort} criterion from the HTTP query parameter {@code sort}.
+ * <ul>
+ * <li>{@code sort} — property name to sort by; prefix with {@code -} for descending (default: {@code null})</li>
+ * </ul>
+ * Examples: {@code ?sort=name} produces {@code Sort.asc("name")},
+ * {@code ?sort=-salary} produces {@code Sort.desc("salary")}.
+ */
+public class SortParamExtractor implements ParameterExtractor {
+
+    @Override
+    public Object extractParameter(ResteasyReactiveRequestContext context) {
+        String value = (String) context.getQueryParameter("sort", true, false);
+        if (value == null) {
+            return null;
+        }
+        return parseSort(value);
+    }
+
+    static Sort<?> parseSort(String value) {
+        if (value.startsWith("-")) {
+            return Sort.desc(value.substring(1));
+        }
+        return Sort.asc(value);
+    }
+
+    static List<Sort<?>> parseSorts(List<String> values) {
+        if (values == null || values.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<Sort<?>> sorts = new ArrayList<>(values.size());
+        for (String value : values) {
+            sorts.add(parseSort(value));
+        }
+        return sorts;
+    }
+}

--- a/extensions/resteasy-reactive/rest-data-hibernate-json-types/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-reactive/rest-data-hibernate-json-types/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,5 @@
+---
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+name: "REST Data Hibernate JSON Types"
+metadata:
+  unlisted: true

--- a/extensions/resteasy-reactive/rest-jackson/deployment/pom.xml
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/pom.xml
@@ -27,6 +27,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-data-hibernate-json-types-deployment</artifactId>
+            <optional>true</optional> <!-- conditional dependency -->
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit-internal</artifactId>
             <scope>test</scope>
         </dependency>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -209,6 +209,7 @@
                 <module>hibernate-orm-panache</module>
                 <module>data-hibernate</module>
                 <module>hibernate-orm-rest-data-panache</module>
+                <module>rest-data-hibernate-json-types</module>
                 <module>hibernate-orm-graphql-panache</module>
                 <module>hibernate-orm-panache-kotlin</module>
                 <module>hibernate-reactive-db2</module>

--- a/integration-tests/rest-data-hibernate-json-types/pom.xml
+++ b/integration-tests/rest-data-hibernate-json-types/pom.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-integration-test-rest-data-hibernate-json-types</artifactId>
+    <name>Quarkus - Integration Tests - REST Data Hibernate JSON Types</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-data-hibernate</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-h2</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-data-hibernate-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-h2-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- test-scoped deployment deps added to prevent build issues -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-data-hibernate-json-types-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.hibernate.orm</groupId>
+                            <artifactId>hibernate-processor</artifactId>
+                        </path>
+                    </annotationProcessorPaths>
+                    <annotationProcessors>
+                        <annotationProcessor>org.hibernate.processor.HibernateProcessor</annotationProcessor>
+                    </annotationProcessors>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integration-tests/rest-data-hibernate-json-types/src/main/java/io/quarkus/it/rest/data/hibernate/Fruit.java
+++ b/integration-tests/rest-data-hibernate-json-types/src/main/java/io/quarkus/it/rest/data/hibernate/Fruit.java
@@ -1,0 +1,22 @@
+package io.quarkus.it.rest.data.hibernate;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+@Entity
+public class Fruit {
+
+    @Id
+    @GeneratedValue
+    public Long id;
+
+    public String name;
+
+    public Fruit() {
+    }
+
+    public Fruit(String name) {
+        this.name = name;
+    }
+}

--- a/integration-tests/rest-data-hibernate-json-types/src/main/java/io/quarkus/it/rest/data/hibernate/FruitRepository.java
+++ b/integration-tests/rest-data-hibernate-json-types/src/main/java/io/quarkus/it/rest/data/hibernate/FruitRepository.java
@@ -1,0 +1,16 @@
+package io.quarkus.it.rest.data.hibernate;
+
+import jakarta.data.Order;
+import jakarta.data.page.Page;
+import jakarta.data.page.PageRequest;
+import jakarta.data.repository.Find;
+import jakarta.data.repository.Repository;
+
+import io.quarkus.hibernate.panache.PanacheRepository;
+
+@Repository
+public interface FruitRepository extends PanacheRepository.Stateless<Fruit, Long> {
+
+    @Find
+    Page<Fruit> findAll(PageRequest pageRequest, Order<Fruit> order);
+}

--- a/integration-tests/rest-data-hibernate-json-types/src/main/java/io/quarkus/it/rest/data/hibernate/FruitResource.java
+++ b/integration-tests/rest-data-hibernate-json-types/src/main/java/io/quarkus/it/rest/data/hibernate/FruitResource.java
@@ -1,0 +1,22 @@
+package io.quarkus.it.rest.data.hibernate;
+
+import jakarta.data.Order;
+import jakarta.data.page.Page;
+import jakarta.data.page.PageRequest;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@Path("fruits")
+public class FruitResource {
+
+    private final FruitRepository repo;
+
+    public FruitResource(FruitRepository repo) {
+        this.repo = repo;
+    }
+
+    @GET
+    public Page<Fruit> list(PageRequest pageRequest, Order<Fruit> order) {
+        return repo.findAll(pageRequest, order);
+    }
+}

--- a/integration-tests/rest-data-hibernate-json-types/src/main/java/io/quarkus/it/rest/data/hibernate/ParamEchoResource.java
+++ b/integration-tests/rest-data-hibernate-json-types/src/main/java/io/quarkus/it/rest/data/hibernate/ParamEchoResource.java
@@ -1,0 +1,127 @@
+package io.quarkus.it.rest.data.hibernate;
+
+import java.util.List;
+import java.util.Map;
+
+import jakarta.data.Direction;
+import jakarta.data.Limit;
+import jakarta.data.Order;
+import jakarta.data.Sort;
+import jakarta.data.page.Page;
+import jakarta.data.page.PageRequest;
+import jakarta.data.page.impl.PageRecord;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@Path("echo")
+public class ParamEchoResource {
+
+    @GET
+    @Path("page-request")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Map<String, Object> pageRequest(PageRequest pageRequest) {
+        return Map.of(
+                "page", pageRequest.page(),
+                "size", pageRequest.size(),
+                "requestTotal", pageRequest.requestTotal());
+    }
+
+    @GET
+    @Path("sort")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Map<String, Object> sort(Sort<?> sort) {
+        if (sort == null) {
+            return null;
+        }
+        return Map.of(
+                "property", sort.property(),
+                "ascending", sort.isAscending());
+    }
+
+    @GET
+    @Path("order")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Map<String, Object> order(Order<?> order) {
+        List<Map<String, Object>> sorts = order.sorts().stream()
+                .map(s -> Map.<String, Object> of(
+                        "property", s.property(),
+                        "ascending", s.isAscending()))
+                .toList();
+        return Map.of("sorts", sorts);
+    }
+
+    @GET
+    @Path("limit")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Map<String, Object> limit(Limit limit) {
+        if (limit == null) {
+            return null;
+        }
+        return Map.of(
+                "maxResults", limit.maxResults(),
+                "startAt", limit.startAt());
+    }
+
+    @GET
+    @Path("direction")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Map<String, Object> direction(Direction direction) {
+        if (direction == null) {
+            return null;
+        }
+        return Map.of("direction", direction.name());
+    }
+
+    @GET
+    @Path("page")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Page<Item> page() {
+        List<Item> items = List.of(new Item("a"), new Item("b"), new Item("c"));
+        return new PageRecord<>(PageRequest.ofPage(1, 3, true), items, 10);
+    }
+
+    @GET
+    @Path("page/no-totals")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Page<Item> pageNoTotals() {
+        List<Item> items = List.of(new Item("x"), new Item("y"));
+        return new PageRecord<>(PageRequest.ofPage(2, 2, false), items, -1);
+    }
+
+    @GET
+    @Path("page/annotated")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Page<AnnotatedItem> pageAnnotated() {
+        List<AnnotatedItem> items = List.of(new AnnotatedItem("Alice", 30, "s3cret"));
+        return new PageRecord<>(PageRequest.ofPage(1, 10, true), items, 1);
+    }
+
+    public static class Item {
+        public String name;
+
+        public Item(String name) {
+            this.name = name;
+        }
+    }
+
+    public static class AnnotatedItem {
+        @JsonProperty("full_name")
+        public String name;
+
+        public int age;
+
+        @JsonIgnore
+        public String secret;
+
+        public AnnotatedItem(String name, int age, String secret) {
+            this.name = name;
+            this.age = age;
+            this.secret = secret;
+        }
+    }
+}

--- a/integration-tests/rest-data-hibernate-json-types/src/main/resources/application.properties
+++ b/integration-tests/rest-data-hibernate-json-types/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
+quarkus.hibernate-orm.database.generation=drop-and-create
+# unclutter the logs
+quarkus.log.category."org.jboss.resteasy.reactive.server.handlers.ParameterHandler".level=OFF
+

--- a/integration-tests/rest-data-hibernate-json-types/src/main/resources/import.sql
+++ b/integration-tests/rest-data-hibernate-json-types/src/main/resources/import.sql
@@ -1,0 +1,5 @@
+INSERT INTO Fruit(id, name) VALUES (1, 'Cherry');
+INSERT INTO Fruit(id, name) VALUES (2, 'Apple');
+INSERT INTO Fruit(id, name) VALUES (3, 'Banana');
+INSERT INTO Fruit(id, name) VALUES (4, 'Date');
+INSERT INTO Fruit(id, name) VALUES (5, 'Elderberry');

--- a/integration-tests/rest-data-hibernate-json-types/src/test/java/io/quarkus/it/rest/data/hibernate/FruitResourceTest.java
+++ b/integration-tests/rest-data-hibernate-json-types/src/test/java/io/quarkus/it/rest/data/hibernate/FruitResourceTest.java
@@ -1,0 +1,85 @@
+package io.quarkus.it.rest.data.hibernate;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+
+@QuarkusTest
+public class FruitResourceTest {
+
+    @Test
+    public void testPaginationDefaults() {
+        given()
+                .when().get("/fruits")
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("content", hasSize(5))
+                .body("content", hasSize(5))
+                .body("totalElements", is(5))
+                .body("hasNext", is(false))
+                .body("hasPrevious", is(false));
+    }
+
+    @Test
+    public void testPaginationWithSize() {
+        given()
+                .queryParam("size", 2)
+                .when().get("/fruits")
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("content", hasSize(2))
+                .body("content", hasSize(2))
+                .body("totalElements", is(5))
+                .body("totalPages", is(3))
+                .body("hasNext", is(true));
+    }
+
+    @Test
+    public void testPaginationSecondPage() {
+        given()
+                .queryParam("page", 2)
+                .queryParam("size", 2)
+                .when().get("/fruits")
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("content", hasSize(2))
+                .body("hasPrevious", is(true))
+                .body("hasNext", is(true));
+    }
+
+    @Test
+    public void testSortAscending() {
+        given()
+                .queryParam("sort", "name")
+                .queryParam("size", 3)
+                .when().get("/fruits")
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("content[0].name", is("Apple"))
+                .body("content[1].name", is("Banana"))
+                .body("content[2].name", is("Cherry"));
+    }
+
+    @Test
+    public void testSortDescending() {
+        given()
+                .queryParam("sort", "-name")
+                .queryParam("size", 3)
+                .when().get("/fruits")
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("content[0].name", is("Elderberry"))
+                .body("content[1].name", is("Date"))
+                .body("content[2].name", is("Cherry"));
+    }
+}

--- a/integration-tests/rest-data-hibernate-json-types/src/test/java/io/quarkus/it/rest/data/hibernate/ParamExtractionTest.java
+++ b/integration-tests/rest-data-hibernate-json-types/src/test/java/io/quarkus/it/rest/data/hibernate/ParamExtractionTest.java
@@ -1,0 +1,305 @@
+package io.quarkus.it.rest.data.hibernate;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class ParamExtractionTest {
+
+    // --- PageRequest ---
+
+    @Test
+    public void testPageRequestDefaults() {
+        given()
+                .when().get("/echo/page-request")
+                .then()
+                .statusCode(200)
+                .body("page", is(1))
+                .body("size", is(10))
+                .body("requestTotal", is(true));
+    }
+
+    @Test
+    public void testPageRequestCustomValues() {
+        given()
+                .queryParam("page", 3)
+                .queryParam("size", 25)
+                .queryParam("requestTotal", false)
+                .when().get("/echo/page-request")
+                .then()
+                .statusCode(200)
+                .body("page", is(3))
+                .body("size", is(25))
+                .body("requestTotal", is(false));
+    }
+
+    @Test
+    public void testPageRequestPartialOverride() {
+        given()
+                .queryParam("size", 50)
+                .when().get("/echo/page-request")
+                .then()
+                .statusCode(200)
+                .body("page", is(1))
+                .body("size", is(50))
+                .body("requestTotal", is(true));
+    }
+
+    // --- Sort ---
+
+    @Test
+    public void testSortAscending() {
+        given()
+                .queryParam("sort", "name")
+                .when().get("/echo/sort")
+                .then()
+                .statusCode(200)
+                .body("property", is("name"))
+                .body("ascending", is(true));
+    }
+
+    @Test
+    public void testSortDescending() {
+        given()
+                .queryParam("sort", "-salary")
+                .when().get("/echo/sort")
+                .then()
+                .statusCode(200)
+                .body("property", is("salary"))
+                .body("ascending", is(false));
+    }
+
+    @Test
+    public void testSortAbsent() {
+        given()
+                .when().get("/echo/sort")
+                .then()
+                .statusCode(204);
+    }
+
+    // --- Order ---
+
+    @Test
+    public void testOrderMultiple() {
+        given()
+                .queryParam("sort", "name")
+                .queryParam("sort", "-salary")
+                .when().get("/echo/order")
+                .then()
+                .statusCode(200)
+                .body("sorts", hasSize(2))
+                .body("sorts[0].property", is("name"))
+                .body("sorts[0].ascending", is(true))
+                .body("sorts[1].property", is("salary"))
+                .body("sorts[1].ascending", is(false));
+    }
+
+    @Test
+    public void testOrderSingle() {
+        given()
+                .queryParam("sort", "age")
+                .when().get("/echo/order")
+                .then()
+                .statusCode(200)
+                .body("sorts", hasSize(1))
+                .body("sorts[0].property", is("age"))
+                .body("sorts[0].ascending", is(true));
+    }
+
+    @Test
+    public void testOrderAbsent() {
+        given()
+                .when().get("/echo/order")
+                .then()
+                .statusCode(200)
+                .body("sorts", hasSize(0));
+    }
+
+    // --- Limit ---
+
+    @Test
+    public void testLimitOnly() {
+        given()
+                .queryParam("limit", 25)
+                .when().get("/echo/limit")
+                .then()
+                .statusCode(200)
+                .body("maxResults", is(25))
+                .body("startAt", is(1));
+    }
+
+    @Test
+    public void testLimitWithStartAt() {
+        given()
+                .queryParam("limit", 10)
+                .queryParam("startAt", 51)
+                .when().get("/echo/limit")
+                .then()
+                .statusCode(200)
+                .body("maxResults", is(10))
+                .body("startAt", is(51));
+    }
+
+    @Test
+    public void testLimitWithEndAt() {
+        given()
+                .queryParam("startAt", 51)
+                .queryParam("endAt", 60)
+                .when().get("/echo/limit")
+                .then()
+                .statusCode(200)
+                .body("maxResults", is(10))
+                .body("startAt", is(51));
+    }
+
+    @Test
+    public void testLimitWithEndAtDefaultStartAt() {
+        given()
+                .queryParam("endAt", 20)
+                .when().get("/echo/limit")
+                .then()
+                .statusCode(200)
+                .body("maxResults", is(20))
+                .body("startAt", is(1));
+    }
+
+    @Test
+    public void testLimitAbsent() {
+        given()
+                .when().get("/echo/limit")
+                .then()
+                .statusCode(204);
+    }
+
+    // --- Direction ---
+
+    @Test
+    public void testDirectionAsc() {
+        given()
+                .queryParam("direction", "ASC")
+                .when().get("/echo/direction")
+                .then()
+                .statusCode(200)
+                .body("direction", is("ASC"));
+    }
+
+    @Test
+    public void testDirectionDescCaseInsensitive() {
+        given()
+                .queryParam("direction", "desc")
+                .when().get("/echo/direction")
+                .then()
+                .statusCode(200)
+                .body("direction", is("DESC"));
+    }
+
+    @Test
+    public void testDirectionAbsent() {
+        given()
+                .when().get("/echo/direction")
+                .then()
+                .statusCode(204);
+    }
+
+    // --- Invalid values ---
+
+    @Test
+    public void testPageRequestInvalidPage() {
+        given()
+                .queryParam("page", "abc")
+                .when().get("/echo/page-request")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    public void testPageRequestInvalidSize() {
+        given()
+                .queryParam("size", "xyz")
+                .when().get("/echo/page-request")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    public void testLimitInvalidValue() {
+        given()
+                .queryParam("limit", "notanumber")
+                .when().get("/echo/limit")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    public void testDirectionInvalidValue() {
+        given()
+                .queryParam("direction", "SIDEWAYS")
+                .when().get("/echo/direction")
+                .then()
+                .statusCode(400);
+    }
+
+    // --- Page serialization ---
+
+    @Test
+    public void testPageWithTotals() {
+        given()
+                .when().get("/echo/page")
+                .then()
+                .statusCode(200)
+                .body("content", hasSize(3))
+                .body("content[0].name", is("a"))
+                .body("content[1].name", is("b"))
+                .body("content[2].name", is("c"))
+                .body("content", hasSize(3))
+                .body("hasNext", is(true))
+                .body("hasPrevious", is(false))
+                .body("totalElements", is(10))
+                .body("totalPages", is(4));
+    }
+
+    @Test
+    public void testPageWithoutTotals() {
+        given()
+                .when().get("/echo/page/no-totals")
+                .then()
+                .statusCode(200)
+                .body("content", hasSize(2))
+                .body("content", hasSize(2))
+                .body("hasNext", is(true))
+                .body("hasPrevious", is(true))
+                .body("totalElements", nullValue())
+                .body("totalPages", nullValue());
+    }
+
+    // --- Jackson annotations in Page content ---
+
+    @Test
+    public void testJsonPropertyRename() {
+        given()
+                .when().get("/echo/page/annotated")
+                .then()
+                .statusCode(200)
+                .body("content", hasSize(1))
+                .body("content[0].full_name", is("Alice"))
+                .body("content[0]", not(hasKey("name")));
+    }
+
+    @Test
+    public void testJsonIgnore() {
+        given()
+                .when().get("/echo/page/annotated")
+                .then()
+                .statusCode(200)
+                .body("content[0]", not(hasKey("secret")))
+                .body("content[0].age", is(30));
+    }
+}


### PR DESCRIPTION
This extension is added automatically (as a Quarkus
conditional dependency) when `quarkus-rest-jackson` and `quarkus-data-hibernate` 
are part of the application's extensions


_P.S. If we are to add anything in this extension in the future that the use code needs to refer to, it can no longer be added using the conditional dependency mechanism as the code would not compile_