### PR TITLE
Fix Dev Services connection URLs when when dev container  reports IPv6 container hosts

### DIFF
--- a/extensions/devservices/common/pom.xml
+++ b/extensions/devservices/common/pom.xml
@@ -39,5 +39,15 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-datasource-common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ContainerAddress.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ContainerAddress.java
@@ -34,8 +34,13 @@ public class ContainerAddress {
         return port;
     }
 
+    /**
+     * Returns {@code host:port} with RFC 2732 bracketing for IPv6. Does not resolve the host via
+     * {@code docker inspect}; callers that need IPv4 gateway resolution must use
+     * {@link DevServicesHostUtil#formatResolvedHostAndPort(String, String, int)} explicitly.
+     */
     public String getUrl() {
-        return String.format("%s:%d", host, port);
+        return DevServicesHostUtil.formatHostAndPort(host, port);
     }
 
     public RunningContainer getRunningContainer() {

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/DatasourceServiceConfigurator.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/DatasourceServiceConfigurator.java
@@ -10,11 +10,15 @@ public interface DatasourceServiceConfigurator {
         return jdbcUrl.replaceFirst("jdbc:", "vertx-reactive:");
     }
 
+    /**
+     * Uses {@link DevServicesHostUtil#formatHostAndPort} for IPv6-safe authorities.
+     * Implementors overriding this method must bracket IPv6 hosts themselves.
+     */
     default String getJdbcUrl(ContainerAddress containerAddress, String databaseName) {
-        return String.format("jdbc:%s://%s:%d/%s%s",
+        return String.format("jdbc:%s://%s/%s%s",
                 getJdbcPrefix(),
-                containerAddress.getHost(),
-                containerAddress.getPort(),
+                DevServicesHostUtil.formatResolvedHostAndPort(containerAddress.getId(), containerAddress.getHost(),
+                        containerAddress.getPort()),
                 databaseName,
                 getParameters(containerAddress.getRunningContainer().containerInfo().labels()));
     }

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/DevServicesHostUtil.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/DevServicesHostUtil.java
@@ -1,0 +1,232 @@
+package io.quarkus.devservices.common;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.jboss.logging.Logger;
+import org.testcontainers.DockerClientFactory;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.model.ContainerNetwork;
+
+/**
+ * Host resolution and URI authority formatting for Dev Services containers.
+ */
+public final class DevServicesHostUtil {
+
+    private static final Logger LOG = Logger.getLogger(DevServicesHostUtil.class);
+
+    private static final String DOCKER_BRIDGE_NETWORK = "bridge";
+
+    private static final String PODMAN_DEFAULT_NETWORK = "podman";
+
+    private static final Map<String, String> RESOLVED_HOST_CACHE = new ConcurrentHashMap<>();
+
+    private static final String HOST_OVERRIDE = resolveHostOverride();
+
+    private DevServicesHostUtil() {
+    }
+
+    public static String formatHostForUriAuthority(String host) {
+        Objects.requireNonNull(host, "host");
+        if (host.isEmpty() || host.charAt(0) == '[' || !isIPv6Literal(host)) {
+            return host;
+        }
+        return "[" + host + "]";
+    }
+
+    public static String formatHostAndPort(String host, int port) {
+        return formatHostForUriAuthority(host) + ":" + port;
+    }
+
+    public static String formatPrefixedAuthority(String prefix, String host, int port) {
+        return prefix + "://" + formatHostAndPort(host, port);
+    }
+
+    /**
+     * Returns the host to use for connecting to a published port, resolving IPv6 gateway
+     * addresses to a reachable IPv4 alternative or {@code localhost} where needed.
+     */
+    public static String resolvePublishedPortHost(String containerId, String reportedHost) {
+        Objects.requireNonNull(reportedHost, "reportedHost");
+
+        // Normalise special "bind-all" address — always means localhost from host side.
+        if (reportedHost.isEmpty() || "0.0.0.0".equals(reportedHost) || "::".equals(reportedHost)) {
+            return "localhost";
+        }
+
+        // Explicit user override takes priority (e.g. Colima, custom Podman machine).
+        if (HOST_OVERRIDE != null) {
+            return HOST_OVERRIDE;
+        }
+
+        String bare = unbracket(reportedHost);
+
+        // Not an IPv6 address — nothing to resolve.
+        if (!isIPv6Literal(bare)) {
+            return bare;
+        }
+
+        // IPv6 reported. Attempt to resolve to an IPv4 gateway reachable from the host.
+        if (containerId == null || containerId.isBlank()) {
+            LOG.infof("Dev Services: no container id available; using localhost instead of IPv6 host %s", bare);
+            return "localhost";
+        }
+
+        String resolved = RESOLVED_HOST_CACHE.computeIfAbsent(containerId,
+                id -> resolveIPv6ToReachableHost(id, bare));
+        return ensureReachableFromHost(resolved, bare);
+    }
+
+    /**
+     * Published ports on the host are never reachable via Docker's IPv6 userland-proxy address
+     * (e.g. {@code fd00:d0ca:1::1}). If resolution still yields an IPv6 literal, use localhost.
+     */
+    private static String ensureReachableFromHost(String resolved, String reportedIPv6) {
+        if (!isIPv6Literal(unbracket(resolved))) {
+            return resolved;
+        }
+        LOG.infof("Dev Services: IPv6 host %s is not reachable from the host JVM; using localhost instead of %s",
+                reportedIPv6, unbracket(resolved));
+        return "localhost";
+    }
+
+    public static String publishedPortHost(String containerId, String reportedHost) {
+        return resolvePublishedPortHost(containerId, reportedHost);
+    }
+
+    public static String publishedPortHost(String containerId, boolean useSharedNetwork,
+            String sharedNetworkHost, String reportedHost) {
+        if (useSharedNetwork) {
+            Objects.requireNonNull(sharedNetworkHost, "sharedNetworkHost");
+            return sharedNetworkHost;
+        }
+        return resolvePublishedPortHost(containerId, reportedHost);
+    }
+
+    public static String formatResolvedHostAndPort(String containerId, String reportedHost, int port) {
+        return formatHostAndPort(resolvePublishedPortHost(containerId, reportedHost), port);
+    }
+
+    public static String formatResolvedPrefixedAuthority(String prefix, String containerId,
+            String reportedHost, int port) {
+        return prefix + "://" + formatResolvedHostAndPort(containerId, reportedHost, port);
+    }
+
+    public static boolean isIPv6Literal(String host) {
+        if (host == null || host.isEmpty()) {
+            return false;
+        }
+        if (host.charAt(0) == '[') {
+            return true;
+        }
+        int colons = 0;
+        for (int i = 0; i < host.length(); i++) {
+            if (host.charAt(i) == ':') {
+                if (++colons >= 2) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static String resolveHostOverride() {
+        String v = System.getenv("TESTCONTAINERS_HOST_OVERRIDE");
+        return (v == null || v.isBlank()) ? null : v.trim();
+    }
+
+    private static String unbracket(String host) {
+        if (host.length() >= 2 && host.charAt(0) == '[' && host.charAt(host.length() - 1) == ']') {
+            return host.substring(1, host.length() - 1);
+        }
+        return host;
+    }
+
+    private static String resolveIPv6ToReachableHost(String containerId, String ipv6Fallback) {
+        try {
+            DockerClient client = DockerClientFactory.lazyClient();
+            Map<String, ContainerNetwork> networks = client
+                    .inspectContainerCmd(containerId)
+                    .exec()
+                    .getNetworkSettings()
+                    .getNetworks();
+
+            if (networks == null || networks.isEmpty()) {
+                // Rootless Podman (pasta / slirp4netns): inspect returns no network info.
+                // Podman Desktop (Mac/Win): same — the VM port-forwards to localhost.
+                LOG.infof(
+                        "Dev Services: container %s has no network entries in inspect response "
+                                + "(rootless Podman / Podman Desktop?); using localhost instead of IPv6 %s",
+                        shortId(containerId), ipv6Fallback);
+                return "localhost";
+            }
+
+            // Docker bridge network (Docker Engine, Docker Desktop, Rancher Desktop dockerd).
+            String gateway = ipv4Gateway(networks.get(DOCKER_BRIDGE_NETWORK));
+            if (gateway != null) {
+                logResolved(containerId, ipv6Fallback, gateway, DOCKER_BRIDGE_NETWORK);
+                return gateway;
+            }
+
+            // Podman default network (rootful Podman with Netavark / CNI).
+            gateway = ipv4Gateway(networks.get(PODMAN_DEFAULT_NETWORK));
+            if (gateway != null) {
+                logResolved(containerId, ipv6Fallback, gateway, PODMAN_DEFAULT_NETWORK);
+                return gateway;
+            }
+
+            // Any other network (Rancher Desktop containerd/CNI, custom named networks).
+            for (Map.Entry<String, ContainerNetwork> entry : networks.entrySet()) {
+                gateway = ipv4Gateway(entry.getValue());
+                if (gateway != null) {
+                    logResolved(containerId, ipv6Fallback, gateway, entry.getKey());
+                    return gateway;
+                }
+            }
+
+            // Networks present but all have empty / IPv6-only gateways.
+            // This happens with rootless Podman using a named bridge network where the
+            // gateway field is populated with an IPv6 address only, or is blank.
+            // Published ports are still reachable via localhost.
+            LOG.infof(
+                    "Dev Services: container %s inspect returned %d network(s) but none had a usable "
+                            + "IPv4 gateway; using localhost instead of IPv6 %s",
+                    shortId(containerId), networks.size(), ipv6Fallback);
+            return "localhost";
+
+        } catch (Exception e) {
+            LOG.infof(e,
+                    "Dev Services: docker inspect failed for container %s; using localhost instead of IPv6 %s",
+                    shortId(containerId), ipv6Fallback);
+            return "localhost";
+        }
+    }
+
+    private static String ipv4Gateway(ContainerNetwork network) {
+        if (network == null) {
+            return null;
+        }
+        String gw = network.getGateway();
+        if (gw == null || gw.isBlank() || isIPv6Literal(gw)) {
+            return null;
+        }
+        // Extra guard: Podman sometimes returns "0.0.0.0" as a placeholder.
+        if ("0.0.0.0".equals(gw)) {
+            return null;
+        }
+        return gw;
+    }
+
+    private static void logResolved(String containerId, String ipv6, String ipv4, String networkName) {
+        LOG.infof(
+                "Dev Services: container %s IPv6 gateway %s resolved to IPv4 gateway %s "
+                        + "via network '%s'",
+                shortId(containerId), ipv6, ipv4, networkName);
+    }
+
+    private static String shortId(String containerId) {
+        return containerId.length() > 12 ? containerId.substring(0, 12) : containerId;
+    }
+}

--- a/extensions/devservices/common/src/test/java/io/quarkus/devservices/common/ContainerAddressTest.java
+++ b/extensions/devservices/common/src/test/java/io/quarkus/devservices/common/ContainerAddressTest.java
@@ -1,0 +1,19 @@
+package io.quarkus.devservices.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class ContainerAddressTest {
+
+    @Test
+    public void getUrlWithIpv6Host() {
+        assertThat(new ContainerAddress("id", "fd00:d0ca:1::1", 27017).getUrl())
+                .isEqualTo("[fd00:d0ca:1::1]:27017");
+    }
+
+    @Test
+    public void getUrlWithAlias() {
+        assertThat(new ContainerAddress("id", "redis-abc12", 6379).getUrl()).isEqualTo("redis-abc12:6379");
+    }
+}

--- a/extensions/devservices/common/src/test/java/io/quarkus/devservices/common/DevServicesHostUtilTest.java
+++ b/extensions/devservices/common/src/test/java/io/quarkus/devservices/common/DevServicesHostUtilTest.java
@@ -1,0 +1,90 @@
+package io.quarkus.devservices.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+public class DevServicesHostUtilTest {
+
+    @Test
+    public void ipv4() {
+        assertThat(DevServicesHostUtil.formatHostAndPort("127.0.0.1", 5432)).isEqualTo("127.0.0.1:5432");
+    }
+
+    @Test
+    public void hostname() {
+        assertThat(DevServicesHostUtil.formatHostAndPort("myhost", 5432)).isEqualTo("myhost:5432");
+    }
+
+    @Test
+    public void aliasPassesThroughUnchanged() {
+        assertThat(DevServicesHostUtil.formatHostAndPort("mariadb-abc12", 3306)).isEqualTo("mariadb-abc12:3306");
+    }
+
+    @Test
+    public void ipv6() {
+        assertThat(DevServicesHostUtil.formatHostAndPort("fd00:d0ca:1::1", 32769))
+                .isEqualTo("[fd00:d0ca:1::1]:32769");
+    }
+
+    @Test
+    public void alreadyBracketed() {
+        assertThat(DevServicesHostUtil.formatHostAndPort("[::1]", 8080)).isEqualTo("[::1]:8080");
+    }
+
+    @Test
+    public void prefixedKafkaListener() {
+        assertThat(DevServicesHostUtil.formatPrefixedAuthority("PLAINTEXT", "fd00:d0ca:1::1", 9092))
+                .isEqualTo("PLAINTEXT://[fd00:d0ca:1::1]:9092");
+    }
+
+    @Test
+    public void nullHostRejected() {
+        assertThatThrownBy(() -> DevServicesHostUtil.formatHostForUriAuthority(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("host");
+    }
+
+    @Test
+    public void isIPv6LiteralDetection() {
+        assertThat(DevServicesHostUtil.isIPv6Literal("fd00::1")).isTrue();
+        assertThat(DevServicesHostUtil.isIPv6Literal("::1")).isTrue();
+        assertThat(DevServicesHostUtil.isIPv6Literal("[fd00::1]")).isTrue();
+        assertThat(DevServicesHostUtil.isIPv6Literal("fd00:d0ca:1::1")).isTrue();
+        assertThat(DevServicesHostUtil.isIPv6Literal("172.17.0.1")).isFalse();
+        assertThat(DevServicesHostUtil.isIPv6Literal("mongo-abc")).isFalse();
+    }
+
+    @Test
+    public void resolvePublishedPortHostNonIPv6Unchanged() {
+        assertThat(DevServicesHostUtil.resolvePublishedPortHost("id", "172.17.0.1")).isEqualTo("172.17.0.1");
+        assertThat(DevServicesHostUtil.resolvePublishedPortHost("id", "postgres-abc")).isEqualTo("postgres-abc");
+        assertThat(DevServicesHostUtil.resolvePublishedPortHost("id", "0.0.0.0")).isEqualTo("localhost");
+    }
+
+    @Test
+    public void publishedPortHostSharedNetworkUsesAlias() {
+        assertThat(DevServicesHostUtil.publishedPortHost("id", true, "mongo-abc12", "fd00:d0ca:1::1"))
+                .isEqualTo("mongo-abc12");
+    }
+
+    @Test
+    public void publishedPortHostTwoArgDelegatesToResolve() {
+        assertThat(DevServicesHostUtil.publishedPortHost("id", "172.17.0.1")).isEqualTo("172.17.0.1");
+    }
+
+    @Test
+    public void resolvePublishedPortHostNeverReturnsIPv6() {
+        assertThat(DevServicesHostUtil.resolvePublishedPortHost("quarkus-nonexistent-container-id",
+                "fd00:d0ca:1::1")).isEqualTo("localhost");
+        assertThat(DevServicesHostUtil.formatResolvedHostAndPort("quarkus-nonexistent-container-id",
+                "fd00:d0ca:1::1", 32783)).isEqualTo("localhost:32783");
+    }
+
+    @Test
+    public void resolvePublishedPortHostWithoutContainerIdFallsBackToLocalhost() {
+        assertThat(DevServicesHostUtil.resolvePublishedPortHost(null, "fd00:d0ca:1::1")).isEqualTo("localhost");
+        assertThat(DevServicesHostUtil.resolvePublishedPortHost("", "fd00:d0ca:1::1")).isEqualTo("localhost");
+    }
+}

--- a/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
+++ b/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
@@ -31,6 +31,7 @@ import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.deployment.util.ContainerRuntimeUtil;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.devservices.common.DevServicesHostUtil;
 import io.quarkus.devservices.common.JBossLoggingConsumer;
 import io.quarkus.devservices.common.Labels;
 import io.quarkus.devservices.common.Volumes;
@@ -207,6 +208,16 @@ public class DB2DevServicesProcessor {
             }
         }
 
+        // this is always reachable from the host JVM, so that testcontainers can determine the status of the
+        // container (which it does by trying to acquire a connection)
+        @Override
+        public String getJdbcUrl() {
+            String host = DevServicesHostUtil.resolvePublishedPortHost(getContainerId(), getHost());
+            String authority = DevServicesHostUtil.formatHostAndPort(host, getMappedPort(DB2_PORT));
+            String additionalUrlParams = constructUrlParameters(":", ";", ";");
+            return "jdbc:db2://" + authority + "/" + getDatabaseName() + additionalUrlParams;
+        }
+
         // this is meant to be called by Quarkus code and is not strictly needed
         // in the DB2 case as testcontainers does not try to establish
         // a connection to determine if the container is ready, but we do it anyway to be consistent across
@@ -216,11 +227,11 @@ public class DB2DevServicesProcessor {
                 // in this case we expose the URL using the network alias we created in 'configure'
                 // and the container port since the application communicating with this container
                 // won't be doing port mapping
+                String authority = DevServicesHostUtil.formatHostAndPort(hostName, DB2_PORT);
                 String additionalUrlParams = constructUrlParameters(":", ";", ";");
-                return "jdbc:db2://" + hostName + ":" + DB2_PORT + "/" + getDatabaseName() + additionalUrlParams;
-            } else {
-                return super.getJdbcUrl();
+                return "jdbc:db2://" + authority + "/" + getDatabaseName() + additionalUrlParams;
             }
+            return getJdbcUrl();
         }
 
         public String getReactiveUrl() {

--- a/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
+++ b/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
@@ -31,6 +31,7 @@ import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.deployment.util.ContainerRuntimeUtil;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.devservices.common.DevServicesHostUtil;
 import io.quarkus.devservices.common.JBossLoggingConsumer;
 import io.quarkus.devservices.common.Labels;
 import io.quarkus.devservices.common.Volumes;
@@ -207,20 +208,21 @@ public class DB2DevServicesProcessor {
             }
         }
 
+        @Override
+        public String getJdbcUrl() {
+            String host = DevServicesHostUtil.publishedPortHost(getContainerId(), useSharedNetwork, hostName, getHost());
+            int port = useSharedNetwork ? DB2_PORT : getMappedPort(DB2_PORT);
+            String authority = DevServicesHostUtil.formatHostAndPort(host, port);
+            String additionalUrlParams = constructUrlParameters(":", ";", ";");
+            return "jdbc:db2://" + authority + "/" + getDatabaseName() + additionalUrlParams;
+        }
+
         // this is meant to be called by Quarkus code and is not strictly needed
         // in the DB2 case as testcontainers does not try to establish
         // a connection to determine if the container is ready, but we do it anyway to be consistent across
         // DB containers
         public String getEffectiveJdbcUrl() {
-            if (useSharedNetwork) {
-                // in this case we expose the URL using the network alias we created in 'configure'
-                // and the container port since the application communicating with this container
-                // won't be doing port mapping
-                String additionalUrlParams = constructUrlParameters(":", ";", ";");
-                return "jdbc:db2://" + hostName + ":" + DB2_PORT + "/" + getDatabaseName() + additionalUrlParams;
-            } else {
-                return super.getJdbcUrl();
-            }
+            return getJdbcUrl();
         }
 
         public String getReactiveUrl() {

--- a/extensions/devservices/keycloak/pom.xml
+++ b/extensions/devservices/keycloak/pom.xml
@@ -22,6 +22,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devservices-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx-deployment</artifactId>
         </dependency>
         <dependency>

--- a/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesProcessor.java
+++ b/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesProcessor.java
@@ -2,10 +2,16 @@ package io.quarkus.devservices.keycloak;
 
 import static io.quarkus.devservices.common.ConfigureUtil.getDefaultImageNameFor;
 import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
+import static io.quarkus.devservices.common.DevServicesHostUtil.formatPrefixedAuthority;
+import static io.quarkus.devservices.common.DevServicesHostUtil.formatResolvedHostAndPort;
+import static io.quarkus.devservices.common.DevServicesHostUtil.formatResolvedPrefixedAuthority;
+import static io.quarkus.devservices.common.DevServicesHostUtil.resolvePublishedPortHost;
 import static io.quarkus.devservices.common.Labels.QUARKUS_DEV_SERVICE;
 import static io.quarkus.devservices.keycloak.KeycloakDevServicesRequiredBuildItem.getDevServicesConfigurator;
 import static io.quarkus.devservices.keycloak.KeycloakDevServicesUtils.createWebClient;
+import static io.quarkus.devservices.keycloak.KeycloakDevServicesUtils.get;
 import static io.quarkus.devservices.keycloak.KeycloakDevServicesUtils.getPasswordAccessToken;
+import static io.quarkus.devservices.keycloak.KeycloakDevServicesUtils.post;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -65,6 +71,7 @@ import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerAddress;
 import io.quarkus.devservices.common.ContainerLocator;
 import io.quarkus.devservices.common.StartableContainer;
+import io.quarkus.devservices.keycloak.KeycloakDevServicesUtils.KeycloakHttpTarget;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
 import io.quarkus.runtime.LaunchMode;
@@ -155,8 +162,12 @@ public class KeycloakDevServicesProcessor {
                         KEYCLOAK_PORT, LaunchMode.current(), useSharedNetwork))
                 .map(containerAddress -> {
                     String sharedContainerUrl = getSharedContainerUrl(containerAddress);
+                    String host = resolvePublishedPortHost(containerAddress.getId(), containerAddress.getHost());
+                    KeycloakHttpTarget httpTarget = createHttpTarget(host, containerAddress.getPort(),
+                            isKeycloakX(config, DockerImageName.parse(imageName).asCompatibleSubstituteFor(imageName)));
                     Map<String, String> configs = prepareConfiguration(config, sharedContainerUrl,
-                            sharedContainerUrl, List.of(), new ArrayList<>(), devServicesConfigurator, sharedContainerUrl);
+                            sharedContainerUrl, List.of(), new ArrayList<>(), devServicesConfigurator, sharedContainerUrl,
+                            httpTarget);
                     return DevServicesResultBuildItem.discovered()
                             .feature(feature)
                             .containerId(containerAddress.getId())
@@ -168,7 +179,8 @@ public class KeycloakDevServicesProcessor {
                         .startable(() -> {
                             QuarkusOidcContainer oidcContainer = createContainer(config, useSharedNetwork,
                                     devServicesConfig.timeout(), composeProjectBuildItem, imageName, devServicesConfigurator);
-                            return new StartableContainer<>(oidcContainer, c -> c.getHost() + ":" + c.getPort());
+                            return new StartableContainer<>(oidcContainer,
+                                    c -> formatResolvedHostAndPort(c.getContainerId(), c.getHost(), c.getPort()));
                         })
                         .postStartHook(containerWrapper -> {
                             for (String error : containerWrapper.getContainer().errors) {
@@ -262,7 +274,12 @@ public class KeycloakDevServicesProcessor {
     }
 
     private static String getBaseURL(String scheme, String host, Integer port) {
-        return scheme + host + ":" + port;
+        return formatPrefixedAuthority(scheme.endsWith("://") ? scheme.substring(0, scheme.length() - 3) : scheme, host,
+                port);
+    }
+
+    private static KeycloakHttpTarget createHttpTarget(String host, int port, boolean keycloakX) {
+        return new KeycloakHttpTarget(port, host, keycloakX ? "" : "/auth");
     }
 
     private static String startURL(String scheme, String host, Integer port, boolean isKeycloakX) {
@@ -284,7 +301,8 @@ public class KeycloakDevServicesProcessor {
     private static KeycloakDevServicesConfigurator.ConfigPropertiesContext createRealmsAndReturnPropertiesContext(
             KeycloakDevServicesConfig config, String internalURL,
             String hostURL, List<RealmRepresentation> realmReps, List<String> errors,
-            KeycloakDevServicesConfigurator devServicesConfigurator, String internalBaseUrl) {
+            KeycloakDevServicesConfigurator devServicesConfigurator, String internalBaseUrl,
+            KeycloakHttpTarget httpTarget) {
         final String realmName = !realmReps.isEmpty() ? realmReps.iterator().next().getRealm()
                 : getDefaultRealmName(config);
         final String authServerInternalUrl = realmsURL(internalURL, realmName);
@@ -307,18 +325,18 @@ public class KeycloakDevServicesProcessor {
             try {
                 WebClient client = createWebClient(vertxInstance);
                 try {
-                    String adminToken = getAdminToken(config, client, clientAuthServerBaseUrl);
+                    String adminToken = getAdminToken(config, client, httpTarget);
                     if (createDefaultRealm) {
-                        if (realmDoesNotExist(realmName, client, clientAuthServerBaseUrl, config, adminToken, errors)) {
-                            createDefaultRealm(config, client, adminToken, clientAuthServerBaseUrl, users, oidcClientId,
+                        if (realmDoesNotExist(realmName, client, httpTarget, config, adminToken, errors)) {
+                            createDefaultRealm(config, client, adminToken, httpTarget, users, oidcClientId,
                                     oidcClientSecret, errors, devServicesConfigurator);
                         }
                         realmNames.add(realmName);
                     } else {
                         for (RealmRepresentation realmRep : realmReps) {
-                            if (realmDoesNotExist(realmRep.getRealm(), client, clientAuthServerBaseUrl, config, adminToken,
+                            if (realmDoesNotExist(realmRep.getRealm(), client, httpTarget, config, adminToken,
                                     errors)) {
-                                createRealm(config, client, adminToken, clientAuthServerBaseUrl, realmRep, errors);
+                                createRealm(config, client, adminToken, httpTarget, realmRep, errors);
                             }
                             realmNames.add(realmRep.getRealm());
                         }
@@ -336,11 +354,11 @@ public class KeycloakDevServicesProcessor {
                 oidcClientSecret, internalBaseUrl, internalURL, clientAuthServerUrl, users, realmNames);
     }
 
-    private static boolean realmDoesNotExist(String realmName, WebClient client, String keycloakUrl,
+    private static boolean realmDoesNotExist(String realmName, WebClient client, KeycloakHttpTarget httpTarget,
             KeycloakDevServicesConfig config, String token, List<String> errors) {
         LOG.tracef("Detecting if the Keycloak realm '%s' exists", realmName);
         try {
-            var response = client.getAbs(keycloakUrl + "/admin/realms/" + realmName)
+            var response = get(client, httpTarget, httpTarget.path("/admin/realms/" + realmName))
                     .putHeader(HttpHeaders.CONTENT_TYPE.toString(), "application/json")
                     .putHeader(HttpHeaders.AUTHORIZATION.toString(), "Bearer " + token)
                     .send().await().atMost(config.webClientTimeout());
@@ -384,9 +402,10 @@ public class KeycloakDevServicesProcessor {
 
     private static Map<String, String> prepareConfiguration(KeycloakDevServicesConfig config,
             String internalURL, String hostURL, List<RealmRepresentation> realmReps, List<String> errors,
-            KeycloakDevServicesConfigurator devServicesConfigurator, String internalBaseUrl) {
+            KeycloakDevServicesConfigurator devServicesConfigurator, String internalBaseUrl,
+            KeycloakHttpTarget httpTarget) {
         var configPropertiesContext = createRealmsAndReturnPropertiesContext(config,
-                internalURL, hostURL, realmReps, errors, devServicesConfigurator, internalBaseUrl);
+                internalURL, hostURL, realmReps, errors, devServicesConfigurator, internalBaseUrl, httpTarget);
         return devServicesConfigurator.getLazyConfigKeys().stream().collect(Collectors.toUnmodifiableMap(
                 Function.identity(),
                 configKey -> devServicesConfigurator.getLazyConfigValue(configKey, configPropertiesContext)));
@@ -415,8 +434,8 @@ public class KeycloakDevServicesProcessor {
     }
 
     private static String getSharedContainerUrl(ContainerAddress containerAddress) {
-        return "http://" + ("0.0.0.0".equals(containerAddress.getHost()) ? "localhost" : containerAddress.getHost())
-                + ":" + containerAddress.getPort();
+        return formatResolvedPrefixedAuthority("http", containerAddress.getId(), containerAddress.getHost(),
+                containerAddress.getPort());
     }
 
     private static final class QuarkusOidcContainer extends GenericContainer<QuarkusOidcContainer> {
@@ -694,15 +713,20 @@ public class KeycloakDevServicesProcessor {
 
         private KeycloakDevServicesConfigurator.ConfigPropertiesContext createConfigPropertiesContext() {
             List<String> errors = new ArrayList<>();
-            String internalBaseUrl = getBaseURL((isHttps() ? "https://" : "http://"), getHost(), getPort());
+            String configHost = useSharedNetwork ? getHost()
+                    : resolvePublishedPortHost(getContainerId(), super.getHost());
+            String internalBaseUrl = getBaseURL((isHttps() ? "https://" : "http://"), configHost, getPort());
             String internalUrl = startURL(internalBaseUrl, keycloakX);
             String hostUrl = useSharedNetwork
                     // we need to use auto-detected host and port, so it works when docker host != localhost
                     ? startURL("http://", getSharedNetworkExternalHost(), getSharedNetworkExternalPort(), keycloakX)
                     : null;
 
+            KeycloakHttpTarget httpTarget = useSharedNetwork
+                    ? createHttpTarget(getSharedNetworkExternalHost(), getSharedNetworkExternalPort(), keycloakX)
+                    : createHttpTarget(resolvePublishedPortHost(getContainerId(), super.getHost()), getPort(), keycloakX);
             return createRealmsAndReturnPropertiesContext(config, internalUrl, hostUrl,
-                    realmReps, errors, devServicesConfigurator, internalBaseUrl);
+                    realmReps, errors, devServicesConfigurator, internalBaseUrl, httpTarget);
         }
 
         private String getConfigValue(String configKey) {
@@ -729,8 +753,8 @@ public class KeycloakDevServicesProcessor {
         return Set.of();
     }
 
-    private static void createDefaultRealm(KeycloakDevServicesConfig config, WebClient client, String token, String keycloakUrl,
-            Map<String, String> users,
+    private static void createDefaultRealm(KeycloakDevServicesConfig config, WebClient client, String token,
+            KeycloakHttpTarget httpTarget, Map<String, String> users,
             String oidcClientId, String oidcClientSecret, List<String> errors,
             KeycloakDevServicesConfigurator devServicesConfigurator) {
         RealmRepresentation realm = createDefaultRealmRep(config);
@@ -744,15 +768,15 @@ public class KeycloakDevServicesProcessor {
 
         devServicesConfigurator.customizeDefaultRealm(realm);
 
-        createRealm(config, client, token, keycloakUrl, realm, errors);
+        createRealm(config, client, token, httpTarget, realm, errors);
     }
 
-    private static String getAdminToken(KeycloakDevServicesConfig config, WebClient client, String keycloakUrl) {
+    private static String getAdminToken(KeycloakDevServicesConfig config, WebClient client, KeycloakHttpTarget httpTarget) {
         try {
-            LOG.tracef("Acquiring admin token");
+            LOG.tracef("Acquiring admin token from %s:%d", httpTarget.host(), httpTarget.port());
 
-            return getPasswordAccessToken(client,
-                    keycloakUrl + "/realms/master/protocol/openid-connect/token",
+            return getPasswordAccessToken(client, httpTarget,
+                    httpTarget.path("/realms/master/protocol/openid-connect/token"),
                     "admin-cli", null, "admin", "admin", null)
                     .await().atMost(config.webClientTimeout());
         } catch (TimeoutException e) {
@@ -764,12 +788,12 @@ public class KeycloakDevServicesProcessor {
         return null;
     }
 
-    private static void createRealm(KeycloakDevServicesConfig config, WebClient client, String token, String keycloakUrl,
-            RealmRepresentation realm,
+    private static void createRealm(KeycloakDevServicesConfig config, WebClient client, String token,
+            KeycloakHttpTarget httpTarget, RealmRepresentation realm,
             List<String> errors) {
         try {
             LOG.tracef("Creating the realm %s", realm.getRealm());
-            HttpResponse<Buffer> createRealmResponse = client.postAbs(keycloakUrl + "/admin/realms")
+            HttpResponse<Buffer> createRealmResponse = post(client, httpTarget, httpTarget.path("/admin/realms"))
                     .putHeader(HttpHeaders.CONTENT_TYPE.toString(), "application/json")
                     .putHeader(HttpHeaders.AUTHORIZATION.toString(), "Bearer " + token)
                     .sendBuffer(Buffer.buffer().appendString(JsonSerialization.writeValueAsString(realm)))
@@ -784,7 +808,7 @@ public class KeycloakDevServicesProcessor {
                         createRealmResponse.statusMessage());
             }
 
-            Uni<Integer> realmStatusCodeUni = client.getAbs(keycloakUrl + "/realms/" + realm.getRealm())
+            Uni<Integer> realmStatusCodeUni = get(client, httpTarget, httpTarget.path("/realms/" + realm.getRealm()))
                     .send().onItem()
                     .transform(resp -> {
                         LOG.debugf("Realm status: %d", resp.statusCode());

--- a/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesUtils.java
+++ b/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesUtils.java
@@ -1,5 +1,7 @@
 package io.quarkus.devservices.keycloak;
 
+import static io.quarkus.devservices.common.DevServicesHostUtil.formatHostAndPort;
+
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -21,6 +23,21 @@ final class KeycloakDevServicesUtils {
     private static final byte AMP = '&';
     private static final byte EQ = '=';
 
+    /**
+     * Host and port for Keycloak admin HTTP calls. Uses raw host (no brackets) with
+     * {@link WebClient#post(int, String, String)} to avoid URL parsing issues with IPv6.
+     */
+    record KeycloakHttpTarget(int port, String host, String pathPrefix) {
+
+        String path(String suffix) {
+            return pathPrefix + suffix;
+        }
+
+        String hostHeader() {
+            return formatHostAndPort(host, port);
+        }
+    }
+
     private KeycloakDevServicesUtils() {
 
     }
@@ -32,14 +49,25 @@ final class KeycloakDevServicesUtils {
         return WebClient.create(new io.vertx.mutiny.core.Vertx(vertx), options);
     }
 
+    static HttpRequest<Buffer> get(WebClient client, KeycloakHttpTarget target, String path) {
+        return client.get(target.port(), target.host(), path)
+                .putHeader(HttpHeaders.HOST.toString(), target.hostHeader());
+    }
+
+    static HttpRequest<Buffer> post(WebClient client, KeycloakHttpTarget target, String path) {
+        return client.post(target.port(), target.host(), path)
+                .putHeader(HttpHeaders.HOST.toString(), target.hostHeader());
+    }
+
     static Uni<String> getPasswordAccessToken(WebClient client,
-            String tokenUrl,
+            KeycloakHttpTarget target,
+            String tokenPath,
             String clientId,
             String clientSecret,
             String userName,
             String userPassword,
             Map<String, String> passwordGrantOptions) {
-        HttpRequest<Buffer> request = client.postAbs(tokenUrl);
+        HttpRequest<Buffer> request = post(client, target, tokenPath);
         request.putHeader(HttpHeaders.CONTENT_TYPE.toString(), HttpHeaders.APPLICATION_X_WWW_FORM_URLENCODED.toString());
 
         io.vertx.core.MultiMap props = MultiMap.caseInsensitiveMultiMap();

--- a/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDevServicesProcessor.java
+++ b/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDevServicesProcessor.java
@@ -24,6 +24,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.DevServicesComposeProjectBuildItem;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.devservices.common.DevServicesHostUtil;
 import io.quarkus.devservices.common.JBossLoggingConsumer;
 import io.quarkus.devservices.common.Labels;
 import io.quarkus.devservices.common.Volumes;
@@ -133,15 +134,28 @@ public class MariaDBDevServicesProcessor {
             }
         }
 
+        // this is always reachable from the host JVM, so that testcontainers can determine the status of the
+        // container (which it does by trying to acquire a connection)
+        @Override
+        public String getJdbcUrl() {
+            String host = DevServicesHostUtil.resolvePublishedPortHost(getContainerId(), getHost());
+            String authority = DevServicesHostUtil.formatHostAndPort(host, getMappedPort(PORT));
+            String additionalUrlParams = constructUrlParameters("?", "&");
+            return "jdbc:mariadb://" + authority + "/" + getDatabaseName() + additionalUrlParams;
+        }
+
         // this is meant to be called by Quarkus code and is needed in order to not disrupt testcontainers
         // from being able to determine the status of the container (which it does by trying to acquire a connection)
         public String getEffectiveJdbcUrl() {
             if (useSharedNetwork) {
+                // in this case we expose the URL using the network alias we created in 'configure'
+                // and the container port since the application communicating with this container
+                // won't be doing port mapping
+                String authority = DevServicesHostUtil.formatHostAndPort(hostName, PORT);
                 String additionalUrlParams = constructUrlParameters("?", "&");
-                return "jdbc:mariadb://" + hostName + ":" + PORT + "/" + getDatabaseName() + additionalUrlParams;
-            } else {
-                return super.getJdbcUrl();
+                return "jdbc:mariadb://" + authority + "/" + getDatabaseName() + additionalUrlParams;
             }
+            return getJdbcUrl();
         }
 
         public String getReactiveUrl() {

--- a/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDevServicesProcessor.java
+++ b/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDevServicesProcessor.java
@@ -24,6 +24,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.DevServicesComposeProjectBuildItem;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.devservices.common.DevServicesHostUtil;
 import io.quarkus.devservices.common.JBossLoggingConsumer;
 import io.quarkus.devservices.common.Labels;
 import io.quarkus.devservices.common.Volumes;
@@ -133,15 +134,19 @@ public class MariaDBDevServicesProcessor {
             }
         }
 
+        @Override
+        public String getJdbcUrl() {
+            String host = DevServicesHostUtil.publishedPortHost(getContainerId(), useSharedNetwork, hostName, getHost());
+            int port = useSharedNetwork ? PORT : getMappedPort(PORT);
+            String authority = DevServicesHostUtil.formatHostAndPort(host, port);
+            String additionalUrlParams = constructUrlParameters("?", "&");
+            return "jdbc:mariadb://" + authority + "/" + getDatabaseName() + additionalUrlParams;
+        }
+
         // this is meant to be called by Quarkus code and is needed in order to not disrupt testcontainers
         // from being able to determine the status of the container (which it does by trying to acquire a connection)
         public String getEffectiveJdbcUrl() {
-            if (useSharedNetwork) {
-                String additionalUrlParams = constructUrlParameters("?", "&");
-                return "jdbc:mariadb://" + hostName + ":" + PORT + "/" + getDatabaseName() + additionalUrlParams;
-            } else {
-                return super.getJdbcUrl();
-            }
+            return getJdbcUrl();
         }
 
         public String getReactiveUrl() {

--- a/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDatasourceServiceConfigurator.java
+++ b/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDatasourceServiceConfigurator.java
@@ -7,6 +7,7 @@ import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProvider.Runnin
 import io.quarkus.deployment.dev.devservices.RunningContainer;
 import io.quarkus.devservices.common.ContainerAddress;
 import io.quarkus.devservices.common.DatasourceServiceConfigurator;
+import io.quarkus.devservices.common.DevServicesHostUtil;
 
 public class MSSQLDatasourceServiceConfigurator implements DatasourceServiceConfigurator {
 
@@ -41,9 +42,8 @@ public class MSSQLDatasourceServiceConfigurator implements DatasourceServiceConf
 
     @Override
     public String getJdbcUrl(ContainerAddress containerAddress, String databaseName) {
-        return String.format("jdbc:%s://%s:%d%s",
-                getJdbcPrefix(),
-                containerAddress.getHost(),
+        return SqlServerDevServicesJdbcUrl.build(
+                DevServicesHostUtil.resolvePublishedPortHost(containerAddress.getId(), containerAddress.getHost()),
                 containerAddress.getPort(),
                 getParameters(containerAddress.getRunningContainer().containerInfo().labels()));
     }

--- a/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
+++ b/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
@@ -24,6 +24,7 @@ import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
 import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.devservices.common.DevServicesHostUtil;
 import io.quarkus.devservices.common.JBossLoggingConsumer;
 import io.quarkus.devservices.common.Labels;
 import io.quarkus.devservices.common.Volumes;
@@ -154,6 +155,15 @@ public class MSSQLDevServicesProcessor {
             }
         }
 
+        // this is always reachable from the host JVM, so that testcontainers can determine the status of the
+        // container (which it does by trying to acquire a connection)
+        @Override
+        public String getJdbcUrl() {
+            String host = DevServicesHostUtil.resolvePublishedPortHost(getContainerId(), getHost());
+            String additionalUrlParams = constructUrlParameters(";", ";");
+            return SqlServerDevServicesJdbcUrl.build(host, getMappedPort(MS_SQL_SERVER_PORT), additionalUrlParams);
+        }
+
         // this is meant to be called by Quarkus code and is needed in order to not disrupt testcontainers
         // from being able to determine the status of the container (which it does by trying to acquire a connection)
         public String getEffectiveJdbcUrl() {
@@ -162,20 +172,15 @@ public class MSSQLDevServicesProcessor {
                 // and the container port since the application communicating with this container
                 // won't be doing port mapping
                 String additionalUrlParams = constructUrlParameters(";", ";");
-                return "jdbc:sqlserver://" + hostName + ":" + MS_SQL_SERVER_PORT + additionalUrlParams;
-            } else {
-                return super.getJdbcUrl();
+                return SqlServerDevServicesJdbcUrl.build(hostName, MS_SQL_SERVER_PORT, additionalUrlParams);
             }
+            return getJdbcUrl();
         }
 
         public String getReactiveUrl() {
-            StringBuilder url = new StringBuilder("vertx-reactive:sqlserver://");
-            if (useSharedNetwork) {
-                url.append(hostName).append(":").append(MS_SQL_SERVER_PORT);
-            } else {
-                url.append(this.getHost()).append(":").append(this.getMappedPort(MS_SQL_SERVER_PORT));
-            }
-            return url.toString();
+            String host = DevServicesHostUtil.publishedPortHost(getContainerId(), useSharedNetwork, hostName, getHost());
+            int port = useSharedNetwork ? MS_SQL_SERVER_PORT : getMappedPort(MS_SQL_SERVER_PORT);
+            return "vertx-reactive:sqlserver://" + DevServicesHostUtil.formatHostAndPort(host, port);
         }
 
         @Override

--- a/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
+++ b/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
@@ -24,6 +24,7 @@ import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
 import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.devservices.common.DevServicesHostUtil;
 import io.quarkus.devservices.common.JBossLoggingConsumer;
 import io.quarkus.devservices.common.Labels;
 import io.quarkus.devservices.common.Volumes;
@@ -154,28 +155,24 @@ public class MSSQLDevServicesProcessor {
             }
         }
 
+        @Override
+        public String getJdbcUrl() {
+            String host = DevServicesHostUtil.publishedPortHost(getContainerId(), useSharedNetwork, hostName, getHost());
+            int port = useSharedNetwork ? MS_SQL_SERVER_PORT : getMappedPort(MS_SQL_SERVER_PORT);
+            String additionalUrlParams = constructUrlParameters(";", ";");
+            return SqlServerDevServicesJdbcUrl.build(host, port, additionalUrlParams);
+        }
+
         // this is meant to be called by Quarkus code and is needed in order to not disrupt testcontainers
         // from being able to determine the status of the container (which it does by trying to acquire a connection)
         public String getEffectiveJdbcUrl() {
-            if (useSharedNetwork) {
-                // in this case we expose the URL using the network alias we created in 'configure'
-                // and the container port since the application communicating with this container
-                // won't be doing port mapping
-                String additionalUrlParams = constructUrlParameters(";", ";");
-                return "jdbc:sqlserver://" + hostName + ":" + MS_SQL_SERVER_PORT + additionalUrlParams;
-            } else {
-                return super.getJdbcUrl();
-            }
+            return getJdbcUrl();
         }
 
         public String getReactiveUrl() {
-            StringBuilder url = new StringBuilder("vertx-reactive:sqlserver://");
-            if (useSharedNetwork) {
-                url.append(hostName).append(":").append(MS_SQL_SERVER_PORT);
-            } else {
-                url.append(this.getHost()).append(":").append(this.getMappedPort(MS_SQL_SERVER_PORT));
-            }
-            return url.toString();
+            String host = DevServicesHostUtil.publishedPortHost(getContainerId(), useSharedNetwork, hostName, getHost());
+            int port = useSharedNetwork ? MS_SQL_SERVER_PORT : getMappedPort(MS_SQL_SERVER_PORT);
+            return "vertx-reactive:sqlserver://" + DevServicesHostUtil.formatHostAndPort(host, port);
         }
 
         @Override

--- a/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/SqlServerDevServicesJdbcUrl.java
+++ b/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/SqlServerDevServicesJdbcUrl.java
@@ -1,0 +1,27 @@
+package io.quarkus.devservices.mssql.deployment;
+
+import io.quarkus.devservices.common.DevServicesHostUtil;
+
+/**
+ * Builds JDBC URLs for SQL Server dev services.
+ * <p>
+ * The Microsoft JDBC driver does not support raw IPv6 literals in the URL authority
+ * ({@code jdbc:sqlserver://host:port}). For IPv6, use the {@code serverName} and {@code port}
+ * connection properties instead. See
+ * <a href="https://learn.microsoft.com/en-us/sql/connect/jdbc/building-the-connection-url">
+ * Building the connection URL</a>.
+ */
+final class SqlServerDevServicesJdbcUrl {
+
+    private static final String JDBC_PREFIX = "jdbc:sqlserver://";
+
+    private SqlServerDevServicesJdbcUrl() {
+    }
+
+    static String build(String host, int port, String additionalUrlParams) {
+        if (DevServicesHostUtil.isIPv6Literal(host)) {
+            return JDBC_PREFIX + ";serverName=" + host + ";port=" + port + additionalUrlParams;
+        }
+        return JDBC_PREFIX + DevServicesHostUtil.formatHostAndPort(host, port) + additionalUrlParams;
+    }
+}

--- a/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/mysql/deployment/MySQLDevServicesProcessor.java
+++ b/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/mysql/deployment/MySQLDevServicesProcessor.java
@@ -25,6 +25,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.DevServicesComposeProjectBuildItem;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.devservices.common.DevServicesHostUtil;
 import io.quarkus.devservices.common.JBossLoggingConsumer;
 import io.quarkus.devservices.common.Labels;
 import io.quarkus.devservices.common.Volumes;
@@ -133,6 +134,16 @@ public class MySQLDevServicesProcessor {
             }
         }
 
+        // this is always reachable from the host JVM, so that testcontainers can determine the status of the
+        // container (which it does by trying to acquire a connection)
+        @Override
+        public String getJdbcUrl() {
+            String host = DevServicesHostUtil.resolvePublishedPortHost(getContainerId(), getHost());
+            String authority = DevServicesHostUtil.formatHostAndPort(host, getMappedPort(MYSQL_PORT));
+            String additionalUrlParams = constructUrlParameters("?", "&");
+            return "jdbc:mysql://" + authority + "/" + getDatabaseName() + additionalUrlParams;
+        }
+
         // this is meant to be called by Quarkus code and is needed in order to not disrupt testcontainers
         // from being able to determine the status of the container (which it does by trying to acquire a connection)
         public String getEffectiveJdbcUrl() {
@@ -140,11 +151,11 @@ public class MySQLDevServicesProcessor {
                 // in this case we expose the URL using the network alias we created in 'configure'
                 // and the container port since the application communicating with this container
                 // won't be doing port mapping
+                String authority = DevServicesHostUtil.formatHostAndPort(hostName, MYSQL_PORT);
                 String additionalUrlParams = constructUrlParameters("?", "&");
-                return "jdbc:mysql://" + hostName + ":" + MYSQL_PORT + "/" + getDatabaseName() + additionalUrlParams;
-            } else {
-                return super.getJdbcUrl();
+                return "jdbc:mysql://" + authority + "/" + getDatabaseName() + additionalUrlParams;
             }
+            return getJdbcUrl();
         }
 
         public String getReactiveUrl() {

--- a/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/mysql/deployment/MySQLDevServicesProcessor.java
+++ b/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/mysql/deployment/MySQLDevServicesProcessor.java
@@ -25,6 +25,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.DevServicesComposeProjectBuildItem;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.devservices.common.DevServicesHostUtil;
 import io.quarkus.devservices.common.JBossLoggingConsumer;
 import io.quarkus.devservices.common.Labels;
 import io.quarkus.devservices.common.Volumes;
@@ -133,18 +134,19 @@ public class MySQLDevServicesProcessor {
             }
         }
 
+        @Override
+        public String getJdbcUrl() {
+            String host = DevServicesHostUtil.publishedPortHost(getContainerId(), useSharedNetwork, hostName, getHost());
+            int port = useSharedNetwork ? MYSQL_PORT : getMappedPort(MYSQL_PORT);
+            String authority = DevServicesHostUtil.formatHostAndPort(host, port);
+            String additionalUrlParams = constructUrlParameters("?", "&");
+            return "jdbc:mysql://" + authority + "/" + getDatabaseName() + additionalUrlParams;
+        }
+
         // this is meant to be called by Quarkus code and is needed in order to not disrupt testcontainers
         // from being able to determine the status of the container (which it does by trying to acquire a connection)
         public String getEffectiveJdbcUrl() {
-            if (useSharedNetwork) {
-                // in this case we expose the URL using the network alias we created in 'configure'
-                // and the container port since the application communicating with this container
-                // won't be doing port mapping
-                String additionalUrlParams = constructUrlParameters("?", "&");
-                return "jdbc:mysql://" + hostName + ":" + MYSQL_PORT + "/" + getDatabaseName() + additionalUrlParams;
-            } else {
-                return super.getJdbcUrl();
-            }
+            return getJdbcUrl();
         }
 
         public String getReactiveUrl() {

--- a/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDatasourceServiceConfigurator.java
+++ b/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDatasourceServiceConfigurator.java
@@ -9,6 +9,7 @@ import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProvider.Runnin
 import io.quarkus.deployment.dev.devservices.RunningContainer;
 import io.quarkus.devservices.common.ContainerAddress;
 import io.quarkus.devservices.common.DatasourceServiceConfigurator;
+import io.quarkus.devservices.common.DevServicesHostUtil;
 
 public class OracleDatasourceServiceConfigurator implements DatasourceServiceConfigurator {
 
@@ -35,10 +36,10 @@ public class OracleDatasourceServiceConfigurator implements DatasourceServiceCon
     }
 
     public String getJdbcUrl(ContainerAddress containerAddress, String databaseName) {
-        return "jdbc:%s:@%s:%d/%s%s".formatted(
+        return "jdbc:%s:@%s/%s%s".formatted(
                 getJdbcPrefix(),
-                containerAddress.getHost(),
-                containerAddress.getPort(),
+                DevServicesHostUtil.formatResolvedHostAndPort(containerAddress.getId(), containerAddress.getHost(),
+                        containerAddress.getPort()),
                 databaseName,
                 getParameters(containerAddress.getRunningContainer().containerInfo().labels()));
     }

--- a/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
+++ b/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
@@ -25,6 +25,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.DevServicesComposeProjectBuildItem;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.devservices.common.DevServicesHostUtil;
 import io.quarkus.devservices.common.JBossLoggingConsumer;
 import io.quarkus.devservices.common.Labels;
 import io.quarkus.devservices.common.Volumes;
@@ -150,6 +151,16 @@ public class OracleDevServicesProcessor {
             }
         }
 
+        // this is always reachable from the host JVM, so that testcontainers can determine the status of the
+        // container (which it does by trying to acquire a connection)
+        @Override
+        public String getJdbcUrl() {
+            String host = DevServicesHostUtil.resolvePublishedPortHost(getContainerId(), getHost());
+            String authority = DevServicesHostUtil.formatHostAndPort(host, getMappedPort(PORT));
+            // Single @ service-name form — works for JDBC and Vert.x reactive (IPv6 via bracketed host).
+            return "jdbc:oracle:thin:@" + authority + "/" + getDatabaseName();
+        }
+
         // this is meant to be called by Quarkus code and is needed in order to not disrupt testcontainers
         // from being able to determine the status of the container (which it does by trying to acquire a connection)
         public String getEffectiveJdbcUrl() {
@@ -157,10 +168,10 @@ public class OracleDevServicesProcessor {
                 // in this case we expose the URL using the network alias we created in 'configure'
                 // and the container port since the application communicating with this container
                 // won't be doing port mapping
-                return "jdbc:oracle:thin:" + "@" + hostName + ":" + PORT + "/" + getDatabaseName();
-            } else {
-                return super.getJdbcUrl();
+                String authority = DevServicesHostUtil.formatHostAndPort(hostName, PORT);
+                return "jdbc:oracle:thin:@" + authority + "/" + getDatabaseName();
             }
+            return getJdbcUrl();
         }
 
         public String getReactiveUrl() {

--- a/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
+++ b/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
@@ -25,6 +25,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.DevServicesComposeProjectBuildItem;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.devservices.common.DevServicesHostUtil;
 import io.quarkus.devservices.common.JBossLoggingConsumer;
 import io.quarkus.devservices.common.Labels;
 import io.quarkus.devservices.common.Volumes;
@@ -150,17 +151,19 @@ public class OracleDevServicesProcessor {
             }
         }
 
+        @Override
+        public String getJdbcUrl() {
+            String host = DevServicesHostUtil.publishedPortHost(getContainerId(), useSharedNetwork, hostName, getHost());
+            int port = useSharedNetwork ? PORT : getMappedPort(PORT);
+            String authority = DevServicesHostUtil.formatHostAndPort(host, port);
+            // Single @ service-name form — works for JDBC and Vert.x reactive (IPv6 via bracketed host).
+            return "jdbc:oracle:thin:@" + authority + "/" + getDatabaseName();
+        }
+
         // this is meant to be called by Quarkus code and is needed in order to not disrupt testcontainers
         // from being able to determine the status of the container (which it does by trying to acquire a connection)
         public String getEffectiveJdbcUrl() {
-            if (useSharedNetwork) {
-                // in this case we expose the URL using the network alias we created in 'configure'
-                // and the container port since the application communicating with this container
-                // won't be doing port mapping
-                return "jdbc:oracle:thin:" + "@" + hostName + ":" + PORT + "/" + getDatabaseName();
-            } else {
-                return super.getJdbcUrl();
-            }
+            return getJdbcUrl();
         }
 
         public String getReactiveUrl() {

--- a/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
+++ b/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
@@ -30,6 +30,7 @@ import io.quarkus.deployment.builditem.DevServicesComposeProjectBuildItem;
 import io.quarkus.deployment.builditem.DevServicesLauncherConfigResultBuildItem;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.devservices.common.DevServicesHostUtil;
 import io.quarkus.devservices.common.JBossLoggingConsumer;
 import io.quarkus.devservices.common.Labels;
 import io.quarkus.devservices.common.Volumes;
@@ -177,6 +178,16 @@ public class PostgresqlDevServicesProcessor {
             }
         }
 
+        // this is always reachable from the host JVM, so that testcontainers can determine the status of the
+        // container (which it does by trying to acquire a connection)
+        @Override
+        public String getJdbcUrl() {
+            String host = DevServicesHostUtil.resolvePublishedPortHost(getContainerId(), getHost());
+            String authority = DevServicesHostUtil.formatHostAndPort(host, getMappedPort(POSTGRESQL_PORT));
+            String additionalUrlParams = constructUrlParameters("?", "&");
+            return "jdbc:postgresql://" + authority + "/" + getDatabaseName() + additionalUrlParams;
+        }
+
         // this is meant to be called by Quarkus code and is not strictly needed
         // in the PostgreSQL case as testcontainers does not try to establish
         // a connection to determine if the container is ready, but we do it anyway to be consistent across
@@ -186,12 +197,11 @@ public class PostgresqlDevServicesProcessor {
                 // in this case we expose the URL using the network alias we created in 'configure'
                 // and the container port since the application communicating with this container
                 // won't be doing port mapping
+                String authority = DevServicesHostUtil.formatHostAndPort(hostName, POSTGRESQL_PORT);
                 String additionalUrlParams = constructUrlParameters("?", "&");
-                return "jdbc:postgresql://" + hostName + ":" + POSTGRESQL_PORT
-                        + "/" + getDatabaseName() + additionalUrlParams;
-            } else {
-                return super.getJdbcUrl();
+                return "jdbc:postgresql://" + authority + "/" + getDatabaseName() + additionalUrlParams;
             }
+            return getJdbcUrl();
         }
 
         public String getReactiveUrl() {

--- a/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
+++ b/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
@@ -30,6 +30,7 @@ import io.quarkus.deployment.builditem.DevServicesComposeProjectBuildItem;
 import io.quarkus.deployment.builditem.DevServicesLauncherConfigResultBuildItem;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.devservices.common.DevServicesHostUtil;
 import io.quarkus.devservices.common.JBossLoggingConsumer;
 import io.quarkus.devservices.common.Labels;
 import io.quarkus.devservices.common.Volumes;
@@ -177,21 +178,21 @@ public class PostgresqlDevServicesProcessor {
             }
         }
 
+        @Override
+        public String getJdbcUrl() {
+            String host = DevServicesHostUtil.publishedPortHost(getContainerId(), useSharedNetwork, hostName, getHost());
+            int port = useSharedNetwork ? POSTGRESQL_PORT : getMappedPort(POSTGRESQL_PORT);
+            String authority = DevServicesHostUtil.formatHostAndPort(host, port);
+            String additionalUrlParams = constructUrlParameters("?", "&");
+            return "jdbc:postgresql://" + authority + "/" + getDatabaseName() + additionalUrlParams;
+        }
+
         // this is meant to be called by Quarkus code and is not strictly needed
         // in the PostgreSQL case as testcontainers does not try to establish
         // a connection to determine if the container is ready, but we do it anyway to be consistent across
         // DB containers
         public String getEffectiveJdbcUrl() {
-            if (useSharedNetwork) {
-                // in this case we expose the URL using the network alias we created in 'configure'
-                // and the container port since the application communicating with this container
-                // won't be doing port mapping
-                String additionalUrlParams = constructUrlParameters("?", "&");
-                return "jdbc:postgresql://" + hostName + ":" + POSTGRESQL_PORT
-                        + "/" + getDatabaseName() + additionalUrlParams;
-            } else {
-                return super.getJdbcUrl();
-            }
+            return getJdbcUrl();
         }
 
         public String getReactiveUrl() {

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
@@ -32,6 +32,7 @@ import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerLocator;
+import io.quarkus.devservices.common.DevServicesHostUtil;
 import io.quarkus.devservices.common.Labels;
 import io.quarkus.devservices.common.StartableContainer;
 import io.quarkus.elasticsearch.restclient.common.deployment.ElasticsearchCommonBuildTimeConfig.ElasticsearchDevServicesBuildTimeConfig;
@@ -123,10 +124,12 @@ public class DevServicesElasticsearchProcessor {
                     container.withEnv(config.containerEnv());
                     container.withReuse(config.reuse());
 
-                    return new StartableContainer<>(container,
-                            c -> createdContainer.hostName() + ":"
-                                    + (useSharedNetwork ? ELASTICSEARCH_PORT
-                                            : c.getMappedPort(ELASTICSEARCH_PORT)));
+                    return new StartableContainer<>(container, c -> {
+                        String host = DevServicesHostUtil.publishedPortHost(c.getContainerId(), useSharedNetwork,
+                                createdContainer.hostName(), c.getHost());
+                        int port = useSharedNetwork ? ELASTICSEARCH_PORT : c.getMappedPort(ELASTICSEARCH_PORT);
+                        return DevServicesHostUtil.formatHostAndPort(host, port);
+                    });
                 })
                 .postStartHook(containerWrapper -> log.infof(
                         "Dev Services for Elasticsearch started. Other Quarkus applications in dev mode will find the "
@@ -152,7 +155,9 @@ public class DevServicesElasticsearchProcessor {
                 .map(containerAddress -> DevServicesResultBuildItem.discovered()
                         .feature(Feature.ELASTICSEARCH_REST_CLIENT_COMMON)
                         .containerId(containerAddress.getId())
-                        .config(buildPropertiesMap(buildItemsConfig, containerAddress.getUrl()))
+                        .config(buildPropertiesMap(buildItemsConfig,
+                                DevServicesHostUtil.formatResolvedHostAndPort(containerAddress.getId(),
+                                        containerAddress.getHost(), containerAddress.getPort())))
                         .build())
                 .orElse(null);
     }

--- a/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devservices/InfinispanDevServiceProcessor.java
+++ b/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devservices/InfinispanDevServiceProcessor.java
@@ -34,6 +34,7 @@ import io.quarkus.deployment.dev.devservices.RunningContainer;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerLocator;
+import io.quarkus.devservices.common.DevServicesHostUtil;
 import io.quarkus.infinispan.client.runtime.InfinispanClientBuildTimeConfig;
 import io.quarkus.infinispan.client.runtime.InfinispanClientUtil;
 import io.quarkus.infinispan.client.runtime.InfinispanClientsBuildTimeConfig;
@@ -145,13 +146,15 @@ public class InfinispanDevServiceProcessor {
                         String password = container != null ? container.tryGetEnv("PASS").orElse(DEFAULT_PASSWORD)
                                 : DEFAULT_PASSWORD;
 
-                        log.infof("The infinispan server is ready to accept connections on %s", containerAddress.getUrl());
+                        String hosts = DevServicesHostUtil.formatResolvedHostAndPort(containerAddress.getId(),
+                                containerAddress.getHost(), containerAddress.getPort());
+                        log.infof("The infinispan server is ready to accept connections on %s", hosts);
 
                         return DevServicesResultBuildItem.discovered()
                                 .feature(Feature.INFINISPAN_CLIENT)
                                 .containerId(containerAddress.getId())
                                 .config(Map.of(
-                                        configPrefix + "hosts", containerAddress.getUrl(),
+                                        configPrefix + "hosts", hosts,
                                         configPrefix + "username", username,
                                         configPrefix + "password", password))
                                 .build();
@@ -288,7 +291,9 @@ public class InfinispanDevServiceProcessor {
 
         @Override
         public String getConnectionInfo() {
-            return getHost() + ":" + getPort();
+            return DevServicesHostUtil.formatHostAndPort(
+                    DevServicesHostUtil.publishedPortHost(getContainerId(), useSharedNetwork, hostName, super.getHost()),
+                    getPort());
         }
 
         @Override

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/DevServicesKafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/DevServicesKafkaProcessor.java
@@ -37,6 +37,7 @@ import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerLocator;
+import io.quarkus.devservices.common.DevServicesHostUtil;
 import io.quarkus.devservices.common.StartableContainer;
 import io.quarkus.runtime.configuration.ConfigUtils;
 import io.strimzi.test.container.StrimziKafkaCluster;
@@ -80,11 +81,13 @@ public class DevServicesKafkaProcessor {
                         List.of(config.effectiveImageName(), "kafka", "strimzi", "redpanda"),
                         KAFKA_PORT, launchMode.getLaunchMode(), useSharedNetwork))
                 .map(containerAddress -> {
-                    createTopicPartitions(containerAddress.getUrl(), config);
+                    String bootstrapServers = DevServicesHostUtil.formatResolvedHostAndPort(containerAddress.getId(),
+                            containerAddress.getHost(), containerAddress.getPort());
+                    createTopicPartitions(bootstrapServers, config);
                     return DevServicesResultBuildItem.discovered()
                             .feature(Feature.KAFKA_CLIENT)
                             .containerId(containerAddress.getId())
-                            .config(Map.of(KAFKA_BOOTSTRAP_SERVERS, containerAddress.getUrl()))
+                            .config(Map.of(KAFKA_BOOTSTRAP_SERVERS, bootstrapServers))
                             .build();
                 }).orElseGet(() -> DevServicesResultBuildItem.owned()
                         .feature(Feature.KAFKA_CLIENT)
@@ -115,7 +118,8 @@ public class DevServicesKafkaProcessor {
                             String hostName = ConfigureUtil.configureNetwork(strimzi,
                                     composeProjectBuildItem.getDefaultNetworkId(), useSharedNetwork, "kafka");
                             if (useSharedNetwork) {
-                                strimzi.withBootstrapServers(c -> String.format("PLAINTEXT://%s:%s", hostName, KAFKA_PORT));
+                                strimzi.withBootstrapServers(c -> DevServicesHostUtil.formatPrefixedAuthority("PLAINTEXT",
+                                        hostName, KAFKA_PORT));
                             }
                             if (config.port().isPresent() && config.port().get() != 0) {
                                 strimzi.withPort(config.port().get());

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaContainer.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaContainer.java
@@ -18,6 +18,7 @@ import com.github.dockerjava.api.command.InspectContainerResponse;
 
 import io.quarkus.deployment.builditem.Startable;
 import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.devservices.common.DevServicesHostUtil;
 import io.quarkus.runtime.LaunchMode;
 
 public class KafkaContainer extends GenericContainer<KafkaContainer> implements Startable {
@@ -167,7 +168,7 @@ public class KafkaContainer extends GenericContainer<KafkaContainer> implements 
     }
 
     public String getEffectiveHostName() {
-        return useSharedNetwork ? hostName : getHost();
+        return DevServicesHostUtil.publishedPortHost(getContainerId(), useSharedNetwork, hostName, getHost());
     }
 
     public int getEffectivePort() {
@@ -175,7 +176,7 @@ public class KafkaContainer extends GenericContainer<KafkaContainer> implements 
     }
 
     public String getBootstrapServers() {
-        return String.format("%s:%s", getEffectiveHostName(), getEffectivePort());
+        return DevServicesHostUtil.formatHostAndPort(getEffectiveHostName(), getEffectivePort());
     }
 
     @Override

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaNativeContainer.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaNativeContainer.java
@@ -14,6 +14,7 @@ import com.github.dockerjava.api.command.InspectContainerResponse;
 
 import io.quarkus.deployment.builditem.Startable;
 import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.devservices.common.DevServicesHostUtil;
 import io.quarkus.runtime.LaunchMode;
 
 public class KafkaNativeContainer extends GenericContainer<KafkaNativeContainer> implements Startable {
@@ -76,11 +77,12 @@ public class KafkaNativeContainer extends GenericContainer<KafkaNativeContainer>
     private String getKafkaAdvertisedListeners() {
         List<String> addresses = new ArrayList<>();
         if (useSharedNetwork) {
-            addresses.add(String.format("BROKER://%s:9093", hostName));
+            addresses.add(DevServicesHostUtil.formatPrefixedAuthority("BROKER", hostName, 9093));
         }
         // See https://github.com/quarkusio/quarkus/issues/21819
         // Kafka is always exposed to the Docker host network
-        addresses.add(String.format("PLAINTEXT://%s:%d", getHost(), getExposedKafkaPort()));
+        addresses.add(DevServicesHostUtil.formatPrefixedAuthority("PLAINTEXT",
+                DevServicesHostUtil.publishedPortHost(getContainerId(), getHost()), getExposedKafkaPort()));
         return String.join(",", addresses);
     }
 

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/RedpandaKafkaContainer.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/RedpandaKafkaContainer.java
@@ -16,6 +16,7 @@ import com.github.dockerjava.api.command.InspectContainerResponse;
 
 import io.quarkus.deployment.builditem.Startable;
 import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.devservices.common.DevServicesHostUtil;
 import io.quarkus.runtime.LaunchMode;
 
 /**
@@ -91,11 +92,13 @@ final class RedpandaKafkaContainer extends GenericContainer<RedpandaKafkaContain
     private String getKafkaAdvertisedAddresses() {
         List<String> addresses = new ArrayList<>();
         if (useSharedNetwork) {
-            addresses.add(String.format("PLAINTEXT://%s:29092", hostName));
+            addresses.add(DevServicesHostUtil.formatPrefixedAuthority("PLAINTEXT", hostName, 29092));
         }
         // See https://github.com/quarkusio/quarkus/issues/21819
         // Kafka is always exposed to the Docker host network
-        addresses.add(String.format("OUTSIDE://%s:%d", getHost(), getMappedPort(DevServicesKafkaProcessor.KAFKA_PORT)));
+        addresses.add(DevServicesHostUtil.formatPrefixedAuthority("OUTSIDE",
+                DevServicesHostUtil.publishedPortHost(getContainerId(), getHost()),
+                getMappedPort(DevServicesKafkaProcessor.KAFKA_PORT)));
         return String.join(",", addresses);
     }
 

--- a/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/DevServicesKubernetesProcessor.java
+++ b/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/DevServicesKubernetesProcessor.java
@@ -2,6 +2,7 @@ package io.quarkus.kubernetes.client.deployment;
 
 import static com.dajudge.kindcontainer.KubernetesVersionEnum.latest;
 import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
+import static io.quarkus.devservices.common.DevServicesHostUtil.formatResolvedHostAndPort;
 import static io.quarkus.devservices.common.Labels.QUARKUS_DEV_SERVICE;
 import static io.quarkus.kubernetes.client.runtime.internal.KubernetesDevServicesBuildTimeConfig.Flavor.api_only;
 import static java.nio.charset.StandardCharsets.US_ASCII;
@@ -455,19 +456,25 @@ public class DevServicesKubernetesProcessor {
             this.containerInfo = dockerClient.inspectContainerCmd(getContainerId()).exec();
         }
 
+        private String resolvedConnectionAddress() {
+            return formatResolvedHostAndPort(containerAddress.getId(), containerAddress.getHost(),
+                    containerAddress.getPort());
+        }
+
         private KubeConfig getKubeconfigFromContainer() {
             var image = getContainerInfo().getConfig().getImage();
+            String connectionAddress = resolvedConnectionAddress();
             if (image.contains("rancher/k3s")) {
                 return KubeConfigUtils
-                        .parseKubeConfig(KubeConfigUtils.replaceServerInKubeconfig("https://" + containerAddress.getUrl(),
+                        .parseKubeConfig(KubeConfigUtils.replaceServerInKubeconfig("https://" + connectionAddress,
                                 getFileContentFromContainer(K3S_KUBECONFIG)));
             } else if (image.contains("kindest/node")) {
                 return KubeConfigUtils
-                        .parseKubeConfig(KubeConfigUtils.replaceServerInKubeconfig("https://" + containerAddress.getUrl(),
+                        .parseKubeConfig(KubeConfigUtils.replaceServerInKubeconfig("https://" + connectionAddress,
                                 getFileContentFromContainer(KIND_KUBECONFIG)));
             } else if (image.contains("k8s.gcr.io/kube-apiserver") ||
                     image.contains("registry.k8s.io/kube-apiserver")) {
-                return getKubeconfigFromApiContainer(containerAddress.getUrl());
+                return getKubeconfigFromApiContainer(connectionAddress);
             }
 
             // this can happen only if the user manually start

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/DevServicesMongoProcessor.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/DevServicesMongoProcessor.java
@@ -35,6 +35,7 @@ import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerLocator;
+import io.quarkus.devservices.common.DevServicesHostUtil;
 import io.quarkus.devservices.common.Labels;
 import io.quarkus.mongodb.deployment.spi.MongoClientBuildItem;
 import io.quarkus.mongodb.deployment.spi.MongoClientsBuildItem;
@@ -140,8 +141,10 @@ public class DevServicesMongoProcessor {
                 .or(() -> ComposeLocator.locateContainer(composeProjectBuildItem,
                         List.of(captured.imageName, "mongo"), MONGO_EXPOSED_PORT, launchMode, useSharedNetwork))
                 .map(containerAddress -> {
-                    String effectiveUrl = getEffectiveUrl(configPrefix, containerAddress.getHost(),
-                            containerAddress.getPort(), captured);
+                    String effectiveUrl = getEffectiveUrl(configPrefix,
+                            DevServicesHostUtil.formatResolvedHostAndPort(containerAddress.getId(),
+                                    containerAddress.getHost(), containerAddress.getPort()),
+                            captured);
                     return DevServicesResultBuildItem.discovered()
                             .feature(Feature.MONGODB_CLIENT)
                             .containerId(containerAddress.getId())
@@ -172,14 +175,21 @@ public class DevServicesMongoProcessor {
 
     private String getEffectiveUrl(String configPrefix, QuarkusMongoDBContainer container,
             CapturedProperties captured) {
-        return getEffectiveUrl(configPrefix, container.getEffectiveHost(), container.getEffectivePort(), captured);
+        String authority;
+        if (container.useSharedNetwork) {
+            authority = DevServicesHostUtil.formatHostAndPort(container.hostName, container.getEffectivePort());
+        } else {
+            authority = DevServicesHostUtil.formatResolvedHostAndPort(container.getContainerId(),
+                    container.getEffectiveHost(), container.getEffectivePort());
+        }
+        return getEffectiveUrl(configPrefix, authority, captured);
     }
 
-    private String getEffectiveUrl(String configPrefix, String host, int port, CapturedProperties capturedProperties) {
+    private String getEffectiveUrl(String configPrefix, String hostAndPort, CapturedProperties capturedProperties) {
         final String databaseName = ConfigProvider.getConfig()
                 .getOptionalValue(configPrefix + "database", String.class)
                 .orElse("test");
-        String effectiveUrl = String.format("%s%s:%d/%s", MONGO_SCHEME, host, port, databaseName);
+        String effectiveUrl = MONGO_SCHEME + hostAndPort + "/" + databaseName;
         if ((capturedProperties.connectionProperties != null) && !capturedProperties.connectionProperties.isEmpty()) {
             effectiveUrl = effectiveUrl + "?"
                     + URLEncodedUtils.format(
@@ -264,18 +274,17 @@ public class DevServicesMongoProcessor {
 
         @Override
         public String getReplicaSetUrl(String databaseName) {
-            if (useSharedNetwork) {
-                if (!isRunning()) { // done by the super method
-                    throw new IllegalStateException("MongoDBContainer should be started first");
-                }
-                return String.format(
-                        "mongodb://%s:%d/%s",
-                        hostName,
-                        MONGODB_INTERNAL_PORT,
-                        databaseName);
-            } else {
-                return super.getReplicaSetUrl(databaseName);
+            if (!isRunning()) {
+                throw new IllegalStateException("MongoDBContainer should be started first");
             }
+            String authority;
+            if (useSharedNetwork) {
+                authority = DevServicesHostUtil.formatHostAndPort(hostName, MONGODB_INTERNAL_PORT);
+            } else {
+                authority = DevServicesHostUtil.formatResolvedHostAndPort(getContainerId(), getHost(),
+                        getMappedPort(MONGO_EXPOSED_PORT));
+            }
+            return "mongodb://" + authority + "/" + databaseName;
         }
 
         public String getEffectiveHost() {
@@ -288,7 +297,10 @@ public class DevServicesMongoProcessor {
 
         @Override
         public String getConnectionInfo() {
-            return getEffectiveHost() + ":" + getEffectivePort();
+            if (useSharedNetwork) {
+                return DevServicesHostUtil.formatHostAndPort(hostName, getEffectivePort());
+            }
+            return DevServicesHostUtil.formatResolvedHostAndPort(getContainerId(), getEffectiveHost(), getEffectivePort());
         }
 
         @Override

--- a/extensions/narayana-lra/deployment/src/main/java/io/quarkus/narayana/lra/deployment/devservice/DevServicesLRAProcessor.java
+++ b/extensions/narayana-lra/deployment/src/main/java/io/quarkus/narayana/lra/deployment/devservice/DevServicesLRAProcessor.java
@@ -22,6 +22,7 @@ import io.quarkus.deployment.builditem.Startable;
 import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ContainerLocator;
+import io.quarkus.devservices.common.DevServicesHostUtil;
 import io.quarkus.narayana.lra.deployment.LRABuildTimeConfiguration;
 import io.quarkus.runtime.configuration.ConfigUtils;
 
@@ -69,7 +70,9 @@ public class DevServicesLRAProcessor {
                 .map(containerAddress -> DevServicesResultBuildItem.discovered()
                         .feature(Feature.NARAYANA_LRA)
                         .containerId(containerAddress.getId())
-                        .config(Map.of(LRA_COORDINATOR_URL_PROPERTY, "http://" + containerAddress.getUrl() + "/lra-coordinator",
+                        .config(Map.of(LRA_COORDINATOR_URL_PROPERTY,
+                                "http://" + DevServicesHostUtil.formatResolvedHostAndPort(containerAddress.getId(),
+                                        containerAddress.getHost(), containerAddress.getPort()) + "/lra-coordinator",
                                 "quarkus.http.host", "0.0.0.0", // Required since the container needs to call the host application
                                 "quarkus.lra.base-uri",
                                 "http://host.containers.internal:"

--- a/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/DevServicesRedisProcessor.java
+++ b/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/DevServicesRedisProcessor.java
@@ -31,6 +31,7 @@ import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerLocator;
+import io.quarkus.devservices.common.DevServicesHostUtil;
 import io.quarkus.redis.runtime.client.config.RedisConfig;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ConfigUtils;
@@ -133,7 +134,8 @@ public class DevServicesRedisProcessor {
                         List.of(devServicesConfig.imageName().orElseGet(() -> getDefaultImageNameFor("redis"))),
                         REDIS_EXPOSED_PORT, launchMode, useSharedNetwork))
                 .map(containerAddress -> {
-                    String redisUrl = REDIS_SCHEME + containerAddress.getUrl();
+                    String redisUrl = REDIS_SCHEME + DevServicesHostUtil.formatResolvedHostAndPort(
+                            containerAddress.getId(), containerAddress.getHost(), containerAddress.getPort());
                     return DevServicesResultBuildItem.discovered()
                             .feature(Feature.REDIS_CLIENT)
                             .containerId(containerAddress.getId())
@@ -223,7 +225,9 @@ public class DevServicesRedisProcessor {
 
         @Override
         public String getConnectionInfo() {
-            return getHost() + ":" + getPort();
+            return DevServicesHostUtil.formatHostAndPort(
+                    DevServicesHostUtil.publishedPortHost(getContainerId(), useSharedNetwork, hostName, super.getHost()),
+                    getPort());
         }
     }
 }

--- a/extensions/schema-registry/devservice/deployment/src/main/java/io/quarkus/apicurio/registry/devservice/DevServicesApicurioRegistryProcessor.java
+++ b/extensions/schema-registry/devservice/deployment/src/main/java/io/quarkus/apicurio/registry/devservice/DevServicesApicurioRegistryProcessor.java
@@ -30,6 +30,7 @@ import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerLocator;
+import io.quarkus.devservices.common.DevServicesHostUtil;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ConfigUtils;
 
@@ -116,7 +117,9 @@ public class DevServicesApicurioRegistryProcessor {
                         .feature(Feature.APICURIO_REGISTRY_AVRO)
                         .containerId(address.getId())
                         // address does not have the URL Scheme - just the host:port, so prepend http://
-                        .config(getRegistryUrlConfigs("http://" + address.getUrl()))
+                        .config(getRegistryUrlConfigs("http://"
+                                + DevServicesHostUtil.formatResolvedHostAndPort(address.getId(), address.getHost(),
+                                        address.getPort())))
                         .build())
                 .orElseGet(() -> DevServicesResultBuildItem.owned()
                         .feature(Feature.APICURIO_REGISTRY_AVRO)
@@ -211,11 +214,11 @@ public class DevServicesApicurioRegistryProcessor {
         }
 
         public String getUrl() {
-            return String.format("http://%s:%s", getHostToUse(), getPortToUse());
+            return DevServicesHostUtil.formatPrefixedAuthority("http", getHostToUse(), getPortToUse());
         }
 
         private String getHostToUse() {
-            return useSharedNetwork ? hostName : getHost();
+            return DevServicesHostUtil.publishedPortHost(getContainerId(), useSharedNetwork, hostName, getHost());
         }
 
         private int getPortToUse() {

--- a/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/amqp/deployment/AmqpDevServicesProcessor.java
+++ b/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/amqp/deployment/AmqpDevServicesProcessor.java
@@ -29,6 +29,7 @@ import io.quarkus.deployment.dev.devservices.RunningContainer;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerLocator;
+import io.quarkus.devservices.common.DevServicesHostUtil;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ConfigUtils;
 
@@ -94,7 +95,9 @@ public class AmqpDevServicesProcessor {
                             .feature(Feature.MESSAGING_AMQP)
                             .containerId(containerAddress.getId())
                             .config(Map.of(
-                                    AMQP_HOST_PROP, containerAddress.getHost(),
+                                    AMQP_HOST_PROP,
+                                    DevServicesHostUtil.resolvePublishedPortHost(containerAddress.getId(),
+                                            containerAddress.getHost()),
                                     AMQP_PORT_PROP, String.valueOf(containerAddress.getPort()),
                                     AMQP_MAPPED_PORT_PROP,
                                     String.valueOf(container.getPortMapping(AMQP_CONSOLE_PORT).orElse(0)),
@@ -233,7 +236,7 @@ public class AmqpDevServicesProcessor {
 
         @Override
         public String getConnectionInfo() {
-            return String.format("amqp://%s:%d", getEffectiveHost(), getPort());
+            return DevServicesHostUtil.formatPrefixedAuthority("amqp", getEffectiveHost(), getPort());
         }
 
         @Override
@@ -246,7 +249,7 @@ public class AmqpDevServicesProcessor {
         }
 
         public String getEffectiveHost() {
-            return useSharedNetwork ? hostName : getHost();
+            return DevServicesHostUtil.publishedPortHost(getContainerId(), useSharedNetwork, hostName, getHost());
         }
 
         public int getMappedConsolePort() {

--- a/extensions/smallrye-reactive-messaging-mqtt/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/mqtt/deployment/MqttDevServicesProcessor.java
+++ b/extensions/smallrye-reactive-messaging-mqtt/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/mqtt/deployment/MqttDevServicesProcessor.java
@@ -29,6 +29,7 @@ import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerLocator;
+import io.quarkus.devservices.common.DevServicesHostUtil;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ConfigUtils;
 
@@ -200,7 +201,7 @@ public class MqttDevServicesProcessor {
 
         @Override
         public String getConnectionInfo() {
-            return String.format("mqtt://%s:%d", getEffectiveHost(), getPort());
+            return DevServicesHostUtil.formatPrefixedAuthority("mqtt", getEffectiveHost(), getPort());
         }
 
         @Override
@@ -209,7 +210,7 @@ public class MqttDevServicesProcessor {
         }
 
         public String getEffectiveHost() {
-            return useSharedNetwork ? hostName : getHost();
+            return DevServicesHostUtil.publishedPortHost(getContainerId(), useSharedNetwork, hostName, getHost());
         }
 
         public int getPort() {

--- a/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/PulsarContainer.java
+++ b/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/PulsarContainer.java
@@ -15,6 +15,7 @@ import com.github.dockerjava.api.command.InspectContainerResponse;
 
 import io.quarkus.deployment.builditem.Startable;
 import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.devservices.common.DevServicesHostUtil;
 
 public class PulsarContainer extends GenericContainer<PulsarContainer> implements Startable {
 
@@ -51,8 +52,10 @@ public class PulsarContainer extends GenericContainer<PulsarContainer> implement
     @Override
     protected void containerIsStarting(InspectContainerResponse containerInfo, boolean reused) {
         super.containerIsStarting(containerInfo, reused);
-        String advertisedListeners = String.format("internal:pulsar://localhost:%s,external:pulsar://%s:%s",
-                BROKER_PORT, this.getHost(), this.getMappedPort(BROKER_PORT));
+        String host = DevServicesHostUtil.publishedPortHost(containerInfo.getId(), useSharedNetwork, hostName,
+                this.getHost());
+        String advertisedListeners = "internal:pulsar://localhost:" + BROKER_PORT + ",external:"
+                + DevServicesHostUtil.formatPrefixedAuthority("pulsar", host, this.getMappedPort(BROKER_PORT));
 
         String command = "#!/bin/bash \n";
         command += "export PULSAR_PREFIX_advertisedListeners=" + advertisedListeners + " \n";
@@ -74,22 +77,26 @@ public class PulsarContainer extends GenericContainer<PulsarContainer> implement
         if (useSharedNetwork) {
             return getServiceUrl(this.hostName, PulsarContainer.BROKER_PORT);
         }
-        return getServiceUrl(this.getHost(), this.getMappedPort(BROKER_PORT));
+        return getServiceUrl(
+                DevServicesHostUtil.publishedPortHost(getContainerId(), this.getHost()),
+                this.getMappedPort(BROKER_PORT));
     }
 
     private String getServiceUrl(String host, int port) {
-        return String.format("pulsar://%s:%d", host, port);
+        return DevServicesHostUtil.formatPrefixedAuthority("pulsar", host, port);
     }
 
     public String getHttpServiceUrl() {
         if (useSharedNetwork) {
             return getHttpServiceUrl(this.hostName, PulsarContainer.BROKER_HTTP_PORT);
         }
-        return getHttpServiceUrl(this.getHost(), this.getMappedPort(BROKER_HTTP_PORT));
+        return getHttpServiceUrl(
+                DevServicesHostUtil.publishedPortHost(getContainerId(), this.getHost()),
+                this.getMappedPort(BROKER_HTTP_PORT));
     }
 
     private String getHttpServiceUrl(String host, int port) {
-        return String.format("http://%s:%d", host, port);
+        return DevServicesHostUtil.formatPrefixedAuthority("http", host, port);
     }
 
     @Override

--- a/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/PulsarDevServicesProcessor.java
+++ b/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/PulsarDevServicesProcessor.java
@@ -25,6 +25,7 @@ import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.deployment.dev.devservices.RunningContainer;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ContainerLocator;
+import io.quarkus.devservices.common.DevServicesHostUtil;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ConfigUtils;
 
@@ -73,8 +74,10 @@ public class PulsarDevServicesProcessor {
                             .locatePublicPort(config.serviceName(), config.shared(),
                                     launchMode.getLaunchMode(), PulsarContainer.BROKER_HTTP_PORT)
                             .orElse(8080);
-                    String pulsarUrl = String.format("pulsar://%s:%d", containerAddress.getHost(), containerAddress.getPort());
-                    String httpUrl = String.format("http://%s:%d", containerAddress.getHost(), httpPort);
+                    String pulsarUrl = DevServicesHostUtil.formatResolvedPrefixedAuthority("pulsar",
+                            containerAddress.getId(), containerAddress.getHost(), containerAddress.getPort());
+                    String httpUrl = DevServicesHostUtil.formatResolvedPrefixedAuthority("http", containerAddress.getId(),
+                            containerAddress.getHost(), httpPort);
                     return DevServicesResultBuildItem.discovered()
                             .feature(Feature.MESSAGING_PULSAR)
                             .containerId(containerAddress.getId())
@@ -92,9 +95,10 @@ public class PulsarDevServicesProcessor {
                                 return null;
                             }
                             int httpPort = container.getPortMapping(PulsarContainer.BROKER_HTTP_PORT).orElse(8080);
-                            String pulsarUrl = String.format("pulsar://%s:%d", containerAddress.getHost(),
-                                    containerAddress.getPort());
-                            String httpUrl = String.format("http://%s:%d", containerAddress.getHost(), httpPort);
+                            String pulsarUrl = DevServicesHostUtil.formatResolvedPrefixedAuthority("pulsar",
+                                    containerAddress.getId(), containerAddress.getHost(), containerAddress.getPort());
+                            String httpUrl = DevServicesHostUtil.formatResolvedPrefixedAuthority("http",
+                                    containerAddress.getId(), containerAddress.getHost(), httpPort);
                             return DevServicesResultBuildItem.discovered()
                                     .feature(Feature.MESSAGING_PULSAR)
                                     .containerId(containerAddress.getId())


### PR DESCRIPTION
When Docker has IPv6 enabled, Testcontainers can report the container host as an IPv6 literal (for example `fd00:d0ca:1::1`). Embedding that address verbatim in JDBC, MongoDB, Kafka, and other Dev Services URLs breaks clients because colons are misread as port separators. Even with RFC 2732 bracketing, the IPv6 gateway is often unreachable from the host JVM.

This change introduces `DevServicesHostUtil` in `quarkus-devservices-common` to centralize host handling for Dev Services:

- Wrap IPv6 literals in `[]` when building URI authorities
- Resolve unreachable IPv6 gateway addresses to a reachable IPv4 bridge/podman gateway via `docker inspect`, or fall back to `localhost` for rootless Podman, Podman Desktop, and similar runtimes
- Honor `TESTCONTAINERS_HOST_OVERRIDE` when set

All affected Dev Services extensions (JDBC databases, MongoDB, Redis, Kafka, Elasticsearch, Keycloak, and others) now use the shared utility for owned containers, discovered containers, and compose-based discovery.


- Fixes: #54696