### PR TITLE
Allow configuring ttlSecondsAfterFinished on init-task Jobs

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/InitTaskBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/InitTaskBuildItem.java
@@ -26,6 +26,7 @@ public final class InitTaskBuildItem extends MultiBuildItem {
     private final Map<String, String> appEnvVars;
     private final boolean sharedEnvironment;
     private final boolean sharedFilesystem;
+    private final Integer ttlSecondsAfterFinished;
 
     public static InitTaskBuildItem create() {
         return new InitTaskBuildItem("init", Optional.empty(), Collections.emptyList(), Collections.emptyList(),
@@ -35,6 +36,12 @@ public final class InitTaskBuildItem extends MultiBuildItem {
     public InitTaskBuildItem(String name, Optional<String> image, List<String> command, List<String> arguments,
             Map<String, String> taskEnvVars, Map<String, String> appEnvVars, boolean sharedEnvironment,
             boolean sharedFilesystem) {
+        this(name, image, command, arguments, taskEnvVars, appEnvVars, sharedEnvironment, sharedFilesystem, null);
+    }
+
+    private InitTaskBuildItem(String name, Optional<String> image, List<String> command, List<String> arguments,
+            Map<String, String> taskEnvVars, Map<String, String> appEnvVars, boolean sharedEnvironment,
+            boolean sharedFilesystem, Integer ttlSecondsAfterFinished) {
         this.name = name;
         this.image = image;
         this.command = command;
@@ -43,6 +50,7 @@ public final class InitTaskBuildItem extends MultiBuildItem {
         this.appEnvVars = appEnvVars;
         this.sharedEnvironment = sharedEnvironment;
         this.sharedFilesystem = sharedFilesystem;
+        this.ttlSecondsAfterFinished = ttlSecondsAfterFinished;
     }
 
     public String getName() {
@@ -51,7 +59,7 @@ public final class InitTaskBuildItem extends MultiBuildItem {
 
     public InitTaskBuildItem withName(String name) {
         return new InitTaskBuildItem(name, image, command, arguments, taskEnvVars, appEnvVars, sharedEnvironment,
-                sharedFilesystem);
+                sharedFilesystem, ttlSecondsAfterFinished);
     }
 
     public Optional<String> getImage() {
@@ -60,7 +68,7 @@ public final class InitTaskBuildItem extends MultiBuildItem {
 
     public InitTaskBuildItem withImage(String image) {
         return new InitTaskBuildItem(name, Optional.of(image), command, arguments, taskEnvVars, appEnvVars, sharedEnvironment,
-                sharedFilesystem);
+                sharedFilesystem, ttlSecondsAfterFinished);
     }
 
     public List<String> getCommand() {
@@ -69,7 +77,7 @@ public final class InitTaskBuildItem extends MultiBuildItem {
 
     public InitTaskBuildItem withCommand(List<String> command) {
         return new InitTaskBuildItem(name, image, command, arguments, taskEnvVars, appEnvVars, sharedEnvironment,
-                sharedFilesystem);
+                sharedFilesystem, ttlSecondsAfterFinished);
     }
 
     public List<String> getArguments() {
@@ -78,7 +86,7 @@ public final class InitTaskBuildItem extends MultiBuildItem {
 
     public InitTaskBuildItem withArguments(List<String> arguments) {
         return new InitTaskBuildItem(name, image, command, arguments, taskEnvVars, appEnvVars, sharedEnvironment,
-                sharedFilesystem);
+                sharedFilesystem, ttlSecondsAfterFinished);
     }
 
     public Map<String, String> getTaskEnvVars() {
@@ -87,7 +95,7 @@ public final class InitTaskBuildItem extends MultiBuildItem {
 
     public InitTaskBuildItem withTaskEnvVars(Map<String, String> taskEnvVars) {
         return new InitTaskBuildItem(name, image, command, arguments, taskEnvVars, appEnvVars, sharedEnvironment,
-                sharedFilesystem);
+                sharedFilesystem, ttlSecondsAfterFinished);
     }
 
     public Map<String, String> getAppEnvVars() {
@@ -96,7 +104,7 @@ public final class InitTaskBuildItem extends MultiBuildItem {
 
     public InitTaskBuildItem withAppEnvVars(Map<String, String> appEnvVars) {
         return new InitTaskBuildItem(name, image, command, arguments, taskEnvVars, appEnvVars, sharedEnvironment,
-                sharedFilesystem);
+                sharedFilesystem, ttlSecondsAfterFinished);
     }
 
     /**
@@ -112,7 +120,7 @@ public final class InitTaskBuildItem extends MultiBuildItem {
 
     public InitTaskBuildItem withSharedEnvironment(boolean sharedEnvironment) {
         return new InitTaskBuildItem(name, image, command, arguments, taskEnvVars, appEnvVars, sharedEnvironment,
-                sharedFilesystem);
+                sharedFilesystem, ttlSecondsAfterFinished);
     }
 
     /**
@@ -130,6 +138,22 @@ public final class InitTaskBuildItem extends MultiBuildItem {
 
     public InitTaskBuildItem withSharedFilesystem(boolean sharedFilesystem) {
         return new InitTaskBuildItem(name, image, command, arguments, taskEnvVars, appEnvVars, sharedEnvironment,
-                sharedFilesystem);
+                sharedFilesystem, ttlSecondsAfterFinished);
+    }
+
+    /**
+     * The number of seconds the task is allowed to stay around after it has finished, before it is eligible to be
+     * automatically deleted. This is a default that may be overridden by the deployment target configuration (e.g.
+     * the Kubernetes init-task configuration).
+     *
+     * @return the time-to-live in seconds, or empty when not set
+     */
+    public Optional<Integer> getTtlSecondsAfterFinished() {
+        return Optional.ofNullable(ttlSecondsAfterFinished);
+    }
+
+    public InitTaskBuildItem withTtlSecondsAfterFinished(Integer ttlSecondsAfterFinished) {
+        return new InitTaskBuildItem(name, image, command, arguments, taskEnvVars, appEnvVars, sharedEnvironment,
+                sharedFilesystem, ttlSecondsAfterFinished);
     }
 }

--- a/docs/src/main/asciidoc/init-tasks.adoc
+++ b/docs/src/main/asciidoc/init-tasks.adoc
@@ -156,6 +156,31 @@ If, for any reason, additional permissions are required either by the init conta
 The application, the init container and the job use the same `ServiceAccount` and therefore, share the same permissions.
 ====
 
+== Controlling the Job lifetime
+
+By default, finished init-task Jobs remain in the cluster until they are manually deleted.
+You can configure Kubernetes to automatically delete them after a given number of seconds using `ttlSecondsAfterFinished`.
+
+To set the TTL for all init-task Jobs:
+
+[source,properties]
+----
+quarkus.kubernetes.init-task-defaults.ttl-seconds-after-finished=120
+----
+
+To set the TTL for a specific task only (e.g. Flyway):
+
+[source,properties]
+----
+quarkus.kubernetes.init-tasks.flyway.ttl-seconds-after-finished=120
+----
+
+[NOTE]
+====
+When a per-task entry is present (e.g. `quarkus.kubernetes.init-tasks.flyway.*`), it fully replaces the defaults for that task.
+If the per-task entry does not specify `ttl-seconds-after-finished`, the global default value is **not** inherited.
+====
+
 == Extensions providing Initialization Tasks
 
 Currently, this feature is used by the following extensions:

--- a/docs/src/main/asciidoc/init-tasks.adoc
+++ b/docs/src/main/asciidoc/init-tasks.adoc
@@ -155,6 +155,31 @@ If, for any reason, additional permissions are required either by the init conta
 The application, the init container and the job use the same `ServiceAccount` and therefore, share the same permissions.
 ====
 
+== Controlling the Job lifetime
+
+By default, finished init-task Jobs remain in the cluster until they are manually deleted.
+You can configure Kubernetes to automatically delete them after a given number of seconds using `ttlSecondsAfterFinished`.
+
+To set the TTL for all init-task Jobs:
+
+[source,properties]
+----
+quarkus.kubernetes.init-task-defaults.ttl-seconds-after-finished=120
+----
+
+To set the TTL for a specific task only (e.g. Flyway):
+
+[source,properties]
+----
+quarkus.kubernetes.init-tasks.flyway.ttl-seconds-after-finished=120
+----
+
+[NOTE]
+====
+When a per-task entry is present (e.g. `quarkus.kubernetes.init-tasks.flyway.*`), it fully replaces the defaults for that task.
+If the per-task entry does not specify `ttl-seconds-after-finished`, the global default value is **not** inherited.
+====
+
 == Extensions providing Initialization Tasks
 
 Currently, this feature is used by the following extensions:

--- a/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/KubernetesJobBuildItem.java
+++ b/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/KubernetesJobBuildItem.java
@@ -147,8 +147,8 @@ public final class KubernetesJobBuildItem extends MultiBuildItem implements Targ
         return Optional.ofNullable(ttlSecondsAfterFinished);
     }
 
-    public KubernetesJobBuildItem withTtlSecondsAfterFinished(Optional<Integer> ttlSecondsAfterFinished) {
+    public KubernetesJobBuildItem withTtlSecondsAfterFinished(Integer ttlSecondsAfterFinished) {
         return new KubernetesJobBuildItem(name, target, image, command, arguments, envVars, sharedEnvironment,
-                sharedFilesystem, ttlSecondsAfterFinished.orElse(null));
+                sharedFilesystem, ttlSecondsAfterFinished);
     }
 }

--- a/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/KubernetesJobBuildItem.java
+++ b/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/KubernetesJobBuildItem.java
@@ -3,6 +3,7 @@ package io.quarkus.kubernetes.spi;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import io.quarkus.builder.item.MultiBuildItem;
 
@@ -23,6 +24,7 @@ public final class KubernetesJobBuildItem extends MultiBuildItem implements Targ
     private final Map<String, String> envVars;
     private final boolean sharedEnvironment;
     private final boolean sharedFilesystem;
+    private final Optional<Integer> ttlSecondsAfterFinished;
 
     public static KubernetesJobBuildItem create(String image) {
         return new KubernetesJobBuildItem("init", null, image, Collections.emptyList(), Collections.emptyList(),
@@ -31,6 +33,12 @@ public final class KubernetesJobBuildItem extends MultiBuildItem implements Targ
 
     public KubernetesJobBuildItem(String name, String target, String image, List<String> command, List<String> arguments,
             Map<String, String> envVars, boolean sharedEnvironment, boolean sharedFilesystem) {
+        this(name, target, image, command, arguments, envVars, sharedEnvironment, sharedFilesystem, Optional.empty());
+    }
+
+    private KubernetesJobBuildItem(String name, String target, String image, List<String> command, List<String> arguments,
+            Map<String, String> envVars, boolean sharedEnvironment, boolean sharedFilesystem,
+            Optional<Integer> ttlSecondsAfterFinished) {
         this.name = name;
         this.target = target;
         this.image = image;
@@ -39,6 +47,7 @@ public final class KubernetesJobBuildItem extends MultiBuildItem implements Targ
         this.envVars = envVars;
         this.sharedEnvironment = sharedEnvironment;
         this.sharedFilesystem = sharedFilesystem;
+        this.ttlSecondsAfterFinished = ttlSecondsAfterFinished;
     }
 
     public String getName() {
@@ -47,7 +56,7 @@ public final class KubernetesJobBuildItem extends MultiBuildItem implements Targ
 
     public KubernetesJobBuildItem withName(String name) {
         return new KubernetesJobBuildItem(name, target, image, command, arguments, envVars, sharedEnvironment,
-                sharedFilesystem);
+                sharedFilesystem, ttlSecondsAfterFinished);
     }
 
     public String getTarget() {
@@ -56,7 +65,7 @@ public final class KubernetesJobBuildItem extends MultiBuildItem implements Targ
 
     public KubernetesJobBuildItem withTarget(String target) {
         return new KubernetesJobBuildItem(name, target, image, command, arguments, envVars, sharedEnvironment,
-                sharedFilesystem);
+                sharedFilesystem, ttlSecondsAfterFinished);
     }
 
     public String getImage() {
@@ -66,7 +75,7 @@ public final class KubernetesJobBuildItem extends MultiBuildItem implements Targ
     @SuppressWarnings("unused")
     public KubernetesJobBuildItem withImage(String image) {
         return new KubernetesJobBuildItem(name, target, image, command, arguments, envVars, sharedEnvironment,
-                sharedFilesystem);
+                sharedFilesystem, ttlSecondsAfterFinished);
     }
 
     public List<String> getCommand() {
@@ -75,7 +84,7 @@ public final class KubernetesJobBuildItem extends MultiBuildItem implements Targ
 
     public KubernetesJobBuildItem withCommand(List<String> command) {
         return new KubernetesJobBuildItem(name, target, image, command, arguments, envVars, sharedEnvironment,
-                sharedFilesystem);
+                sharedFilesystem, ttlSecondsAfterFinished);
     }
 
     public List<String> getArguments() {
@@ -84,7 +93,7 @@ public final class KubernetesJobBuildItem extends MultiBuildItem implements Targ
 
     public KubernetesJobBuildItem withArguments(List<String> arguments) {
         return new KubernetesJobBuildItem(name, target, image, command, arguments, envVars, sharedEnvironment,
-                sharedFilesystem);
+                sharedFilesystem, ttlSecondsAfterFinished);
     }
 
     public Map<String, String> getEnvVars() {
@@ -93,7 +102,7 @@ public final class KubernetesJobBuildItem extends MultiBuildItem implements Targ
 
     public KubernetesJobBuildItem withEnvVars(Map<String, String> envVars) {
         return new KubernetesJobBuildItem(name, target, image, command, arguments, envVars, sharedEnvironment,
-                sharedFilesystem);
+                sharedFilesystem, ttlSecondsAfterFinished);
     }
 
     /**
@@ -109,7 +118,7 @@ public final class KubernetesJobBuildItem extends MultiBuildItem implements Targ
 
     public KubernetesJobBuildItem withSharedEnvironment(boolean sharedEnvironment) {
         return new KubernetesJobBuildItem(name, target, image, command, arguments, envVars, sharedEnvironment,
-                sharedFilesystem);
+                sharedFilesystem, ttlSecondsAfterFinished);
     }
 
     /**
@@ -127,6 +136,19 @@ public final class KubernetesJobBuildItem extends MultiBuildItem implements Targ
 
     public KubernetesJobBuildItem withSharedFilesystem(boolean sharedFilesystem) {
         return new KubernetesJobBuildItem(name, target, image, command, arguments, envVars, sharedEnvironment,
-                sharedFilesystem);
+                sharedFilesystem, ttlSecondsAfterFinished);
+    }
+
+    /**
+     * Returns the number of seconds after the init-task Job finishes before Kubernetes automatically deletes it.
+     * When set, the Job is eligible to be automatically deleted after this many seconds following completion or failure.
+     */
+    public Optional<Integer> getTtlSecondsAfterFinished() {
+        return ttlSecondsAfterFinished;
+    }
+
+    public KubernetesJobBuildItem withTtlSecondsAfterFinished(Optional<Integer> ttlSecondsAfterFinished) {
+        return new KubernetesJobBuildItem(name, target, image, command, arguments, envVars, sharedEnvironment,
+                sharedFilesystem, ttlSecondsAfterFinished);
     }
 }

--- a/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/KubernetesJobBuildItem.java
+++ b/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/KubernetesJobBuildItem.java
@@ -24,7 +24,7 @@ public final class KubernetesJobBuildItem extends MultiBuildItem implements Targ
     private final Map<String, String> envVars;
     private final boolean sharedEnvironment;
     private final boolean sharedFilesystem;
-    private final Optional<Integer> ttlSecondsAfterFinished;
+    private final Integer ttlSecondsAfterFinished;
 
     public static KubernetesJobBuildItem create(String image) {
         return new KubernetesJobBuildItem("init", null, image, Collections.emptyList(), Collections.emptyList(),
@@ -33,12 +33,12 @@ public final class KubernetesJobBuildItem extends MultiBuildItem implements Targ
 
     public KubernetesJobBuildItem(String name, String target, String image, List<String> command, List<String> arguments,
             Map<String, String> envVars, boolean sharedEnvironment, boolean sharedFilesystem) {
-        this(name, target, image, command, arguments, envVars, sharedEnvironment, sharedFilesystem, Optional.empty());
+        this(name, target, image, command, arguments, envVars, sharedEnvironment, sharedFilesystem, null);
     }
 
     private KubernetesJobBuildItem(String name, String target, String image, List<String> command, List<String> arguments,
             Map<String, String> envVars, boolean sharedEnvironment, boolean sharedFilesystem,
-            Optional<Integer> ttlSecondsAfterFinished) {
+            Integer ttlSecondsAfterFinished) {
         this.name = name;
         this.target = target;
         this.image = image;
@@ -144,11 +144,11 @@ public final class KubernetesJobBuildItem extends MultiBuildItem implements Targ
      * When set, the Job is eligible to be automatically deleted after this many seconds following completion or failure.
      */
     public Optional<Integer> getTtlSecondsAfterFinished() {
-        return ttlSecondsAfterFinished;
+        return Optional.ofNullable(ttlSecondsAfterFinished);
     }
 
     public KubernetesJobBuildItem withTtlSecondsAfterFinished(Optional<Integer> ttlSecondsAfterFinished) {
         return new KubernetesJobBuildItem(name, target, image, command, arguments, envVars, sharedEnvironment,
-                sharedFilesystem, ttlSecondsAfterFinished);
+                sharedFilesystem, ttlSecondsAfterFinished.orElse(null));
     }
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/BaseKubeProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/BaseKubeProcessor.java
@@ -931,6 +931,9 @@ public abstract class BaseKubeProcessor<P, C extends PlatformConfiguration> {
                             .endSpec()
                             .endTemplate()
                             .endSpec();
+
+                    item.getTtlSecondsAfterFinished()
+                            .ifPresent(ttl -> builder.editOrNewSpec().withTtlSecondsAfterFinished(ttl).endSpec());
                 }
 
                 @Override

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/InitTaskConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/InitTaskConfig.java
@@ -21,6 +21,12 @@ public interface InitTaskConfig {
     Optional<String> image();
 
     /**
+     * Limits the lifetime of an init-task Job that has finished execution (either Complete or Failed).
+     * If set, after this many seconds the Job is eligible to be automatically deleted by Kubernetes.
+     */
+    Optional<Integer> ttlSecondsAfterFinished();
+
+    /**
      * The configuration of the `wait for` container.
      */
     InitTaskContainerConfig waitForContainer();

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/InitTaskProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/InitTaskProcessor.java
@@ -57,7 +57,8 @@ public class InitTaskProcessor {
                         .withCommand(task.getCommand())
                         .withArguments(task.getArguments())
                         .withSharedEnvironment(task.isSharedEnvironment())
-                        .withSharedFilesystem(task.isSharedFilesystem()));
+                        .withSharedFilesystem(task.isSharedFilesystem())
+                        .withTtlSecondsAfterFinished(config.ttlSecondsAfterFinished()));
 
                 task.getAppEnvVars().forEach((k, v) -> {
                     decorators.produce(new DecoratorBuildItem(target,

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/InitTaskProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/InitTaskProcessor.java
@@ -58,7 +58,8 @@ public class InitTaskProcessor {
                         .withArguments(task.getArguments())
                         .withSharedEnvironment(task.isSharedEnvironment())
                         .withSharedFilesystem(task.isSharedFilesystem())
-                        .withTtlSecondsAfterFinished(config.ttlSecondsAfterFinished()));
+                        .withTtlSecondsAfterFinished(
+                                config.ttlSecondsAfterFinished().or(task::getTtlSecondsAfterFinished).orElse(null)));
 
                 task.getAppEnvVars().forEach((k, v) -> {
                     decorators.produce(new DecoratorBuildItem(target,

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithFlywayInitAndPerTaskTtlTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithFlywayInitAndPerTaskTtlTest.java
@@ -25,7 +25,6 @@ public class KubernetesWithFlywayInitAndPerTaskTtlTest {
 
     private static final String NAME = "kubernetes-with-flyway-per-task-ttl";
     private static final String TASK_NAME = "flyway";
-    private static final String IMAGE_PULL_SECRET = "my-pull-secret";
     private static final int TTL = 60;
 
     @RegisterExtension
@@ -34,7 +33,6 @@ public class KubernetesWithFlywayInitAndPerTaskTtlTest {
             .setApplicationName(NAME)
             .setApplicationVersion("0.1-SNAPSHOT")
             .setLogFileName("k8s.log")
-            .overrideConfigKey("quarkus.kubernetes.image-pull-secrets", IMAGE_PULL_SECRET)
             .overrideConfigKey("quarkus.kubernetes.init-tasks.\"flyway\".ttl-seconds-after-finished", String.valueOf(TTL))
             .setForcedDependencies(Arrays.asList(
                     Dependency.of("io.quarkus", "quarkus-kubernetes", Version.getVersion()),

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithFlywayInitAndPerTaskTtlTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithFlywayInitAndPerTaskTtlTest.java
@@ -1,0 +1,67 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.batch.v1.Job;
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class KubernetesWithFlywayInitAndPerTaskTtlTest {
+
+    private static final String NAME = "kubernetes-with-flyway-per-task-ttl";
+    private static final String TASK_NAME = "flyway";
+    private static final String IMAGE_PULL_SECRET = "my-pull-secret";
+    private static final int TTL = 60;
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(GreetingResource.class))
+            .setApplicationName(NAME)
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .setLogFileName("k8s.log")
+            .overrideConfigKey("quarkus.kubernetes.image-pull-secrets", IMAGE_PULL_SECRET)
+            .overrideConfigKey("quarkus.kubernetes.init-tasks.\"flyway\".ttl-seconds-after-finished", String.valueOf(TTL))
+            .setForcedDependencies(Arrays.asList(
+                    Dependency.of("io.quarkus", "quarkus-kubernetes", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-flyway", Version.getVersion())));
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        final Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        assertThat(kubernetesDir)
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.json"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.yml"));
+
+        List<HasMetadata> kubernetesList = DeserializationUtil.deserializeAsList(kubernetesDir.resolve("kubernetes.yml"));
+
+        String jobName = NAME + "-" + TASK_NAME + "-init";
+        Optional<Job> job = kubernetesList.stream()
+                .filter(j -> "Job".equals(j.getKind()) && jobName.equals(j.getMetadata().getName()))
+                .map(j -> (Job) j)
+                .findAny();
+
+        assertThat(job).isPresent().get().satisfies(j -> {
+            assertThat(j.getSpec()).satisfies(jobSpec -> {
+                assertThat(jobSpec.getTtlSecondsAfterFinished()).isEqualTo(TTL);
+            });
+        });
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithFlywayInitAndTtlTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithFlywayInitAndTtlTest.java
@@ -25,7 +25,6 @@ public class KubernetesWithFlywayInitAndTtlTest {
 
     private static final String NAME = "kubernetes-with-flyway-ttl";
     private static final String TASK_NAME = "flyway";
-    private static final String IMAGE_PULL_SECRET = "my-pull-secret";
     private static final int TTL = 30;
 
     @RegisterExtension
@@ -34,7 +33,6 @@ public class KubernetesWithFlywayInitAndTtlTest {
             .setApplicationName(NAME)
             .setApplicationVersion("0.1-SNAPSHOT")
             .setLogFileName("k8s.log")
-            .overrideConfigKey("quarkus.kubernetes.image-pull-secrets", IMAGE_PULL_SECRET)
             .overrideConfigKey("quarkus.kubernetes.init-task-defaults.ttl-seconds-after-finished", String.valueOf(TTL))
             .setForcedDependencies(Arrays.asList(
                     Dependency.of("io.quarkus", "quarkus-kubernetes", Version.getVersion()),

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithFlywayInitAndTtlTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithFlywayInitAndTtlTest.java
@@ -1,0 +1,67 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.batch.v1.Job;
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class KubernetesWithFlywayInitAndTtlTest {
+
+    private static final String NAME = "kubernetes-with-flyway-ttl";
+    private static final String TASK_NAME = "flyway";
+    private static final String IMAGE_PULL_SECRET = "my-pull-secret";
+    private static final int TTL = 30;
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(GreetingResource.class))
+            .setApplicationName(NAME)
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .setLogFileName("k8s.log")
+            .overrideConfigKey("quarkus.kubernetes.image-pull-secrets", IMAGE_PULL_SECRET)
+            .overrideConfigKey("quarkus.kubernetes.init-task-defaults.ttl-seconds-after-finished", String.valueOf(TTL))
+            .setForcedDependencies(Arrays.asList(
+                    Dependency.of("io.quarkus", "quarkus-kubernetes", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-flyway", Version.getVersion())));
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        final Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        assertThat(kubernetesDir)
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.json"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.yml"));
+
+        List<HasMetadata> kubernetesList = DeserializationUtil.deserializeAsList(kubernetesDir.resolve("kubernetes.yml"));
+
+        String jobName = NAME + "-" + TASK_NAME + "-init";
+        Optional<Job> job = kubernetesList.stream()
+                .filter(j -> "Job".equals(j.getKind()) && jobName.equals(j.getMetadata().getName()))
+                .map(j -> (Job) j)
+                .findAny();
+
+        assertThat(job).isPresent().get().satisfies(j -> {
+            assertThat(j.getSpec()).satisfies(jobSpec -> {
+                assertThat(jobSpec.getTtlSecondsAfterFinished()).isEqualTo(TTL);
+            });
+        });
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithFlywayInitBase.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithFlywayInitBase.java
@@ -57,6 +57,7 @@ public class KubernetesWithFlywayInitBase {
         assertThat(job).isPresent().get().satisfies(j -> {
             assertThat(j.getSpec()).satisfies(jobSpec -> {
                 assertThat(jobSpec.getCompletionMode()).isEqualTo("NonIndexed");
+                assertThat(jobSpec.getTtlSecondsAfterFinished()).isNull();
                 assertThat(jobSpec.getTemplate()).satisfies(t -> {
                     assertThat(t.getSpec()).satisfies(podSpec -> {
                         assertThat(podSpec.getImagePullSecrets()).singleElement()

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithInitTaskBuildItemTtlOverriddenByConfigTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithInitTaskBuildItemTtlOverriddenByConfigTest.java
@@ -1,0 +1,81 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.batch.v1.Job;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.deployment.builditem.InitTaskBuildItem;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestBuildStep;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+/**
+ * Verifies that a per-task {@code ttlSecondsAfterFinished} configuration overrides the default provided through the
+ * {@link InitTaskBuildItem}.
+ */
+public class KubernetesWithInitTaskBuildItemTtlOverriddenByConfigTest {
+
+    private static final String NAME = "kubernetes-with-init-task-ttl-override";
+    private static final int BUILD_ITEM_TTL = 45;
+    private static final int CONFIG_TTL = 90;
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot((jar) -> jar.addClasses(GreetingResource.class))
+            .setApplicationName(NAME)
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .setLogFileName("k8s.log")
+            .overrideConfigKey("quarkus.kubernetes.init-tasks.\"init\".ttl-seconds-after-finished",
+                    String.valueOf(CONFIG_TTL))
+            .addBuildChainCustomizerEntries(
+                    new QuarkusProdModeTest.BuildChainCustomizerEntry(InitTaskProducer.class,
+                            Collections.singletonList(InitTaskBuildItem.class), Collections.emptyList()));
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        final Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        assertThat(kubernetesDir)
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.json"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.yml"));
+
+        List<HasMetadata> kubernetesList = DeserializationUtil.deserializeAsList(kubernetesDir.resolve("kubernetes.yml"));
+
+        Optional<Job> job = kubernetesList.stream()
+                .filter(j -> "Job".equals(j.getKind()))
+                .map(j -> (Job) j)
+                .findAny();
+
+        assertThat(job).isPresent().get().satisfies(j -> assertThat(j.getSpec())
+                .satisfies(jobSpec -> assertThat(jobSpec.getTtlSecondsAfterFinished()).isEqualTo(CONFIG_TTL)));
+    }
+
+    public static class InitTaskProducer extends ProdModeTestBuildStep {
+
+        public InitTaskProducer(Map<String, Object> testContext) {
+            super(testContext);
+        }
+
+        @Override
+        public void execute(BuildContext context) {
+            context.produce(InitTaskBuildItem.create()
+                    .withName("init")
+                    .withCommand(List.of("/bin/sh"))
+                    .withTtlSecondsAfterFinished(BUILD_ITEM_TTL));
+        }
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithInitTaskBuildItemTtlTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithInitTaskBuildItemTtlTest.java
@@ -1,0 +1,78 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.batch.v1.Job;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.deployment.builditem.InitTaskBuildItem;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestBuildStep;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+/**
+ * Verifies that an {@link InitTaskBuildItem} carrying a {@code ttlSecondsAfterFinished} default is honoured when no
+ * configuration overrides it.
+ */
+public class KubernetesWithInitTaskBuildItemTtlTest {
+
+    private static final String NAME = "kubernetes-with-init-task-build-item-ttl";
+    private static final int TTL = 45;
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot((jar) -> jar.addClasses(GreetingResource.class))
+            .setApplicationName(NAME)
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .setLogFileName("k8s.log")
+            .addBuildChainCustomizerEntries(
+                    new QuarkusProdModeTest.BuildChainCustomizerEntry(InitTaskProducer.class,
+                            Collections.singletonList(InitTaskBuildItem.class), Collections.emptyList()));
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        final Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        assertThat(kubernetesDir)
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.json"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.yml"));
+
+        List<HasMetadata> kubernetesList = DeserializationUtil.deserializeAsList(kubernetesDir.resolve("kubernetes.yml"));
+
+        Optional<Job> job = kubernetesList.stream()
+                .filter(j -> "Job".equals(j.getKind()))
+                .map(j -> (Job) j)
+                .findAny();
+
+        assertThat(job).isPresent().get().satisfies(j -> assertThat(j.getSpec())
+                .satisfies(jobSpec -> assertThat(jobSpec.getTtlSecondsAfterFinished()).isEqualTo(TTL)));
+    }
+
+    public static class InitTaskProducer extends ProdModeTestBuildStep {
+
+        public InitTaskProducer(Map<String, Object> testContext) {
+            super(testContext);
+        }
+
+        @Override
+        public void execute(BuildContext context) {
+            context.produce(InitTaskBuildItem.create()
+                    .withName("init")
+                    .withCommand(List.of("/bin/sh"))
+                    .withTtlSecondsAfterFinished(TTL));
+        }
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithFlywayInitAndTtlTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithFlywayInitAndTtlTest.java
@@ -1,0 +1,65 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.batch.v1.Job;
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class OpenshiftWithFlywayInitAndTtlTest {
+
+    private static final String NAME = "openshift-with-flyway-ttl";
+    private static final String TASK_NAME = "flyway";
+    private static final int TTL = 45;
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(GreetingResource.class))
+            .setApplicationName(NAME)
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .setLogFileName("k8s.log")
+            .overrideConfigKey("quarkus.openshift.init-task-defaults.ttl-seconds-after-finished", String.valueOf(TTL))
+            .setForcedDependencies(Arrays.asList(
+                    Dependency.of("io.quarkus", "quarkus-openshift", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-flyway", Version.getVersion())));
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        final Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        assertThat(kubernetesDir)
+                .isDirectoryContaining(p -> p.getFileName().endsWith("openshift.json"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("openshift.yml"));
+
+        List<HasMetadata> kubernetesList = DeserializationUtil.deserializeAsList(kubernetesDir.resolve("openshift.yml"));
+
+        String jobName = NAME + "-" + TASK_NAME + "-init";
+        Optional<Job> job = kubernetesList.stream()
+                .filter(j -> "Job".equals(j.getKind()) && jobName.equals(j.getMetadata().getName()))
+                .map(j -> (Job) j)
+                .findAny();
+
+        assertThat(job).isPresent().get().satisfies(j -> {
+            assertThat(j.getSpec()).satisfies(jobSpec -> {
+                assertThat(jobSpec.getTtlSecondsAfterFinished()).isEqualTo(TTL);
+            });
+        });
+    }
+}


### PR DESCRIPTION
Users have no way to control the lifetime of finished Kubernetes init-task Jobs, so they accumulate in the cluster and must be cleaned up manually. This adds `ttlSecondsAfterFinished` support so that Kubernetes can automatically delete them after a configurable number of seconds.

Two levels of configuration are supported:

- Global default applied to every init-task Job:
  `quarkus.kubernetes.init-task-defaults.ttl-seconds-after-finished=120`
- Per-task override (e.g. for Flyway only):
  `quarkus.kubernetes.init-tasks.flyway.ttl-seconds-after-finished=120`

Both `quarkus.kubernetes` and `quarkus.openshift` prefixes are supported. The field is optional and defaults to absent, preserving existing behavior.

Fixes #33829

Release note: Init-task Jobs generated by the Kubernetes and OpenShift extensions now support `ttl-seconds-after-finished` to let Kubernetes automatically clean up finished Jobs.