### PR TITLE
Generate JavaScript client for REST endpoints via OpenAPI schema

### DIFF
--- a/extensions/smallrye-openapi-common/deployment/src/main/java/io/quarkus/smallrye/openapi/common/deployment/SmallRyeOpenApiConfig.java
+++ b/extensions/smallrye-openapi-common/deployment/src/main/java/io/quarkus/smallrye/openapi/common/deployment/SmallRyeOpenApiConfig.java
@@ -474,6 +474,12 @@ public interface SmallRyeOpenApiConfig {
     }
 
     /**
+     * Configuration properties for the JavaScript client proxy generation
+     */
+    @WithName("js-client")
+    SmallRyeOpenApiJsClientConfig jsClient();
+
+    /**
      * OpenAPI documents
      */
     @ConfigDocMapKey("document-name")

--- a/extensions/smallrye-openapi-common/deployment/src/main/java/io/quarkus/smallrye/openapi/common/deployment/SmallRyeOpenApiJsClientConfig.java
+++ b/extensions/smallrye-openapi-common/deployment/src/main/java/io/quarkus/smallrye/openapi/common/deployment/SmallRyeOpenApiJsClientConfig.java
@@ -1,0 +1,14 @@
+package io.quarkus.smallrye.openapi.common.deployment;
+
+import io.smallrye.config.WithDefault;
+
+public interface SmallRyeOpenApiJsClientConfig {
+
+    /**
+     * Generate a JavaScript client proxy for all REST operations discovered by OpenAPI.
+     * When enabled, a static client library and a typed proxy module are generated
+     * as web resources, along with an import map for bare module imports.
+     */
+    @WithDefault("false")
+    boolean enabled();
+}

--- a/extensions/smallrye-openapi/deployment/pom.xml
+++ b/extensions/smallrye-openapi/deployment/pom.xml
@@ -116,6 +116,11 @@
             <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-web-dependency-locator-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -48,7 +48,12 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.eclipse.microprofile.openapi.models.Operation;
+import org.eclipse.microprofile.openapi.models.PathItem;
+import org.eclipse.microprofile.openapi.models.Paths;
+import org.eclipse.microprofile.openapi.models.media.Content;
+import org.eclipse.microprofile.openapi.models.parameters.Parameter;
 import org.eclipse.microprofile.openapi.spi.OASFactoryResolver;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
@@ -90,6 +95,7 @@ import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.logging.LogCleanupFilterBuildItem;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
 import io.quarkus.deployment.util.IoUtil;
 import io.quarkus.resteasy.common.spi.ResteasyDotNames;
@@ -126,7 +132,9 @@ import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.SecurityInformationBuildItem;
 import io.quarkus.vertx.http.deployment.devmode.NotFoundPageDisplayableEndpointBuildItem;
+import io.quarkus.vertx.http.deployment.spi.GeneratedStaticResourceBuildItem;
 import io.quarkus.vertx.http.deployment.spi.RouteBuildItem;
+import io.quarkus.vertx.http.deployment.spi.WebDependencyJarBuildItem;
 import io.quarkus.vertx.http.runtime.management.ManagementInterfaceBuildTimeConfig;
 import io.quarkus.vertx.http.runtime.security.SecurityHandlerPriorities;
 import io.quarkus.vertx.http.security.AuthorizationPolicy;
