### PR TITLE
Enforce the @AuthenticationContext step-up policy for @TestSecurity tests

### DIFF
--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/StepUpAuthenticationTestSecurityTest.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/StepUpAuthenticationTestSecurityTest.java
@@ -1,0 +1,70 @@
+package io.quarkus.it.keycloak;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.security.TestSecurity;
+import io.quarkus.test.security.oidc.Claim;
+import io.quarkus.test.security.oidc.OidcSecurity;
+import io.restassured.RestAssured;
+
+/**
+ * Verifies the {@code @AuthenticationContext} step-up policy is enforced for {@code @TestSecurity}
+ * tests, with the required 'acr' and 'auth_time' claims supplied via {@code @OidcSecurity}.
+ */
+@TestProfile(BearerTokenStepUpAuthenticationTest.StepUpAuthTestProfile.class)
+@QuarkusTestResource(KeycloakRealmResourceManager.class)
+@QuarkusTest
+public class StepUpAuthenticationTestSecurityTest {
+
+    @Test
+    @TestSecurity(user = "alice")
+    public void testRequiredAcrClaimMissing() {
+        RestAssured.given()
+                .when().get("/step-up-auth/method-level/no-rbac-annotation")
+                .then().statusCode(401);
+    }
+
+    @Test
+    @TestSecurity(user = "alice")
+    @OidcSecurity(claims = @Claim(key = "acr", value = "5"))
+    public void testWrongAcrClaim() {
+        RestAssured.given()
+                .when().get("/step-up-auth/method-level/no-rbac-annotation")
+                .then().statusCode(401);
+    }
+
+    @Test
+    @TestSecurity(user = "alice")
+    @OidcSecurity(claims = @Claim(key = "acr", value = "1"))
+    public void testMatchingAcrClaim() {
+        RestAssured.given()
+                .when().get("/step-up-auth/method-level/no-rbac-annotation")
+                .then().statusCode(200)
+                .body(is("no-rbac-annotation"));
+    }
+
+    @Test
+    @TestSecurity(user = "alice")
+    @OidcSecurity(claims = @Claim(key = "acr", value = "myACR"))
+    public void testMaxAgeWithFreshToken() {
+        // no 'auth_time' claim is defined, so the 'iat' claim of the generated token is used
+        RestAssured.given()
+                .when().get("/step-up-auth/method-level/max-age-and-acr-required")
+                .then().statusCode(200)
+                .body(is("max-age-and-acr-required"));
+    }
+
+    @Test
+    @TestSecurity(user = "alice")
+    @OidcSecurity(claims = { @Claim(key = "acr", value = "myACR"), @Claim(key = "auth_time", value = "123") })
+    public void testMaxAgeExceeded() {
+        RestAssured.given()
+                .when().get("/step-up-auth/method-level/max-age-and-acr-required")
+                .then().statusCode(401);
+    }
+}

