### PR TITLE
Add Vary: Origin header to CORS responses when origin varies

### DIFF
--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/DevUICORSFilter.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/DevUICORSFilter.java
@@ -164,6 +164,11 @@ public class DevUICORSFilter implements Handler<RoutingContext> {
             public boolean returnExactOrigins() {
                 return true;
             }
+
+            @Override
+            public boolean varyOrigin() {
+                return baseCorsConfig.varyOrigin();
+            }
         };
     }
 }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSVaryOriginRejectionTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSVaryOriginRejectionTestCase.java
@@ -1,0 +1,33 @@
+package io.quarkus.vertx.http.cors;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.nullValue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class CORSVaryOriginRejectionTestCase {
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(BeanRegisteringRoute.class)
+                    .addAsResource("conf/cors-config-wildcard-origins.properties", "application.properties"));
+
+    @Test
+    @DisplayName("Vary: Origin is present when origin is rejected")
+    public void corsVaryPresentOnRejection() {
+        String origin = "http://non.matching.origin.quarkus";
+        given().header("Origin", origin)
+                .header("Access-Control-Request-Method", "POST")
+                .when()
+                .options("/test").then()
+                .statusCode(403)
+                .header("Access-Control-Allow-Origin", nullValue())
+                .header("Vary", containsString("origin"));
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSVaryOriginTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSVaryOriginTestCase.java
@@ -1,0 +1,44 @@
+package io.quarkus.vertx.http.cors;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class CORSVaryOriginTestCase {
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(BeanRegisteringRoute.class)
+                    .addAsResource("conf/cors-config.properties", "application.properties"));
+
+    @Test
+    @DisplayName("Vary: Origin is present when echoing exact origin on simple request")
+    public void corsVaryPresentOnSimpleRequest() {
+        String origin = "http://custom.origin.quarkus";
+        given().header("Origin", origin)
+                .when()
+                .get("/test").then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", origin)
+                .header("Vary", containsString("origin"));
+    }
+
+    @Test
+    @DisplayName("Vary: Origin is present when echoing exact origin on preflight request")
+    public void corsVaryPresentOnPreflightRequest() {
+        String origin = "http://custom.origin.quarkus";
+        given().header("Origin", origin)
+                .header("Access-Control-Request-Method", "POST")
+                .when()
+                .options("/test").then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", origin)
+                .header("Vary", containsString("origin"));
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSConfig.java
@@ -87,4 +87,15 @@ public interface CORSConfig {
      */
     @WithDefault("true")
     boolean returnExactOrigins();
+
+    /**
+     * Whether to add the {@code Vary: Origin} response header to CORS responses when the origin is not a wildcard.
+     * <p>
+     * The {@code Vary: Origin} header tells HTTP caches that the response depends on the request's {@code Origin} header,
+     * preventing a cached response for one origin from being served to a different origin.
+     * <p>
+     * This should remain enabled (the default) in most setups, especially when a reverse proxy or CDN may cache responses.
+     */
+    @WithDefault("true")
+    boolean varyOrigin();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSFilter.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSFilter.java
@@ -157,6 +157,9 @@ public class CORSFilter implements Handler<RoutingContext> {
                 LOG.debugf("Invalid origin %s", origin);
                 response.setStatusCode(403);
                 response.setStatusMessage("CORS Rejected - Invalid origin");
+                if (corsConfig.varyOrigin()) {
+                    response.headers().add(HttpHeaders.VARY, HttpHeaders.ORIGIN);
+                }
             } else {
                 if (wildcardOrigin && !corsConfig.returnExactOrigins()) {
                     // Return literal * for public APIs where caching matters.
@@ -170,6 +173,9 @@ public class CORSFilter implements Handler<RoutingContext> {
                     response.headers().set(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS,
                             String.valueOf(allowCredentials));
                     response.headers().set(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, origin);
+                    if (corsConfig.varyOrigin()) {
+                        response.headers().add(HttpHeaders.VARY, HttpHeaders.ORIGIN);
+                    }
                 }
             }
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/security/CORS.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/security/CORS.java
@@ -48,6 +48,7 @@ public sealed interface CORS permits CORS.Builder.CORSImpl {
         private Optional<List<String>> methods;
         private Optional<List<String>> origins;
         private boolean returnExactOrigins;
+        private boolean varyOrigin;
 
         public Builder() {
             this(HttpSecurityUtils.getDefaultAuthConfig().cors());
@@ -61,6 +62,7 @@ public sealed interface CORS permits CORS.Builder.CORSImpl {
             this.methods = corsConfig.methods();
             this.origins = corsConfig.origins();
             this.returnExactOrigins = corsConfig.returnExactOrigins();
+            this.varyOrigin = corsConfig.varyOrigin();
         }
 
         /**
@@ -191,7 +193,7 @@ public sealed interface CORS permits CORS.Builder.CORSImpl {
          */
         public CORS build() {
             return new CORSImpl(accessControlAllowCredentials, accessControlMaxAge, exposedHeaders, headers, methods, origins,
-                    returnExactOrigins);
+                    returnExactOrigins, varyOrigin);
         }
 
         private static Optional<List<String>> merge(Optional<List<String>> optionalOriginalList, Set<String> newSet,
@@ -214,7 +216,7 @@ public sealed interface CORS permits CORS.Builder.CORSImpl {
         record CORSImpl(Optional<Boolean> accessControlAllowCredentials, Optional<Duration> accessControlMaxAge,
                 Optional<List<String>> exposedHeaders, Optional<List<String>> headers,
                 Optional<List<String>> methods, Optional<List<String>> origins,
-                boolean returnExactOrigins) implements CORS, CORSConfig {
+                boolean returnExactOrigins, boolean varyOrigin) implements CORS, CORSConfig {
             @Override
             public boolean enabled() {
                 return true;

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/cors/CORSFilterTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/cors/CORSFilterTest.java
@@ -106,14 +106,14 @@ public class CORSFilterTest {
         record CORSConfigImpl(Optional<Boolean> accessControlAllowCredentials, Optional<Duration> accessControlMaxAge,
                 Optional<List<String>> exposedHeaders, Optional<List<String>> headers,
                 Optional<List<String>> methods, Optional<List<String>> origins,
-                boolean returnExactOrigins) implements CORSConfig {
+                boolean returnExactOrigins, boolean varyOrigin) implements CORSConfig {
             @Override
             public boolean enabled() {
                 return true;
             }
         }
         var config = new CORSConfigImpl(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
-                Optional.empty(), Optional.empty(), true);
+                Optional.empty(), Optional.empty(), true, true);
         var emptyConfig = (CORSConfig) new CORS.Builder(config).build();
         Assertions.assertTrue(emptyConfig.enabled());
         Assertions.assertTrue(emptyConfig.origins().isEmpty());


### PR DESCRIPTION
Prevents HTTP caches from serving stale CORS responses for different origins.

