### PR TITLE
Use latest Stork 2.7.10

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -59,7 +59,7 @@
         <smallrye-reactive-types-converter.version>3.0.3</smallrye-reactive-types-converter.version>
         <smallrye-mutiny-vertx-binding.version>3.22.2</smallrye-mutiny-vertx-binding.version>
         <smallrye-reactive-messaging.version>4.34.0</smallrye-reactive-messaging.version>
-        <smallrye-stork.version>2.7.9</smallrye-stork.version>
+        <smallrye-stork.version>2.7.10</smallrye-stork.version>
         <jakarta.activation.version>2.1.4</jakarta.activation.version>
         <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>
         <jakarta.authentication-api>3.1.0</jakarta.authentication-api>

--- a/extensions/smallrye-stork/runtime/src/main/java/io/quarkus/stork/SmallRyeStorkRegistrationRecorder.java
+++ b/extensions/smallrye-stork/runtime/src/main/java/io/quarkus/stork/SmallRyeStorkRegistrationRecorder.java
@@ -1,8 +1,8 @@
 package io.quarkus.stork;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -11,6 +11,8 @@ import org.jboss.logging.Logger;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.stork.Stork;
 import io.smallrye.stork.api.config.ServiceConfig;
 
@@ -18,6 +20,7 @@ import io.smallrye.stork.api.config.ServiceConfig;
 public class SmallRyeStorkRegistrationRecorder {
 
     private static final Logger LOGGER = Logger.getLogger(SmallRyeStorkRegistrationRecorder.class.getName());
+    private static final Duration REGISTRATION_TIMEOUT = Duration.ofSeconds(10);
 
     private final RuntimeValue<StorkConfiguration> runtimeConfig;
 
@@ -42,8 +45,9 @@ public class SmallRyeStorkRegistrationRecorder {
                 String host = StorkConfigUtil.getOrDefaultHost(parameters,
                         quarkusConfig);
                 int port = StorkConfigUtil.getOrDefaultPort(parameters, quarkusConfig);
-                Stork.getInstance().getService(serviceName).registerInstance(serviceName, host,
-                        port).await().indefinitely();
+                Uni<Void> registration = Stork.getInstance().getService(serviceName)
+                        .registerInstance(serviceName, host, port);
+                awaitOrSubscribe(registration, serviceName, "registration");
             }
 
         }
@@ -58,6 +62,32 @@ public class SmallRyeStorkRegistrationRecorder {
         });
     }
 
+    /**
+     * Waits for the given {@link Uni} to complete if the caller thread can be blocked,
+     * otherwise subscribes and logs on failure. In both cases, a timeout is applied to
+     * avoid hanging indefinitely if the registrar is unreachable.
+     *
+     * @param uni the operation to execute
+     * @param serviceName the service name, used for logging
+     * @param action a description of the action (e.g. "registration", "deregistration"), used for logging
+     */
+    private void awaitOrSubscribe(Uni<Void> uni, String serviceName, String action) {
+        if (Infrastructure.canCallerThreadBeBlocked()) {
+            try {
+                uni.await().atMost(REGISTRATION_TIMEOUT);
+                LOGGER.debugf("'%s' successfully completed for service '%s'", action, serviceName);
+            } catch (Exception failure) {
+                LOGGER.warnf("Failed to complete %s for service '%s': %s", action, serviceName, failure.getMessage());
+            }
+        } else {
+            uni.ifNoItem().after(REGISTRATION_TIMEOUT).fail()
+                    .subscribe().with(
+                            success -> LOGGER.debugf("'%s' successfully completed for service '%s'", action, serviceName),
+                            failure -> LOGGER.warnf("Failed to complete %s for service '%s': %s", action, serviceName,
+                                    failure.getMessage()));
+        }
+    }
+
     private void deregisterServiceInstance(StorkConfiguration configuration) {
         List<ServiceConfig> serviceConfigs = StorkConfigUtil.toStorkServiceConfig(configuration);
         for (ServiceConfig serviceConfig : serviceConfigs) {
@@ -68,19 +98,11 @@ public class SmallRyeStorkRegistrationRecorder {
                 if (!storkServiceRegistrarConfiguration.enabled()) {
                     continue;
                 }
+                Uni<Void> deregistration = Stork.getInstance()
+                        .getService(serviceName)
+                        .deregisterServiceInstance(serviceName);
+                awaitOrSubscribe(deregistration, serviceName, "deregistration");
             }
-            CountDownLatch registrationLatch = new CountDownLatch(1);
-            Stork.getInstance()
-                    .getService(serviceName)
-                    .deregisterServiceInstance(serviceName)
-                    .subscribe()
-                    .with(
-                            success -> registrationLatch.countDown(),
-                            failure -> {
-                                LOGGER.warnf("Failed to deregister service '%s': %s", serviceName, failure.getMessage());
-                                registrationLatch.countDown();
-                            });
-
         }
     }
 }

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -62,7 +62,7 @@
         <rest-assured.version>6.0.0</rest-assured.version>
         <commons-logging-jboss-logging.version>2.0.0.Final</commons-logging-jboss-logging.version>
         <jackson-bom.version>2.22.0</jackson-bom.version>
