### PR TITLE
Fix startup NPE when the access log is enabled without a framework router

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/accesslog/AccessLogWithManagementInterfaceTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/accesslog/AccessLogWithManagementInterfaceTestCase.java
@@ -1,0 +1,92 @@
+package io.quarkus.vertx.http.accesslog;
+
+import java.util.function.Consumer;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Singleton;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
+import io.quarkus.vertx.http.deployment.RouteBuildItem;
+import io.restassured.RestAssured;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Reproducer for the management-interface variant of
+ * https://github.com/quarkusio/quarkus/issues/40420.
+ * <p>
+ * With the management interface enabled, the non-application (framework) routes move to the
+ * management interface, so no framework router exists on the main server. Enabling the access log
+ * together with a custom HTTP root path used to crash startup with a {@link NullPointerException}
+ * while attaching the access-log handler to the (null) framework router.
+ */
+public class AccessLogWithManagementInterfaceTestCase {
+
+    private static final String APP_PROPS = """
+            quarkus.management.enabled=true
+            quarkus.http.root-path=/app
+            quarkus.http.non-application-root-path=/q
+            quarkus.http.access-log.enabled=true
+            """;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset(APP_PROPS), "application.properties")
+                    .addClasses(MyObserver.class))
+            .addBuildChainCustomizer(buildCustomizer());
+
+    static Consumer<BuildChainBuilder> buildCustomizer() {
+        return new Consumer<BuildChainBuilder>() {
+            @Override
+            public void accept(BuildChainBuilder builder) {
+                builder.addBuildStep(new BuildStep() {
+                    @Override
+                    public void execute(BuildContext context) {
+                        // An application route (classified APPLICATION_ROUTE), so no framework router is created.
+                        HttpRootPathBuildItem buildItem = context.consume(HttpRootPathBuildItem.class);
+                        context.produce(buildItem.routeBuilder()
+                                .route("hello")
+                                .handler(new MyHandler())
+                                .blockingRoute()
+                                .build());
+                    }
+                }).produces(RouteBuildItem.class)
+                        .consumes(HttpRootPathBuildItem.class)
+                        .build();
+            }
+        };
+    }
+
+    public static class MyHandler implements Handler<RoutingContext> {
+        @Override
+        public void handle(RoutingContext routingContext) {
+            routingContext.response()
+                    .setStatusCode(200)
+                    .end(routingContext.request().path());
+        }
+    }
+
+    @Test
+    public void testApplicationStartsWithManagementInterfaceAndAccessLog() {
+        // The application boots (no NPE) and the application route is reachable under the HTTP root path.
+        RestAssured.given().get("/hello")
+                .then().statusCode(200).body(Matchers.equalTo("/app/hello"));
+    }
+
+    @Singleton
+    static class MyObserver {
+        void test(@Observes String event) {
+            // Do nothing
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/accesslog/AccessLogWithNonApplicationRootPathTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/accesslog/AccessLogWithNonApplicationRootPathTestCase.java
@@ -1,0 +1,146 @@
+package io.quarkus.vertx.http.accesslog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Singleton;
+
+import org.awaitility.Awaitility;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.bootstrap.util.IoUtils;
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
+import io.quarkus.vertx.http.deployment.RouteBuildItem;
+import io.restassured.RestAssured;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Reproducer for https://github.com/quarkusio/quarkus/issues/40420.
+ * <p>
+ * When the access log is enabled together with a custom non-application root path that is disjoint
+ * from the HTTP root path, and no framework router was ever created (no route is classified as a
+ * framework route), startup used to fail with a {@link NullPointerException} while attaching the
+ * access-log handler to the (null) framework router.
+ * <p>
+ * The application must start and the access log of application routes must keep working.
+ */
+public class AccessLogWithNonApplicationRootPathTestCase {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    try {
+                        Path logDirectory = Files.createTempDirectory("quarkus-tests");
+                        Properties p = new Properties();
+                        p.setProperty("quarkus.http.root-path", "/auth");
+                        p.setProperty("quarkus.http.non-application-root-path", "/q");
+                        p.setProperty("quarkus.http.access-log.enabled", "true");
+                        p.setProperty("quarkus.http.access-log.log-to-file", "true");
+                        p.setProperty("quarkus.http.access-log.base-file-name", "server");
+                        p.setProperty("quarkus.http.access-log.log-directory", logDirectory.toAbsolutePath().toString());
+                        ByteArrayOutputStream out = new ByteArrayOutputStream();
+                        p.store(out, null);
+                        return ShrinkWrap.create(JavaArchive.class)
+                                .add(new ByteArrayAsset(out.toByteArray()), "application.properties")
+                                .addClasses(MyObserver.class);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            })
+            .addBuildChainCustomizer(buildCustomizer());
+
+    static Consumer<BuildChainBuilder> buildCustomizer() {
+        return new Consumer<BuildChainBuilder>() {
+            @Override
+            public void accept(BuildChainBuilder builder) {
+                builder.addBuildStep(new BuildStep() {
+                    @Override
+                    public void execute(BuildContext context) {
+                        // An application route (classified APPLICATION_ROUTE), so no framework router is created.
+                        HttpRootPathBuildItem buildItem = context.consume(HttpRootPathBuildItem.class);
+                        context.produce(buildItem.routeBuilder()
+                                .route("hello")
+                                .handler(new MyHandler())
+                                .blockingRoute()
+                                .build());
+                    }
+                }).produces(RouteBuildItem.class)
+                        .consumes(HttpRootPathBuildItem.class)
+                        .build();
+            }
+        };
+    }
+
+    // Injected at runtime so the value survives the QuarkusUnitTest classloader boundary
+    // (a static field set by the archive producer would not be visible to the test method).
+    @ConfigProperty(name = "quarkus.http.access-log.log-directory")
+    Path logDirectory;
+
+    @BeforeEach
+    public void before() throws IOException {
+        Files.createDirectories(logDirectory);
+    }
+
+    @AfterEach
+    public void after() throws IOException {
+        IoUtils.recursiveDelete(logDirectory);
+    }
+
+    public static class MyHandler implements Handler<RoutingContext> {
+        @Override
+        public void handle(RoutingContext routingContext) {
+            routingContext.response()
+                    .setStatusCode(200)
+                    .end(routingContext.request().path());
+        }
+    }
+
+    @Test
+    public void testAccessLogWithDisjointNonApplicationRootPath() {
+        // The application boots (no NPE) and the application route is reachable under the HTTP root path.
+        // RestAssured is configured with the configured HTTP root path (/auth) as its base path.
+        RestAssured.given().get("/hello")
+                .then().statusCode(200).body(Matchers.equalTo("/auth/hello"));
+
+        // The request to the application route is written to the access log.
+        Awaitility.given().pollInterval(100, TimeUnit.MILLISECONDS)
+                .atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    Path logFile = logDirectory.resolve("server.log");
+                    assertThat(Files.exists(logFile)).isTrue();
+                    assertThat(Files.readString(logFile)).contains("/auth/hello");
+                });
+    }
+
+    @Singleton
+    static class MyObserver {
+        void test(@Observes String event) {
+            // Do nothing
+        }
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -653,10 +653,21 @@ public class VertxHttpRecorder {
         } else if (nonRootPath.startsWith(rootPath)) {
             httpRouteRouter.route().order(RouteConstants.ROUTE_ORDER_ACCESS_LOG_HANDLER).handler(handler);
         } else if (rootPath.startsWith(nonRootPath)) {
-            frameworkRouter.getValue().route().order(RouteConstants.ROUTE_ORDER_ACCESS_LOG_HANDLER).handler(handler);
+            // The framework (non-application) routes live on a dedicated router mounted above the
+            // application router. If that router was never created (e.g. all non-application routes
+            // moved to the management interface, or none were classified as framework routes), fall
+            // back to the application router so application routes are still logged.
+            if (frameworkRouter != null) {
+                frameworkRouter.getValue().route().order(RouteConstants.ROUTE_ORDER_ACCESS_LOG_HANDLER).handler(handler);
+            } else {
+                httpRouteRouter.route().order(RouteConstants.ROUTE_ORDER_ACCESS_LOG_HANDLER).handler(handler);
+            }
         } else {
             httpRouteRouter.route().order(RouteConstants.ROUTE_ORDER_ACCESS_LOG_HANDLER).handler(handler);
-            frameworkRouter.getValue().route().order(RouteConstants.ROUTE_ORDER_ACCESS_LOG_HANDLER).handler(handler);
+            // Only attach to the framework router when it exists; see comment above.
+            if (frameworkRouter != null) {
+                frameworkRouter.getValue().route().order(RouteConstants.ROUTE_ORDER_ACCESS_LOG_HANDLER).handler(handler);
+            }
         }
     }
 


