### PR TITLE
Add CardText support to Dev UI extension cards

### DIFF
--- a/docs/src/main/asciidoc/dev-ui.adoc
+++ b/docs/src/main/asciidoc/dev-ui.adoc
@@ -137,6 +137,9 @@ Each card may include the following elements:
 | *Underlying Library* _(optional)_
 | Shows the version of the main library powering the extension (if any).
 
+| *Text* _(optional)_
+| Displays informational text values (such as versions, counts, or status) as badge-style elements. Can show static, dynamic (fetched once), or streaming (continuously updated) values.
+
 | *More Details*
 | Opens a dialog with all information
 |===
@@ -349,6 +352,59 @@ cardPageBuildItem.addAction(CardAction.actionBuilder()
         .jsonRpcMethodName("cleanAll")
         .build());
 ----
+
+===== Optional: Card Texts
+
+You can display text values directly on your extension's card. Unlike page links (which navigate to a page) or actions (which trigger behavior), card texts show informational data — such as versions, counts, or status indicators — as badge-style elements on the card itself.
+
+Card texts support three modes:
+
+- **Static** — a fixed value known at build time.
+- **Dynamic** — a value fetched once at runtime via a JsonRPC method call.
+- **Streaming** — a value continuously updated at runtime via a streaming JsonRPC method.
+
+To add a text, use the `addText` method on `CardPageBuildItem`:
+
+[source,java]
+----
+cardPageBuildItem.addText(CardText.textBuilder() // <1>
+        .title("Version") // <2>
+        .icon("font-awesome-solid:tag") // <3>
+        .staticText("2.1.0") // <4>
+        .build());
+----
+<1> Create a card text using the `CardText.textBuilder()` factory.
+<2> An optional label displayed next to the value.
+<3> A Font Awesome icon displayed next to the label (optional).
+<4> A static text value known at build time.
+
+For runtime values fetched once, use `dynamicText` with a JsonRPC method name:
+
+[source,java]
+----
+cardPageBuildItem.addText(CardText.textBuilder()
+        .title("Status")
+        .icon("font-awesome-solid:circle-info")
+        .dynamicText("getStatus") // <1>
+        .build());
+----
+<1> The JsonRPC method to call once to fetch the current value.
+
+For continuously updated values, use `streamingText`:
+
+[source,java]
+----
+cardPageBuildItem.addText(CardText.textBuilder()
+        .title("Connections")
+        .icon("font-awesome-solid:link")
+        .streamingText("streamConnectionCount") // <1>
+        .streamingTextParams("param1", "param2") // <2>
+        .build());
+----
+<1> The streaming JsonRPC method that pushes updated values.
+<2> Optional parameters to pass to the streaming method. These are resolved from the extension's local storage.
+
+You can add multiple card texts, and combine them with page links and actions on the same card.
 
 ==== Footer
 

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/page/CardPageBuildItem.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/page/CardPageBuildItem.java
@@ -17,6 +17,7 @@ public final class CardPageBuildItem extends AbstractPageBuildItem {
     private Optional<Card> optionalCard = Optional.empty();
     private List<LibraryLink> libraryVersions;
     private List<CardAction> cardActions;
+    private List<CardText> cardTexts;
 
     private String darkLogo;
     private String lightLogo;
@@ -69,6 +70,20 @@ public final class CardPageBuildItem extends AbstractPageBuildItem {
 
     public boolean hasCardActions() {
         return this.cardActions != null && !this.cardActions.isEmpty();
+    }
+
+    public void addText(CardText text) {
+        if (cardTexts == null)
+            cardTexts = new ArrayList<>();
+        cardTexts.add(text);
+    }
+
+    public List<CardText> getCardTexts() {
+        return this.cardTexts == null ? Collections.emptyList() : this.cardTexts;
+    }
+
+    public boolean hasCardTexts() {
+        return this.cardTexts != null && !this.cardTexts.isEmpty();
     }
 
     public void setLogo(String darkLogo, String lightLogo) {

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/page/CardText.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/page/CardText.java
@@ -1,0 +1,49 @@
+package io.quarkus.devui.spi.page;
+
+public class CardText {
+
+    private final String title;
+    private final String icon;
+    private final String staticText;
+    private final String dynamicText;
+    private final String streamingText;
+    private final String streamingTextParams;
+
+    CardText(String title, String icon, String staticText,
+            String dynamicText, String streamingText, String streamingTextParams) {
+        this.title = title;
+        this.icon = icon;
+        this.staticText = staticText;
+        this.dynamicText = dynamicText;
+        this.streamingText = streamingText;
+        this.streamingTextParams = streamingTextParams;
+    }
+
+    public static CardTextBuilder textBuilder() {
+        return new CardTextBuilder();
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getIcon() {
+        return icon;
+    }
+
+    public String getStaticText() {
+        return staticText;
+    }
+
+    public String getDynamicText() {
+        return dynamicText;
+    }
+
+    public String getStreamingText() {
+        return streamingText;
+    }
+
+    public String getStreamingTextParams() {
+        return streamingTextParams;
+    }
+}

--- a/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/page/CardTextBuilder.java
+++ b/extensions/devui/deployment-spi/src/main/java/io/quarkus/devui/spi/page/CardTextBuilder.java
@@ -1,0 +1,55 @@
+package io.quarkus.devui.spi.page;
+
+public class CardTextBuilder {
+
+    private String title;
+    private String icon;
+    private String staticText;
+    private String dynamicText;
+    private String streamingText;
+    private String[] streamingTextParams;
+
+    CardTextBuilder() {
+    }
+
+    public CardTextBuilder title(String title) {
+        this.title = title;
+        return this;
+    }
+
+    public CardTextBuilder icon(String icon) {
+        this.icon = icon;
+        return this;
+    }
+
+    public CardTextBuilder staticText(String text) {
+        this.staticText = text;
+        return this;
+    }
+
+    public CardTextBuilder dynamicText(String jsonRpcMethodName) {
+        this.dynamicText = jsonRpcMethodName;
+        return this;
+    }
+
+    public CardTextBuilder streamingText(String jsonRpcMultiMethodName) {
+        this.streamingText = jsonRpcMultiMethodName;
+        return this;
+    }
+
+    public CardTextBuilder streamingTextParams(String... params) {
+        this.streamingTextParams = params;
+        return this;
+    }
+
+    public CardText build() {
+        if (staticText == null && dynamicText == null && streamingText == null) {
+            throw new RuntimeException("CardText requires either staticText(), dynamicText(), or streamingText()");
+        }
+        String joinedParams = null;
+        if (streamingTextParams != null && streamingTextParams.length > 0) {
+            joinedParams = String.join(",", streamingTextParams);
+        }
+        return new CardText(title, icon, staticText, dynamicText, streamingText, joinedParams);
+    }
+}

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/DevUIProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/DevUIProcessor.java
@@ -89,6 +89,7 @@ import io.quarkus.devui.spi.buildtime.jsonrpc.RecordedJsonRpcMethod;
 import io.quarkus.devui.spi.buildtime.jsonrpc.RuntimeJsonRpcMethod;
 import io.quarkus.devui.spi.page.CardAction;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
+import io.quarkus.devui.spi.page.CardText;
 import io.quarkus.devui.spi.page.FooterPageBuildItem;
 import io.quarkus.devui.spi.page.LibraryLink;
 import io.quarkus.devui.spi.page.MenuPageBuildItem;
@@ -879,7 +880,8 @@ public class DevUIProcessor {
 
                                 if (cardPagesMap.containsKey(namespace)
                                         && (cardPagesMap.get(namespace).hasPages()
-                                                || cardPagesMap.get(namespace).hasCardActions())) { // Active
+                                                || cardPagesMap.get(namespace).hasCardActions()
+                                                || cardPagesMap.get(namespace).hasCardTexts())) { // Active
                                     CardPageBuildItem cardPageBuildItem = cardPagesMap.get(namespace);
 
                                     // Add all card links
@@ -896,6 +898,11 @@ public class DevUIProcessor {
                                     // Add card actions
                                     for (CardAction action : cardPageBuildItem.getCardActions()) {
                                         extension.addCardAction(action);
+                                    }
+
+                                    // Add card texts
+                                    for (CardText text : cardPageBuildItem.getCardTexts()) {
+                                        extension.addCardText(text);
                                     }
 
                                     // See if there is a custom card component

--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/extension/Extension.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/extension/Extension.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import io.quarkus.devui.spi.page.Card;
 import io.quarkus.devui.spi.page.CardAction;
+import io.quarkus.devui.spi.page.CardText;
 import io.quarkus.devui.spi.page.LibraryLink;
 import io.quarkus.devui.spi.page.Page;
 
@@ -34,6 +35,7 @@ public class Extension {
     private final List<Page> unlistedPages = new ArrayList<>();
     private Card card = null; // Custom card
     private List<CardAction> cardActions = null;
+    private List<CardText> cardTexts = null;
     private List<LibraryLink> libraryLinks = null;
     private String darkLogo = null;
     private String lightLogo = null;
@@ -210,6 +212,16 @@ public class Extension {
 
     public List<CardAction> getCardActions() {
         return cardActions == null ? Collections.emptyList() : cardActions;
+    }
+
+    public void addCardText(CardText text) {
+        if (this.cardTexts == null)
+            this.cardTexts = new LinkedList<>();
+        this.cardTexts.add(text);
+    }
+
+    public List<CardText> getCardTexts() {
+        return cardTexts == null ? Collections.emptyList() : cardTexts;
     }
 
     public void addMenuPage(Page page) {

--- a/extensions/devui/deployment/src/test/java/io/quarkus/devui/CardTextTest.java
+++ b/extensions/devui/deployment/src/test/java/io/quarkus/devui/CardTextTest.java
@@ -1,0 +1,148 @@
+package io.quarkus.devui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkus.devui.spi.page.CardPageBuildItem;
+import io.quarkus.devui.spi.page.CardText;
+
+public class CardTextTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void testStaticTextBuilder() {
+        CardText text = CardText.textBuilder()
+                .title("Version")
+                .icon("font-awesome-solid:tag")
+                .staticText("2.1.0")
+                .build();
+
+        assertEquals("Version", text.getTitle());
+        assertEquals("font-awesome-solid:tag", text.getIcon());
+        assertEquals("2.1.0", text.getStaticText());
+        assertNull(text.getDynamicText());
+        assertNull(text.getStreamingText());
+        assertNull(text.getStreamingTextParams());
+    }
+
+    @Test
+    public void testDynamicTextBuilder() {
+        CardText text = CardText.textBuilder()
+                .title("Status")
+                .dynamicText("getStatus")
+                .build();
+
+        assertEquals("Status", text.getTitle());
+        assertEquals("getStatus", text.getDynamicText());
+        assertNull(text.getStaticText());
+        assertNull(text.getStreamingText());
+    }
+
+    @Test
+    public void testStreamingTextBuilder() {
+        CardText text = CardText.textBuilder()
+                .title("Connections")
+                .icon("font-awesome-solid:link")
+                .streamingText("streamConnectionCount")
+                .streamingTextParams("param1", "param2")
+                .build();
+
+        assertEquals("Connections", text.getTitle());
+        assertEquals("font-awesome-solid:link", text.getIcon());
+        assertEquals("streamConnectionCount", text.getStreamingText());
+        assertEquals("param1,param2", text.getStreamingTextParams());
+        assertNull(text.getStaticText());
+        assertNull(text.getDynamicText());
+    }
+
+    @Test
+    public void testBuilderRequiresTextSource() {
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> {
+            CardText.textBuilder()
+                    .title("No Text")
+                    .build();
+        });
+        assertTrue(ex.getMessage().contains("staticText"));
+    }
+
+    @Test
+    public void testTitleIsOptional() {
+        CardText text = CardText.textBuilder()
+                .staticText("just text")
+                .build();
+
+        assertNull(text.getTitle());
+        assertEquals("just text", text.getStaticText());
+    }
+
+    @Test
+    public void testCardPageBuildItemTexts() {
+        CardPageBuildItem item = new CardPageBuildItem();
+        assertFalse(item.hasCardTexts());
+        assertTrue(item.getCardTexts().isEmpty());
+
+        CardText text1 = CardText.textBuilder()
+                .title("Text 1")
+                .staticText("value1")
+                .build();
+        CardText text2 = CardText.textBuilder()
+                .title("Text 2")
+                .dynamicText("getValue2")
+                .build();
+
+        item.addText(text1);
+        item.addText(text2);
+
+        assertTrue(item.hasCardTexts());
+        List<CardText> texts = item.getCardTexts();
+        assertEquals(2, texts.size());
+        assertEquals("Text 1", texts.get(0).getTitle());
+        assertEquals("Text 2", texts.get(1).getTitle());
+    }
+
+    @Test
+    public void testJacksonSerialization() throws Exception {
+        CardText text = CardText.textBuilder()
+                .title("Active Sessions")
+                .icon("font-awesome-solid:users")
+                .staticText("42")
+                .build();
+
+        String json = mapper.writeValueAsString(text);
+        JsonNode node = mapper.readTree(json);
+
+        assertEquals("Active Sessions", node.get("title").asText());
+        assertEquals("font-awesome-solid:users", node.get("icon").asText());
+        assertEquals("42", node.get("staticText").asText());
+        assertTrue(node.get("dynamicText").isNull());
+        assertTrue(node.get("streamingText").isNull());
+        assertTrue(node.get("streamingTextParams").isNull());
+    }
+
+    @Test
+    public void testJacksonSerializationDynamic() throws Exception {
+        CardText text = CardText.textBuilder()
+                .dynamicText("fetchCount")
+                .build();
+
+        String json = mapper.writeValueAsString(text);
+        JsonNode node = mapper.readTree(json);
+
+        assertEquals("fetchCount", node.get("dynamicText").asText());
+        assertTrue(node.get("title").isNull());
+        assertTrue(node.get("icon").isNull());
+        assertTrue(node.get("staticText").isNull());
+        assertTrue(node.get("streamingText").isNull());
+    }
+}

--- a/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-extension-text.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-extension-text.js
@@ -1,0 +1,130 @@
+import { QwcHotReloadElement, html, css } from 'qwc-hot-reload-element';
+import { JsonRpc } from 'jsonrpc';
+import { StorageController } from 'storage-controller';
+import '@vaadin/icon';
+import '@qomponent/qui-badge';
+
+export class QwcExtensionText extends QwcHotReloadElement {
+
+    static styles = css`
+        :host {
+            display: flex;
+            flex-direction: row;
+            justify-content: space-between;
+            align-items: center;
+            color: var(--lumo-contrast-70pct);
+            font-size: var(--lumo-font-size-s);
+            padding: 2px 5px;
+            gap: 5px;
+        }
+        .textRow {
+            display: flex;
+            flex-direction: row;
+            justify-content: space-between;
+            align-items: center;
+            color: var(--lumo-contrast-70pct);
+            font-size: var(--lumo-font-size-s);
+            padding: 4px 8px;
+            gap: 5px;
+        }
+        .icon {
+            padding-right: 5px;
+            width: var(--lumo-icon-size-s);
+            height: var(--lumo-icon-size-s);
+        }
+        .iconAndName {
+            display: flex;
+            flex-direction: row;
+            justify-content: flex-start;
+            align-items: center;
+        }
+    `;
+
+    static properties = {
+        namespace: { type: String },
+        displayName: { type: String },
+        iconName: { type: String },
+        staticText: { type: String },
+        dynamicText: { type: String },
+        streamingText: { type: String },
+        streamingTextParams: { type: String },
+        _effectiveText: { state: true },
+        _observer: { state: false }
+    };
+
+    constructor() {
+        super();
+        this._effectiveText = null;
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        this.hotReload();
+    }
+
+    hotReload() {
+        if (this._observer) {
+            this._observer.cancel();
+        }
+
+        this._effectiveText = null;
+        if (this.streamingText) {
+            this.jsonRpc = new JsonRpc(this);
+            if (this.streamingTextParams) {
+                let streamingTextParamsArray = this.streamingTextParams.split(',');
+                let storageController = new StorageController(this.namespace);
+                let params = {};
+                for (const localParam of streamingTextParamsArray) {
+                    let val = storageController.get(localParam);
+                    if (!val) val = "";
+                    params[localParam] = val;
+                }
+                this._observer = this.jsonRpc[this.streamingText](params).onNext(jsonRpcResponse => {
+                    this._effectiveText = jsonRpcResponse.result;
+                    this.requestUpdate();
+                });
+            } else {
+                this._observer = this.jsonRpc[this.streamingText]().onNext(jsonRpcResponse => {
+                    this._effectiveText = jsonRpcResponse.result;
+                    this.requestUpdate();
+                });
+            }
+        } else if (this.dynamicText) {
+            this.jsonRpc = new JsonRpc(this);
+            this.jsonRpc[this.dynamicText]().then(jsonRpcResponse => {
+                this._effectiveText = jsonRpcResponse.result;
+                this.requestUpdate();
+            });
+        } else if (this.staticText) {
+            this._effectiveText = this.staticText;
+        }
+    }
+
+    disconnectedCallback() {
+        if (this._observer) {
+            this._observer.cancel();
+        }
+        super.disconnectedCallback();
+    }
+
+    render() {
+        return html`
+            <div class="textRow">
+                <span class="iconAndName">
+                    ${this.iconName && this.iconName !== 'null'
+                        ? html`<vaadin-icon class="icon" icon="${this.iconName}"></vaadin-icon>`
+                        : ''}
+                    ${this.displayName && this.displayName !== 'null' ? this.displayName : ''}
+                </span>
+            </div>
+            ${this._renderText()}
+        `;
+    }
+
+    _renderText() {
+        if (this._effectiveText !== null) {
+            return html`<qui-badge tiny pill><span>${this._effectiveText}</span></qui-badge>`;
+        }
+    }
+}
+customElements.define('qwc-extension-text', QwcExtensionText);

--- a/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-extensions.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-extensions.js
@@ -7,6 +7,7 @@ import { allowExtensionManagement } from 'devui-data';
 import 'qwc/qwc-extension.js';
 import 'qwc/qwc-extension-link.js';
 import 'qwc/qwc-extension-action.js';
+import 'qwc/qwc-extension-text.js';
 import 'qwc/qwc-extension-add.js';
 import { StorageController } from 'storage-controller';
 import '@vaadin/dialog';
@@ -407,6 +408,7 @@ export class QwcExtensions extends observeState(LitElement) {
                     </span>
                     ${this._renderCardLinks(extension)}
                     ${this._renderCardActions(extension)}
+                    ${this._renderCardTexts(extension)}
                 </div>
                 ${this._renderLibraryVersions(extension)}
             </div>`;
@@ -480,6 +482,24 @@ export class QwcExtensions extends observeState(LitElement) {
                         actionReference="${action.actionReference}"
                         ?showResultNotification=${action.showResultNotification}>
                     </qwc-extension-action>`;
+    }
+
+    _renderCardTexts(extension){
+        if (extension.cardTexts && extension.cardTexts.length > 0) {
+            return html`${extension.cardTexts.map(text => html`${this._renderCardText(extension, text)}`)}`;
+        }
+    }
+
+    _renderCardText(extension, text){
+        return html`<qwc-extension-text
+                        namespace="${extension.namespace}"
+                        displayName="${text.title}"
+                        iconName="${text.icon}"
+                        staticText="${text.staticText}"
+                        dynamicText="${text.dynamicText}"
+                        streamingText="${text.streamingText}"
+                        streamingTextParams="${text.streamingTextParams}">
+                    </qwc-extension-text>`;
     }
 
     _renderLibraryVersions(extension) {


### PR DESCRIPTION
Extensions can now display text on their Dev UI card, alongside existing card pages (links) and card actions (buttons). Card text supports three modes — static (hardcoded string), dynamic (fetched once via JsonRPC), and streaming (live-updating via JsonRPC Multi subscription) — following the same pattern already used by card page labels.

This adds a new `CardText` SPI class with a fluent builder, a `qwc-extension-text` Lit web component that renders inline with existing card links and actions, and the wiring through `CardPageBuildItem`, `Extension`, and `DevUIProcessor`.

Usage from an extension deployment processor:

```java
CardPageBuildItem card = new CardPageBuildItem();
card.addText(CardText.textBuilder()
    .title("Version")
    .icon("font-awesome-solid:tag")
    .staticText("1.0.0")
    .build());
card.addText(CardText.textBuilder()
    .title("Active connections")
    .streamingText("streamConnectionCount")
    .build());
```

<img width="338" height="365" alt="image" src="https://github.com/user-attachments/assets/6fc711f6-7ecf-4c62-a5cb-f72986346206" />
