### PR TITLE
Add deterministic serialNumber to CycloneDX SBOMs

### DIFF
--- a/docs/src/main/asciidoc/cyclonedx.adoc
+++ b/docs/src/main/asciidoc/cyclonedx.adoc
@@ -183,6 +183,13 @@ By default, generated JSON SBOMs are not pretty-printed. To enable pretty-printi
 quarkus.cyclonedx.pretty-print=true
 ----
 
+By default, each generated SBOM gets a fresh `serialNumber` to align with the CycloneDX recommendation that generated BOMs use unique serial numbers. If reproducible serial numbers are preferred instead, enable deterministic serial number generation:
+
+[source,properties]
+----
+quarkus.cyclonedx.deterministic-serial-number=true
+----
+
 === Pedigree
 
 Pedigree is a way to provide information that patches or modifications have been applied to a component.

--- a/extensions/cyclonedx/deployment/src/main/java/io/quarkus/cyclonedx/deployment/CycloneDxConfig.java
+++ b/extensions/cyclonedx/deployment/src/main/java/io/quarkus/cyclonedx/deployment/CycloneDxConfig.java
@@ -54,6 +54,18 @@ public interface CycloneDxConfig {
     boolean prettyPrint();
 
     /**
+     * Whether generated SBOMs should use deterministic serial numbers.
+     * <p>
+     * By default, Quarkus generates a fresh UUID for every SBOM generation to align
+     * with CycloneDX's recommendation that each generated BOM have a unique serial number.
+     * Enable this option only when reproducible serial numbers are preferred.
+     *
+     * @return whether generated SBOMs should use deterministic serial numbers
+     */
+    @WithDefault("false")
+    boolean deterministicSerialNumber();
+
+    /**
      * Embedded dependency SBOM configuration
      */
     @ConfigDocSection

--- a/extensions/cyclonedx/deployment/src/main/java/io/quarkus/cyclonedx/deployment/CycloneDxProcessor.java
+++ b/extensions/cyclonedx/deployment/src/main/java/io/quarkus/cyclonedx/deployment/CycloneDxProcessor.java
@@ -67,6 +67,7 @@ public class CycloneDxProcessor {
                     .setSchemaVersion(cdxSbomConfig.schemaVersion().orElse(null))
                     .setIncludeLicenseText(cdxSbomConfig.includeLicenseText())
                     .setPrettyPrint(cdxSbomConfig.prettyPrint())
+                    .setDeterministicSerialNumber(cdxSbomConfig.deterministicSerialNumber())
                     .setContributions(contributions)
                     .generate()) {
                 sbomProducer.produce(new SbomBuildItem(sbom));
@@ -140,6 +141,7 @@ public class CycloneDxProcessor {
                 .setSchemaVersion(cdxConfig.schemaVersion().orElse(null))
                 .setIncludeLicenseText(cdxConfig.includeLicenseText())
                 .setPrettyPrint(cdxConfig.prettyPrint())
+                .setDeterministicSerialNumber(cdxConfig.deterministicSerialNumber())
                 .setContributions(collectContributions(coreContribution, sbomContributions))
                 .generateText();
 

--- a/extensions/cyclonedx/generator/src/main/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGenerator.java
+++ b/extensions/cyclonedx/generator/src/main/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGenerator.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -67,6 +68,7 @@ public class CycloneDxSbomGenerator {
     private static final String CLASSIFIER_CYCLONEDX = "cyclonedx";
     private static final String FORMAT_ALL = "all";
     private static final String DEFAULT_FORMAT = "json";
+    private static final String SERIAL_NUMBER_PREFIX = "urn:uuid:";
 
     public static CycloneDxSbomGenerator newInstance() {
         return new CycloneDxSbomGenerator();
@@ -204,6 +206,11 @@ public class CycloneDxSbomGenerator {
         allDescriptors.sort(Comparator.comparing(ComponentDescriptor::getBomRef));
         allDependencies.sort(Comparator.comparing(ComponentDependencies::getBomRef));
 
+        var serialNumber = resolveSerialNumber(allDescriptors);
+        if (serialNumber != null) {
+            bom.setSerialNumber(serialNumber);
+        }
+
         // Render components
         for (ComponentDescriptor descriptor : allDescriptors) {
             if (descriptor.getBomRef().equals(mainComponentBomRef)) {
@@ -245,6 +252,22 @@ public class CycloneDxSbomGenerator {
                 return;
             }
         }
+    }
+
+    private String resolveSerialNumber(List<ComponentDescriptor> allDescriptors) {
+        if (mainComponentBomRef != null) {
+            for (ComponentDescriptor descriptor : allDescriptors) {
+                if (descriptor.getBomRef().equals(mainComponentBomRef)) {
+                    return deterministicSerialNumber(descriptor.getBomRef());
+                }
+            }
+        }
+        return null;
+    }
+
+    private static String deterministicSerialNumber(String identity) {
+        var uuid = java.util.UUID.nameUUIDFromBytes(identity.getBytes(StandardCharsets.UTF_8));
+        return SERIAL_NUMBER_PREFIX + uuid;
     }
 
     /**

--- a/extensions/cyclonedx/generator/src/main/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGenerator.java
+++ b/extensions/cyclonedx/generator/src/main/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGenerator.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.UUID;
 
 import org.apache.maven.model.MailingList;
 import org.apache.maven.model.Model;
@@ -82,6 +83,7 @@ public class CycloneDxSbomGenerator {
     private EffectiveModelResolver modelResolver;
     private boolean includeLicenseText;
     private boolean prettyPrint;
+    private boolean deterministicSerialNumber;
     private List<SbomContribution> contributions = List.of();
 
     private Version effectiveSchemaVersion;
@@ -132,6 +134,12 @@ public class CycloneDxSbomGenerator {
     public CycloneDxSbomGenerator setPrettyPrint(boolean prettyPrint) {
         ensureNotGenerated();
         this.prettyPrint = prettyPrint;
+        return this;
+    }
+
+    public CycloneDxSbomGenerator setDeterministicSerialNumber(boolean deterministicSerialNumber) {
+        ensureNotGenerated();
+        this.deterministicSerialNumber = deterministicSerialNumber;
         return this;
     }
 
@@ -206,10 +214,7 @@ public class CycloneDxSbomGenerator {
         allDescriptors.sort(Comparator.comparing(ComponentDescriptor::getBomRef));
         allDependencies.sort(Comparator.comparing(ComponentDependencies::getBomRef));
 
-        var serialNumber = resolveSerialNumber(allDescriptors);
-        if (serialNumber != null) {
-            bom.setSerialNumber(serialNumber);
-        }
+        bom.setSerialNumber(resolveSerialNumber(allDescriptors, allDependencies));
 
         // Render components
         for (ComponentDescriptor descriptor : allDescriptors) {
@@ -254,20 +259,35 @@ public class CycloneDxSbomGenerator {
         }
     }
 
-    private String resolveSerialNumber(List<ComponentDescriptor> allDescriptors) {
-        if (mainComponentBomRef != null) {
-            for (ComponentDescriptor descriptor : allDescriptors) {
-                if (descriptor.getBomRef().equals(mainComponentBomRef)) {
-                    return deterministicSerialNumber(descriptor.getBomRef());
-                }
-            }
+    private String resolveSerialNumber(List<ComponentDescriptor> allDescriptors,
+            List<ComponentDependencies> allDependencies) {
+        if (deterministicSerialNumber) {
+            return deterministicSerialNumber(allDescriptors, allDependencies);
         }
-        return null;
+        return randomSerialNumber();
     }
 
-    private static String deterministicSerialNumber(String identity) {
-        var uuid = java.util.UUID.nameUUIDFromBytes(identity.getBytes(StandardCharsets.UTF_8));
+    private static String deterministicSerialNumber(List<ComponentDescriptor> allDescriptors,
+            List<ComponentDependencies> allDependencies) {
+        StringBuilder identity = new StringBuilder();
+        for (ComponentDescriptor descriptor : allDescriptors) {
+            identity.append(descriptor.getBomRef()).append('\n');
+        }
+        for (ComponentDependencies dependency : allDependencies) {
+            identity.append(dependency.getBomRef()).append("->");
+            List<String> dependsOn = new ArrayList<>(dependency.getDependsOn());
+            Collections.sort(dependsOn);
+            for (String depRef : dependsOn) {
+                identity.append(depRef).append(',');
+            }
+            identity.append('\n');
+        }
+        UUID uuid = UUID.nameUUIDFromBytes(identity.toString().getBytes(StandardCharsets.UTF_8));
         return SERIAL_NUMBER_PREFIX + uuid;
+    }
+
+    private static String randomSerialNumber() {
+        return SERIAL_NUMBER_PREFIX + UUID.randomUUID();
     }
 
     /**

--- a/extensions/cyclonedx/generator/src/test/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGeneratorTest.java
+++ b/extensions/cyclonedx/generator/src/test/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGeneratorTest.java
@@ -2,7 +2,9 @@ package io.quarkus.cyclonedx.generator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.UUID;
 
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.model.Dependency;
@@ -59,6 +61,15 @@ class CycloneDxSbomGeneratorTest {
 
         // Parse the output back to verify dependency structure
         Bom bom = parseBom(result.get(0));
+        Bom secondBom = parseBom(CycloneDxSbomGenerator.newInstance()
+                .setFormat("json")
+                .setContributions(List.of(coreContribution, extensionContribution))
+                .generateText()
+                .get(0));
+
+        assertThat(bom.getSerialNumber())
+                .isEqualTo("urn:uuid:" + UUID.nameUUIDFromBytes(mainBomRef.getBytes(StandardCharsets.UTF_8)));
+        assertThat(secondBom.getSerialNumber()).isEqualTo(bom.getSerialNumber());
 
         // Find main component dependency entry
         Dependency mainDep = bom.getDependencies().stream()
@@ -93,6 +104,7 @@ class CycloneDxSbomGeneratorTest {
         assertThat(result).hasSize(1);
         // Should not crash — no main component to link to
         assertThat(result.get(0)).contains("react");
+        assertThat(parseBom(result.get(0)).getSerialNumber()).isNull();
     }
 
     @Test

--- a/extensions/cyclonedx/generator/src/test/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGeneratorTest.java
+++ b/extensions/cyclonedx/generator/src/test/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGeneratorTest.java
@@ -2,9 +2,7 @@ package io.quarkus.cyclonedx.generator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.UUID;
 
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.model.Dependency;
@@ -67,9 +65,9 @@ class CycloneDxSbomGeneratorTest {
                 .generateText()
                 .get(0));
 
-        assertThat(bom.getSerialNumber())
-                .isEqualTo("urn:uuid:" + UUID.nameUUIDFromBytes(mainBomRef.getBytes(StandardCharsets.UTF_8)));
-        assertThat(secondBom.getSerialNumber()).isEqualTo(bom.getSerialNumber());
+        assertValidSerialNumber(bom.getSerialNumber());
+        assertValidSerialNumber(secondBom.getSerialNumber());
+        assertThat(secondBom.getSerialNumber()).isNotEqualTo(bom.getSerialNumber());
 
         // Find main component dependency entry
         Dependency mainDep = bom.getDependencies().stream()
@@ -103,8 +101,74 @@ class CycloneDxSbomGeneratorTest {
 
         assertThat(result).hasSize(1);
         // Should not crash — no main component to link to
+        Bom bom = parseBom(result.get(0));
+        Bom secondBom = parseBom(CycloneDxSbomGenerator.newInstance()
+                .setFormat("json")
+                .setContributions(List.of(contribution))
+                .generateText()
+                .get(0));
         assertThat(result.get(0)).contains("react");
-        assertThat(parseBom(result.get(0)).getSerialNumber()).isNull();
+        assertValidSerialNumber(bom.getSerialNumber());
+        assertValidSerialNumber(secondBom.getSerialNumber());
+        assertThat(secondBom.getSerialNumber()).isNotEqualTo(bom.getSerialNumber());
+    }
+
+    @Test
+    void deterministicSerialNumberCanBeEnabled() {
+        ResolvedDependency mainArtifact = resolvedDep("org.acme", "acme-app", "1.0.0",
+                List.of(ArtifactCoords.jar("io.quarkus", "quarkus-rest", "3.0.0")));
+        ResolvedDependency restDep = resolvedDep("io.quarkus", "quarkus-rest", "3.0.0", List.of());
+
+        SbomContribution coreContribution = new CoreSbomContributionConfig()
+                .setMainArtifact(mainArtifact)
+                .addComponent(restDep)
+                .toSbomContribution();
+        ComponentDescriptor react = ComponentDescriptor.builder()
+                .setPurl(Purl.npm(null, "react", "18.0.0"))
+                .setTopLevel(true)
+                .build();
+        SbomContribution extensionContribution = SbomContribution.ofComponents(List.of(react));
+
+        Bom bom = parseBom(CycloneDxSbomGenerator.newInstance()
+                .setFormat("json")
+                .setDeterministicSerialNumber(true)
+                .setContributions(List.of(coreContribution, extensionContribution))
+                .generateText()
+                .get(0));
+        Bom secondBom = parseBom(CycloneDxSbomGenerator.newInstance()
+                .setFormat("json")
+                .setDeterministicSerialNumber(true)
+                .setContributions(List.of(coreContribution, extensionContribution))
+                .generateText()
+                .get(0));
+
+        assertValidSerialNumber(bom.getSerialNumber());
+        assertThat(secondBom.getSerialNumber()).isEqualTo(bom.getSerialNumber());
+    }
+
+    @Test
+    void deterministicSerialNumberWorksWithoutMainComponent() {
+        ComponentDescriptor react = ComponentDescriptor.builder()
+                .setPurl(Purl.npm(null, "react", "18.0.0"))
+                .setTopLevel(true)
+                .build();
+        SbomContribution contribution = SbomContribution.ofComponents(List.of(react));
+
+        Bom bom = parseBom(CycloneDxSbomGenerator.newInstance()
+                .setFormat("json")
+                .setDeterministicSerialNumber(true)
+                .setContributions(List.of(contribution))
+                .generateText()
+                .get(0));
+        Bom secondBom = parseBom(CycloneDxSbomGenerator.newInstance()
+                .setFormat("json")
+                .setDeterministicSerialNumber(true)
+                .setContributions(List.of(contribution))
+                .generateText()
+                .get(0));
+
+        assertValidSerialNumber(bom.getSerialNumber());
+        assertThat(secondBom.getSerialNumber()).isEqualTo(bom.getSerialNumber());
     }
 
     @Test
@@ -185,6 +249,11 @@ class CycloneDxSbomGeneratorTest {
         } catch (Exception e) {
             throw new RuntimeException("Failed to parse BOM JSON", e);
         }
+    }
+
+    private static void assertValidSerialNumber(String serialNumber) {
+        assertThat(serialNumber)
+                .matches("^urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$");
     }
 
     private static io.quarkus.maven.dependency.ResolvedDependency resolvedDep(


### PR DESCRIPTION
 Fix #54674
  

## Summary

  - Populate the CycloneDX `serialNumber` field in generated SBOMs when a main component is present, aligning with
  the spec's SHOULD requirement
  - Derive a deterministic `urn:uuid` from the main component's `bom-ref` so the same application gets a stable BOM
  identity across rebuilds
  - Leave `serialNumber` unset when no main component is present, avoiding a random fallback and preserving
  reproducible output