### PR TITLE
Generate JavaScript client for GraphQL operations at build time

### DIFF
--- a/docs/src/main/asciidoc/smallrye-graphql.adoc
+++ b/docs/src/main/asciidoc/smallrye-graphql.adoc
@@ -1299,6 +1299,92 @@ When `SomeBusinessException` occurs, the error output will contain the Error cod
 
 <1> The error code
 
+== JavaScript Client
+
+When `quarkus.smallrye-graphql.js-client.enabled` is set to `true`, the extension generates a JavaScript client library and a typed proxy module as web resources at build time. These can be imported via the standard https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap[import map] convention when using https://quarkus.io/guides/web-dependency-locator[Web Dependency Locator].
+
+=== Enabling the Client
+
+Add to `application.properties`:
+
+[source,properties]
+----
+quarkus.smallrye-graphql.js-client.enabled=true
+----
+
+This generates two resources:
+
+[cols="1,2"]
+|===
+| Resource | Purpose
+
+| `@quarkus/graphql`
+| Reusable `GraphQLClient` class with `query()`, `mutate()`, and `subscribe()` methods
+
+| `@quarkus/graphql-api`
+| Typed proxy with exports for each GraphQL query, mutation, and subscription
+|===
+
+=== Using the Typed Proxy
+
+The generated proxy exports `Queries`, `Mutations`, and `Subscriptions` objects, plus the underlying `client` instance:
+
+[source,javascript]
+----
+import { client, Queries, Mutations } from '@quarkus/graphql-api';
+
+// Call a query
+const data = await Queries.allBooks();
+
+// Call a query with variables
+const result = await Queries.book({ id: 42 });
+
+// Call a mutation
+const created = await Mutations.createBook({ title: 'Quarkus in Action' });
+----
+
+Each function accepts a `variables` object matching the GraphQL operation's arguments. The GraphQL query string, including the selection set, is generated automatically at build time.
+
+=== Subscriptions
+
+Subscription operations return a `Subscription` object:
+
+[source,javascript]
+----
+import { Subscriptions } from '@quarkus/graphql-api';
+
+const sub = Subscriptions.onBookCreated()
+    .onData(data => console.log('New book:', data))
+    .onError(err => console.error('Error:', err))
+    .onComplete(() => console.log('Stream completed'));
+
+// Cancel later
+await sub.cancel();
+----
+
+Subscriptions use the `graphql-transport-ws` WebSocket subprotocol.
+
+=== Using the Client Library Directly
+
+For more control, import the `GraphQLClient` class directly:
+
+[source,javascript]
+----
+import { GraphQLClient } from '@quarkus/graphql';
+
+const client = new GraphQLClient({ endpoint: '/graphql' });
+
+// Custom query
+const data = await client.query(`
+    query {
+        allBooks {
+            title
+            author { name }
+        }
+    }
+`);
+----
+
 == Conclusion
 
 SmallRye GraphQL enables clients to retrieve the exact data that is

--- a/extensions/smallrye-graphql/deployment/pom.xml
+++ b/extensions/smallrye-graphql/deployment/pom.xml
@@ -87,6 +87,11 @@
             <artifactId>quarkus-elytron-security-properties-file-deployment</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-web-dependency-locator-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
@@ -3,6 +3,7 @@ package io.quarkus.smallrye.graphql.deployment;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -61,6 +62,8 @@ import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.metrics.MetricsCapabilityBuildItem;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.deployment.util.IoUtil;
 import io.quarkus.devui.spi.buildtime.FooterLogBuildItem;
 import io.quarkus.maven.dependency.GACT;
 import io.quarkus.runtime.LaunchMode;
@@ -77,6 +80,8 @@ import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.deployment.WebsocketSubProtocolsBuildItem;
+import io.quarkus.vertx.http.deployment.spi.GeneratedStaticResourceBuildItem;
+import io.quarkus.vertx.http.deployment.spi.WebDependencyJarBuildItem;
 import io.quarkus.vertx.http.deployment.webjar.WebJarBuildItem;
 import io.quarkus.vertx.http.deployment.webjar.WebJarResourcesFilter;
 import io.quarkus.vertx.http.deployment.webjar.WebJarResultsBuildItem;
@@ -120,14 +125,18 @@ import io.smallrye.graphql.schema.SchemaBuilder;
 import io.smallrye.graphql.schema.helper.TypeAutoNameStrategy;
 import io.smallrye.graphql.schema.model.Argument;
 import io.smallrye.graphql.schema.model.DirectiveType;
+import io.smallrye.graphql.schema.model.EnumType;
+import io.smallrye.graphql.schema.model.EnumValue;
 import io.smallrye.graphql.schema.model.Field;
 import io.smallrye.graphql.schema.model.InputType;
 import io.smallrye.graphql.schema.model.Operation;
 import io.smallrye.graphql.schema.model.Reference;
