### PR TITLE
Fix Panache DTO projection and Jackson serialization for Kotlin value classes

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm-panache-kotlin.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache-kotlin.adoc
@@ -214,6 +214,32 @@ val namesButEmmanuels = persons
 
 NOTE: The `stream` methods require a transaction to work.
 
+=== Projecting with data classes and value classes
+
+`project()` works with Kotlin data classes, including ones that expose their properties as
+`@JvmInline` value classes:
+
+[source,kotlin]
+----
+@RegisterForReflection // <1>
+@JvmInline
+value class GreetingId(val value: Long)
+
+@RegisterForReflection // <2>
+data class GreetingValueClassDto(val id: GreetingId? = null, val name: String)
+
+val greetings = personRepository.find("status", Status.Alive).project(GreetingValueClassDto::class.java)
+----
+<1> The value class is instantiated by Hibernate ORM when it builds the projection, so it needs its own
+reflection metadata to work in native mode.
+<2> As in the Java version, the projection DTO itself must be registered for reflection.
+
+Kotlin generates synthetic constructors for data classes that use value classes or default parameter
+values. Panache skips those and selects the constructor matching the declared properties, so no extra
+annotation is required. If your DTO declares several constructors and you want to pick one explicitly,
+annotate it with `@ProjectedConstructor` as described in the
+xref:hibernate-orm-panache.adoc#query-projection[Java version].
+
 For more examples, please consult the xref:hibernate-orm-panache.adoc[Java version] for complete details.  Both APIs
 are the same and work identically except for some Kotlin-specific tweaks to make things feel more natural to
 Kotlin developers.  These tweaks include things like better use of nullability and the lack of `Optional` on API

--- a/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/CommonPanacheQueryImpl.java
+++ b/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/CommonPanacheQueryImpl.java
@@ -1,9 +1,5 @@
 package io.quarkus.hibernate.orm.panache.common.runtime;
 
-import java.lang.reflect.AnnotatedElement;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.Parameter;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -11,7 +7,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
+import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
 import jakarta.persistence.LockModeType;
@@ -23,14 +19,12 @@ import org.hibernate.query.KeyedResultList;
 import org.hibernate.query.SelectionQuery;
 import org.hibernate.query.spi.SqmQuery;
 
-import io.quarkus.hibernate.orm.panache.common.NestedProjectedClass;
-import io.quarkus.hibernate.orm.panache.common.ProjectedConstructor;
-import io.quarkus.hibernate.orm.panache.common.ProjectedFieldName;
 import io.quarkus.panache.common.Page;
 import io.quarkus.panache.common.Range;
 import io.quarkus.panache.common.Sort;
 import io.quarkus.panache.common.exception.PanacheQueryException;
 import io.quarkus.panache.hibernate.common.runtime.PanacheJpaUtil;
