### PR TITLE
Fix dead links in security guides

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-client-registration.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-registration.adoc
@@ -75,7 +75,7 @@ quarkus.oidc-client-registration.initial-token=${initial-registration-token}
 
 The above configuration will lead to two new client registrations created in your OIDC provider.
 
-You or may not need to acquire an initial registration access token. If you don't, then you will have to enable one or more client registration policies in your OIDC provider's dashboard. For example, see https://www.keycloak.org/docs/latest/securing_apps/#_client_registration_policies[Keycloak client registration policies].
+You or may not need to acquire an initial registration access token. If you don't, then you will have to enable one or more client registration policies in your OIDC provider's dashboard. For example, see https://www.keycloak.org/securing-apps/client-registration[Keycloak client registration policies].
 
 The next step is to inject either `quarkus.oidc.client.registration.OidcClientRegistration` if only a single default client registration is done, or `quarkus.oidc.client.registration.OidcClientRegistrations` if more than one registration is configured, and use metadata of the clients registered with these configurations.
 
@@ -714,7 +714,7 @@ include::{generated-dir}/config/quarkus-oidc-client-registration.adoc[opts=optio
 
 * https://openid.net/specs/openid-connect-registration-1_0.html[OIDC client registration]
 * https://datatracker.ietf.org/doc/html/rfc7592[OAuth2 Dynamic Client Registration Management Protocol]
-* https://www.keycloak.org/docs/latest/securing_apps/#_client_registration[Keycloak Dynamic Client Registration Service]
+* https://www.keycloak.org/securing-apps/client-registration[Keycloak Dynamic Client Registration Service]
 * xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer token authentication]
 * xref:security-oidc-code-flow-authentication.adoc[OIDC code flow mechanism for protecting web applications]
 * xref:security-overview.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/tls-registry-reference.adoc
+++ b/docs/src/main/asciidoc/tls-registry-reference.adoc
@@ -1781,10 +1781,6 @@ The following ACME providers are known to work with Quarkus:
 |`https://acme.zerossl.com/v2/DV90`
 |N/A (use Let's Encrypt staging for testing)
 
-|BuyPass Go
-|`https://api.buypass.com/acme/directory`
-|`https://api.test4.buypass.no/acme/directory`
-
 |Google Trust Services
 |`https://dv.acme-v02.api.pki.goog/directory`
 |`https://dv.acme-v02.test-api.pki.goog/directory`


### PR DESCRIPTION
- security-openid-connect-client-registration.adoc: Keycloak moved securing_apps docs to keycloak.org/securing-apps/, updated both client registration links
- tls-registry-reference.adoc: remove BuyPass Go ACME provider row, service was discontinued October 2025
