### PR TITLE
Allow extensions to provide multiple codestarts via extra-names

### DIFF
--- a/docs/src/main/asciidoc/extension-codestart.adoc
+++ b/docs/src/main/asciidoc/extension-codestart.adoc
@@ -238,6 +238,19 @@ metadata:
     - "java"
     artifact: "io.quarkiverse.aloha:quarkus-aloha:codestarts:jar:${project.version}"
 ----
++
+If your extension provides a base codestart but also needs to activate additional codestarts (e.g., for shared configuration or common setup provided by other codestarts in the same artifact), you can use the `extra-names` property alongside `name`:
++
+[source,yaml]
+----
+  codestart:
+    name: "aloha"
+    extra-names:
+    - "aloha-extra"
+    languages:
+    - "java"
+    artifact: "io.quarkiverse.aloha:quarkus-aloha:codestarts:jar:${project.version}"
+----
 
 * Add the readme <<readme-md>> section template in `base/README.tpl.qute.md`:
 +

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartCatalog.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartCatalog.java
@@ -13,7 +13,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -204,8 +203,7 @@ public final class QuarkusCodestartCatalog extends GenericCodestartCatalog<Quark
 
     private Set<String> getExtensionCodestarts(QuarkusCodestartProjectInput projectInput) {
         return getSelectedExtensionsAsStream(projectInput)
-                .map(ExtensionProcessor::getCodestartName)
-                .filter(Objects::nonNull)
+                .flatMap(e -> ExtensionProcessor.getCodestartNames(e).stream())
                 .collect(Collectors.toSet());
     }
 

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/catalog/processor/ExtensionProcessor.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/catalog/processor/ExtensionProcessor.java
@@ -63,8 +63,15 @@ public final class ExtensionProcessor {
         return getMetadataValue(extension, MD_BUILT_WITH_QUARKUS_CORE).asString();
     }
 
