### PR TITLE
ArC: support method-level interceptor bindings on default interface methods

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Methods.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Methods.java
@@ -258,7 +258,8 @@ final class Methods {
             classLevelBindings = Set.of();
         }
 
-        if (ignoreMethodLevelBindings) {
+        // default methods keep their method-level bindings
+        if (ignoreMethodLevelBindings && !isDefault(method)) {
             return classLevelBindings;
         }
 

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/defaultmethod/DefaultMethodInterceptorTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/defaultmethod/DefaultMethodInterceptorTest.java
@@ -22,7 +22,7 @@ public class DefaultMethodInterceptorTest {
         InstanceHandle<DefaultMethodBean> handle = arc.instance(DefaultMethodBean.class);
         DefaultMethodBean simpleBean = handle.get();
         Assertions.assertEquals("intercepted:next:hello", simpleBean.hello());
-        Assertions.assertEquals("intercepted:default method", simpleBean.defaultMethod());
+        Assertions.assertEquals("intercepted:next:default method", simpleBean.defaultMethod());
         Assertions.assertEquals("intercepted:pong", simpleBean.ping());
     }
 

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/defaultmethod/DefaultMethodInterface.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/defaultmethod/DefaultMethodInterface.java
@@ -2,11 +2,11 @@ package io.quarkus.arc.test.interceptors.defaultmethod;
 
 public interface DefaultMethodInterface {
 
-    @NextBinding // This annotation should be ignored
+    @NextBinding
     default String defaultMethod() {
         return "default method";
     }
 
-    @NextBinding // This annotation should be ignored
+    @NextBinding // ignored on abstract interface methods
     String ping();
 }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/defaultmethod/DefaultMethodMethodLevelBindingTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/defaultmethod/DefaultMethodMethodLevelBindingTest.java
@@ -1,0 +1,153 @@
+package io.quarkus.arc.test.interceptors.defaultmethod;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.NoClassInterceptors;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class DefaultMethodMethodLevelBindingTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(
+            ClassBinding.class, MethodBinding.class,
+            ClassBindingInterceptor.class, MethodBindingInterceptor.class,
+            MyInterface.class,
+            InterfaceWithNoClassInterceptors.class,
+            BeanWithClassBinding.class,
+            BeanWithoutClassBinding.class,
+            BeanOverridingDefault.class,
+            BeanWithNoClassInterceptorsInterface.class);
+
+    @Test
+    void methodLevelBindingOnDefaultMethodIsApplied() {
+        BeanWithoutClassBinding bean = Arc.container().instance(BeanWithoutClassBinding.class).get();
+        assertThat(bean.defaultMethod()).isEqualTo("method:default");
+    }
+
+    @Test
+    void methodLevelAndClassLevelBindingsOnDefaultMethod() {
+        BeanWithClassBinding bean = Arc.container().instance(BeanWithClassBinding.class).get();
+        assertThat(bean.defaultMethod()).isEqualTo("class:method:default");
+    }
+
+    @Test
+    void abstractMethodBindingNotInherited() {
+        BeanWithoutClassBinding bean = Arc.container().instance(BeanWithoutClassBinding.class).get();
+        assertThat(bean.abstractWithBinding()).isEqualTo("abstract-impl");
+    }
+
+    @Test
+    void overrideDefaultMethodUsesOwnBindings() {
+        BeanOverridingDefault bean = Arc.container().instance(BeanOverridingDefault.class).get();
+        assertThat(bean.defaultMethod()).isEqualTo("class:overridden");
+    }
+
+    @Test
+    void noClassInterceptorsWithMethodLevelBindingOnDefault() {
+        BeanWithNoClassInterceptorsInterface bean = Arc.container().instance(BeanWithNoClassInterceptorsInterface.class).get();
+        assertThat(bean.noClassButMethodLevel()).isEqualTo("method:noclass");
+    }
+
+    @Target({ TYPE, METHOD })
+    @Retention(RUNTIME)
+    @InterceptorBinding
+    @interface ClassBinding {
+    }
+
+    @Target({ TYPE, METHOD })
+    @Retention(RUNTIME)
+    @InterceptorBinding
+    @interface MethodBinding {
+    }
+
+    @ClassBinding
+    @Interceptor
+    @Priority(1)
+    static class ClassBindingInterceptor {
+        @AroundInvoke
+        Object intercept(InvocationContext ctx) throws Exception {
+            return "class:" + ctx.proceed();
+        }
+    }
+
+    @MethodBinding
+    @Interceptor
+    @Priority(2)
+    static class MethodBindingInterceptor {
+        @AroundInvoke
+        Object intercept(InvocationContext ctx) throws Exception {
+            return "method:" + ctx.proceed();
+        }
+    }
+
+    interface MyInterface {
+        @MethodBinding
+        default String defaultMethod() {
+            return "default";
+        }
+
+        @MethodBinding
+        String abstractWithBinding();
+    }
+
+    interface InterfaceWithNoClassInterceptors {
+        @MethodBinding
+        @NoClassInterceptors
+        default String noClassButMethodLevel() {
+            return "noclass";
+        }
+    }
+
+    @ClassBinding
+    @ApplicationScoped
+    static class BeanWithClassBinding implements MyInterface {
+        @Override
+        public String abstractWithBinding() {
+            return "abstract-impl";
+        }
+    }
+
+    @ApplicationScoped
+    static class BeanWithoutClassBinding implements MyInterface {
+        @Override
+        public String abstractWithBinding() {
+            return "abstract-impl";
+        }
+    }
+
+    @ClassBinding
+    @ApplicationScoped
+    static class BeanOverridingDefault implements MyInterface {
+        @Override
+        public String defaultMethod() {
+            return "overridden";
+        }
+
+        @Override
+        public String abstractWithBinding() {
+            return "abstract-impl";
+        }
+    }
+
+    @ClassBinding
+    @ApplicationScoped
+    static class BeanWithNoClassInterceptorsInterface implements InterfaceWithNoClassInterceptors {
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/noclassinterceptors/NoClassInterceptorsTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/noclassinterceptors/NoClassInterceptorsTest.java
@@ -89,12 +89,12 @@ public class NoClassInterceptorsTest {
 
         assertEquals(4, ClassLevelInterceptor.AROUND_INVOKE_COUNTER);
         assertEquals(4, InheritedClassLevelInterceptor.AROUND_INVOKE_COUNTER);
-        assertEquals(4, MethodLevelInterceptor.AROUND_INVOKE_COUNTER);
+        assertEquals(5, MethodLevelInterceptor.AROUND_INVOKE_COUNTER);
 
         bean.inheritedDefaultMethod();
 
         assertEquals(5, ClassLevelInterceptor.AROUND_INVOKE_COUNTER);
         assertEquals(5, InheritedClassLevelInterceptor.AROUND_INVOKE_COUNTER);
-        assertEquals(4, MethodLevelInterceptor.AROUND_INVOKE_COUNTER);
+        assertEquals(5, MethodLevelInterceptor.AROUND_INVOKE_COUNTER);
     }
 }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/noclassinterceptors/Superinterface.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/noclassinterceptors/Superinterface.java
@@ -9,8 +9,8 @@ public interface Superinterface extends SuperSuperinterface {
 
     void inheritedNoInterceptors();
 
-    @MethodLevel // this should be ignored, only class-level interceptors apply to default methods
-    @NoClassInterceptors // and this makes sure that even class-level interceptors do not apply
+    @MethodLevel
+    @NoClassInterceptors
     default void defaultMethod() {
     }
 

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/producer/ProducerWithAbstractClassAndInterfaceInterceptionTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/producer/ProducerWithAbstractClassAndInterfaceInterceptionTest.java
@@ -33,7 +33,7 @@ public class ProducerWithAbstractClassAndInterfaceInterceptionTest {
         MyNonbeanBase nonbean = Arc.container().instance(MyNonbeanBase.class).get();
         assertEquals("intercepted1: hello1_foobar", nonbean.hello1());
         assertEquals("intercepted1: hello2_foobar", nonbean.hello2());
-        assertEquals("hello3", nonbean.hello3());
+        assertEquals("intercepted2: hello3", nonbean.hello3());
         assertEquals("hello4_foobar", nonbean.hello4());
         assertEquals("hello5", nonbean.hello5());
     }
@@ -73,10 +73,10 @@ public class ProducerWithAbstractClassAndInterfaceInterceptionTest {
     interface MyNonbean {
         String hello1();
 
-        @MyBinding2 // this should be ignored, because interceptor bindings are ignored on interfaces
+        @MyBinding2 // ignored on abstract interface methods
         String hello2();
 
-        @MyBinding2 // this should be ignored, because interceptor bindings are ignored on interfaces
+        @MyBinding2
         @NoClassInterceptors
         default String hello3() {
             return "hello3";


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/53825

Allows Arc to intercept default interface methods but keeps ignoring annotations on abstract interface methods.
After some digging, it turned out that all the cogs are in place and we just need a simple one liner fix to take these annotations into account.
The added test has various combinations of interface methods w/ and w/o method and class level annotations and overriding.

CC @FroMage - this should be what you wanted for `@Transactional` on default interface methods.