### PR TITLE
Jandex: upgrade to 3.6.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -22,7 +22,7 @@
         <cyclonedx.version>12.1.0</cyclonedx.version>
         <expressly.version>6.0.0</expressly.version>
         <findbugs.version>3.0.2</findbugs.version>
-        <jandex.version>3.5.3</jandex.version>
+        <jandex.version>3.6.0</jandex.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <javax.inject.version>1</javax.inject.version>
         <parsson.version>1.1.9</parsson.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -30,7 +30,7 @@
         <jboss-bridger-plugin.version>1.6.Final</jboss-bridger-plugin.version>
 
         <!-- Jandex versions -->
-        <jandex.version>3.5.3</jandex.version>
+        <jandex.version>3.6.0</jandex.version>
         <jandex-gradle-plugin.version>2.3.0</jandex-gradle-plugin.version>
 
         <asciidoctorj.version>3.0.0</asciidoctorj.version>

--- a/core/deployment/src/main/java/io/quarkus/deployment/index/IndexWrapper.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/index/IndexWrapper.java
@@ -271,6 +271,12 @@ public class IndexWrapper implements IndexView {
     }
 
     @Override
+    public Collection<AnnotationInstance> getAnnotationsWithRepeatable(DotName annotationName,
+            DotName containerAnnotationName) {
+        return this.index.getAnnotationsWithRepeatable(annotationName, containerAnnotationName);
+    }
+
+    @Override
     public Collection<ModuleInfo> getKnownModules() {
         return this.index.getKnownModules();
     }

--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/OverridableIndex.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/OverridableIndex.java
@@ -101,6 +101,15 @@ public class OverridableIndex implements IndexView {
     }
 
     @Override
+    public Collection<AnnotationInstance> getAnnotationsWithRepeatable(DotName annotationName,
+            DotName containerAnnotationName) {
+        return overrideCollection(
+                original.getAnnotationsWithRepeatable(annotationName, containerAnnotationName),
+                override.getAnnotationsWithRepeatable(annotationName, containerAnnotationName),
+                annotationInstanceComparator);
+    }
+
+    @Override
     public Collection<ModuleInfo> getKnownModules() {
         return overrideCollection(original.getKnownModules(), override.getKnownModules(), moduleInfoComparator);
     }

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/FinalIndexModifierTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/FinalIndexModifierTest.java
@@ -170,6 +170,12 @@ public class FinalIndexModifierTest {
         }
 
         @Override
+        public Collection<AnnotationInstance> getAnnotationsWithRepeatable(DotName annotationName,
+                DotName containerAnnotationName) {
+            return delegate.getAnnotationsWithRepeatable(annotationName, containerAnnotationName);
+        }
+
+        @Override
         public Collection<org.jboss.jandex.ModuleInfo> getKnownModules() {
             return delegate.getKnownModules();
         }

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -45,7 +45,7 @@
         <version.jta>2.0.1</version.jta>
         <!-- main versions -->
         <version.gizmo>1.10.1</version.gizmo>
-        <version.jandex>3.5.3</version.jandex>
+        <version.jandex>3.6.0</version.jandex>
         <version.gizmo2>2.1.1</version.gizmo2>
         <version.jboss-logging>3.6.3.Final</version.jboss-logging>
         <version.mutiny>3.2.1</version.mutiny>

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanArchives.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanArchives.java
@@ -327,6 +327,12 @@ public final class BeanArchives {
         }
 
         @Override
+        public Collection<AnnotationInstance> getAnnotationsWithRepeatable(DotName annotationName,
+                DotName containerAnnotationName) {
+            return this.index.getAnnotationsWithRepeatable(annotationName, containerAnnotationName);
+        }
+
+        @Override
         public Collection<ModuleInfo> getKnownModules() {
             return this.index.getKnownModules();
         }

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -33,7 +33,7 @@
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <javax.inject.version>1</javax.inject.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jandex.version>3.5.3</jandex.version>
+        <jandex.version>3.6.0</jandex.version>
         <jmh.version>1.37</jmh.version>
 
         <!-- Dependency versions -->

--- a/independent-projects/extension-maven-plugin/pom.xml
+++ b/independent-projects/extension-maven-plugin/pom.xml
@@ -41,7 +41,7 @@
         <smallrye-beanbag.version>1.6.1</smallrye-beanbag.version>
         <junit.version>6.1.0</junit.version>
         <mockito.version>5.21.0</mockito.version>
-        <version.jandex>3.5.3</version.jandex>
+        <version.jandex>3.6.0</version.jandex>
     </properties>
     <build>
         <testResources>

--- a/independent-projects/junit-virtual-threads/pom.xml
+++ b/independent-projects/junit-virtual-threads/pom.xml
@@ -41,7 +41,7 @@
         <compiler.plugin.version>3.15.0</compiler.plugin.version>
         <enforcer.plugin.version>3.2.1</enforcer.plugin.version>
         <surefire.plugin.version>3.5.4</surefire.plugin.version>
-        <jandex.version>3.5.3</jandex.version>
+        <jandex.version>3.6.0</jandex.version>
         <smallrye-common.version>2.18.1</smallrye-common.version>
 
         <junit.version>6.1.0</junit.version>

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -40,7 +40,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.junit>6.1.0</version.junit>
         <version.assertj>3.27.7</version.assertj>
-        <version.jandex>3.5.3</version.jandex>
+        <version.jandex>3.6.0</version.jandex>
         <version.gizmo2>2.1.1</version.gizmo2>
         <version.jboss-logging>3.6.3.Final</version.jboss-logging>
         <version.smallrye-common>2.18.1</version.smallrye-common>

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/CalculatingIndexView.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/CalculatingIndexView.java
@@ -256,6 +256,12 @@ public class CalculatingIndexView implements IndexView {
     }
 
     @Override
+    public Collection<AnnotationInstance> getAnnotationsWithRepeatable(DotName annotationName,
+            DotName containerAnnotationName) {
+        return this.index.getAnnotationsWithRepeatable(annotationName, containerAnnotationName);
+    }
+
+    @Override
     public Collection<ModuleInfo> getKnownModules() {
         return this.index.getKnownModules();
     }

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -44,7 +44,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Versions -->
         <jakarta.enterprise.cdi-api.version>4.1.0</jakarta.enterprise.cdi-api.version>
-        <jandex.version>3.5.3</jandex.version>
+        <jandex.version>3.6.0</jandex.version>
         <bytebuddy.version>1.17.6</bytebuddy.version>
         <junit.version>6.1.0</junit.version>
         <maven.version>3.9.16</maven.version>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -59,7 +59,7 @@
         <mockito.version>5.21.0</mockito.version>
         <quarkus.version>${project.version}</quarkus.version>
         <maven-model-helper.version>41</maven-model-helper.version>
-        <jandex.version>3.5.3</jandex.version>
+        <jandex.version>3.6.0</jandex.version>
         <system-stubs-jupiter.version>2.0.2</system-stubs-jupiter.version>
         <awaitility.version>4.3.0</awaitility.version>
         <java-properties.version>0.0.7</java-properties.version>


### PR DESCRIPTION
- https://smallrye.io/blog/jandex-3-6-0/

The addition of `ClassInfo.hashCode()` should fix many reproducibility problems; I know it fixes #54515