### PR TITLE
Add useConfigDir option to generate config in config/ directory

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/project/quarkus/codestart.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/project/quarkus/codestart.yml
@@ -16,6 +16,9 @@ output-strategy:
   "src/test/resources/application.yml": smart-config-merge
   "src/test/resources/application-*.yml": smart-config-merge
   "src/test/resources/application.properties": forbidden
+  "config/application.yml": forbidden
+  "config/application-*.yml": forbidden
+  "config/application.properties": forbidden
   "*.java": smart-package
   "*.kt": smart-package
   "*.scala": smart-package

--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/strategy/SmartConfigMergeCodestartFileStrategyHandler.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/strategy/SmartConfigMergeCodestartFileStrategyHandler.java
@@ -24,6 +24,8 @@ final class SmartConfigMergeCodestartFileStrategyHandler implements CodestartFil
     private static final ObjectMapper YAML_MAPPER = new ObjectMapper(
             new YAMLFactory().configure(YAMLGenerator.Feature.WRITE_DOC_START_MARKER, false));
     private static final String APP_CONFIG = "app-config";
+    private static final String USE_CONFIG_DIR = "use-config-dir";
+    private static final String SRC_MAIN_RESOURCES_PREFIX = "src/main/resources/";
 
     @Override
     public String name() {
@@ -45,7 +47,8 @@ final class SmartConfigMergeCodestartFileStrategyHandler implements CodestartFil
                 config.putAll(NestedMaps.deepMerge(config, o));
             }
         }
-        final Path targetPath = targetDirectory.resolve(relativePath);
+        final String resolvedRelativePath = resolveConfigPath(relativePath, data);
+        final Path targetPath = targetDirectory.resolve(resolvedRelativePath);
         createDirectories(targetPath);
         if (Objects.equals(configType, "config-properties")) {
             writePropertiesConfig(targetPath, config);
@@ -96,6 +99,14 @@ final class SmartConfigMergeCodestartFileStrategyHandler implements CodestartFil
         }
 
         return "\"" + key.replaceAll("\"", "\\\"") + "\"";
+    }
+
+    private static String resolveConfigPath(String relativePath, Map<String, Object> data) {
+        if (Boolean.TRUE.equals(data.get(USE_CONFIG_DIR))
+                && relativePath.startsWith(SRC_MAIN_RESOURCES_PREFIX)) {
+            return "config/" + relativePath.substring(SRC_MAIN_RESOURCES_PREFIX.length());
+        }
+        return relativePath;
     }
 
     private static String getConfigType(Map<String, Object> data) {

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartProjectInputBuilder.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartProjectInputBuilder.java
@@ -139,6 +139,16 @@ public class QuarkusCodestartProjectInputBuilder extends CodestartProjectInputBu
         return this;
     }
 
