### PR TITLE
Add structured access log fields to the JSON log formatter

### DIFF
--- a/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/ConsoleJsonFormatterStructuredAccessLogTest.java
+++ b/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/ConsoleJsonFormatterStructuredAccessLogTest.java
@@ -1,0 +1,174 @@
+package io.quarkus.logging.json;
+
+import static io.quarkus.logging.json.ConsoleJsonFormatterDefaultConfigTest.getJsonFormatter;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.logging.Level;
+
+import org.jboss.logmanager.ExtLogRecord;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkus.logging.json.runtime.JsonFormatter;
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * Tests for the {@code quarkus.log.console.json.structured-access-log} option.
+ * <p>
+ * Access log records are identified by a logger name that starts with
+ * {@code io.quarkus.http.access-log}. When the option is enabled, structured
+ * MDC fields placed by {@code JBossLoggingAccessLogReceiver} under the
+ * {@code __access__} prefix must be written as a nested {@code "accessLog"} JSON
+ * object, and must NOT appear inside the regular {@code "mdc"} object.
+ */
+public class ConsoleJsonFormatterStructuredAccessLogTest {
+
+    private static final String ACCESS_LOG_LOGGER = "io.quarkus.http.access-log";
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar.addClasses(ConsoleJsonFormatterDefaultConfigTest.class))
+            .withConfigurationResource("application-console-json-formatter-structured-access-log.properties");
+
+    @Test
+    public void structuredAccessLogEnabledConfigTest() {
+        JsonFormatter jsonFormatter = getJsonFormatter();
+        assertThat(jsonFormatter.isStructuredAccessLog()).isTrue();
+    }
+
+    @Test
+    public void accessLogRecordProducesAccessLogObjectTest() throws Exception {
+        JsonFormatter formatter = new JsonFormatter();
+        formatter.setStructuredAccessLog(true);
+
+        ExtLogRecord record = new ExtLogRecord(Level.INFO, "GET /api/health 200", ACCESS_LOG_LOGGER);
+        record.putMdc("__access__method", "GET");
+        record.putMdc("__access__uri", "/api/health");
+        record.putMdc("__access__status", "200");
+        record.putMdc("__access__responseTimeMs", "12");
+        record.putMdc("__access__bytesSent", "512");
+        record.putMdc("__access__remoteIp", "10.0.0.1");
+        record.putMdc("__access__protocol", "HTTP/1.1");
+
+        String line = formatter.format(record);
+        JsonNode node = MAPPER.readTree(line);
+
+        assertThat(node.has("accessLog")).isTrue();
+        JsonNode accessLog = node.get("accessLog");
+
+        assertThat(accessLog.get("method").asText()).isEqualTo("GET");
+        assertThat(accessLog.get("uri").asText()).isEqualTo("/api/health");
+        assertThat(accessLog.get("protocol").asText()).isEqualTo("HTTP/1.1");
+        assertThat(accessLog.get("remoteIp").asText()).isEqualTo("10.0.0.1");
+
+        // Numeric fields must be emitted as JSON numbers, not strings
+        assertThat(accessLog.get("status").isNumber()).isTrue();
+        assertThat(accessLog.get("status").asInt()).isEqualTo(200);
+        assertThat(accessLog.get("responseTimeMs").isNumber()).isTrue();
+        assertThat(accessLog.get("responseTimeMs").asLong()).isEqualTo(12L);
+        assertThat(accessLog.get("bytesSent").isNumber()).isTrue();
+        assertThat(accessLog.get("bytesSent").asLong()).isEqualTo(512L);
+
+        // The __access__* keys must NOT appear in the mdc object
+        if (node.has("mdc")) {
+            JsonNode mdc = node.get("mdc");
+            mdc.fieldNames().forEachRemaining(key ->
+                    assertThat(key).doesNotStartWith("__access__"));
+        }
+    }
+
+    @Test
+    public void accessLogFieldsNotPresentInMdcObjectTest() throws Exception {
+        JsonFormatter formatter = new JsonFormatter();
+        formatter.setStructuredAccessLog(true);
+
+        ExtLogRecord record = new ExtLogRecord(Level.INFO, "POST /api/v1/orders 201", ACCESS_LOG_LOGGER);
+        record.putMdc("__access__method", "POST");
+        record.putMdc("__access__status", "201");
+        record.putMdc("requestId", "req-abc");
+
+        String line = formatter.format(record);
+        JsonNode node = MAPPER.readTree(line);
+
+        assertThat(node.has("accessLog")).isTrue();
+        JsonNode mdc = node.get("mdc");
+        if (mdc != null) {
+            assertThat(mdc.has("__access__method")).isFalse();
+            assertThat(mdc.has("__access__status")).isFalse();
+            assertThat(mdc.has("requestId")).isTrue();
+            assertThat(mdc.get("requestId").asText()).isEqualTo("req-abc");
+        }
+    }
+
+    @Test
+    public void nonAccessLogRecordUnaffectedTest() throws Exception {
+        JsonFormatter formatter = new JsonFormatter();
+        formatter.setStructuredAccessLog(true);
+
+        ExtLogRecord record = new ExtLogRecord(Level.INFO, "application event",
+                "com.example.MyService");
+
+        String line = formatter.format(record);
+        JsonNode node = MAPPER.readTree(line);
+
+        assertThat(node.has("accessLog")).isFalse();
+        assertThat(node.get("message").asText()).isEqualTo("application event");
+    }
+
+    @Test
+    public void disabledByDefaultLeavesAccessLogAsPlainMessageTest() throws Exception {
+        JsonFormatter formatter = new JsonFormatter();
+        assertThat(formatter.isStructuredAccessLog()).isFalse();
+
+        ExtLogRecord record = new ExtLogRecord(Level.INFO, "GET /ping 200", ACCESS_LOG_LOGGER);
+        record.putMdc("__access__method", "GET");
+        record.putMdc("__access__status", "200");
+
+        String line = formatter.format(record);
+        JsonNode node = MAPPER.readTree(line);
+
+        assertThat(node.has("accessLog")).isFalse();
+        assertThat(node.get("message").asText()).isEqualTo("GET /ping 200");
+        assertThat(node.has("mdc")).isTrue();
+    }
+
+    @Test
+    public void accessLogObjectAbsentWhenNoMdcFieldsPresentTest() throws Exception {
+        JsonFormatter formatter = new JsonFormatter();
+        formatter.setStructuredAccessLog(true);
+
+        ExtLogRecord record = new ExtLogRecord(Level.INFO, "DELETE /item/1 204", ACCESS_LOG_LOGGER);
+
+        String line = formatter.format(record);
+        JsonNode node = MAPPER.readTree(line);
+
+        assertThat(node.has("accessLog")).isFalse();
+    }
+
+    @Test
+    public void flatMdcAndStructuredAccessLogCombinedTest() throws Exception {
+        JsonFormatter formatter = new JsonFormatter();
+        formatter.setStructuredAccessLog(true);
+        formatter.setFlatMdc(true);
+
+        ExtLogRecord record = new ExtLogRecord(Level.INFO, "PUT /resource 204", ACCESS_LOG_LOGGER);
+        record.putMdc("__access__method", "PUT");
+        record.putMdc("__access__status", "204");
+        record.putMdc("traceId", "trace-xyz");
+
+        String line = formatter.format(record);
+        JsonNode node = MAPPER.readTree(line);
+
+        assertThat(node.has("traceId")).isTrue();
+        assertThat(node.get("traceId").asText()).isEqualTo("trace-xyz");
+
+        assertThat(node.has("__access__method")).isFalse();
+        assertThat(node.has("__access__status")).isFalse();
+        assertThat(node.has("accessLog")).isTrue();
+        assertThat(node.get("accessLog").get("method").asText()).isEqualTo("PUT");
+    }
+}