@@ -1658,5 +1666,351 @@ public class SmallRyeOpenApiProcessor {
 
         IndexView getIndex();
 
+    }
+
+    @BuildStep
+    void generateRestJsClient(
+            SmallRyeOpenApiConfig openApiConfig,
+            List<OpenApiDocumentBuildItem> openApiDocuments,
+            BuildProducer<GeneratedStaticResourceBuildItem> staticResourceProducer) {
+
+        if (!openApiConfig.jsClient().enabled()) {
+            return;
+        }
+
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        for (String resource : List.of("rest/rest-client.js", "rest/rest-client.d.ts")) {
+            try (InputStream is = tccl.getResourceAsStream(resource)) {
+                if (is == null) {
+                    throw new IllegalStateException(resource + " not found on classpath");
+                }
+                String fileName = resource.substring(resource.lastIndexOf('/') + 1);
+                staticResourceProducer.produce(
+                        new GeneratedStaticResourceBuildItem(
+                                "/_static/quarkus-rest/" + fileName,
+                                IoUtil.readBytes(is)));
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        for (OpenApiDocumentBuildItem doc : openApiDocuments) {
+            if (!doc.isDefaultDocument()) {
+                continue;
+            }
+            OpenAPI model = doc.getSmallRyeOpenAPI().model();
+            String proxyJs = generateRestProxy(model);
+            staticResourceProducer.produce(
+                    new GeneratedStaticResourceBuildItem(
+                            "/_static/quarkus-rest-api/rest-api.js",
+                            proxyJs.getBytes(StandardCharsets.UTF_8)));
+            String proxyDts = generateRestProxyDts(model);
+            staticResourceProducer.produce(
+                    new GeneratedStaticResourceBuildItem(
+                            "/_static/quarkus-rest-api/rest-api.d.ts",
+                            proxyDts.getBytes(StandardCharsets.UTF_8)));
+        }
+    }
+
+    @BuildStep
+    void registerRestWebDependency(
+            SmallRyeOpenApiConfig openApiConfig,
+            CurateOutcomeBuildItem curateOutcome,
+            BuildProducer<WebDependencyJarBuildItem> webDependencyProducer) {
+
+        if (!openApiConfig.jsClient().enabled()) {
+            return;
+        }
+
+        curateOutcome.getApplicationModel().getDependencies().stream()
+                .filter(dep -> dep.getGroupId().equals("io.quarkus")
+                        && dep.getArtifactId().equals("quarkus-smallrye-openapi"))
+                .findFirst()
+                .ifPresent(dep -> webDependencyProducer.produce(new WebDependencyJarBuildItem(
+                        dep.getKey(),
+                        dep.getResolvedPaths().getSinglePath(),
+                        Map.of(
+                                "@quarkus/rest", "/_static/quarkus-rest/rest-client.js",
+                                "@quarkus/rest/", "/_static/quarkus-rest/",
+                                "@quarkus/rest-api", "/_static/quarkus-rest-api/rest-api.js",
+                                "@quarkus/rest-api/", "/_static/quarkus-rest-api/"))));
+    }
+
+    private String generateRestProxy(OpenAPI model) {
+        StringBuilder js = new StringBuilder();
+        js.append("import { RestClient } from '@quarkus/rest';\n\n");
+        js.append("export const client = new RestClient();\n\n");
+
+        Paths paths = model.getPaths();
+        if (paths == null || paths.getPathItems() == null) {
+            return js.toString();
+        }
+
+        Map<String, List<OperationEntry>> byTag = new java.util.TreeMap<>();
+
+        for (Map.Entry<String, PathItem> pathEntry : paths.getPathItems().entrySet()) {
+            String path = pathEntry.getKey();
+            PathItem pathItem = pathEntry.getValue();
+            if (pathItem.getOperations() == null) {
+                continue;
+            }
+            for (Map.Entry<PathItem.HttpMethod, Operation> opEntry : pathItem.getOperations().entrySet()) {
+                PathItem.HttpMethod httpMethod = opEntry.getKey();
+                Operation op = opEntry.getValue();
+
+                String functionName = op.getOperationId();
+                if (functionName == null || functionName.isEmpty()) {
+                    functionName = httpMethod.name().toLowerCase()
+                            + sanitizePath(path);
+                }
+
+                String tag = "Default";
+                if (op.getTags() != null && !op.getTags().isEmpty()) {
+                    tag = op.getTags().get(0);
+                }
+
+                byTag.computeIfAbsent(tag, k -> new ArrayList<>())
+                        .add(new OperationEntry(functionName, httpMethod, path, op));
+            }
+        }
+
+        for (Map.Entry<String, List<OperationEntry>> tagEntry : byTag.entrySet()) {
+            String tag = sanitizeIdentifier(tagEntry.getKey());
+            List<OperationEntry> ops = tagEntry.getValue();
+            ops.sort(Comparator.comparing(e -> e.functionName));
+
+            js.append("export const ").append(tag).append(" = {\n");
+            for (int i = 0; i < ops.size(); i++) {
+                OperationEntry entry = ops.get(i);
+                generateOperationFunction(js, entry);
+                if (i < ops.size() - 1) {
+                    js.append(",");
+                }
+                js.append("\n");
+            }
+            js.append("};\n\n");
+        }
+
+        return js.toString();
+    }
+
+    private void generateOperationFunction(StringBuilder js, OperationEntry entry) {
+        Operation op = entry.operation;
+        String method = entry.httpMethod.name();
+
+        List<String> pathParamNames = new ArrayList<>();
+        List<String> queryParamNames = new ArrayList<>();
+        List<String> headerParamNames = new ArrayList<>();
+        List<String> cookieParamNames = new ArrayList<>();
+
+        if (op.getParameters() != null) {
+            for (Parameter param : op.getParameters()) {
+                if (param.getIn() == null || param.getName() == null) {
+                    continue;
+                }
+                switch (param.getIn()) {
+                    case PATH -> pathParamNames.add(param.getName());
+                    case QUERY -> queryParamNames.add(param.getName());
+                    case HEADER -> headerParamNames.add(param.getName());
+                    case COOKIE -> cookieParamNames.add(param.getName());
+                }
+            }
+        }
+
+        boolean hasBody = op.getRequestBody() != null;
+        String consumesType = null;
+        if (hasBody && op.getRequestBody().getContent() != null) {
+            Content content = op.getRequestBody().getContent();
+            if (content.getMediaTypes() != null && !content.getMediaTypes().isEmpty()) {
+                consumesType = content.getMediaTypes().keySet().iterator().next();
+            }
+        }
+
+        String producesType = null;
+        if (op.getResponses() != null) {
+            var successResp = op.getResponses().getAPIResponse("200");
+            if (successResp == null) {
+                successResp = op.getResponses().getAPIResponse("201");
+            }
+            if (successResp != null && successResp.getContent() != null
+                    && successResp.getContent().getMediaTypes() != null
+                    && !successResp.getContent().getMediaTypes().isEmpty()) {
+                producesType = successResp.getContent().getMediaTypes().keySet().iterator().next();
+            }
+        }
+
+        List<String> allParamNames = new ArrayList<>();
+        if (hasBody) {
+            allParamNames.add("body");
+        }
+        allParamNames.addAll(pathParamNames);
+        allParamNames.addAll(queryParamNames);
+        allParamNames.addAll(headerParamNames);
+        allParamNames.addAll(cookieParamNames);
+
+        js.append("    ").append(escapeJsIdentifier(entry.functionName)).append(": (");
+        if (!allParamNames.isEmpty()) {
+            js.append("{ ");
+            js.append(String.join(", ", allParamNames));
+            js.append(" } = {}");
+        }
+        js.append(") => client.request('").append(method).append("', '")
+                .append(escapeJs(entry.path)).append("', { ");
+
+        List<String> opts = new ArrayList<>();
+        if (!pathParamNames.isEmpty()) {
+            opts.add("pathParams: { " + String.join(", ", pathParamNames) + " }");
+        }
+        if (!queryParamNames.isEmpty()) {
+            opts.add("queryParams: { " + String.join(", ", queryParamNames) + " }");
+        }
+        if (!headerParamNames.isEmpty()) {
+            opts.add("headerParams: { " + String.join(", ", headerParamNames) + " }");
+        }
+        if (!cookieParamNames.isEmpty()) {
+            opts.add("cookieParams: { " + String.join(", ", cookieParamNames) + " }");
+        }
+        if (hasBody) {
+            opts.add("body");
+        }
+        if (consumesType != null && !"application/json".equals(consumesType)) {
+            opts.add("contentType: '" + escapeJs(consumesType) + "'");
+        }
+        if (producesType != null && !"application/json".equals(producesType)) {
+            opts.add("accept: '" + escapeJs(producesType) + "'");
+        }
+
+        js.append(String.join(", ", opts));
+        js.append(" })");
+    }
+
+    private String generateRestProxyDts(OpenAPI model) {
+        StringBuilder dts = new StringBuilder();
+        dts.append("import { RestClient } from '@quarkus/rest';\n\n");
+        dts.append("export declare const client: RestClient;\n\n");
+
+        Paths paths = model.getPaths();
+        if (paths == null || paths.getPathItems() == null) {
+            return dts.toString();
+        }
+
+        Map<String, List<OperationEntry>> byTag = new java.util.TreeMap<>();
+
+        for (Map.Entry<String, PathItem> pathEntry : paths.getPathItems().entrySet()) {
+            String path = pathEntry.getKey();
+            PathItem pathItem = pathEntry.getValue();
+            if (pathItem.getOperations() == null) {
+                continue;
+            }
+            for (Map.Entry<PathItem.HttpMethod, Operation> opEntry : pathItem.getOperations().entrySet()) {
+                PathItem.HttpMethod httpMethod = opEntry.getKey();
+                Operation op = opEntry.getValue();
+
+                String functionName = op.getOperationId();
+                if (functionName == null || functionName.isEmpty()) {
+                    functionName = httpMethod.name().toLowerCase()
+                            + sanitizePath(path);
+                }
+
+                String tag = "Default";
+                if (op.getTags() != null && !op.getTags().isEmpty()) {
+                    tag = op.getTags().get(0);
+                }
+
+                byTag.computeIfAbsent(tag, k -> new ArrayList<>())
+                        .add(new OperationEntry(functionName, httpMethod, path, op));
+            }
+        }
+
+        for (Map.Entry<String, List<OperationEntry>> tagEntry : byTag.entrySet()) {
+            String tag = sanitizeIdentifier(tagEntry.getKey());
+            List<OperationEntry> ops = tagEntry.getValue();
+            ops.sort(Comparator.comparing(e -> e.functionName));
+
+            dts.append("export declare const ").append(tag).append(": {\n");
+            for (OperationEntry entry : ops) {
+                generateOperationDts(dts, entry);
+            }
+            dts.append("};\n\n");
+        }
+
+        return dts.toString();
+    }
+
+    private void generateOperationDts(StringBuilder dts, OperationEntry entry) {
+        Operation op = entry.operation;
+
+        List<String> paramFields = new ArrayList<>();
+
+        if (op.getRequestBody() != null) {
+            paramFields.add("body?: unknown");
+        }
+
+        if (op.getParameters() != null) {
+            for (Parameter param : op.getParameters()) {
+                if (param.getIn() == null || param.getName() == null) {
+                    continue;
+                }
+                String tsType = param.getIn() == Parameter.In.PATH ? "string | number" : "string";
+                boolean required = param.getIn() == Parameter.In.PATH;
+                paramFields.add(param.getName() + (required ? "" : "?") + ": " + tsType);
+            }
+        }
+
+        dts.append("    ").append(escapeJsIdentifier(entry.functionName)).append(": (");
+        if (!paramFields.isEmpty()) {
+            dts.append("params: { ");
+            dts.append(String.join("; ", paramFields));
+            dts.append(" }");
+        }
+        dts.append(") => Promise<unknown>;\n");
+    }
+
+    static String sanitizePath(String path) {
+        StringBuilder sb = new StringBuilder();
+        boolean capitalizeNext = true;
+        for (char c : path.toCharArray()) {
+            if (c == '/' || c == '{' || c == '}' || c == '-' || c == '_' || c == '.') {
+                capitalizeNext = true;
+            } else if (capitalizeNext) {
+                sb.append(Character.toUpperCase(c));
+                capitalizeNext = false;
+            } else {
+                sb.append(c);
+            }
+        }
+        return sb.toString();
+    }
+
+    static String sanitizeIdentifier(String name) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < name.length(); i++) {
+            char c = name.charAt(i);
+            if (sb.isEmpty() ? Character.isJavaIdentifierStart(c) : Character.isJavaIdentifierPart(c)) {
+                sb.append(c);
+            }
+        }
+        return sb.isEmpty() ? "Default" : sb.toString();
+    }
+
+    static String escapeJsIdentifier(String name) {
+        if (name == null || name.isEmpty()) {
+            return "unnamed";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < name.length(); i++) {
+            char c = name.charAt(i);
+            if (sb.isEmpty() ? Character.isJavaIdentifierStart(c) : Character.isJavaIdentifierPart(c)) {
+                sb.append(c);
+            }
+        }
+        return sb.isEmpty() ? "unnamed" : sb.toString();
+    }
+
+    static String escapeJs(String value) {
+        return value.replace("\\", "\\\\").replace("'", "\\'");
+    }
+
+    private record OperationEntry(String functionName, PathItem.HttpMethod httpMethod, String path, Operation operation) {
     }
 }