+    @Deprecated(forRemoval = true)
     public static String getCodestartName(Extension extension) {
         return getMetadataValue(extension, MD_NESTED_CODESTART_NAME).asString();
+    }
+
+    public static List<String> getCodestartNames(Extension extension) {
+        final List<String> names = new ArrayList<>(getMetadataValue(extension, MD_NESTED_CODESTART_NAME).asStringList());
+        names.addAll(getMetadataValue(extension, MD_NESTED_CODESTART_EXTRA_NAMES).asStringList());
+        return names;
     }
 
     public static Optional<ArtifactCoords> getBom(Extension extension) {
@@ -87,7 +94,7 @@ public final class ExtensionProcessor {
     }
 
     public static CodestartKind getCodestartKind(Extension extension) {
-        if (getCodestartName(extension) == null) {
+        if (getCodestartNames(extension).isEmpty()) {
             return null;
         }
         return getMetadataValue(extension, MD_NESTED_CODESTART_KIND).toEnum(CodestartKind.class,
@@ -177,8 +184,13 @@ public final class ExtensionProcessor {
         return getShortName(extension);
     }
 
+    @Deprecated(forRemoval = true)
     public String getCodestartName() {
         return getCodestartName(extension);
+    }
+
+    public List<String> getCodestartNames() {
+        return getCodestartNames(extension);
     }
 
     public List<String> getCategories() {

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/Extension.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/Extension.java
@@ -12,6 +12,7 @@ public interface Extension {
 
     String MD_SHORT_NAME = "short-name";
     String MD_NESTED_CODESTART_NAME = "codestart.name";
+    String MD_NESTED_CODESTART_EXTRA_NAMES = "codestart.extra-names";
     String MD_NESTED_CODESTART_LANGUAGES = "codestart.languages";
     String MD_NESTED_CODESTART_KIND = "codestart.kind";
     String MD_NESTED_CODESTART_ARTIFACT = "codestart.artifact";

--- a/integration-tests/devtools/src/test/java/io/quarkus/platform/catalog/ExtensionProcessorTest.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/platform/catalog/ExtensionProcessorTest.java
@@ -2,7 +2,9 @@ package io.quarkus.platform.catalog;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -30,6 +32,7 @@ public class ExtensionProcessorTest extends PlatformAwareTestBase {
         assertThat(extensionProcessor.getCategories()).contains("web");
         assertThat(extensionProcessor.getCodestartKind()).isEqualTo(ExtensionProcessor.CodestartKind.EXTENSION_CODESTART);
         assertThat(extensionProcessor.getCodestartName()).isEqualTo("resteasy");
+        assertThat(extensionProcessor.getCodestartNames()).containsExactly("resteasy");
         assertThat(extensionProcessor.getCodestartArtifact())
                 .isEqualTo("io.quarkus:quarkus-project-core-extension-codestarts::jar:" + getQuarkusCoreVersion());
         assertThat(extensionProcessor.getCodestartLanguages()).contains("java", "kotlin", "scala");
@@ -65,12 +68,53 @@ public class ExtensionProcessorTest extends PlatformAwareTestBase {
         assertThat(extensionProcessor.getCategories()).contains("alt-languages");
         assertThat(extensionProcessor.getCodestartKind()).isEqualTo(ExtensionProcessor.CodestartKind.CORE);
         assertThat(extensionProcessor.getCodestartName()).isEqualTo("kotlin");
+        assertThat(extensionProcessor.getCodestartNames()).containsExactly("kotlin");
         assertThat(extensionProcessor.getCodestartLanguages()).isEmpty();
         assertThat(extensionProcessor.getCodestartArtifact())
                 .isEqualTo("io.quarkus:quarkus-project-core-extension-codestarts::jar:" + getQuarkusCoreVersion());
         assertThat(extensionProcessor.getKeywords()).contains("kotlin");
         assertThat(extensionProcessor.getExtendedKeywords()).contains("kotlin", "quarkus-kotlin", "services", "write");
         assertThat(extensionProcessor.getGuide()).isEqualTo("https://quarkus.io/guides/kotlin");
+    }
+
+    @Test
+    void testCodestartExtraNames() {
+        final Map<String, Object> codestart = new HashMap<>();
+        codestart.put("name", "primary-codestart");
+        codestart.put("extra-names", List.of("extra-one", "extra-two"));
+        final Extension extension = Extension.builder()
+                .setGroupId("io.quarkus")
+                .setArtifactId("quarkus-test")
+                .setVersion("1.0")
+                .setMetadata("codestart", codestart)
+                .build();
+        assertThat(ExtensionProcessor.getCodestartName(extension)).isEqualTo("primary-codestart");
+        assertThat(ExtensionProcessor.getCodestartNames(extension))
+                .containsExactly("primary-codestart", "extra-one", "extra-two");
+    }
+
+    @Test
+    void testCodestartNoExtraNames() {
+        final Map<String, Object> codestart = new HashMap<>();
+        codestart.put("name", "only-codestart");
+        final Extension extension = Extension.builder()
+                .setGroupId("io.quarkus")
+                .setArtifactId("quarkus-test")
+                .setVersion("1.0")
+                .setMetadata("codestart", codestart)
+                .build();
+        assertThat(ExtensionProcessor.getCodestartNames(extension)).containsExactly("only-codestart");
+    }
+
+    @Test
+    void testCodestartNamesEmpty() {
+        final Extension extension = Extension.builder()
+                .setGroupId("io.quarkus")
+                .setArtifactId("quarkus-test")
+                .setVersion("1.0")
+                .build();
+        assertThat(ExtensionProcessor.getCodestartNames(extension)).isEmpty();
+        assertThat(ExtensionProcessor.getCodestartKind(extension)).isNull();
     }
 
     @Test


### PR DESCRIPTION
## Summary

This allows extensions to potentially have a shared base + specific stuff.

- Add `codestart.extra-names` metadata field so extensions can declare additional codestarts alongside the existing `codestart.name`
- Add `ExtensionProcessor.getCodestartNames()` that merges `name` + `extra-names` into a single list
- Update `QuarkusCodestartCatalog.getExtensionCodestarts()` to use the new method with `flatMap`
- Deprecate `ExtensionProcessor.getCodestartName()` (singular)
- Fully backward compatible: old CLIs ignore `extra-names`, new CLIs fall back to `name` when `extra-names` is absent

Extensions can now declare:
```yaml
codestart:
  name: "primary-codestart"
  extra-names:
    - "additional-codestart"
  artifact: "io.quarkus:quarkus-project-core-extension-codestarts"
```