### PR TITLE
Fix dead links in REST guides

### DIFF
--- a/docs/src/main/asciidoc/rest-json.adoc
+++ b/docs/src/main/asciidoc/rest-json.adoc
@@ -72,13 +72,13 @@ implementation("io.quarkus:quarkus-rest-jackson")
 To improve user experience, Quarkus registers the three Jackson https://github.com/FasterXML/jackson-modules-java8[Java 8 modules] so you don't need to do it manually.
 ====
 
-Quarkus also supports https://eclipse-ee4j.github.io/jsonb-api/[JSON-B] so, if you prefer JSON-B over Jackson, you can create a project relying on the Quarkus REST JSON-B extension instead:
+Quarkus also supports https://jakarta.ee/specifications/jsonb/[JSON-B] so, if you prefer JSON-B over Jackson, you can create a project relying on the Quarkus REST JSON-B extension instead:
 
 :create-app-artifact-id: rest-json-quickstart
 :create-app-extensions: rest-jsonb
 include::{includes}/devtools/create-app.adoc[]
 
-This command generates a new project importing the Quarkus REST/Jakarta REST and https://eclipse-ee4j.github.io/jsonb-api/[JSON-B] extensions,
+This command generates a new project importing the Quarkus REST/Jakarta REST and https://jakarta.ee/specifications/jsonb/[JSON-B] extensions,
 and in particular adds the following dependency:
 
 [source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
@@ -176,7 +176,7 @@ public class FruitResource {
 
 The implementation is pretty straightforward, and you just need to define your endpoints using the Jakarta REST annotations.
 
-The `Fruit` objects will be automatically serialized/deserialized by https://eclipse-ee4j.github.io/jsonb-api/[JSON-B] or https://github.com/FasterXML/jackson[Jackson],
+The `Fruit` objects will be automatically serialized/deserialized by https://jakarta.ee/specifications/jsonb/[JSON-B] or https://github.com/FasterXML/jackson[Jackson],
 depending on the extension you chose when initializing the project.
 
 [NOTE]

--- a/docs/src/main/asciidoc/rest.adoc
+++ b/docs/src/main/asciidoc/rest.adoc
@@ -2025,7 +2025,7 @@ Using this injected bean of type `RestLinksProvider`, you can get the links by t
 
 ==== JSON Hypertext Application Language (HAL) support
 
-The https://tools.ietf.org/id/draft-kelly-json-hal-01.html[HAL] standard is a simple format to represent web links.
+The https://datatracker.ietf.org/doc/html/draft-kelly-json-hal-08[HAL] standard is a simple format to represent web links.
 
 To enable the HAL support, add the `quarkus-hal` extension to your project. Also, as HAL needs JSON support, you need to add either the `quarkus-rest-jsonb` or the `quarkus-rest-jackson` extension.
 
@@ -2033,7 +2033,7 @@ To enable the HAL support, add the `quarkus-hal` extension to your project. Also
 |GAV|Usage
 
 |`io.quarkus:quarkus-hal`
-|https://tools.ietf.org/id/draft-kelly-json-hal-01.html[HAL]
+|https://datatracker.ietf.org/doc/html/draft-kelly-json-hal-08[HAL]
 
 |===
 


### PR DESCRIPTION
- rest.adoc: JSON HAL draft moved from tools.ietf.org to datatracker.ietf.org, update to latest draft revision (08)
- rest-json.adoc: JSON-B API site moved from eclipse-ee4j.github.io to jakarta.ee/specifications/jsonb/
