### PR TITLE
Update CycloneDX to 12.2.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -191,6 +191,7 @@ updates:
       - dependency-name: org.codejive:java-properties
       - dependency-name: org.json:json
       - dependency-name: de.thetaphi:forbiddenapis
+      - dependency-name: org.cyclonedx:*
     groups:
       # Only group Hibernate ORM/Search/Reactive as Hibernate Validator is much more independent.
       Hibernate:

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -19,7 +19,7 @@
         <bouncycastle.version>1.84</bouncycastle.version>
         <bouncycastle.fips.version>2.1.2</bouncycastle.fips.version>
         <bouncycastle.tls.fips.version>2.1.23</bouncycastle.tls.fips.version>
-        <cyclonedx.version>12.1.0</cyclonedx.version>
+        <cyclonedx.version>12.2.0</cyclonedx.version>
         <expressly.version>6.0.0</expressly.version>
         <findbugs.version>3.0.2</findbugs.version>
         <jandex.version>3.5.3</jandex.version>


### PR DESCRIPTION
The main purpose of this update is to fix the alignment issue we have here:

https://github.com/quarkusio/quarkus/pull/53855

```
Dependency convergence error for com.networknt:json-schema-validator:jar:2.0.1. Paths to dependency are:
+-io.quarkus:quarkus-tck-resteasy-reactive:pom:999-SNAPSHOT
  +-io.quarkus:quarkus-maven-plugin:pom:999-SNAPSHOT:compile
    +-io.quarkus:quarkus-devtools-common:jar:999-SNAPSHOT:compile
      +-com.networknt:json-schema-validator:jar:2.0.1:compile
and
+-io.quarkus:quarkus-tck-resteasy-reactive:pom:999-SNAPSHOT
  +-io.quarkus:quarkus-maven-plugin:pom:999-SNAPSHOT:compile
    +-io.quarkus:quarkus-cyclonedx-generator:jar:999-SNAPSHOT:compile
      +-org.cyclonedx:cyclonedx-core-java:jar:12.1.0:compile
        +-com.networknt:json-schema-validator:jar:1.5.9:compile
```

Also added it to Dependabot.