### PR TITLE
Fix memory leak in REST Client reactive pipelines

### DIFF
--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientRequestContextImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientRequestContextImpl.java
@@ -46,6 +46,7 @@ import io.smallrye.stork.api.ServiceInstance;
 import io.vertx.core.Context;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.impl.ContextInternal;
 
 public class ClientRequestContextImpl implements ResteasyReactiveClientRequestContext {
 
@@ -64,10 +65,18 @@ public class ClientRequestContextImpl implements ResteasyReactiveClientRequestCo
         this.headersMap = new ClientRequestHeadersMap(); //restClientRequestContext.requestHeaders.getHeaders()
         this.providers = new ProvidersImpl(restClientRequestContext);
 
-        // Always create a duplicated context because each REST Client invocation must have its own context
-        // A separate context allows integrations like OTel to create a separate Span for each invocation (expected)
+        // Always create a duplicated context because each REST Client invocation must have its own context.
+        // A separate context allows integrations like OTel to create a separate Span for each invocation (expected).
+        // We use createNewDuplicatedContext (which always duplicates from the root) instead of newNestedContext
+        // to avoid creating a chain of parent references that prevents GC of previous calls' contexts.
         Context current = client.vertx.getOrCreateContext();
-        this.context = VertxContext.newNestedContext(current);
+        this.context = VertxContext.createNewDuplicatedContext(current);
+        if (VertxContext.isDuplicatedContext(current)) {
+            // Copy old-style locals from the caller context so they remain visible
+            ((ContextInternal) this.context).localContextData()
+                    .putAll(((ContextInternal) current).localContextData());
+        }
+        this.context.putLocal(VertxContext.PARENT_CONTEXT, current);
         restClientRequestContext.properties.put(VERTX_CONTEXT_PROPERTY, context);
     }
 

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/RestClientRequestContext.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/RestClientRequestContext.java
@@ -36,6 +36,7 @@ import org.jboss.resteasy.reactive.client.api.QuarkusRestClientProperties;
 import org.jboss.resteasy.reactive.client.impl.multipart.QuarkusMultipartForm;
 import org.jboss.resteasy.reactive.client.spi.ClientRestHandler;
 import org.jboss.resteasy.reactive.client.spi.MultipartResponseData;
+import org.jboss.resteasy.reactive.client.spi.ResteasyReactiveClientRequestContext;
 import org.jboss.resteasy.reactive.common.core.AbstractResteasyReactiveContext;
 import org.jboss.resteasy.reactive.common.core.Serialisers;
 import org.jboss.resteasy.reactive.common.jaxrs.ConfigurationImpl;
@@ -44,6 +45,7 @@ import org.jboss.resteasy.reactive.common.util.CaseInsensitiveMap;
 import org.jboss.resteasy.reactive.spi.ThreadSetupAction;
 
 import io.netty.handler.codec.http.multipart.InterfaceHttpData;
+import io.smallrye.common.vertx.VertxContext;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.stork.api.ServiceInstance;
@@ -381,7 +383,20 @@ public class RestClientRequestContext extends AbstractResteasyReactiveContext<Re
 
     @Override
     public void close() {
+        if (closed) {
+            return;
+        }
         super.close();
+        // Release the duplicated Vert.x context and break any parent-context reference chains
+        // to prevent memory leaks in reactive pipelines (see #54639)
+        if (this.clientRequestContext != null) {
+            Context ctx = this.clientRequestContext.getContext();
+            if (ctx != null) {
+                ctx.removeLocal(VertxContext.PARENT_CONTEXT);
+            }
+            this.clientRequestContext = null;
+        }
+        this.properties.remove(ResteasyReactiveClientRequestContext.VERTX_CONTEXT_PROPERTY);
         if (!result.isDone()) {
             try {
                 ClientRestHandler[] handlers = this.handlers;

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/core/AbstractResteasyReactiveContext.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/core/AbstractResteasyReactiveContext.java
@@ -41,7 +41,7 @@ public abstract class AbstractResteasyReactiveContext<T extends AbstractResteasy
     private List<CompletionCallback> completionCallbacks;
     private boolean abortHandlerChainStarted;
 
-    private boolean closed = false;
+    protected boolean closed = false;
 
     public AbstractResteasyReactiveContext(H[] handlerChain, H[] abortHandlerChain, ThreadSetupAction requestContext) {
         this.handlers = handlerChain;


### PR DESCRIPTION
There were essentially two leaks and the first one AFAICT only showed up when
`Multi#transformToUniAndConcatenate` was used.

1. Context chaining via `newNestedContext`: In a reactive pipeline, the next REST client call runs on the previous call's duplicated context. `newNestedContext` stores a `__PARENT_CONTEXT__` reference to it, forming an unbounded chain where no context can be GC'd.

2. Context retention via `Response`: The `Response` object retains the `RestClientRequestContext`, which holds the duplicated context through both the clientRequestContext field and the properties map. These references outlive the handler chain.

----

- Closes: #54639

