### PR TITLE
Fix miscellaneous dead links across guides

### DIFF
--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -273,7 +273,7 @@ Outside of this use-case, just use `@Identifier`.
 == Native Executables and Private Members
 
 Quarkus is using GraalVM to build a native executable.
-One of the limitations of GraalVM is the usage of link:https://www.graalvm.org/{graalvm-docs-version}/reference-manual/native-image/Reflection/[Reflection, window="_blank"].
+One of the limitations of GraalVM is the usage of link:https://www.graalvm.org/{graalvm-docs-version}/reference-manual/native-image/dynamic-features/Reflection/[Reflection, window="_blank"].
 Reflective operations are supported, but all relevant members must be registered for reflection explicitly.
 Those registrations result in a bigger native executable.
 

--- a/docs/src/main/asciidoc/extension-maturity-matrix.adoc
+++ b/docs/src/main/asciidoc/extension-maturity-matrix.adoc
@@ -147,7 +147,7 @@ Quarkus's reactive core is a key contributor to its excellent throughput and sca
 === Add Mutiny-based APIs
 
 For maximum scalability, go beyond the reactive core and enable fully reactive programming, using Mutiny. Most projects that support a reactive programming model offer two distinct extensions, a `-reactive` and a plain one.
-See, for example, https://quarkus.io/extensions/io.quarkiverse.quarkus-elasticsearch/quarkus-elasticsearch/[ElasticSearch] and https://quarkus.io/extensions/io.quarkiverse.quarkus-elasticsearch-reactive/quarkus-elasticsearch-reactive/[ElasticSearch Reactive] extensions.
+See, for example, the https://quarkus.io/extensions/io.quarkus/quarkus-hibernate-orm/[Hibernate ORM] and https://quarkus.io/extensions/io.quarkus/quarkus-hibernate-reactive/[Hibernate Reactive] extensions.
 
 == Operations
 

--- a/docs/src/main/asciidoc/opentelemetry-metrics.adoc
+++ b/docs/src/main/asciidoc/opentelemetry-metrics.adoc
@@ -688,7 +688,7 @@ These are the metrics produced by the OpenTelemetry extension when metrics are e
 
 [WARNING]
 ====
-The instrumentation for JVM metrics uses JFR events and not all native VM implementations support the listed events. For more details, please see https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/runtime-telemetry/runtime-telemetry-java17/library[OpenTelemetry's Runtime Telemetry Java 17 documentation].
+The instrumentation for JVM metrics uses JFR events and not all native VM implementations support the listed events. For more details, please see https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/runtime-telemetry/library[OpenTelemetry's Runtime Telemetry documentation].
 ====
 
 The native image assessment above was performed using GraalVM 23.0.2.

--- a/docs/src/main/asciidoc/scripting.adoc
+++ b/docs/src/main/asciidoc/scripting.adoc
@@ -150,7 +150,7 @@ For now the application does nothing new.
 ====
 To edit the JBang script in an IDE/editor with content assist you can run `jbang edit quarkusapp.java` or `jbang edit quarkusapp.java`.
 
-For more information please refer to the https://www.jbang.dev/documentation/guide/latest/editing.html[the JBang documentation].
+For more information please refer to the https://www.jbang.dev/documentation/jbang/latest/editing.html[the JBang documentation].
 ====
 
 

--- a/docs/src/main/asciidoc/software-transactional-memory.adoc
+++ b/docs/src/main/asciidoc/software-transactional-memory.adoc
@@ -228,7 +228,7 @@ aa.begin(); <2>
 
 <1> An object for manually controlling transaction boundaries (AtomicAction and many other useful
     classes are included in the extension).
-    Refer https://narayana.io//docs/api/com/arjuna/ats/arjuna/AtomicAction.html[to the javadoc] for more detail.
+    Refer https://javadoc.io/doc/org.jboss.narayana.jta/narayana-jta/latest/com/arjuna/ats/arjuna/AtomicAction.html[to the javadoc] for more detail.
 <2> Programmatically begin a transaction.
 <3> Notice that object updates can be composed which means that updates to multiple objects can be committed together as a single action.
     [Note that it is also possible to begin nested transactions so that you can perform speculative work which may then be abandoned


### PR DESCRIPTION
- opentelemetry-metrics.adoc: OTel runtime-telemetry-java17 directory merged into runtime-telemetry/library
- cdi-reference.adoc: GraalVM Reflection docs moved under dynamic-features/
- scripting.adoc: JBang docs URL changed from /guide/ to /jbang/
- software-transactional-memory.adoc: Narayana javadoc moved to javadoc.io (linked from narayana.io/documentation)
- extension-maturity-matrix.adoc: Quarkiverse Elasticsearch extension page removed, use Hibernate as an example of reactive/not-reactive pair instead
