### PR TITLE
Document Basic authentication realm compatibility

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AuthRuntimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AuthRuntimeConfig.java
@@ -74,7 +74,8 @@ public interface AuthRuntimeConfig {
     Optional<Path> certificateRoleProperties();
 
     /**
-     * The authentication realm
+     * The authentication realm used for Basic authentication.
+     * Legacy HTTP clients may fail to parse a Basic authentication challenge when this property is not set.
      */
     Optional<String> realm();
 


### PR DESCRIPTION
Legacy HTTP clients may fail to parse a Basic authentication challenge when `quarkus.http.auth.realm` is not configured.

Document this compatibility consideration directly on the configuration property so it appears in the generated configuration reference.

Fixes #54689.
