### PR TITLE
Introduce ExactlyOnce annotation to simplify Kafka exactly-once processing

### DIFF
--- a/docs/src/main/asciidoc/kafka.adoc
+++ b/docs/src/main/asciidoc/kafka.adoc
@@ -1735,7 +1735,161 @@ If the incoming record does have a _null_ key, the `mp.messaging.outgoing.$chann
 Kafka Transactions allows managing consumer offsets inside a transaction, together with produced messages.
 This enables coupling a consumer with a transactional producer in a _consume-transform-produce_ pattern, also known as *exactly-once processing*.
 
-The `KafkaTransactions` custom emitter provides a way to apply exactly-once processing to an incoming Kafka message inside a transaction.
+==== Declarative Exactly-Once with `@ExactlyOnce`
+
+The simplest way to enable exactly-once processing is to annotate a processor method with `@ExactlyOnce`.
+The method must have both `@Incoming` and `@Outgoing` annotations, and both channels must be managed by the Kafka connector:
+
+[source, java]
+----
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import io.quarkus.smallrye.reactivemessaging.kafka.ExactlyOnce;
+import io.smallrye.reactive.messaging.kafka.Record;
+
+@ApplicationScoped
+public class OrderProcessor {
+
+    @Incoming("orders-in")
+    @Outgoing("orders-out")
+    @ExactlyOnce
+    Record<String, Integer> process(Record<String, Integer> order) {
+        return Record.of(order.key(), order.value() + 1);
+    }
+}
+----
+
+Each incoming record is consumed and the result is produced within a single Kafka transaction, ensuring atomic consumption and production -- no duplicates and no message loss.
+
+The method can also return a `List` to produce multiple records per input:
+
+[source, java]
+----
+@Incoming("orders-in")
+@Outgoing("orders-out")
+@ExactlyOnce
+List<Record<String, Integer>> process(Record<String, Integer> order) {
+    return List.of(
+            Record.of(order.key(), order.value() * 10),
+            Record.of(order.key(), order.value() * 10 + 1));
+}
+----
+
+Quarkus auto-configures the following Kafka properties when `@ExactlyOnce` is detected:
+
+[cols="1,1"]
+|===
+| Property | Value
+
+| `transactional.id` (outgoing)
+| `${quarkus.application.name}-<channel-name>`
+
+| `enable.idempotence` (outgoing)
+| `true`
+
+| `acks` (outgoing)
+| `all`
+
+| `commit-strategy` (incoming)
+| `ignore`
+
+| `isolation.level` (incoming)
+| `read_committed`
+|===
+
+These can be overridden in `application.properties` if needed.
+
+The method can also return reactive types (`Uni`, `CompletionStage`).
+In that case, the method runs non-blocking and the transaction commits when the returned `Uni` completes:
+
+[source, java]
+----
+@Incoming("orders-in")
+@Outgoing("orders-out")
+@ExactlyOnce
+Uni<Record<String, Integer>> process(Record<String, Integer> order) {
+    return invokeExternalService(order)
+            .onItem().transform(result -> Record.of(order.key(), result));
+}
+----
+
+[NOTE]
+====
+`@ExactlyOnce` methods must use payload parameters (e.g., `Record<K, V>`, plain types), not `Message<?>`.
+====
+
+===== Combining with Database Transactions
+
+`@ExactlyOnce` can be combined with database transactions.
+The database transaction runs inside the Kafka transaction: if the database commit fails, the Kafka transaction is rolled back too.
+If the database commit succeeds but the Kafka transaction fails, the database changes persist but the message will be reprocessed.
+So you need to design your consumer to be idempotent to handle this case.
+For stronger guarantees, consider using the transactional outbox pattern.
+
+For **Hibernate ORM** (blocking), use `@Transactional`:
+
+[source, java]
+----
+@Incoming("orders-in")
+@Outgoing("orders-out")
+@ExactlyOnce
+@Transactional
+Record<String, Order> process(Record<String, Order> order) {
+    OrderEntity entity = new OrderEntity(order.value());
+    entity.persist();
+    return Record.of(order.key(), order.value());
+}
+----
+
+For **Hibernate Reactive**, use `@Transactional` or `@WithTransaction` with a reactive return type:
+
+[source, java]
+----
+@Incoming("orders-in")
+@Outgoing("orders-out")
+@ExactlyOnce
+@Transactional
+Uni<Record<String, Order>> process(Record<String, Order> order) {
+    OrderEntity entity = new OrderEntity(order.value());
+    return entity.persist()
+            .map(e -> Record.of(order.key(), order.value()));
+}
+----
+
+===== Error Handling
+
+When an `@ExactlyOnce` method throws an exception, the Kafka transaction is aborted and the consumer offset is reset to the last committed position.
+The message will be retried automatically on the next poll.
+If the method is also annotated with `@Transactional`, the database transaction is rolled back as well.
+
+Using the `@ExactlyOnce` annotation, the incoming channel `commit-strategy` and `failure-strategy` attributes are set by default to `ignore`,
+in order to allow the Kafka transaction to manage the offset commits.
+
+===== Routing to a Different Topic
+
+To route records to a different topic within the exactly-once transaction (e.g., a dead-letter topic), return a `ProducerRecord` with the target topic:
+
+[source, java]
+----
+@Incoming("orders-in")
+@Outgoing("orders-out")
+@ExactlyOnce
+ProducerRecord<String, Order> process(Record<String, Order> order) {
+    if (order.value().isInvalid()) {
+        return new ProducerRecord<>("orders-dlq", order.key(), order.value());
+    }
+    return new ProducerRecord<>("orders-out", order.key(), order.value());
+}
+----
+
+The record is sent transactionally — if the transaction is aborted, neither the main output nor the dead-letter record is published.
+
+==== Manual Exactly-Once with `KafkaTransactions`
+
+For more advanced use cases, the `KafkaTransactions` custom emitter provides a way to apply exactly-once processing to an incoming Kafka message inside a transaction.
 
 The following example includes a batch of Kafka records inside a transaction.
 

--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/DotNames.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/DotNames.java
@@ -17,6 +17,7 @@ final class DotNames {
     static final DotName MUTINY_EMITTER = DotName.createSimple(io.smallrye.reactive.messaging.MutinyEmitter.class.getName());
     static final DotName CONTEXTUAL_EMITTER = DotName.createSimple(io.quarkus.smallrye.reactivemessaging.runtime.ContextualEmitter.class.getName());
     static final DotName KAFKA_TRANSACTIONS_EMITTER = DotName.createSimple(io.smallrye.reactive.messaging.kafka.transactions.KafkaTransactions.class.getName());
+    static final DotName EXACTLY_ONCE = DotName.createSimple(io.quarkus.smallrye.reactivemessaging.kafka.ExactlyOnce.class.getName());
     static final DotName KAFKA_REQUEST_REPLY_EMITTER = DotName.createSimple(io.smallrye.reactive.messaging.kafka.reply.KafkaRequestReply.class.getName());
 
     static final DotName TARGETED = DotName.createSimple(io.smallrye.reactive.messaging.Targeted.class.getName());
@@ -56,5 +57,13 @@ final class DotNames {
     static final DotName LIST = DotName.createSimple(java.util.List.class.getName());
     static final DotName KAFKA_BATCH_RECORD = DotName.createSimple(io.smallrye.reactive.messaging.kafka.KafkaRecordBatch.class.getName());
     static final DotName CONSUMER_RECORDS = DotName.createSimple(org.apache.kafka.clients.consumer.ConsumerRecords.class.getName());
+
+    static final DotName VOID = DotName.createSimple(void.class.getName());
+    static final DotName VOID_BOXED = DotName.createSimple(Void.class.getName());
+    static final DotName BLOCKING = DotName.createSimple(io.smallrye.reactive.messaging.annotations.Blocking.class.getName());
+    static final DotName SMALLRYE_BLOCKING = DotName.createSimple(io.smallrye.common.annotation.Blocking.class.getName());
+    static final DotName TRANSACTIONAL = DotName.createSimple("jakarta.transaction.Transactional");
+    static final DotName WITH_TRANSACTION = DotName.createSimple("io.quarkus.hibernate.reactive.panache.common.WithTransaction");
+    static final DotName CONTINUATION = DotName.createSimple("kotlin.coroutines.Continuation");
     // @formatter:on
 }

--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/SmallRyeReactiveMessagingKafkaProcessor.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/SmallRyeReactiveMessagingKafkaProcessor.java
@@ -1,9 +1,11 @@
 package io.quarkus.smallrye.reactivemessaging.kafka.deployment;
 
+import static io.quarkus.smallrye.reactivemessaging.kafka.deployment.DotNames.VOID_BOXED;
 import static io.quarkus.smallrye.reactivemessaging.runtime.ReactiveMessagingConfiguration.getChannelIncomingPropertyName;
 import static io.quarkus.smallrye.reactivemessaging.runtime.ReactiveMessagingConfiguration.getChannelOutgoingPropertyName;
 import static io.quarkus.smallrye.reactivemessaging.runtime.ReactiveMessagingConfiguration.getChannelPropertyName;
 
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -15,7 +17,9 @@ import java.util.function.Function;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.ConfigValue;
+import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
 import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
@@ -26,6 +30,7 @@ import org.jboss.logging.Logger;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.processor.KotlinUtils;
 import io.quarkus.deployment.Feature;
+import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Consume;
@@ -39,12 +44,27 @@ import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
 import io.quarkus.deployment.builditem.RuntimeConfigSetupCompleteBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.logging.LogCleanupFilterBuildItem;
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.ClassOutput;
+import io.quarkus.gizmo.FieldDescriptor;
+import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.runtime.util.HashUtil;
 import io.quarkus.smallrye.reactivemessaging.deployment.ReactiveMessagingDotNames;
 import io.quarkus.smallrye.reactivemessaging.deployment.items.ChannelDirection;
 import io.quarkus.smallrye.reactivemessaging.deployment.items.ConnectorManagedChannelBuildItem;
+import io.quarkus.smallrye.reactivemessaging.deployment.items.CustomInvokerBuildItem;
+import io.quarkus.smallrye.reactivemessaging.deployment.items.InjectedEmitterBuildItem;
+import io.quarkus.smallrye.reactivemessaging.kafka.ExactlyOnceInvoker;
 import io.quarkus.smallrye.reactivemessaging.kafka.KafkaConfigCustomizer;
+import io.quarkus.smallrye.reactivemessaging.kafka.ReactiveExactlyOnceInvoker;
 import io.smallrye.mutiny.tuples.Functions.TriConsumer;
+import io.smallrye.reactive.messaging.MediatorConfiguration;
+import io.smallrye.reactive.messaging.Shape;
 import io.smallrye.reactive.messaging.kafka.KafkaConnector;
+import io.smallrye.reactive.messaging.kafka.api.IncomingKafkaRecordBatchMetadata;
+import io.smallrye.reactive.messaging.kafka.api.IncomingKafkaRecordMetadata;
 import io.smallrye.reactive.messaging.kafka.commit.ProcessingState;
 
 public class SmallRyeReactiveMessagingKafkaProcessor {
@@ -107,6 +127,231 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
             }
         }
         return values;
+    }
+
+    @BuildStep
+    public void exactlyOnceProcessing(
+            CombinedIndexBuildItem combinedIndex,
+            List<ConnectorManagedChannelBuildItem> channelsManagedByConnectors,
+            BuildProducer<RunTimeConfigurationDefaultBuildItem> defaultConfigProducer,
+            BuildProducer<InjectedEmitterBuildItem> emitters) {
+
+        DefaultSerdeDiscoveryState discoveryState = new DefaultSerdeDiscoveryState(combinedIndex.getIndex());
+
+        for (AnnotationInstance annotation : combinedIndex.getIndex().getAnnotations(DotNames.EXACTLY_ONCE)) {
+            if (annotation.target().kind() != AnnotationTarget.Kind.METHOD) {
+                continue;
+            }
+            MethodInfo method = annotation.target().asMethod();
+            String methodName = method.declaringClass().name() + "#" + method.name();
+
+            AnnotationInstance incoming = method.annotation(DotNames.INCOMING);
+            AnnotationInstance outgoing = method.annotation(DotNames.OUTGOING);
+
+            if (incoming == null || outgoing == null) {
+                throw new IllegalArgumentException(
+                        "@ExactlyOnce on method " + methodName + " requires both @Incoming and @Outgoing annotations");
+            }
+
+            if (method.parametersCount() == 0) {
+                throw new IllegalArgumentException(
+                        "@ExactlyOnce on method " + methodName + " requires at least one parameter");
+            }
+
+            for (Type paramType : method.parameterTypes()) {
+                if (paramType.name().equals(DotNames.MESSAGE)) {
+                    throw new IllegalArgumentException(
+                            "@ExactlyOnce on method " + methodName
+                                    + " does not support Message parameters, use payload types instead");
+                }
+            }
+
+            if (method.returnType().name().equals(DotNames.VOID)
+                    || method.returnType().name().equals(VOID_BOXED)) {
+                throw new IllegalArgumentException(
+                        "@ExactlyOnce on method " + methodName
+                                + " must return a value to produce to the outgoing channel");
+            }
+
+            if (method.hasAnnotation(DotNames.BLOCKING) || method.hasAnnotation(DotNames.SMALLRYE_BLOCKING)) {
+                throw new IllegalArgumentException(
+                        "@ExactlyOnce on method " + methodName
+                                + " cannot be combined with @Blocking");
+            }
+
+            DotName returnTypeName = method.returnType().name();
+            boolean reactive = DotNames.UNI.equals(returnTypeName) || DotNames.MULTI.equals(returnTypeName)
+                    || DotNames.COMPLETION_STAGE.equals(returnTypeName);
+
+            if (reactive && method.returnType().kind() == Type.Kind.PARAMETERIZED_TYPE) {
+                DotName typeArg = method.returnType().asParameterizedType().arguments().get(0).name();
+                if (typeArg.equals(VOID_BOXED)) {
+                    throw new IllegalArgumentException(
+                            "@ExactlyOnce on method " + methodName
+                                    + " must return a value to produce to the outgoing channel");
+                }
+            }
+
+            if (method.hasAnnotation(DotNames.WITH_TRANSACTION) && !reactive) {
+                throw new IllegalArgumentException(
+                        "@ExactlyOnce on method " + methodName
+                                + " cannot combine @WithTransaction with a synchronous return type"
+                                + ", use @Transactional instead");
+            }
+
+            if (method.hasAnnotation(DotNames.TRANSACTIONAL) && method.hasAnnotation(DotNames.WITH_TRANSACTION)) {
+                throw new IllegalArgumentException(
+                        "@ExactlyOnce on method " + methodName
+                                + " cannot combine @Transactional with @WithTransaction");
+            }
+
+            boolean isSuspend = method.parameterTypes().stream()
+                    .anyMatch(t -> t.name().equals(DotNames.CONTINUATION));
+            if (isSuspend) {
+                throw new IllegalArgumentException(
+                        "@ExactlyOnce on method " + methodName
+                                + " does not support Kotlin suspend functions");
+            }
+
+            String incomingChannel = incoming.value().asString();
+            String outgoingChannel = outgoing.value().asString();
+
+            if (!discoveryState.isKafkaConnector(channelsManagedByConnectors, true, incomingChannel)) {
+                throw new IllegalArgumentException(
+                        "@ExactlyOnce on method " + methodName
+                                + ": incoming channel '" + incomingChannel + "' is not managed by the Kafka connector");
+            }
+            if (!discoveryState.isKafkaConnector(channelsManagedByConnectors, false, outgoingChannel)) {
+                throw new IllegalArgumentException(
+                        "@ExactlyOnce on method " + methodName
+                                + ": outgoing channel '" + outgoingChannel + "' is not managed by the Kafka connector");
+            }
+
+            LOGGER.infof("Exactly-once processing detected on method %s#%s, " +
+                    "configuring channels '%s' (incoming) and '%s' (outgoing)",
+                    method.declaringClass().name(), method.name(), incomingChannel, outgoingChannel);
+
+            // Auto-configure outgoing channel for transactions
+            produceRuntimeConfigurationDefaultBuildItem(discoveryState, defaultConfigProducer,
+                    getChannelOutgoingPropertyName(outgoingChannel, "transactional.id"),
+                    "${quarkus.application.name}-" + outgoingChannel);
+            produceRuntimeConfigurationDefaultBuildItem(discoveryState, defaultConfigProducer,
+                    getChannelOutgoingPropertyName(outgoingChannel, "enable.idempotence"), "true");
+            produceRuntimeConfigurationDefaultBuildItem(discoveryState, defaultConfigProducer,
+                    getChannelOutgoingPropertyName(outgoingChannel, "acks"), "all");
+
+            // Auto-configure incoming channel for exactly-once
+            produceRuntimeConfigurationDefaultBuildItem(discoveryState, defaultConfigProducer,
+                    getChannelIncomingPropertyName(incomingChannel, "commit-strategy"), "ignore");
+            produceRuntimeConfigurationDefaultBuildItem(discoveryState, defaultConfigProducer,
+                    getChannelIncomingPropertyName(incomingChannel, "isolation.level"), "read_committed");
+            produceRuntimeConfigurationDefaultBuildItem(discoveryState, defaultConfigProducer,
+                    getChannelIncomingPropertyName(incomingChannel, "failure-strategy"), "fail");
+
+            // Register a KafkaTransactions emitter for the outgoing channel
+            emitters.produce(InjectedEmitterBuildItem.of(outgoingChannel,
+                    DotNames.KAFKA_TRANSACTIONS_EMITTER.toString(),
+                    null, -1, false, -1));
+        }
+    }
+
+    @BuildStep
+    public void generateExactlyOnceInvokers(
+            CombinedIndexBuildItem combinedIndex,
+            BuildProducer<GeneratedClassBuildItem> generatedClass,
+            BuildProducer<CustomInvokerBuildItem> customInvokers,
+            BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
+
+        ClassOutput classOutput = new GeneratedClassGizmoAdaptor(generatedClass, true);
+
+        for (AnnotationInstance annotation : combinedIndex.getIndex().getAnnotations(DotNames.EXACTLY_ONCE)) {
+            if (annotation.target().kind() != AnnotationTarget.Kind.METHOD) {
+                continue;
+            }
+            MethodInfo method = annotation.target().asMethod();
+
+            String generatedName = generateExactlyOnceInvoker(method, classOutput);
+            String invokerClassName = generatedName.replace('/', '.');
+
+            customInvokers.produce(CustomInvokerBuildItem
+                    .builder(CustomInvokerBuildItem.mediatorMethodId(method), invokerClassName)
+                    .shape(Shape.SUBSCRIBER)
+                    .production(MediatorConfiguration.Production.NONE)
+                    .acknowledgment(Acknowledgment.Strategy.POST_PROCESSING)
+                    .syntheticParameterTypes(List.of(
+                            IncomingKafkaRecordMetadata.class.getName(),
+                            IncomingKafkaRecordBatchMetadata.class.getName()))
+                    .build());
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(invokerClassName).build());
+        }
+    }
+
+    private String generateExactlyOnceInvoker(MethodInfo method, ClassOutput classOutput) {
+        AnnotationInstance outgoing = method.annotation(DotNames.OUTGOING);
+        String outgoingChannel = outgoing != null ? outgoing.value().asString() : "";
+
+        DotName returnTypeName = method.returnType().name();
+        boolean reactive = DotNames.UNI.equals(returnTypeName) || DotNames.MULTI.equals(returnTypeName)
+                || DotNames.COMPLETION_STAGE.equals(returnTypeName);
+
+        String superClass;
+        if (reactive) {
+            superClass = ReactiveExactlyOnceInvoker.class.getName();
+        } else {
+            superClass = ExactlyOnceInvoker.class.getName();
+        }
+
+        String baseName = method.declaringClass().name().withoutPackagePrefix();
+        StringBuilder sigBuilder = new StringBuilder();
+        sigBuilder.append(method.name()).append("_").append(method.returnType().name().toString());
+        for (Type i : method.parameterTypes()) {
+            sigBuilder.append(i.name().toString());
+        }
+        String targetPackage = method.declaringClass().name().packagePrefix().replace('.', '/') + "/";
+        String generatedName = targetPackage + baseName
+                + "_ExactlyOnceInvoker_" + method.name() + "_"
+                + HashUtil.sha1(sigBuilder.toString());
+
+        try (ClassCreator invoker = ClassCreator.builder().classOutput(classOutput).className(generatedName)
+                .superClass(superClass)
+                .build()) {
+
+            String beanInstanceType = method.declaringClass().name().toString();
+            FieldDescriptor beanInstanceField = invoker.getFieldCreator("beanInstance", beanInstanceType)
+                    .getFieldDescriptor();
+
+            try (MethodCreator ctor = invoker.getMethodCreator("<init>", void.class, Object.class)) {
+                ctor.setModifiers(Modifier.PUBLIC);
+                ctor.invokeSpecialMethod(
+                        MethodDescriptor.ofConstructor(superClass, String.class),
+                        ctor.getThis(), ctor.load(outgoingChannel));
+                ctor.writeInstanceField(beanInstanceField, ctor.getThis(), ctor.getMethodParam(0));
+                ctor.returnValue(null);
+            }
+
+            try (MethodCreator invokeBean = invoker.getMethodCreator(
+                    MethodDescriptor.ofMethod(generatedName, "invokeBean", Object.class, Object[].class))) {
+                invokeBean.setModifiers(Modifier.PROTECTED);
+
+                int parametersCount = method.parametersCount();
+                String[] argTypes = new String[parametersCount];
+                ResultHandle[] args = new ResultHandle[parametersCount];
+                for (int i = 0; i < parametersCount; i++) {
+                    args[i] = invokeBean.readArrayValue(invokeBean.getMethodParam(0), i);
+                    argTypes[i] = method.parameterType(i).name().toString();
+                }
+                ResultHandle result = invokeBean.invokeVirtualMethod(
+                        MethodDescriptor.ofMethod(beanInstanceType, method.name(),
+                                method.returnType().name().toString(), argTypes),
+                        invokeBean.readInstanceField(beanInstanceField, invokeBean.getThis()), args);
+                if (DotNames.VOID.equals(method.returnType().name())) {
+                    invokeBean.returnValue(invokeBean.loadNull());
+                } else {
+                    invokeBean.returnValue(result);
+                }
+            }
+        }
+        return generatedName;
     }
 
     /**

--- a/extensions/smallrye-reactive-messaging-kafka/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/ExactlyOnce.java
+++ b/extensions/smallrye-reactive-messaging-kafka/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/ExactlyOnce.java
@@ -1,0 +1,38 @@
+package io.quarkus.smallrye.reactivemessaging.kafka;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Enables Kafka exactly-once processing semantics on a method annotated with
+ * both {@code @Incoming} and {@code @Outgoing}.
+ * <p>
+ * The annotated method consumes records from an incoming Kafka topic and produces results
+ * to an outgoing Kafka topic within a single Kafka transaction, ensuring that consumption
+ * and production are atomic — no duplicates and no message loss.
+ * <p>
+ * The method must use payload parameters (not {@code Message}) and both channels must be
+ * managed by the Kafka connector. Both synchronous and reactive ({@code Uni}, {@code CompletionStage})
+ * return types are supported.
+ * <p>
+ * The following Kafka properties are auto-configured:
+ * <ul>
+ * <li>Outgoing: {@code transactional.id}, {@code enable.idempotence=true}, {@code acks=all}</li>
+ * <li>Incoming: {@code commit-strategy=ignore}, {@code isolation.level=read_committed}</li>
+ * </ul>
+ *
+ * <pre>
+ * &#64;Incoming("orders-in")
+ * &#64;Outgoing("orders-out")
+ * &#64;ExactlyOnce
+ * Record&lt;String, Order&gt; process(Record&lt;String, Order&gt; order) {
+ *     // transform and return
+ * }
+ * </pre>
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExactlyOnce {
+}

--- a/extensions/smallrye-reactive-messaging-kafka/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/ExactlyOnceInvoker.java
+++ b/extensions/smallrye-reactive-messaging-kafka/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/ExactlyOnceInvoker.java
@@ -1,0 +1,75 @@
+package io.quarkus.smallrye.reactivemessaging.kafka;
+
+import java.util.Arrays;
+
+import jakarta.enterprise.inject.spi.CDI;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.reactive.messaging.ChannelRegistry;
+import io.smallrye.reactive.messaging.Invoker;
+import io.smallrye.reactive.messaging.kafka.api.IncomingKafkaRecordBatchMetadata;
+import io.smallrye.reactive.messaging.kafka.api.IncomingKafkaRecordMetadata;
+import io.smallrye.reactive.messaging.kafka.transactions.KafkaTransactions;
+import io.smallrye.reactive.messaging.kafka.transactions.TransactionalEmitter;
+
+public abstract class ExactlyOnceInvoker implements Invoker {
+
+    private static final int SYNTHETIC_PARAM_COUNT = 2;
+
+    private final KafkaTransactions<Object> kafkaTransactions;
+
+    @SuppressWarnings("unchecked")
+    protected ExactlyOnceInvoker(String outgoingChannel) {
+        ChannelRegistry registry = CDI.current().select(ChannelRegistry.class).get();
+        this.kafkaTransactions = registry.getEmitter(outgoingChannel, KafkaTransactions.class);
+    }
+
+    protected abstract Object invokeBean(Object... args);
+
+    @Override
+    public Object invoke(Object... args) {
+        IncomingKafkaRecordMetadata<?, ?> recordMeta = (IncomingKafkaRecordMetadata<?, ?>) args[args.length - 2];
+        IncomingKafkaRecordBatchMetadata<?, ?> batchMeta = (IncomingKafkaRecordBatchMetadata<?, ?>) args[args.length - 1];
+
+        Object[] beanArgs = Arrays.copyOf(args, args.length - SYNTHETIC_PARAM_COUNT);
+
+        return invokeBeanInTransaction(kafkaTransactions, beanArgs, recordMeta, batchMeta);
+    }
+
+    protected Object invokeBeanInTransaction(KafkaTransactions<Object> tx, Object[] beanArgs,
+            IncomingKafkaRecordMetadata<?, ?> recordMeta, IncomingKafkaRecordBatchMetadata<?, ?> batchMeta) {
+        if (batchMeta != null) {
+            tx.withTransactionAndAwait(batchMeta, emitter -> {
+                sendResult(invokeBean(beanArgs), emitter);
+                return Uni.createFrom().voidItem();
+            });
+        } else if (recordMeta != null) {
+            tx.withTransactionAndAwait(recordMeta, emitter -> {
+                sendResult(invokeBean(beanArgs), emitter);
+                return Uni.createFrom().voidItem();
+            });
+        } else {
+            throw new IllegalStateException("No Kafka record metadata found on incoming message");
+        }
+        return null;
+    }
+
+    protected void sendResult(Object result, TransactionalEmitter<Object> emitter) {
+        if (result == null) {
+            return;
+        }
+        if (result instanceof Iterable<?> items) {
+            for (Object item : items) {
+                emitter.send(item);
+            }
+        } else if (result instanceof Multi<?> multi) {
+            for (Object item : multi.subscribe().asIterable()) {
+                emitter.send(item);
+            }
+        } else {
+            emitter.send(result);
+        }
+    }
+
+}

--- a/extensions/smallrye-reactive-messaging-kafka/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/ReactiveExactlyOnceInvoker.java
+++ b/extensions/smallrye-reactive-messaging-kafka/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/ReactiveExactlyOnceInvoker.java
@@ -1,0 +1,50 @@
+package io.quarkus.smallrye.reactivemessaging.kafka;
+
+import java.util.concurrent.CompletionStage;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.reactive.messaging.kafka.api.IncomingKafkaRecordBatchMetadata;
+import io.smallrye.reactive.messaging.kafka.api.IncomingKafkaRecordMetadata;
+import io.smallrye.reactive.messaging.kafka.transactions.KafkaTransactions;
+import io.smallrye.reactive.messaging.kafka.transactions.TransactionalEmitter;
+
+public abstract class ReactiveExactlyOnceInvoker extends ExactlyOnceInvoker {
+
+    protected ReactiveExactlyOnceInvoker(String outgoingChannel) {
+        super(outgoingChannel);
+    }
+
+    @Override
+    protected Object invokeBeanInTransaction(KafkaTransactions<Object> tx, Object[] beanArgs,
+            IncomingKafkaRecordMetadata<?, ?> recordMeta, IncomingKafkaRecordBatchMetadata<?, ?> batchMeta) {
+        if (batchMeta != null) {
+            return tx.withTransaction(batchMeta, emitter -> handleResult(invokeBean(beanArgs), emitter));
+        } else if (recordMeta != null) {
+            return tx.withTransaction(recordMeta, emitter -> handleResult(invokeBean(beanArgs), emitter));
+        } else {
+            throw new IllegalStateException("No Kafka record metadata found on incoming message");
+        }
+    }
+
+    private Uni<Void> handleResult(Object result, TransactionalEmitter<Object> emitter) {
+        if (result == null) {
+            return Uni.createFrom().voidItem();
+        }
+        if (result instanceof Uni<?> uni) {
+            return uni.onItem().invoke(item -> sendResult(item, emitter))
+                    .replaceWithVoid();
+        }
+        if (result instanceof CompletionStage<?> cs) {
+            return Uni.createFrom().completionStage(cs)
+                    .onItem().invoke(item -> sendResult(item, emitter))
+                    .replaceWithVoid();
+        }
+        if (result instanceof Multi<?> multi) {
+            return multi.onItem().invoke(emitter::send)
+                    .onItem().ignoreAsUni();
+        }
+        sendResult(result, emitter);
+        return Uni.createFrom().voidItem();
+    }
+}

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/QuarkusMediatorConfigurationUtil.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/QuarkusMediatorConfigurationUtil.java
@@ -34,6 +34,7 @@ import org.jboss.jandex.Type;
 import io.quarkus.arc.processor.BeanInfo;
 import io.quarkus.deployment.recording.RecorderContext;
 import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.smallrye.reactivemessaging.deployment.items.CustomInvokerBuildItem;
 import io.quarkus.smallrye.reactivemessaging.runtime.QuarkusMediatorConfiguration;
 import io.quarkus.smallrye.reactivemessaging.runtime.QuarkusParameterDescriptor;
 import io.quarkus.smallrye.reactivemessaging.runtime.QuarkusWorkerPoolRegistry;
@@ -52,7 +53,8 @@ public final class QuarkusMediatorConfigurationUtil {
 
     public static QuarkusMediatorConfiguration create(MethodInfo methodInfo, boolean isSuspendMethod, BeanInfo bean,
             RecorderContext recorderContext,
-            ClassLoader cl, boolean strict, ReactiveMessagingConfiguration.ExecutionMode executionMode) {
+            ClassLoader cl, boolean strict, ReactiveMessagingConfiguration.ExecutionMode executionMode,
+            CustomInvokerBuildItem customInvoker) {
 
         Class[] parameterTypeClasses;
         Class<?> returnTypeClass;
@@ -182,6 +184,35 @@ public final class QuarkusMediatorConfigurationUtil {
                     }
                 }));
         configuration.setHasTargetedOutput(mediatorConfigurationSupport.processTargetedOutput());
+
+        if (customInvoker != null) {
+            if (customInvoker.getShape() != null) {
+                configuration.setShape(customInvoker.getShape());
+                configuration.setOutgoings(List.of());
+            }
+            if (customInvoker.getProduction() != null) {
+                configuration.setProduction(customInvoker.getProduction());
+            }
+            if (customInvoker.getConsumption() != null) {
+                configuration.setConsumption(customInvoker.getConsumption());
+            }
+            if (customInvoker.getAcknowledgment() != null) {
+                configuration.setAcknowledgment(customInvoker.getAcknowledgment());
+            }
+            if (customInvoker.getMerge() != null) {
+                configuration.setMerge(customInvoker.getMerge());
+            }
+            if (customInvoker.getBlocking() != null) {
+                configuration.setBlocking(customInvoker.getBlocking());
+            }
+            for (String syntheticParamType : customInvoker.getSyntheticParameterTypes()) {
+                TypeInfo ti = new TypeInfo();
+                ti.setName(recorderContext.classProxy(syntheticParamType));
+                ti.setGenerics(List.of());
+                gen.add(ti);
+            }
+        }
+
         if (!hasBlockingAnnotation(methodInfo)
                 && !hasNonBlockingAnnotation(methodInfo)
                 && hasBlockingPayloadSignature(methodInfo)) {

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/SmallRyeReactiveMessagingProcessor.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/SmallRyeReactiveMessagingProcessor.java
@@ -74,6 +74,7 @@ import io.quarkus.runtime.util.HashUtil;
 import io.quarkus.smallrye.health.deployment.spi.HealthBuildItem;
 import io.quarkus.smallrye.reactivemessaging.deployment.items.ChannelDirection;
 import io.quarkus.smallrye.reactivemessaging.deployment.items.ConnectorManagedChannelBuildItem;
+import io.quarkus.smallrye.reactivemessaging.deployment.items.CustomInvokerBuildItem;
 import io.quarkus.smallrye.reactivemessaging.deployment.items.InjectedChannelBuildItem;
 import io.quarkus.smallrye.reactivemessaging.deployment.items.InjectedEmitterBuildItem;
 import io.quarkus.smallrye.reactivemessaging.deployment.items.MediatorBuildItem;
@@ -272,6 +273,7 @@ public class SmallRyeReactiveMessagingProcessor {
             List<ConnectorManagedChannelBuildItem> connectorManagedChannels,
             List<InjectedEmitterBuildItem> emitterFields,
             List<InjectedChannelBuildItem> channelFields,
+            List<CustomInvokerBuildItem> customInvokers,
             BuildProducer<GeneratedClassBuildItem> generatedClass,
             BuildProducer<GeneratedResourceBuildItem> generatedResources,
             BuildProducer<GeneratedServiceProviderBuildItem> generatedServiceProviders,
@@ -287,6 +289,11 @@ public class SmallRyeReactiveMessagingProcessor {
                 .map(ConnectorManagedChannelBuildItem::getName)
                 .collect(Collectors.toSet());
 
+        Map<String, CustomInvokerBuildItem> customInvokerMap = new HashMap<>();
+        for (CustomInvokerBuildItem item : customInvokers) {
+            customInvokerMap.put(item.getMethodId(), item);
+        }
+
         List<QuarkusMediatorConfiguration> mediatorConfigurations = new ArrayList<>(mediatorMethods.size());
         List<WorkerConfiguration> workerConfigurations = new ArrayList<>();
         Map<String, EmitterConfiguration> emittersConfigurations = new HashMap<>();
@@ -300,6 +307,9 @@ public class SmallRyeReactiveMessagingProcessor {
         for (MediatorBuildItem mediatorMethod : mediatorMethods) {
             MethodInfo methodInfo = mediatorMethod.getMethod();
             BeanInfo bean = mediatorMethod.getBean();
+
+            String methodId = CustomInvokerBuildItem.mediatorMethodId(methodInfo);
+            CustomInvokerBuildItem customInvoker = customInvokerMap.get(methodId);
 
             if (QuarkusMediatorConfigurationUtil.hasBlockingAnnotation(methodInfo)) {
                 // Just in case both annotation are used, use @Blocking value.
@@ -333,11 +343,12 @@ public class SmallRyeReactiveMessagingProcessor {
                                 Thread.currentThread().getContextClassLoader(), conf.strict(),
                                 consumesFromConnector(methodInfo, connectorManagedIncomingChannels)
                                         ? conf.blockingSignaturesExecutionMode()
-                                        : ReactiveMessagingConfiguration.ExecutionMode.EVENT_LOOP); // disable execution mode setting for inner channels
+                                        : ReactiveMessagingConfiguration.ExecutionMode.EVENT_LOOP,
+                                customInvoker); // disable execution mode setting for inner channels
                 mediatorConfigurations.add(mediatorConfiguration);
 
                 String generatedInvokerName = generateInvoker(bean, methodInfo, isSuspendMethod, mediatorConfiguration,
-                        gizmo);
+                        gizmo, customInvokerMap);
                 /*
                  * We need to register the invoker's constructor for reflection since it will be called inside smallrye.
                  * We could potentially lift this restriction with some extra CDI bean generation, but it's probably not worth
@@ -401,7 +412,14 @@ public class SmallRyeReactiveMessagingProcessor {
      */
     private String generateInvoker(BeanInfo bean, MethodInfo method, boolean isSuspendMethod,
             QuarkusMediatorConfiguration mediatorConfiguration,
-            Gizmo gizmo) {
+            Gizmo gizmo, Map<String, CustomInvokerBuildItem> customInvokerMap) {
+
+        String methodId = CustomInvokerBuildItem.mediatorMethodId(method);
+        CustomInvokerBuildItem customInvoker = customInvokerMap.get(methodId);
+        if (customInvoker != null) {
+            return customInvoker.getInvokerClassName();
+        }
+
         String baseName;
         if (bean.getImplClazz().enclosingClass() != null) {
             baseName = DotNames.simpleName(bean.getImplClazz().enclosingClass()) + "_"

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/items/CustomInvokerBuildItem.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/items/CustomInvokerBuildItem.java
@@ -1,0 +1,147 @@
+package io.quarkus.smallrye.reactivemessaging.deployment.items;
+
+import java.util.List;
+
+import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
+import org.jboss.jandex.MethodInfo;
+
+import io.quarkus.builder.item.MultiBuildItem;
+import io.smallrye.reactive.messaging.MediatorConfiguration;
+import io.smallrye.reactive.messaging.Shape;
+import io.smallrye.reactive.messaging.annotations.Merge;
+
+/**
+ * Provides a pre-generated invoker class for a specific mediator method.
+ * When present, the core messaging processor skips invoker generation for the matching method
+ * and applies the specified mediator configuration overrides.
+ * <p>
+ * All override fields are nullable — when {@code null}, the default configuration from
+ * the mediator annotation processing is preserved.
+ */
+public final class CustomInvokerBuildItem extends MultiBuildItem {
+
+    private final String methodId;
+    private final String invokerClassName;
+    private final List<String> syntheticParameterTypes;
+    // Overrides for MediatorConfiguration
+    private final Shape shape;
+    private final MediatorConfiguration.Production production;
+    private final MediatorConfiguration.Consumption consumption;
+    private final Acknowledgment.Strategy acknowledgment;
+    private final Merge.Mode merge;
+    private final Boolean blocking;
+
+    private CustomInvokerBuildItem(Builder builder) {
+        this.methodId = builder.methodId;
+        this.invokerClassName = builder.invokerClassName;
+        this.shape = builder.shape;
+        this.production = builder.production;
+        this.consumption = builder.consumption;
+        this.acknowledgment = builder.acknowledgment;
+        this.merge = builder.merge;
+        this.blocking = builder.blocking;
+        this.syntheticParameterTypes = builder.syntheticParameterTypes != null
+                ? builder.syntheticParameterTypes
+                : List.of();
+    }
+
+    public static Builder builder(String methodId, String invokerClassName) {
+        return new Builder(methodId, invokerClassName);
+    }
+
+    public static String mediatorMethodId(MethodInfo method) {
+        return method.declaringClass().name().toString() + "#" + method.name() + method.descriptor();
+    }
+
+    public String getMethodId() {
+        return methodId;
+    }
+
+    public String getInvokerClassName() {
+        return invokerClassName;
+    }
+
+    public Shape getShape() {
+        return shape;
+    }
+
+    public MediatorConfiguration.Production getProduction() {
+        return production;
+    }
+
+    public MediatorConfiguration.Consumption getConsumption() {
+        return consumption;
+    }
+
+    public Acknowledgment.Strategy getAcknowledgment() {
+        return acknowledgment;
+    }
+
+    public Merge.Mode getMerge() {
+        return merge;
+    }
+
+    public Boolean getBlocking() {
+        return blocking;
+    }
+
+    public List<String> getSyntheticParameterTypes() {
+        return syntheticParameterTypes;
+    }
+
+    public static class Builder {
+        private final String methodId;
+        private final String invokerClassName;
+        private Shape shape;
+        private MediatorConfiguration.Production production;
+        private MediatorConfiguration.Consumption consumption;
+        private Acknowledgment.Strategy acknowledgment;
+        private Merge.Mode merge;
+        private Boolean blocking;
+        private List<String> syntheticParameterTypes;
+
+        private Builder(String methodId, String invokerClassName) {
+            this.methodId = methodId;
+            this.invokerClassName = invokerClassName;
+        }
+
+        public Builder shape(Shape shape) {
+            this.shape = shape;
+            return this;
+        }
+
+        public Builder production(MediatorConfiguration.Production production) {
+            this.production = production;
+            return this;
+        }
+
+        public Builder consumption(MediatorConfiguration.Consumption consumption) {
+            this.consumption = consumption;
+            return this;
+        }
+
+        public Builder acknowledgment(Acknowledgment.Strategy acknowledgment) {
+            this.acknowledgment = acknowledgment;
+            return this;
+        }
+
+        public Builder merge(Merge.Mode merge) {
+            this.merge = merge;
+            return this;
+        }
+
+        public Builder blocking(boolean blocking) {
+            this.blocking = blocking;
+            return this;
+        }
+
+        public Builder syntheticParameterTypes(List<String> syntheticParameterTypes) {
+            this.syntheticParameterTypes = syntheticParameterTypes;
+            return this;
+        }
+
+        public CustomInvokerBuildItem build() {
+            return new CustomInvokerBuildItem(this);
+        }
+    }
+}

--- a/integration-tests/reactive-messaging-hibernate-orm/src/main/java/io/quarkus/it/kafka/KafkaEndpoint.java
+++ b/integration-tests/reactive-messaging-hibernate-orm/src/main/java/io/quarkus/it/kafka/KafkaEndpoint.java
@@ -11,6 +11,9 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
 import io.quarkus.hibernate.orm.PersistenceUnit;
+import io.quarkus.it.kafka.fruit.ExactlyOnceFruit;
+import io.quarkus.it.kafka.fruit.ExactlyOnceFruitConsumer;
+import io.quarkus.it.kafka.fruit.ExactlyOnceFruitProcessor;
 import io.quarkus.it.kafka.fruit.Fruit;
 import io.quarkus.it.kafka.people.Person;
 import io.quarkus.it.kafka.pet.Pet;
@@ -19,6 +22,12 @@ import io.quarkus.it.kafka.pet.Pet;
 public class KafkaEndpoint {
     @Inject
     KafkaReceivers receivers;
+
+    @Inject
+    ExactlyOnceFruitProcessor exactlyOnceFruitProcessor;
+
+    @Inject
+    ExactlyOnceFruitConsumer exactlyOnceFruitConsumer;
 
     @Inject
     @PersistenceUnit("people")
@@ -51,6 +60,28 @@ public class KafkaEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     public List<Pet> getConsumedPets() {
         return receivers.getPetsConsumed();
+    }
+
+    @GET
+    @Path("/exactly-once-fruit-processed")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<String> getExactlyOnceFruitProcessed() {
+        return exactlyOnceFruitProcessor.getProcessed();
+    }
+
+    @GET
+    @Path("/exactly-once-fruit-results")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<String> getExactlyOnceFruitResults() {
+        return exactlyOnceFruitConsumer.getResults();
+    }
+
+    @GET
+    @Path("/exactly-once-fruits")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Transactional
+    public List<ExactlyOnceFruit> getExactlyOnceFruits() {
+        return ExactlyOnceFruit.listAll();
     }
 
 }

--- a/integration-tests/reactive-messaging-hibernate-orm/src/main/java/io/quarkus/it/kafka/KafkaReceivers.java
+++ b/integration-tests/reactive-messaging-hibernate-orm/src/main/java/io/quarkus/it/kafka/KafkaReceivers.java
@@ -15,6 +15,7 @@ import io.quarkus.it.kafka.fruit.Fruit;
 import io.quarkus.it.kafka.fruit.FruitDto;
 import io.quarkus.it.kafka.people.Person;
 import io.quarkus.it.kafka.pet.Pet;
+import io.smallrye.reactive.messaging.annotations.Blocking;
 
 @ApplicationScoped
 public class KafkaReceivers {
@@ -28,6 +29,9 @@ public class KafkaReceivers {
 
     @Incoming("fruits-in")
     @Transactional
+    // Before the transactional methods were forcibly Blocking, now if the method is annotated with @Transactional,
+    // it can be non-blocking, so we need to explicitly annotate it with @Blocking to keep the same behavior as before.
+    @Blocking
     public CompletionStage<Void> persist(Fruit fruit) {
         fruit.persist();
         return emitter.send(new FruitDto(fruit));

--- a/integration-tests/reactive-messaging-hibernate-orm/src/main/java/io/quarkus/it/kafka/fruit/ExactlyOnceFruit.java
+++ b/integration-tests/reactive-messaging-hibernate-orm/src/main/java/io/quarkus/it/kafka/fruit/ExactlyOnceFruit.java
@@ -1,0 +1,25 @@
+package io.quarkus.it.kafka.fruit;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+
+@Entity
+public class ExactlyOnceFruit extends PanacheEntityBase {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public Long id;
+
+    public String name;
+
+    public ExactlyOnceFruit(String name) {
+        this.name = name;
+    }
+
+    public ExactlyOnceFruit() {
+    }
+}

--- a/integration-tests/reactive-messaging-hibernate-orm/src/main/java/io/quarkus/it/kafka/fruit/ExactlyOnceFruitConsumer.java
+++ b/integration-tests/reactive-messaging-hibernate-orm/src/main/java/io/quarkus/it/kafka/fruit/ExactlyOnceFruitConsumer.java
@@ -1,0 +1,25 @@
+package io.quarkus.it.kafka.fruit;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+import io.smallrye.reactive.messaging.kafka.Record;
+
+@ApplicationScoped
+public class ExactlyOnceFruitConsumer {
+
+    private final List<String> results = new CopyOnWriteArrayList<>();
+
+    @Incoming("exactly-once-fruit-result")
+    void consume(Record<String, String> record) {
+        results.add(record.value());
+    }
+
+    public List<String> getResults() {
+        return results;
+    }
+}

--- a/integration-tests/reactive-messaging-hibernate-orm/src/main/java/io/quarkus/it/kafka/fruit/ExactlyOnceFruitProcessor.java
+++ b/integration-tests/reactive-messaging-hibernate-orm/src/main/java/io/quarkus/it/kafka/fruit/ExactlyOnceFruitProcessor.java
@@ -1,0 +1,46 @@
+package io.quarkus.it.kafka.fruit;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.transaction.Transactional;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import io.quarkus.logging.Log;
+import io.quarkus.smallrye.reactivemessaging.kafka.ExactlyOnce;
+import io.smallrye.reactive.messaging.kafka.Record;
+
+@ApplicationScoped
+public class ExactlyOnceFruitProcessor {
+
+    private final List<String> processed = new CopyOnWriteArrayList<>();
+    private volatile boolean failOnce = true;
+
+    @Incoming("exactly-once-fruit-in")
+    @Outgoing("exactly-once-fruit-out")
+    @ExactlyOnce
+    @Transactional
+    ProducerRecord<String, String> process(Record<String, String> record) {
+        Log.info("Processing record with key: " + record.key() + " and value: " + record.value());
+        if ("fail-fruit".equals(record.value()) && failOnce) {
+            failOnce = false;
+            throw new RuntimeException("Simulated failure for fail-fruit");
+        }
+        if ("dlq-fruit".equals(record.value())) {
+            processed.add(record.value());
+            return new ProducerRecord<>("exactly-once-fruit-dlq", 0, record.key(), record.value());
+        }
+        ExactlyOnceFruit fruit = new ExactlyOnceFruit(record.value());
+        fruit.persist();
+        processed.add(record.value());
+        return new ProducerRecord<>("exactly-once-fruit-out", record.key(), "persisted-" + record.value());
+    }
+
+    public List<String> getProcessed() {
+        return processed;
+    }
+}

--- a/integration-tests/reactive-messaging-hibernate-orm/src/main/java/io/quarkus/it/kafka/fruit/ExactlyOnceFruitProducer.java
+++ b/integration-tests/reactive-messaging-hibernate-orm/src/main/java/io/quarkus/it/kafka/fruit/ExactlyOnceFruitProducer.java
@@ -1,0 +1,22 @@
+package io.quarkus.it.kafka.fruit;
+
+import java.time.Duration;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.kafka.Record;
+
+@ApplicationScoped
+public class ExactlyOnceFruitProducer {
+
+    @Outgoing("exactly-once-fruit-source")
+    Multi<Record<String, String>> produce() {
+        return Multi.createFrom().ticks().every(Duration.ofMillis(100))
+                .onOverflow().drop()
+                .map(tick -> Record.of("fruit-" + tick, "fruit-" + tick))
+                .select().first(4);
+    }
+}

--- a/integration-tests/reactive-messaging-hibernate-orm/src/main/resources/application.properties
+++ b/integration-tests/reactive-messaging-hibernate-orm/src/main/resources/application.properties
@@ -23,3 +23,13 @@ quarkus.hibernate-orm."people".packages=io.quarkus.it.kafka.people
 
 mp.messaging.incoming.pets-in.topic=pets
 mp.messaging.incoming.pets-in.read-committed=true
+
+###### Exactly-once transactional processing test
+mp.messaging.outgoing.exactly-once-fruit-source.topic=exactly-once-fruit-in
+mp.messaging.incoming.exactly-once-fruit-in.topic=exactly-once-fruit-in
+mp.messaging.incoming.exactly-once-fruit-in.failure-strategy=ignore
+mp.messaging.incoming.exactly-once-fruit-in.commit-strategy=ignore
+mp.messaging.incoming.exactly-once-fruit-in.group.id=exactly-once-fruit-consumer
+mp.messaging.outgoing.exactly-once-fruit-out.topic=exactly-once-fruit-out
+mp.messaging.incoming.exactly-once-fruit-result.topic=exactly-once-fruit-out
+mp.messaging.incoming.exactly-once-fruit-result.group.id=exactly-once-fruit-result-consumer

--- a/integration-tests/reactive-messaging-hibernate-orm/src/test/java/io/quarkus/it/kafka/KafkaConnectorTest.java
+++ b/integration-tests/reactive-messaging-hibernate-orm/src/test/java/io/quarkus/it/kafka/KafkaConnectorTest.java
@@ -4,15 +4,21 @@ import static io.restassured.RestAssured.get;
 import static io.restassured.RestAssured.given;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.Duration;
 import java.util.List;
 
 import jakarta.ws.rs.core.Response;
 
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.common.serialization.StringDeserializer;
-import org.junit.jupiter.api.Assertions;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import io.quarkus.it.kafka.fruit.Fruit;
 import io.quarkus.it.kafka.pet.Pet;
@@ -26,6 +32,7 @@ import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
 
 @QuarkusTest
 @QuarkusTestResource(KafkaCompanionResource.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class KafkaConnectorTest {
 
     protected static final TypeRef<List<Fruit>> TYPE_REF = new TypeRef<List<Fruit>>() {
@@ -49,10 +56,10 @@ public class KafkaConnectorTest {
         given().body(new Fruit("pear")).contentType(ContentType.JSON).when().post("/kafka/fruits").then()
                 .assertThat().statusCode(is(Response.Status.NO_CONTENT.getStatusCode()));
 
-        await().untilAsserted(() -> Assertions.assertEquals(6, get("/kafka/fruits").as(TYPE_REF).size()));
+        await().untilAsserted(() -> assertEquals(6, get("/kafka/fruits").as(TYPE_REF).size()));
 
         for (ConsumerRecord<String, String> record : companion
-                .consumeWithDeserializers(new StringDeserializer(), new StringDeserializer())
+                .consumeStrings()
                 .fromTopics("fruits-persisted", 6)
                 .awaitCompletion()) {
             System.out.println(record);
@@ -64,7 +71,7 @@ public class KafkaConnectorTest {
 
     @Test
     public void testPets() {
-        await().untilAsserted(() -> Assertions.assertEquals(0, get("/kafka/pets").as(PET_TYPE_REF).size()));
+        await().untilAsserted(() -> assertEquals(0, get("/kafka/pets").as(PET_TYPE_REF).size()));
 
         given().body("cat").contentType(ContentType.TEXT).when().post("/kafka/pets").then()
                 .assertThat().statusCode(is(Response.Status.NO_CONTENT.getStatusCode()));
@@ -81,8 +88,90 @@ public class KafkaConnectorTest {
         given().body("hamster").contentType(ContentType.TEXT).when().post("/kafka/pets").then()
                 .assertThat().statusCode(is(Response.Status.NO_CONTENT.getStatusCode()));
 
-        await().untilAsserted(() -> Assertions.assertEquals(6, get("/kafka/pets").as(PET_TYPE_REF).size()));
-        await().untilAsserted(() -> Assertions.assertEquals(6, get("/kafka/pets-consumed").as(PET_TYPE_REF).size()));
+        await().untilAsserted(() -> assertEquals(6, get("/kafka/pets").as(PET_TYPE_REF).size()));
+        await().untilAsserted(() -> assertEquals(6, get("/kafka/pets-consumed").as(PET_TYPE_REF).size()));
+    }
+
+    @Test
+    @Order(1)
+    public void testExactlyOnceTransactional() {
+        await().atMost(Duration.ofSeconds(30)).untilAsserted(() -> {
+            List<String> processed = get("/kafka/exactly-once-fruit-processed").as(new TypeRef<List<String>>() {
+            });
+            assertTrue(processed.size() >= 4, "Expected at least 4 processed, got " + processed.size());
+        });
+        await().atMost(Duration.ofSeconds(30)).untilAsserted(() -> {
+            List<String> results = get("/kafka/exactly-once-fruit-results").as(new TypeRef<List<String>>() {
+            });
+            assertTrue(results.size() >= 4, "Expected at least 4 results, got " + results.size());
+            assertTrue(results.contains("persisted-fruit-0"));
+        });
+        // Verify fruits were persisted to the database by the @Transactional method
+        await().atMost(Duration.ofSeconds(30)).untilAsserted(() -> {
+            List<?> fruits = get("/kafka/exactly-once-fruits").as(new TypeRef<List<?>>() {
+            });
+            assertTrue(fruits.size() >= 4, "Expected at least 4 persisted fruits, got " + fruits.size());
+        });
+    }
+
+    @Test
+    @Order(2)
+    public void testExactlyOnceTransactionalDlq() {
+        int initialCount = get("/kafka/exactly-once-fruits").as(new TypeRef<List<?>>() {
+        }).size();
+
+        // Send a message that will be routed to DLQ instead of the main output
+        companion.produceStrings().fromRecords(new ProducerRecord<>("exactly-once-fruit-in", "dlq-key", "dlq-fruit"));
+
+        // Verify the record arrives on the DLQ topic
+        List<ConsumerRecord<String, String>> dlqRecords = companion
+                .consumeStrings()
+                .withOffsetReset("earliest")
+                .withProp(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed")
+                .fromTopics("exactly-once-fruit-dlq", 1)
+                .awaitCompletion(Duration.ofSeconds(30))
+                .getRecords();
+        assertEquals(1, dlqRecords.size());
+        assertEquals("dlq-fruit", dlqRecords.get(0).value());
+        assertEquals(0, dlqRecords.get(0).partition());
+
+        // Verify "dlq-fruit" was NOT persisted to the database
+        List<?> fruits = get("/kafka/exactly-once-fruits").as(new TypeRef<List<?>>() {
+        });
+        assertEquals(initialCount, fruits.size(),
+                "dlq-fruit should not have been persisted");
+
+        // Verify it was processed (not skipped)
+        List<String> processed = get("/kafka/exactly-once-fruit-processed").as(new TypeRef<List<String>>() {
+        });
+        assertTrue(processed.contains("dlq-fruit"),
+                "dlq-fruit should have been processed");
+    }
+
+    @Test
+    @Order(3)
+    public void testExactlyOnceTransactionalRetryAfterFailure() {
+        int initialCount = get("/kafka/exactly-once-fruits").as(new TypeRef<List<?>>() {
+        }).size();
+
+        // Send a message that will cause the processor to throw on first attempt, then succeed on retry
+        companion.produceStrings().fromRecords(new ProducerRecord<>("exactly-once-fruit-in", "fail-key", "fail-fruit"));
+
+        // The first attempt fails and rolls back; the retry succeeds
+        await().atMost(Duration.ofSeconds(30)).untilAsserted(() -> {
+            List<String> processed = get("/kafka/exactly-once-fruit-processed").as(new TypeRef<List<String>>() {
+            });
+            assertTrue(processed.contains("fail-fruit"),
+                    "fail-fruit should have been processed on retry");
+        });
+
+        // Verify fail-fruit was persisted exactly once after the successful retry
+        await().atMost(Duration.ofSeconds(30)).untilAsserted(() -> {
+            List<?> fruits = get("/kafka/exactly-once-fruits").as(new TypeRef<List<?>>() {
+            });
+            assertEquals(initialCount + 1, fruits.size(),
+                    "fail-fruit should have been persisted on retry");
+        });
     }
 
 }

--- a/integration-tests/reactive-messaging-hibernate-reactive/src/main/java/io/quarkus/it/kafka/ExactlyOnceFruit.java
+++ b/integration-tests/reactive-messaging-hibernate-reactive/src/main/java/io/quarkus/it/kafka/ExactlyOnceFruit.java
@@ -1,0 +1,18 @@
+package io.quarkus.it.kafka;
+
+import jakarta.persistence.Entity;
+
+import io.quarkus.hibernate.reactive.panache.PanacheEntity;
+
+@Entity
+public class ExactlyOnceFruit extends PanacheEntity {
+
+    public String name;
+
+    public ExactlyOnceFruit(String name) {
+        this.name = name;
+    }
+
+    public ExactlyOnceFruit() {
+    }
+}

--- a/integration-tests/reactive-messaging-hibernate-reactive/src/main/java/io/quarkus/it/kafka/ExactlyOnceFruitConsumer.java
+++ b/integration-tests/reactive-messaging-hibernate-reactive/src/main/java/io/quarkus/it/kafka/ExactlyOnceFruitConsumer.java
@@ -1,0 +1,25 @@
+package io.quarkus.it.kafka;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+import io.smallrye.reactive.messaging.kafka.Record;
+
+@ApplicationScoped
+public class ExactlyOnceFruitConsumer {
+
+    private final List<String> results = new CopyOnWriteArrayList<>();
+
+    @Incoming("exactly-once-fruit-result")
+    void consume(Record<String, String> record) {
+        results.add(record.value());
+    }
+
+    public List<String> getResults() {
+        return results;
+    }
+}

--- a/integration-tests/reactive-messaging-hibernate-reactive/src/main/java/io/quarkus/it/kafka/ExactlyOnceFruitProcessor.java
+++ b/integration-tests/reactive-messaging-hibernate-reactive/src/main/java/io/quarkus/it/kafka/ExactlyOnceFruitProcessor.java
@@ -1,0 +1,37 @@
+package io.quarkus.it.kafka;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import io.quarkus.hibernate.reactive.panache.common.WithTransaction;
+import io.quarkus.logging.Log;
+import io.quarkus.smallrye.reactivemessaging.kafka.ExactlyOnce;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.reactive.messaging.kafka.Record;
+
+@ApplicationScoped
+public class ExactlyOnceFruitProcessor {
+
+    private final List<String> processed = new CopyOnWriteArrayList<>();
+
+    @Incoming("exactly-once-fruit-in")
+    @Outgoing("exactly-once-fruit-out")
+    @ExactlyOnce
+    @WithTransaction
+    Uni<Record<String, String>> process(Record<String, String> record) {
+        Log.infof("Processing record with key %s and value %s", record.key(), record.value());
+        ExactlyOnceFruit fruit = new ExactlyOnceFruit(record.value());
+        processed.add(record.value());
+        return fruit.persist()
+                .map(f -> Record.of(record.key(), "persisted-" + record.value()));
+    }
+
+    public List<String> getProcessed() {
+        return processed;
+    }
+}

--- a/integration-tests/reactive-messaging-hibernate-reactive/src/main/java/io/quarkus/it/kafka/ExactlyOnceFruitProducer.java
+++ b/integration-tests/reactive-messaging-hibernate-reactive/src/main/java/io/quarkus/it/kafka/ExactlyOnceFruitProducer.java
@@ -1,0 +1,22 @@
+package io.quarkus.it.kafka;
+
+import java.time.Duration;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.kafka.Record;
+
+@ApplicationScoped
+public class ExactlyOnceFruitProducer {
+
+    @Outgoing("exactly-once-fruit-source")
+    Multi<Record<String, String>> produce() {
+        return Multi.createFrom().ticks().every(Duration.ofMillis(100))
+                .onOverflow().drop()
+                .map(tick -> Record.of("fruit-" + tick, "fruit-" + tick))
+                .select().first(4);
+    }
+}

--- a/integration-tests/reactive-messaging-hibernate-reactive/src/main/java/io/quarkus/it/kafka/KafkaEndpoint.java
+++ b/integration-tests/reactive-messaging-hibernate-reactive/src/main/java/io/quarkus/it/kafka/KafkaEndpoint.java
@@ -18,6 +18,12 @@ public class KafkaEndpoint {
     KafkaReceivers receivers;
 
     @Inject
+    ExactlyOnceFruitProcessor exactlyOnceFruitProcessor;
+
+    @Inject
+    ExactlyOnceFruitConsumer exactlyOnceFruitConsumer;
+
+    @Inject
     Mutiny.SessionFactory sf;
 
     @GET
@@ -46,6 +52,27 @@ public class KafkaEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     public List<Pet> getConsumedPets() {
         return receivers.getConsumedPets();
+    }
+
+    @GET
+    @Path("/exactly-once-fruit-processed")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<String> getExactlyOnceFruitProcessed() {
+        return exactlyOnceFruitProcessor.getProcessed();
+    }
+
+    @GET
+    @Path("/exactly-once-fruit-results")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<String> getExactlyOnceFruitResults() {
+        return exactlyOnceFruitConsumer.getResults();
+    }
+
+    @GET
+    @Path("/exactly-once-fruits")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Uni<List<ExactlyOnceFruit>> getExactlyOnceFruits() {
+        return sf.withSession(s -> ExactlyOnceFruit.listAll());
     }
 
 }

--- a/integration-tests/reactive-messaging-hibernate-reactive/src/main/resources/application.properties
+++ b/integration-tests/reactive-messaging-hibernate-reactive/src/main/resources/application.properties
@@ -16,3 +16,11 @@ mp.messaging.outgoing.people-out.acks=all
 
 mp.messaging.incoming.pets-in.topic=pets
 mp.messaging.incoming.pets-in.read-committed=true
+
+###### Exactly-once reactive transactional processing test
+mp.messaging.outgoing.exactly-once-fruit-source.topic=exactly-once-fruit-in
+mp.messaging.incoming.exactly-once-fruit-in.topic=exactly-once-fruit-in
+mp.messaging.incoming.exactly-once-fruit-in.group.id=exactly-once-fruit-consumer
+mp.messaging.outgoing.exactly-once-fruit-out.topic=exactly-once-fruit-out
+mp.messaging.incoming.exactly-once-fruit-result.topic=exactly-once-fruit-out
+mp.messaging.incoming.exactly-once-fruit-result.group.id=exactly-once-fruit-result-consumer

--- a/integration-tests/reactive-messaging-hibernate-reactive/src/test/java/io/quarkus/it/kafka/KafkaConnectorTest.java
+++ b/integration-tests/reactive-messaging-hibernate-reactive/src/test/java/io/quarkus/it/kafka/KafkaConnectorTest.java
@@ -67,4 +67,25 @@ public class KafkaConnectorTest {
         await().untilAsserted(() -> Assertions.assertEquals(6, get("/kafka/pets").as(PET_TYPE_REF).size()));
         await().untilAsserted(() -> Assertions.assertEquals(6, get("/kafka/pets-consumed").as(PET_TYPE_REF).size()));
     }
+
+    @Test
+    public void testExactlyOnceWithTransaction() {
+        await().atMost(java.time.Duration.ofSeconds(30)).untilAsserted(() -> {
+            List<String> processed = get("/kafka/exactly-once-fruit-processed").as(new TypeRef<List<String>>() {
+            });
+            Assertions.assertTrue(processed.size() >= 4, "Expected at least 4 processed, got " + processed.size());
+        });
+        await().atMost(java.time.Duration.ofSeconds(30)).untilAsserted(() -> {
+            List<String> results = get("/kafka/exactly-once-fruit-results").as(new TypeRef<List<String>>() {
+            });
+            Assertions.assertTrue(results.size() >= 4, "Expected at least 4 results, got " + results.size());
+            Assertions.assertTrue(results.contains("persisted-fruit-0"));
+        });
+        // Verify fruits were persisted to the database by the @WithTransaction method
+        await().atMost(java.time.Duration.ofSeconds(30)).untilAsserted(() -> {
+            List<?> fruits = get("/kafka/exactly-once-fruits").as(new TypeRef<List<?>>() {
+            });
+            Assertions.assertTrue(fruits.size() >= 4, "Expected at least 4 persisted fruits, got " + fruits.size());
+        });
+    }
 }

--- a/integration-tests/reactive-messaging-kafka/src/main/java/io/quarkus/it/kafka/ExactlyOnceConsumer.java
+++ b/integration-tests/reactive-messaging-kafka/src/main/java/io/quarkus/it/kafka/ExactlyOnceConsumer.java
@@ -1,0 +1,25 @@
+package io.quarkus.it.kafka;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+import io.smallrye.reactive.messaging.kafka.Record;
+
+@ApplicationScoped
+public class ExactlyOnceConsumer {
+
+    private final List<Integer> results = new CopyOnWriteArrayList<>();
+
+    @Incoming("exactly-once-result")
+    void consume(Record<String, Integer> record) {
+        results.add(record.value());
+    }
+
+    public List<Integer> getResults() {
+        return results;
+    }
+}

--- a/integration-tests/reactive-messaging-kafka/src/main/java/io/quarkus/it/kafka/ExactlyOnceListConsumer.java
+++ b/integration-tests/reactive-messaging-kafka/src/main/java/io/quarkus/it/kafka/ExactlyOnceListConsumer.java
@@ -1,0 +1,25 @@
+package io.quarkus.it.kafka;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+import io.smallrye.reactive.messaging.kafka.Record;
+
+@ApplicationScoped
+public class ExactlyOnceListConsumer {
+
+    private final List<Integer> results = new CopyOnWriteArrayList<>();
+
+    @Incoming("exactly-once-list-result")
+    void consume(Record<String, Integer> record) {
+        results.add(record.value());
+    }
+
+    public List<Integer> getResults() {
+        return results;
+    }
+}

--- a/integration-tests/reactive-messaging-kafka/src/main/java/io/quarkus/it/kafka/ExactlyOnceListProcessor.java
+++ b/integration-tests/reactive-messaging-kafka/src/main/java/io/quarkus/it/kafka/ExactlyOnceListProcessor.java
@@ -1,0 +1,32 @@
+package io.quarkus.it.kafka;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import io.quarkus.smallrye.reactivemessaging.kafka.ExactlyOnce;
+import io.smallrye.reactive.messaging.kafka.Record;
+
+@ApplicationScoped
+public class ExactlyOnceListProcessor {
+
+    private final List<Integer> processed = new CopyOnWriteArrayList<>();
+
+    @Incoming("exactly-once-list-in")
+    @Outgoing("exactly-once-list-out")
+    @ExactlyOnce
+    List<Record<String, Integer>> process(Record<String, Integer> record) {
+        processed.add(record.value());
+        return List.of(
+                Record.of(record.key(), record.value() * 10),
+                Record.of(record.key(), record.value() * 10 + 1));
+    }
+
+    public List<Integer> getProcessed() {
+        return processed;
+    }
+}

--- a/integration-tests/reactive-messaging-kafka/src/main/java/io/quarkus/it/kafka/ExactlyOnceListProducer.java
+++ b/integration-tests/reactive-messaging-kafka/src/main/java/io/quarkus/it/kafka/ExactlyOnceListProducer.java
@@ -1,0 +1,22 @@
+package io.quarkus.it.kafka;
+
+import java.time.Duration;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.kafka.Record;
+
+@ApplicationScoped
+public class ExactlyOnceListProducer {
+
+    @Outgoing("exactly-once-list-source")
+    Multi<Record<String, Integer>> produce() {
+        return Multi.createFrom().ticks().every(Duration.ofMillis(100))
+                .onOverflow().drop()
+                .map(tick -> Record.of("key-" + tick, tick.intValue()))
+                .select().first(4);
+    }
+}

--- a/integration-tests/reactive-messaging-kafka/src/main/java/io/quarkus/it/kafka/ExactlyOnceProcessor.java
+++ b/integration-tests/reactive-messaging-kafka/src/main/java/io/quarkus/it/kafka/ExactlyOnceProcessor.java
@@ -1,0 +1,32 @@
+package io.quarkus.it.kafka;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import io.quarkus.logging.Log;
+import io.quarkus.smallrye.reactivemessaging.kafka.ExactlyOnce;
+import io.smallrye.reactive.messaging.kafka.Record;
+
+@ApplicationScoped
+public class ExactlyOnceProcessor {
+
+    private final List<Integer> processed = new CopyOnWriteArrayList<>();
+
+    @Incoming("exactly-once-in")
+    @Outgoing("exactly-once-out")
+    @ExactlyOnce
+    Record<String, Integer> process(Record<String, Integer> record) {
+        processed.add(record.value());
+        Log.info("Processing record with key: " + record.key() + " and value: " + record.value());
+        return Record.of(record.key(), record.value() + 1);
+    }
+
+    public List<Integer> getProcessed() {
+        return processed;
+    }
+}

--- a/integration-tests/reactive-messaging-kafka/src/main/java/io/quarkus/it/kafka/ExactlyOnceProducer.java
+++ b/integration-tests/reactive-messaging-kafka/src/main/java/io/quarkus/it/kafka/ExactlyOnceProducer.java
@@ -1,0 +1,22 @@
+package io.quarkus.it.kafka;
+
+import java.time.Duration;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.kafka.Record;
+
+@ApplicationScoped
+public class ExactlyOnceProducer {
+
+    @Outgoing("exactly-once-source")
+    Multi<Record<String, Integer>> produce() {
+        return Multi.createFrom().ticks().every(Duration.ofMillis(100))
+                .onOverflow().drop()
+                .map(tick -> Record.of("key-" + tick, tick.intValue()))
+                .select().first(6);
+    }
+}

--- a/integration-tests/reactive-messaging-kafka/src/main/java/io/quarkus/it/kafka/ExactlyOnceUniConsumer.java
+++ b/integration-tests/reactive-messaging-kafka/src/main/java/io/quarkus/it/kafka/ExactlyOnceUniConsumer.java
@@ -1,0 +1,25 @@
+package io.quarkus.it.kafka;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+import io.smallrye.reactive.messaging.kafka.Record;
+
+@ApplicationScoped
+public class ExactlyOnceUniConsumer {
+
+    private final List<Integer> results = new CopyOnWriteArrayList<>();
+
+    @Incoming("exactly-once-uni-result")
+    void consume(Record<String, Integer> record) {
+        results.add(record.value());
+    }
+
+    public List<Integer> getResults() {
+        return results;
+    }
+}

--- a/integration-tests/reactive-messaging-kafka/src/main/java/io/quarkus/it/kafka/ExactlyOnceUniProcessor.java
+++ b/integration-tests/reactive-messaging-kafka/src/main/java/io/quarkus/it/kafka/ExactlyOnceUniProcessor.java
@@ -1,0 +1,36 @@
+package io.quarkus.it.kafka;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import io.quarkus.logging.Log;
+import io.quarkus.smallrye.reactivemessaging.kafka.ExactlyOnce;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.reactive.messaging.kafka.Record;
+
+@ApplicationScoped
+public class ExactlyOnceUniProcessor {
+
+    private final List<Integer> processed = new CopyOnWriteArrayList<>();
+
+    @Incoming("exactly-once-uni-in")
+    @Outgoing("exactly-once-uni-out")
+    @ExactlyOnce
+    Uni<Record<String, Integer>> process(Record<String, Integer> record) {
+        Log.info("Uni processing record with key: " + record.key() + " and value: " + record.value());
+        return Uni.createFrom().item(record)
+                .onItem().transform(r -> {
+                    processed.add(r.value());
+                    return Record.of(r.key(), r.value() + 1);
+                });
+    }
+
+    public List<Integer> getProcessed() {
+        return processed;
+    }
+}

--- a/integration-tests/reactive-messaging-kafka/src/main/java/io/quarkus/it/kafka/ExactlyOnceUniProducer.java
+++ b/integration-tests/reactive-messaging-kafka/src/main/java/io/quarkus/it/kafka/ExactlyOnceUniProducer.java
@@ -1,0 +1,22 @@
+package io.quarkus.it.kafka;
+
+import java.time.Duration;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.kafka.Record;
+
+@ApplicationScoped
+public class ExactlyOnceUniProducer {
+
+    @Outgoing("exactly-once-uni-source")
+    Multi<Record<String, Integer>> produce() {
+        return Multi.createFrom().ticks().every(Duration.ofMillis(100))
+                .onOverflow().drop()
+                .map(tick -> Record.of("key-" + tick, tick.intValue()))
+                .select().first(6);
+    }
+}

--- a/integration-tests/reactive-messaging-kafka/src/main/java/io/quarkus/it/kafka/KafkaEndpoint.java
+++ b/integration-tests/reactive-messaging-kafka/src/main/java/io/quarkus/it/kafka/KafkaEndpoint.java
@@ -17,6 +17,24 @@ public class KafkaEndpoint {
     @Inject
     KafkaReceivers receivers;
 
+    @Inject
+    ExactlyOnceProcessor exactlyOnceProcessor;
+
+    @Inject
+    ExactlyOnceConsumer exactlyOnceConsumer;
+
+    @Inject
+    ExactlyOnceListProcessor exactlyOnceListProcessor;
+
+    @Inject
+    ExactlyOnceListConsumer exactlyOnceListConsumer;
+
+    @Inject
+    ExactlyOnceUniProcessor exactlyOnceUniProcessor;
+
+    @Inject
+    ExactlyOnceUniConsumer exactlyOnceUniConsumer;
+
     @GET
     @Path("/fruits")
     @Produces(MediaType.APPLICATION_JSON)
@@ -43,5 +61,47 @@ public class KafkaEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     public List<String> getDataForKeyed() {
         return receivers.getDataForKeyed();
+    }
+
+    @GET
+    @Path("/exactly-once-processed")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<Integer> getExactlyOnceProcessed() {
+        return exactlyOnceProcessor.getProcessed();
+    }
+
+    @GET
+    @Path("/exactly-once-results")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<Integer> getExactlyOnceResults() {
+        return exactlyOnceConsumer.getResults();
+    }
+
+    @GET
+    @Path("/exactly-once-list-processed")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<Integer> getExactlyOnceListProcessed() {
+        return exactlyOnceListProcessor.getProcessed();
+    }
+
+    @GET
+    @Path("/exactly-once-list-results")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<Integer> getExactlyOnceListResults() {
+        return exactlyOnceListConsumer.getResults();
+    }
+
+    @GET
+    @Path("/exactly-once-uni-processed")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<Integer> getExactlyOnceUniProcessed() {
+        return exactlyOnceUniProcessor.getProcessed();
+    }
+
+    @GET
+    @Path("/exactly-once-uni-results")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<Integer> getExactlyOnceUniResults() {
+        return exactlyOnceUniConsumer.getResults();
     }
 }

--- a/integration-tests/reactive-messaging-kafka/src/main/resources/application.properties
+++ b/integration-tests/reactive-messaging-kafka/src/main/resources/application.properties
@@ -34,5 +34,41 @@ mp.messaging.incoming.data-for-keyed-in.topic=data-for-keyed
 mp.messaging.outgoing.request-reply.topic=request
 mp.messaging.outgoing.request-reply.reply.batch=true
 
+###### Exactly-once processing test
+mp.messaging.outgoing.exactly-once-source.topic=exactly-once-in
+mp.messaging.outgoing.exactly-once-source.value.serializer=org.apache.kafka.common.serialization.IntegerSerializer
+mp.messaging.incoming.exactly-once-in.topic=exactly-once-in
+mp.messaging.incoming.exactly-once-in.group.id=exactly-once-consumer
+mp.messaging.incoming.exactly-once-in.value.deserializer=org.apache.kafka.common.serialization.IntegerDeserializer
+mp.messaging.outgoing.exactly-once-out.topic=exactly-once-out
+mp.messaging.outgoing.exactly-once-out.value.serializer=org.apache.kafka.common.serialization.IntegerSerializer
+mp.messaging.incoming.exactly-once-result.topic=exactly-once-out
+mp.messaging.incoming.exactly-once-result.group.id=exactly-once-result-consumer
+mp.messaging.incoming.exactly-once-result.value.deserializer=org.apache.kafka.common.serialization.IntegerDeserializer
+
+###### Exactly-once list processing test
+mp.messaging.outgoing.exactly-once-list-source.topic=exactly-once-list-in
+mp.messaging.outgoing.exactly-once-list-source.value.serializer=org.apache.kafka.common.serialization.IntegerSerializer
+mp.messaging.incoming.exactly-once-list-in.topic=exactly-once-list-in
+mp.messaging.incoming.exactly-once-list-in.group.id=exactly-once-list-consumer
+mp.messaging.incoming.exactly-once-list-in.value.deserializer=org.apache.kafka.common.serialization.IntegerDeserializer
+mp.messaging.outgoing.exactly-once-list-out.topic=exactly-once-list-out
+mp.messaging.outgoing.exactly-once-list-out.value.serializer=org.apache.kafka.common.serialization.IntegerSerializer
+mp.messaging.incoming.exactly-once-list-result.topic=exactly-once-list-out
+mp.messaging.incoming.exactly-once-list-result.group.id=exactly-once-list-result-consumer
+mp.messaging.incoming.exactly-once-list-result.value.deserializer=org.apache.kafka.common.serialization.IntegerDeserializer
+
+###### Exactly-once Uni processing test
+mp.messaging.outgoing.exactly-once-uni-source.topic=exactly-once-uni-in
+mp.messaging.outgoing.exactly-once-uni-source.value.serializer=org.apache.kafka.common.serialization.IntegerSerializer
+mp.messaging.incoming.exactly-once-uni-in.topic=exactly-once-uni-in
+mp.messaging.incoming.exactly-once-uni-in.group.id=exactly-once-uni-consumer
+mp.messaging.incoming.exactly-once-uni-in.value.deserializer=org.apache.kafka.common.serialization.IntegerDeserializer
+mp.messaging.outgoing.exactly-once-uni-out.topic=exactly-once-uni-out
+mp.messaging.outgoing.exactly-once-uni-out.value.serializer=org.apache.kafka.common.serialization.IntegerSerializer
+mp.messaging.incoming.exactly-once-uni-result.topic=exactly-once-uni-out
+mp.messaging.incoming.exactly-once-uni-result.group.id=exactly-once-uni-result-consumer
+mp.messaging.incoming.exactly-once-uni-result.value.deserializer=org.apache.kafka.common.serialization.IntegerDeserializer
+
 quarkus.micrometer.binder.messaging.enabled=true
 smallrye.messaging.observation.enabled=true

--- a/integration-tests/reactive-messaging-kafka/src/test/java/io/quarkus/it/kafka/KafkaConnectorTest.java
+++ b/integration-tests/reactive-messaging-kafka/src/test/java/io/quarkus/it/kafka/KafkaConnectorTest.java
@@ -112,4 +112,66 @@ public class KafkaConnectorTest {
                 .body(not(containsString("kafka_version=\"unknown\"")));
     }
 
+    @Test
+    @Order(8)
+    public void testExactlyOnceProcessing() {
+        await().atMost(java.time.Duration.ofSeconds(30)).untilAsserted(() -> {
+            List<Integer> processed = get("/kafka/exactly-once-processed").as(new TypeRef<List<Integer>>() {
+            });
+            Assertions.assertTrue(processed.size() >= 6, "Expected at least 6 processed, got " + processed.size());
+        });
+        await().atMost(java.time.Duration.ofSeconds(30)).untilAsserted(() -> {
+            List<Integer> results = get("/kafka/exactly-once-results").as(new TypeRef<List<Integer>>() {
+            });
+            Assertions.assertTrue(results.size() >= 6, "Expected at least 6 results, got " + results.size());
+            // values should be original + 1
+            Assertions.assertTrue(results.contains(1));
+            Assertions.assertTrue(results.contains(2));
+            Assertions.assertTrue(results.contains(3));
+        });
+    }
+
+    @Test
+    @Order(9)
+    public void testExactlyOnceListProcessing() {
+        // Each input record produces 2 output records (value*10 and value*10+1)
+        // 4 input records -> 8 output records
+        await().atMost(java.time.Duration.ofSeconds(30)).untilAsserted(() -> {
+            List<Integer> processed = get("/kafka/exactly-once-list-processed").as(new TypeRef<List<Integer>>() {
+            });
+            Assertions.assertTrue(processed.size() >= 4, "Expected at least 4 processed, got " + processed.size());
+        });
+        await().atMost(java.time.Duration.ofSeconds(30)).untilAsserted(() -> {
+            List<Integer> results = get("/kafka/exactly-once-list-results").as(new TypeRef<List<Integer>>() {
+            });
+            Assertions.assertTrue(results.size() >= 8, "Expected at least 8 results, got " + results.size());
+            // input 0 -> 0, 1; input 1 -> 10, 11; input 2 -> 20, 21; input 3 -> 30, 31
+            Assertions.assertTrue(results.contains(0));
+            Assertions.assertTrue(results.contains(1));
+            Assertions.assertTrue(results.contains(10));
+            Assertions.assertTrue(results.contains(11));
+            Assertions.assertTrue(results.contains(20));
+            Assertions.assertTrue(results.contains(21));
+        });
+    }
+
+    @Test
+    @Order(10)
+    public void testExactlyOnceUniProcessing() {
+        await().atMost(java.time.Duration.ofSeconds(30)).untilAsserted(() -> {
+            List<Integer> processed = get("/kafka/exactly-once-uni-processed").as(new TypeRef<List<Integer>>() {
+            });
+            Assertions.assertTrue(processed.size() >= 6, "Expected at least 6 processed, got " + processed.size());
+        });
+        await().atMost(java.time.Duration.ofSeconds(30)).untilAsserted(() -> {
+            List<Integer> results = get("/kafka/exactly-once-uni-results").as(new TypeRef<List<Integer>>() {
+            });
+            Assertions.assertTrue(results.size() >= 6, "Expected at least 6 results, got " + results.size());
+            // values should be original + 1
+            Assertions.assertTrue(results.contains(1));
+            Assertions.assertTrue(results.contains(2));
+            Assertions.assertTrue(results.contains(3));
+        });
+    }
+
 }


### PR DESCRIPTION
Introduces `@io.quarkus.smallrye.reactivemessaging.kafka.ExactlyOnce` annotation to use on message processors (methods with both`@Incoming` and `@Outgoing` annotations). The results of the processing method are sent within a Kafka transaction, and offsets of the incoming record are committed as part of the same transaction.

It builds on the `CustomInvokerBuildItem` exposed by the reactive messaging extension to customise the invoker used to call processor methods. 

For methods annotated with `@ExactlyOnce`, the quarkus-messaging-kafka extension proposes different invoker implementations:
- `ExactlyOnceInvoker` blocking method signature, uses KafkaTransactions#withTransactionAndAwait
- `ReactiveExactlyOnceInvoker` reactive method signature, uses KafkaTransactions#withTransaction and returns the Uni
~- `TransactionalExactlyOnceInvoker` uses `TransactionManager` to make sure the transaction that is started before the invoker call, is committed _after_ the Kafka transaction is completed. Enabled when the processing method is annotated with `@Transactional` and it is blocking~
~- `ReactiveTransactionalExactlyOnceInvoker` uses `Mutiny.SessionFactory` to do the same thing above, but with Hibernate reactive. Enabled when the processing method is annotated with `@Transactional` and reactive, or is annotated with `@WithTransaction`.~

**Limitations**
- For now, the `@ExactlyOnce` doesn't work with Kotlin suspend functions.
- Only processing methods receiving payload types are supported; methods receiving/returning `Message` are not, and very likely won't be supported.