+    // Generate config in config/ instead of src/main/resources/ (used by code.quarkus.io and Roq CLI)
+    public QuarkusCodestartProjectInputBuilder useConfigDir() {
+        return this.useConfigDir(true);
+    }
+
+    public QuarkusCodestartProjectInputBuilder useConfigDir(boolean useConfigDir) {
+        putData("use-config-dir", useConfigDir);
+        return this;
+    }
+
     public QuarkusCodestartProjectInputBuilder buildTool(BuildTool buildTool) {
         if (buildTool == null) {
             return this;

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/CreateProject.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/CreateProject.java
@@ -47,6 +47,8 @@ public class CreateProject {
         String NO_DOCKERFILES = "codegen.no-dockerfiles";
         String NO_BUILDTOOL_WRAPPER = "codegen.no-buildtool-wrapper";
         String NO_CODE = "codegen.no-code";
+        // Used by code.quarkus.io and Roq CLI to generate config in config/ instead of src/main/resources/
+        String USE_CONFIG_DIR = "codegen.use-config-dir";
         String EXAMPLE = "codegen.example";
         String EXTRA_CODESTARTS = "codegen.extra-codestarts";
 
@@ -196,6 +198,15 @@ public class CreateProject {
 
     public CreateProject noDockerfiles() {
         return noDockerfiles(true);
+    }
+
+    public CreateProject useConfigDir(boolean value) {
+        setValue(USE_CONFIG_DIR, value);
+        return this;
+    }
+
+    public CreateProject useConfigDir() {
+        return useConfigDir(true);
     }
 
     public CreateProject data(String dataAsString) {

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateProjectCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateProjectCommandHandler.java
@@ -249,6 +249,7 @@ public class CreateProjectCommandHandler implements QuarkusCommandHandler {
                     .addCodestarts(invocation.getValue(EXTRA_CODESTARTS, Set.of()))
                     .noBuildToolWrapper(invocation.getValue(NO_BUILDTOOL_WRAPPER, false))
                     .noDockerfiles(invocation.getValue(NO_DOCKERFILES, false))
+                    .useConfigDir(invocation.getValue(USE_CONFIG_DIR, false))
                     .addData(depInfo.getPlatformProjectData())
                     .addData(platformData)
                     .addData(toCodestartData(invocation.getValues()))

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartGenerationTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartGenerationTest.java
@@ -274,6 +274,33 @@ class QuarkusCodestartGenerationTest {
     }
 
     @Test
+    void generateMavenConfigDirProperties(TestInfo testInfo) throws Throwable {
+        final QuarkusCodestartProjectInput input = newInputBuilder()
+                .addData(getGenerationTestInputData())
+                .useConfigDir()
+                .build();
+        final Path projectDir = testDirPath.resolve("maven-configdir-properties");
+        getCatalog().createProject(input).generate(projectDir);
+
+        checkMaven(projectDir);
+        checkConfigDirProperties(projectDir);
+    }
+
+    @Test
+    void generateMavenConfigDirYaml(TestInfo testInfo) throws Throwable {
+        final QuarkusCodestartProjectInput input = newInputBuilder()
+                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-config-yaml"))
+                .addData(getGenerationTestInputData())
+                .useConfigDir()
+                .build();
+        final Path projectDir = testDirPath.resolve("maven-configdir-yaml");
+        getCatalog().createProject(input).generate(projectDir);
+
+        checkMaven(projectDir);
+        checkConfigDirYaml(projectDir);
+    }
+
+    @Test
     public void generateGradleWrapperGithubAction(TestInfo testInfo) throws Throwable {
         final QuarkusCodestartProjectInput input = newInputBuilder()
                 .buildTool(BuildTool.GRADLE)
@@ -393,11 +420,29 @@ class QuarkusCodestartGenerationTest {
     private void checkConfigProperties(Path projectDir) {
         assertThat(projectDir.resolve("src/main/resources/application.yml")).doesNotExist();
         assertThat(projectDir.resolve("src/main/resources/application.properties")).exists();
+        assertThat(projectDir.resolve("config/application.properties")).doesNotExist();
+        assertThat(projectDir.resolve("config/application.yml")).doesNotExist();
     }
 
     private void checkConfigYaml(Path projectDir) {
         assertThat(projectDir.resolve("src/main/resources/application.yml")).exists();
         assertThat(projectDir.resolve("src/main/resources/application.properties")).doesNotExist();
+        assertThat(projectDir.resolve("config/application.properties")).doesNotExist();
+        assertThat(projectDir.resolve("config/application.yml")).doesNotExist();
+    }
+
+    private void checkConfigDirProperties(Path projectDir) {
+        assertThat(projectDir.resolve("config/application.properties")).exists();
+        assertThat(projectDir.resolve("config/application.yml")).doesNotExist();
+        assertThat(projectDir.resolve("src/main/resources/application.properties")).doesNotExist();
+        assertThat(projectDir.resolve("src/main/resources/application.yml")).doesNotExist();
+    }
+
+    private void checkConfigDirYaml(Path projectDir) {
+        assertThat(projectDir.resolve("config/application.yml")).exists();
+        assertThat(projectDir.resolve("config/application.properties")).doesNotExist();
+        assertThat(projectDir.resolve("src/main/resources/application.properties")).doesNotExist();
+        assertThat(projectDir.resolve("src/main/resources/application.yml")).doesNotExist();
     }
 
     private void checkReadme(Path projectDir) {


### PR DESCRIPTION
## Summary
- Add a `useConfigDir` option to the project creation API that places `application.properties`/`application.yml` in `config/` instead of `src/main/resources/`
- The option flows through the full builder chain: `CreateProject` -> `CreateProjectCommandHandler` -> `QuarkusCodestartProjectInputBuilder` -> `SmartConfigMergeCodestartFileStrategyHandler`
- Only main resources are redirected to `config/`, test resources remain in `src/test/resources/`
- `config/application*` paths are forbidden in codestarts to prevent direct placement (config must go through the merge handler)
- Existing codestarts are untouched, this is purely an output path concern