### PR TITLE
Fix dead links in streaming- and messaging-related guides

### DIFF
--- a/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
+++ b/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
@@ -90,7 +90,7 @@ include::{includes}/devtools/build.adoc[]
 the `movies.avsc` will get compiled to a `Movie.java` file
 placed in the `target/generated-sources/avsc` directory.
 
-Take a look at the https://avro.apache.org/docs/current/spec.html#schemas[Avro specification] to learn more about
+Take a look at the https://avro.apache.org/docs/current/specification/#schemas[Avro specification] to learn more about
 the Avro syntax and supported types.
 
 TIP: With Quarkus, there's no need to use a specific Maven plugin to process the Avro schema, this is all done for you by the `quarkus-avro` extension!

--- a/docs/src/main/asciidoc/kafka-schema-registry-json-schema.adoc
+++ b/docs/src/main/asciidoc/kafka-schema-registry-json-schema.adoc
@@ -37,12 +37,7 @@ The same concept applies if you are using the Confluent JSON Schema _serde_ and 
 
 == Solution
 
-We recommend that you follow the instructions in the next sections and create the application step by step.
-However, you can go right to the completed example.
-
-Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {quickstarts-archive-url}[archive].
-
-The solution is located in the `kafka-json-schema-quickstart` link:{quickstarts-tree-url}/kafka-json-schema-quickstart[directory].
+Follow the instructions in the next sections to create the application step by step.
 
 == Creating the Maven Project
 

--- a/docs/src/main/asciidoc/kafka-streams.adoc
+++ b/docs/src/main/asciidoc/kafka-streams.adoc
@@ -59,7 +59,7 @@ A second component (`aggregator`) reads from the two Kafka topics and processes 
 * this aggregated data is written out to a third topic (`temperatures-aggregated`)
 
 The data can be examined by inspecting the output topic.
-By exposing a Kafka Streams https://kafka.apache.org/22/documentation/streams/developer-guide/interactive-queries.html[interactive query],
+By exposing a Kafka Streams https://kafka.apache.org/documentation/streams/developer-guide/interactive-queries[interactive query],
 the latest result for each weather station can alternatively be obtained via a simple REST query.
 
 The overall architecture looks like so:
@@ -787,7 +787,7 @@ Date: Tue, 18 Jun 2019 19:29:16 GMT
 A very interesting trait of Kafka Streams applications is that they can be scaled out,
 i.e. the load and state can be distributed amongst multiple application instances running the same pipeline.
 Each node will then contain a subset of the aggregation results,
-but Kafka Streams provides you with https://kafka.apache.org/22/documentation/streams/developer-guide/interactive-queries.html#querying-remote-state-stores-for-the-entire-app[an API] to obtain the information which node is hosting a given key.
+but Kafka Streams provides you with https://kafka.apache.org/documentation/streams/developer-guide/interactive-queries#querying-remote-state-stores-for-the-entire-app[an API] to obtain the information which node is hosting a given key.
 The application can then either fetch the data directly from the other instance, or simply point the client to the location of that other node.
 
 Launching multiple instances of the `aggregator` application will make look the overall architecture like so:

--- a/docs/src/main/asciidoc/messaging.adoc
+++ b/docs/src/main/asciidoc/messaging.adoc
@@ -15,9 +15,9 @@ include::_attributes.adoc[]
 :rm_doc_emitter: https://smallrye.io/smallrye-reactive-messaging/latest/concepts/emitter/
 :mutiny: https://smallrye.io/smallrye-mutiny/latest/
 :eclipse-vertx: https://vertx.io/
-:camel-smallrye-reactive-messaging: https://camel.apache.org/camel-quarkus/3.8.x/reference/extensions/smallrye-reactive-messaging.html
+:camel-smallrye-reactive-messaging: https://camel.apache.org/camel-quarkus/latest/reference/extensions/smallrye-reactive-messaging.html
 :nats-jetstream: https://docs.quarkiverse.io/quarkus-reactive-messaging-nats-jetstream/dev/index.html
-:solace-quarkus: https://solacelabs.github.io/solace-quarkus/
+:solace-quarkus: https://solaceproducts.github.io/solace-quarkus/
 :http-websocket-connector: https://quarkus.io/extensions/io.quarkiverse.reactivemessaging.http/quarkus-reactive-messaging-http/
 
 Event-driven messaging systems have become the backbone of most modern applications,

--- a/docs/src/main/asciidoc/pulsar.adoc
+++ b/docs/src/main/asciidoc/pulsar.adoc
@@ -1162,8 +1162,8 @@ StreamNative Cloud is a fully managed Pulsar-as-a-Service available in different
 whether it is fully-hosted, on a public cloud but managed by StreamNative or self-managed on Kubernetes.
 
 The StreamNative Pulsar clusters use Oauth2 authentication,
-so you need to make sure that a https://docs.streamnative.io/docs/service-account[service account] exists with
-required https://docs.streamnative.io/docs/access-control#authorize-namespaces[permissions to the Pulsar namespace/topic] your application is using.
+so you need to make sure that a https://docs.streamnative.io/cloud/security/authentication/service-accounts/service-accounts[service account] exists with
+required https://docs.streamnative.io/cloud/security/access/access-control-lists/authorization-and-acls[permissions to the Pulsar namespace/topic] your application is using.
 
 Next, you need to download the **Key file** (which serves as **private key**) of the service account and note the **issuer URL** (typically `https://auth.streamnative.cloud/`)
 and the **audience** (for example `urn:sn:pulsar:o-rf3ol:redhat`) for your cluster.


### PR DESCRIPTION
- kafka-schema-registry-avro.adoc: Avro spec moved from spec.html to specification/
- kafka-streams.adoc: use unversioned Kafka docs URL for interactive queries instead of pinned /22/ version
- messaging.adoc: update Camel Quarkus from pinned 3.8.x to latest, update Solace from SolaceLabs to SolaceProducts GitHub org
- pulsar.adoc: update StreamNative docs URLs which moved from /docs/* to /cloud/security/* paths
- removed quickstart; added some generic instructions instead