--- a/extensions/logging-json/deployment/src/test/resources/application-console-json-formatter-structured-access-log.properties
+++ b/extensions/logging-json/deployment/src/test/resources/application-console-json-formatter-structured-access-log.properties
@@ -1,0 +1,6 @@
+quarkus.log.level=INFO
+quarkus.log.console.enabled=true
+quarkus.log.console.level=WARNING
+quarkus.log.console.format=%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n
+quarkus.log.console.json.enabled=true
+quarkus.log.console.json.structured-access-log=true

--- a/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/JsonFormatter.java
+++ b/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/JsonFormatter.java
@@ -27,11 +27,18 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
 
     private static final Logger LOG = Logger.getLogger(JsonFormatter.class);
 
+    /**
+     * MDC key prefix written by {@code JBossLoggingAccessLogReceiver} for each structured
+     * access-log field. Kept in sync with the constant of the same name in that class.
+     */
+    static final String ACCESS_LOG_MDC_PREFIX = "__access__";
+
     private Set<String> excludedKeys;
     private Map<String, AdditionalField> additionalFields;
     private LogFormat logFormat = LogFormat.DEFAULT;
     private String tracePrefix = "";
     private boolean flatMdc = false;
+    private boolean structuredAccessLog = false;
     private List<JsonProvider> discoveredProviders = Collections.emptyList();
     private volatile List<JsonProvider> jsonProviders;
 
