### PR TITLE
Move Order/Sort to PanacheQuery.sort() in quarkus-data-hibernate

### DIFF
--- a/docs/src/main/asciidoc/quarkus-data-hibernate.adoc
+++ b/docs/src/main/asciidoc/quarkus-data-hibernate.adoc
@@ -347,6 +347,8 @@ packed with most of the operations you need to work on your entity, such as, out
 [source,java]
 ----
 import io.quarkus.hibernate.panache.blocking.PanacheBlockingQuery;
+import jakarta.data.Order;
+import jakarta.data.Sort;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import org.hibernate.Session;
@@ -372,6 +374,7 @@ public class Code {
         List<Cat> allCats = repo.listAll();
         repo.streamAll().forEach(kitty -> kitty.name = kitty.name.toUpperCase());
         PanacheBlockingQuery<Cat> catQuery = repo.findAll();
+        List<Cat> sortedCats = repo.findAll().sort(Sort.asc("name")).list();
         // operations on the Hibernate session
         repo.flush();
         Session session = repo.getSession();
@@ -391,6 +394,8 @@ you want to write non-type-safe queries, you can always use the provided methods
 [source,java]
 ----
 import io.quarkus.hibernate.panache.blocking.PanacheBlockingQuery;
+import jakarta.data.Order;
+import jakarta.data.Sort;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import org.hibernate.Session;
@@ -418,8 +423,26 @@ public class Code {
         repo.count("breed = ?1 and name is null", Cat.Breed.HAIRLESS);
         // Make every cat cute
         repo.update("breed = CUTE");
+        // Sort results using PanacheQuery
+        List<Cat> sortedByName = repo.findAll().sort(Sort.asc("name")).list();
+        List<Cat> sortedMatches = repo.find("breed = ?1", Cat.Breed.CUTE)
+                .sort(Sort.desc("name"))
+                .list();
     }
 }
+----
+
+Sorting is applied on the `PanacheQuery` returned by `find()` and `findAll()`, not on the shortcut
+`list()`, `listAll()`, `stream()`, or `streamAll()` methods. For a single criterion, pass a `Sort`
+directly — there is no need to wrap it in `Order.by()`. Use `Order` only when you need multiple
+criteria, or when receiving an `Order` from a REST endpoint:
+
+[source,java]
+----
+List<Cat> byName = repo.findAll().sort(Sort.asc("name")).list();
+List<Cat> byNameThenBirth = repo.findAll()
+        .sort(Order.by(Sort.asc("name"), Sort.desc("birth")))
+        .list();
 ----
 
 == About entity identifiers
@@ -1199,14 +1222,14 @@ The following Jakarta Data types are automatically mapped from query parameters:
 |`page=1`, `size=10`, `requestTotal=true`
 |`?page=2&size=25`
 
-|`Sort<?>`
+|`Sort<Cat>`
 |`sort`
 |`null`
 |`?sort=name` (asc) or `?sort=-name` (desc)
 
-|`Order<?>`
+|`Order<Cat>`
 |`sort` (repeating)
-|`null`
+|empty `Order.by()`
 |`?sort=name&sort=-salary`
 
 |`Limit`
@@ -1222,6 +1245,27 @@ The following Jakarta Data types are automatically mapped from query parameters:
 |===
 
 For `Sort` and `Order`, prefix the property name with `-` to indicate descending order.
+
+When binding sort parameters from REST endpoints to `PanacheQuery`, prefer `Order<Cat>` over
+`Sort<Cat>`. A missing `sort` query parameter yields `null` for `Sort<Cat>` but an empty
+`Order.by()` for `Order<Cat>`. Only call `sort()` when the client requested sorting:
+
+[source,java]
+----
+import jakarta.data.Order;
+import jakarta.ws.rs.GET;
+
+import io.quarkus.hibernate.panache.blocking.PanacheBlockingQuery;
+
+@GET
+public List<Cat> list(Order<Cat> order) {
+    PanacheBlockingQuery<Cat> query = Cat_.managedBlocking().findAll();
+    if (!order.sorts().isEmpty()) {
+        query = query.sort(order);
+    }
+    return query.list();
+}
+----
 
 NOTE: Cursor-based pagination (`PageRequest.Mode.CURSOR_NEXT` / `CURSOR_PREVIOUS`) is not currently supported
 by this REST integration. Only offset-based pagination is available via query parameters.
