### PR TITLE
ArC: add generated bytecode reproducibility check to ArcTestContainer 

### DIFF
--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -53,6 +53,7 @@
         <version.smallrye-common>2.18.1</version.smallrye-common>
         <!-- test versions -->
         <version.assertj>3.27.7</version.assertj>
+        <version.vineflower>1.12.0</version.vineflower>
         <version.junit>6.1.0</version.junit>
         <version.kotlin>2.4.0</version.kotlin>
         <version.kotlin-coroutines>1.11.0</version.kotlin-coroutines>
@@ -211,6 +212,13 @@
                 <artifactId>gizmo</artifactId>
                 <version>${version.gizmo}</version>
                 <type>test-jar</type>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.vineflower</groupId>
+                <artifactId>vineflower</artifactId>
+                <version>${version.vineflower}</version>
                 <scope>test</scope>
             </dependency>
 

--- a/independent-projects/arc/tests/pom.xml
+++ b/independent-projects/arc/tests/pom.xml
@@ -52,6 +52,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.vineflower</groupId>
+            <artifactId>vineflower</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
             <version>${version.kotlin}</version>

--- a/independent-projects/arc/tests/pom.xml
+++ b/independent-projects/arc/tests/pom.xml
@@ -122,12 +122,16 @@
                             <!-- Replacing default-compile as it is treated specially by Maven -->
                             <execution>
                                 <id>default-compile</id>
-                                <phase>none</phase>
+                                <configuration>
+                                    <skipMain>true</skipMain>
+                                </configuration>
                             </execution>
                             <!-- Replacing default-testCompile as it is treated specially by Maven -->
                             <execution>
                                 <id>default-testCompile</id>
-                                <phase>none</phase>
+                                <configuration>
+                                    <skip>true</skip>
+                                </configuration>
                             </execution>
                             <execution>
                                 <id>java-compile</id>

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/ArcTestContainer.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/ArcTestContainer.java
@@ -6,11 +6,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
@@ -61,12 +64,17 @@ import io.quarkus.arc.processor.bcextensions.ExtensionsEntryPoint;
 public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
 
     // our specific namespace for storing anything into ExtensionContext.Store
-    private static ExtensionContext.Namespace EXTENSION_NAMESPACE;
+    private static ExtensionContext.Namespace EXTENSION_NAMESPACE = ExtensionContext.Namespace.create(ArcTestContainer.class);
 
     // Strings used as keys in ExtensionContext.Store
     private static final String KEY_OLD_TCCL = "arcExtensionOldTccl";
+    private static final String KEY_IMMUTABLE_INDEX = "arcReproducibilityImmutableIndex";
+    private static final String KEY_APPLICATION_INDEX = "arcReproducibilityApplicationIndex";
+    private static final String KEY_REPRODUCIBILITY_DONE = "arcReproducibilityDone";
 
     private static final String TARGET_TEST_CLASSES = "target/test-classes";
