### PR TITLE
Expose useSemicolonAsQueryParamDelimiter config for HTTP server

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/SemicolonQueryParamDefaultTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/SemicolonQueryParamDefaultTest.java
@@ -1,0 +1,42 @@
+package io.quarkus.vertx.http;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vertx.ext.web.Router;
+
+public class SemicolonQueryParamDefaultTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Routes.class));
+
+    @Test
+    public void testSemicolonIsTreatedAsDelimiterByDefault() {
+        given()
+                .urlEncodingEnabled(false)
+                .get("/echo?a=1;b=2")
+                .then()
+                .statusCode(200)
+                .body(is("a=1|b=2"));
+    }
+
+    @ApplicationScoped
+    static class Routes {
+        public void register(@Observes Router router) {
+            router.route("/echo").handler(rc -> {
+                String a = rc.queryParams().get("a");
+                String b = rc.queryParams().get("b");
+                rc.response().end("a=" + a + "|b=" + b);
+            });
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/SemicolonQueryParamDisabledTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/SemicolonQueryParamDisabledTest.java
@@ -1,0 +1,58 @@
+package io.quarkus.vertx.http;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vertx.ext.web.Router;
+
+/**
+ * Tests that semicolons are treated as literal characters when
+ * {@code quarkus.http.use-semicolon-as-query-param-delimiter} is set to {@code false}.
+ */
+public class SemicolonQueryParamDisabledTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(SemicolonQueryParamDefaultTest.Routes.class))
+            .withRuntimeConfiguration("""
+                    quarkus.http.use-semicolon-as-query-param-delimiter=false
+                    """);
+
+    @Test
+    public void testSemicolonIsLiteralWhenDisabled() {
+        given()
+                .urlEncodingEnabled(false)
+                .get("/echo?a=1;b=2")
+                .then()
+                .statusCode(200)
+                .body(is("a=1;b=2|b=null"));
+    }
+
+    @Test
+    public void testAmpersandStillWorksAsDelimiter() {
+        given().urlEncodingEnabled(false)
+                .get("/echo?a=1&b=2")
+                .then()
+                .statusCode(200)
+                .body(is("a=1|b=2"));
+    }
+
+    @ApplicationScoped
+    static class Routes {
+        public void register(@Observes Router router) {
+            router.route("/echo").handler(rc -> {
+                String a = rc.queryParams().get("a");
+                String b = rc.queryParams().get("b");
+                rc.response().end("a=" + a + "|b=" + b);
+            });
+        }
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpConfig.java
@@ -226,6 +226,22 @@ public interface VertxHttpConfig {
     boolean tcpFastOpen();
 
     /**
+     * Whether the HTTP server should treat the semicolon ({@code ;}) as a query parameter
+     * delimiter, in addition to the ampersand ({@code &}).
+     * <p>
+     * When set to {@code true} (the default), a request like {@code /path?a=1;b=2} is parsed
+     * as two parameters ({@code a=1} and {@code b=2}). When set to {@code false}, the
+     * semicolon is treated as a literal character and the request yields a single parameter
+     * ({@code a=1;b=2}).
+     * <p>
+     * The default is {@code true} to preserve backward compatibility. It will change to
+     * {@code false} in Quarkus 4, as using the semicolon as a query parameter delimiter is
+     * uncommon and can cause issues when semicolons appear as part of parameter values.
+     */
+    @WithDefault("true")
+    boolean useSemicolonAsQueryParamDelimiter();
+
+    /**
      * The accept backlog, this is how many connections can be waiting to be accepted before connections start being rejected
      */
     @WithDefault("-1")

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementConfig.java
@@ -97,6 +97,22 @@ public interface ManagementConfig {
     boolean handle100ContinueAutomatically();
 
     /**
+     * Whether the HTTP server should treat the semicolon ({@code ;}) as a query parameter
+     * delimiter, in addition to the ampersand ({@code &}).
+     * <p>
+     * When set to {@code true} (the default), a request like {@code /path?a=1;b=2} is parsed
+     * as two parameters ({@code a=1} and {@code b=2}). When set to {@code false}, the
+     * semicolon is treated as a literal character and the request yields a single parameter
+     * ({@code a=1;b=2}).
+     * <p>
+     * The default is {@code true} to preserve backward compatibility. It will change to
+     * {@code false} in Quarkus 4, as using the semicolon as a query parameter delimiter is
+     * uncommon and can cause issues when semicolons appear as part of parameter values.
+     */
+    @WithDefault("true")
+    boolean useSemicolonAsQueryParamDelimiter();
+
+    /**
      * Server limits configuration
      */
     ServerLimitsConfig limits();

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtils.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtils.java
@@ -301,6 +301,8 @@ public class HttpServerOptionsUtils {
         httpServerOptions.setTcpCork(httpConfig.tcpCork());
         httpServerOptions.setAcceptBacklog(httpConfig.acceptBacklog());
         httpServerOptions.setTcpFastOpen(httpConfig.tcpFastOpen());
+        httpServerOptions
+                .setUseSemicolonAsQueryParamDelimiter(httpConfig.useSemicolonAsQueryParamDelimiter());
         httpServerOptions.setCompressionSupported(httpBuildTimeConfig.enableCompression());
         if (httpBuildTimeConfig.compressionLevel().isPresent()) {
             httpServerOptions.setCompressionLevel(httpBuildTimeConfig.compressionLevel().getAsInt());
@@ -431,6 +433,7 @@ public class HttpServerOptionsUtils {
         }
         options.setDecompressionSupported(managementBuildTimeConfig.enableDecompression());
         options.setHandle100ContinueAutomatically(managementConfig.handle100ContinueAutomatically());
+        options.setUseSemicolonAsQueryParamDelimiter(managementConfig.useSemicolonAsQueryParamDelimiter());
 
         options.setUseProxyProtocol(managementConfig.proxy().useProxyProtocol());
     }


### PR DESCRIPTION
Allows users to disable semicolon as a query parameter delimiter via quarkus.http.use-semicolon-as-query-param-delimiter=false. (I picked a long long name to avoid any ambiguity)

Defaults to true; will change to false in Quarkus 4.

Fixes #50685