--- a/extensions/smallrye-openapi/deployment/src/main/resources/rest/rest-client.d.ts
+++ b/extensions/smallrye-openapi/deployment/src/main/resources/rest/rest-client.d.ts
@@ -1,0 +1,34 @@
+export interface RestClientOptions {
+    basePath?: string;
+    token?: string;
+    tokenProvider?: () => string | Promise<string>;
+}
+
+export interface RequestOptions {
+    pathParams?: Record<string, string | number>;
+    queryParams?: Record<string, string | number | boolean>;
+    headerParams?: Record<string, string>;
+    cookieParams?: Record<string, string>;
+    body?: unknown;
+    contentType?: string;
+    accept?: string;
+}
+
+export class RestClient {
+    static configure(options?: RestClientOptions): void;
+
+    constructor(options?: RestClientOptions);
+
+    basePath: string;
+    token: string | null;
+
+    request(method: string, pathTemplate: string, opts?: RequestOptions): Promise<unknown>;
+}
+
+export class RestError extends Error {
+    status: number;
+    statusText: string;
+    body: string;
+
+    constructor(status: number, statusText: string, body: string);
+}

--- a/extensions/smallrye-openapi/deployment/src/main/resources/rest/rest-client.js
+++ b/extensions/smallrye-openapi/deployment/src/main/resources/rest/rest-client.js
@@ -1,0 +1,124 @@
+export class RestClient {
+    static _config = {};
+
+    static configure(options = {}) {
+        RestClient._config = { ...RestClient._config, ...options };
+    }
+
+    _basePath;
+    _token = null;
+    _tokenProvider = null;
+
+    constructor(options = {}) {
+        const merged = { ...RestClient._config, ...options };
+        this._basePath = merged.basePath || '';
+        this._token = merged.token || null;
+        this._tokenProvider = merged.tokenProvider || null;
+    }
+
+    get basePath() {
+        return this._basePath;
+    }
+
+    set basePath(value) {
+        this._basePath = value;
+    }
+
+    get token() {
+        return this._token;
+    }
+
+    set token(value) {
+        this._token = value;
+    }
+
+    async request(method, pathTemplate, opts = {}) {
+        const { pathParams, queryParams, headerParams, cookieParams, body, contentType, accept } = opts;
+
+        let resolvedPath = pathTemplate;
+        if (pathParams) {
+            resolvedPath = pathTemplate.replace(/\{([^}]+)\}/g, (_, key) =>
+                encodeURIComponent(pathParams[key]));
+        }
+
+        let url = this._basePath + resolvedPath;
+
+        if (queryParams) {
+            const search = new URLSearchParams();
+            for (const [key, value] of Object.entries(queryParams)) {
+                if (value !== undefined && value !== null) {
+                    search.append(key, value);
+                }
+            }
+            const qs = search.toString();
+            if (qs) {
+                url += '?' + qs;
+            }
+        }
+
+        const headers = {};
+        headers['Accept'] = accept || 'application/json';
+
+        if (body !== null && body !== undefined) {
+            headers['Content-Type'] = contentType || 'application/json';
+        }
+
+        if (headerParams) {
+            for (const [key, value] of Object.entries(headerParams)) {
+                if (value !== undefined && value !== null) {
+                    headers[key] = value;
+                }
+            }
+        }
+
+        if (cookieParams) {
+            for (const [key, value] of Object.entries(cookieParams)) {
+                if (value !== undefined && value !== null) {
+                    document.cookie = `${encodeURIComponent(key)}=${encodeURIComponent(value)}`;
+                }
+            }
+        }
+
+        const token = await this._resolveToken();
+        if (token) {
+            headers['Authorization'] = token;
+        }
+
+        const options = { method, headers };
+        if (body !== null && body !== undefined) {
+            options.body = typeof body === 'string' ? body : JSON.stringify(body);
+        }
+
+        const resp = await fetch(url, options);
+        if (!resp.ok) {
+            throw new RestError(resp.status, resp.statusText, await resp.text().catch(() => ''));
+        }
+        const text = await resp.text();
+        if (!text) {
+            return null;
+        }
+        try {
+            return JSON.parse(text);
+        } catch {
+            return text;
+        }
+    }
+
+    _resolveToken() {
+        const provider = this._tokenProvider || RestClient._config.tokenProvider;
+        if (provider) {
+            return provider();
+        }
+        return this._token || RestClient._config.token || null;
+    }
+}
+
+export class RestError extends Error {
+    constructor(status, statusText, body) {
+        super(`${status} ${statusText}`);
+        this.name = 'RestError';
+        this.status = status;
+        this.statusText = statusText;
+        this.body = body;
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/deployment/RestJsClientUtilsTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/deployment/RestJsClientUtilsTest.java
@@ -1,0 +1,97 @@
+package io.quarkus.smallrye.openapi.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+class RestJsClientUtilsTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "'/greeting'             , 'Greeting'",
+            "'/greeting/{name}'      , 'GreetingName'",
+            "'/api/tasks'            , 'ApiTasks'",
+            "'/api/tasks/{id}'       , 'ApiTasksId'",
+            "'/users-list'           , 'UsersList'",
+            "'/user_profile'         , 'UserProfile'",
+            "'/v1.0/items'           , 'V10Items'",
+            "'/'                     , ''",
+            "'/a'                    , 'A'",
+            "'/a/b/c'               , 'ABC'",
+            "'/api/{org}/{repo}'     , 'ApiOrgRepo'",
+    })
+    void sanitizePath(String input, String expected) {
+        assertEquals(expected, SmallRyeOpenApiProcessor.sanitizePath(input));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "'GreetingResource' , 'GreetingResource'",
+            "'Default'          , 'Default'",
+            "'my-tag'           , 'mytag'",
+            "'my tag'           , 'mytag'",
+            "'123invalid'       , 'invalid'",
+            "'_private'         , '_private'",
+            "'$special'         , '$special'",
+            "'validName123'     , 'validName123'",
+    })
+    void sanitizeIdentifier(String input, String expected) {
+        assertEquals(expected, SmallRyeOpenApiProcessor.sanitizeIdentifier(input));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "''          , 'Default'",
+            "'!!!'       , 'Default'",
+    })
+    void sanitizeIdentifierFallsBackToDefault(String input, String expected) {
+        assertEquals(expected, SmallRyeOpenApiProcessor.sanitizeIdentifier(input));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "'getGreeting'     , 'getGreeting'",
+            "'hello_world'     , 'hello_world'",
+            "'my-method'       , 'mymethod'",
+            "'_private'        , '_private'",
+            "'$special'        , '$special'",
+            "'valid123'        , 'valid123'",
+    })
+    void escapeJsIdentifier(String input, String expected) {
+        assertEquals(expected, SmallRyeOpenApiProcessor.escapeJsIdentifier(input));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void escapeJsIdentifierFallsBackToUnnamed(String input) {
+        assertEquals("unnamed", SmallRyeOpenApiProcessor.escapeJsIdentifier(input));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "'!!!'       , 'unnamed'",
+    })
+    void escapeJsIdentifierInvalidChars(String input, String expected) {
+        assertEquals(expected, SmallRyeOpenApiProcessor.escapeJsIdentifier(input));
+    }
+
+    @ParameterizedTest
+    @MethodSource("escapeJsArgs")
+    void escapeJs(String input, String expected) {
+        assertEquals(expected, SmallRyeOpenApiProcessor.escapeJs(input));
+    }
+
+    static Stream<Arguments> escapeJsArgs() {
+        return Stream.of(
+                Arguments.of("hello", "hello"),
+                Arguments.of("it's", "it\\'s"),
+                Arguments.of("back\\slash", "back\\\\slash"),
+                Arguments.of("no special chars", "no special chars"));
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/deployment/filter/SecurityConfigFilterTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/deployment/filter/SecurityConfigFilterTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.smallrye.openapi.common.deployment.OpenApiDocumentConfig;
 import io.quarkus.smallrye.openapi.common.deployment.SmallRyeOpenApiConfig;
+import io.quarkus.smallrye.openapi.common.deployment.SmallRyeOpenApiJsClientConfig;
 
 class SecurityConfigFilterTest {
 
@@ -74,6 +75,11 @@ class SecurityConfigFilterTest {
         @Override
         public boolean managementEnabled() {
             return false;
+        }
+
+        @Override
+        public SmallRyeOpenApiJsClientConfig jsClient() {
+            return () -> false;
         }
 
         @Override

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/RestJsClientDisabledTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/RestJsClientDisabledTest.java
@@ -1,0 +1,45 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+
+public class RestJsClientDisabledTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(RestJsClientTest.GreetingResource.class)
+                    .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"));
+
+    @Test
+    public void testClientLibraryNotServedWhenDisabled() {
+        RestAssured.get("/_static/quarkus-rest/rest-client.js")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    public void testTypedProxyNotServedWhenDisabled() {
+        RestAssured.get("/_static/quarkus-rest-api/rest-api.js")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    public void testClientDeclarationsNotServedWhenDisabled() {
+        RestAssured.get("/_static/quarkus-rest/rest-client.d.ts")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    public void testProxyDeclarationsNotServedWhenDisabled() {
+        RestAssured.get("/_static/quarkus-rest-api/rest-api.d.ts")
+                .then()
+                .statusCode(404);
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/RestJsClientTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/RestJsClientTest.java
@@ -1,0 +1,108 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import static org.hamcrest.CoreMatchers.containsString;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+
+public class RestJsClientTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(GreetingResource.class)
+                    .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"))
+            .overrideConfigKey("quarkus.smallrye-openapi.js-client.enabled", "true");
+
+    @Path("/greeting")
+    public static class GreetingResource {
+
+        @GET
+        public String hello() {
+            return "hello";
+        }
+
+        @GET
+        @Path("/{name}")
+        public String helloName(@PathParam("name") String name) {
+            return "hello " + name;
+        }
+
+        @POST
+        public String create(String body) {
+            return "created: " + body;
+        }
+    }
+
+    @Test
+    public void testClientLibraryIsServed() {
+        RestAssured.get("/_static/quarkus-rest/rest-client.js")
+                .then()
+                .statusCode(200)
+                .body(containsString("export class RestClient"));
+    }
+
+    @Test
+    public void testTypedProxyIsServed() {
+        RestAssured.get("/_static/quarkus-rest-api/rest-api.js")
+                .then()
+                .statusCode(200)
+                .body(containsString("import { RestClient }"))
+                .body(containsString("export const client"));
+    }
+
+    @Test
+    public void testProxyContainsOperations() {
+        RestAssured.get("/_static/quarkus-rest-api/rest-api.js")
+                .then()
+                .statusCode(200)
+                .body(containsString("/greeting"))
+                .body(containsString("client.request('GET'"))
+                .body(containsString("client.request('POST'"));
+    }
+
+    @Test
+    public void testProxyContainsPathParams() {
+        RestAssured.get("/_static/quarkus-rest-api/rest-api.js")
+                .then()
+                .statusCode(200)
+                .body(containsString("pathParams"))
+                .body(containsString("{ name }"));
+    }
+
+    @Test
+    public void testClientDeclarationsAreServed() {
+        RestAssured.get("/_static/quarkus-rest/rest-client.d.ts")
+                .then()
+                .statusCode(200)
+                .body(containsString("export class RestClient"))
+                .body(containsString("export class RestError"));
+    }
+
+    @Test
+    public void testProxyDeclarationsAreServed() {
+        RestAssured.get("/_static/quarkus-rest-api/rest-api.d.ts")
+                .then()
+                .statusCode(200)
+                .body(containsString("import { RestClient }"))
+                .body(containsString("export declare const client: RestClient"));
+    }
+
+    @Test
+    public void testProxyDeclarationsContainOperations() {
+        RestAssured.get("/_static/quarkus-rest-api/rest-api.d.ts")
+                .then()
+                .statusCode(200)
+                .body(containsString("Promise<unknown>"))
+                .body(containsString("name: string | number"));
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/RestWebDependencyLocatorTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/RestWebDependencyLocatorTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import static org.hamcrest.CoreMatchers.containsString;
+
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+
+public class RestWebDependencyLocatorTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(RestJsClientTest.GreetingResource.class)
+                    .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"))
+            .overrideConfigKey("quarkus.smallrye-openapi.js-client.enabled", "true");
+
+    @Test
+    public void testImportMapContainsRestMappings() {
+        RestAssured.get("/_importmap/generated_importmap.js")
+                .then()
+                .statusCode(200)
+                .body(containsString("@quarkus/rest"))
+                .body(containsString("/_static/quarkus-rest/rest-client.js"))
+                .body(containsString("@quarkus/rest-api"))
+                .body(containsString("/_static/quarkus-rest-api/rest-api.js"));
+    }
+}


### PR DESCRIPTION
When `quarkus.smallrye-openapi.js-client.enabled` is set to `true`, the SmallRye OpenAPI extension generates a JavaScript client library and a typed proxy module from the OpenAPI schema at build time.

The typed proxy exports one object per OpenAPI tag (mapping to REST resource classes) with functions for each operation. Parameters are extracted from the OpenAPI model by type — `@PathParam` is substituted into the URL, `@QueryParam` appended as search params, `@HeaderParam` set as headers, `@CookieParam` set as cookies. Content negotiation is per-operation based on `@Produces`/`@Consumes`.

```javascript
import { TaskResource } from '@quarkus/rest-api';

const tasks = await TaskResource.getApiTasks();
const task = await TaskResource.postApiTasks({ body: { title: 'New' } });
await TaskResource.deleteApiTasksId({ id: 42 }); // path param resolved
```

A `WebDependencyJarBuildItem` is produced so web-dependency-locator can resolve bare `@quarkus/rest` and `@quarkus/rest-api` imports via import maps.

Security is supported via `RestClient.configure({ token, tokenProvider })` — tokens are sent as `Authorization` headers on all requests.

This follows the same pattern as the GraphQL JS client ([#54680](https://github.com/quarkusio/quarkus/pull/54680)) and quarkus-json-rpc ([quarkiverse/quarkus-json-rpc#102](https://github.com/quarkiverse/quarkus-json-rpc/pull/102)).