### PR TITLE
Ensure generated bytecode is reproducible in extensions/vertx/deployment

### DIFF
--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
@@ -248,7 +248,6 @@ class VertxCoreProcessor {
         recorder.wrapMainExecutorForMutiny(executorBuildItem.getExecutorProxy());
 
         List<Consumer<VertxOptions>> consumers = vertxOptionsConsumers.stream()
-                .sorted()
                 .map(VertxOptionsConsumerBuildItem::getConsumer)
                 .toList();
 

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/EventConsumerBusinessMethodItem.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/EventConsumerBusinessMethodItem.java
@@ -1,23 +1,37 @@
 package io.quarkus.vertx.deployment;
 
+import static io.quarkus.arc.processor.Reproducibility.BEAN_COMPARATOR;
+import static io.quarkus.arc.processor.Reproducibility.METHOD_COMPARATOR;
+
+import java.util.Comparator;
+
 import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.MethodInfo;
 
 import io.quarkus.arc.processor.BeanInfo;
 import io.quarkus.arc.processor.InvokerInfo;
 import io.quarkus.builder.item.MultiBuildItem;
 
-public final class EventConsumerBusinessMethodItem extends MultiBuildItem {
+public final class EventConsumerBusinessMethodItem extends MultiBuildItem
+        implements Comparable<EventConsumerBusinessMethodItem> {
+
+    private static final Comparator<EventConsumerBusinessMethodItem> COMPARATOR = Comparator
+            .comparing(EventConsumerBusinessMethodItem::getBean, BEAN_COMPARATOR)
+            .thenComparing(EventConsumerBusinessMethodItem::getMethod, METHOD_COMPARATOR);
 
     private final BeanInfo bean;
+    private final MethodInfo method;
     private final AnnotationInstance consumeEvent;
     private final boolean blockingAnnotation;
     private final boolean runOnVirtualThreadAnnotation;
     private final boolean splitHeadersBodyParams;
     private final InvokerInfo invoker;
 
-    public EventConsumerBusinessMethodItem(BeanInfo bean, AnnotationInstance consumeEvent, boolean blockingAnnotation,
-            boolean runOnVirtualThreadAnnotation, boolean splitHeadersBodyParams, InvokerInfo invoker) {
+    public EventConsumerBusinessMethodItem(BeanInfo bean, MethodInfo method, AnnotationInstance consumeEvent,
+            boolean blockingAnnotation, boolean runOnVirtualThreadAnnotation,
+            boolean splitHeadersBodyParams, InvokerInfo invoker) {
         this.bean = bean;
+        this.method = method;
         this.consumeEvent = consumeEvent;
         this.blockingAnnotation = blockingAnnotation;
         this.runOnVirtualThreadAnnotation = runOnVirtualThreadAnnotation;
@@ -38,6 +52,13 @@ public final class EventConsumerBusinessMethodItem extends MultiBuildItem {
      */
     public AnnotationInstance getConsumeEvent() {
         return consumeEvent;
+    }
+
+    /**
+     * Returns the event consumer method.
+     */
+    public MethodInfo getMethod() {
+        return method;
     }
 
     /**
@@ -71,6 +92,11 @@ public final class EventConsumerBusinessMethodItem extends MultiBuildItem {
      */
     public InvokerInfo getInvoker() {
         return invoker;
+    }
+
+    @Override
+    public int compareTo(EventConsumerBusinessMethodItem o) {
+        return COMPARATOR.compare(this, o);
     }
 
 }

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
@@ -10,7 +10,7 @@ import static io.quarkus.vertx.deployment.VertxConstants.isMessageHeaders;
 
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadFactory;
@@ -126,7 +126,7 @@ class VertxProcessor {
         }
 
         ClassLoader tccl = Thread.currentThread().getContextClassLoader();
-        Map<Class<?>, Class<?>> codecByClass = new HashMap<>();
+        Map<Class<?>, Class<?>> codecByClass = new LinkedHashMap<>();
         for (MessageCodecBuildItem messageCodecItem : codecs) {
             reflectiveClassBuildItemBuildProducer
                     .produce(ReflectiveClassBuildItem.builder(messageCodecItem.getType()).constructors(false).build());
@@ -239,7 +239,7 @@ class VertxProcessor {
 
                     InvokerInfo invoker = builder.build();
 
-                    messageConsumerBusinessMethods.produce(new EventConsumerBusinessMethodItem(bean, consumeEvent,
+                    messageConsumerBusinessMethods.produce(new EventConsumerBusinessMethodItem(bean, method, consumeEvent,
                             method.hasAnnotation(Blocking.class), method.hasAnnotation(RunOnVirtualThread.class),
                             parametersCount == 2, invoker));
                     LOGGER.debugf("Found event consumer business method %s declared on %s", method, bean);


### PR DESCRIPTION
This is achieved via introducing stable sort order to `EventConsumerBusinessMethodItem`s.