--- a/test-framework/security-oidc/src/main/java/io/quarkus/test/security/oidc/StepUpAuthenticationPolicyAugmentor.java
+++ b/test-framework/security-oidc/src/main/java/io/quarkus/test/security/oidc/StepUpAuthenticationPolicyAugmentor.java
@@ -1,0 +1,65 @@
+package io.quarkus.test.security.oidc;
+
+import java.util.Map;
+import java.util.function.Consumer;
+
+import jakarta.inject.Singleton;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.oidc.AccessTokenCredential;
+import io.quarkus.oidc.runtime.OidcUtils;
+import io.quarkus.oidc.runtime.TokenVerificationResult;
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.test.security.TestSecurityIdentityAugmentorExtension;
+import io.quarkus.vertx.http.runtime.security.HttpSecurityUtils;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Enforces the {@code @AuthenticationContext} step-up policy for {@code @TestSecurity} tests, which
+ * otherwise bypass the OIDC token verification that normally enforces it.
+ */
+@Singleton
+@Unremovable
+public class StepUpAuthenticationPolicyAugmentor implements TestSecurityIdentityAugmentorExtension {
+
+    @Override
+    public Uni<SecurityIdentity> augment(SecurityIdentity identity, AuthenticationRequestContext context) {
+        return Uni.createFrom().item(identity);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Uni<SecurityIdentity> augment(SecurityIdentity identity, AuthenticationRequestContext context,
+            Map<String, Object> attributes) {
+        if (identity.isAnonymous()) {
+            return Uni.createFrom().item(identity);
+        }
+        RoutingContext routingContext = HttpSecurityUtils.getRoutingContextAttribute(attributes);
+        if (routingContext == null) {
+            return Uni.createFrom().item(identity);
+        }
+        // StepUpAuthenticationPolicy is stored as a Consumer<TokenVerificationResult> that throws
+        // AuthenticationFailedException when the required acr values or max token age are not met
+        Object policy = routingContext.get("io.quarkus.oidc.runtime.step-up-auth");
+        if (policy != null) {
+            ((Consumer<TokenVerificationResult>) policy).accept(tokenVerificationResult(identity));
+        }
+        return Uni.createFrom().item(identity);
+    }
+
+    private static TokenVerificationResult tokenVerificationResult(SecurityIdentity identity) {
+        io.quarkus.oidc.TokenIntrospection introspection = identity.getAttribute(OidcUtils.INTROSPECTION_ATTRIBUTE);
+        if (introspection != null) {
+            return new TokenVerificationResult(null, introspection);
+        }
+        JsonObject claims = null;
+        AccessTokenCredential accessToken = identity.getCredential(AccessTokenCredential.class);
+        if (accessToken != null && accessToken.getToken() != null) {
+            claims = OidcUtils.decodeJwtContent(accessToken.getToken());
+        }
+        return new TokenVerificationResult(claims != null ? claims : new JsonObject(), null);
+    }
+}

--- a/test-framework/security/src/main/java/io/quarkus/test/security/QuarkusSecurityTestExtension.java
+++ b/test-framework/security/src/main/java/io/quarkus/test/security/QuarkusSecurityTestExtension.java
@@ -136,6 +136,12 @@ public class QuarkusSecurityTestExtension implements QuarkusTestBeforeEachCallba
         if (quarkusPermissionAugmentor.isResolvable()) {
             augmentors.add(quarkusPermissionAugmentor);
         }
+        // 3. a test framework extension contributes an augmentor applied automatically, like the
+        // OIDC one enforcing the @AuthenticationContext step-up authentication policy
+        var augmentorExtension = container.select(TestSecurityIdentityAugmentorExtension.class);
+        if (augmentorExtension.isResolvable()) {
+            augmentors.add(augmentorExtension);
+        }
         if (!augmentors.isEmpty()) {
             for (var testMechanism : container.select(AbstractTestHttpAuthenticationMechanism.class)) {
                 testMechanism.setSecurityIdentityAugmentors(augmentors);

--- a/test-framework/security/src/main/java/io/quarkus/test/security/TestSecurityIdentityAugmentorExtension.java
+++ b/test-framework/security/src/main/java/io/quarkus/test/security/TestSecurityIdentityAugmentorExtension.java
@@ -1,0 +1,15 @@
+package io.quarkus.test.security;
+
+import io.quarkus.security.identity.SecurityIdentityAugmentor;
+
+/**
+ * A {@link SecurityIdentityAugmentor} contributed by a test framework extension that
+ * {@code @TestSecurity} applies automatically, without the user having to list it in
+ * {@code @TestSecurity#augmentors}.
+ * <p>
+ * Regular {@link SecurityIdentityAugmentor} CDI beans are not applied during a
+ * {@code @TestSecurity} test, so augmentors needing a database or external systems do not run.
+ * Implementing this interface is how a test framework extension opts its augmentor into the test.
+ */
+public interface TestSecurityIdentityAugmentorExtension extends SecurityIdentityAugmentor {
+}


### PR DESCRIPTION
`@TestSecurity` bypasses the OIDC token verification that enforces the `@AuthenticationContext` step-up policy, so a step-up test passes vacuously with a 200 even when the required `acr` claim is absent.

This adds `TestSecurityIdentityAugmentorExtension`, a `SecurityIdentityAugmentor` that `QuarkusSecurityTestExtension` discovers by type and applies automatically, the same way it already handles the permission augmentor. Only augmentors implementing this interface run under `@TestSecurity`, so regular augmentors that may require a database or other external systems are not invoked. The OIDC test framework contributes `StepUpAuthenticationPolicyAugmentor`, which verifies the test identity claims against the step-up policy stored on the routing context. `quarkus-oidc` is unchanged.

Step-up tests that previously passed vacuously now return a 401 until they define the required claims, which is the intended behavior change. Covered by `StepUpAuthenticationTestSecurityTest` in `integration-tests/oidc-tenancy`: missing, wrong and matching `acr`, plus fresh and exceeded `maxAge`.
