### PR TITLE
Fix NPE in JSON Logging

### DIFF
--- a/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/ConsoleJsonFormatterDefaultConfigTest.java
+++ b/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/ConsoleJsonFormatterDefaultConfigTest.java
@@ -9,12 +9,16 @@ import java.util.logging.Formatter;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
+import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
 import org.jboss.logmanager.formatters.StructuredFormatter;
 import org.jboss.logmanager.handlers.ConsoleHandler;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkus.bootstrap.logging.InitialConfigurator;
 import io.quarkus.bootstrap.logging.QuarkusDelayedHandler;
@@ -39,6 +43,20 @@ public class ConsoleJsonFormatterDefaultConfigTest {
         assertThat(jsonFormatter.isPrintDetails()).isFalse();
         assertThat(jsonFormatter.getExcludedKeys()).isEmpty();
         assertThat(jsonFormatter.getAdditionalFields().entrySet()).isEmpty();
+    }
+
+    @Test
+    public void exceptionFormattingWorksWithDefaultConfig() throws Exception {
+        JsonFormatter jsonFormatter = getJsonFormatter();
+
+        LogRecord record = new LogRecord(Level.WARNING, "Something went wrong");
+        record.setThrown(new RuntimeException("boom"));
+
+        String line = jsonFormatter.format(record);
+
+        JsonNode node = new ObjectMapper().readTree(line);
+        assertThat(node.has("message")).isTrue();
+        assertThat(node.has("exception")).isTrue();
     }
 
     public static JsonFormatter getJsonFormatter() {

--- a/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/ConsoleJsonFormatterJsonProviderExcludedKeyTest.java
+++ b/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/ConsoleJsonFormatterJsonProviderExcludedKeyTest.java
@@ -88,6 +88,18 @@ public class ConsoleJsonFormatterJsonProviderExcludedKeyTest {
         assertThat(node.has("customfield")).isTrue();
     }
 
+    @Test
+    public void exceptionFormattingWorksWithExcludedKeys() throws Exception {
+        LogRecord record = new LogRecord(Level.WARNING, "Something went wrong");
+        record.setThrown(new RuntimeException("boom"));
+
+        String line = getJsonFormatter().format(record);
+
+        JsonNode node = new ObjectMapper().readTree(line);
+        assertThat(node.has("message")).isTrue();
+        assertThat(node.has("exception")).isTrue();
+    }
+
     @ApplicationScoped
     public static class NestedObjectProvider implements JsonProvider {
 

--- a/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/JsonFormatter.java
+++ b/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/JsonFormatter.java
@@ -281,7 +281,7 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
         }
 
         public JsonLogGenerator startObject(final String key) throws Exception {
-            if (skippedDepth > 0 || excludedKeys.contains(key)) {
+            if (skippedDepth > 0 || (key != null && excludedKeys.contains(key))) {
                 skippedDepth++;
             } else {
                 delegate.startObject(key);
@@ -299,7 +299,7 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
         }
 
         public JsonLogGenerator startArray(final String key) throws Exception {
-            if (skippedDepth > 0 || excludedKeys.contains(key)) {
+            if (skippedDepth > 0 || (key != null && excludedKeys.contains(key))) {
                 skippedDepth++;
             } else {
                 delegate.startArray(key);
@@ -407,7 +407,7 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
 
         @Override
         public Generator startObject(final String key) throws Exception {
-            if (skippedDepth > 0 || excludedKeys.contains(key)) {
+            if (skippedDepth > 0 || (key != null && excludedKeys.contains(key))) {
                 skippedDepth++;
             } else {
                 delegate.startObject(key);
@@ -427,7 +427,7 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
 
         @Override
         public Generator startArray(final String key) throws Exception {
-            if (skippedDepth > 0 || excludedKeys.contains(key)) {
+            if (skippedDepth > 0 || (key != null && excludedKeys.contains(key))) {
                 skippedDepth++;
             } else {
                 delegate.startArray(key);


### PR DESCRIPTION
JBoss LogManager can send null keys so we need to be null safe.

Fixes #54765
The regression was introduced in #54343