+import io.quarkus.panache.hibernate.common.runtime.ProjectionConstructorUtil;
 
 public class CommonPanacheQueryImpl<Entity> {
 
@@ -163,91 +157,10 @@ public class CommonPanacheQueryImpl<Entity> {
     }
 
     private static StringBuilder getParametersFromClass(Class<?> type, String parentParameter) {
-        StringBuilder selectClause = new StringBuilder();
-        Constructor<?> constructor = getConstructor(type);
-
-        selectClause.append("new ").append(type.getName()).append(" (");
-        String parametersListStr = Stream.of(constructor.getParameters())
-                .map(parameter -> getParameterName(type, parentParameter, parameter))
-                .collect(Collectors.joining(","));
-        selectClause.append(parametersListStr);
-        selectClause.append(") ");
-        return selectClause;
-    }
-
-    private static Constructor<?> getConstructor(Class<?> type) {
-        Constructor<?>[] typeConstructors = type.getDeclaredConstructors();
-
-        //We start to look for constructors with @ProjectedConstructor
-        for (Constructor<?> typeConstructor : typeConstructors) {
-            if (typeConstructor.isAnnotationPresent(ProjectedConstructor.class)) {
-                return typeConstructor;
-            }
-        }
-
-        //If didn't find anything early,
-        //we try to find a constructor with parameters annotated with @ProjectedFieldName
-        for (Constructor<?> typeConstructor : typeConstructors) {
-            for (Parameter parameter : typeConstructor.getParameters()) {
-                if (parameter.isAnnotationPresent(ProjectedFieldName.class)) {
-                    return typeConstructor;
-                }
-            }
-        }
-
-        //We fall back to the first constructor that has parameters
-        for (Constructor<?> typeConstructor : typeConstructors) {
-            Parameter[] parameters = typeConstructor.getParameters();
-            if (parameters.length == 0) {
-                continue;
-            }
-
-            return typeConstructor;
-        }
-
-        //If everything fails, we return the first available constructor
-        return typeConstructors[0];
-    }
-
-    private static String getParameterName(Class<?> parentType, String parentParameter, Parameter parameter) {
-        String parameterName;
-        // Check if constructor param is annotated with ProjectedFieldName
-        if (hasProjectedFieldName(parameter)) {
-            parameterName = getNameFromProjectedFieldName(parameter);
-        } else if (!parameter.isNamePresent()) {
-            throw new PanacheQueryException(
-                    "Your application must be built with parameter names, this should be the default if" +
-                            " using Quarkus project generation. Check the Maven or Gradle compiler configuration to include '-parameters'.");
-        } else {
-            // Check if class field with same parameter name exists and contains @ProjectFieldName annotation
-            try {
-                Field field = parentType.getDeclaredField(parameter.getName());
-                parameterName = hasProjectedFieldName(field) ? getNameFromProjectedFieldName(field) : parameter.getName();
-            } catch (NoSuchFieldException e) {
-                parameterName = parameter.getName();
-            }
-        }
-        // For nested classes, add parent parameter in parameterName
-        parameterName = (parentParameter == null) ? parameterName : parentParameter.concat(".").concat(parameterName);
-        // Test if the parameter is a nested Class that should be projected too.
-        if (parameter.getType().isAnnotationPresent(NestedProjectedClass.class)) {
-            Class<?> nestedType = parameter.getType();
-            return getParametersFromClass(nestedType, parameterName).toString();
-        } else {
-            return parameterName;
-        }
-    }
-
-    private static boolean hasProjectedFieldName(AnnotatedElement annotatedElement) {
-        return annotatedElement.isAnnotationPresent(ProjectedFieldName.class);
-    }
-
-    private static String getNameFromProjectedFieldName(AnnotatedElement annotatedElement) {
-        final String name = annotatedElement.getAnnotation(ProjectedFieldName.class).value();
-        if (name.isEmpty()) {
-            throw new PanacheQueryException("The annotation ProjectedFieldName must have a non-empty value.");
-        }
-        return name;
+        BiFunction<Class<?>, String, String> nestedProjectionBuilder = (nestedType, parameterName) -> getParametersFromClass(
+                nestedType, parameterName).toString();
+        return new StringBuilder(
+                ProjectionConstructorUtil.buildConstructorExpression(type, parentParameter, nestedProjectionBuilder));
     }
 
     public void filter(String filterName, Map<String, Object> parameters) {

--- a/extensions/panache/hibernate-orm-panache-common/runtime/src/test/java/io/quarkus/hibernate/orm/panache/common/runtime/ProjectionConstructorUtilTest.java
+++ b/extensions/panache/hibernate-orm-panache-common/runtime/src/test/java/io/quarkus/hibernate/orm/panache/common/runtime/ProjectionConstructorUtilTest.java
@@ -1,0 +1,98 @@
+package io.quarkus.hibernate.orm.panache.common.runtime;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Parameter;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.hibernate.orm.panache.common.ProjectedConstructor;
+import io.quarkus.panache.hibernate.common.runtime.ProjectionConstructorUtil;
+
+public class ProjectionConstructorUtilTest {
+
+    public static class SimpleDto {
+        public final Long id;
+        public final String name;
+
+        public SimpleDto(Long id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+    }
+
+    public static class AnnotatedDto {
+        public final Long id;
+        public final String name;
+
+        public AnnotatedDto(Long id, String name, Object ignored) {
+            this.id = id;
+            this.name = name;
+        }
+
+        @ProjectedConstructor
+        public AnnotatedDto(Long id, String name) {
+            this(id, name, null);
+        }
+    }
+
+    @Test
+    public void testBuildSelectClauseForSimpleDto() {
+        String selectClause = ProjectionConstructorUtil.buildSelectClause(SimpleDto.class, (type, parameterName) -> null);
+        Assertions.assertEquals(
+                "SELECT new io.quarkus.hibernate.orm.panache.common.runtime.ProjectionConstructorUtilTest$SimpleDto (id,name) ",
+                selectClause);
+    }
+
+    @Test
+    public void testPrefersProjectedConstructor() {
+        Constructor<?> constructor = ProjectionConstructorUtil.getProjectionConstructor(AnnotatedDto.class);
+        Assertions.assertEquals(2, constructor.getParameterCount());
+        Assertions.assertNotNull(constructor.getAnnotation(ProjectedConstructor.class));
+    }
+
+    public static class SyntheticLikeDto {
+        public final Long id;
+        public final String name;
+
+        public SyntheticLikeDto(Long id, String name) {
+            this(id, name, 0);
+        }
+
+        SyntheticLikeDto(Long id, String name, int bitmask) {
+            this.id = id;
+            this.name = name;
+        }
+    }
+
+    public static class DoubleConstructorWithOneEmpty {
+        public String name;
+        public String ownerName;
+
+        public DoubleConstructorWithOneEmpty() {
+        }
+
+        public DoubleConstructorWithOneEmpty(String name) {
+            this.name = name;
+        }
+
+        public DoubleConstructorWithOneEmpty(String name, String ownerName) {
+            this.name = name;
+            this.ownerName = ownerName;
+        }
+    }
+
+    @Test
+    public void testPrefersConstructorWithFewestParameters() {
+        Constructor<?> constructor = ProjectionConstructorUtil.getProjectionConstructor(SyntheticLikeDto.class);
+        Parameter[] parameters = constructor.getParameters();
+        Assertions.assertEquals(2, parameters.length);
+        Assertions.assertEquals("id", parameters[0].getName());
+        Assertions.assertEquals("name", parameters[1].getName());
+
+        Constructor<?> doubleConstructor = ProjectionConstructorUtil
+                .getProjectionConstructor(DoubleConstructorWithOneEmpty.class);
+        Assertions.assertEquals(1, doubleConstructor.getParameterCount());
+        Assertions.assertEquals("name", doubleConstructor.getParameters()[0].getName());
+    }
+}

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/CommonAbstractPanacheQueryImpl.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/CommonAbstractPanacheQueryImpl.java
@@ -1,31 +1,24 @@
 package io.quarkus.hibernate.reactive.panache.common.runtime;
 
-import java.lang.reflect.AnnotatedElement;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.Parameter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletionException;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import jakarta.persistence.LockModeType;
 
 import org.hibernate.Filter;
 import org.hibernate.reactive.mutiny.Mutiny;
 
-import io.quarkus.hibernate.reactive.panache.common.NestedProjectedClass;
-import io.quarkus.hibernate.reactive.panache.common.ProjectedConstructor;
-import io.quarkus.hibernate.reactive.panache.common.ProjectedFieldName;
 import io.quarkus.panache.common.Page;
 import io.quarkus.panache.common.Range;
 import io.quarkus.panache.common.Sort;
 import io.quarkus.panache.common.exception.PanacheQueryException;
 import io.quarkus.panache.hibernate.common.runtime.PanacheJpaUtil;
+import io.quarkus.panache.hibernate.common.runtime.ProjectionConstructorUtil;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 
@@ -133,91 +126,10 @@ public abstract class CommonAbstractPanacheQueryImpl<Entity, SessionType extends
     }
 
     private StringBuilder getParametersFromClass(Class<?> type, String parentParameter) {
-        StringBuilder selectClause = new StringBuilder();
-        Constructor<?> constructor = getConstructor(type);
-
-        selectClause.append("new ").append(type.getName()).append(" (");
-        String parametersListStr = Stream.of(constructor.getParameters())
-                .map(parameter -> getParameterName(type, parentParameter, parameter))
-                .collect(Collectors.joining(","));
-        selectClause.append(parametersListStr);
-        selectClause.append(") ");
-        return selectClause;
-    }
-
-    private Constructor<?> getConstructor(Class<?> type) {
-        Constructor<?>[] typeConstructors = type.getDeclaredConstructors();
-
-        //We start to look for constructors with @ProjectedConstructor
-        for (Constructor<?> typeConstructor : typeConstructors) {
-            if (typeConstructor.isAnnotationPresent(ProjectedConstructor.class)) {
-                return typeConstructor;
-            }
-        }
-
-        //If didn't find anything early,
-        //we try to find a constructor with parameters annotated with @ProjectedFieldName
-        for (Constructor<?> typeConstructor : typeConstructors) {
-            for (Parameter parameter : typeConstructor.getParameters()) {
-                if (parameter.isAnnotationPresent(ProjectedFieldName.class)) {
-                    return typeConstructor;
-                }
-            }
-        }
-
-        //We fall back to the first constructor that has parameters
-        for (Constructor<?> typeConstructor : typeConstructors) {
-            Parameter[] parameters = typeConstructor.getParameters();
-            if (parameters.length == 0) {
-                continue;
-            }
-
-            return typeConstructor;
-        }
-
-        //If everything fails, we return the first available constructor
-        return typeConstructors[0];
-    }
-
-    private String getParameterName(Class<?> parentType, String parentParameter, Parameter parameter) {
-        String parameterName;
-        // Check if constructor param is annotated with ProjectedFieldName
-        if (hasProjectedFieldName(parameter)) {
-            parameterName = getNameFromProjectedFieldName(parameter);
-        } else if (!parameter.isNamePresent()) {
-            throw new PanacheQueryException(
-                    "Your application must be built with parameter names, this should be the default if" +
-                            " using Quarkus project generation. Check the Maven or Gradle compiler configuration to include '-parameters'.");
-        } else {
-            // Check if class field with same parameter name exists and contains @ProjectFieldName annotation
-            try {
-                Field field = parentType.getDeclaredField(parameter.getName());
-                parameterName = hasProjectedFieldName(field) ? getNameFromProjectedFieldName(field) : parameter.getName();
-            } catch (NoSuchFieldException e) {
-                parameterName = parameter.getName();
-            }
-        }
-        // For nested classes, add parent parameter in parameterName
-        parameterName = (parentParameter == null) ? parameterName : parentParameter.concat(".").concat(parameterName);
-        // Test if the parameter is a nested Class that should be projected too.
-        if (parameter.getType().isAnnotationPresent(NestedProjectedClass.class)) {
-            Class<?> nestedType = parameter.getType();
-            return getParametersFromClass(nestedType, parameterName).toString();
-        } else {
-            return parameterName;
-        }
-    }
-
-    private boolean hasProjectedFieldName(AnnotatedElement annotatedElement) {
-        return annotatedElement.isAnnotationPresent(ProjectedFieldName.class);
-    }
-
-    private String getNameFromProjectedFieldName(AnnotatedElement annotatedElement) {
-        final String name = annotatedElement.getAnnotation(ProjectedFieldName.class).value();
-        if (name.isEmpty()) {
-            throw new PanacheQueryException("The annotation ProjectedFieldName must have a non-empty value.");
-        }
-        return name;
+        BiFunction<Class<?>, String, String> nestedProjectionBuilder = (nestedType, parameterName) -> getParametersFromClass(
+                nestedType, parameterName).toString();
+        return new StringBuilder(
+                ProjectionConstructorUtil.buildConstructorExpression(type, parentParameter, nestedProjectionBuilder));
     }
 
     public void filter(String filterName, Map<String, Object> parameters) {

--- a/extensions/panache/panache-hibernate-common/runtime/src/main/java/io/quarkus/panache/hibernate/common/runtime/ProjectionConstructorUtil.java
+++ b/extensions/panache/panache-hibernate-common/runtime/src/main/java/io/quarkus/panache/hibernate/common/runtime/ProjectionConstructorUtil.java
@@ -1,0 +1,243 @@
+package io.quarkus.panache.hibernate.common.runtime;
+
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+
+import io.quarkus.panache.common.exception.PanacheQueryException;
+
+/**
+ * Shared support for Panache DTO projection constructor selection and parameter mapping.
+ * <p>
+ * Kotlin data classes (especially with {@code @JvmInline} value classes and default parameters)
+ * generate synthetic constructors for default-argument handling. This utility skips those
+ * constructors via {@link Constructor#isSynthetic()} and maps only the real component parameters
+ * to entity fields.
+ */
+public final class ProjectionConstructorUtil {
+
+    private static final Set<String> PROJECTED_CONSTRUCTOR_ANNOTATIONS = Set.of(
+            "io.quarkus.hibernate.orm.panache.common.ProjectedConstructor",
+            "io.quarkus.hibernate.reactive.panache.common.ProjectedConstructor");
+
+    private static final Set<String> PROJECTED_FIELD_NAME_ANNOTATIONS = Set.of(
+            "io.quarkus.hibernate.orm.panache.common.ProjectedFieldName",
+            "io.quarkus.hibernate.reactive.panache.common.ProjectedFieldName");
+
+    private static final Set<String> NESTED_PROJECTED_CLASS_ANNOTATIONS = Set.of(
+            "io.quarkus.hibernate.orm.panache.common.NestedProjectedClass",
+            "io.quarkus.hibernate.reactive.panache.common.NestedProjectedClass");
+
+    private static final String JVM_INLINE_ANNOTATION = "kotlin.jvm.JvmInline";
+
+    private ProjectionConstructorUtil() {
+    }
+
+    public static String buildSelectClause(Class<?> type,
+            BiFunction<Class<?>, String, String> nestedProjectionBuilder) {
+        return "SELECT " + buildConstructorExpression(type, null, nestedProjectionBuilder);
+    }
+
+    public static String buildConstructorExpression(Class<?> type, String parentParameter,
+            BiFunction<Class<?>, String, String> nestedProjectionBuilder) {
+        Constructor<?> constructor = getProjectionConstructor(type);
+        String parametersListStr = getProjectionParameters(constructor).stream()
+                .map(parameter -> getProjectionParameterName(type, parentParameter, parameter, nestedProjectionBuilder))
+                .collect(Collectors.joining(","));
+        return "new " + type.getName() + " (" + parametersListStr + ") ";
+    }
+
+    public static Constructor<?> getProjectionConstructor(Class<?> type) {
+        Constructor<?>[] constructors = type.getDeclaredConstructors();
+
+        for (Constructor<?> constructor : constructors) {
+            if (hasAnnotation(constructor, PROJECTED_CONSTRUCTOR_ANNOTATIONS)) {
+                return constructor;
+            }
+        }
+
+        for (Constructor<?> constructor : constructors) {
+            for (Parameter parameter : constructor.getParameters()) {
+                if (hasAnnotation(parameter, PROJECTED_FIELD_NAME_ANNOTATIONS)) {
+                    return constructor;
+                }
+            }
+        }
+
+        List<Constructor<?>> usableConstructors = new ArrayList<>();
+        for (Constructor<?> constructor : constructors) {
+            if (isUsableProjectionConstructor(constructor)) {
+                usableConstructors.add(constructor);
+            }
+        }
+
+        if (!usableConstructors.isEmpty()) {
+            Constructor<?> selectedConstructor = null;
+            int minParameterCount = Integer.MAX_VALUE;
+            for (Constructor<?> constructor : usableConstructors) {
+                int parameterCount = getProjectionParameters(constructor).size();
+                if (parameterCount < minParameterCount) {
+                    minParameterCount = parameterCount;
+                    selectedConstructor = constructor;
+                }
+            }
+            return selectedConstructor;
+        }
+
+        for (Constructor<?> constructor : constructors) {
+            if (constructor.getParameterCount() > 0) {
+                throw new PanacheQueryException(buildNoSuitableConstructorMessage(type, constructor));
+            }
+        }
+        throw new PanacheQueryException("No suitable projection constructor found for " + type.getName()
+                + ". Projection DTOs require a constructor with at least one parameter.");
+    }
+
+    public static String getProjectionParameterName(Class<?> parentType, String parentParameter, Parameter parameter,
+            BiFunction<Class<?>, String, String> nestedProjectionBuilder) {
+        String parameterName;
+        if (hasProjectedFieldName(parameter)) {
+            parameterName = getNameFromProjectedFieldName(parameter);
+        } else if (!parameter.isNamePresent()) {
+            throw new PanacheQueryException(
+                    "Your application must be built with parameter names, this should be the default if"
+                            + " using Quarkus project generation. Check the Maven or Gradle compiler configuration to include '-parameters'."
+                            + " When using Kotlin data classes with value classes or default parameters, Panache skips synthetic"
+                            + " constructors automatically; if this error persists, annotate the constructor with @ProjectedConstructor"
+                            + " or annotate parameters with @ProjectedFieldName.");
+        } else {
+            try {
+                Field field = parentType.getDeclaredField(parameter.getName());
+                parameterName = hasProjectedFieldName(field) ? getNameFromProjectedFieldName(field)
+                        : parameter.getName();
+            } catch (NoSuchFieldException e) {
+                parameterName = parameter.getName();
+            }
+        }
+        parameterName = parentParameter == null ? parameterName : parentParameter + "." + parameterName;
+        if (hasNestedProjectedClass(parameter.getType())) {
+            return nestedProjectionBuilder.apply(parameter.getType(), parameterName);
+        }
+        return wrapInlineValueClass(parameter.getType(), parameterName);
+    }
+
+    private static String wrapInlineValueClass(Class<?> parameterType, String entityPath) {
+        if (!isInlineValueClass(parameterType)) {
+            return entityPath;
+        }
+        return "new " + parameterType.getName() + "(" + entityPath + ")";
+    }
+
+    private static boolean isInlineValueClass(Class<?> type) {
+        if (type == null || type.isPrimitive()) {
+            return false;
+        }
+        if (!hasAnnotation(type, JVM_INLINE_ANNOTATION)) {
+            return false;
+        }
+        try {
+            Field valueField = type.getDeclaredField("value");
+            return !Modifier.isStatic(valueField.getModifiers());
+        } catch (NoSuchFieldException e) {
+            return false;
+        }
+    }
+
+    private static List<Parameter> getProjectionParameters(Constructor<?> constructor) {
+        return Arrays.asList(constructor.getParameters());
+    }
+
+    private static boolean isUsableProjectionConstructor(Constructor<?> constructor) {
+        // Kotlin default-parameter helpers are marked synthetic at the constructor level;
+        // their trailing int/$mask and DefaultConstructorMarker parameters are not.
+        if (constructor.isSynthetic()) {
+            return false;
+        }
+        Parameter[] parameters = constructor.getParameters();
+        if (parameters.length == 0) {
+            return false;
+        }
+        for (Parameter parameter : parameters) {
+            if (!parameter.isNamePresent()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean hasProjectedFieldName(AnnotatedElement annotatedElement) {
+        return hasAnnotation(annotatedElement, PROJECTED_FIELD_NAME_ANNOTATIONS);
+    }
+
+    private static boolean hasNestedProjectedClass(Class<?> type) {
+        return hasAnnotation(type, NESTED_PROJECTED_CLASS_ANNOTATIONS);
+    }
+
+    private static boolean hasAnnotation(AnnotatedElement annotatedElement, Set<String> annotationTypeNames) {
+        for (java.lang.annotation.Annotation annotation : annotatedElement.getAnnotations()) {
+            if (annotationTypeNames.contains(annotation.annotationType().getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasAnnotation(AnnotatedElement annotatedElement, String annotationTypeName) {
+        for (java.lang.annotation.Annotation annotation : annotatedElement.getAnnotations()) {
+            if (annotationTypeName.equals(annotation.annotationType().getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String getNameFromProjectedFieldName(AnnotatedElement annotatedElement) {
+        for (java.lang.annotation.Annotation annotation : annotatedElement.getAnnotations()) {
+            if (PROJECTED_FIELD_NAME_ANNOTATIONS.contains(annotation.annotationType().getName())) {
+                try {
+                    String name = (String) annotation.annotationType().getMethod("value").invoke(annotation);
+                    if (name.isEmpty()) {
+                        throw new PanacheQueryException("The annotation ProjectedFieldName must have a non-empty value.");
+                    }
+                    return name;
+                } catch (ReflectiveOperationException e) {
+                    throw new PanacheQueryException("Unable to read ProjectedFieldName value", e);
+                }
+            }
+        }
+        throw new PanacheQueryException("Missing ProjectedFieldName annotation");
+    }
+
+    private static String buildNoSuitableConstructorMessage(Class<?> type, Constructor<?> rejected) {
+        StringBuilder message = new StringBuilder("No suitable projection constructor found for ")
+                .append(type.getName())
+                .append(" (rejected constructor: ")
+                .append(rejected)
+                .append(").");
+        if (isKotlinClass(type)) {
+            message.append(" Kotlin value classes and default parameters may produce synthetic constructors.")
+                    .append(" Use @ProjectedConstructor, @ProjectedFieldName, or a DTO with plain property types such as Long.");
+        } else {
+            message.append(" Use @ProjectedConstructor or @ProjectedFieldName to select a usable constructor,")
+                    .append(" and ensure the application is built with parameter names (-parameters).");
+        }
+        return message.toString();
+    }
+
+    private static boolean isKotlinClass(Class<?> type) {
+        for (java.lang.annotation.Annotation annotation : type.getAnnotations()) {
+            if ("kotlin.Metadata".equals(annotation.annotationType().getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/integration-tests/hibernate-orm-panache-kotlin/src/main/kotlin/io/quarkus/it/panache/kotlin/TestEndpoint.kt
+++ b/integration-tests/hibernate-orm-panache-kotlin/src/main/kotlin/io/quarkus/it/panache/kotlin/TestEndpoint.kt
@@ -28,7 +28,6 @@ import java.util.stream.Collectors
 import java.util.stream.Stream
 import org.hibernate.engine.spi.SelfDirtinessTracker
 import org.hibernate.jpa.QueryHints
-import org.hibernate.query.SemanticException
 import org.junit.jupiter.api.Assertions
 
 /**
@@ -1256,16 +1255,12 @@ class TestEndpoint {
         Assertions.assertNotNull(annotatedConstructor)
         Assertions.assertEquals(mark.name, annotatedConstructor?.name)
 
-        val semanticException =
-            Assertions.assertThrowsExactly(SemanticException::class.java) {
-                Person.find("name = ?1", "Mark")
-                    .project(MyProjectionDoubleConstructor::class.java)
-                    .firstResult()
-            }
-        Assertions.assertEquals(
-            "Could not interpret path expression 'fakeParameter'",
-            semanticException.message,
-        )
+        val withoutAnnotation =
+            Person.find("name = ?1", "Mark")
+                .project(MyProjectionDoubleConstructor::class.java)
+                .firstResult()
+        Assertions.assertNotNull(withoutAnnotation)
+        Assertions.assertEquals(mark.name, withoutAnnotation?.name)
 
         Person.deleteAll()
 
@@ -1311,16 +1306,12 @@ class TestEndpoint {
         Assertions.assertNotNull(annotatedConstructor)
         Assertions.assertEquals(mark.name, annotatedConstructor?.name)
 
-        val semanticException =
-            Assertions.assertThrowsExactly(SemanticException::class.java) {
-                Person.find("name = ?1", "Mark")
-                    .project(MyProjectionDoubleConstructor::class.java)
-                    .firstResult()
-            }
-        Assertions.assertEquals(
-            "Could not interpret path expression 'fakeParameter'",
-            semanticException.message,
-        )
+        val withoutAnnotation =
+            Person.find("name = ?1", "Mark")
+                .project(MyProjectionDoubleConstructor::class.java)
+                .firstResult()
+        Assertions.assertNotNull(withoutAnnotation)
+        Assertions.assertEquals(mark.name, withoutAnnotation?.name)
 
         Person.deleteAll()
 
@@ -1364,16 +1355,31 @@ class TestEndpoint {
         Assertions.assertNotNull(annotatedConstructor)
         Assertions.assertEquals(mark.name, annotatedConstructor?.name)
 
-        val semanticException =
-            Assertions.assertThrowsExactly(SemanticException::class.java) {
-                Person.find("name = ?1", "Mark")
-                    .project(MyProjectionDoubleConstructor::class.java)
-                    .firstResult()
-            }
-        Assertions.assertEquals(
-            "Could not interpret path expression 'fakeParameter'",
-            semanticException.message,
-        )
+        val withoutAnnotation =
+            Person.find("name = ?1", "Mark")
+                .project(MyProjectionDoubleConstructor::class.java)
+                .firstResult()
+        Assertions.assertNotNull(withoutAnnotation)
+        Assertions.assertEquals(mark.name, withoutAnnotation?.name)
+
+        Person.deleteAll()
+
+        return "OK"
+    }
+
+    @GET
+    @Path("projection-value-class")
+    @Transactional
+    fun testValueClassProjection(): String {
+        val mark = Person()
+        mark.name = "Mark"
+        mark.persistAndFlush()
+
+        val projected =
+            Person.find("id", mark.id!!).project(GreetingValueClassDto::class.java).firstResult()
+        Assertions.assertNotNull(projected)
+        Assertions.assertEquals(mark.id, projected?.id?.value)
+        Assertions.assertEquals(mark.name, projected?.name)
 
         Person.deleteAll()
 

--- a/integration-tests/hibernate-orm-panache-kotlin/src/main/kotlin/io/quarkus/it/panache/kotlin/ValueClassProjection.kt
+++ b/integration-tests/hibernate-orm-panache-kotlin/src/main/kotlin/io/quarkus/it/panache/kotlin/ValueClassProjection.kt
@@ -1,0 +1,8 @@
+package io.quarkus.it.panache.kotlin
+
+import io.quarkus.runtime.annotations.RegisterForReflection
+
+@JvmInline value class GreetingId(val value: Long)
+
+@RegisterForReflection
+data class GreetingValueClassDto(val id: GreetingId? = null, val name: String)

--- a/integration-tests/hibernate-orm-panache-kotlin/src/main/kotlin/io/quarkus/it/panache/kotlin/ValueClassProjection.kt
+++ b/integration-tests/hibernate-orm-panache-kotlin/src/main/kotlin/io/quarkus/it/panache/kotlin/ValueClassProjection.kt
@@ -1,0 +1,10 @@
+package io.quarkus.it.panache.kotlin
+
+import io.quarkus.runtime.annotations.RegisterForReflection
+
+// Hibernate instantiates the value class itself through the generated `new GreetingId(id)`
+// constructor, so it needs its own reflection metadata in native mode.
+@RegisterForReflection @JvmInline value class GreetingId(val value: Long)
+
+@RegisterForReflection
+data class GreetingValueClassDto(val id: GreetingId? = null, val name: String)

--- a/integration-tests/hibernate-orm-panache-kotlin/src/test/kotlin/io/quarkus/it/panache/ProjectionTest.kt
+++ b/integration-tests/hibernate-orm-panache-kotlin/src/test/kotlin/io/quarkus/it/panache/ProjectionTest.kt
@@ -22,5 +22,6 @@ open class ProjectionTest {
             .body(Matchers.`is`("OK"))
         RestAssured.`when`()["/test/projection-no-arguments-constructor"].then()
             .body(Matchers.`is`("OK"))
+        RestAssured.`when`()["/test/projection-value-class"].then().body(Matchers.`is`("OK"))
     }
 }

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/defaultpu/TestEndpoint.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/defaultpu/TestEndpoint.java
@@ -1484,18 +1484,15 @@ public class TestEndpoint {
         Assertions.assertEquals(1,
                 Person.findAll().project(PersonNameDoubleConstructorWithConstructorAnnotation.class).count());
 
-        //Test class with multiple constructors but none with @ProjectedConstructor annotation
-        SemanticException semanticException = Assertions.assertThrowsExactly(SemanticException.class,
-                () -> Person.findAll().project(PersonNameDoubleConstructor.class).firstResult());
-        Assertions.assertEquals("Could not interpret path expression 'fakeParameter'", semanticException.getMessage());
+        // Without @ProjectedConstructor, the constructor with the fewest parameters is used
+        person = Person.findAll().project(PersonNameDoubleConstructor.class).firstResult();
+        Assertions.assertNotNull(person);
 
-        semanticException = Assertions.assertThrowsExactly(SemanticException.class,
-                () -> Person.find("name", "2").project(PersonNameDoubleConstructor.class).firstResult());
-        Assertions.assertEquals("Could not interpret path expression 'fakeParameter'", semanticException.getMessage());
+        person = Person.find("name", "2").project(PersonNameDoubleConstructor.class).firstResult();
+        Assertions.assertEquals("2", person.name);
 
-        semanticException = Assertions.assertThrowsExactly(SemanticException.class,
-                () -> Person.find("name = ?1", "2").project(PersonNameDoubleConstructor.class).firstResult());
-        Assertions.assertEquals("Could not interpret path expression 'fakeParameter'", semanticException.getMessage());
+        person = Person.find("name = ?1", "2").project(PersonNameDoubleConstructor.class).firstResult();
+        Assertions.assertEquals("2", person.name);
 
         person = Person.find(String.format(
                 "select uniqueName, name%sfrom io.quarkus.it.panache.defaultpu.Person%swhere name = ?1",
@@ -1504,27 +1501,21 @@ public class TestEndpoint {
                 .firstResult();
         Assertions.assertEquals("2", person.name);
 
-        semanticException = Assertions.assertThrowsExactly(SemanticException.class, () -> Person
-                .find("name = :name", Parameters.with("name", "2")).project(PersonNameDoubleConstructor.class).firstResult());
-        Assertions.assertEquals("Could not interpret path expression 'fakeParameter'", semanticException.getMessage());
+        person = Person.find("name = :name", Parameters.with("name", "2"))
+                .project(PersonNameDoubleConstructor.class).firstResult();
+        Assertions.assertEquals("2", person.name);
 
-        semanticException = Assertions.assertThrowsExactly(SemanticException.class,
-                () -> Person.find("#Person.getByName", Parameters.with("name", "2")).project(PersonNameDoubleConstructor.class)
-                        .firstResult());
-        Assertions.assertEquals("Could not interpret path expression 'fakeParameter'", semanticException.getMessage());
+        person = Person.find("#Person.getByName", Parameters.with("name", "2"))
+                .project(PersonNameDoubleConstructor.class).firstResult();
+        Assertions.assertEquals("2", person.name);
 
-        final PanacheQuery<? extends PersonName> failQuery = Person.findAll().project(PersonNameDoubleConstructor.class).page(0,
-                2);
-        semanticException = Assertions.assertThrowsExactly(SemanticException.class, () -> failQuery.list().size());
-        Assertions.assertEquals("Could not interpret path expression 'fakeParameter'", semanticException.getMessage());
+        PanacheQuery<PersonNameDoubleConstructor> doubleConstructorQuery = Person.findAll()
+                .project(PersonNameDoubleConstructor.class).page(0, 2);
+        Assertions.assertEquals(1, doubleConstructorQuery.list().size());
+        doubleConstructorQuery.nextPage();
+        Assertions.assertEquals(0, doubleConstructorQuery.list().size());
 
-        failQuery.nextPage();
-        semanticException = Assertions.assertThrowsExactly(SemanticException.class, () -> failQuery.list().size());
-        Assertions.assertEquals("Could not interpret path expression 'fakeParameter'", semanticException.getMessage());
-
-        semanticException = Assertions.assertThrowsExactly(SemanticException.class,
-                () -> Person.findAll().project(PersonNameDoubleConstructor.class).count());
-        Assertions.assertEquals("Could not interpret path expression 'fakeParameter'", semanticException.getMessage());
+        Assertions.assertEquals(1, Person.findAll().project(PersonNameDoubleConstructor.class).count());
         return "OK";
     }
 
@@ -1571,18 +1562,14 @@ public class TestEndpoint {
         Assertions.assertEquals(1,
                 Person.findAll().project(PersonNameDoubleConstructorWithProjectFieldNameAnnotation.class).count());
 
-        //Test class with multiple constructors but no parameters with @ProjectedFieldName annotation
-        SemanticException semanticException = Assertions.assertThrowsExactly(SemanticException.class,
-                () -> Person.findAll().project(PersonNameDoubleConstructor.class).firstResult());
-        Assertions.assertEquals("Could not interpret path expression 'fakeParameter'", semanticException.getMessage());
+        person = Person.findAll().project(PersonNameDoubleConstructor.class).firstResult();
+        Assertions.assertNotNull(person);
 
-        semanticException = Assertions.assertThrowsExactly(SemanticException.class,
-                () -> Person.find("name", "2").project(PersonNameDoubleConstructor.class).firstResult());
-        Assertions.assertEquals("Could not interpret path expression 'fakeParameter'", semanticException.getMessage());
+        person = Person.find("name", "2").project(PersonNameDoubleConstructor.class).firstResult();
+        Assertions.assertEquals("2", person.name);
 
-        semanticException = Assertions.assertThrowsExactly(SemanticException.class,
-                () -> Person.find("name = ?1", "2").project(PersonNameDoubleConstructor.class).firstResult());
-        Assertions.assertEquals("Could not interpret path expression 'fakeParameter'", semanticException.getMessage());
+        person = Person.find("name = ?1", "2").project(PersonNameDoubleConstructor.class).firstResult();
+        Assertions.assertEquals("2", person.name);
 
         person = Person.find(String.format(
                 "select uniqueName, name%sfrom io.quarkus.it.panache.defaultpu.Person%swhere name = ?1",
@@ -1591,27 +1578,21 @@ public class TestEndpoint {
                 .firstResult();
         Assertions.assertEquals("2", person.name);
 
-        semanticException = Assertions.assertThrowsExactly(SemanticException.class, () -> Person
-                .find("name = :name", Parameters.with("name", "2")).project(PersonNameDoubleConstructor.class).firstResult());
-        Assertions.assertEquals("Could not interpret path expression 'fakeParameter'", semanticException.getMessage());
+        person = Person.find("name = :name", Parameters.with("name", "2"))
+                .project(PersonNameDoubleConstructor.class).firstResult();
+        Assertions.assertEquals("2", person.name);
 
-        semanticException = Assertions.assertThrowsExactly(SemanticException.class,
-                () -> Person.find("#Person.getByName", Parameters.with("name", "2")).project(PersonNameDoubleConstructor.class)
-                        .firstResult());
-        Assertions.assertEquals("Could not interpret path expression 'fakeParameter'", semanticException.getMessage());
+        person = Person.find("#Person.getByName", Parameters.with("name", "2"))
+                .project(PersonNameDoubleConstructor.class).firstResult();
+        Assertions.assertEquals("2", person.name);
 
-        final PanacheQuery<? extends PersonName> failQuery = Person.findAll().project(PersonNameDoubleConstructor.class).page(0,
-                2);
-        semanticException = Assertions.assertThrowsExactly(SemanticException.class, () -> failQuery.list().size());
-        Assertions.assertEquals("Could not interpret path expression 'fakeParameter'", semanticException.getMessage());
+        PanacheQuery<PersonNameDoubleConstructor> doubleConstructorQuery = Person.findAll()
+                .project(PersonNameDoubleConstructor.class).page(0, 2);
+        Assertions.assertEquals(1, doubleConstructorQuery.list().size());
+        doubleConstructorQuery.nextPage();
+        Assertions.assertEquals(0, doubleConstructorQuery.list().size());
 
-        failQuery.nextPage();
-        semanticException = Assertions.assertThrowsExactly(SemanticException.class, () -> failQuery.list().size());
-        Assertions.assertEquals("Could not interpret path expression 'fakeParameter'", semanticException.getMessage());
-
-        semanticException = Assertions.assertThrowsExactly(SemanticException.class,
-                () -> Person.findAll().project(PersonNameDoubleConstructor.class).count());
-        Assertions.assertEquals("Could not interpret path expression 'fakeParameter'", semanticException.getMessage());
+        Assertions.assertEquals(1, Person.findAll().project(PersonNameDoubleConstructor.class).count());
         return "OK";
     }
 
@@ -1654,18 +1635,14 @@ public class TestEndpoint {
 
         Assertions.assertEquals(1, Person.findAll().project(PersonNameDoubleConstructorWithOneEmpty.class).count());
 
-        //Test class with multiple constructors but no parameters with @ProjectedFieldName annotation
-        SemanticException semanticException = Assertions.assertThrowsExactly(SemanticException.class,
-                () -> Person.findAll().project(PersonNameDoubleConstructor.class).firstResult());
-        Assertions.assertEquals("Could not interpret path expression 'fakeParameter'", semanticException.getMessage());
+        person = Person.findAll().project(PersonNameDoubleConstructor.class).firstResult();
+        Assertions.assertNotNull(person);
 
-        semanticException = Assertions.assertThrowsExactly(SemanticException.class,
-                () -> Person.find("name", "2").project(PersonNameDoubleConstructor.class).firstResult());
-        Assertions.assertEquals("Could not interpret path expression 'fakeParameter'", semanticException.getMessage());
+        person = Person.find("name", "2").project(PersonNameDoubleConstructor.class).firstResult();
+        Assertions.assertEquals("2", person.name);
 
-        semanticException = Assertions.assertThrowsExactly(SemanticException.class,
-                () -> Person.find("name = ?1", "2").project(PersonNameDoubleConstructor.class).firstResult());
-        Assertions.assertEquals("Could not interpret path expression 'fakeParameter'", semanticException.getMessage());
+        person = Person.find("name = ?1", "2").project(PersonNameDoubleConstructor.class).firstResult();
+        Assertions.assertEquals("2", person.name);
 
         person = Person.find(String.format(
                 "select uniqueName, name%sfrom io.quarkus.it.panache.defaultpu.Person%swhere name = ?1",
@@ -1674,27 +1651,21 @@ public class TestEndpoint {
                 .firstResult();
         Assertions.assertEquals("2", person.name);
 
-        semanticException = Assertions.assertThrowsExactly(SemanticException.class, () -> Person
-                .find("name = :name", Parameters.with("name", "2")).project(PersonNameDoubleConstructor.class).firstResult());
-        Assertions.assertEquals("Could not interpret path expression 'fakeParameter'", semanticException.getMessage());
+        person = Person.find("name = :name", Parameters.with("name", "2"))
+                .project(PersonNameDoubleConstructor.class).firstResult();
+        Assertions.assertEquals("2", person.name);
 
-        semanticException = Assertions.assertThrowsExactly(SemanticException.class,
-                () -> Person.find("#Person.getByName", Parameters.with("name", "2")).project(PersonNameDoubleConstructor.class)
-                        .firstResult());
-        Assertions.assertEquals("Could not interpret path expression 'fakeParameter'", semanticException.getMessage());
+        person = Person.find("#Person.getByName", Parameters.with("name", "2"))
+                .project(PersonNameDoubleConstructor.class).firstResult();
+        Assertions.assertEquals("2", person.name);
 
-        final PanacheQuery<? extends PersonName> failQuery = Person.findAll().project(PersonNameDoubleConstructor.class).page(0,
-                2);
-        semanticException = Assertions.assertThrowsExactly(SemanticException.class, () -> failQuery.list().size());
-        Assertions.assertEquals("Could not interpret path expression 'fakeParameter'", semanticException.getMessage());
+        PanacheQuery<PersonNameDoubleConstructor> doubleConstructorQuery = Person.findAll()
+                .project(PersonNameDoubleConstructor.class).page(0, 2);
+        Assertions.assertEquals(1, doubleConstructorQuery.list().size());
+        doubleConstructorQuery.nextPage();
+        Assertions.assertEquals(0, doubleConstructorQuery.list().size());
 
-        failQuery.nextPage();
-        semanticException = Assertions.assertThrowsExactly(SemanticException.class, () -> failQuery.list().size());
-        Assertions.assertEquals("Could not interpret path expression 'fakeParameter'", semanticException.getMessage());
-
-        semanticException = Assertions.assertThrowsExactly(SemanticException.class,
-                () -> Person.findAll().project(PersonNameDoubleConstructor.class).count());
-        Assertions.assertEquals("Could not interpret path expression 'fakeParameter'", semanticException.getMessage());
+        Assertions.assertEquals(1, Person.findAll().project(PersonNameDoubleConstructor.class).count());
         return "OK";
     }
 


### PR DESCRIPTION
Kotlin data classes that use `@JvmInline` value classes (especially with default parameters) were failing Panache DTO projection with a misleading `-parameters` compiler error, and REST responses were serializing properties under mangled JVM names such as `id-8c0ahUI` instead of `id`.

Panache projection now selects a usable non-synthetic constructor, wraps inline value-class arguments in HQL (`new GreetingId(id)`), and shares the logic between blocking and reactive paths via `ProjectionConstructorUtil`. REST Jackson codegen now picks Kotlin-friendly constructors, resolves constructor parameters safely when names are missing, and demangles inline value-class property names for JSON output.

Existing projection integration tests were updated to reflect improved constructor selection when a better matching constructor is available.

- Fixes: #53293