### PR TITLE
Fall back to plain PostgreSQL when PostGIS image is unavailable for the host architecture

### DIFF
--- a/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresImageSelector.java
+++ b/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresImageSelector.java
@@ -9,12 +9,16 @@ import org.jboss.logging.Logger;
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.quarkus.datasource.deployment.spi.DatabaseFeature;
 import io.quarkus.devservices.common.ConfigureUtil;
+import io.smallrye.common.cpu.CPU;
 
 class PostgresImageSelector {
 
     private static final Logger log = Logger.getLogger(PostgresImageSelector.class);
 
-    static String selectImage(Optional<String> explicitImage, Set<DatabaseFeature> requiredFeatures, String datasourceName) {
+    static final Set<CPU> POSTGIS_SUPPORTED_ARCHITECTURES = Set.of(CPU.x64);
+
+    static String selectImage(Optional<String> explicitImage, Set<DatabaseFeature> requiredFeatures,
+            String datasourceName, CPU architecture) {
         if (explicitImage.isPresent()) {
             return explicitImage.get();
         }
@@ -27,7 +31,7 @@ class PostgresImageSelector {
             DatabaseFeature feature = requiredFeatures.iterator().next();
             return switch (feature) {
                 case VECTOR -> ConfigureUtil.getDefaultImageNameFor("pgvector");
-                case SPATIAL -> ConfigureUtil.getDefaultImageNameFor("postgis");
+                case SPATIAL -> selectPostgisOrFallback(datasourceName, architecture);
             };
         }
 
@@ -41,6 +45,18 @@ class PostgresImageSelector {
                 featureNames,
                 DataSourceUtil.dataSourcePropertyKey(datasourceName, "devservices.image-name"));
 
+        return ConfigureUtil.getDefaultImageNameFor("postgresql");
+    }
+
+    private static String selectPostgisOrFallback(String datasourceName, CPU architecture) {
+        if (POSTGIS_SUPPORTED_ARCHITECTURES.contains(architecture)) {
+            return ConfigureUtil.getDefaultImageNameFor("postgis");
+        }
+        log.warnv("The PostGIS container image is not available for architecture '{0}'."
+                + " Falling back to a plain PostgreSQL image without PostGIS support."
+                + " To use PostGIS on this architecture, specify a compatible image using '{1}'.",
+                architecture,
+                DataSourceUtil.dataSourcePropertyKey(datasourceName, "devservices.image-name"));
         return ConfigureUtil.getDefaultImageNameFor("postgresql");
     }
 }

--- a/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
+++ b/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
@@ -34,6 +34,7 @@ import io.quarkus.devservices.common.JBossLoggingConsumer;
 import io.quarkus.devservices.common.Labels;
 import io.quarkus.devservices.common.Volumes;
 import io.quarkus.runtime.LaunchMode;
+import io.smallrye.common.cpu.CPU;
 
 public class PostgresqlDevServicesProcessor {
 
@@ -72,7 +73,8 @@ public class PostgresqlDevServicesProcessor {
                         DataSourceUtil.isDefault(datasourceName) ? DEFAULT_DATABASE_NAME : datasourceName);
 
                 String selectedImage = PostgresImageSelector.selectImage(containerConfig.getImageName(),
-                        containerConfig.getRequiredFeatures(), containerConfig.getDatasourceName());
+                        containerConfig.getRequiredFeatures(), containerConfig.getDatasourceName(),
+                        CPU.host());
                 QuarkusPostgreSQLContainer container = new QuarkusPostgreSQLContainer(Optional.of(selectedImage),
                         containerConfig.getFixedExposedPort(),
                         composeProjectBuildItem.getDefaultNetworkId(),
@@ -114,7 +116,8 @@ public class PostgresqlDevServicesProcessor {
                     DevServicesComposeProjectBuildItem composeProjectBuildItem) {
 
                 String selectedImage = PostgresImageSelector.selectImage(containerConfig.getImageName(),
-                        containerConfig.getRequiredFeatures(), containerConfig.getDatasourceName());
+                        containerConfig.getRequiredFeatures(), containerConfig.getDatasourceName(),
+                        CPU.host());
                 List<String> images = List.of(selectedImage, "postgres");
                 return ComposeLocator
                         .locateContainer(composeProjectBuildItem, images, POSTGRESQL_PORT, launchMode, useSharedNetwork)

--- a/extensions/devservices/postgresql/src/test/java/io/quarkus/devservices/postgresql/deployment/PostgresImageSelectorTest.java
+++ b/extensions/devservices/postgresql/src/test/java/io/quarkus/devservices/postgresql/deployment/PostgresImageSelectorTest.java
@@ -8,38 +8,50 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.datasource.deployment.spi.DatabaseFeature;
 import io.quarkus.devservices.common.ConfigureUtil;
+import io.smallrye.common.cpu.CPU;
 
 class PostgresImageSelectorTest {
+
+    private static final CPU DEFAULT_ARCH = CPU.x64;
 
     @Test
     void shouldReturnExplicitImageIfPresent() {
         String image = PostgresImageSelector.selectImage(Optional.of("postgres:latest"),
-                Set.of(DatabaseFeature.VECTOR, DatabaseFeature.SPATIAL), "pgsql");
+                Set.of(DatabaseFeature.VECTOR, DatabaseFeature.SPATIAL), "pgsql", DEFAULT_ARCH);
         Assertions.assertEquals("postgres:latest", image);
     }
 
     @Test
     void shouldReturnDefaultImageIfNoFeatures() {
-        String image = PostgresImageSelector.selectImage(Optional.empty(), Set.of(), "pgsql");
+        String image = PostgresImageSelector.selectImage(Optional.empty(), Set.of(), "pgsql", DEFAULT_ARCH);
         Assertions.assertEquals(ConfigureUtil.getDefaultImageNameFor("postgresql"), image);
     }
 
     @Test
     void shouldReturnDefaultImageIfCombinationOfFeatures() {
         String image = PostgresImageSelector.selectImage(Optional.empty(),
-                Set.of(DatabaseFeature.VECTOR, DatabaseFeature.SPATIAL), "pgsql");
+                Set.of(DatabaseFeature.VECTOR, DatabaseFeature.SPATIAL), "pgsql", DEFAULT_ARCH);
         Assertions.assertEquals(ConfigureUtil.getDefaultImageNameFor("postgresql"), image);
     }
 
     @Test
     void shouldReturnVectorImageIfVectorFeatureIsPresent() {
-        String image = PostgresImageSelector.selectImage(Optional.empty(), Set.of(DatabaseFeature.VECTOR), "pgsql");
+        String image = PostgresImageSelector.selectImage(Optional.empty(), Set.of(DatabaseFeature.VECTOR), "pgsql",
+                DEFAULT_ARCH);
         Assertions.assertEquals(ConfigureUtil.getDefaultImageNameFor("pgvector"), image);
     }
 
     @Test
-    void shouldReturnSpatialImageIfSpatialFeatureIsPresent() {
-        String image = PostgresImageSelector.selectImage(Optional.empty(), Set.of(DatabaseFeature.SPATIAL), "pgsql");
+    void shouldReturnSpatialImageIfSpatialFeatureIsPresentOnSupportedArch() {
+        String image = PostgresImageSelector.selectImage(Optional.empty(), Set.of(DatabaseFeature.SPATIAL), "pgsql",
+                DEFAULT_ARCH);
         Assertions.assertEquals(ConfigureUtil.getDefaultImageNameFor("postgis"), image);
+    }
+
+    @Test
+    void shouldFallBackToDefaultImageIfSpatialFeatureOnUnsupportedArch() {
+        String image = PostgresImageSelector.selectImage(Optional.empty(), Set.of(DatabaseFeature.SPATIAL), "pgsql",
+                CPU.aarch64);
+        Assertions.assertEquals(ConfigureUtil.getDefaultImageNameFor("postgresql"), image);
     }
 }


### PR DESCRIPTION
The postgis/postgis Docker image does not publish aarch64 variants, causing dev services to fail with "exec format error" on ARM64 hosts. PostgresImageSelector now checks os.arch against a hardcoded set of supported architectures and falls back to the default PostgreSQL image with a warning when PostGIS is unavailable.

* Fixes #54734

Assisted-By: Claude Code <noreply@anthropic.com>
