### PR TITLE
Show external link icon on embedded Dev UI pages with dynamic URLs

### DIFF
--- a/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-extension-link.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/qwc/qwc-extension-link.js
@@ -137,7 +137,7 @@ export class QwcExtensionLink extends QwcHotReloadElement {
             this._observer.cancel();
         }
         
-        if(!this.embed && this.dynamicUrlMethodName){
+        if(this.dynamicUrlMethodName){
             let jrpc;
             let methodName = this.dynamicUrlMethodName;
             if (this.dynamicUrlMethodName.includes(':')) {
@@ -245,6 +245,7 @@ export class QwcExtensionLink extends QwcHotReloadElement {
                     </span>
                 </a>
                 ${this._renderBadge()}
+                ${this._renderExternalIcon()}
                 `;
         }else{
             return html`<a class="extensionLink" ?router-ignore=true>
@@ -262,6 +263,15 @@ export class QwcExtensionLink extends QwcHotReloadElement {
             }else{
                 return html`<qui-badge tiny pill><span>${this._effectiveLabel}</span></qui-badge>`;
             }
+        }
+    }
+
+    _renderExternalIcon() {
+        if (this.embed && this._effectiveExternalUrl) {
+            if (this._effectiveLabel && this.isHTML(this._effectiveLabel)) {
+                return;
+            }
+            return html`<a style='color: var(--lumo-contrast-80pct);' href='${this._effectiveExternalUrl}' target='_blank'><vaadin-icon class='icon' icon='font-awesome-solid:up-right-from-square'></vaadin-icon></a>`;
         }
     }
 


### PR DESCRIPTION
When extensions use `dynamicUrlJsonRPCMethodName()` for embedded pages, the external link icon (↗) was missing — unlike `url(url, externalLink)` which bakes the icon into `staticLabel` at build time. Since the URL isn't known until the JSON-RPC call resolves at runtime, the `staticLabel` approach can't work for dynamic URLs.

This fixes it by resolving dynamic URLs even when the page is embedded (previously gated by `!this.embed`), and rendering the icon as a live anchor once the URL is available. The `render()` method already gates the main link behavior on `!this.embed`, so this doesn't change navigation — it just makes the resolved URL available for the icon.

Pages that already have an HTML `staticLabel` (from the two-arg `url()` method) are skipped to avoid duplicate icons. This also means one-arg `url(u)` embedded pages now get the icon for consistency — every embedded external page offers an escape hatch to open the URL directly in a new tab.

Relates to #54564