### PR TITLE
Use more consistent null checks in `AbstractQuarkusExtensionTest#afterAll`

### DIFF
--- a/test-framework/junit-internal/src/main/java/io/quarkus/test/AbstractQuarkusExtensionTest.java
+++ b/test-framework/junit-internal/src/main/java/io/quarkus/test/AbstractQuarkusExtensionTest.java
@@ -801,7 +801,9 @@ public abstract class AbstractQuarkusExtensionTest<S extends AbstractQuarkusExte
         if (assertLogRecords != null) {
             records = new ArrayList<>(inMemoryLogHandler.records);
         }
-        rootLogger.setHandlers(originalHandlers);
+        if (originalHandlers != null) {
+            rootLogger.setHandlers(originalHandlers);
+        }
         inMemoryLogHandler.clearRecords();
         inMemoryLogHandler.setFilter(null);
         if (testMethodInvokers != null) {
@@ -827,10 +829,14 @@ public abstract class AbstractQuarkusExtensionTest<S extends AbstractQuarkusExte
                 quarkusUnitTestClassLoader.close();
                 quarkusUnitTestClassLoader = null;
             }
-            timeoutTask.cancel();
-            timeoutTask = null;
-            timeoutTimer.cancel();
-            timeoutTimer = null;
+            if (timeoutTask != null) {
+                timeoutTask.cancel();
+                timeoutTask = null;
+            }
+            if (timeoutTimer != null) {
+                timeoutTimer.cancel();
+                timeoutTimer = null;
+            }
             if (deploymentDir != null) {
                 FileUtil.deleteDirectory(deploymentDir);
             }


### PR DESCRIPTION
With `QuarkusExtensionTest` allowing to run tests in reproducibility checks mode, I stumbled upon an edge-case where missing null checks are causing test failures.

`io.quarkus.funqy.test.BadBinaryArrayTest` registers `QuarkusExtensionTest` 4 times, and when ran with reproducibility checks, a `TestAbortedException` is thrown to abort the tests in the first `beforeAll` hook. Consequent `beforeAll` hooks are not invoked, but `afterAll` hooks are invoked 4 times, and on the second invocation we get a `null` related error.

Guarding against nulls resolves a failing test as well as follows a more consistent pattern that is already used in the `afterAll` hook when doing a necessary cleaning-up.