### PR TITLE
Bump to Vert.x 4.5.28 and Netty 4.1.135.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -111,7 +111,7 @@
         <wildfly-elytron.version>2.9.1.Final</wildfly-elytron.version>
         <jboss-marshalling.version>2.3.0</jboss-marshalling.version>
         <jboss-threads.version>3.9.2</jboss-threads.version>
-        <vertx.version>4.5.27</vertx.version>
+        <vertx.version>4.5.28</vertx.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
         <httpasync.version>4.1.5</httpasync.version>
@@ -132,7 +132,7 @@
         <infinispan.version>16.0.12</infinispan.version>
         <infinispan.protostream.version>6.0.7</infinispan.protostream.version>
         <caffeine.version>3.2.4</caffeine.version>
-        <netty.version>4.1.133.Final</netty.version>
+        <netty.version>4.1.135.Final</netty.version>
         <brotli4j.version>1.23.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.6.3.Final</jboss-logging.version>

--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -194,6 +194,8 @@ class NettyProcessor {
                 // Use small chunks to avoid a lot of wasted space. Default is 16mb * arenas (derived from core count)
                 // Since buffers are cached to threads, the malloc overhead is temporary anyway
                 .addNativeImageSystemProperty("io.netty.allocator.maxOrder", maxOrder)
+                // Spotted with Netty 4.1.135.Final
+                .addRuntimeInitializedClass("io.netty.internal.tcnative.SSL")
                 // Runtime initialize to respect io.netty.handler.ssl.conscrypt.useBufferAllocator
                 .addRuntimeInitializedClass("io.netty.handler.ssl.ConscryptAlpnSslEngine")
                 // Runtime initialize due to the use of tcnative in the static initializers?

--- a/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/VertxUtilTest.java
+++ b/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/VertxUtilTest.java
@@ -171,6 +171,11 @@ class VertxUtilTest {
             }
 
             @Override
+            public MultiMap params() {
+                return MultiMap.caseInsensitiveMultiMap();
+            }
+
+            @Override
             public MultiMap params(boolean semicolonIsNormalChar) {
                 return null;
             }

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -58,7 +58,7 @@
         <mutiny.version>3.2.1</mutiny.version>
         <smallrye-mutiny-vertx-core.version>3.22.2</smallrye-mutiny-vertx-core.version>
         <smallrye-common.version>2.18.1</smallrye-common.version>
-        <vertx.version>4.5.27</vertx.version>
+        <vertx.version>4.5.28</vertx.version>
         <rest-assured.version>6.0.0</rest-assured.version>
         <commons-logging-jboss-logging.version>2.0.0.Final</commons-logging-jboss-logging.version>
         <jackson-bom.version>2.21.4</jackson-bom.version>

--- a/independent-projects/vertx-utils/pom.xml
+++ b/independent-projects/vertx-utils/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <jboss-logging.version>3.6.3.Final</jboss-logging.version>
-        <vertx.version>4.5.27</vertx.version>
+        <vertx.version>4.5.28</vertx.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
- Minor API breakage in HttpServerRequest
- io.netty.internal.tcnative.SSL needs to be runtime-initialized

See https://vertx.io/blog/eclipse-vert-x-4-5-28/