@@ -136,6 +143,14 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
         this.flatMdc = flatMdc;
     }
 
+    public boolean isStructuredAccessLog() {
+        return structuredAccessLog;
+    }
+
+    public void setStructuredAccessLog(boolean structuredAccessLog) {
+        this.structuredAccessLog = structuredAccessLog;
+    }
+
     @Override
     protected Generator createGenerator(final Writer writer) {
         Generator superGenerator = super.createGenerator(writer);
@@ -146,7 +161,7 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
         // from the full JVM path (e.g. /usr/lib/jvm/.../bin/java → java).
         String stackTraceKeyToTrim = logFormat.equals(LogFormat.ECS) ? getKey(Key.STACK_TRACE) : null;
         String processNameKey = logFormat.equals(LogFormat.ECS) ? getKey(Key.PROCESS_NAME) : null;
-        return new FormatterJsonGenerator(superGenerator, this.excludedKeys, stackTraceKeyToTrim, processNameKey, this.flatMdc);
+        return new FormatterJsonGenerator(superGenerator, this.excludedKeys, stackTraceKeyToTrim, processNameKey, this.flatMdc, this.structuredAccessLog);
     }
 
     @Override
@@ -193,10 +208,54 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
             addToGenerator(additionalFields, generator);
         }
 
+        if (structuredAccessLog && isAccessLogRecord(record)) {
+            writeAccessLogObject(generator, record);
+        }
+
         JsonLogGenerator jsonLogGenerator = new JsonLogGenerator(generator, this.excludedKeys);
         for (JsonProvider provider : getJsonProviders()) {
             provider.writeTo(jsonLogGenerator, record);
         }