@@ -1248,17 +1292,19 @@ The `totalElements` and `totalPages` fields are only included when the `PageRequ
 === Example endpoint
 
 Here is an example of a REST endpoint that uses `PageRequest` and `Order` to return a paginated, sorted
-list of cats. `PanacheRepository` already provides a `findAll(PageRequest, Order)` method, so you can use
-the entity and repository we defined earlier directly:
+list of cats. Paging and sorting are configured on the `PanacheQuery` returned by `findAll()`:
 
 [source,java]
 ----
 import jakarta.data.Order;
-import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+
+import java.util.List;
+
+import io.quarkus.hibernate.panache.blocking.PanacheBlockingQuery;
 
 @Path("cats")
 public class CatResource {
@@ -1267,8 +1313,12 @@ public class CatResource {
     Cat.Repo repo;
 
     @GET
-    public Page<Cat> list(PageRequest pageRequest, Order<Cat> order) { // <1>
-        return repo.findAll(pageRequest, order);
+    public List<Cat> list(PageRequest pageRequest, Order<Cat> order) { // <1>
+        PanacheBlockingQuery<Cat> query = repo.findAll().pages().request(pageRequest);
+        if (!order.sorts().isEmpty()) {
+            query = query.sort(order);
+        }
+        return query.list();
     }
 }
 ----

--- a/docs/src/main/asciidoc/quarkus-data-hibernate.adoc
+++ b/docs/src/main/asciidoc/quarkus-data-hibernate.adoc
@@ -1248,24 +1248,9 @@ For `Sort` and `Order`, prefix the property name with `-` to indicate descending
 
 When binding sort parameters from REST endpoints to `PanacheQuery`, prefer `Order<Cat>` over
 `Sort<Cat>`. A missing `sort` query parameter yields `null` for `Sort<Cat>` but an empty
-`Order.by()` for `Order<Cat>`. Only call `sort()` when the client requested sorting:
-
-[source,java]
-----
-import jakarta.data.Order;
-import jakarta.ws.rs.GET;
-
-import io.quarkus.hibernate.panache.blocking.PanacheBlockingQuery;
-
-@GET
-public List<Cat> list(Order<Cat> order) {
-    PanacheBlockingQuery<Cat> query = Cat_.managedBlocking().findAll();
-    if (!order.sorts().isEmpty()) {
-        query = query.sort(order);
-    }
-    return query.list();
-}
-----
+`Order.by()` for `Order<Cat>`. If you use `Sort<Cat>` and the parameter is `null`, you can
+safely call `.sort(null)` and it is a no-op; `Order` is still preferred when multiple columns
+may be requested.
 
 NOTE: Cursor-based pagination (`PageRequest.Mode.CURSOR_NEXT` / `CURSOR_PREVIOUS`) is not currently supported
 by this REST integration. Only offset-based pagination is available via query parameters.
@@ -1304,8 +1289,6 @@ import jakarta.ws.rs.Path;
 
 import java.util.List;
 
-import io.quarkus.hibernate.panache.blocking.PanacheBlockingQuery;
-
 @Path("cats")
 public class CatResource {
 
@@ -1314,11 +1297,7 @@ public class CatResource {
 
     @GET
     public List<Cat> list(PageRequest pageRequest, Order<Cat> order) { // <1>
-        PanacheBlockingQuery<Cat> query = repo.findAll().pages().request(pageRequest);
-        if (!order.sorts().isEmpty()) {
-            query = query.sort(order);
-        }
-        return query.list();
+        return repo.findAll().pages().request(pageRequest).sort(order).list();
     }
 }
 ----

--- a/extensions/data/hibernate/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/PagingTest.java
+++ b/extensions/data/hibernate/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/PagingTest.java
@@ -44,7 +44,7 @@ public class PagingTest {
 
     @Transactional
     void offsetPageBasic() {
-        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+        PanacheBlockingQuery<MyEntity> query = repo.findAll().sort(Order.by(_MyEntity.foo.asc()));
 
         List<MyEntity> page0 = query.pages().page(0, 10).list();
         assertThat(page0).hasSize(10);
@@ -62,7 +62,7 @@ public class PagingTest {
 
     @Transactional
     void offsetPageNavigation() {
-        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+        PanacheBlockingQuery<MyEntity> query = repo.findAll().sort(Order.by(_MyEntity.foo.asc()));
 
         query.pages().page(0, 10);
         List<MyEntity> page0 = query.list();
@@ -100,7 +100,7 @@ public class PagingTest {
 
     @Transactional
     void offsetPageCount() {
-        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+        PanacheBlockingQuery<MyEntity> query = repo.findAll().sort(Order.by(_MyEntity.foo.asc()));
 
         query.pages().page(0, 10);
         assertThat(query.pages().count()).isEqualTo(3L);
@@ -109,7 +109,7 @@ public class PagingTest {
 
     @Transactional
     void offsetPageIterateAll() {
-        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+        PanacheBlockingQuery<MyEntity> query = repo.findAll().sort(Order.by(_MyEntity.foo.asc()));
 
         int totalResults = 0;
         List<MyEntity> list = query.pages().page(0, 10).list();
@@ -125,7 +125,7 @@ public class PagingTest {
 
     @Transactional
     void cursorPageBasic() {
-        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+        PanacheBlockingQuery<MyEntity> query = repo.findAll().sort(Order.by(_MyEntity.foo.asc()));
 
         List<MyEntity> page0 = query.pages().cursor(0, 10).list();
         assertThat(page0).hasSize(10);
@@ -135,7 +135,7 @@ public class PagingTest {
 
     @Transactional
     void cursorPageNavigation() {
-        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+        PanacheBlockingQuery<MyEntity> query = repo.findAll().sort(Order.by(_MyEntity.foo.asc()));
 
         List<MyEntity> page0 = query.pages().cursor(0, 10).list();
         assertThat(page0).hasSize(10);
@@ -164,7 +164,7 @@ public class PagingTest {
 
     @Transactional
     void cursorPageIterateAll() {
-        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+        PanacheBlockingQuery<MyEntity> query = repo.findAll().sort(Order.by(_MyEntity.foo.asc()));
 
         int totalResults = 0;
         List<MyEntity> list = query.pages().cursor(0, 10).list();
@@ -187,7 +187,7 @@ public class PagingTest {
 
     @Transactional
     void cursorPageLastThrows() {
-        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+        PanacheBlockingQuery<MyEntity> query = repo.findAll().sort(Order.by(_MyEntity.foo.asc()));
 
         query.pages().cursor(0, 10).list();
         assertThatThrownBy(() -> query.pages().last())
@@ -198,7 +198,7 @@ public class PagingTest {
 
     @Transactional
     void limitBasic() {
-        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+        PanacheBlockingQuery<MyEntity> query = repo.findAll().sort(Order.by(_MyEntity.foo.asc()));
 
         List<MyEntity> list = query.limits().limit(10).list();
         assertThat(list).hasSize(10);
@@ -208,7 +208,7 @@ public class PagingTest {
 
     @Transactional
     void limitWithStartOffset() {
-        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+        PanacheBlockingQuery<MyEntity> query = repo.findAll().sort(Order.by(_MyEntity.foo.asc()));
 
         List<MyEntity> list = query.limits().limit(5, 10).list();
         assertThat(list).hasSize(10);
@@ -217,7 +217,7 @@ public class PagingTest {
 
     @Transactional
     void limitRange() {
-        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+        PanacheBlockingQuery<MyEntity> query = repo.findAll().sort(Order.by(_MyEntity.foo.asc()));
 
         List<MyEntity> list = query.limits().range(5, 14).list();
         assertThat(list).hasSize(10);
@@ -227,7 +227,7 @@ public class PagingTest {
 
     @Transactional
     void limitAll() {
-        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+        PanacheBlockingQuery<MyEntity> query = repo.findAll().sort(Order.by(_MyEntity.foo.asc()));
 
         List<MyEntity> list = query.limits().limit(100).list();
         assertThat(list).hasSize(25);
@@ -243,7 +243,7 @@ public class PagingTest {
 
     @Transactional
     void limitFrom() {
-        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+        PanacheBlockingQuery<MyEntity> query = repo.findAll().sort(Order.by(_MyEntity.foo.asc()));
 
         List<MyEntity> list = query.limits().limitFrom(5).list();
         assertThat(list).hasSize(10);
@@ -253,7 +253,7 @@ public class PagingTest {
 
     @Transactional
     void limitFromBeyondEnd() {
-        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+        PanacheBlockingQuery<MyEntity> query = repo.findAll().sort(Order.by(_MyEntity.foo.asc()));
 
         List<MyEntity> list = query.limits().limitFrom(20).list();
         assertThat(list).hasSize(5);
@@ -262,7 +262,7 @@ public class PagingTest {
 
     @Transactional
     void limitWithJakartaLimit() {
-        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+        PanacheBlockingQuery<MyEntity> query = repo.findAll().sort(Order.by(_MyEntity.foo.asc()));
 
         List<MyEntity> list = query.limits().limit(Limit.of(10)).list();
         assertThat(list).hasSize(10);
@@ -272,7 +272,7 @@ public class PagingTest {
 
     @Transactional
     void limitWithJakartaLimitRange() {
-        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+        PanacheBlockingQuery<MyEntity> query = repo.findAll().sort(Order.by(_MyEntity.foo.asc()));
 
         List<MyEntity> list = query.limits().limit(Limit.range(6, 15)).list();
         assertThat(list).hasSize(10);
@@ -282,7 +282,7 @@ public class PagingTest {
 
     @Transactional
     void requestWithPageRequest() {
-        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+        PanacheBlockingQuery<MyEntity> query = repo.findAll().sort(Order.by(_MyEntity.foo.asc()));
 
         List<MyEntity> page0 = query.pages().request(PageRequest.ofPage(1, 10, false)).list();
         assertThat(page0).hasSize(10);
@@ -302,7 +302,7 @@ public class PagingTest {
 
     @Transactional
     void switchFromOffsetToLimit() {
-        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+        PanacheBlockingQuery<MyEntity> query = repo.findAll().sort(Order.by(_MyEntity.foo.asc()));
 
         query.pages().page(0, 10);
         List<MyEntity> paged = query.list();
@@ -315,7 +315,7 @@ public class PagingTest {
 
     @Transactional
     void switchFromLimitToOffset() {
-        PanacheBlockingQuery<MyEntity> query = repo.findAll(Order.by(_MyEntity.foo.asc()));
+        PanacheBlockingQuery<MyEntity> query = repo.findAll().sort(Order.by(_MyEntity.foo.asc()));
 
         query.limits().limit(5);
         List<MyEntity> limited = query.list();
@@ -330,7 +330,7 @@ public class PagingTest {
 
     @Transactional
     void noPaging() {
-        PanacheBlockingQuery<MyEntity> query = repo.findAll(_MyEntity.foo.asc());
+        PanacheBlockingQuery<MyEntity> query = repo.findAll().sort(_MyEntity.foo.asc());
 
         List<MyEntity> all = query.list();
         assertThat(all).hasSize(25);

--- a/extensions/data/hibernate/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/ReactivePagingTest.java
+++ b/extensions/data/hibernate/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/ReactivePagingTest.java
@@ -53,7 +53,7 @@ public class ReactivePagingTest {
 
     @WithTransaction
     Uni<Void> offsetPageBasic() {
-        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(Order.by(_MyReactiveEntity.foo.asc()));
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll().sort(Order.by(_MyReactiveEntity.foo.asc()));
 
         return query.pages().page(0, 10).list().flatMap(page0 -> {
             assertThat(page0).hasSize(10);
@@ -75,7 +75,7 @@ public class ReactivePagingTest {
 
     @WithTransaction
     Uni<Void> offsetPageNavigation() {
-        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(Order.by(_MyReactiveEntity.foo.asc()));
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll().sort(Order.by(_MyReactiveEntity.foo.asc()));
 
         query.pages().page(0, 10);
         return query.list().flatMap(page0 -> {
@@ -122,7 +122,7 @@ public class ReactivePagingTest {
 
     @WithTransaction
     Uni<Void> offsetPageCount() {
-        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(Order.by(_MyReactiveEntity.foo.asc()));
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll().sort(Order.by(_MyReactiveEntity.foo.asc()));
 
         query.pages().page(0, 10);
         return query.pages().count().flatMap(pageCount -> {
@@ -136,7 +136,7 @@ public class ReactivePagingTest {
 
     @WithTransaction
     Uni<Void> offsetPageIterateAll() {
-        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(Order.by(_MyReactiveEntity.foo.asc()));
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll().sort(Order.by(_MyReactiveEntity.foo.asc()));
 
         int[] totalResults = { 0 };
         return query.pages().page(0, 10).list().flatMap(list -> {
@@ -165,7 +165,7 @@ public class ReactivePagingTest {
 
     @WithTransaction
     Uni<Void> cursorPageThrows() {
-        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(Order.by(_MyReactiveEntity.foo.asc()));
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll().sort(Order.by(_MyReactiveEntity.foo.asc()));
 
         assertThatThrownBy(() -> query.pages().cursor(0, 10))
                 .isInstanceOf(UnsupportedOperationException.class)
@@ -177,7 +177,7 @@ public class ReactivePagingTest {
 
     @WithTransaction
     Uni<Void> limitBasic() {
-        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(Order.by(_MyReactiveEntity.foo.asc()));
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll().sort(Order.by(_MyReactiveEntity.foo.asc()));
 
         return query.limits().limit(10).list().map(list -> {
             assertThat(list).hasSize(10);
@@ -189,7 +189,7 @@ public class ReactivePagingTest {
 
     @WithTransaction
     Uni<Void> limitWithStartOffset() {
-        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(Order.by(_MyReactiveEntity.foo.asc()));
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll().sort(Order.by(_MyReactiveEntity.foo.asc()));
 
         return query.limits().limit(5, 10).list().map(list -> {
             assertThat(list).hasSize(10);
@@ -200,7 +200,7 @@ public class ReactivePagingTest {
 
     @WithTransaction
     Uni<Void> limitRange() {
-        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(Order.by(_MyReactiveEntity.foo.asc()));
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll().sort(Order.by(_MyReactiveEntity.foo.asc()));
 
         return query.limits().range(5, 14).list().map(list -> {
             assertThat(list).hasSize(10);
@@ -212,7 +212,7 @@ public class ReactivePagingTest {
 
     @WithTransaction
     Uni<Void> limitAll() {
-        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(Order.by(_MyReactiveEntity.foo.asc()));
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll().sort(Order.by(_MyReactiveEntity.foo.asc()));
 
         return query.limits().limit(100).list().map(list -> {
             assertThat(list).hasSize(25);
@@ -231,7 +231,7 @@ public class ReactivePagingTest {
 
     @WithTransaction
     Uni<Void> limitFrom() {
-        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(Order.by(_MyReactiveEntity.foo.asc()));
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll().sort(Order.by(_MyReactiveEntity.foo.asc()));
 
         return query.limits().limitFrom(5).list().map(list -> {
             assertThat(list).hasSize(10);
@@ -243,7 +243,7 @@ public class ReactivePagingTest {
 
     @WithTransaction
     Uni<Void> limitFromBeyondEnd() {
-        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(Order.by(_MyReactiveEntity.foo.asc()));
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll().sort(Order.by(_MyReactiveEntity.foo.asc()));
 
         return query.limits().limitFrom(20).list().map(list -> {
             assertThat(list).hasSize(5);
@@ -254,7 +254,7 @@ public class ReactivePagingTest {
 
     @WithTransaction
     Uni<Void> limitWithJakartaLimit() {
-        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(Order.by(_MyReactiveEntity.foo.asc()));
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll().sort(Order.by(_MyReactiveEntity.foo.asc()));
 
         return query.limits().limit(Limit.of(10)).list().map(list -> {
             assertThat(list).hasSize(10);
@@ -266,7 +266,7 @@ public class ReactivePagingTest {
 
     @WithTransaction
     Uni<Void> limitWithJakartaLimitRange() {
-        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(Order.by(_MyReactiveEntity.foo.asc()));
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll().sort(Order.by(_MyReactiveEntity.foo.asc()));
 
         return query.limits().limit(Limit.range(6, 15)).list().map(list -> {
             assertThat(list).hasSize(10);
@@ -278,7 +278,7 @@ public class ReactivePagingTest {
 
     @WithTransaction
     Uni<Void> requestWithPageRequest() {
-        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(Order.by(_MyReactiveEntity.foo.asc()));
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll().sort(Order.by(_MyReactiveEntity.foo.asc()));
 
         return query.pages().request(PageRequest.ofPage(1, 10, false)).list().flatMap(page0 -> {
             assertThat(page0).hasSize(10);
@@ -302,7 +302,7 @@ public class ReactivePagingTest {
 
     @WithTransaction
     Uni<Void> switchFromOffsetToLimit() {
-        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(Order.by(_MyReactiveEntity.foo.asc()));
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll().sort(Order.by(_MyReactiveEntity.foo.asc()));
 
         query.pages().page(0, 10);
         return query.list().flatMap(paged -> {
@@ -318,7 +318,7 @@ public class ReactivePagingTest {
 
     @WithTransaction
     Uni<Void> switchFromLimitToOffset() {
-        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(Order.by(_MyReactiveEntity.foo.asc()));
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll().sort(Order.by(_MyReactiveEntity.foo.asc()));
 
         return query.limits().limit(5).list().flatMap(limited -> {
             assertThat(limited).hasSize(5);
@@ -335,7 +335,7 @@ public class ReactivePagingTest {
 
     @WithTransaction
     Uni<Void> noPaging() {
-        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll(_MyReactiveEntity.foo.asc());
+        PanacheReactiveQuery<MyReactiveEntity> query = repo.findAll().sort(_MyReactiveEntity.foo.asc());
 
         return query.list().map(all -> {
             assertThat(all).hasSize(25);

--- a/extensions/data/hibernate/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/SortOnPanacheQueryTest.java
+++ b/extensions/data/hibernate/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/SortOnPanacheQueryTest.java
@@ -1,0 +1,146 @@
+package io.quarkus.hibernate.panache.deployment.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import jakarta.data.Order;
+import jakarta.data.Sort;
+import jakarta.data.page.PageRequest;
+import jakarta.transaction.Transactional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.panache.blocking.PanacheBlockingQuery;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class SortOnPanacheQueryTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("application-test.properties", "application.properties")
+                    .addClasses(MyEntity.class, MyEntity_.class, _MyEntity.class,
+                            MyEntity_.ManagedBlockingQueries_.class));
+
+    @Transactional
+    void createEntities() {
+        MyEntity_.managedBlocking().deleteAll();
+        for (int i = 0; i < 5; i++) {
+            MyEntity entity = new MyEntity();
+            entity.foo = "foo" + i;
+            entity.bar = "bar" + (4 - i);
+            entity.persist();
+        }
+    }
+
+    @Transactional
+    void findAllWithSort() {
+        List<MyEntity> sorted = MyEntity_.managedBlocking().findAll()
+                .sort(Sort.asc("foo"))
+                .list();
+        assertThat(sorted).hasSize(5);
+        assertThat(sorted.get(0).foo).isEqualTo("foo0");
+        assertThat(sorted.get(4).foo).isEqualTo("foo4");
+    }
+
+    @Transactional
+    void findAllWithSortDesc() {
+        List<MyEntity> sorted = MyEntity_.managedBlocking().findAll()
+                .sort(Sort.desc("foo"))
+                .list();
+        assertThat(sorted.get(0).foo).isEqualTo("foo4");
+        assertThat(sorted.get(4).foo).isEqualTo("foo0");
+    }
+
+    @Transactional
+    void findWithSort() {
+        List<MyEntity> sorted = MyEntity_.managedBlocking().find("foo", "foo2")
+                .sort(Sort.asc("bar"))
+                .list();
+        assertThat(sorted).hasSize(1);
+        assertThat(sorted.get(0).foo).isEqualTo("foo2");
+    }
+
+    @Transactional
+    void findAllWithNoSort() {
+        List<MyEntity> unsorted = MyEntity_.managedBlocking().findAll()
+                .sort((Order<? super MyEntity>) null)
+                .list();
+        assertThat(unsorted).hasSize(5);
+
+        unsorted = MyEntity_.managedBlocking().findAll()
+                .sort((Sort<? super MyEntity>) null)
+                .list();
+        assertThat(unsorted).hasSize(5);
+
+        unsorted = MyEntity_.managedBlocking().findAll()
+                .sort(Order.by())
+                .list();
+        assertThat(unsorted).hasSize(5);
+    }
+
+    @Transactional
+    void streamWithSort() {
+        List<String> names = MyEntity_.managedBlocking().findAll()
+                .sort(Sort.asc("foo"))
+                .stream()
+                .map(e -> e.foo)
+                .collect(Collectors.toList());
+        assertThat(names).containsExactly("foo0", "foo1", "foo2", "foo3", "foo4");
+    }
+
+    @Transactional
+    void findAllWithPageRequestAndSort() {
+        List<MyEntity> page = MyEntity_.managedBlocking().findAll()
+                .pages().request(PageRequest.ofPage(1, 2, false))
+                .sort(Sort.asc("foo"))
+                .list();
+        assertThat(page).hasSize(2);
+        assertThat(page.get(0).foo).isEqualTo("foo0");
+        assertThat(page.get(1).foo).isEqualTo("foo1");
+    }
+
+    @Transactional
+    void findAllWithPageRequestAndEmptyOrder() {
+        PanacheBlockingQuery<MyEntity> query = MyEntity_.managedBlocking().findAll()
+                .pages().request(PageRequest.ofPage(2, 2, false));
+        Order<? super MyEntity> order = Order.by();
+        if (!order.sorts().isEmpty()) {
+            query = query.sort(order);
+        }
+        List<MyEntity> page = query.list();
+        assertThat(page).hasSize(2);
+    }
+
+    @Transactional
+    void replaceSort() {
+        PanacheBlockingQuery<MyEntity> query = MyEntity_.managedBlocking().findAll()
+                .sort(Sort.asc("foo"));
+        assertThat(query.list().get(0).foo).isEqualTo("foo0");
+
+        List<MyEntity> resorted = query.sort(Sort.desc("foo")).list();
+        assertThat(resorted.get(0).foo).isEqualTo("foo4");
+    }
+
+    @Transactional
+    void clear() {
+        MyEntity_.managedBlocking().deleteAll();
+    }
+
+    @Test
+    void testSortOnPanacheQuery() {
+        createEntities();
+        findAllWithSort();
+        findAllWithSortDesc();
+        findWithSort();
+        findAllWithNoSort();
+        findAllWithPageRequestAndSort();
+        findAllWithPageRequestAndEmptyOrder();
+        streamWithSort();
+        replaceSort();
+        clear();
+    }
+}

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/PanacheQuery.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/PanacheQuery.java
@@ -5,6 +5,8 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import jakarta.data.Limit;
+import jakarta.data.Order;
+import jakarta.data.Sort;
 import jakarta.data.page.PageRequest;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.NoResultException;
@@ -15,20 +17,23 @@ import org.hibernate.annotations.Filter;
 import org.hibernate.annotations.FilterDef;
 import org.hibernate.query.Page;
 
+import io.quarkus.panache.hibernate.common.runtime.PanacheJpaUtil;
+
 /**
  * <p>
  * Interface representing an entity query, which abstracts the use of paging, getting the number of results, and
  * operating on {@link List} or {@link Stream}.
  * </p>
  * <p>
- * Instances of this interface cannot mutate the query itself or its parameters: only paging information can be
- * modified, and instances of this interface can be reused to obtain multiple pages of results.
+ * Instances of this interface cannot mutate the query itself or its parameters: only paging and sort
+ * information can be modified, and instances of this interface can be reused to obtain multiple pages of results.
  * </p>
  *
  * @author Stéphane Épardaud
- * @param <Entity> The entity type being queried
+ * @param <Entity> The result type returned by single-result operations
+ * @param <SortEntity> The entity type used for typed sorting
  */
-public interface PanacheQuery<Query extends PanacheQuery<Query, Entity, EntityList, QueryAfterCount, Confirmation, Count>, Entity, EntityList, QueryAfterCount, Confirmation, Count> {
+public interface PanacheQuery<Query extends PanacheQuery<Query, Entity, SortEntity, EntityList, QueryAfterCount, Confirmation, Count>, Entity, SortEntity, EntityList, QueryAfterCount, Confirmation, Count> {
 
     /**
      * Provides operations for limiting the number of results returned by a query using absolute row indices.
@@ -38,7 +43,7 @@ public interface PanacheQuery<Query extends PanacheQuery<Query, Entity, EntityLi
      *
      * @param <Query> the query type, so that fluent methods return the correct query type
      */
-    public interface Limits<Query extends PanacheQuery<?, ?, ?, ?, ?, ?>> {
+    public interface Limits<Query extends PanacheQuery<?, ?, ?, ?, ?, ?, ?>> {
 
         /**
          * Returns the current limit as a Jakarta Data {@link Limit}.
@@ -109,7 +114,7 @@ public interface PanacheQuery<Query extends PanacheQuery<Query, Entity, EntityLi
      * @param <Confirmation> the return type for boolean checks (may be async)
      * @param <Count> the return type for count values (may be async)
      */
-    public interface Pages<Query extends PanacheQuery<?, ?, ?, ?, ?, ?>, QueryAfterCount, Confirmation, Count> {
+    public interface Pages<Query extends PanacheQuery<?, ?, ?, ?, ?, ?, ?>, QueryAfterCount, Confirmation, Count> {
 
         /**
          * Returns the current page as a Jakarta Data {@link PageRequest}.
@@ -231,6 +236,24 @@ public interface PanacheQuery<Query extends PanacheQuery<Query, Entity, EntityLi
     Pages<Query, QueryAfterCount, Confirmation, Count> pages();
 
     // Builder
+
+    /**
+     * Applies sort criteria to this query.
+     *
+     * @param order the sort order to use
+     * @return this query, modified
+     */
+    public Query sort(Order<? super SortEntity> order);
+
+    /**
+     * Applies sort criteria to this query.
+     *
+     * @param sort the sort strategy to use
+     * @return this query, modified
+     */
+    default Query sort(Sort<? super SortEntity> sort) {
+        return sort(PanacheJpaUtil.toOrder(sort));
+    }
 
     /**
      * Define the locking strategy used for this query.

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/PanacheRepositoryQueries.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/PanacheRepositoryQueries.java
@@ -2,11 +2,9 @@ package io.quarkus.hibernate.panache;
 
 import java.util.Map;
 
-import jakarta.data.Order;
-import jakarta.data.Sort;
 import jakarta.persistence.LockModeType;
 
-public interface PanacheRepositoryQueries<EntityResult, EntityList, Query extends PanacheQuery<?, ?, ?, ?, ?, ?>, Count, Confirmation, Id> {
+public interface PanacheRepositoryQueries<EntityResult, EntityList, Query extends PanacheQuery<?, ?, ?, ?, ?, ?, ?>, Count, Confirmation, Id> {
 
     // Queries
 
@@ -33,7 +31,6 @@ public interface PanacheRepositoryQueries<EntityResult, EntityList, Query extend
      * @param query a {@link io.quarkus.hibernate.panache query string}
      * @param params optional sequence of indexed parameters
      * @return a new {@link PanacheQuery} instance for the given query
-     * @see #find(String, Sort, Object...)
      * @see #find(String, Map)
      * @see #list(String, Object...)
      * @see #stream(String, Object...)
@@ -41,39 +38,11 @@ public interface PanacheRepositoryQueries<EntityResult, EntityList, Query extend
     Query find(String query, Object... params);
 
     /**
-     * Find entities using a query and the given sort options, with optional indexed parameters.
-     *
-     * @param query a {@link io.quarkus.hibernate.panache query string}
-     * @param order the sort strategy to use
-     * @param params optional sequence of indexed parameters
-     * @return a new {@link PanacheQuery} instance for the given query
-     * @see #find(String, Object...)
-     * @see #find(String, Order, Map)
-     * @see #list(String, Order, Object...)
-     * @see #stream(String, Order, Object...)
-     */
-    Query find(String query, Order<?> order, Object... params);
-
-    /**
-     * Find entities using a query and the given sort option, with optional indexed parameters.
-     * This is a shortcut for <code>find(query, Order.by(sort), params)</code>.
-     *
-     * @param query a {@link io.quarkus.hibernate.panache query string}
-     * @param sort the sort strategy to use
-     * @param params optional sequence of indexed parameters
-     * @return a new {@link PanacheQuery} instance for the given query
-     */
-    default Query find(String query, Sort<?> sort, Object... params) {
-        return find(query, Order.by(sort), params);
-    }
-
-    /**
      * Find entities using a query, with named parameters.
      *
      * @param query a {@link io.quarkus.hibernate.panache query string}
      * @param params {@link Map} of named parameters
      * @return a new {@link PanacheQuery} instance for the given query
-     * @see #find(String, Sort, Map)
      * @see #find(String, Object...)
      * @see #list(String, Map)
      * @see #stream(String, Map)
@@ -81,63 +50,13 @@ public interface PanacheRepositoryQueries<EntityResult, EntityList, Query extend
     Query find(String query, Map<String, Object> params);
 
     /**
-     * Find entities using a query and the given sort options, with named parameters.
-     *
-     * @param query a {@link io.quarkus.hibernate.panache query string}
-     * @param order the sort strategy to use
-     * @param params {@link Map} of indexed parameters
-     * @return a new {@link PanacheQuery} instance for the given query
-     * @see #find(String, Map)
-     * @see #find(String, Order, Object...)
-     * @see #list(String, Order, Map)
-     * @see #stream(String, Order, Map)
-     */
-    Query find(String query, Order<?> order, Map<String, Object> params);
-
-    /**
-     * Find entities using a query and the given sort option, with named parameters.
-     * This is a shortcut for <code>find(query, Order.by(sort), params)</code>.
-     *
-     * @param query a {@link io.quarkus.hibernate.panache query string}
-     * @param sort the sort strategy to use
-     * @param params {@link Map} of named parameters
-     * @return a new {@link PanacheQuery} instance for the given query
-     */
-    default Query find(String query, Sort<?> sort, Map<String, Object> params) {
-        return find(query, Order.by(sort), params);
-    }
-
-    /**
      * Find all entities of this type.
      *
      * @return a new {@link PanacheQuery} instance to find all entities of this type.
-     * @see #findAll(Sort)
      * @see #listAll()
      * @see #streamAll()
      */
     Query findAll();
-
-    /**
-     * Find all entities of this type, in the given order.
-     *
-     * @param order the sort order to use
-     * @return a new {@link PanacheQuery} instance to find all entities of this type.
-     * @see #findAll()
-     * @see #listAll(Order)
-     * @see #streamAll(Order)
-     */
-    Query findAll(Order<?> order);
-
-    /**
-     * Find all entities of this type, in the given order.
-     * This is a shortcut for <code>findAll(Order.by(sort))</code>.
-     *
-     * @param sort the sort order to use
-     * @return a new {@link PanacheQuery} instance to find all entities of this type.
-     */
-    default Query findAll(Sort<?> sort) {
-        return findAll(Order.by(sort));
-    }
 
     /**
      * Find entities matching a query, with optional indexed parameters.
@@ -146,40 +65,11 @@ public interface PanacheRepositoryQueries<EntityResult, EntityList, Query extend
      * @param query a {@link io.quarkus.hibernate.panache query string}
      * @param params optional sequence of indexed parameters
      * @return a {@link List} containing all results, without paging
-     * @see #list(String, Sort, Object...)
      * @see #list(String, Map)
      * @see #find(String, Object...)
      * @see #stream(String, Object...)
      */
     EntityList list(String query, Object... params);
-
-    /**
-     * Find entities matching a query and the given sort options, with optional indexed parameters.
-     * This method is a shortcut for <code>find(query, order, params).list()</code>.
-     *
-     * @param query a {@link io.quarkus.hibernate.panache query string}
-     * @param order the sort strategy to use
-     * @param params optional sequence of indexed parameters
-     * @return a {@link List} containing all results, without paging
-     * @see #list(String, Object...)
-     * @see #list(String, Order, Map)
-     * @see #find(String, Order, Object...)
-     * @see #stream(String, Order, Object...)
-     */
-    EntityList list(String query, Order<?> order, Object... params);
-
-    /**
-     * Find entities matching a query and the given sort option, with optional indexed parameters.
-     * This is a shortcut for <code>list(query, Order.by(sort), params)</code>.
-     *
-     * @param query a {@link io.quarkus.hibernate.panache query string}
-     * @param sort the sort strategy to use
-     * @param params optional sequence of indexed parameters
-     * @return a {@link List} containing all results, without paging
-     */
-    default EntityList list(String query, Sort<?> sort, Object... params) {
-        return list(query, Order.by(sort), params);
-    }
 
     /**
      * Find entities matching a query, with named parameters.
@@ -188,7 +78,6 @@ public interface PanacheRepositoryQueries<EntityResult, EntityList, Query extend
      * @param query a {@link io.quarkus.hibernate.panache query string}
      * @param params {@link Map} of named parameters
      * @return a {@link List} containing all results, without paging
-     * @see #list(String, Sort, Map)
      * @see #list(String, Object...)
      * @see #find(String, Map)
      * @see #stream(String, Map)
@@ -196,66 +85,14 @@ public interface PanacheRepositoryQueries<EntityResult, EntityList, Query extend
     EntityList list(String query, Map<String, Object> params);
 
     /**
-     * Find entities matching a query and the given sort options, with named parameters.
-     * This method is a shortcut for <code>find(query, order, params).list()</code>.
-     *
-     * @param query a {@link io.quarkus.hibernate.panache query string}
-     * @param order the sort strategy to use
-     * @param params {@link Map} of indexed parameters
-     * @return a {@link List} containing all results, without paging
-     * @see #list(String, Map)
-     * @see #list(String, Order, Object...)
-     * @see #find(String, Order, Map)
-     * @see #stream(String, Order, Map)
-     */
-    EntityList list(String query, Order<?> order, Map<String, Object> params);
-
-    /**
-     * Find entities matching a query and the given sort option, with named parameters.
-     * This is a shortcut for <code>list(query, Order.by(sort), params)</code>.
-     *
-     * @param query a {@link io.quarkus.hibernate.panache query string}
-     * @param sort the sort strategy to use
-     * @param params {@link Map} of named parameters
-     * @return a {@link List} containing all results, without paging
-     */
-    default EntityList list(String query, Sort<?> sort, Map<String, Object> params) {
-        return list(query, Order.by(sort), params);
-    }
-
-    /**
      * Find all entities of this type.
      * This method is a shortcut for <code>findAll().list()</code>.
      *
      * @return a {@link List} containing all results, without paging
-     * @see #listAll(Sort)
      * @see #findAll()
      * @see #streamAll()
      */
     EntityList listAll();
-
-    /**
-     * Find all entities of this type, in the given order.
-     * This method is a shortcut for <code>findAll(order).list()</code>.
-     *
-     * @param order the sort order to use
-     * @return a {@link List} containing all results, without paging
-     * @see #listAll()
-     * @see #findAll(Order)
-     * @see #streamAll(Order)
-     */
-    EntityList listAll(Order<?> order);
-
-    /**
-     * Find all entities of this type, in the given order.
-     * This is a shortcut for <code>listAll(Order.by(sort))</code>.
-     *
-     * @param sort the sort order to use
-     * @return a {@link List} containing all results, without paging
-     */
-    default EntityList listAll(Sort<?> sort) {
-        return listAll(Order.by(sort));
-    }
 
     /**
      * Counts the number of this type of entity in the database.

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/blocking/PanacheBlockingQuery.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/blocking/PanacheBlockingQuery.java
@@ -4,12 +4,24 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import jakarta.data.Order;
+import jakarta.data.Sort;
 import jakarta.persistence.NonUniqueResultException;
 
 import io.quarkus.hibernate.panache.PanacheQuery;
+import io.quarkus.panache.hibernate.common.runtime.PanacheJpaUtil;
 
 public interface PanacheBlockingQuery<Entity>
-        extends PanacheQuery<PanacheBlockingQuery<Entity>, Entity, List<Entity>, PanacheBlockingQuery<Entity>, Boolean, Long> {
+        extends
+        PanacheQuery<PanacheBlockingQuery<Entity>, Entity, Entity, List<Entity>, PanacheBlockingQuery<Entity>, Boolean, Long> {
+
+    @Override
+    PanacheBlockingQuery<Entity> sort(Order<? super Entity> order);
+
+    @Override
+    default PanacheBlockingQuery<Entity> sort(Sort<? super Entity> sort) {
+        return sort(PanacheJpaUtil.toOrder(sort));
+    }
 
     /**
      * Defines a projection class. This will transform the returned values into instances of the given type using the following

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/blocking/PanacheRepositoryBlockingQueries.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/blocking/PanacheRepositoryBlockingQueries.java
@@ -5,8 +5,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import jakarta.data.Order;
-import jakarta.data.Sort;
 import jakarta.persistence.LockModeType;
 
 import io.quarkus.hibernate.panache.PanacheRepositoryQueries;
@@ -41,42 +39,11 @@ public interface PanacheRepositoryBlockingQueries<Entity, Id>
      * @param query a {@link io.quarkus.hibernate.panache query string}
      * @param params optional sequence of indexed parameters
      * @return a {@link Stream} containing all results, without paging
-     * @see #stream(String, Sort, Object...)
      * @see #stream(String, Map)
      * @see #find(String, Object...)
      * @see #list(String, Object...)
      */
     Stream<Entity> stream(String query, Object... params);
-
-    /**
-     * Find entities matching a query and the given sort options, with optional indexed parameters.
-     * This method is a shortcut for <code>find(query, order, params).stream()</code>.
-     * It requires a transaction to work.
-     * Without a transaction, the underlying cursor can be closed before the end of the stream.
-     *
-     * @param query a {@link io.quarkus.hibernate.panache query string}
-     * @param order the sort strategy to use
-     * @param params optional sequence of indexed parameters
-     * @return a {@link Stream} containing all results, without paging
-     * @see #stream(String, Object...)
-     * @see #stream(String, Order, Map)
-     * @see #find(String, Order, Object...)
-     * @see #list(String, Order, Object...)
-     */
-    Stream<Entity> stream(String query, Order<?> order, Object... params);
-
-    /**
-     * Find entities matching a query and the given sort option, with optional indexed parameters.
-     * This is a shortcut for <code>stream(query, Order.by(sort), params)</code>.
-     *
-     * @param query a {@link io.quarkus.hibernate.panache query string}
-     * @param sort the sort strategy to use
-     * @param params optional sequence of indexed parameters
-     * @return a {@link Stream} containing all results, without paging
-     */
-    default Stream<Entity> stream(String query, Sort<?> sort, Object... params) {
-        return stream(query, Order.by(sort), params);
-    }
 
     /**
      * Find entities matching a query, with named parameters.
@@ -87,42 +54,11 @@ public interface PanacheRepositoryBlockingQueries<Entity, Id>
      * @param query a {@link io.quarkus.hibernate.panache query string}
      * @param params {@link Map} of named parameters
      * @return a {@link Stream} containing all results, without paging
-     * @see #stream(String, Sort, Map)
      * @see #stream(String, Object...)
      * @see #find(String, Map)
      * @see #list(String, Map)
      */
     Stream<Entity> stream(String query, Map<String, Object> params);
-
-    /**
-     * Find entities matching a query and the given sort options, with named parameters.
-     * This method is a shortcut for <code>find(query, order, params).stream()</code>.
-     * It requires a transaction to work.
-     * Without a transaction, the underlying cursor can be closed before the end of the stream.
-     *
-     * @param query a {@link io.quarkus.hibernate.panache query string}
-     * @param order the sort strategy to use
-     * @param params {@link Map} of indexed parameters
-     * @return a {@link Stream} containing all results, without paging
-     * @see #stream(String, Map)
-     * @see #stream(String, Order, Object...)
-     * @see #find(String, Order, Map)
-     * @see #list(String, Order, Map)
-     */
-    Stream<Entity> stream(String query, Order<?> order, Map<String, Object> params);
-
-    /**
-     * Find entities matching a query and the given sort option, with named parameters.
-     * This is a shortcut for <code>stream(query, Order.by(sort), params)</code>.
-     *
-     * @param query a {@link io.quarkus.hibernate.panache query string}
-     * @param sort the sort strategy to use
-     * @param params {@link Map} of named parameters
-     * @return a {@link Stream} containing all results, without paging
-     */
-    default Stream<Entity> stream(String query, Sort<?> sort, Map<String, Object> params) {
-        return stream(query, Order.by(sort), params);
-    }
 
     /**
      * Find all entities of this type.
@@ -131,33 +67,8 @@ public interface PanacheRepositoryBlockingQueries<Entity, Id>
      * Without a transaction, the underlying cursor can be closed before the end of the stream.
      *
      * @return a {@link Stream} containing all results, without paging
-     * @see #streamAll(Order)
      * @see #findAll()
      * @see #listAll()
-     */
-    Stream<Entity> streamAll(Order<?> order);
-
-    /**
-     * Find all entities of this type, in the given order.
-     * This is a shortcut for <code>streamAll(Order.by(sort))</code>.
-     *
-     * @param sort the sort order to use
-     * @return a {@link Stream} containing all results, without paging
-     */
-    default Stream<Entity> streamAll(Sort<?> sort) {
-        return streamAll(Order.by(sort));
-    }
-
-    /**
-     * Find all entities of this type, in the given order.
-     * This method is a shortcut for <code>findAll().stream()</code>.
-     * It requires a transaction to work.
-     * Without a transaction, the underlying cursor can be closed before the end of the stream.
-     *
-     * @return a {@link Stream} containing all results, without paging
-     * @see #streamAll()
-     * @see #findAll(Order)
-     * @see #listAll(Order)
      */
     Stream<Entity> streamAll();
 }

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/managed/blocking/PanacheManagedBlockingRepositoryQueries.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/managed/blocking/PanacheManagedBlockingRepositoryQueries.java
@@ -5,7 +5,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import jakarta.data.Order;
 import jakarta.persistence.LockModeType;
 
 import io.quarkus.hibernate.orm.panache.common.runtime.AbstractJpaOperations;
@@ -49,18 +48,8 @@ public interface PanacheManagedBlockingRepositoryQueries<Entity, Id> extends Pan
     }
 
     @Override
-    default PanacheBlockingQuery<Entity> find(String query, Order<?> order, Object... params) {
-        return (PanacheBlockingQuery<Entity>) operations().find(getEntityClass(), query, order, params);
-    }
-
-    @Override
     default PanacheBlockingQuery<Entity> find(String query, Map<String, Object> params) {
         return (PanacheBlockingQuery<Entity>) operations().find(getEntityClass(), query, params);
-    }
-
-    @Override
-    default PanacheBlockingQuery<Entity> find(String query, Order<?> order, Map<String, Object> params) {
-        return (PanacheBlockingQuery<Entity>) operations().find(getEntityClass(), query, order, params);
     }
 
     @Override
@@ -69,18 +58,8 @@ public interface PanacheManagedBlockingRepositoryQueries<Entity, Id> extends Pan
     }
 
     @Override
-    default PanacheBlockingQuery<Entity> findAll(Order<?> order) {
-        return (PanacheBlockingQuery<Entity>) operations().findAll(getEntityClass(), order);
-    }
-
-    @Override
     default List<Entity> list(String query, Object... params) {
         return (List<Entity>) operations().list(getEntityClass(), query, params);
-    }
-
-    @Override
-    default List<Entity> list(String query, Order<?> order, Object... params) {
-        return (List<Entity>) operations().list(getEntityClass(), query, order, params);
     }
 
     @Override
@@ -89,18 +68,8 @@ public interface PanacheManagedBlockingRepositoryQueries<Entity, Id> extends Pan
     }
 
     @Override
-    default List<Entity> list(String query, Order<?> order, Map<String, Object> params) {
-        return (List<Entity>) operations().list(getEntityClass(), query, order, params);
-    }
-
-    @Override
     default List<Entity> listAll() {
         return (List<Entity>) operations().listAll(getEntityClass());
-    }
-
-    @Override
-    default List<Entity> listAll(Order<?> order) {
-        return (List<Entity>) operations().listAll(getEntityClass(), order);
     }
 
     @Override
@@ -109,23 +78,8 @@ public interface PanacheManagedBlockingRepositoryQueries<Entity, Id> extends Pan
     }
 
     @Override
-    default Stream<Entity> stream(String query, Order<?> order, Object... params) {
-        return (Stream<Entity>) operations().stream(getEntityClass(), query, order, params);
-    }
-
-    @Override
     default Stream<Entity> stream(String query, Map<String, Object> params) {
         return (Stream<Entity>) operations().stream(getEntityClass(), query, params);
-    }
-
-    @Override
-    default Stream<Entity> stream(String query, Order<?> order, Map<String, Object> params) {
-        return (Stream<Entity>) operations().stream(getEntityClass(), query, order, params);
-    }
-
-    @Override
-    default Stream<Entity> streamAll(Order<?> order) {
-        return (Stream<Entity>) operations().streamAll(getEntityClass(), order);
     }
 
     @Override

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/managed/reactive/PanacheManagedReactiveRepositoryQueries.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/managed/reactive/PanacheManagedReactiveRepositoryQueries.java
@@ -3,7 +3,6 @@ package io.quarkus.hibernate.panache.managed.reactive;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.data.Order;
 import jakarta.persistence.LockModeType;
 
 import io.quarkus.hibernate.orm.panache.common.runtime.AbstractJpaOperations;
@@ -38,18 +37,8 @@ public interface PanacheManagedReactiveRepositoryQueries<Entity, Id> extends Pan
     }
 
     @Override
-    default PanacheReactiveQuery<Entity> find(String query, Order<?> order, Object... params) {
-        return (PanacheReactiveQuery<Entity>) operations().find(getEntityClass(), query, order, params);
-    }
-
-    @Override
     default PanacheReactiveQuery<Entity> find(String query, Map<String, Object> params) {
         return (PanacheReactiveQuery<Entity>) operations().find(getEntityClass(), query, params);
-    }
-
-    @Override
-    default PanacheReactiveQuery<Entity> find(String query, Order<?> order, Map<String, Object> params) {
-        return (PanacheReactiveQuery<Entity>) operations().find(getEntityClass(), query, order, params);
     }
 
     @Override
@@ -58,18 +47,8 @@ public interface PanacheManagedReactiveRepositoryQueries<Entity, Id> extends Pan
     }
 
     @Override
-    default PanacheReactiveQuery<Entity> findAll(Order<?> order) {
-        return (PanacheReactiveQuery<Entity>) operations().findAll(getEntityClass(), order);
-    }
-
-    @Override
     default Uni<List<Entity>> list(String query, Object... params) {
         return (Uni) operations().list(getEntityClass(), query, params);
-    }
-
-    @Override
-    default Uni<List<Entity>> list(String query, Order<?> order, Object... params) {
-        return (Uni) operations().list(getEntityClass(), query, order, params);
     }
 
     @Override
@@ -78,18 +57,8 @@ public interface PanacheManagedReactiveRepositoryQueries<Entity, Id> extends Pan
     }
 
     @Override
-    default Uni<List<Entity>> list(String query, Order<?> order, Map<String, Object> params) {
-        return (Uni) operations().list(getEntityClass(), query, order, params);
-    }
-
-    @Override
     default Uni<List<Entity>> listAll() {
         return (Uni) operations().listAll(getEntityClass());
-    }
-
-    @Override
-    default Uni<List<Entity>> listAll(Order<?> order) {
-        return (Uni) operations().listAll(getEntityClass(), order);
     }
 
     @Override

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/reactive/PanacheReactiveQuery.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/reactive/PanacheReactiveQuery.java
@@ -2,14 +2,26 @@ package io.quarkus.hibernate.panache.reactive;
 
 import java.util.List;
 
+import jakarta.data.Order;
+import jakarta.data.Sort;
+
 import io.quarkus.hibernate.orm.panache.common.ProjectedFieldName;
 import io.quarkus.hibernate.panache.PanacheQuery;
 import io.quarkus.panache.common.exception.PanacheQueryException;
+import io.quarkus.panache.hibernate.common.runtime.PanacheJpaUtil;
 import io.smallrye.mutiny.Uni;
 
 public interface PanacheReactiveQuery<Entity>
         extends
-        PanacheQuery<PanacheReactiveQuery<Entity>, Uni<Entity>, Uni<List<Entity>>, Uni<PanacheReactiveQuery<Entity>>, Uni<Boolean>, Uni<Long>> {
+        PanacheQuery<PanacheReactiveQuery<Entity>, Uni<Entity>, Entity, Uni<List<Entity>>, Uni<PanacheReactiveQuery<Entity>>, Uni<Boolean>, Uni<Long>> {
+
+    @Override
+    PanacheReactiveQuery<Entity> sort(Order<? super Entity> order);
+
+    @Override
+    default PanacheReactiveQuery<Entity> sort(Sort<? super Entity> sort) {
+        return sort(PanacheJpaUtil.toOrder(sort));
+    }
 
     /**
      * Defines a projection class. This will transform the returned values into instances of the given type using the following

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/hr/ManagedReactiveOperations.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/hr/ManagedReactiveOperations.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import jakarta.data.Order;
 import jakarta.persistence.LockModeType;
 
 import org.hibernate.Session;
@@ -13,7 +12,6 @@ import org.hibernate.reactive.mutiny.Mutiny;
 
 import io.quarkus.hibernate.panache.reactive.PanacheReactiveQuery;
 import io.quarkus.hibernate.panache.runtime.spi.PanacheReactiveOperations;
-import io.quarkus.panache.hibernate.common.runtime.PanacheJpaUtil;
 import io.smallrye.mutiny.Uni;
 
 public class ManagedReactiveOperations implements PanacheReactiveOperations {
@@ -126,18 +124,8 @@ public class ManagedReactiveOperations implements PanacheReactiveOperations {
     }
 
     @Override
-    public PanacheReactiveQuery<?> find(Class<?> entityClass, String query, Order<?> order, Object... params) {
-        return DELEGATE.find(entityClass, query, PanacheJpaUtil.toSort(order), params);
-    }
-
-    @Override
     public PanacheReactiveQuery<?> find(Class<?> entityClass, String query, Map<String, Object> params) {
         return DELEGATE.find(entityClass, query, params);
-    }
-
-    @Override
-    public PanacheReactiveQuery<?> find(Class<?> entityClass, String query, Order<?> order, Map<String, Object> params) {
-        return DELEGATE.find(entityClass, query, PanacheJpaUtil.toSort(order), params);
     }
 
     @Override
@@ -146,18 +134,8 @@ public class ManagedReactiveOperations implements PanacheReactiveOperations {
     }
 
     @Override
-    public PanacheReactiveQuery<?> findAll(Class<?> entityClass, Order<?> order) {
-        return DELEGATE.findAll(entityClass, PanacheJpaUtil.toSort(order));
-    }
-
-    @Override
     public Uni<List<?>> list(Class<?> entityClass, String query, Object... params) {
         return DELEGATE.list(entityClass, query, params);
-    }
-
-    @Override
-    public Uni<List<?>> list(Class<?> entityClass, String query, Order<?> order, Object... params) {
-        return DELEGATE.list(entityClass, query, PanacheJpaUtil.toSort(order), params);
     }
 
     @Override
@@ -166,18 +144,8 @@ public class ManagedReactiveOperations implements PanacheReactiveOperations {
     }
 
     @Override
-    public Uni<List<?>> list(Class<?> entityClass, String query, Order<?> order, Map<String, Object> params) {
-        return DELEGATE.list(entityClass, query, PanacheJpaUtil.toSort(order), params);
-    }
-
-    @Override
     public Uni<List<?>> listAll(Class<?> entityClass) {
         return DELEGATE.listAll(entityClass);
-    }
-
-    @Override
-    public Uni<List<?>> listAll(Class<?> entityClass, Order<?> order) {
-        return DELEGATE.listAll(entityClass, PanacheJpaUtil.toSort(order));
     }
 
     @Override

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/hr/PanacheManagedReactiveQueryImpl.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/hr/PanacheManagedReactiveQueryImpl.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 
 import jakarta.data.Limit;
+import jakarta.data.Order;
 import jakarta.data.page.PageRequest;
 import jakarta.persistence.LockModeType;
 
@@ -14,6 +15,7 @@ import io.quarkus.hibernate.panache.reactive.PanacheReactiveQuery;
 import io.quarkus.hibernate.reactive.panache.common.runtime.CommonManagedPanacheQueryImpl;
 import io.quarkus.panache.common.Page;
 import io.quarkus.panache.common.Sort;
+import io.quarkus.panache.hibernate.common.runtime.PanacheJpaUtil;
 import io.smallrye.mutiny.Uni;
 
 public class PanacheManagedReactiveQueryImpl<Entity> implements PanacheReactiveQuery<Entity> {
@@ -139,6 +141,12 @@ public class PanacheManagedReactiveQueryImpl<Entity> implements PanacheReactiveQ
 
     PanacheManagedReactiveQueryImpl(CommonManagedPanacheQueryImpl<Entity> delegate) {
         this.delegate = delegate;
+    }
+
+    @Override
+    public PanacheManagedReactiveQueryImpl<Entity> sort(Order<? super Entity> order) {
+        delegate.sort(PanacheJpaUtil.toSort(order));
+        return this;
     }
 
     @Override

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/hr/PanacheStatelessReactiveQueryImpl.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/hr/PanacheStatelessReactiveQueryImpl.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 
 import jakarta.data.Limit;
+import jakarta.data.Order;
 import jakarta.data.page.PageRequest;
 import jakarta.persistence.LockModeType;
 
@@ -14,6 +15,7 @@ import io.quarkus.hibernate.panache.reactive.PanacheReactiveQuery;
 import io.quarkus.hibernate.reactive.panache.common.runtime.CommonStatelessPanacheQueryImpl;
 import io.quarkus.panache.common.Page;
 import io.quarkus.panache.common.Sort;
+import io.quarkus.panache.hibernate.common.runtime.PanacheJpaUtil;
 import io.smallrye.mutiny.Uni;
 
 public class PanacheStatelessReactiveQueryImpl<Entity> implements PanacheReactiveQuery<Entity> {
@@ -139,6 +141,12 @@ public class PanacheStatelessReactiveQueryImpl<Entity> implements PanacheReactiv
 
     PanacheStatelessReactiveQueryImpl(CommonStatelessPanacheQueryImpl<Entity> delegate) {
         this.delegate = delegate;
+    }
+
+    @Override
+    public PanacheStatelessReactiveQueryImpl<Entity> sort(Order<? super Entity> order) {
+        delegate.sort(PanacheJpaUtil.toSort(order));
+        return this;
     }
 
     @Override

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/hr/StatelessReactiveOperations.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/hr/StatelessReactiveOperations.java
@@ -4,14 +4,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import jakarta.data.Order;
 import jakarta.persistence.LockModeType;
 
 import org.hibernate.reactive.mutiny.Mutiny;
 
 import io.quarkus.hibernate.panache.reactive.PanacheReactiveQuery;
 import io.quarkus.hibernate.panache.runtime.spi.PanacheReactiveOperations;
-import io.quarkus.panache.hibernate.common.runtime.PanacheJpaUtil;
 import io.smallrye.mutiny.Uni;
 
 public class StatelessReactiveOperations implements PanacheReactiveOperations {
@@ -125,18 +123,8 @@ public class StatelessReactiveOperations implements PanacheReactiveOperations {
     }
 
     @Override
-    public PanacheReactiveQuery<?> find(Class<?> entityClass, String query, Order<?> order, Object... params) {
-        return DELEGATE.find(entityClass, query, PanacheJpaUtil.toSort(order), params);
-    }
-
-    @Override
     public PanacheReactiveQuery<?> find(Class<?> entityClass, String query, Map<String, Object> params) {
         return DELEGATE.find(entityClass, query, params);
-    }
-
-    @Override
-    public PanacheReactiveQuery<?> find(Class<?> entityClass, String query, Order<?> order, Map<String, Object> params) {
-        return DELEGATE.find(entityClass, query, PanacheJpaUtil.toSort(order), params);
     }
 
     @Override
@@ -145,18 +133,8 @@ public class StatelessReactiveOperations implements PanacheReactiveOperations {
     }
 
     @Override
-    public PanacheReactiveQuery<?> findAll(Class<?> entityClass, Order<?> order) {
-        return DELEGATE.findAll(entityClass, PanacheJpaUtil.toSort(order));
-    }
-
-    @Override
     public Uni<List<?>> list(Class<?> entityClass, String query, Object... params) {
         return DELEGATE.list(entityClass, query, params);
-    }
-
-    @Override
-    public Uni<List<?>> list(Class<?> entityClass, String query, Order<?> order, Object... params) {
-        return DELEGATE.list(entityClass, query, PanacheJpaUtil.toSort(order), params);
     }
 
     @Override
@@ -165,18 +143,8 @@ public class StatelessReactiveOperations implements PanacheReactiveOperations {
     }
 
     @Override
-    public Uni<List<?>> list(Class<?> entityClass, String query, Order<?> order, Map<String, Object> params) {
-        return DELEGATE.list(entityClass, query, PanacheJpaUtil.toSort(order), params);
-    }
-
-    @Override
     public Uni<List<?>> listAll(Class<?> entityClass) {
         return DELEGATE.listAll(entityClass);
-    }
-
-    @Override
-    public Uni<List<?>> listAll(Class<?> entityClass, Order<?> order) {
-        return DELEGATE.listAll(entityClass, PanacheJpaUtil.toSort(order));
     }
 
     @Override

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/orm/ManagedBlockingOperations.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/orm/ManagedBlockingOperations.java
@@ -5,7 +5,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import jakarta.data.Order;
 import jakarta.persistence.LockModeType;
 
 import org.hibernate.Session;
@@ -13,7 +12,6 @@ import org.hibernate.StatelessSession;
 
 import io.quarkus.hibernate.panache.blocking.PanacheBlockingQuery;
 import io.quarkus.hibernate.panache.runtime.spi.PanacheBlockingOperations;
-import io.quarkus.panache.hibernate.common.runtime.PanacheJpaUtil;
 
 public class ManagedBlockingOperations implements PanacheBlockingOperations {
 
@@ -134,18 +132,8 @@ public class ManagedBlockingOperations implements PanacheBlockingOperations {
     }
 
     @Override
-    public PanacheBlockingQuery<?> find(Class<?> entityClass, String query, Order<?> order, Object... params) {
-        return DELEGATE.find(entityClass, query, PanacheJpaUtil.toSort(order), params);
-    }
-
-    @Override
     public PanacheBlockingQuery<?> find(Class<?> entityClass, String query, Map<String, Object> params) {
         return DELEGATE.find(entityClass, query, params);
-    }
-
-    @Override
-    public PanacheBlockingQuery<?> find(Class<?> entityClass, String query, Order<?> order, Map<String, Object> params) {
-        return DELEGATE.find(entityClass, query, PanacheJpaUtil.toSort(order), params);
     }
 
     @Override
@@ -154,18 +142,8 @@ public class ManagedBlockingOperations implements PanacheBlockingOperations {
     }
 
     @Override
-    public PanacheBlockingQuery<?> findAll(Class<?> entityClass, Order<?> order) {
-        return DELEGATE.findAll(entityClass, PanacheJpaUtil.toSort(order));
-    }
-
-    @Override
     public List<?> list(Class<?> entityClass, String query, Object... params) {
         return DELEGATE.list(entityClass, query, params);
-    }
-
-    @Override
-    public List<?> list(Class<?> entityClass, String query, Order<?> order, Object... params) {
-        return DELEGATE.list(entityClass, query, PanacheJpaUtil.toSort(order), params);
     }
 
     @Override
@@ -174,18 +152,8 @@ public class ManagedBlockingOperations implements PanacheBlockingOperations {
     }
 
     @Override
-    public List<?> list(Class<?> entityClass, String query, Order<?> order, Map<String, Object> params) {
-        return DELEGATE.list(entityClass, query, PanacheJpaUtil.toSort(order), params);
-    }
-
-    @Override
     public List<?> listAll(Class<?> entityClass) {
         return DELEGATE.listAll(entityClass);
-    }
-
-    @Override
-    public List<?> listAll(Class<?> entityClass, Order<?> order) {
-        return DELEGATE.listAll(entityClass, PanacheJpaUtil.toSort(order));
     }
 
     @Override
@@ -249,23 +217,8 @@ public class ManagedBlockingOperations implements PanacheBlockingOperations {
     }
 
     @Override
-    public Stream<?> stream(Class<?> entityClass, String query, Order<?> order, Object... params) {
-        return DELEGATE.stream(entityClass, query, PanacheJpaUtil.toSort(order), params);
-    }
-
-    @Override
     public Stream<?> stream(Class<?> entityClass, String query, Map<String, Object> params) {
         return DELEGATE.stream(entityClass, query, params);
-    }
-
-    @Override
-    public Stream<?> stream(Class<?> entityClass, String query, Order<?> order, Map<String, Object> params) {
-        return DELEGATE.stream(entityClass, query, PanacheJpaUtil.toSort(order), params);
-    }
-
-    @Override
-    public Stream<?> streamAll(Class<?> entityClass, Order<?> order) {
-        return DELEGATE.streamAll(entityClass, PanacheJpaUtil.toSort(order));
     }
 
     @Override

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/orm/PanacheBlockingQueryImpl.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/orm/PanacheBlockingQueryImpl.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import jakarta.data.Limit;
+import jakarta.data.Order;
 import jakarta.data.page.PageRequest;
 import jakarta.persistence.LockModeType;
 
@@ -16,6 +17,7 @@ import io.quarkus.hibernate.orm.panache.common.runtime.CommonPanacheQueryImpl;
 import io.quarkus.hibernate.panache.blocking.PanacheBlockingQuery;
 import io.quarkus.panache.common.Page;
 import io.quarkus.panache.common.Sort;
+import io.quarkus.panache.hibernate.common.runtime.PanacheJpaUtil;
 
 public class PanacheBlockingQueryImpl<Entity> implements PanacheBlockingQuery<Entity> {
 
@@ -141,6 +143,12 @@ public class PanacheBlockingQueryImpl<Entity> implements PanacheBlockingQuery<En
 
     PanacheBlockingQueryImpl(CommonPanacheQueryImpl<Entity> delegate) {
         this.delegate = delegate;
+    }
+
+    @Override
+    public PanacheBlockingQueryImpl<Entity> sort(Order<? super Entity> order) {
+        delegate.sort(PanacheJpaUtil.toSort(order));
+        return this;
     }
 
     @Override

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/orm/StatelessBlockingOperations.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/orm/StatelessBlockingOperations.java
@@ -5,7 +5,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import jakarta.data.Order;
 import jakarta.persistence.LockModeType;
 
 import org.hibernate.Session;
@@ -13,7 +12,6 @@ import org.hibernate.StatelessSession;
 
 import io.quarkus.hibernate.panache.blocking.PanacheBlockingQuery;
 import io.quarkus.hibernate.panache.runtime.spi.PanacheBlockingOperations;
-import io.quarkus.panache.hibernate.common.runtime.PanacheJpaUtil;
 
 public class StatelessBlockingOperations implements PanacheBlockingOperations {
 
@@ -132,18 +130,8 @@ public class StatelessBlockingOperations implements PanacheBlockingOperations {
     }
 
     @Override
-    public PanacheBlockingQuery<?> find(Class<?> entityClass, String query, Order<?> order, Object... params) {
-        return DELEGATE.find(entityClass, query, PanacheJpaUtil.toSort(order), params);
-    }
-
-    @Override
     public PanacheBlockingQuery<?> find(Class<?> entityClass, String query, Map<String, Object> params) {
         return DELEGATE.find(entityClass, query, params);
-    }
-
-    @Override
-    public PanacheBlockingQuery<?> find(Class<?> entityClass, String query, Order<?> order, Map<String, Object> params) {
-        return DELEGATE.find(entityClass, query, PanacheJpaUtil.toSort(order), params);
     }
 
     @Override
@@ -152,18 +140,8 @@ public class StatelessBlockingOperations implements PanacheBlockingOperations {
     }
 
     @Override
-    public PanacheBlockingQuery<?> findAll(Class<?> entityClass, Order<?> order) {
-        return DELEGATE.findAll(entityClass, PanacheJpaUtil.toSort(order));
-    }
-
-    @Override
     public List<?> list(Class<?> entityClass, String query, Object... params) {
         return DELEGATE.list(entityClass, query, params);
-    }
-
-    @Override
-    public List<?> list(Class<?> entityClass, String query, Order<?> order, Object... params) {
-        return DELEGATE.list(entityClass, query, PanacheJpaUtil.toSort(order), params);
     }
 
     @Override
@@ -172,18 +150,8 @@ public class StatelessBlockingOperations implements PanacheBlockingOperations {
     }
 
     @Override
-    public List<?> list(Class<?> entityClass, String query, Order<?> order, Map<String, Object> params) {
-        return DELEGATE.list(entityClass, query, PanacheJpaUtil.toSort(order), params);
-    }
-
-    @Override
     public List<?> listAll(Class<?> entityClass) {
         return DELEGATE.listAll(entityClass);
-    }
-
-    @Override
-    public List<?> listAll(Class<?> entityClass, Order<?> order) {
-        return DELEGATE.listAll(entityClass, PanacheJpaUtil.toSort(order));
     }
 
     @Override
@@ -247,23 +215,8 @@ public class StatelessBlockingOperations implements PanacheBlockingOperations {
     }
 
     @Override
-    public Stream<?> stream(Class<?> entityClass, String query, Order<?> order, Object... params) {
-        return DELEGATE.stream(entityClass, query, PanacheJpaUtil.toSort(order), params);
-    }
-
-    @Override
     public Stream<?> stream(Class<?> entityClass, String query, Map<String, Object> params) {
         return DELEGATE.stream(entityClass, query, params);
-    }
-
-    @Override
-    public Stream<?> stream(Class<?> entityClass, String query, Order<?> order, Map<String, Object> params) {
-        return DELEGATE.stream(entityClass, query, PanacheJpaUtil.toSort(order), params);
-    }
-
-    @Override
-    public Stream<?> streamAll(Class<?> entityClass, Order<?> order) {
-        return DELEGATE.streamAll(entityClass, PanacheJpaUtil.toSort(order));
     }
 
     @Override

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/spi/PanacheBlockingOperations.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/spi/PanacheBlockingOperations.java
@@ -5,7 +5,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import jakarta.data.Order;
 import jakarta.persistence.LockModeType;
 
 import org.hibernate.Session;
@@ -26,13 +25,7 @@ public interface PanacheBlockingOperations extends
 
     Stream<?> stream(Class<?> entityClass, String query, Object... params);
 
-    Stream<?> stream(Class<?> entityClass, String query, Order<?> order, Object... params);
-
     Stream<?> stream(Class<?> entityClass, String query, Map<String, Object> params);
-
-    Stream<?> stream(Class<?> entityClass, String query, Order<?> order, Map<String, Object> params);
-
-    Stream<?> streamAll(Class<?> entityClass, Order<?> order);
 
     Stream<?> streamAll(Class<?> entityClass);
 }

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/spi/PanacheOperations.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/spi/PanacheOperations.java
@@ -3,7 +3,6 @@ package io.quarkus.hibernate.panache.runtime.spi;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import jakarta.data.Order;
 import jakarta.persistence.LockModeType;
 
 import io.quarkus.hibernate.panache.runtime.hr.ManagedReactiveOperations;
@@ -69,27 +68,15 @@ public interface PanacheOperations<One, Many, Query, Count, Completion, Confirma
 
     Query find(Class<?> entityClass, String query, Object... params);
 
-    Query find(Class<?> entityClass, String query, Order<?> order, Object... params);
-
     Query find(Class<?> entityClass, String query, Map<String, Object> params);
-
-    Query find(Class<?> entityClass, String query, Order<?> order, Map<String, Object> params);
 
     Query findAll(Class<?> entityClass);
 
-    Query findAll(Class<?> entityClass, Order<?> order);
-
     Many list(Class<?> entityClass, String query, Object... params);
-
-    Many list(Class<?> entityClass, String query, Order<?> order, Object... params);
 
     Many list(Class<?> entityClass, String query, Map<String, Object> params);
 
-    Many list(Class<?> entityClass, String query, Order<?> order, Map<String, Object> params);
-
     Many listAll(Class<?> entityClass);
-
-    Many listAll(Class<?> entityClass, Order<?> order);
 
     Count count(Class<?> entityClass);
 

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/stateless/blocking/PanacheStatelessBlockingRepositoryQueries.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/stateless/blocking/PanacheStatelessBlockingRepositoryQueries.java
@@ -5,7 +5,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import jakarta.data.Order;
 import jakarta.persistence.LockModeType;
 
 import io.quarkus.hibernate.orm.panache.common.runtime.AbstractJpaOperations;
@@ -49,18 +48,8 @@ public interface PanacheStatelessBlockingRepositoryQueries<Entity, Id> extends P
     }
 
     @Override
-    default PanacheBlockingQuery<Entity> find(String query, Order<?> order, Object... params) {
-        return (PanacheBlockingQuery<Entity>) operations().find(getEntityClass(), query, order, params);
-    }
-
-    @Override
     default PanacheBlockingQuery<Entity> find(String query, Map<String, Object> params) {
         return (PanacheBlockingQuery<Entity>) operations().find(getEntityClass(), query, params);
-    }
-
-    @Override
-    default PanacheBlockingQuery<Entity> find(String query, Order<?> order, Map<String, Object> params) {
-        return (PanacheBlockingQuery<Entity>) operations().find(getEntityClass(), query, order, params);
     }
 
     @Override
@@ -69,18 +58,8 @@ public interface PanacheStatelessBlockingRepositoryQueries<Entity, Id> extends P
     }
 
     @Override
-    default PanacheBlockingQuery<Entity> findAll(Order<?> order) {
-        return (PanacheBlockingQuery<Entity>) operations().findAll(getEntityClass(), order);
-    }
-
-    @Override
     default List<Entity> list(String query, Object... params) {
         return (List<Entity>) operations().list(getEntityClass(), query, params);
-    }
-
-    @Override
-    default List<Entity> list(String query, Order<?> order, Object... params) {
-        return (List<Entity>) operations().list(getEntityClass(), query, order, params);
     }
 
     @Override
@@ -89,18 +68,8 @@ public interface PanacheStatelessBlockingRepositoryQueries<Entity, Id> extends P
     }
 
     @Override
-    default List<Entity> list(String query, Order<?> order, Map<String, Object> params) {
-        return (List<Entity>) operations().list(getEntityClass(), query, order, params);
-    }
-
-    @Override
     default List<Entity> listAll() {
         return (List<Entity>) operations().listAll(getEntityClass());
-    }
-
-    @Override
-    default List<Entity> listAll(Order<?> order) {
-        return (List<Entity>) operations().listAll(getEntityClass(), order);
     }
 
     @Override
@@ -109,23 +78,8 @@ public interface PanacheStatelessBlockingRepositoryQueries<Entity, Id> extends P
     }
 
     @Override
-    default Stream<Entity> stream(String query, Order<?> order, Object... params) {
-        return (Stream<Entity>) operations().stream(getEntityClass(), query, order, params);
-    }
-
-    @Override
     default Stream<Entity> stream(String query, Map<String, Object> params) {
         return (Stream<Entity>) operations().stream(getEntityClass(), query, params);
-    }
-
-    @Override
-    default Stream<Entity> stream(String query, Order<?> order, Map<String, Object> params) {
-        return (Stream<Entity>) operations().stream(getEntityClass(), query, order, params);
-    }
-
-    @Override
-    default Stream<Entity> streamAll(Order<?> order) {
-        return (Stream<Entity>) operations().streamAll(getEntityClass(), order);
     }
 
     @Override

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/stateless/reactive/PanacheStatelessReactiveRepositoryQueries.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/stateless/reactive/PanacheStatelessReactiveRepositoryQueries.java
@@ -3,7 +3,6 @@ package io.quarkus.hibernate.panache.stateless.reactive;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.data.Order;
 import jakarta.persistence.LockModeType;
 
 import io.quarkus.hibernate.orm.panache.common.runtime.AbstractJpaOperations;
@@ -38,18 +37,8 @@ public interface PanacheStatelessReactiveRepositoryQueries<Entity, Id> extends P
     }
 
     @Override
-    default PanacheReactiveQuery<Entity> find(String query, Order<?> order, Object... params) {
-        return (PanacheReactiveQuery<Entity>) operations().find(getEntityClass(), query, order, params);
-    }
-
-    @Override
     default PanacheReactiveQuery<Entity> find(String query, Map<String, Object> params) {
         return (PanacheReactiveQuery<Entity>) operations().find(getEntityClass(), query, params);
-    }
-
-    @Override
-    default PanacheReactiveQuery<Entity> find(String query, Order<?> order, Map<String, Object> params) {
-        return (PanacheReactiveQuery<Entity>) operations().find(getEntityClass(), query, order, params);
     }
 
     @Override
@@ -58,18 +47,8 @@ public interface PanacheStatelessReactiveRepositoryQueries<Entity, Id> extends P
     }
 
     @Override
-    default PanacheReactiveQuery<Entity> findAll(Order<?> order) {
-        return (PanacheReactiveQuery<Entity>) operations().findAll(getEntityClass(), order);
-    }
-
-    @Override
     default Uni<List<Entity>> list(String query, Object... params) {
         return (Uni) operations().list(getEntityClass(), query, params);
-    }
-
-    @Override
-    default Uni<List<Entity>> list(String query, Order<?> order, Object... params) {
-        return (Uni) operations().list(getEntityClass(), query, order, params);
     }
 
     @Override
@@ -78,18 +57,8 @@ public interface PanacheStatelessReactiveRepositoryQueries<Entity, Id> extends P
     }
 
     @Override
-    default Uni<List<Entity>> list(String query, Order<?> order, Map<String, Object> params) {
-        return (Uni) operations().list(getEntityClass(), query, order, params);
-    }
-
-    @Override
     default Uni<List<Entity>> listAll() {
         return (Uni) operations().listAll(getEntityClass());
-    }
-
-    @Override
-    default Uni<List<Entity>> listAll(Order<?> order) {
-        return (Uni) operations().listAll(getEntityClass(), order);
     }
 
     @Override

--- a/extensions/data/hibernate/runtime/src/test/java/io/quarkus/hibernate/panache/JakartaDataSortConversionTest.java
+++ b/extensions/data/hibernate/runtime/src/test/java/io/quarkus/hibernate/panache/JakartaDataSortConversionTest.java
@@ -2,21 +2,39 @@ package io.quarkus.hibernate.panache;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.data.Order;
+import jakarta.data.Sort;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.panache.common.Sort;
 import io.quarkus.panache.hibernate.common.runtime.PanacheJpaUtil;
 
 public class JakartaDataSortConversionTest {
 
+    private static final class Cat {
+    }
+
+    @Test
+    public void testToOrderNull() {
+        assertNull(PanacheJpaUtil.toOrder(null));
+    }
+
+    @Test
+    public void testToOrderFromSort() {
+        Order<?> order = PanacheJpaUtil.toOrder(Sort.<Cat> asc("name"));
+        io.quarkus.panache.common.Sort panacheSort = PanacheJpaUtil.toSort(order);
+
+        assertEquals(1, panacheSort.getColumns().size());
+        assertEquals(" ORDER BY `name`", PanacheJpaUtil.toOrderBy(panacheSort));
+    }
+
     @Test
     public void testJakartaDataIgnoreCasePreserved() {
-        jakarta.data.Order<?> order = Order.by(jakarta.data.Sort.ascIgnoreCase("name"));
-        Sort panacheSort = PanacheJpaUtil.toSort(order);
+        Order<? super Cat> order = Order.by(Sort.<Cat> ascIgnoreCase("name"));
+        io.quarkus.panache.common.Sort panacheSort = PanacheJpaUtil.toSort(order);
 
         assertEquals(1, panacheSort.getColumns().size());
         assertTrue(panacheSort.getColumns().get(0).isIgnoreCase());
@@ -25,10 +43,10 @@ public class JakartaDataSortConversionTest {
 
     @Test
     public void testJakartaDataMixedIgnoreCase() {
-        jakarta.data.Order<?> order = Order.by(
-                jakarta.data.Sort.asc("id"),
-                jakarta.data.Sort.descIgnoreCase("name"));
-        Sort panacheSort = PanacheJpaUtil.toSort(order);
+        Order<? super Cat> order = Order.by(
+                Sort.<Cat> asc("id"),
+                Sort.<Cat> descIgnoreCase("name"));
+        io.quarkus.panache.common.Sort panacheSort = PanacheJpaUtil.toSort(order);
 
         assertEquals(2, panacheSort.getColumns().size());
         assertFalse(panacheSort.getColumns().get(0).isIgnoreCase());
@@ -38,8 +56,8 @@ public class JakartaDataSortConversionTest {
 
     @Test
     public void testJakartaDataCaseSensitiveNotAffected() {
-        jakarta.data.Order<?> order = Order.by(jakarta.data.Sort.asc("name"));
-        Sort panacheSort = PanacheJpaUtil.toSort(order);
+        Order<? super Cat> order = Order.by(Sort.<Cat> asc("name"));
+        io.quarkus.panache.common.Sort panacheSort = PanacheJpaUtil.toSort(order);
 
         assertEquals(1, panacheSort.getColumns().size());
         assertFalse(panacheSort.getColumns().get(0).isIgnoreCase());

--- a/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/CommonPanacheQueryImpl.java
+++ b/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/CommonPanacheQueryImpl.java
@@ -126,6 +126,11 @@ public class CommonPanacheQueryImpl<Entity> {
 
     // Builder
 
+    public CommonPanacheQueryImpl<Entity> sort(Sort sort) {
+        this.sort = sort;
+        return this;
+    }
+
     public <T> CommonPanacheQueryImpl<T> project(Class<T> type) {
         String selectQuery = query;
         if (PanacheJpaUtil.isNamedQuery(query)) {

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/CommonAbstractPanacheQueryImpl.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/CommonAbstractPanacheQueryImpl.java
@@ -101,6 +101,11 @@ public abstract class CommonAbstractPanacheQueryImpl<Entity, SessionType extends
 
     // Builder
 
+    public CommonAbstractPanacheQueryImpl<Entity, SessionType> sort(Sort sort) {
+        this.sort = sort;
+        return this;
+    }
+
     public <T> CommonAbstractPanacheQueryImpl<T, SessionType> project(Class<T> type) {
         String selectQuery = query;
         if (PanacheJpaUtil.isNamedQuery(query)) {

--- a/extensions/panache/panache-hibernate-common/runtime/src/main/java/io/quarkus/panache/hibernate/common/runtime/PanacheJpaUtil.java
+++ b/extensions/panache/panache-hibernate-common/runtime/src/main/java/io/quarkus/panache/hibernate/common/runtime/PanacheJpaUtil.java
@@ -5,10 +5,11 @@ import java.util.List;
 import java.util.Locale;
 import java.util.regex.Pattern;
 
-import org.hibernate.query.Order;
+import jakarta.data.Order;
+import jakarta.data.Sort;
+
 import org.hibernate.query.SortDirection;
 
-import io.quarkus.panache.common.Sort;
 import io.quarkus.panache.common.exception.PanacheQueryException;
 
 public class PanacheJpaUtil {
@@ -163,7 +164,7 @@ public class PanacheJpaUtil {
         return "DELETE FROM " + getEntityName(entityClass) + " WHERE " + query;
     }
 
-    public static String toOrderBy(Sort sort) {
+    public static String toOrderBy(io.quarkus.panache.common.Sort sort) {
         if (sort == null) {
             return null;
         }
@@ -172,7 +173,7 @@ public class PanacheJpaUtil {
         }
         StringBuilder sb = new StringBuilder(" ORDER BY ");
         for (int i = 0; i < sort.getColumns().size(); i++) {
-            Sort.Column column = sort.getColumns().get(i);
+            io.quarkus.panache.common.Sort.Column column = sort.getColumns().get(i);
             if (i > 0)
                 sb.append(" , ");
 
@@ -191,12 +192,12 @@ public class PanacheJpaUtil {
                 sb.append(columnRef);
             }
 
-            if (column.getDirection() != Sort.Direction.Ascending) {
+            if (column.getDirection() != io.quarkus.panache.common.Sort.Direction.Ascending) {
                 sb.append(" DESC");
             }
 
             if (column.getNullPrecedence() != null) {
-                if (column.getNullPrecedence() == Sort.NullPrecedence.NULLS_FIRST) {
+                if (column.getNullPrecedence() == io.quarkus.panache.common.Sort.NullPrecedence.NULLS_FIRST) {
                     sb.append(" NULLS FIRST");
                 } else {
                     sb.append(" NULLS LAST");
@@ -208,29 +209,39 @@ public class PanacheJpaUtil {
     }
 
     /**
+     * Convert Jakarta Data Sort to Jakarta Data Order.
+     *
+     * @param sort the Jakarta Data sort, may be null
+     * @return the Jakarta Data order, or null if sort is null
+     */
+    public static <T> Order<T> toOrder(Sort<? super T> sort) {
+        return sort == null ? null : Order.by(sort);
+    }
+
+    /**
      * Convert Jakarta Data Order to Panache Sort.
      *
      * @param order the Jakarta Data order, may be null
      * @return the Panache Sort, or null if order is null
      */
-    public static Sort toSort(jakarta.data.Order<?> order) {
+    public static <T> io.quarkus.panache.common.Sort toSort(Order<? super T> order) {
         if (order == null) {
             return null;
         }
 
         if (order.sorts().isEmpty()) {
-            return Sort.empty();
+            return io.quarkus.panache.common.Sort.empty();
         }
 
-        Sort result = null;
-        for (jakarta.data.Sort<?> jdSort : order.sorts()) {
+        io.quarkus.panache.common.Sort result = null;
+        for (Sort<? super T> jdSort : order.sorts()) {
             String property = jdSort.property();
-            Sort.Direction direction = jdSort.isAscending()
-                    ? Sort.Direction.Ascending
-                    : Sort.Direction.Descending;
+            io.quarkus.panache.common.Sort.Direction direction = jdSort.isAscending()
+                    ? io.quarkus.panache.common.Sort.Direction.Ascending
+                    : io.quarkus.panache.common.Sort.Direction.Descending;
 
             if (result == null) {
-                result = Sort.by(property, direction);
+                result = io.quarkus.panache.common.Sort.by(property, direction);
             } else {
                 result = result.and(property, direction);
             }
@@ -245,19 +256,21 @@ public class PanacheJpaUtil {
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static List<Order<?>> toHibernateOrders(Class<?> entityClass, Sort sort) {
+    public static List<org.hibernate.query.Order<?>> toHibernateOrders(Class<?> entityClass,
+            io.quarkus.panache.common.Sort sort) {
         if (sort == null || sort.getColumns().isEmpty()) {
             return List.of();
         }
-        List<Order<?>> orders = new ArrayList<>();
-        for (Sort.Column column : sort.getColumns()) {
-            SortDirection direction = column.getDirection() == Sort.Direction.Ascending
+        List<org.hibernate.query.Order<?>> orders = new ArrayList<>();
+        for (io.quarkus.panache.common.Sort.Column column : sort.getColumns()) {
+            SortDirection direction = column.getDirection() == io.quarkus.panache.common.Sort.Direction.Ascending
                     ? SortDirection.ASCENDING
                     : SortDirection.DESCENDING;
-            Order<?> order = Order.by((Class) entityClass, column.getName(), direction, column.isIgnoreCase());
-            if (column.getNullPrecedence() == Sort.NullPrecedence.NULLS_FIRST) {
+            org.hibernate.query.Order<?> order = org.hibernate.query.Order.by((Class) entityClass, column.getName(),
+                    direction, column.isIgnoreCase());
+            if (column.getNullPrecedence() == io.quarkus.panache.common.Sort.NullPrecedence.NULLS_FIRST) {
                 order = order.withNullsFirst();
-            } else if (column.getNullPrecedence() == Sort.NullPrecedence.NULLS_LAST) {
+            } else if (column.getNullPrecedence() == io.quarkus.panache.common.Sort.NullPrecedence.NULLS_LAST) {
                 order = order.withNullsLast();
             }
             orders.add(order);


### PR DESCRIPTION
Fixes #54539

Quarkus Data Hibernate currently accepts `Order`/`Sort` on every repository shortcut (`find`, `findAll`, `list`, `listAll`, `stream`, `streamAll`), which makes the API noisy and awkward to combine with paging. Sorting belongs on the query object, consistent with how paging already works 

This PR moves sorting to `PanacheQuery.sort()` and removes all `Order`/`Sort` overloads from the repository and operations APIs. Sort criteria are now applied fluently after building a query:

```java
repo.findAll().sort(Sort.asc("name")).list();
repo.find("breed = ?1", Cat.Breed.CUTE).sort(Sort.desc("name")).stream();
repo.findAll().sort(Order.by(Sort.asc("name"), Sort.desc("birth"))).list();
```

`PanacheQuery.sort()` accepts both `Order<? super Entity>` and `Sort<? super Entity>`. Null values and empty `Order.by()` are treated as "no sorting", which aligns with REST parameter  (`Sort` → `null`, `Order` → empty `Order.by()`). For REST endpoints, prefer `Order<Cat>` over `Sort<Cat>`.

The `PanacheQuery` type parameters are updated to separate the result type from the sort entity type, so sort methods can be properly bounded. Jakarta Data `@Find` repository methods with `Order` parameters are unchanged.

**Release note:** Quarkus Data Hibernate now applies sorting via `PanacheQuery.sort()` instead of `Order`/`Sort` parameters on repository query shortcuts.