-        <smallrye-stork.version>2.7.9</smallrye-stork.version>
+        <smallrye-stork.version>2.7.10</smallrye-stork.version>
         <jakarta.validation-api.version>3.1.1</jakarta.validation-api.version>
         <yasson.version>3.0.4</yasson.version>
         <jakarta.json.bind-api.version>3.0.2</jakarta.json.bind-api.version>

--- a/integration-tests/smallrye-stork-consul-registration-prod-mode/src/test/java/org/acme/DeregistrationTest.java
+++ b/integration-tests/smallrye-stork-consul-registration-prod-mode/src/test/java/org/acme/DeregistrationTest.java
@@ -1,6 +1,8 @@
 package org.acme;
 
 import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
 
 import java.util.concurrent.TimeUnit;
 
@@ -36,9 +38,10 @@ public class DeregistrationTest {
     public void testDeregistrationAfterShutdown() throws Exception {
 
         // Ensure service is registered
-        RestAssured.get("http://localhost:8500/v1/agent/service/consul-deregistration-test")
+        RestAssured.get("http://localhost:8500/v1/catalog/service/consul-deregistration-test")
                 .then()
-                .statusCode(200);
+                .statusCode(200)
+                .body(containsString("\"ServiceName\": \"consul-deregistration-test\""));
 
         // Stop the app
         app.stop();
@@ -47,9 +50,10 @@ public class DeregistrationTest {
         await()
                 .atMost(20, TimeUnit.SECONDS)
                 .pollInterval(100, TimeUnit.MILLISECONDS)
-                .untilAsserted(() -> RestAssured.get("http://localhost:8500/v1/agent/service/consul-deregistration-test")
+                .untilAsserted(() -> RestAssured.get("http://localhost:8500/v1/catalog/service/consul-deregistration-test")
                         .then()
-                        .statusCode(404));
+                        .statusCode(200)
+                        .body("$", hasSize(0)));
 
     }
 

--- a/integration-tests/smallrye-stork-consul-registration/src/test/java/org/acme/CustomExplicitConfigRegistrationTest.java
+++ b/integration-tests/smallrye-stork-consul-registration/src/test/java/org/acme/CustomExplicitConfigRegistrationTest.java
@@ -42,12 +42,12 @@ public class CustomExplicitConfigRegistrationTest {
 
     @Test
     public void test() {
-        RestAssured.get("http://localhost:8500/v1/agent/service/my-service")
+        RestAssured.get("http://localhost:8500/v1/catalog/service/my-service")
                 .then()
                 .statusCode(200)
-                .body(containsString("\"Service\": \"my-service\""),
+                .body(containsString("\"ServiceID\": \"my-service::145.123.145.145::9090\""),
                         containsString("\"Port\": 9090"),
-                        containsString("\"Address\": \"145.123.145.145\""));
+                        containsString("\"ServiceAddress\": \"145.123.145.145\""));
 
     }
 

--- a/integration-tests/smallrye-stork-consul-registration/src/test/java/org/acme/DisabledRegistrationTest.java
+++ b/integration-tests/smallrye-stork-consul-registration/src/test/java/org/acme/DisabledRegistrationTest.java
@@ -1,5 +1,7 @@
 package org.acme;
 
+import static org.hamcrest.Matchers.hasSize;
+
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -39,9 +41,10 @@ public class DisabledRegistrationTest {
 
     @Test
     public void test() {
-        RestAssured.get("http://localhost:8500/v1/agent/service/my-service")
+        RestAssured.get("http://localhost:8500/v1/catalog/service/my-service")
                 .then()
-                .statusCode(404);
+                .statusCode(200)
+                .body("$", hasSize(0));
 
     }
 

--- a/integration-tests/smallrye-stork-consul-registration/src/test/java/org/acme/ImplicitConfigRegistrationTest.java
+++ b/integration-tests/smallrye-stork-consul-registration/src/test/java/org/acme/ImplicitConfigRegistrationTest.java
@@ -27,10 +27,10 @@ public class ImplicitConfigRegistrationTest {
 
     @Test
     public void test() {
-        RestAssured.get("http://localhost:8500/v1/agent/service/quarkus-integration-test-smallrye-stork-consul-registration")
+        RestAssured.get("http://localhost:8500/v1/catalog/service/quarkus-integration-test-smallrye-stork-consul-registration")
                 .then()
                 .statusCode(200)
-                .body(containsString("\"Service\": \"quarkus-integration-test-smallrye-stork-consul-registration\""));
+                .body(containsString("\"ServiceName\": \"quarkus-integration-test-smallrye-stork-consul-registration\""));
 
     }
 

--- a/integration-tests/smallrye-stork-consul-registration/src/test/java/org/acme/MixedStorkServicesConfigIsolationTest.java
+++ b/integration-tests/smallrye-stork-consul-registration/src/test/java/org/acme/MixedStorkServicesConfigIsolationTest.java
@@ -1,6 +1,9 @@
 package org.acme;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.matchesPattern;
 
 import java.util.Map;
 
@@ -43,14 +46,16 @@ public class MixedStorkServicesConfigIsolationTest {
 
     @Test
     public void test() {
-        RestAssured.get("http://localhost:8500/v1/agent/service/red-service")
+        RestAssured.get("http://localhost:8500/v1/catalog/service/red-service")
                 .then()
                 .statusCode(200)
-                .body(containsString("\"Service\": \"red-service\""));
+                .body(containsString("\"ServiceName\": \"red-service\""))
+                .body("ServiceID", hasItem(matchesPattern("^red-service::[0-9.]+::8080")));
 
-        RestAssured.get("http://localhost:8500/v1/agent/service/blue-service")
+        RestAssured.get("http://localhost:8500/v1/catalog/service/blue-service")
                 .then()
-                .statusCode(404);
+                .statusCode(200)
+                .body("$", hasSize(0));
 
     }
 

--- a/integration-tests/smallrye-stork-consul-registration/src/test/java/org/acme/MultipleRegistrarsConfigRegistrationTest.java
+++ b/integration-tests/smallrye-stork-consul-registration/src/test/java/org/acme/MultipleRegistrarsConfigRegistrationTest.java
@@ -1,6 +1,8 @@
 package org.acme;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.matchesPattern;
 
 import java.util.Map;
 
@@ -44,17 +46,19 @@ public class MultipleRegistrarsConfigRegistrationTest {
 
     @Test
     public void test() {
-        RestAssured.get("http://localhost:8500/v1/agent/service/red-service")
+        RestAssured.get("http://localhost:8500/v1/catalog/service/red-service")
                 .then()
                 .statusCode(200)
-                .body(containsString("\"Service\": \"red-service\""),
-                        containsString("\"145.123.145.145\""));
+                .body(containsString("\"ServiceName\": \"red-service\""),
+                        containsString("\"ServiceAddress\": \"145.123.145.145\""))
+                .body("ServiceID", hasItem(matchesPattern("^red-service::145.123.145.145::8080")));
 
-        RestAssured.get("http://localhost:8500/v1/agent/service/blue-service")
+        RestAssured.get("http://localhost:8500/v1/catalog/service/blue-service")
                 .then()
                 .statusCode(200)
-                .body(containsString("\"Service\": \"blue-service\""),
-                        containsString("\"145.123.145.157\""));
+                .body(containsString("\"ServiceName\": \"blue-service\""),
+                        containsString("\"ServiceAddress\": \"145.123.145.157\""),
+                        containsString("\"ServiceID\": \"blue-service::145.123.145.157::8080\""));
 
     }
 

--- a/integration-tests/smallrye-stork-consul-registration/src/test/java/org/acme/RegistrarConfigDoesNotLeakBetweenServicesTest.java
+++ b/integration-tests/smallrye-stork-consul-registration/src/test/java/org/acme/RegistrarConfigDoesNotLeakBetweenServicesTest.java
@@ -1,6 +1,7 @@
 package org.acme;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
 
 import java.util.Map;
 
@@ -42,14 +43,15 @@ public class RegistrarConfigDoesNotLeakBetweenServicesTest {
 
     @Test
     public void test() {
-        RestAssured.get("http://localhost:8500/v1/agent/service/red-service")
+        RestAssured.get("http://localhost:8500/v1/catalog/service/red-service")
                 .then()
                 .statusCode(200)
-                .body(containsString("\"Service\": \"red-service\""));
+                .body(containsString("\"ServiceName\": \"red-service\""));
 
-        RestAssured.get("http://localhost:8500/v1/agent/service/blue-service")
+        RestAssured.get("http://localhost:8500/v1/catalog/service/blue-service")
                 .then()
-                .statusCode(404);
+                .statusCode(200)
+                .body("$", hasSize(0));
 
     }
 

--- a/integration-tests/smallrye-stork-consul-registration/src/test/java/org/acme/SingleServiceWithDiscoveryAndRegistrarConfigTest.java
+++ b/integration-tests/smallrye-stork-consul-registration/src/test/java/org/acme/SingleServiceWithDiscoveryAndRegistrarConfigTest.java
@@ -1,6 +1,8 @@
 package org.acme;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.matchesPattern;
 
 import java.util.Map;
 
@@ -42,10 +44,11 @@ public class SingleServiceWithDiscoveryAndRegistrarConfigTest {
 
     @Test
     public void test() {
-        RestAssured.get("http://localhost:8500/v1/agent/service/red-service")
+        RestAssured.get("http://localhost:8500/v1/catalog/service/red-service")
                 .then()
                 .statusCode(200)
-                .body(containsString("\"Service\": \"red-service\""));
+                .body(containsString("\"ServiceName\": \"red-service\""))
+                .body("ServiceID", hasItem(matchesPattern("^red-service::[0-9.]+::8080")));
 
     }
 


### PR DESCRIPTION
The Stork 2.7.10 de-registration now performs two HTTP calls (catalog lookup + deregister by instance ID) instead of a single direct call. Without blocking, the shutdown task returns immediately and deregistration is not completed.   
Replaced .await().indefinitely() with .await().atMost(Duration.ofSeconds(10)) in both registerInstance and deregisterServiceInstance to ensure the operations complete before shutdown proceeds, while avoiding an indefinite block if the Consul is unreachable.
Updated integration tests to use the Consul catalog API (/v1/catalog/service/) instead of the agent API (/v1/agent/service/) because instance IDs are now dynamically generated (serviceName::ip::port) rather than matching the service name. The catalog API allows querying by service name regardless of the instance ID. After deregistration, the test now asserts an empty list instead of a 404 status, since the catalog endpoint always returns 200.

- Closes: https://github.com/quarkusio/quarkus/issues/54651