+import io.smallrye.graphql.schema.model.ReferenceType;
 import io.smallrye.graphql.schema.model.Scalars;
 import io.smallrye.graphql.schema.model.Schema;
 import io.smallrye.graphql.schema.model.Type;
 import io.smallrye.graphql.schema.model.UnionType;
+import io.smallrye.graphql.schema.model.Wrapper;
 import io.smallrye.graphql.spi.EventingService;
 import io.smallrye.graphql.spi.LookupService;
 import io.smallrye.graphql.spi.config.Config;
@@ -368,6 +377,20 @@ public class SmallRyeGraphQLProcessor {
         graphQLDevUILogProducer.produce(new GraphQLDevUILogBuildItem(publisher));
     }
 
+    @BuildStep
+    void buildSchema(
+            BuildProducer<SmallRyeGraphQLSchemaBuildItem> schemaBuildItemProducer,
+            BuildProducer<SystemPropertyBuildItem> systemPropertyProducer,
+            SmallRyeGraphQLFinalIndexBuildItem graphQLFinalIndexBuildItem,
+            SmallRyeGraphQLConfig graphQLConfig) {
+
+        activateFederation(graphQLConfig, systemPropertyProducer, graphQLFinalIndexBuildItem);
+        graphQLConfig.extraScalars().ifPresent(this::registerExtraScalarsInSchema);
+        Schema schema = SchemaBuilder.build(graphQLFinalIndexBuildItem.getFinalIndex(),
+                Converters.getImplicitConverter(TypeAutoNameStrategy.class).convert(graphQLConfig.autoNameStrategy()));
+        schemaBuildItemProducer.produce(new SmallRyeGraphQLSchemaBuildItem(schema));
+    }
+
     @Record(ExecutionTime.STATIC_INIT)
     @BuildStep
     void buildExecutionService(
@@ -375,16 +398,12 @@ public class SmallRyeGraphQLProcessor {
             BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchyProducer,
             BuildProducer<SmallRyeGraphQLInitializedBuildItem> graphQLInitializedProducer,
             SmallRyeGraphQLRecorder recorder,
-            SmallRyeGraphQLFinalIndexBuildItem graphQLFinalIndexBuildItem,
+            SmallRyeGraphQLSchemaBuildItem schemaBuildItem,
             BeanContainerBuildItem beanContainer,
-            BuildProducer<SystemPropertyBuildItem> systemPropertyProducer,
             SmallRyeGraphQLConfig graphQLConfig,
             Optional<GraphQLDevUILogBuildItem> graphQLDevUILogBuildItem) {
 
-        activateFederation(graphQLConfig, systemPropertyProducer, graphQLFinalIndexBuildItem);
-        graphQLConfig.extraScalars().ifPresent(this::registerExtraScalarsInSchema);
-        Schema schema = SchemaBuilder.build(graphQLFinalIndexBuildItem.getFinalIndex(),
-                Converters.getImplicitConverter(TypeAutoNameStrategy.class).convert(graphQLConfig.autoNameStrategy()));
+        Schema schema = schemaBuildItem.getSchema();
 
         Optional publisher = Optional.empty();
         if (graphQLDevUILogBuildItem.isPresent()) {
@@ -416,6 +435,377 @@ public class SmallRyeGraphQLProcessor {
                     Scalars.addJson();
             }
         }
+    }
+
+    @BuildStep
+    void generateJsClient(
+            SmallRyeGraphQLConfig graphQLConfig,
+            SmallRyeGraphQLSchemaBuildItem schemaBuildItem,
+            HttpRootPathBuildItem httpRootPathBuildItem,
+            BuildProducer<GeneratedStaticResourceBuildItem> staticResourceProducer) {
+
+        if (!graphQLConfig.jsClient().enabled()) {
+            return;
+        }
+
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        try (InputStream is = tccl.getResourceAsStream("graphql/graphql-client.js")) {
+            if (is == null) {
+                throw new IllegalStateException("graphql/graphql-client.js not found on classpath");
+            }
+            staticResourceProducer.produce(
+                    new GeneratedStaticResourceBuildItem(
+                            "/_static/quarkus-graphql/graphql-client.js",
+                            IoUtil.readBytes(is)));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        try (InputStream is = tccl.getResourceAsStream("graphql/graphql-client.d.ts")) {
+            if (is == null) {
+                throw new IllegalStateException("graphql/graphql-client.d.ts not found on classpath");
+            }
+            staticResourceProducer.produce(
+                    new GeneratedStaticResourceBuildItem(
+                            "/_static/quarkus-graphql/graphql-client.d.ts",
+                            IoUtil.readBytes(is)));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        Schema schema = schemaBuildItem.getSchema();
+        String resolvedPath = httpRootPathBuildItem.resolvePath(graphQLConfig.rootPath());
+        String proxyJs = generateGraphQLProxy(schema, resolvedPath);
+        staticResourceProducer.produce(
+                new GeneratedStaticResourceBuildItem(
+                        "/_static/quarkus-graphql-api/graphql-api.js",
+                        proxyJs.getBytes(StandardCharsets.UTF_8)));
+
+        String proxyDts = generateGraphQLDeclarations(schema);
+        staticResourceProducer.produce(
+                new GeneratedStaticResourceBuildItem(
+                        "/_static/quarkus-graphql-api/graphql-api.d.ts",
+                        proxyDts.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @BuildStep
+    void registerGraphQLWebDependency(
+            SmallRyeGraphQLConfig graphQLConfig,
+            CurateOutcomeBuildItem curateOutcome,
+            BuildProducer<WebDependencyJarBuildItem> webDependencyProducer) {
+
+        if (!graphQLConfig.jsClient().enabled()) {
+            return;
+        }
+
+        curateOutcome.getApplicationModel().getDependencies().stream()
+                .filter(dep -> dep.getGroupId().equals("io.quarkus")
+                        && dep.getArtifactId().equals("quarkus-smallrye-graphql"))
+                .findFirst()
+                .ifPresent(dep -> webDependencyProducer.produce(new WebDependencyJarBuildItem(
+                        dep.getKey(),
+                        dep.getResolvedPaths().getSinglePath(),
+                        Map.of(
+                                "@quarkus/graphql", "/_static/quarkus-graphql/graphql-client.js",
+                                "@quarkus/graphql/", "/_static/quarkus-graphql/",
+                                "@quarkus/graphql-api", "/_static/quarkus-graphql-api/graphql-api.js"))));
+    }
+
+    private String generateGraphQLProxy(Schema schema, String endpointPath) {
+        StringBuilder js = new StringBuilder();
+        js.append("import { GraphQLClient } from '@quarkus/graphql';\n\n");
+        js.append("export const client = new GraphQLClient({ endpoint: '")
+                .append(escapeJs(endpointPath)).append("' });\n\n");
+
+        generateOperationExports(js, "Queries", "query", schema.getQueries(), schema);
+        generateOperationExports(js, "Mutations", "mutation", schema.getMutations(), schema);
+        generateOperationExports(js, "Subscriptions", "subscription", schema.getSubscriptions(), schema);
+
+        return js.toString();
+    }
+
+    private void generateOperationExports(StringBuilder js, String exportName, String operationKeyword,
+            Set<Operation> operations, Schema schema) {
+        if (operations == null || operations.isEmpty()) {
+            js.append("export const ").append(exportName).append(" = {};\n\n");
+            return;
+        }
+
+        js.append("export const ").append(exportName).append(" = {\n");
+        List<Operation> sorted = operations.stream()
+                .sorted(Comparator.comparing(Operation::getName))
+                .collect(Collectors.toList());
+
+        for (int i = 0; i < sorted.size(); i++) {
+            Operation op = sorted.get(i);
+            String queryString = generateQueryString(op, operationKeyword, schema);
+            String clientMethod = "subscription".equals(operationKeyword) ? "subscribe"
+                    : "mutation".equals(operationKeyword) ? "mutate" : "query";
+            js.append("    ").append(escapeJs(op.getName()))
+                    .append(": (variables) => client.").append(clientMethod).append("('")
+                    .append(escapeJs(queryString)).append("', variables)");
+            if (i < sorted.size() - 1) {
+                js.append(",");
+            }
+            js.append("\n");
+        }
+        js.append("};\n\n");
+    }
+
+    private String generateQueryString(Operation op, String operationKeyword, Schema schema) {
+        StringBuilder qs = new StringBuilder();
+        qs.append(operationKeyword).append(" ").append(op.getName());
+
+        if (op.hasArguments()) {
+            qs.append("(");
+            List<Argument> args = op.getArguments();
+            for (int i = 0; i < args.size(); i++) {
+                Argument arg = args.get(i);
+                qs.append("$").append(arg.getName()).append(": ").append(graphqlTypeName(arg));
+                if (i < args.size() - 1) {
+                    qs.append(", ");
+                }
+            }
+            qs.append(")");
+        }
+
+        qs.append(" { ").append(op.getName());
+
+        if (op.hasArguments()) {
+            qs.append("(");
+            List<Argument> args = op.getArguments();
+            for (int i = 0; i < args.size(); i++) {
+                Argument arg = args.get(i);
+                qs.append(arg.getName()).append(": $").append(arg.getName());
+                if (i < args.size() - 1) {
+                    qs.append(", ");
+                }
+            }
+            qs.append(")");
+        }
+
+        Reference returnRef = op.getReference();
+        if (returnRef != null && needsSelectionSet(returnRef)) {
+            String selectionSet = generateSelectionSet(returnRef, schema);
+            if (!selectionSet.isEmpty()) {
+                qs.append(" { ").append(selectionSet).append("}");
+            }
+        }
+
+        qs.append(" }");
+        return qs.toString();
+    }
+
+    private boolean needsSelectionSet(Reference ref) {
+        ReferenceType type = ref.getType();
+        return type == ReferenceType.TYPE || type == ReferenceType.INTERFACE;
+    }
+
+    private String generateSelectionSet(Reference ref, Schema schema) {
+        Type type = schema.getTypes().get(ref.getName());
+        if (type == null || type.getFields() == null || type.getFields().isEmpty()) {
+            return "";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (Map.Entry<String, Field> entry : new java.util.TreeMap<>(type.getFields()).entrySet()) {
+            Field field = entry.getValue();
+            Reference fieldRef = field.getReference();
+            if (fieldRef != null) {
+                ReferenceType fieldType = fieldRef.getType();
+                if (fieldType == ReferenceType.SCALAR || fieldType == ReferenceType.ENUM) {
+                    sb.append(field.getName()).append(" ");
+                }
+            }
+        }
+        return sb.toString();
+    }
+
+    private String graphqlTypeName(Field field) {
+        Reference ref = field.getReference();
+        String baseName = ref.getName();
+
+        if (field.hasWrapper()) {
+            Wrapper wrapper = field.getWrapper();
+            if (wrapper.getWrapperType() == io.smallrye.graphql.schema.model.WrapperType.COLLECTION
+                    || wrapper.getWrapperType() == io.smallrye.graphql.schema.model.WrapperType.ARRAY) {
+                String inner = baseName;
+                if (wrapper.isWrappedTypeNotNull()) {
+                    inner += "!";
+                }
+                baseName = "[" + inner + "]";
+            }
+        }
+
+        if (field.isNotNull()) {
+            baseName += "!";
+        }
+
+        return baseName;
+    }
+
+    private static String escapeJs(String value) {
+        return value.replace("\\", "\\\\").replace("'", "\\'");
+    }
+
+    private String generateGraphQLDeclarations(Schema schema) {
+        StringBuilder ts = new StringBuilder();
+        ts.append("import { GraphQLClient, Subscription } from '@quarkus/graphql';\n\n");
+        ts.append("export declare const client: GraphQLClient;\n");
+
+        if (schema.getEnums() != null) {
+            for (Map.Entry<String, EnumType> entry : new java.util.TreeMap<>(schema.getEnums()).entrySet()) {
+                EnumType enumType = entry.getValue();
+                if (enumType.hasValues()) {
+                    ts.append("\nexport type ").append(enumType.getName()).append(" = ");
+                    List<EnumValue> values = new ArrayList<>(enumType.getValues());
+                    for (int i = 0; i < values.size(); i++) {
+                        ts.append("'").append(values.get(i).getValue()).append("'");
+                        if (i < values.size() - 1) {
+                            ts.append(" | ");
+                        }
+                    }
+                    ts.append(";\n");
+                }
+            }
+        }
+
+        if (schema.getTypes() != null) {
+            for (Map.Entry<String, Type> entry : new java.util.TreeMap<>(schema.getTypes()).entrySet()) {
+                generateTypeInterface(ts, entry.getKey(), entry.getValue().getFields());
+            }
+        }
+
+        if (schema.getInputs() != null) {
+            for (Map.Entry<String, InputType> entry : new java.util.TreeMap<>(schema.getInputs()).entrySet()) {
+                generateTypeInterface(ts, entry.getKey(), entry.getValue().getFields());
+            }
+        }
+
+        generateOperationDeclarations(ts, "Queries", schema.getQueries(), schema, false);
+        generateOperationDeclarations(ts, "Mutations", schema.getMutations(), schema, false);
+        generateOperationDeclarations(ts, "Subscriptions", schema.getSubscriptions(), schema, true);
+
+        return ts.toString();
+    }
+
+    private void generateTypeInterface(StringBuilder ts, String name, Map<String, Field> fields) {
+        ts.append("\nexport interface ").append(name).append(" {\n");
+        if (fields != null) {
+            for (Map.Entry<String, Field> fieldEntry : new java.util.TreeMap<>(fields).entrySet()) {
+                Field field = fieldEntry.getValue();
+                String tsType = typescriptType(field);
+                ts.append("    ").append(field.getName()).append(": ").append(tsType).append(";\n");
+            }
+        }
+        ts.append("}\n");
+    }
+
+    private void generateOperationDeclarations(StringBuilder ts, String exportName, Set<Operation> operations,
+            Schema schema, boolean isSubscription) {
+        ts.append("\nexport declare const ").append(exportName).append(": {\n");
+        if (operations != null && !operations.isEmpty()) {
+            List<Operation> sorted = operations.stream()
+                    .sorted(Comparator.comparing(Operation::getName))
+                    .collect(Collectors.toList());
+
+            for (int i = 0; i < sorted.size(); i++) {
+                Operation op = sorted.get(i);
+                ts.append("    ").append(op.getName()).append(": (");
+
+                if (op.hasArguments()) {
+                    ts.append("variables: { ");
+                    List<Argument> args = op.getArguments();
+                    for (int j = 0; j < args.size(); j++) {
+                        Argument arg = args.get(j);
+                        ts.append(arg.getName()).append(": ").append(typescriptType(arg));
+                        if (j < args.size() - 1) {
+                            ts.append("; ");
+                        }
+                    }
+                    ts.append(" }");
+                } else {
+                    ts.append("variables?: Record<string, never>");
+                }
+
+                String returnType = typescriptReturnType(op, schema);
+                if (isSubscription) {
+                    ts.append(") => Subscription");
+                } else {
+                    ts.append(") => Promise<").append(returnType).append(">");
+                }
+
+                if (i < sorted.size() - 1) {
+                    ts.append(";");
+                }
+                ts.append("\n");
+            }
+        }
+        ts.append("};\n");
+    }
+
+    private String typescriptReturnType(Operation op, Schema schema) {
+        Reference ref = op.getReference();
+        if (ref == null) {
+            return "unknown";
+        }
+        String baseType = typescriptBaseType(ref);
+        if (op.hasWrapper()) {
+            Wrapper wrapper = op.getWrapper();
+            if (wrapper.getWrapperType() == io.smallrye.graphql.schema.model.WrapperType.COLLECTION
+                    || wrapper.getWrapperType() == io.smallrye.graphql.schema.model.WrapperType.ARRAY) {
+                return baseType + "[]";
+            }
+        }
+        return baseType;
+    }
+
+    private String typescriptType(Field field) {
+        Reference ref = field.getReference();
+        if (ref == null) {
+            return "unknown";
+        }
+        String baseType = typescriptBaseType(ref);
+
+        if (field.hasWrapper()) {
+            Wrapper wrapper = field.getWrapper();
+            if (wrapper.getWrapperType() == io.smallrye.graphql.schema.model.WrapperType.COLLECTION
+                    || wrapper.getWrapperType() == io.smallrye.graphql.schema.model.WrapperType.ARRAY) {
+                baseType = baseType + "[]";
+            }
+        }
+
+        if (!field.isNotNull()) {
+            baseType += " | null";
+        }
+
+        return baseType;
+    }
+
+    private static final Map<String, String> GRAPHQL_TO_TS = Map.ofEntries(
+            Map.entry("String", "string"),
+            Map.entry("ID", "string"),
+            Map.entry("Boolean", "boolean"),
+            Map.entry("Int", "number"),
+            Map.entry("Float", "number"),
+            Map.entry("BigInteger", "number"),
+            Map.entry("BigDecimal", "number"),
+            Map.entry("Date", "string"),
+            Map.entry("DateTime", "string"),
+            Map.entry("Time", "string"),
+            Map.entry("Period", "string"),
+            Map.entry("Duration", "string"));
+
+    private String typescriptBaseType(Reference ref) {
+        String name = ref.getName();
+        String mapped = GRAPHQL_TO_TS.get(name);
+        if (mapped != null) {
+            return mapped;
+        }
+        if (ref.getType() == ReferenceType.SCALAR) {
+            return "unknown";
+        }
+        return name;
     }
 
     @Record(ExecutionTime.RUNTIME_INIT)

--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLSchemaBuildItem.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLSchemaBuildItem.java
@@ -1,0 +1,17 @@
+package io.quarkus.smallrye.graphql.deployment;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+import io.smallrye.graphql.schema.model.Schema;
+
+final class SmallRyeGraphQLSchemaBuildItem extends SimpleBuildItem {
+
+    private final Schema schema;
+
+    SmallRyeGraphQLSchemaBuildItem(Schema schema) {
+        this.schema = schema;
+    }
+
+    public Schema getSchema() {
+        return schema;
+    }
+}

--- a/extensions/smallrye-graphql/deployment/src/main/resources/graphql/graphql-client.d.ts
+++ b/extensions/smallrye-graphql/deployment/src/main/resources/graphql/graphql-client.d.ts
@@ -1,0 +1,27 @@
+export interface GraphQLClientOptions {
+    endpoint?: string;
+    token?: string;
+    tokenProvider?: () => string | Promise<string>;
+}
+
+export class GraphQLClient {
+    static configure(options?: GraphQLClientOptions): void;
+    constructor(options?: GraphQLClientOptions);
+    endpoint: string;
+    token: string | null;
+    query<T = unknown>(queryString: string, variables?: Record<string, unknown>): Promise<T>;
+    mutate<T = unknown>(queryString: string, variables?: Record<string, unknown>): Promise<T>;
+    subscribe(queryString: string, variables?: Record<string, unknown>): Subscription;
+}
+
+export class GraphQLError extends Error {
+    errors: Array<{ message: string; [key: string]: unknown }>;
+    data: unknown;
+}
+
+export class Subscription {
+    onData(callback: (data: unknown) => void): Subscription;
+    onError(callback: (error: unknown) => void): Subscription;
+    onComplete(callback: () => void): Subscription;
+    cancel(): Promise<void>;
+}

--- a/extensions/smallrye-graphql/deployment/src/main/resources/graphql/graphql-client.js
+++ b/extensions/smallrye-graphql/deployment/src/main/resources/graphql/graphql-client.js
@@ -1,0 +1,203 @@
+export class GraphQLClient {
+    static _config = {};
+
+    static configure(options = {}) {
+        GraphQLClient._config = { ...GraphQLClient._config, ...options };
+    }
+
+    _endpoint;
+    _token = null;
+    _tokenProvider = null;
+
+    constructor(options = {}) {
+        const merged = { ...GraphQLClient._config, ...options };
+        this._endpoint = merged.endpoint || '/graphql';
+        this._token = merged.token || null;
+        this._tokenProvider = merged.tokenProvider || null;
+    }
+
+    get endpoint() {
+        return this._endpoint;
+    }
+
+    set endpoint(value) {
+        this._endpoint = value;
+    }
+
+    get token() {
+        return this._token;
+    }
+
+    set token(value) {
+        this._token = value;
+    }
+
+    async query(queryString, variables) {
+        return this._fetch(queryString, variables);
+    }
+
+    async mutate(queryString, variables) {
+        return this._fetch(queryString, variables);
+    }
+
+    subscribe(queryString, variables) {
+        const token = this._resolveTokenSync();
+        return new Subscription(this._wsUrl(), queryString, variables, token);
+    }
+
+    async _fetch(queryString, variables) {
+        const body = { query: queryString };
+        if (variables && Object.keys(variables).length > 0) {
+            body.variables = variables;
+        }
+        const headers = {
+            'Content-Type': 'application/json',
+            'Accept': 'application/graphql-response+json, application/json',
+        };
+
+        const token = await this._resolveToken();
+        if (token) {
+            headers['Authorization'] = token;
+        }
+
+        const resp = await fetch(this._endpoint, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify(body),
+        });
+        const json = await resp.json();
+        if (json.errors && json.errors.length > 0) {
+            throw new GraphQLError(json.errors, json.data);
+        }
+        return json.data;
+    }
+
+    _wsUrl() {
+        const loc = typeof location !== 'undefined' ? location : {};
+        const proto = (loc.protocol === 'https:') ? 'wss:' : 'ws:';
+        return `${proto}//${loc.host}${this._endpoint}`;
+    }
+
+    _resolveToken() {
+        const provider = this._tokenProvider || GraphQLClient._config.tokenProvider;
+        if (provider) {
+            return provider();
+        }
+        return this._token || GraphQLClient._config.token || null;
+    }
+
+    _resolveTokenSync() {
+        const provider = this._tokenProvider || GraphQLClient._config.tokenProvider;
+        if (provider) {
+            const result = provider();
+            if (result && typeof result.then === 'function') {
+                return null;
+            }
+            return result;
+        }
+        return this._token || GraphQLClient._config.token || null;
+    }
+}
+
+export class GraphQLError extends Error {
+    constructor(errors, data) {
+        super(errors.map(e => e.message).join('; '));
+        this.name = 'GraphQLError';
+        this.errors = errors;
+        this.data = data;
+    }
+}
+
+export class Subscription {
+    _ws = null;
+    _url;
+    _query;
+    _variables;
+    _token;
+    _id = '1';
+    _dataCallback = null;
+    _errorCallback = null;
+    _completeCallback = null;
+
+    constructor(url, query, variables, token) {
+        this._url = url;
+        this._query = query;
+        this._variables = variables;
+        this._token = token;
+        this._connect();
+    }
+
+    onData(callback) {
+        this._dataCallback = callback;
+        return this;
+    }
+
+    onError(callback) {
+        this._errorCallback = callback;
+        return this;
+    }
+
+    onComplete(callback) {
+        this._completeCallback = callback;
+        return this;
+    }
+
+    async cancel() {
+        if (this._ws && this._ws.readyState === WebSocket.OPEN) {
+            this._ws.send(JSON.stringify({ id: this._id, type: 'complete' }));
+            this._ws.close();
+        }
+        this._ws = null;
+    }
+
+    _connect() {
+        const protocols = ['graphql-transport-ws'];
+        if (this._token) {
+            const encoded = encodeURIComponent(
+                'quarkus-http-upgrade#Authorization#' + this._token
+            );
+            protocols.push('bearer-token-carrier', encoded);
+        }
+        this._ws = new WebSocket(this._url, protocols);
+
+        this._ws.onopen = () => {
+            this._ws.send(JSON.stringify({ type: 'connection_init' }));
+        };
+
+        this._ws.onmessage = (event) => {
+            const msg = JSON.parse(event.data);
+            switch (msg.type) {
+                case 'connection_ack':
+                    this._ws.send(JSON.stringify({
+                        id: this._id,
+                        type: 'subscribe',
+                        payload: { query: this._query, variables: this._variables },
+                    }));
+                    break;
+                case 'next':
+                    if (this._dataCallback && msg.payload) {
+                        const data = msg.payload.data;
+                        this._dataCallback(data);
+                    }
+                    break;
+                case 'error':
+                    if (this._errorCallback) {
+                        this._errorCallback(msg.payload);
+                    }
+                    break;
+                case 'complete':
+                    if (this._completeCallback) {
+                        this._completeCallback();
+                    }
+                    this._ws.close();
+                    break;
+            }
+        };
+
+        this._ws.onerror = (err) => {
+            if (this._errorCallback) {
+                this._errorCallback(err);
+            }
+        };
+    }
+}

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLJsClientDisabledTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLJsClientDisabledTest.java
@@ -1,0 +1,34 @@
+package io.quarkus.smallrye.graphql.deployment;
+
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+
+public class GraphQLJsClientDisabledTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(TestResource.class, TestPojo.class, TestPojo.Number.class,
+                            TestGenericsPojo.class, TestRandom.class,
+                            TestUnion.class, TestUnionMember.class,
+                            BusinessException.class, CustomDirective.class)
+                    .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"));
+
+    @Test
+    public void testClientLibraryNotServedWhenDisabled() {
+        RestAssured.get("/_static/quarkus-graphql/graphql-client.js")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    public void testTypedProxyNotServedWhenDisabled() {
+        RestAssured.get("/_static/quarkus-graphql-api/graphql-api.js")
+                .then()
+                .statusCode(404);
+    }
+}

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLJsClientTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLJsClientTest.java
@@ -1,0 +1,95 @@
+package io.quarkus.smallrye.graphql.deployment;
+
+import static org.hamcrest.CoreMatchers.containsString;
+
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+
+public class GraphQLJsClientTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(TestResource.class, TestPojo.class, TestPojo.Number.class,
+                            TestGenericsPojo.class, TestRandom.class,
+                            TestUnion.class, TestUnionMember.class,
+                            BusinessException.class, CustomDirective.class)
+                    .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"))
+            .overrideConfigKey("quarkus.smallrye-graphql.js-client.enabled", "true");
+
+    @Test
+    public void testClientLibraryIsServed() {
+        RestAssured.get("/_static/quarkus-graphql/graphql-client.js")
+                .then()
+                .statusCode(200)
+                .body(containsString("export class GraphQLClient"));
+    }
+
+    @Test
+    public void testTypedProxyIsServed() {
+        RestAssured.get("/_static/quarkus-graphql-api/graphql-api.js")
+                .then()
+                .statusCode(200)
+                .body(containsString("import { GraphQLClient }"))
+                .body(containsString("export const client"))
+                .body(containsString("export const Queries"))
+                .body(containsString("export const Mutations"));
+    }
+
+    @Test
+    public void testProxyContainsQueryOperations() {
+        RestAssured.get("/_static/quarkus-graphql-api/graphql-api.js")
+                .then()
+                .statusCode(200)
+                .body(containsString("ping"))
+                .body(containsString("query ping"))
+                .body(containsString("message"));
+    }
+
+    @Test
+    public void testProxyContainsMutationOperations() {
+        RestAssured.get("/_static/quarkus-graphql-api/graphql-api.js")
+                .then()
+                .statusCode(200)
+                .body(containsString("moo"))
+                .body(containsString("mutation moo"));
+    }
+
+    @Test
+    public void testClientDeclarationsAreServed() {
+        RestAssured.get("/_static/quarkus-graphql/graphql-client.d.ts")
+                .then()
+                .statusCode(200)
+                .body(containsString("export class GraphQLClient"))
+                .body(containsString("export class GraphQLError"))
+                .body(containsString("export class Subscription"));
+    }
+
+    @Test
+    public void testTypedProxyDeclarationsAreServed() {
+        RestAssured.get("/_static/quarkus-graphql-api/graphql-api.d.ts")
+                .then()
+                .statusCode(200)
+                .body(containsString("import { GraphQLClient, Subscription }"))
+                .body(containsString("export declare const client: GraphQLClient"))
+                .body(containsString("export declare const Queries"))
+                .body(containsString("export declare const Mutations"))
+                .body(containsString("export interface TestPojo"));
+    }
+
+    @Test
+    public void testDeclarationsContainOperationTypes() {
+        RestAssured.get("/_static/quarkus-graphql-api/graphql-api.d.ts")
+                .then()
+                .statusCode(200)
+                .body(containsString("ping:"))
+                .body(containsString("Promise<TestPojo>"))
+                .body(containsString("moo:"))
+                .body(containsString("name: string"));
+    }
+
+}

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLWebDependencyLocatorTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLWebDependencyLocatorTest.java
@@ -1,0 +1,34 @@
+package io.quarkus.smallrye.graphql.deployment;
+
+import static org.hamcrest.CoreMatchers.containsString;
+
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+
+public class GraphQLWebDependencyLocatorTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(TestResource.class, TestPojo.class, TestPojo.Number.class,
+                            TestGenericsPojo.class, TestRandom.class,
+                            TestUnion.class, TestUnionMember.class,
+                            BusinessException.class, CustomDirective.class)
+                    .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"))
+            .overrideConfigKey("quarkus.smallrye-graphql.js-client.enabled", "true");
+
+    @Test
+    public void testImportMapContainsGraphQLMappings() {
+        RestAssured.get("/_importmap/generated_importmap.js")
+                .then()
+                .statusCode(200)
+                .body(containsString("@quarkus/graphql"))
+                .body(containsString("/_static/quarkus-graphql/graphql-client.js"))
+                .body(containsString("@quarkus/graphql-api"))
+                .body(containsString("/_static/quarkus-graphql-api/graphql-api.js"));
+    }
+}

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLConfig.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLConfig.java
@@ -90,6 +90,12 @@ public interface SmallRyeGraphQLConfig {
     SmallRyeGraphQLUIConfig ui();
 
     /**
+     * Configuration properties for the JavaScript client proxy generation
+     */
+    @WithName("js-client")
+    SmallRyeGraphQLJsClientConfig jsClient();
+
+    /**
      * Additional scalars to register in the schema.
      * These are taken from the `graphql-java-extended-scalars` library.
      */

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLJsClientConfig.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLJsClientConfig.java
@@ -1,0 +1,14 @@
+package io.quarkus.smallrye.graphql.runtime;
+
+import io.smallrye.config.WithDefault;
+
+public interface SmallRyeGraphQLJsClientConfig {
+
+    /**
+     * Generate a JavaScript client proxy for all GraphQL operations.
+     * When enabled, a static client library and a typed proxy module are generated
+     * as web resources, along with an import map for bare module imports.
+     */
+    @WithDefault("false")
+    boolean enabled();
+}


### PR DESCRIPTION
When `quarkus.smallrye-graphql.js-client.enabled` is set to `true`, the SmallRye GraphQL extension generates a JavaScript client library and a typed proxy module from the GraphQL schema at build time.

The typed proxy exports `Queries`, `Mutations`, and `Subscriptions` objects with auto-generated GraphQL query strings including variable declarations and selection sets. A `WebDependencyJarBuildItem` is produced so web-dependency-locator can resolve bare `@quarkus/graphql` and `@quarkus/graphql-api` imports via import maps.

```javascript
import { Queries, Mutations } from '@quarkus/graphql-api';

const data = await Queries.allBooks();
const created = await Mutations.createBook({ title: 'Quarkus in Action' });
```

The schema build is extracted into its own build step via `SmallRyeGraphQLSchemaBuildItem` so it can be consumed by both the existing execution service and the JS client generation.

Security is supported via `GraphQLClient.configure({ token, tokenProvider })` — tokens are sent as `Authorization` headers on HTTP queries/mutations and via `Sec-WebSocket-Protocol` encoding on subscriptions.

This follows the same pattern established by quarkus-json-rpc ([quarkiverse/quarkus-json-rpc#102](https://github.com/quarkiverse/quarkus-json-rpc/pull/102)).