### PR TITLE
Introduce AdditionalPersistenceUnitBuildItem

### DIFF
--- a/extensions/hibernate-orm/deployment-spi/src/main/java/io/quarkus/hibernate/orm/deployment/spi/AdditionalPersistenceUnitBuildItem.java
+++ b/extensions/hibernate-orm/deployment-spi/src/main/java/io/quarkus/hibernate/orm/deployment/spi/AdditionalPersistenceUnitBuildItem.java
@@ -1,0 +1,165 @@
+package io.quarkus.hibernate.orm.deployment.spi;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * Requests the creation of a (static) Hibernate ORM persistence unit that is <em>not</em> declared in
+ * user-provided configuration, i.e. neither through {@code quarkus.hibernate-orm.*} properties nor through
+ * a {@code persistence.xml} file.
+ * <p>
+ * This is the supported way for an extension to contribute a persistence unit of its own: the extension
+ * declares its intent (name, datasource, managed classes, mapping files and a few extra properties) and
+ * the Hibernate ORM extension takes care of the rest (datasource and dialect resolution, descriptor
+ * recording, CDI bean generation).
+ */
+public final class AdditionalPersistenceUnitBuildItem extends MultiBuildItem {
+
+    private final String persistenceUnitName;
+    private final Optional<String> dataSourceName;
+    private final Set<String> managedClassNames;
+    private final Set<String> mappingFileNames;
+    private final Map<String, String> properties;
+
+    private AdditionalPersistenceUnitBuildItem(Builder builder) {
+        this.persistenceUnitName = builder.persistenceUnitName;
+        this.dataSourceName = builder.dataSourceName;
+        this.managedClassNames = Collections.unmodifiableSet(new LinkedHashSet<>(builder.managedClassNames));
+        this.mappingFileNames = Collections.unmodifiableSet(new LinkedHashSet<>(builder.mappingFileNames));
+        this.properties = Collections.unmodifiableMap(new LinkedHashMap<>(builder.properties));
+    }
+
+    public String getPersistenceUnitName() {
+        return persistenceUnitName;
+    }
+
+    public Optional<String> getDataSourceName() {
+        return dataSourceName;
+    }
+
+    public Set<String> getManagedClassNames() {
+        return managedClassNames;
+    }
+
+    public Set<String> getMappingFileNames() {
+        return mappingFileNames;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public static Builder builder(String persistenceUnitName) {
+        return new Builder(persistenceUnitName);
+    }
+
+    public static final class Builder {
+
+        private final String persistenceUnitName;
+        private Optional<String> dataSourceName = Optional.empty();
+        private final Set<String> managedClassNames = new LinkedHashSet<>();
+        private final Set<String> mappingFileNames = new LinkedHashSet<>();
+        private final Map<String, String> properties = new LinkedHashMap<>();
+
+        private Builder(String persistenceUnitName) {
+            Objects.requireNonNull(persistenceUnitName, "persistenceUnitName must not be null");
+            if (persistenceUnitName.isBlank()) {
+                throw new IllegalArgumentException("persistenceUnitName must not be blank");
+            }
+            this.persistenceUnitName = persistenceUnitName;
+        }
+
+        /**
+         * Sets the datasource backing this persistence unit. When not set (or set to {@code null}), the default
+         * datasource is used.
+         *
+         * @param dataSourceName The name of the datasource backing this persistence unit.
+         * @return This builder.
+         */
+        public Builder dataSourceName(String dataSourceName) {
+            this.dataSourceName = Optional.ofNullable(dataSourceName);
+            return this;
+        }
+
+        /**
+         * Adds a managed class to this persistence unit. The class is automatically added to the JPA model and
+         * assigned to this persistence unit by the Hibernate ORM extension.
+         *
+         * @param className The fully-qualified name of the managed class.
+         * @return This builder.
+         */
+        public Builder managedClass(String className) {
+            this.managedClassNames.add(Objects.requireNonNull(className, "className must not be null"));
+            return this;
+        }
+
+        /**
+         * Adds managed classes to this persistence unit. Each class is automatically added to the JPA model and
+         * assigned to this persistence unit by the Hibernate ORM extension.
+         *
+         * @param classNames The fully-qualified names of the managed classes.
+         * @return This builder.
+         */
+        public Builder managedClasses(Collection<String> classNames) {
+            this.managedClassNames.addAll(Objects.requireNonNull(classNames, "classNames must not be null"));
+            return this;
+        }
+
+        /**
+         * Adds a mapping file to this persistence unit.
+         *
+         * @param mappingFileName The name of the mapping file resource.
+         * @return This builder.
+         */
+        public Builder mappingFile(String mappingFileName) {
+            this.mappingFileNames.add(Objects.requireNonNull(mappingFileName, "mappingFileName must not be null"));
+            return this;
+        }
+
+        /**
+         * Adds mapping files to this persistence unit.
+         *
+         * @param mappingFileNames The names of the mapping file resources.
+         * @return This builder.
+         */
+        public Builder mappingFiles(Collection<String> mappingFileNames) {
+            this.mappingFileNames.addAll(Objects.requireNonNull(mappingFileNames, "mappingFileNames must not be null"));
+            return this;
+        }
+
+        /**
+         * Sets an additional Hibernate ORM property on this persistence unit.
+         *
+         * @param key The property key.
+         * @param value The property value.
+         * @return This builder.
+         */
+        public Builder property(String key, String value) {
+            this.properties.put(Objects.requireNonNull(key, "key must not be null"), value);
+            return this;
+        }
+
+        /**
+         * Sets additional Hibernate ORM properties on this persistence unit.
+         *
+         * @param properties The properties to set.
+         * @return This builder.
+         */
+        public Builder properties(Map<String, String> properties) {
+            this.properties.putAll(Objects.requireNonNull(properties, "properties must not be null"));
+            return this;
+        }
+
+        public AdditionalPersistenceUnitBuildItem build() {
+            return new AdditionalPersistenceUnitBuildItem(this);
+        }
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -131,6 +131,7 @@ import io.quarkus.hibernate.orm.deployment.integration.HibernateOrmIntegrationRu
 import io.quarkus.hibernate.orm.deployment.integration.HibernateOrmIntegrationStaticConfiguredBuildItem;
 import io.quarkus.hibernate.orm.deployment.integration.QuarkusClassFileLocator;
 import io.quarkus.hibernate.orm.deployment.spi.AdditionalJpaModelBuildItem;
+import io.quarkus.hibernate.orm.deployment.spi.AdditionalPersistenceUnitBuildItem;
 import io.quarkus.hibernate.orm.deployment.spi.DatabaseKindDialectBuildItem;
 import io.quarkus.hibernate.orm.deployment.spi.SqlLoadScriptDefaultBuildItem;
 import io.quarkus.hibernate.orm.dev.HibernateOrmDevIntegrator;
@@ -396,6 +397,7 @@ public final class HibernateOrmProcessor {
             List<ReactiveDataSourceBuildItem> reactiveDataSources,
             ApplicationArchivesBuildItem applicationArchivesBuildItem,
             LaunchModeBuildItem launchMode,
+            List<AdditionalPersistenceUnitBuildItem> additionalPersistenceUnits,
             JpaModelBuildItem jpaModel,
             JpaModelPerPersistenceUnitBuildItem jpaModelPerPersistenceUnit,
             Capabilities capabilities,
@@ -406,21 +408,36 @@ public final class HibernateOrmProcessor {
             BuildProducer<ReflectiveMethodBuildItem> reflectiveMethods,
             BuildProducer<UnremovableBeanBuildItem> unremovableBeans,
             List<DatabaseKindDialectBuildItem> dbKindMetadataBuildItems) {
+
+        if (!additionalPersistenceUnits.isEmpty()) {
+            Set<String> userConfiguredPersistenceUnitNames = new HashSet<>(hibernateOrmConfig.namedPersistenceUnits().keySet());
+            for (PersistenceXmlDescriptorBuildItem persistenceXmlDescriptor : persistenceXmlDescriptors) {
+                userConfiguredPersistenceUnitNames.add(persistenceXmlDescriptor.getDescriptor().getName());
+            }
+            for (AdditionalPersistenceUnitBuildItem additionalPersistenceUnit : additionalPersistenceUnits) {
+                String persistenceUnitName = additionalPersistenceUnit.getPersistenceUnitName();
+                if (PersistenceUnitUtil.isDefaultPersistenceUnit(persistenceUnitName)) {
+                    throw new ConfigurationException(
+                            "An extension attempted to contribute the default persistence unit through the SPI."
+                                    + " Contributed persistence units must use a non-default name.");
+                }
+                if (userConfiguredPersistenceUnitNames.contains(persistenceUnitName)) {
+                    throw new ConfigurationException(String.format(Locale.ROOT,
+                            "Persistence unit '%s' is contributed by an extension but is also configured by the application."
+                                    + " A persistence unit contributed through the SPI must use a name that is not already"
+                                    + " configured through Quarkus configuration or a persistence.xml file.",
+                            persistenceUnitName));
+                }
+            }
+        }
+
         // First produce the PUs having a persistence.xml: these are not reactive, as we don't allow using a persistence.xml for them.
         for (PersistenceXmlDescriptorBuildItem persistenceXmlDescriptorBuildItem : persistenceXmlDescriptors) {
             PersistenceUnitDescriptor xmlDescriptor = persistenceXmlDescriptorBuildItem.getDescriptor();
             String puName = xmlDescriptor.getName();
             Optional<JdbcDataSourceBuildItem> jdbcDataSource = findDefaultDataSource(jdbcDataSources);
             collectDialectConfigForPersistenceXml(puName, xmlDescriptor);
-            Optional<FormatMapperKind> jsonMapper = jsonMapperKind(capabilities,
-                    hibernateOrmConfig.mapping().format().global());
-            Optional<FormatMapperKind> xmlMapper = xmlMapperKind(capabilities, hibernateOrmConfig.mapping().format().global());
-            jsonMapper.flatMap(FormatMapperKind::requiredBeanType)
-                    .ifPresent(type -> unremovableBeans.produce(UnremovableBeanBuildItem.beanClassNames(type)));
-            xmlMapper.flatMap(FormatMapperKind::requiredBeanType)
-                    .ifPresent(type -> unremovableBeans.produce(UnremovableBeanBuildItem.beanClassNames(type)));
-            JsonFormatterCustomizationCheck jsonFormatterCustomizationCheck = jsonFormatterCustomizationCheck(
-                    capabilities, jsonMapper);
+            FormatMappers formatMappers = resolveFormatMappers(capabilities, hibernateOrmConfig, unremovableBeans);
             persistenceUnitDescriptors
                     .produce(new PersistenceUnitDescriptorBuildItem(
                             QuarkusPersistenceUnitDescriptor.validateAndReadFrom(xmlDescriptor),
@@ -436,11 +453,12 @@ public final class HibernateOrmProcessor {
                                                     .getProperties().getProperty("hibernate.multiTenancy"))), //FIXME this property is meaningless in Hibernate ORM 6
                                     hibernateOrmConfig.database().ormCompatibilityVersion(),
                                     hibernateOrmConfig.mapping().format().global(),
-                                    jsonFormatterCustomizationCheck,
+                                    formatMappers.jsonFormatterCustomizationCheck(),
                                     Collections.emptyMap()),
                             null,
                             jpaModel.getXmlMappings(persistenceXmlDescriptorBuildItem.getDescriptor().getName()),
-                            true, isHibernateValidatorPresent(capabilities), jsonMapper, xmlMapper));
+                            true, isHibernateValidatorPresent(capabilities), formatMappers.jsonMapper(),
+                            formatMappers.xmlMapper()));
         }
 
         if (persistenceXmlDescriptors.isEmpty() && impliedPU.shouldGenerateImpliedBlockingPersistenceUnit()) {
@@ -451,6 +469,101 @@ public final class HibernateOrmProcessor {
                     nativeImageResources, hotDeploymentWatchedFiles, persistenceUnitDescriptors,
                     reflectiveMethods, unremovableBeans, dbKindMetadataBuildItems);
         }
+
+        // Finally, produce the persistence units contributed by other extensions through the SPI.
+        for (AdditionalPersistenceUnitBuildItem additionalPersistenceUnit : additionalPersistenceUnits) {
+            producePersistenceUnitDescriptorFromSpi(hibernateOrmConfig, additionalPersistenceUnit, jpaModel,
+                    jdbcDataSources, capabilities, reflectiveMethods, unremovableBeans,
+                    persistenceUnitDescriptors, dbKindMetadataBuildItems);
+        }
+    }
+
+    private static void producePersistenceUnitDescriptorFromSpi(
+            HibernateOrmConfig hibernateOrmConfig,
+            AdditionalPersistenceUnitBuildItem additionalPersistenceUnit,
+            JpaModelBuildItem jpaModel,
+            List<JdbcDataSourceBuildItem> jdbcDataSources,
+            Capabilities capabilities,
+            BuildProducer<ReflectiveMethodBuildItem> reflectiveMethods,
+            BuildProducer<UnremovableBeanBuildItem> unremovableBeans,
+            BuildProducer<PersistenceUnitDescriptorBuildItem> persistenceUnitDescriptors,
+            List<DatabaseKindDialectBuildItem> dbKindMetadataBuildItems) {
+        String persistenceUnitName = additionalPersistenceUnit.getPersistenceUnitName();
+
+        // Resolve the datasource: an explicit name is looked up by name, otherwise the default datasource is used.
+        Optional<String> configuredDataSourceName = additionalPersistenceUnit.getDataSourceName();
+        Optional<JdbcDataSourceBuildItem> jdbcDataSource;
+        if (configuredDataSourceName.isPresent()) {
+            String dataSourceName = configuredDataSourceName.get();
+            jdbcDataSource = jdbcDataSources.stream()
+                    .filter(i -> dataSourceName.equals(i.getName()))
+                    .findFirst();
+        } else {
+            jdbcDataSource = jdbcDataSources.stream()
+                    .filter(JdbcDataSourceBuildItem::isDefault)
+                    .findFirst();
+        }
+
+        if (jdbcDataSource.isEmpty()) {
+            String dataSourceName = configuredDataSourceName.orElse(DataSourceUtil.DEFAULT_DATASOURCE_NAME);
+            throw PersistenceUnitUtil.unableToFindDataSource(persistenceUnitName, dataSourceName,
+                    DataSourceUtil.dataSourceNotConfigured(dataSourceName));
+        }
+
+        Optional<String> dataSourceName = jdbcDataSource.map(JdbcDataSourceBuildItem::getName);
+
+        Properties properties = new Properties();
+        properties.putAll(additionalPersistenceUnit.getProperties());
+
+        QuarkusPersistenceUnitDescriptor descriptor = new QuarkusPersistenceUnitDescriptor(
+                persistenceUnitName,
+                new HibernateOrmPersistenceUnitProviderHelper(),
+                PersistenceUnitTransactionType.JTA,
+                new ArrayList<>(additionalPersistenceUnit.getManagedClassNames()),
+                properties,
+                false);
+        Set<String> entityClassNames = new HashSet<>(descriptor.getManagedClassNames());
+        entityClassNames.retainAll(jpaModel.getEntityClassNames());
+
+        MultiTenancyStrategy multiTenancyStrategy = MultiTenancyStrategy.NONE;
+        Optional<String> dbKind = jdbcDataSource.map(JdbcDataSourceBuildItem::getDbKind);
+        Optional<DatabaseKind.SupportedDatabaseKind> supportedDatabaseKind = setDialectAndStorageEngine(
+                persistenceUnitName,
+                dbKind,
+                Optional.empty(),
+                jdbcDataSource.flatMap(JdbcDataSourceBuildItem::getDbVersion),
+                null,
+                dbKindMetadataBuildItems,
+                descriptor.getProperties()::setProperty);
+
+        if (dbKind.isPresent() && DatabaseKind.isPostgreSQL(dbKind.get())) {
+            // Workaround for https://hibernate.atlassian.net/browse/HHH-19063
+            reflectiveMethods.produce(new ReflectiveMethodBuildItem(
+                    "Accessed in org.hibernate.engine.jdbc.env.internal.DefaultSchemaNameResolver.determineAppropriateResolverDelegate",
+                    true, "org.postgresql.jdbc.PgConnection", "getSchema"));
+        }
+
+        FormatMappers formatMappers = resolveFormatMappers(capabilities, hibernateOrmConfig, unremovableBeans);
+
+        persistenceUnitDescriptors.produce(
+                new PersistenceUnitDescriptorBuildItem(descriptor,
+                        new RecordedConfig(
+                                dataSourceName,
+                                dbKind,
+                                supportedDatabaseKind.map(DatabaseKind.SupportedDatabaseKind::getMainName),
+                                jdbcDataSource.flatMap(JdbcDataSourceBuildItem::getDbVersion),
+                                Optional.empty(),
+                                entityClassNames,
+                                multiTenancyStrategy,
+                                hibernateOrmConfig.database().ormCompatibilityVersion(),
+                                hibernateOrmConfig.mapping().format().global(),
+                                formatMappers.jsonFormatterCustomizationCheck(),
+                                Collections.emptyMap()),
+                        null,
+                        jpaModel.getXmlMappings(persistenceUnitName),
+                        false,
+                        isHibernateValidatorPresent(capabilities), formatMappers.jsonMapper(),
+                        formatMappers.xmlMapper()));
     }
 
     @BuildStep
