### PR TITLE
Gradle plugin: Avoid resolving deployment classpaths during task graph calculation

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -629,7 +629,11 @@ public class QuarkusPlugin implements Plugin<Project> {
         task.getPlatformInfo().configureFrom(classpath.getPlatformPropertiesConfiguration());
         task.getDeploymentClasspath().configureFrom(classpath.getDeploymentConfiguration());
         task.getCompileOnlyClasspath().configureFrom(classpath.getCompileOnlyWithoutResolvingDeployment());
-        task.getDeploymentResolvedWorkaround().from(classpath.getDeploymentConfiguration().getIncoming().getFiles());
+        task.dependsOn(classpath.getDeploymentConfiguration().getIncoming().getFiles().getBuildDependencies());
+        Path projectDir = project.getLayout().getProjectDirectory().getAsFile().toPath();
+        task.getDeploymentClasspathSnapshot().set(project.provider(() -> QuarkusApplicationModelTask
+                .deploymentClasspathSnapshot(classpath.getDeploymentConfiguration().getIncoming().getArtifacts(),
+                        projectDir)));
         task.getApplicationModel().set(project.getLayout().getBuildDirectory().file(quarkusModelFile));
     }
 

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusApplicationModelTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusApplicationModelTask.java
@@ -14,6 +14,7 @@ import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -38,6 +39,7 @@ import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
+import org.gradle.api.attributes.Attribute;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.ProjectLayout;
@@ -47,12 +49,9 @@ import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.CompileClasspath;
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.OutputFile;
-import org.gradle.api.tasks.PathSensitive;
-import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
 import org.gradle.work.DisableCachingByDefault;
@@ -105,9 +104,8 @@ public abstract class QuarkusApplicationModelTask extends DefaultTask {
     @CompileClasspath
     public abstract ConfigurableFileCollection getOriginalClasspath();
 
-    @InputFiles
-    @PathSensitive(PathSensitivity.RELATIVE)
-    public abstract ConfigurableFileCollection getDeploymentResolvedWorkaround();
+    @Input
+    public abstract ListProperty<String> getDeploymentClasspathSnapshot();
 
     @Nested
     public abstract QuarkusResolvedClasspath getPlatformConfiguration();
@@ -528,6 +526,41 @@ public abstract class QuarkusApplicationModelTask extends DefaultTask {
                 .setCoords(artifactCoords)
                 .setResolvedPaths(PathList.of(file.toPath()))
                 .setFlags(allFlags);
+    }
+
+    public static List<String> deploymentClasspathSnapshot(ArtifactCollection artifactCollection, Path projectDir) {
+        return artifactCollection.getArtifacts().stream()
+                .map(artifact -> deploymentArtifactSnapshot(artifact, projectDir))
+                .sorted()
+                .collect(toList());
+    }
+
+    private static String deploymentArtifactSnapshot(ResolvedArtifactResult artifact, Path projectDir) {
+        var attributes = artifact.getVariant().getAttributes();
+        return artifact.getId().getDisplayName() + "|" + artifact.getId().getComponentIdentifier().getDisplayName() + "|"
+                + artifact.getFile().getName() + "|"
+                // Use lastModified and length to distinguish rebuilt artifacts with the same name,
+                // identifier, version, and selected variant.
+                // A content checksum would be more precise, but it would add file I/O while Gradle
+                // calculates task inputs before execution. This task is not cacheable, so the
+                // timestamp/size pair is the pragmatic local up-to-date check here.
+                + artifact.getFile().lastModified() + "|"
+                + artifact.getFile().length() + "|"
+                + projectArtifactPath(artifact, projectDir) + "|"
+                + attributes.keySet().stream()
+                        .sorted(Comparator.comparing(Attribute::getName))
+                        .map(attribute -> attribute.getName() + "=" + attributes.getAttribute(attribute))
+                        .collect(Collectors.joining(","));
+    }
+
+    private static String projectArtifactPath(ResolvedArtifactResult artifact, Path projectDir) {
+        if (!(artifact.getId().getComponentIdentifier() instanceof ProjectComponentIdentifier)) {
+            return "";
+        }
+        return projectDir.toAbsolutePath().normalize()
+                .relativize(artifact.getFile().toPath().toAbsolutePath().normalize())
+                .toString()
+                .replace(File.separatorChar, '/');
     }
 
     public static abstract class QuarkusPlatformInfo {

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/JavaPlatformWithEagerResolutionTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/JavaPlatformWithEagerResolutionTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
@@ -22,5 +23,33 @@ public class JavaPlatformWithEagerResolutionTest extends QuarkusGradleWrapperTes
 
         final Path quarkusOutput = buildDir.toPath().resolve("quarkus-app");
         assertThat(quarkusOutput.resolve("quarkus-run.jar")).exists();
+    }
+
+    @Test
+    public void dryRunShouldNotResolveDeploymentConfigurations()
+            throws IOException, InterruptedException {
+
+        var projectDir = getProjectDir("java-platform-with-eager-resolution-project");
+        var initScript = projectDir.toPath().resolve("log-resolution.init.gradle.kts");
+        Files.writeString(initScript, """
+                allprojects {
+                	configurations.configureEach {
+                		incoming.beforeResolve {
+                			println("QUARKUS_TEST_RESOLVED:${project.path}:${name}")
+                		}
+                	}
+                }
+                """);
+
+        var result = runGradleWrapper(projectDir, "test", "--dry-run", "--no-configuration-cache",
+                "-I", initScript.toString());
+
+        assertThat(result.getOutput())
+                .contains(":quarkusGenerateAppModel SKIPPED")
+                .contains(":quarkusGenerateCode SKIPPED")
+                .contains(":quarkusGenerateTestAppModel SKIPPED")
+                .contains(":quarkusGenerateCodeTests SKIPPED")
+                .doesNotContain("QUARKUS_TEST_RESOLVED:::quarkusProdRuntimeClasspathConfigurationDeployment")
+                .doesNotContain("QUARKUS_TEST_RESOLVED:::quarkusTestRuntimeClasspathConfigurationDeployment");
     }
 }


### PR DESCRIPTION
PR #44032 fixed #43258 by avoiding deployment configuration resolution while configuring `QuarkusApplicationModelTask`.

However, the replacement `deploymentResolvedWorkaround` modeled the deployment classpath as `@InputFiles`. That means Gradle still inspects the file collection while calculating the task graph, before task execution. A `--dry-run` build makes this visible because it builds the graph but skips task actions, so the deployment configurations are resolved even though no Quarkus task actually runs.

This changes the workaround to a lazy scalar snapshot input. Real task execution still resolves and fingerprints the deployment artifacts for app-model invalidation, but task graph calculation no longer resolves the deployment classpaths.

The regression test extends the #43258 fixture to cover this pre-execution task graph behavior.
