### PR TITLE
Register StateManagement fields for native image reflection

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -148,6 +148,7 @@ import io.quarkus.hibernate.orm.runtime.config.DialectVersions;
 import io.quarkus.hibernate.orm.runtime.customized.FormatMapperKind;
 import io.quarkus.hibernate.orm.runtime.customized.JsonFormatterCustomizationCheck;
 import io.quarkus.hibernate.orm.runtime.graal.RegisterServicesForReflectionFeature;
+import io.quarkus.hibernate.orm.runtime.graal.RegisterStateManagementForReflectionFeature;
 import io.quarkus.hibernate.orm.runtime.integration.HibernateOrmIntegrationStaticDescriptor;
 import io.quarkus.hibernate.orm.runtime.migration.MultiTenancyStrategy;
 import io.quarkus.hibernate.orm.runtime.proxies.PreGeneratedProxies;
@@ -211,6 +212,11 @@ public final class HibernateOrmProcessor {
         }
 
         return new NativeImageFeatureBuildItem(RegisterServicesForReflectionFeature.class);
+    }
+
+    @BuildStep
+    NativeImageFeatureBuildItem registerStateManagementForReflection() {
+        return new NativeImageFeatureBuildItem(RegisterStateManagementForReflectionFeature.class);
     }
 
     @BuildStep

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/softdelete/SoftDeleteEntity.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/softdelete/SoftDeleteEntity.java
@@ -1,0 +1,41 @@
+package io.quarkus.hibernate.orm.softdelete;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+import org.hibernate.annotations.SoftDelete;
+
+@SoftDelete
+@Entity
+public class SoftDeleteEntity {
+
+    @Id
+    @GeneratedValue
+    Long id;
+
+    String name;
+
+    public SoftDeleteEntity() {
+    }
+
+    public SoftDeleteEntity(String name) {
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/softdelete/SoftDeleteTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/softdelete/SoftDeleteTest.java
@@ -1,0 +1,61 @@
+package io.quarkus.hibernate.orm.softdelete;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
+import org.hibernate.Session;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * Verifies that entities annotated with {@code @SoftDelete} work correctly.
+ * <p>
+ * This exercises the {@code Stateful.getStateManagement()} code path which
+ * reflectively accesses the {@code INSTANCE} field on {@code StateManagement}
+ * implementations via {@code getDeclaredField("INSTANCE")}. In native mode,
+ * these fields must be registered for reflection.
+ *
+ * @see <a href="https://github.com/quarkusio/quarkus/issues/54777">GitHub issue #54777</a>
+ */
+public class SoftDeleteTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(SoftDeleteEntity.class)
+                    .addAsResource("application.properties"));
+
+    @Inject
+    Session session;
+
+    @Test
+    @Transactional
+    public void testSoftDeleteEntityPersistAndFind() {
+        SoftDeleteEntity entity = new SoftDeleteEntity("test");
+        session.persist(entity);
+        session.flush();
+
+        SoftDeleteEntity found = session.find(SoftDeleteEntity.class, entity.getId());
+        assertThat(found).isNotNull();
+        assertThat(found.getName()).isEqualTo("test");
+    }
+
+    @Test
+    @Transactional
+    public void testSoftDeleteEntityRemove() {
+        SoftDeleteEntity entity = new SoftDeleteEntity("to-delete");
+        session.persist(entity);
+        session.flush();
+
+        Long id = entity.getId();
+        session.remove(entity);
+        session.flush();
+
+        SoftDeleteEntity found = session.find(SoftDeleteEntity.class, id);
+        assertThat(found).isNull();
+    }
+}

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/graal/RegisterStateManagementForReflectionFeature.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/graal/RegisterStateManagementForReflectionFeature.java
@@ -1,0 +1,41 @@
+package io.quarkus.hibernate.orm.runtime.graal;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.hosted.RuntimeReflection;
+import org.hibernate.persister.state.spi.StateManagement;
+
+/**
+ * Makes fields of reachable Hibernate StateManagement implementations accessible through
+ * {@link Class#getDeclaredField(String)}.
+ * <p>
+ * Hibernate ORM 7.4+ uses reflection to access the static {@code INSTANCE} field of
+ * StateManagement implementations at runtime. This feature ensures those fields are
+ * available for reflection in native mode.
+ * <p>
+ * See <a href="https://github.com/quarkusio/quarkus/issues/54777">GitHub issue #54777</a>.
+ */
+public class RegisterStateManagementForReflectionFeature implements Feature {
+
+    @Override
+    public String getDescription() {
+        return "Makes fields of reachable Hibernate StateManagement implementations accessible through Class#getDeclaredField()";
+    }
+
+    // The {@code duringAnalysis} method is invoked multiple times and increases the set of reachable types, thus we
+    // need to invoke {@link DuringAnalysisAccess#requireAnalysisIteration()} each time we register new fields.
+    private static final int ANTICIPATED_STATE_MANAGEMENT_CLASSES = 10;
+    private static final Set<Class<?>> registeredClasses = new HashSet<>(ANTICIPATED_STATE_MANAGEMENT_CLASSES);
+
+    @Override
+    public void duringAnalysis(DuringAnalysisAccess access) {
+        for (Class<?> stateManagement : access.reachableSubtypes(StateManagement.class)) {
+            if (registeredClasses.add(stateManagement)) {
+                RuntimeReflection.registerAllDeclaredFields(stateManagement);
+                access.requireAnalysisIteration();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes native image startup failure (`NoSuchFieldException: INSTANCE`) when using `@SoftDelete` or other `StateManagement` strategies introduced in Hibernate ORM 7.4
- Adds a GraalVM `Feature` (`RegisterStateManagementForReflectionFeature`) that dynamically registers all reachable `StateManagement` subtypes' fields for reflection, mirroring the existing `RegisterServicesForReflectionFeature` pattern
- Adds a `@SoftDelete` entity test covering persist/find/remove

Fixes #54777

## Test plan

- [x] New `SoftDeleteTest` passes in JVM mode (persist, find, soft-delete)
- [x] Native image build with `@SoftDelete` entity starts without `NoSuchFieldException` (verified by quarkus-test-suite native CI)