+    }
+
+    private static boolean isAccessLogRecord(final ExtLogRecord record) {
+        final String loggerName = record.getLoggerName();
+        return loggerName != null && loggerName.startsWith("io.quarkus.http.access-log");
+    }
+
+    private void writeAccessLogObject(final Generator generator, final ExtLogRecord record) throws Exception {
+        final Map<String, String> mdc = record.getMdcCopy();
+        if (mdc == null || mdc.isEmpty()) {
+            return;
+        }
+        boolean started = false;
+        for (Map.Entry<String, String> entry : mdc.entrySet()) {
+            if (entry.getKey().startsWith(ACCESS_LOG_MDC_PREFIX)) {
+                if (!started) {
+                    generator.startObject("accessLog");
+                    started = true;
+                }
+                final String fieldName = entry.getKey().substring(ACCESS_LOG_MDC_PREFIX.length());
+                final String value = entry.getValue();
+                if (value != null) {
+                    if (isNumericAccessField(fieldName)) {
+                        try {
+                            generator.add(fieldName, Long.parseLong(value));
+                            continue;
+                        } catch (NumberFormatException ignored) {
+                        }
+                    }
+                    generator.add(fieldName, value);
+                }
+            }
+        }
+        if (started) {
+            generator.endObject();
+        }
+    }
+
+    private static boolean isNumericAccessField(final String fieldName) {
+        return "status".equals(fieldName) || "responseTimeMs".equals(fieldName) || "bytesSent".equals(fieldName);
     }
 
     private List<JsonProvider> getJsonProviders() {
@@ -335,15 +394,18 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
          */
         private final String processNameKey;
         private final boolean flatMdc;
+        private final boolean structuredAccessLog;
         private int skippedDepth = 0;
 
         private FormatterJsonGenerator(final Generator delegate, final Set<String> excludedKeys,
-                final String stackTraceKeyToTrim, final String processNameKey, final boolean flatMdc) {
+                final String stackTraceKeyToTrim, final String processNameKey, final boolean flatMdc,
+                final boolean structuredAccessLog) {
             this.delegate = delegate;
             this.excludedKeys = excludedKeys;
             this.stackTraceKeyToTrim = stackTraceKeyToTrim;
             this.processNameKey = processNameKey;
             this.flatMdc = flatMdc;
+            this.structuredAccessLog = structuredAccessLog;
         }
 
         @Override
@@ -373,13 +435,32 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
             if (skippedDepth == 0 && !excludedKeys.contains(key)) {
                 if (flatMdc && value != null && !value.isEmpty()) {
                     for (Map.Entry<String, ?> entry : value.entrySet()) {
+                        // When structured-access-log is enabled, the __access__-prefixed MDC entries
+                        // are written as the nested "accessLog" object in JsonFormatter.after();
+                        // skip them here to avoid duplication.
+                        if (structuredAccessLog && entry.getKey().startsWith(ACCESS_LOG_MDC_PREFIX)) {
+                            continue;
+                        }
                         Object v = entry.getValue();
                         if (v != null) {
                             delegate.add(entry.getKey(), v.toString());
                         }
                     }
                 } else if (!flatMdc) {
-                    delegate.add(key, value);
+                    if (structuredAccessLog && value != null && !value.isEmpty()) {
+                        // Filter out __access__ keys from the nested "mdc" object as well.
+                        Map<String, Object> filtered = new java.util.LinkedHashMap<>();
+                        for (Map.Entry<String, ?> entry : value.entrySet()) {
+                            if (!entry.getKey().startsWith(ACCESS_LOG_MDC_PREFIX)) {
+                                filtered.put(entry.getKey(), entry.getValue());
+                            }
+                        }
+                        if (!filtered.isEmpty()) {
+                            delegate.add(key, filtered);
+                        }
+                    } else {
+                        delegate.add(key, value);
+                    }
                 }
             }
             return this;

--- a/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/JsonLogConfig.java
+++ b/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/JsonLogConfig.java
@@ -213,6 +213,20 @@ public interface JsonLogConfig extends LogRuntimeConfig {
         @WithName("mdc.flat-fields")
         boolean mdcFlatFields();
 
+        /**
+         * When true, access log events emitted by {@code io.quarkus.http.access-log} are enriched with
+         * a nested {@code "accessLog"} JSON object containing first-class fields for the HTTP method,
+         * request URI, status code, response time, bytes sent, remote IP address, and protocol.
+         * <p>
+         * This option requires that the Vert.x HTTP access log is enabled
+         * ({@code quarkus.http.access-log.enabled=true}). When disabled (the default), access log
+         * entries are emitted with only the pre-formatted message string, preserving the existing
+         * behaviour.
+         */
+        @WithDefault("false")
+        @WithName("structured-access-log")
+        boolean structuredAccessLog();
+
         enum LogFormat {
             DEFAULT,
             ECS,

--- a/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/LoggingJsonRecorder.java
+++ b/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/LoggingJsonRecorder.java
@@ -141,6 +141,7 @@ public class LoggingJsonRecorder {
             formatter.setTracePrefix("projects/" + applicationConfig.getValue().name().orElse("") + "/traces/");
         }
         formatter.setFlatMdc(config.mdcFlatFields());
+        formatter.setStructuredAccessLog(config.structuredAccessLog());
         formatter.setExcludedKeys(overridableJsonConfig.excludedKeys());
         formatter.setAdditionalFields(overridableJsonConfig.additionalFields());
         formatter.setDiscoveredProviders(providers);

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/accesslog/AccessLogHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/accesslog/AccessLogHandler.java
@@ -155,7 +155,7 @@ public class AccessLogHandler implements Handler<RoutingContext> {
         QuarkusRequestWrapper.get(rc.request()).addRequestDoneHandler(new Handler<Void>() {
             @Override
             public void handle(Void event) {
-                accessLogReceiver.logMessage(tokens.readAttribute(rc));
+                accessLogReceiver.logMessage(tokens.readAttribute(rc), rc);
             }
         });
         if (consolidateReroutedRequests) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/accesslog/AccessLogReceiver.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/accesslog/AccessLogReceiver.java
@@ -29,4 +29,18 @@ public interface AccessLogReceiver {
 
     void logMessage(final String message);
 
+    /**
+     * Log a message with the originating {@link io.vertx.ext.web.RoutingContext} so that
+     * implementations can extract structured fields (method, URI, status code, etc.) from
+     * the exchange and attach them to the log record.
+     * <p>
+     * Implementations that do not need structured access to the exchange may rely on the
+     * default implementation which simply delegates to {@link #logMessage(String)}.
+     *
+     * @param message  the pre-formatted access log line
+     * @param exchange the Vert.x routing context for the completed request
+     */
+    default void logMessage(final String message, final io.vertx.ext.web.RoutingContext exchange) {
+        logMessage(message);
+    }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/accesslog/JBossLoggingAccessLogReceiver.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/accesslog/JBossLoggingAccessLogReceiver.java
@@ -18,14 +18,58 @@
 
 package io.quarkus.vertx.http.runtime.filters.accesslog;
 
+import java.util.concurrent.TimeUnit;
+
 import org.jboss.logging.Logger;
+import org.jboss.logging.MDC;
+
+import io.quarkus.vertx.http.runtime.attribute.BytesSentAttribute;
+import io.quarkus.vertx.http.runtime.attribute.RemoteIPAttribute;
+import io.quarkus.vertx.http.runtime.attribute.RequestMethodAttribute;
+import io.quarkus.vertx.http.runtime.attribute.RequestProtocolAttribute;
+import io.quarkus.vertx.http.runtime.attribute.RequestURLAttribute;
+import io.quarkus.vertx.http.runtime.attribute.ResponseCodeAttribute;
+import io.quarkus.vertx.http.runtime.attribute.ResponseTimeAttribute;
+import io.vertx.ext.web.RoutingContext;
 
 /**
- * Access log receiver that logs messages at INFO level.
+ * Access log receiver that logs messages at INFO level via JBoss Logging.
+ * <p>
+ * When {@link #logMessage(String, RoutingContext)} is called, structured request
+ * fields are injected into the thread-local MDC under reserved keys
+ * (all prefixed with {@value #MDC_FIELD_PREFIX}) so that log formatters such as
+ * {@code quarkus-logging-json} can emit them as first-class JSON fields.
+ * The MDC entries are removed in a {@code finally} block, so they never leak
+ * beyond the log call.
  *
  * @author Stuart Douglas
  */
 public class JBossLoggingAccessLogReceiver implements AccessLogReceiver {
+
+    /**
+     * Prefix shared by every MDC key written by this receiver.
+     * Consumers (e.g. logging-json) can use this prefix to discover
+     * and process structured access-log fields.
+     */
+    public static final String MDC_FIELD_PREFIX = "__access__";
+
+    /** MDC key for the HTTP request method (e.g. {@code GET}). */
+    public static final String MDC_METHOD = MDC_FIELD_PREFIX + "method";
+    /** MDC key for the request URI, including the query string when present. */
+    public static final String MDC_URI = MDC_FIELD_PREFIX + "uri";
+    /** MDC key for the HTTP response status code (e.g. {@code 200}). */
+    public static final String MDC_STATUS = MDC_FIELD_PREFIX + "status";
+    /** MDC key for the response time in milliseconds. */
+    public static final String MDC_RESPONSE_TIME_MS = MDC_FIELD_PREFIX + "responseTimeMs";
+    /** MDC key for the number of bytes sent (excluding HTTP headers). */
+    public static final String MDC_BYTES_SENT = MDC_FIELD_PREFIX + "bytesSent";
+    /** MDC key for the remote IP address of the client. */
+    public static final String MDC_REMOTE_IP = MDC_FIELD_PREFIX + "remoteIp";
+    /** MDC key for the HTTP protocol version (e.g. {@code HTTP/1.1}). */
+    public static final String MDC_PROTOCOL = MDC_FIELD_PREFIX + "protocol";
+
+    private static final ResponseTimeAttribute RESPONSE_TIME_ATTR = new ResponseTimeAttribute(TimeUnit.MILLISECONDS);
+    private static final BytesSentAttribute BYTES_SENT_ATTR = new BytesSentAttribute(false);
 
     public static final String DEFAULT_CATEGORY = "io.quarkus.vertx.http.accesslog";
 
@@ -42,5 +86,37 @@ public class JBossLoggingAccessLogReceiver implements AccessLogReceiver {
     @Override
     public void logMessage(String message) {
         logger.info(message);
+    }
+
+    /**
+     * Log the access-log line and populate the thread-local MDC with structured
+     * request/response fields for the duration of the logging call.
+     */
+    @Override
+    public void logMessage(String message, RoutingContext exchange) {
+        putMdcField(MDC_METHOD, RequestMethodAttribute.INSTANCE.readAttribute(exchange));
+        putMdcField(MDC_URI, RequestURLAttribute.INSTANCE.readAttribute(exchange));
+        putMdcField(MDC_STATUS, ResponseCodeAttribute.INSTANCE.readAttribute(exchange));
+        putMdcField(MDC_RESPONSE_TIME_MS, RESPONSE_TIME_ATTR.readAttribute(exchange));
+        putMdcField(MDC_BYTES_SENT, BYTES_SENT_ATTR.readAttribute(exchange));
+        putMdcField(MDC_REMOTE_IP, RemoteIPAttribute.INSTANCE.readAttribute(exchange));
+        putMdcField(MDC_PROTOCOL, RequestProtocolAttribute.INSTANCE.readAttribute(exchange));
+        try {
+            logger.info(message);
+        } finally {
+            MDC.remove(MDC_METHOD);
+            MDC.remove(MDC_URI);
+            MDC.remove(MDC_STATUS);
+            MDC.remove(MDC_RESPONSE_TIME_MS);
+            MDC.remove(MDC_BYTES_SENT);
+            MDC.remove(MDC_REMOTE_IP);
+            MDC.remove(MDC_PROTOCOL);
+        }
+    }
+
+    private static void putMdcField(String key, String value) {
+        if (value != null) {
+            MDC.put(key, value);
+        }
     }
 }


### PR DESCRIPTION
Fixes #23407.

When \`quarkus.log.[console|file|syslog|socket].json.structured-access-log=true\` is set, access log records from \`io.quarkus.http.access-log\` are enriched with a nested \`accessLog\` JSON object containing: \`method\`, \`uri\`, \`status\`, \`responseTimeMs\`, \`bytesSent\`, \`remoteIp\`, \`protocol\`. Defaults to \`false\` — no change to existing output.

## Implementation

Uses thread-local MDC as a zero-coupling bridge between vertx-http and logging-json:

- \`AccessLogReceiver\` gains a \`default logMessage(String, RoutingContext)\` overload so all existing implementations compile unchanged.
- \`AccessLogHandler\` calls the new overload, passing the \`RoutingContext\`.
- \`JBossLoggingAccessLogReceiver\` overrides it to populate MDC keys under the \`__access__\` prefix, then removes them in a \`finally\` block.
- \`JsonFormatter\` collects those keys into a nested \`accessLog\` object and suppresses them from regular MDC/flat-MDC output.

Analogous to #54038.

/cc @gsmet