### PR TITLE
Missing %l in the access log documentation

### DIFF
--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -497,6 +497,7 @@ include::{generated-dir}/config/quarkus-vertx-http_quarkus.http.access-log.adoc[
 |Bytes sent, excluding HTTP headers, or '-' if no bytes were sent             | `%b`     |
 |Bytes sent, excluding HTTP headers                                           | `%B`     | `%{BYTES_SENT}`
 |Remote host name                                                             | `%h`     | `%{REMOTE_HOST}`
+|Remote logical username from identd (always returns '-')                     | `%l`     |
 |Request protocol                                                             | `%H`     | `%{PROTOCOL}`
 |Request method                                                               | `%m`     | `%{METHOD}`
 |Local port                                                                   | `%p`     | `%{LOCAL_PORT}`


### PR DESCRIPTION
Fix https://github.com/quarkusio/quarkusio.github.io/issues/2671

