### PR TITLE
Rename property `quarkus.test.reproducibility-check` to `quarkus-internal.test.reproducibility-check`

### DIFF
--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/ArcTestContainer.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/ArcTestContainer.java
@@ -74,7 +74,7 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
 
     private static final String TARGET_TEST_CLASSES = "target/test-classes";
 
-    private static final String REPRODUCIBILITY_CHECK_PROPERTY = "quarkus.test.reproducibility-check";
+    private static final String REPRODUCIBILITY_CHECK_PROPERTY = "quarkus-internal.test.reproducibility-check";
 
     public static Builder builder() {
         return new Builder();

--- a/test-framework/junit-internal/src/main/java/io/quarkus/test/AbstractQuarkusExtensionTest.java
+++ b/test-framework/junit-internal/src/main/java/io/quarkus/test/AbstractQuarkusExtensionTest.java
@@ -94,7 +94,7 @@ public abstract class AbstractQuarkusExtensionTest<S extends AbstractQuarkusExte
 
     public static final String THE_BUILD_WAS_EXPECTED_TO_FAIL = "The build was expected to fail";
     private static final String APP_ROOT = "app-root";
-    private static final String REPRODUCIBILITY_CHECK_PROPERTY_NAME = "quarkus.test.reproducibility-check";
+    private static final String REPRODUCIBILITY_CHECK_PROPERTY_NAME = "quarkus-internal.test.reproducibility-check";
 
     private static final Logger rootLogger;
     private Handler[] originalHandlers;

--- a/test-framework/junit-internal/src/main/java/io/quarkus/test/BytecodeTools.java
+++ b/test-framework/junit-internal/src/main/java/io/quarkus/test/BytecodeTools.java
@@ -41,7 +41,7 @@ class BytecodeTools {
 
     private static Set<String> loadExclusions() {
         Set<String> result = new TreeSet<>(DEFAULT_EXCLUDED);
-        String additional = System.getProperty("quarkus.test.reproducibility-check.excludes");
+        String additional = System.getProperty("quarkus-internal.test.reproducibility-check.excludes");
         if (additional != null && !additional.isBlank()) {
             for (String prefix : additional.split(",")) {
                 String trimmed = prefix.trim();


### PR DESCRIPTION
Prefer using `quarkus-internal` in the prefix because then such property does not cause log messages like "Unrecognized configuration key...". Additionally, using prefix `quarkus.*` causes `OpenShiftConfigFallbackTest` to fail when it is ran in reproducibility mode.