### PR TITLE
Only analyze Java code in CI job

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
       with:
-        languages: java-kotlin
+        languages: java
         queries: security-extended
 
     - name: Build


### PR DESCRIPTION
This is temporary as Kotlin 2.4 is not yet supported and the job fails in CI