### PR TITLE
Carry acr_values and max_age in the code flow authorization request

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-bearer-token-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-bearer-token-authentication.adoc
@@ -1638,6 +1638,7 @@ public class OidcStartup {
 For more complex setup involving multiple tenants please see the xref:security-openid-connect-multitenancy.adoc#programmatic-startup[Programmatic OIDC start-up for multitenant application]
 section of the OpenID Connect Multi-Tenancy guide.
 
+[[step-up-authentication]]
 == Step Up Authentication
 
 The `io.quarkus.oidc.AuthenticationContext` annotation can be used to list one or more Authentication Context Class Reference (ACR) values to enforce a required authentication level for the Jakarta REST resource classes and methods.

--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
@@ -1703,7 +1703,7 @@ This redirect also includes the `acr_values` parameter, so the provider can requ
 How the requested ACR values are enforced is specific to each OIDC provider.
 For example, see the link:https://www.keycloak.org/docs/latest/server_admin/index.html#_step-up-flow[Keycloak Step-up Authentication] documentation describing how Keycloak maps ACR values to Levels of Authentication (LoA) in browser authentication flows.
 
-For more information about how the `acr` claim is verified, see the xref:security-oidc-bearer-token-authentication.adoc#step-up-authentication[Step Up Authentication] section of the Quarkus OIDC Bearer token authentication guide.
+For information about how a required authentication level is enforced in a Bearer token authentication flow, see the xref:security-oidc-bearer-token-authentication.adoc#step-up-authentication[Step Up Authentication] section of the Quarkus OIDC Bearer token authentication guide.
 
 [[oauth2]]
 === Integration with GitHub and non-OIDC OAuth2 providers

--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
@@ -1663,6 +1663,48 @@ You cannot extend the user session indefinitely.
 The returning user with the expired ID token will have to re-authenticate at the OIDC provider endpoint once the refresh token expires.
 ====
 
+[[code-flow-step-up-authentication]]
+=== Step Up Authentication
+
+The `io.quarkus.oidc.AuthenticationContext` annotation can be used to list one or more Authentication Context Class Reference (ACR) values to enforce a required authentication level for the Jakarta REST resource classes and methods.
+Consider the following example:
+
+[source,java]
+----
+package org.acme.security;
+
+import io.quarkus.oidc.AuthenticationContext;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@Path("/transfer")
+public class TransferResource {
+
+    @GET
+    @AuthenticationContext("gold") <1>
+    public String transfer() {
+        return "transferred";
+    }
+}
+----
+<1> The ID token of the current session must have an `acr` claim with the `gold` ACR value.
+
+[source,properties]
+----
+quarkus.http.auth.proactive=false <1>
+----
+<1> Disable proactive authentication so that the `@AuthenticationContext` annotation can be matched with the endpoint before Quarkus authenticates incoming requests.
+
+The authorization request to the OIDC provider includes the `acr_values` parameter listing the required ACR values, and the `max_age` parameter when the annotation's `maxAge` attribute is set.
+
+When the current session does not provide the required authentication level, for example, because the ID token `acr` claim does not list the required ACR values, the user is redirected to the OIDC provider to re-authenticate.
+This redirect also includes the `acr_values` parameter, so the provider can request a stronger authentication method, for example, a multi-factor authentication, before issuing new tokens.
+
+How the requested ACR values are enforced is specific to each OIDC provider.
+For example, see the link:https://www.keycloak.org/docs/latest/server_admin/index.html#_step-up-flow[Keycloak Step-up Authentication] documentation describing how Keycloak maps ACR values to Levels of Authentication (LoA) in browser authentication flows.
+
+For more information about how the `acr` claim is verified, see the xref:security-oidc-bearer-token-authentication.adoc#step-up-authentication[Step Up Authentication] section of the Quarkus OIDC Bearer token authentication guide.
+
 [[oauth2]]
 === Integration with GitHub and non-OIDC OAuth2 providers
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -404,7 +404,13 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
 
                                                 boolean unresolvedKey = t.getCause() instanceof InvalidJwtException
                                                         && (t.getCause().getCause() instanceof UnresolvableKeyException);
-                                                if (unresolvedKey
+                                                if (StepUpAuthenticationPolicy.isInsufficientUserAuthException(t)) {
+                                                    // Session does not have the required authentication level,
+                                                    // redirect the user to the OIDC provider to re-authenticate
+                                                    LOG.debug(
+                                                            "Session does not have the required authentication level, reauthentication is required");
+                                                    failure = t;
+                                                } else if (unresolvedKey
                                                         && !configContext.oidcConfig().authentication().failOnUnresolvedKid()
                                                         && OidcUtils.isJwtTokenExpired(currentIdToken)) {
                                                     // It can happen in multi-tab applications where a user login causes a JWK set refresh
@@ -806,6 +812,19 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
 
                         // extra redirect parameters, see https://openid.net/specs/openid-connect-core-1_0.html#AuthRequests
                         addExtraParamsToUri(codeFlowParams, authenticationConfig.extraParams());
+
+                        // acr_values and max_age, set when the requested endpoint requires
+                        // a specific authentication level, see https://www.rfc-editor.org/rfc/rfc9470
+                        StepUpAuthenticationPolicy stepUpAuthPolicy = StepUpAuthenticationPolicy.getFromRoutingContext(context);
+                        if (stepUpAuthPolicy != null) {
+                            codeFlowParams.append(AMP).append(OidcConstants.ACR_VALUES).append(EQ)
+                                    .append(OidcCommonUtils
+                                            .urlEncode(String.join(" ", stepUpAuthPolicy.expectedAcrValues())));
+                            if (stepUpAuthPolicy.maxAge() != null) {
+                                codeFlowParams.append(AMP).append(OidcConstants.MAX_AGE).append(EQ)
+                                        .append(stepUpAuthPolicy.maxAge());
+                            }
+                        }
 
                         if (pushedAuthorizationRequest) {
                             return configContext.getOidcProviderClient()

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -814,7 +814,7 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                         addExtraParamsToUri(codeFlowParams, authenticationConfig.extraParams());
 
                         // acr_values and max_age, set when the requested endpoint requires
-                        // a specific authentication level, see https://www.rfc-editor.org/rfc/rfc9470
+                        // a specific authentication level
                         StepUpAuthenticationPolicy stepUpAuthPolicy = StepUpAuthenticationPolicy.getFromRoutingContext(context);
                         if (stepUpAuthPolicy != null) {
                             codeFlowParams.append(AMP).append(OidcConstants.ACR_VALUES).append(EQ)

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/StepUpAuthenticationPolicy.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/StepUpAuthenticationPolicy.java
@@ -110,8 +110,16 @@ record StepUpAuthenticationPolicy(String[] expectedAcrValues, Long maxAge) imple
     }
 
     static StepUpAuthenticationPolicy getFromRequest(TokenAuthenticationRequest request) {
-        RoutingContext routingContext = getRoutingContextAttribute(request);
+        return getFromRoutingContext(getRoutingContextAttribute(request));
+    }
+
+    static StepUpAuthenticationPolicy getFromRoutingContext(RoutingContext routingContext) {
         return routingContext != null ? routingContext.get(AUTHENTICATION_POLICY_KEY) : null;
+    }
+
+    static boolean isInsufficientUserAuthException(Throwable throwable) {
+        return throwable instanceof AuthenticationFailedException authFailure
+                && isInsufficientUserAuthException(authFailure);
     }
 
     static boolean isInsufficientUserAuthException(RoutingContext routingContext) {

--- a/integration-tests/oidc-tenancy/src/main/resources/application.properties
+++ b/integration-tests/oidc-tenancy/src/main/resources/application.properties
@@ -224,6 +224,10 @@ quarkus.oidc.step-up-auth-custom-validator.introspection-path=${quarkus.oidc.ste
 %step-up-auth.quarkus.oidc.step-up-auth-annotation-selection-2.jwks-path=jwks
 %step-up-auth.quarkus.oidc.step-up-auth-annotation-selection-2.auth-server-url=http://localhost:${quarkus.http.test-port}/oidc
 %step-up-auth.quarkus.oidc.step-up-auth-annotation-selection-2.introspection-path=${quarkus.oidc.step-up-auth-annotation-selection.auth-server-url}
+%step-up-auth.quarkus.oidc.step-up-auth-web-app.auth-server-url=${keycloak.url}/realms/quarkus-webapp
+%step-up-auth.quarkus.oidc.step-up-auth-web-app.client-id=quarkus-app-webapp-stepup
+%step-up-auth.quarkus.oidc.step-up-auth-web-app.credentials.secret=secret
+%step-up-auth.quarkus.oidc.step-up-auth-web-app.application-type=web-app
 
 quarkus.oidc.concurrent-token-refresh.client-id=client
 quarkus.oidc.concurrent-token-refresh.allow-token-introspection-cache=false

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/CodeFlowStepUpAuthenticationTest.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/CodeFlowStepUpAuthenticationTest.java
@@ -1,0 +1,145 @@
+package io.quarkus.it.keycloak;
+
+import static io.quarkus.it.keycloak.BearerTokenAuthorizationTest.createWebClient;
+import static io.quarkus.it.keycloak.BearerTokenAuthorizationTest.getSessionCookie;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.IOException;
+import java.net.URI;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.htmlunit.WebClient;
+import org.htmlunit.WebRequest;
+import org.htmlunit.WebResponse;
+import org.htmlunit.html.HtmlForm;
+import org.htmlunit.html.HtmlPage;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.oidc.AuthenticationContext;
+import io.quarkus.oidc.IdToken;
+import io.quarkus.oidc.Tenant;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+
+@TestProfile(BearerTokenStepUpAuthenticationTest.StepUpAuthTestProfile.class)
+@QuarkusTestResource(KeycloakRealmResourceManager.class)
+@QuarkusTest
+public class CodeFlowStepUpAuthenticationTest {
+
+    @Test
+    public void testLoginRedirectContainsAcrValues() {
+        // anonymous request to the endpoint requiring an authentication level,
+        // the authorization request must ask for it with the 'acr_values' parameter
+        String location = RestAssured.given().redirects().follow(false)
+                .when().get("/code-flow-step-up-auth/acr-3")
+                .then().statusCode(302).extract().header("location");
+        assertThat(location, containsString("/realms/quarkus-webapp/protocol/openid-connect/auth"));
+        assertThat(location, containsString("acr_values=3"));
+        assertThat(location, not(containsString("max_age")));
+    }
+
+    @Test
+    public void testLoginRedirectContainsMultipleAcrValuesAndMaxAge() {
+        String location = RestAssured.given().redirects().follow(false)
+                .when().get("/code-flow-step-up-auth/acr-multiple-max-age")
+                .then().statusCode(302).extract().header("location");
+        assertThat(location, containsString("/realms/quarkus-webapp/protocol/openid-connect/auth"));
+        // the required acr values are passed as a space separated list, in no particular order
+        assertThat(location, anyOf(containsString("acr_values=2+3"), containsString("acr_values=3+2")));
+        assertThat(location, containsString("max_age=300"));
+    }
+
+    @Test
+    public void testCodeFlowSatisfiesRequiredAcr() throws IOException {
+        try (WebClient webClient = createWebClient()) {
+            HtmlPage page = webClient.getPage("http://localhost:8081/code-flow-step-up-auth/acr-1");
+            // Keycloak login page, reached with the authorization request requiring acr '1'
+            assertEquals("Sign in to quarkus-webapp", page.getTitleText());
+            assertThat(page.getUrl().toString(), containsString("acr_values=1"));
+
+            HtmlForm loginForm = page.getForms().get(0);
+            loginForm.getInputByName("username").setValueAttribute("alice");
+            loginForm.getInputByName("password").setValueAttribute("alice");
+            page = loginForm.getButtonByName("login").click();
+            // a fresh login satisfies acr '1', the ID token carries the claim
+            assertEquals("granted:1", page.getBody().asNormalizedText());
+            assertNotNull(getSessionCookie(webClient, "step-up-auth-web-app"));
+
+            // the existing session satisfies the required level, no new challenge
+            page = webClient.getPage("http://localhost:8081/code-flow-step-up-auth/acr-1");
+            assertEquals("granted:1", page.getBody().asNormalizedText());
+
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    @Test
+    public void testStepUpFromExistingSession() throws IOException {
+        try (WebClient webClient = createWebClient()) {
+            // establish a session with the standard acr level '1'
+            HtmlPage page = webClient.getPage("http://localhost:8081/code-flow-step-up-auth/acr-1");
+            HtmlForm loginForm = page.getForms().get(0);
+            loginForm.getInputByName("username").setValueAttribute("alice");
+            loginForm.getInputByName("password").setValueAttribute("alice");
+            page = loginForm.getButtonByName("login").click();
+            assertEquals("granted:1", page.getBody().asNormalizedText());
+            assertNotNull(getSessionCookie(webClient, "step-up-auth-web-app"));
+
+            // the session does not satisfy acr '3', the user must be redirected
+            // to the provider to re-authenticate with the required acr, not get a 401
+            webClient.getOptions().setRedirectEnabled(false);
+            WebResponse webResponse = webClient.loadWebResponse(
+                    new WebRequest(URI.create("http://localhost:8081/code-flow-step-up-auth/acr-3").toURL()));
+            assertEquals(302, webResponse.getStatusCode());
+            String location = webResponse.getResponseHeaderValue("location");
+            assertThat(location, containsString("/realms/quarkus-webapp/protocol/openid-connect/auth"));
+            assertThat(location, containsString("acr_values=3"));
+            // the session cookie is removed so that a new login can replace the session
+            assertNull(getSessionCookie(webClient, "step-up-auth-web-app"));
+
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    @Tenant("step-up-auth-web-app")
+    @Path("/code-flow-step-up-auth")
+    public static class CodeFlowStepUpResource {
+
+        @Inject
+        @IdToken
+        JsonWebToken idToken;
+
+        @GET
+        @Path("acr-1")
+        @AuthenticationContext("1")
+        public String acr1() {
+            return "granted:" + idToken.getClaim("acr");
+        }
+
+        @GET
+        @Path("acr-3")
+        @AuthenticationContext("3")
+        public String acr3() {
+            return "granted";
+        }
+
+        @GET
+        @Path("acr-multiple-max-age")
+        @AuthenticationContext(value = { "2", "3" }, maxAge = "PT300s")
+        public String acrMultipleMaxAge() {
+            return "granted";
+        }
+    }
+}

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
@@ -32,6 +32,9 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
             if ("b".equals(realmId)) {
                 realm.getClients().add(createClient("quarkus-app-b2"));
             }
+            if ("webapp".equals(realmId)) {
+                realm.getClients().add(createStepUpClient("quarkus-app-webapp-stepup"));
+            }
             realm.getUsers().add(createUser("alice", "user"));
             realm.getUsers().add(createUser("admin", "user", "admin"));
             realm.getUsers().add(createUser("jdoe", "user", "confidential"));
@@ -79,6 +82,20 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
             client.setDefaultClientScopes(Arrays.asList("microprofile-jwt"));
         }
         client.setProtocolMappers(List.of(audienceMapper(clientId)));
+
+        return client;
+    }
+
+    private static ClientRepresentation createStepUpClient(String clientId) {
+        ClientRepresentation client = new ClientRepresentation();
+
+        client.setClientId(clientId);
+        client.setPublicClient(false);
+        client.setSecret("secret");
+        client.setEnabled(true);
+        client.setRedirectUris(Arrays.asList("*"));
+        // Default client scopes are not overridden so that the 'basic' scope
+        // adds the 'acr' claim to the ID token
 
         return client;
     }


### PR DESCRIPTION
`@AuthenticationContext` works for `service` applications, where the bearer mechanism returns the RFC 9470 `insufficient_user_authentication` challenge with `acr_values`. For `web-app` applications the required values were verified against the session tokens but never communicated to the OIDC provider, so the provider re-used its SSO session at the original acr level and the user could never step up.

This change makes the code flow mechanism honor the step-up policy:

* The authorization request now includes the `acr_values` parameter (space separated, per OpenID Connect Core 3.1.2.1) and the `max_age` parameter when the annotation sets `maxAge`. This applies both to the initial login and to re-authentication, which also matches the client behavior described in RFC 9470 section 4.
* When an existing session does not meet the required authentication level, the user is redirected to the provider to re-authenticate instead of getting a plain 401 with a removed session.

New `CodeFlowStepUpAuthenticationTest` in `integration-tests/oidc-tenancy` covers the authorization request parameters (single value, multiple values plus `max_age`), the full code flow against Keycloak where the fresh login satisfies the required acr, a session that already satisfies the requirement, and the re-authentication redirect from an insufficient session. All four tests fail without the runtime change.

The docs gain a step-up section in the code flow guide, since the existing one only covered bearer tokens.

* Fixes #54785

🤖 Generated with [Claude Code](https://claude.com/claude-code)