@@ -481,6 +594,33 @@ public final class HibernateOrmProcessor {
             jpaModelPuContributions.produce(new JpaModelPersistenceUnitContributionBuildItem(
                     descriptor.getName(), descriptor.getPersistenceUnitRootUrl(), descriptor.getManagedClassNames(),
                     descriptor.getMappingFileNames()));
+        }
+    }
+
+    @BuildStep
+    public void contributeAdditionalPersistenceUnitsToJpaModel(
+            BuildProducer<JpaModelPersistenceUnitContributionBuildItem> jpaModelPuContributions,
+            List<AdditionalPersistenceUnitBuildItem> additionalPersistenceUnits) {
+        for (AdditionalPersistenceUnitBuildItem additionalPersistenceUnit : additionalPersistenceUnits) {
+            jpaModelPuContributions.produce(new JpaModelPersistenceUnitContributionBuildItem(
+                    additionalPersistenceUnit.getPersistenceUnitName(), null,
+                    additionalPersistenceUnit.getManagedClassNames(),
+                    additionalPersistenceUnit.getMappingFileNames()));
+        }
+    }
+
+    @BuildStep
+    public void contributeAdditionalPersistenceUnitModelClasses(
+            List<AdditionalPersistenceUnitBuildItem> additionalPersistenceUnits,
+            BuildProducer<AdditionalJpaModelBuildItem> additionalJpaModel) {
+        // Synthesize the JPA model build items for the managed classes of SPI-contributed persistence units,
+        // so that those classes are indexed, bytecode-enhanced, registered for reflection and assigned to their
+        // persistence unit without the contributing extension having to produce a separate AdditionalJpaModelBuildItem.
+        for (AdditionalPersistenceUnitBuildItem additionalPersistenceUnit : additionalPersistenceUnits) {
+            Set<String> persistenceUnits = Set.of(additionalPersistenceUnit.getPersistenceUnitName());
+            for (String className : additionalPersistenceUnit.getManagedClassNames()) {
+                additionalJpaModel.produce(new AdditionalJpaModelBuildItem(className, persistenceUnits));
+            }
         }
     }
 
