### PR TITLE
Dev-UI: Update German translation for 'Read me' to 'Lies mich'

### DIFF
--- a/extensions/devui/resources/src/main/resources/dev-ui/i18n/de.js
+++ b/extensions/devui/resources/src/main/resources/dev-ui/i18n/de.js
@@ -10,7 +10,7 @@ export const templates = {
     'menu-continuous_testing': 'Kontinuierliches Testen',
     'menu-dev_services': 'Entwicklungsdienste',
     'menu-build_metrics': 'Build-Metriken',
-    'menu-readme': 'Lese mich',
+    'menu-readme': 'Lies mich',
     'menu-dependencies': 'Abhängigkeiten',
     'menu-remove-context-item': 'Entfernen',
     'settings-title': 'Einstellungen',


### PR DESCRIPTION
Fixed a minor grammar error in the german translation of the dev-Ui: "Lese mich" -> "Lies mich".

Imperative (2nd-person singular) of "lesen" is "lies", not "lese" (though "lese" is often heard), see: https://de.pons.com/verbtabellen/deutsch/lesen?instance=53818710#imperativ.