+
+    private static final String REPRODUCIBILITY_CHECK_PROPERTY = "quarkus.test.reproducibility-check";
 
     public static Builder builder() {
         return new Builder();
@@ -282,6 +290,8 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
     private final boolean optimizeContexts;
     private final boolean testMode;
 
+    private final int reproducibilityRuns;
+
     public ArcTestContainer(Class<?>... beanClasses) {
         this.resourceReferenceProviders = Collections.emptyList();
         this.beanClasses = Arrays.asList(beanClasses);
@@ -307,6 +317,7 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
         this.optimizeContexts = false;
         this.excludeTypes = Collections.emptyList();
         this.testMode = false;
+        this.reproducibilityRuns = parseReproducibilityRuns();
     }
 
     public ArcTestContainer(Builder builder) {
@@ -334,6 +345,7 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
         this.optimizeContexts = builder.optimizeContexts;
         this.excludeTypes = builder.excludeTypes;
         this.testMode = builder.testMode;
+        this.reproducibilityRuns = parseReproducibilityRuns();
     }
 
     // this is where we start Arc, we operate on a per-method basis
@@ -345,16 +357,29 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
     // this is where we shutdown Arc
     @Override
     public void afterEach(ExtensionContext extensionContext) throws Exception {
-        ClassLoader oldTccl = getRootExtensionStore(extensionContext).get(KEY_OLD_TCCL, ClassLoader.class);
-        Thread.currentThread().setContextClassLoader(oldTccl);
+        ExtensionContext.Store rootStore = getRootExtensionStore(extensionContext);
+        ClassLoader oldTccl = rootStore.get(KEY_OLD_TCCL, ClassLoader.class);
+        if (oldTccl != null) {
+            Thread.currentThread().setContextClassLoader(oldTccl);
+        }
         shutdown();
+
+        ExtensionContext.Store classStore = getClassExtensionStore(extensionContext);
+        IndexView immutableIndex = classStore.get(KEY_IMMUTABLE_INDEX, IndexView.class);
+        if (immutableIndex != null && classStore.get(KEY_REPRODUCIBILITY_DONE) == null) {
+            IndexView applicationIndex = classStore.get(KEY_APPLICATION_INDEX, IndexView.class);
+            runReproducibilityCheck(extensionContext.getRequiredTestClass(),
+                    immutableIndex, applicationIndex, reproducibilityRuns);
+            classStore.put(KEY_REPRODUCIBILITY_DONE, Boolean.TRUE);
+        }
     }
 
     private static synchronized ExtensionContext.Store getRootExtensionStore(ExtensionContext context) {
-        if (EXTENSION_NAMESPACE == null) {
-            EXTENSION_NAMESPACE = ExtensionContext.Namespace.create(ArcTestContainer.class);
-        }
         return context.getRoot().getStore(EXTENSION_NAMESPACE);
+    }
+
+    private static synchronized ExtensionContext.Store getClassExtensionStore(ExtensionContext context) {
+        return context.getParent().orElseThrow().getStore(EXTENSION_NAMESPACE);
     }
 
     /**
@@ -417,6 +442,14 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
 
         ClassLoader old = Thread.currentThread().getContextClassLoader();
 
+        if (reproducibilityRuns > 0 && !shouldFail) {
+            ExtensionContext.Store classStore = getClassExtensionStore(context);
+            if (classStore.get(KEY_REPRODUCIBILITY_DONE) == null) {
+                classStore.put(KEY_IMMUTABLE_INDEX, immutableBeanArchiveIndex);
+                classStore.put(KEY_APPLICATION_INDEX, applicationIndex);
+            }
+        }
+
         try {
             String arcContainerAbsolutePath = ArcTestContainer.class.getClassLoader()
                     .getResource(ArcTestContainer.class.getName().replace(".", "/") + ".class").getFile();
@@ -443,31 +476,8 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
             }
 
             String deploymentName = testClass.getName().replace('.', '_');
-            BeanProcessor.Builder builder = BeanProcessor.builder()
-                    .setName(deploymentName)
-                    .setImmutableBeanArchiveIndex(immutableBeanArchiveIndex)
-                    .setComputingBeanArchiveIndex(BeanArchives.buildComputingBeanArchiveIndex(getClass().getClassLoader(),
-                            new ConcurrentHashMap<>(), immutableBeanArchiveIndex))
-                    .setApplicationIndex(applicationIndex)
-                    .setBuildCompatibleExtensions(buildCompatibleExtensions)
-                    .setStrictCompatibility(strictCompatibility)
-                    .setOptimizeContexts(optimizeContexts);
-            if (!resourceAnnotations.isEmpty()) {
-                builder.addResourceAnnotations(resourceAnnotations.stream()
-                        .map(c -> DotName.createSimple(c.getName()))
-                        .collect(Collectors.toList()));
-            }
-            beanRegistrars.forEach(builder::addBeanRegistrar);
-            observerRegistrars.forEach(builder::addObserverRegistrar);
-            contextRegistrars.forEach(builder::addContextRegistrar);
-            qualifierRegistrars.forEach(builder::addQualifierRegistrar);
-            interceptorBindingRegistrars.forEach(builder::addInterceptorBindingRegistrar);
-            stereotypeRegistrars.forEach(builder::addStereotypeRegistrar);
-            annotationsTransformers.forEach(builder::addAnnotationTransformation);
-            injectionPointsTransformers.forEach(builder::addInjectionPointTransformer);
-            observerTransformers.forEach(builder::addObserverTransformer);
-            beanDeploymentValidators.forEach(builder::addBeanDeploymentValidator);
-            excludeTypes.forEach(builder::addExcludeType);
+            BeanProcessor.Builder builder = configureBeanProcessorBuilder(deploymentName,
+                    immutableBeanArchiveIndex, applicationIndex, buildCompatibleExtensions);
             builder.setOutput(new ResourceOutput() {
 
                 @Override
@@ -491,11 +501,6 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
                     }
                 }
             });
-            builder.setRemoveUnusedBeans(removeUnusedBeans);
-            for (Predicate<BeanInfo> exclusion : removalExclusions) {
-                builder.addRemovalExclusion(exclusion);
-            }
-            builder.setAlternativePriorities(alternativePriorities);
 
             BeanProcessor beanProcessor = builder.build();
 
@@ -532,6 +537,106 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
             }
         }
         return old;
+    }
+
+    private void runReproducibilityCheck(Class<?> testClass, IndexView immutableBeanArchiveIndex,
+            IndexView applicationIndex, int runs) {
+        String testName = testClass.getSimpleName();
+        System.out.printf("[ArcTestContainer] Reproducibility check (%d runs) for %s%n", runs, testName);
+
+        String deploymentName = testClass.getName().replace('.', '_');
+        Map<String, byte[]> referenceClasses = null;
+
+        IndexView bceIndex = applicationIndex != null
+                ? CompositeIndex.create(immutableBeanArchiveIndex, applicationIndex)
+                : immutableBeanArchiveIndex;
+
+        for (int run = 1; run <= runs; run++) {
+            Map<String, byte[]> capturedClasses = new HashMap<>();
+            ExtensionsEntryPoint bcextensions = new ExtensionsEntryPoint(this.buildCompatibleExtensions);
+            // Additional classes from discovery are already merged in the immutable index
+            bcextensions.runDiscovery(bceIndex, new HashSet<>());
+            BeanProcessor.Builder builder = configureBeanProcessorBuilder(deploymentName,
+                    immutableBeanArchiveIndex, applicationIndex, bcextensions);
+            builder.setOutput(resource -> {
+                if (resource.getType() == ResourceOutput.Resource.Type.JAVA_CLASS) {
+                    capturedClasses.put(resource.getName(), resource.getData());
+                }
+            });
+
+            try {
+                builder.build().process();
+            } catch (Exception e) {
+                throw new IllegalStateException("Error generating resources during reproducibility check run " + run, e);
+            }
+
+            if (referenceClasses == null) {
+                referenceClasses = capturedClasses;
+            } else {
+                ReproducibilityCheck.Diff diff = ReproducibilityCheck.diff(referenceClasses, capturedClasses);
+                if (!diff.isEmpty()) {
+                    Path dumpDir = Path.of("target", "debug", testClass.getName(), "reproducibility-mismatch");
+                    Path mismatchPath = ReproducibilityCheck.dumpMismatch(diff,
+                            referenceClasses, capturedClasses, run, dumpDir);
+                    throw new AssertionError("Build reproducibility check failed on run " + run + "/"
+                            + runs + ": " + diff + ". Dumped to " + mismatchPath);
+                }
+            }
+        }
+
+        System.out.printf("[ArcTestContainer] Reproducibility check passed for %s; %s checked classes%n", testName,
+                referenceClasses.size());
+    }
+
+    private BeanProcessor.Builder configureBeanProcessorBuilder(String deploymentName,
+            IndexView immutableBeanArchiveIndex, IndexView applicationIndex,
+            ExtensionsEntryPoint buildCompatibleExtensions) {
+        BeanProcessor.Builder builder = BeanProcessor.builder()
+                .setName(deploymentName)
+                .setImmutableBeanArchiveIndex(immutableBeanArchiveIndex)
+                .setComputingBeanArchiveIndex(BeanArchives.buildComputingBeanArchiveIndex(getClass().getClassLoader(),
+                        new ConcurrentHashMap<>(), immutableBeanArchiveIndex))
+                .setApplicationIndex(applicationIndex)
+                .setBuildCompatibleExtensions(buildCompatibleExtensions)
+                .setStrictCompatibility(strictCompatibility)
+                .setOptimizeContexts(optimizeContexts);
+        if (!resourceAnnotations.isEmpty()) {
+            builder.addResourceAnnotations(resourceAnnotations.stream()
+                    .map(c -> DotName.createSimple(c.getName()))
+                    .collect(Collectors.toList()));
+        }
+        beanRegistrars.forEach(builder::addBeanRegistrar);
+        observerRegistrars.forEach(builder::addObserverRegistrar);
+        contextRegistrars.forEach(builder::addContextRegistrar);
+        qualifierRegistrars.forEach(builder::addQualifierRegistrar);
+        interceptorBindingRegistrars.forEach(builder::addInterceptorBindingRegistrar);
+        stereotypeRegistrars.forEach(builder::addStereotypeRegistrar);
+        annotationsTransformers.forEach(builder::addAnnotationTransformation);
+        injectionPointsTransformers.forEach(builder::addInjectionPointTransformer);
+        observerTransformers.forEach(builder::addObserverTransformer);
+        beanDeploymentValidators.forEach(builder::addBeanDeploymentValidator);
+        excludeTypes.forEach(builder::addExcludeType);
+        builder.setRemoveUnusedBeans(removeUnusedBeans);
+        for (Predicate<BeanInfo> exclusion : removalExclusions) {
+            builder.addRemovalExclusion(exclusion);
+        }
+        builder.setAlternativePriorities(alternativePriorities);
+        return builder;
+    }
+
+    private static int parseReproducibilityRuns() {
+        String value = System.getProperty(REPRODUCIBILITY_CHECK_PROPERTY);
+        if (value == null) {
+            return 0;
+        }
+        if (value.isEmpty() || Boolean.parseBoolean(value)) {
+            return 3;
+        }
+        int runs = Integer.parseInt(value);
+        if (runs < 2) {
+            throw new IllegalArgumentException(REPRODUCIBILITY_CHECK_PROPERTY + " must be >= 2, got: " + runs);
+        }
+        return runs;
     }
 
     private Index index(Iterable<Class<?>> classes) throws IOException {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/ReproducibilityCheck.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/ReproducibilityCheck.java
@@ -1,0 +1,225 @@
+package io.quarkus.arc.test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeSet;
+import java.util.jar.Manifest;
+
+import org.jetbrains.java.decompiler.main.decompiler.BaseDecompiler;
+import org.jetbrains.java.decompiler.main.decompiler.PrintStreamLogger;
+import org.jetbrains.java.decompiler.main.extern.IFernflowerPreferences;
+import org.jetbrains.java.decompiler.main.extern.IResultSaver;
+
+class ReproducibilityCheck {
+
+    private static final Map<String, Object> VINEFLOWER_OPTIONS;
+
+    static {
+        Map<String, Object> options = new HashMap<>(IFernflowerPreferences.getDefaults());
+        options.put(IFernflowerPreferences.REMOVE_SYNTHETIC, "0");
+        options.put(IFernflowerPreferences.REMOVE_BRIDGE, "0");
+        VINEFLOWER_OPTIONS = Map.copyOf(options);
+    }
+
+    record Diff(TreeSet<String> missing, TreeSet<String> extra, TreeSet<String> changed) {
+
+        boolean isEmpty() {
+            return missing.isEmpty() && extra.isEmpty() && changed.isEmpty();
+        }
+
+        @Override
+        public String toString() {
+            return "missing=" + missing.size() + " [" + String.join(", ", missing) + "]"
+                    + ", extra=" + extra.size() + " [" + String.join(", ", extra) + "]"
+                    + ", changed=" + changed.size() + " [" + String.join(", ", changed) + "]";
+        }
+    }
+
+    static Diff diff(Map<String, byte[]> reference, Map<String, byte[]> current) {
+        TreeSet<String> missing = new TreeSet<>(reference.keySet());
+        missing.removeAll(current.keySet());
+
+        TreeSet<String> extra = new TreeSet<>(current.keySet());
+        extra.removeAll(reference.keySet());
+
+        TreeSet<String> changed = new TreeSet<>();
+        for (Map.Entry<String, byte[]> entry : reference.entrySet()) {
+            byte[] currentBytes = current.get(entry.getKey());
+            if (currentBytes != null && !Arrays.equals(entry.getValue(), currentBytes)) {
+                changed.add(entry.getKey());
+            }
+        }
+        return new Diff(missing, extra, changed);
+    }
+
+    static Path dumpMismatch(Diff diff, Map<String, byte[]> reference, Map<String, byte[]> current,
+            int run, Path baseDir) {
+        Path run1Dir = baseDir.resolve("run-1");
+        Path runNDir = baseDir.resolve("run-" + run);
+        StringBuilder index = new StringBuilder();
+        index.append("run-1 vs run-").append(run).append('\n');
+
+        try {
+            Files.createDirectories(run1Dir);
+            Files.createDirectories(runNDir);
+
+            for (String resource : diff.missing()) {
+                writeClass(run1Dir, resource, reference.get(resource));
+                index.append("MISSING_IN_RUN_").append(run).append(' ').append(resource)
+                        .append(" run-1-sha256=").append(sha256(reference.get(resource))).append('\n');
+            }
+            for (String resource : diff.extra()) {
+                writeClass(runNDir, resource, current.get(resource));
+                index.append("EXTRA_IN_RUN_").append(run).append(' ').append(resource)
+                        .append(" run-").append(run).append("-sha256=").append(sha256(current.get(resource))).append('\n');
+            }
+            for (String resource : diff.changed()) {
+                writeClass(run1Dir, resource, reference.get(resource));
+                writeClass(runNDir, resource, current.get(resource));
+                index.append("CHANGED ").append(resource)
+                        .append(" run-1-sha256=").append(sha256(reference.get(resource)))
+                        .append(" run-").append(run).append("-sha256=").append(sha256(current.get(resource))).append('\n');
+            }
+
+            decompile(run1Dir, baseDir.resolve("run-1-decompiled"), index);
+            decompile(runNDir, baseDir.resolve("run-" + run + "-decompiled"), index);
+
+            Files.writeString(baseDir.resolve("mismatch.txt"), index.toString());
+            return baseDir;
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to dump reproducibility mismatch to " + baseDir, e);
+        }
+    }
+
+    private static void decompile(Path classDir, Path outputDir, StringBuilder index) throws IOException {
+        if (!Files.exists(classDir)) {
+            return;
+        }
+        Files.createDirectories(outputDir);
+        ByteArrayOutputStream logBuffer = new ByteArrayOutputStream();
+        try (PrintStream logStream = new PrintStream(logBuffer, true, StandardCharsets.UTF_8)) {
+            BaseDecompiler decompiler = new BaseDecompiler(
+                    new DirectoryResultSaver(outputDir), VINEFLOWER_OPTIONS, new PrintStreamLogger(logStream));
+            decompiler.addSource(classDir.toFile());
+            decompiler.decompileContext();
+            index.append("DECOMPILED ").append(classDir).append(" -> ").append(outputDir).append('\n');
+        } catch (Exception e) {
+            index.append("DECOMPILE_FAILED ").append(classDir).append(" -> ").append(outputDir)
+                    .append(" (").append(e.getClass().getSimpleName()).append(": ")
+                    .append(Objects.toString(e.getMessage(), "no message")).append(")\n");
+        } finally {
+            Files.write(outputDir.resolve("decompile.log"), logBuffer.toByteArray());
+        }
+    }
+
+    private static void writeClass(Path dir, String resource, byte[] data) throws IOException {
+        Path file = dir.resolve(resource + ".class");
+        Files.createDirectories(file.getParent());
+        Files.write(file, data);
+    }
+
+    private static String sha256(byte[] data) {
+        try {
+            byte[] hash = MessageDigest.getInstance("SHA-256").digest(data);
+            StringBuilder sb = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                sb.append(Character.forDigit((b >> 4) & 0xF, 16));
+                sb.append(Character.forDigit(b & 0xF, 16));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+
+    private static final class DirectoryResultSaver implements IResultSaver {
+
+        private final Path outputDir;
+
+        DirectoryResultSaver(Path outputDir) {
+            this.outputDir = outputDir;
+        }
+
+        @Override
+        public void saveFolder(String path) {
+            mkdirs(outputDir.resolve(path));
+        }
+
+        @Override
+        public void copyFile(String source, String path, String entryName) {
+            Path target = resolve(path, entryName);
+            mkdirs(target.getParent());
+            try {
+                Files.copy(Path.of(source), target);
+            } catch (IOException e) {
+                throw new IllegalStateException("Unable to copy " + source + " to " + target, e);
+            }
+        }
+
+        @Override
+        public void saveClassFile(String path, String qualifiedName, String entryName, String content, int[] mapping) {
+            writeString(resolve(path, entryName), content);
+        }
+
+        @Override
+        public void createArchive(String path, String archiveName, Manifest manifest) {
+        }
+
+        @Override
+        public void saveDirEntry(String path, String archiveName, String entryName) {
+            mkdirs(resolve(path, entryName));
+        }
+
+        @Override
+        public void copyEntry(String source, String path, String archiveName, String entryName) {
+            Path target = resolve(path, entryName);
+            mkdirs(target.getParent());
+            try {
+                Files.copy(Path.of(source), target);
+            } catch (IOException e) {
+                throw new IllegalStateException("Unable to copy " + source + " to " + target, e);
+            }
+        }
+
+        @Override
+        public void saveClassEntry(String path, String archiveName, String qualifiedName, String entryName, String content) {
+            writeString(resolve(path, entryName), content);
+        }
+
+        @Override
+        public void closeArchive(String path, String archiveName) {
+        }
+
+        private Path resolve(String path, String entryName) {
+            return (path == null || path.isEmpty()) ? outputDir.resolve(entryName)
+                    : outputDir.resolve(path).resolve(entryName);
+        }
+
+        private static void writeString(Path target, String content) {
+            mkdirs(target.getParent());
+            try {
+                Files.writeString(target, content, StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                throw new IllegalStateException("Unable to write " + target, e);
+            }
+        }
+
+        private static void mkdirs(Path dir) {
+            try {
+                Files.createDirectories(dir);
+            } catch (IOException e) {
+                throw new IllegalStateException("Unable to create directory " + dir, e);
+            }
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/ReproducibilityCheckTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/ReproducibilityCheckTest.java
@@ -1,0 +1,146 @@
+package io.quarkus.arc.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class ReproducibilityCheckTest {
+
+    @Test
+    public void diffIdentical() {
+        Map<String, byte[]> snapshot = Map.of(
+                "com/example/Foo", new byte[] { 1, 2, 3 },
+                "com/example/Bar", new byte[] { 4, 5, 6 });
+
+        ReproducibilityCheck.Diff diff = ReproducibilityCheck.diff(snapshot, snapshot);
+        assertTrue(diff.isEmpty());
+        assertTrue(diff.missing().isEmpty());
+        assertTrue(diff.extra().isEmpty());
+        assertTrue(diff.changed().isEmpty());
+    }
+
+    @Test
+    public void diffMissing() {
+        Map<String, byte[]> reference = Map.of(
+                "com/example/Foo", new byte[] { 1 },
+                "com/example/Bar", new byte[] { 2 });
+        Map<String, byte[]> current = Map.of(
+                "com/example/Bar", new byte[] { 2 });
+
+        ReproducibilityCheck.Diff diff = ReproducibilityCheck.diff(reference, current);
+        assertFalse(diff.isEmpty());
+        assertEquals(1, diff.missing().size());
+        assertTrue(diff.missing().contains("com/example/Foo"));
+        assertTrue(diff.extra().isEmpty());
+        assertTrue(diff.changed().isEmpty());
+    }
+
+    @Test
+    public void diffExtra() {
+        Map<String, byte[]> reference = Map.of(
+                "com/example/Foo", new byte[] { 1 });
+        Map<String, byte[]> current = Map.of(
+                "com/example/Foo", new byte[] { 1 },
+                "com/example/New", new byte[] { 9 });
+
+        ReproducibilityCheck.Diff diff = ReproducibilityCheck.diff(reference, current);
+        assertFalse(diff.isEmpty());
+        assertTrue(diff.missing().isEmpty());
+        assertEquals(1, diff.extra().size());
+        assertTrue(diff.extra().contains("com/example/New"));
+        assertTrue(diff.changed().isEmpty());
+    }
+
+    @Test
+    public void diffChanged() {
+        Map<String, byte[]> reference = Map.of(
+                "com/example/Foo", new byte[] { 1, 2 });
+        Map<String, byte[]> current = Map.of(
+                "com/example/Foo", new byte[] { 1, 3 });
+
+        ReproducibilityCheck.Diff diff = ReproducibilityCheck.diff(reference, current);
+        assertFalse(diff.isEmpty());
+        assertTrue(diff.missing().isEmpty());
+        assertTrue(diff.extra().isEmpty());
+        assertEquals(1, diff.changed().size());
+        assertTrue(diff.changed().contains("com/example/Foo"));
+    }
+
+    @Test
+    public void diffCombined() {
+        Map<String, byte[]> reference = Map.of(
+                "com/example/Removed", new byte[] { 1 },
+                "com/example/Same", new byte[] { 2 },
+                "com/example/Modified", new byte[] { 3 });
+        Map<String, byte[]> current = Map.of(
+                "com/example/Same", new byte[] { 2 },
+                "com/example/Modified", new byte[] { 99 },
+                "com/example/Added", new byte[] { 4 });
+
+        ReproducibilityCheck.Diff diff = ReproducibilityCheck.diff(reference, current);
+        assertFalse(diff.isEmpty());
+        assertEquals(1, diff.missing().size());
+        assertEquals(1, diff.extra().size());
+        assertEquals(1, diff.changed().size());
+        assertTrue(diff.missing().contains("com/example/Removed"));
+        assertTrue(diff.extra().contains("com/example/Added"));
+        assertTrue(diff.changed().contains("com/example/Modified"));
+    }
+
+    @Test
+    public void diffEmpty() {
+        ReproducibilityCheck.Diff diff = ReproducibilityCheck.diff(Map.of(), Map.of());
+        assertTrue(diff.isEmpty());
+    }
+
+    @Test
+    public void dumpMismatchCreatesFiles(@TempDir Path tempDir) {
+        byte[] refBytes = new byte[] { 1, 2, 3 };
+        byte[] curBytes = new byte[] { 1, 2, 4 };
+        Map<String, byte[]> reference = Map.of("com/example/Foo", refBytes);
+        Map<String, byte[]> current = Map.of("com/example/Foo", curBytes);
+
+        ReproducibilityCheck.Diff diff = ReproducibilityCheck.diff(reference, current);
+        Path result = ReproducibilityCheck.dumpMismatch(diff, reference, current, 2, tempDir);
+
+        assertEquals(tempDir, result);
+        assertTrue(Files.exists(tempDir.resolve("run-1/com/example/Foo.class")));
+        assertTrue(Files.exists(tempDir.resolve("run-2/com/example/Foo.class")));
+        assertTrue(Files.exists(tempDir.resolve("mismatch.txt")));
+    }
+
+    @Test
+    public void dumpMismatchMissingAndExtra(@TempDir Path tempDir) {
+        Map<String, byte[]> reference = Map.of("com/example/Old", new byte[] { 1 });
+        Map<String, byte[]> current = Map.of("com/example/New", new byte[] { 2 });
+
+        ReproducibilityCheck.Diff diff = ReproducibilityCheck.diff(reference, current);
+        ReproducibilityCheck.dumpMismatch(diff, reference, current, 3, tempDir);
+
+        assertTrue(Files.exists(tempDir.resolve("run-1/com/example/Old.class")));
+        assertFalse(Files.exists(tempDir.resolve("run-3/com/example/Old.class")));
+        assertTrue(Files.exists(tempDir.resolve("run-3/com/example/New.class")));
+        assertFalse(Files.exists(tempDir.resolve("run-1/com/example/New.class")));
+    }
+
+    @Test
+    public void dumpMismatchIndexContainsSha256(@TempDir Path tempDir) throws Exception {
+        Map<String, byte[]> reference = Map.of("com/example/Foo", new byte[] { 1 });
+        Map<String, byte[]> current = Map.of("com/example/Foo", new byte[] { 2 });
+
+        ReproducibilityCheck.Diff diff = ReproducibilityCheck.diff(reference, current);
+        ReproducibilityCheck.dumpMismatch(diff, reference, current, 2, tempDir);
+
+        String mismatch = Files.readString(tempDir.resolve("mismatch.txt"));
+        assertTrue(mismatch.contains("CHANGED com/example/Foo"));
+        assertTrue(mismatch.contains("run-1-sha256="));
+        assertTrue(mismatch.contains("run-2-sha256="));
+    }
+}


### PR DESCRIPTION
- run BeanProcessor multiple times and compare generated bytecode
 when -Dquarkus.test.reproducibility-check=<runs> is set
- on mismatch, dump raw .class files and Vineflower-decompiled sources
- tests are skipped after a successful check; shouldFail tests are
 skipped entirely

When I ran this locally I got `Tests run: 664, Failures: 0, Errors: 0, Skipped: 664` -- no reproducibility issue found. So had to change the `BeanGenerator` and introduce a reproducibility issue to verify the "dump functionality" :smile:.

This is a follow-up of https://github.com/quarkusio/quarkus/pull/54420 and I copied some parts of it (because ArC is an independent project). We also use the same system property name.