### PR TITLE
Fix broken GitHub links across several guides

### DIFF
--- a/docs/src/main/asciidoc/extension-codestart.adoc
+++ b/docs/src/main/asciidoc/extension-codestart.adoc
@@ -62,7 +62,7 @@ Each codestart consists of:
 
 - In the Quarkus core repository, the extension codestarts are all in the same https://github.com/quarkusio/quarkus/tree/main/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts[module, window="_blank"].
 
-- Quarkus REST (formerly RESTEasy Reactive), RESTEasy and Spring Web extension codestarts are part of https://github.com/quarkusio/quarkus/tree/main/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts[the base codestarts, window="_blank"].
+- Quarkus REST (formerly RESTEasy Reactive), RESTEasy and Spring Web extension codestarts are also part of https://github.com/quarkusio/quarkus/tree/main/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts[the same module, window="_blank"].
 
 - For other extensions, the codestart will typically be located in the runtime module (with special instruction in the `pom.xml` to generate a separate codestart artifact).
 

--- a/docs/src/main/asciidoc/grpc-service-consumption.adoc
+++ b/docs/src/main/asciidoc/grpc-service-consumption.adoc
@@ -473,7 +473,7 @@ quarkus.micrometer.binder.grpc-client.enabled=false
 
 == Custom exception handling
 
-If any of the gRPC services or server interceptors throw an (custom) exception, you can add your own https://github.com/quarkusio/quarkus/extensions/grpc/api/src/main/java/io/quarkus/grpc/ExceptionHandlerProvider.java[ExceptionHandlerProvider]
+If any of the gRPC services or server interceptors throw an (custom) exception, you can add your own https://github.com/quarkusio/quarkus/blob/main/extensions/grpc/api/src/main/java/io/quarkus/grpc/ExceptionHandlerProvider.java[ExceptionHandlerProvider]
 as a CDI bean in your application, to provide a custom handling of those exceptions.
 
 e.g.

--- a/docs/src/main/asciidoc/spring-data-jpa.adoc
+++ b/docs/src/main/asciidoc/spring-data-jpa.adoc
@@ -607,7 +607,7 @@ An extensive list of examples can be seen in the https://github.com/quarkusio/qu
 is not used at all (since all the necessary plumbing is done at build time). Similar support might be added to Quarkus in the future.
 * Using `java.util.concurrent.Future` and classes that extend it as return types of repository methods.
 * Native and named queries when using `@Query`
-* https://github.com/spring-projects/spring-data-jpa/blob/main/src/main/asciidoc/jpa.adoc#entity-state-detection-strategies[Entity State-detection Strategies]
+* https://docs.spring.io/spring-data/jpa/reference/data-commons/is-new-state-detection.html[Entity State-detection Strategies]
 via `EntityInformation`.
 * The use of `org.springframework.data.jpa.repository.Lock`
 

--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -1580,7 +1580,7 @@ Build step ShutdownListenerBuildStep.setupShutdown completed in: 1ms
 ==== Using Gizmo
 
 In some scenarios, more significant manipulation of bytecode may be needed.
-If bytecode recording isn't sufficient, link:https://github.com/quarkusio/gizmo/blob/main/USAGE.adoc[Gizmo] is a convenient alternative to ASM, with a higher-level API.
+If bytecode recording isn't sufficient, link:https://github.com/quarkusio/gizmo/blob/main/MANUAL.adoc[Gizmo] is a convenient alternative to ASM, with a higher-level API.
 
 ==== Runtime Classpath check
 


### PR DESCRIPTION
- writing-extensions.adoc: gizmo USAGE.adoc renamed to MANUAL.adoc
- grpc-service-consumption.adoc: add missing /blob/main/ to ExceptionHandlerProvider.java link
- extension-codestart.adoc: base-codestarts moved into project-core-extension-codestarts module
- spring-data-jpa.adoc: Spring Data JPA docs migrated from asciidoc to Antora directory structure
