### PR TITLE
Work around lack of os-specific download endpoints

### DIFF
--- a/docs/src/main/asciidoc/podman.adoc
+++ b/docs/src/main/asciidoc/podman.adoc
@@ -22,9 +22,14 @@ The Homebrew package manager on Mac (*brew*) *should not be used to install Podm
 
 On Linux, Podman is integrated as part of the operating system, and installed through the system's packager manager. As with Mac, and Windows, Podman Desktop can also be installed to supplement the Podman CLI. However, on Linux, Podman Desktop acts as a client to the native Podman integration, and does not manage the underlying Podman installation.
 
-See https://podman-desktop.io/downloads/ for the latest version of Podman Desktop.
+See https://podman-desktop.io/downloads/ for the latest version of Podman Desktop or, for more detailed instructions, pick your operating system from the list below:
 
-Additionally, if you are using Linux, see the Podman https://podman.io/docs/installation#installing-on-linux[Linux installation documentation] for instructions installing Podman to your specific Linux distribution.
+- https://podman-desktop.io/docs/installation/macos-install[MacOS]
+- https://podman-desktop.io/docs/installation/windows-install[Windows]
+- https://podman-desktop.io/docs/installation/linux-install[Linux]
+
+
+If you are using Linux, do see the Podman https://podman.io/docs/installation#installing-on-linux[Linux installation documentation] for instructions installing Podman to your specific Linux distribution.
 
 === Docker compatibility mode
 


### PR DESCRIPTION
Discovered while testing https://github.com/quarkusio/quarkusio.github.io/pull/2697.
Podman no longer has individual endpoints for platform installs, just one big landing page.