@@ -1163,14 +1303,7 @@ public final class HibernateOrmProcessor {
                 additionalSqlLoadScriptDefaults,
                 nativeImageResources, hotDeploymentWatchedFiles, descriptor);
 
-        Optional<FormatMapperKind> jsonMapper = jsonMapperKind(capabilities, hibernateOrmConfig.mapping().format().global());
-        Optional<FormatMapperKind> xmlMapper = xmlMapperKind(capabilities, hibernateOrmConfig.mapping().format().global());
-        jsonMapper.flatMap(FormatMapperKind::requiredBeanType)
-                .ifPresent(type -> unremovableBeans.produce(UnremovableBeanBuildItem.beanClassNames(type)));
-        xmlMapper.flatMap(FormatMapperKind::requiredBeanType)
-                .ifPresent(type -> unremovableBeans.produce(UnremovableBeanBuildItem.beanClassNames(type)));
-        JsonFormatterCustomizationCheck jsonFormatterCustomizationCheck = jsonFormatterCustomizationCheck(
-                capabilities, jsonMapper);
+        FormatMappers formatMappers = resolveFormatMappers(capabilities, hibernateOrmConfig, unremovableBeans);
         persistenceUnitDescriptors.produce(
                 new PersistenceUnitDescriptorBuildItem(descriptor,
                         new RecordedConfig(
@@ -1183,12 +1316,13 @@ public final class HibernateOrmProcessor {
                                 multiTenancyStrategy,
                                 hibernateOrmConfig.database().ormCompatibilityVersion(),
                                 hibernateOrmConfig.mapping().format().global(),
-                                jsonFormatterCustomizationCheck,
+                                formatMappers.jsonFormatterCustomizationCheck(),
                                 persistenceUnitConfig.unsupportedProperties()),
                         persistenceUnitConfig.multitenantSchemaDatasource().orElse(null),
                         model.xmlMappings(),
                         false,
-                        isHibernateValidatorPresent(capabilities), jsonMapper, xmlMapper));
+                        isHibernateValidatorPresent(capabilities), formatMappers.jsonMapper(),
+                        formatMappers.xmlMapper()));
     }
 
     private static Optional<DatabaseKind.SupportedDatabaseKind> collectDialectConfig(String persistenceUnitName,
@@ -1232,6 +1366,21 @@ public final class HibernateOrmProcessor {
         }
 
         return supportedDatabaseKind;
+    }
+
+    private static FormatMappers resolveFormatMappers(Capabilities capabilities, HibernateOrmConfig hibernateOrmConfig,
+            BuildProducer<UnremovableBeanBuildItem> unremovableBeans) {
+        Optional<FormatMapperKind> jsonMapper = jsonMapperKind(capabilities, hibernateOrmConfig.mapping().format().global());
+        Optional<FormatMapperKind> xmlMapper = xmlMapperKind(capabilities, hibernateOrmConfig.mapping().format().global());
+        jsonMapper.flatMap(FormatMapperKind::requiredBeanType)
+                .ifPresent(type -> unremovableBeans.produce(UnremovableBeanBuildItem.beanClassNames(type)));
+        xmlMapper.flatMap(FormatMapperKind::requiredBeanType)
+                .ifPresent(type -> unremovableBeans.produce(UnremovableBeanBuildItem.beanClassNames(type)));
+        return new FormatMappers(jsonMapper, xmlMapper, jsonFormatterCustomizationCheck(capabilities, jsonMapper));
+    }
+
+    private record FormatMappers(Optional<FormatMapperKind> jsonMapper, Optional<FormatMapperKind> xmlMapper,
+            JsonFormatterCustomizationCheck jsonFormatterCustomizationCheck) {
     }
 
     private static void collectDialectConfigForPersistenceXml(String persistenceUnitName,

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/util/HibernateProcessorUtil.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/util/HibernateProcessorUtil.java
@@ -141,11 +141,15 @@ public final class HibernateProcessorUtil {
 
         Optional<SupportedDatabaseKind> supportedDbKind = dbKind.flatMap(SupportedDatabaseKind::from);
 
-        handleDialectSpecificSettings(
-                persistenceUnitName,
-                puPropertiesCollector,
-                dialectConfig,
-                supportedDbKind);
+        // dialectConfig is null for persistence units contributed through the SPI, which do not support
+        // storage-engine or dialect-specific customization.
+        if (dialectConfig != null) {
+            handleDialectSpecificSettings(
+                    persistenceUnitName,
+                    puPropertiesCollector,
+                    dialectConfig,
+                    supportedDbKind);
+        }
 
         return supportedDbKind;
     }

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/spi/AdditionalPersistenceUnitClashTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/spi/AdditionalPersistenceUnitClashTest.java
@@ -1,0 +1,59 @@
+package io.quarkus.hibernate.orm.spi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.function.Consumer;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.hibernate.orm.deployment.spi.AdditionalPersistenceUnitBuildItem;
+import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class AdditionalPersistenceUnitClashTest {
+
+    static final String PERSISTENCE_UNIT_NAME = "contributed";
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(ContributedEntity.class)
+                    .addAsResource("application-additional-persistence-unit-clash.properties", "application.properties"))
+            .addBuildChainCustomizer(buildCustomizer())
+            .assertException(throwable -> assertThat(throwable)
+                    .isInstanceOf(ConfigurationException.class)
+                    .hasMessageContaining(PERSISTENCE_UNIT_NAME)
+                    .hasMessageContaining("contributed by an extension but is also configured by the application"));
+
+    static Consumer<BuildChainBuilder> buildCustomizer() {
+        return new Consumer<BuildChainBuilder>() {
+            @Override
+            public void accept(BuildChainBuilder builder) {
+                builder.addBuildStep(new BuildStep() {
+                    @Override
+                    public void execute(BuildContext context) {
+                        // Contribute a persistence unit whose name clashes with the one configured in
+                        // application.properties.
+                        context.produce(AdditionalPersistenceUnitBuildItem.builder(PERSISTENCE_UNIT_NAME)
+                                .dataSourceName("vector")
+                                .managedClass(ContributedEntity.class.getName())
+                                .build());
+                    }
+                })
+                        .produces(AdditionalPersistenceUnitBuildItem.class)
+                        .build();
+            }
+        };
+    }
+
+    @Test
+    public void buildFailsOnClash() {
+        // The build is expected to fail; the assertion is performed in assertException above.
+        Assertions.assertThat(true).isTrue();
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/spi/AdditionalPersistenceUnitTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/spi/AdditionalPersistenceUnitTest.java
@@ -1,0 +1,76 @@
+package io.quarkus.hibernate.orm.spi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.function.Consumer;
+
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
+import org.hibernate.Session;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.hibernate.orm.PersistenceUnit;
+import io.quarkus.hibernate.orm.deployment.spi.AdditionalPersistenceUnitBuildItem;
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * Tests that an extension can contribute a static persistence unit through
+ * {@link AdditionalPersistenceUnitBuildItem}, even though the application does not declare it in
+ * configuration, and that doing so does not spuriously activate the default persistence unit
+ * (see <a href="https://github.com/quarkusio/quarkus/issues/54592">#54592</a> and
+ * <a href="https://github.com/quarkusio/quarkus/issues/54493">#54493</a>).
+ */
+public class AdditionalPersistenceUnitTest {
+
+    static final String PERSISTENCE_UNIT_NAME = "contributed";
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(ContributedEntity.class)
+                    .addAsResource("application-additional-persistence-unit.properties", "application.properties"))
+            .addBuildChainCustomizer(buildCustomizer());
+
+    static Consumer<BuildChainBuilder> buildCustomizer() {
+        return new Consumer<BuildChainBuilder>() {
+            @Override
+            public void accept(BuildChainBuilder builder) {
+                builder.addBuildStep(new BuildStep() {
+                    @Override
+                    public void execute(BuildContext context) {
+                        // Declare the persistence unit; its managed classes are automatically added to the JPA
+                        // model and assigned to it by the Hibernate ORM extension.
+                        context.produce(AdditionalPersistenceUnitBuildItem.builder(PERSISTENCE_UNIT_NAME)
+                                .dataSourceName("vector")
+                                .managedClass(ContributedEntity.class.getName())
+                                .build());
+                    }
+                })
+                        .produces(AdditionalPersistenceUnitBuildItem.class)
+                        .build();
+            }
+        };
+    }
+
+    @Inject
+    @PersistenceUnit(PERSISTENCE_UNIT_NAME)
+    Session contributedSession;
+
+    @Test
+    @Transactional
+    public void contributedPersistenceUnitIsUsable() {
+        ContributedEntity entity = new ContributedEntity("hello");
+        contributedSession.persist(entity);
+        contributedSession.flush();
+        contributedSession.clear();
+
+        ContributedEntity loaded = contributedSession.get(ContributedEntity.class, entity.getId());
+        assertThat(loaded).isNotNull();
+        assertThat(loaded.getName()).isEqualTo("hello");
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/spi/ContributedEntity.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/spi/ContributedEntity.java
@@ -1,0 +1,39 @@
+package io.quarkus.hibernate.orm.spi;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+/**
+ * An entity owned by an extension and contributed to a persistence unit through the SPI,
+ * not declared by the application.
+ */
+@Entity
+public class ContributedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    public ContributedEntity() {
+    }
+
+    public ContributedEntity(String name) {
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-additional-persistence-unit-clash.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-additional-persistence-unit-clash.properties
@@ -1,0 +1,7 @@
+# A named datasource is defined, plus a persistence unit "contributed" configured by the application.
+# The same "contributed" persistence unit is also contributed by an extension through the SPI in the test,
+# which must be rejected at build time.
+quarkus.datasource.vector.db-kind=h2
+
+quarkus.hibernate-orm."contributed".datasource=vector
+quarkus.hibernate-orm."contributed".packages=io.quarkus.hibernate.orm.spi

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-additional-persistence-unit.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-additional-persistence-unit.properties
@@ -1,0 +1,8 @@
+# Only a named datasource is defined: there is intentionally NO default datasource.
+# This guards against a persistence unit contributed through the SPI must not spuriously activate the default persistence unit.
+quarkus.datasource.vector.db-kind=h2
+
+# Schema management must be set explicitly because dev services do not auto-detect SPI-contributed PUs.
+# This is a runtime-only property, so it does NOT make "contributed" appear in the build-time
+# namedPersistenceUnits() and therefore does NOT trigger the SPI/user config clash check.
+quarkus.hibernate-orm."contributed".schema-management.strategy=drop-and-create


### PR DESCRIPTION
# Introduces AdditionalPersistenceUnitBuildItem

<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
and the AI/LLM usage policy at https://github.com/quarkusio/quarkus/blob/main/AI_POLICY.md
-->

Introduce the `AdditionalPersistenceUnitBuildItem` which allows external extensions to contribute with a static `PersistenceUnit`. This is the supported way for an extension to contribute a persistence unit of its own: the extension declares its intent (name, datasource, managed classes, mapping files and a few extra properties) and the Hibernate ORM extension takes care of the rest (datasource and dialect resolution, descriptor recording, CDI bean generation). 

Fixes #54592 

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