### PR DESCRIPTION
The application fails to start with a `NullPointerException` when the access log is enabled and no framework (non-application) router exists on the main HTTP server. `VertxHttpRecorder.setupAccessLogHandler` dereferences the framework router's `RuntimeValue` unconditionally, but the deployment only creates that router when a dedicated non-application router is required *and* at least one route is classified as a framework route. When that is not the case the value is `null`, and startup crashes in `finalizeRouter`.

Two configurations trigger this:

- A custom, disjoint non-application root path, with no framework routes present:
  ```
  quarkus.http.root-path=/auth
  quarkus.http.non-application-root-path=/q
  quarkus.http.access-log.enabled=true
  ```
- The management interface enabled together with a custom root path. All non-application routes move to the management interface, so the main server has no framework router (reported on a production OpenShift deployment in https://github.com/quarkusio/quarkus/issues/40420#issuecomment-3833926675):
  ```
  quarkus.management.enabled=true
  quarkus.http.root-path=/app
  quarkus.http.access-log.enabled=true
  ```

The fix is deliberately defensive: when there is no framework router there are no framework routes to log, so the access-log handler is simply not attached to it, and application-route logging is unaffected. It does not change how routes are classified, which would be riskier and is out of scope here.

Workarounds exist (disabling the access log, or aligning the management / non-application paths), but the startup crash is a bug regardless.

- Fixes: #40420