### PR TITLE
Fix ClassNotFoundException when external library uses Class.forName in @QuarkusTest

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
@@ -548,6 +548,20 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
                 }
                 String resourceName = fromClassNameToResourceName(name);
                 if (classPathResourceIndex.isBanned(resourceName)) {
+                    // Application classes are banned in the base runtime classloader so they are
+                    // exclusively loaded by the child runtime classloader.  However, when an
+                    // external library (loaded in the base classloader) calls Class.forName(name),
+                    // the JVM resolves the *caller's* classloader — the base one — and never
+                    // reaches the child.  If the Thread Context ClassLoader is a different loader
+                    // (i.e. the runtime classloader set by @QuarkusTest), delegate to it so that
+                    // external libraries can still reflectively load application classes.
+                    ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+                    if (tccl != null && tccl != this) {
+                        try {
+                            return tccl.loadClass(name);
+                        } catch (ClassNotFoundException ignored) {
+                        }
+                    }
                     throw new ClassNotFoundException(name);
                 }
                 boolean parentFirst = parentFirst(resourceName, classPathResourceIndex);


### PR DESCRIPTION
Fix #54052

When an external library (e.g. `spotify-hamcrest`) calls `Class.forName(name)` from inside a @QuarkusTest, the JVM resolves the caller's classloader — the Base Runtime ClassLoader — rather than the Thread Context ClassLoader. Application classes are registered as banned elements in the Base Runtime ClassLoader (so they are owned exclusively by the child Runtime ClassLoader), causing the banned check in `QuarkusClassLoader.loadClass `to throw `ClassNotFoundException `immediately, before any attempt to find the class elsewhere.

The fix adds a TCCL fallback inside the banned-class path: if the Thread Context ClassLoader is a different loader, it is tried before the exception is thrown. During `@QuarkusTest` the TCCL is always the child Runtime ClassLoader that holds the application classes, so the reflective lookup from an external library now succeeds. If the TCCL also cannot find the class, the original` ClassNotFoundException` is still propagated, leaving all other behaviour unchanged.


