### PR TITLE
Add type support to KnownCompatibleBeanArchiveBuildItem and quarkus.index-dependency

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/IndexDependencyBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/IndexDependencyBuildItem.java
@@ -3,6 +3,7 @@ package io.quarkus.deployment.builditem;
 import java.util.Objects;
 
 import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.maven.dependency.ArtifactCoords;
 
 /**
  * Build item that defines dependencies that should be indexed. This can be used when a dependency does not contain
@@ -12,15 +13,21 @@ public final class IndexDependencyBuildItem extends MultiBuildItem {
     private final String groupId;
     private final String artifactId;
     private final String classifier;
+    private final String type;
 
     public IndexDependencyBuildItem(String groupId, String artifactId) {
-        this(groupId, artifactId, null);
+        this(groupId, artifactId, null, ArtifactCoords.TYPE_JAR);
     }
 
     public IndexDependencyBuildItem(String groupId, String artifactId, String classifier) {
-        this.groupId = Objects.requireNonNull(groupId);
+        this(groupId, artifactId, classifier, ArtifactCoords.TYPE_JAR);
+    }
+
+    public IndexDependencyBuildItem(String groupId, String artifactId, String classifier, String type) {
+        this.groupId = Objects.requireNonNull(groupId, "groupId must be set");
         this.artifactId = artifactId;
         this.classifier = classifier;
+        this.type = Objects.requireNonNull(type, "type must be set");
     }
 
     /**
@@ -45,5 +52,13 @@ public final class IndexDependencyBuildItem extends MultiBuildItem {
      */
     public String getClassifier() {
         return classifier;
+    }
+
+    /**
+     *
+     * @return the type, never {@code null}
+     */
+    public String getType() {
+        return type;
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/index/ApplicationArchiveBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/index/ApplicationArchiveBuildStep.java
@@ -51,6 +51,7 @@ import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithParentName;
 
 public class ApplicationArchiveBuildStep {
@@ -88,6 +89,12 @@ public class ApplicationArchiveBuildStep {
              * The maven classifier of the artifact (optional).
              */
             Optional<String> classifier();
+
+            /**
+             * The maven type of the artifact.
+             */
+            @WithDefault(ArtifactCoords.TYPE_JAR)
+            String type();
         }
     }
 
@@ -96,7 +103,8 @@ public class ApplicationArchiveBuildStep {
             BuildProducer<IndexDependencyBuildItem> indexDependencyBuildItemBuildProducer) {
         for (IndexDependencyConfiguration.IndexDependencyConfig indexDependencyConfig : config.indexDependency().values()) {
             indexDependencyBuildItemBuildProducer.produce(new IndexDependencyBuildItem(indexDependencyConfig.groupId(),
-                    indexDependencyConfig.artifactId().orElse(null), indexDependencyConfig.classifier().orElse(null)));
+                    indexDependencyConfig.artifactId().orElse(null), indexDependencyConfig.classifier().orElse(null),
+                    indexDependencyConfig.type()));
         }
     }
 
@@ -204,7 +212,7 @@ public class ApplicationArchiveBuildStep {
                 indexDependencyKeys.add(ArtifactKey.of(indexDependencyBuildItem.getGroupId(),
                         indexDependencyBuildItem.getArtifactId(),
                         indexDependencyBuildItem.getClassifier(),
-                        ArtifactCoords.TYPE_JAR));
+                        indexDependencyBuildItem.getType()));
             } else {
                 indexGroupIds.add(indexDependencyBuildItem.getGroupId());
             }

--- a/core/deployment/src/main/java/io/quarkus/deployment/index/IndexDependencyConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/index/IndexDependencyConfig.java
@@ -2,7 +2,9 @@ package io.quarkus.deployment.index;
 
 import java.util.Optional;
 
+import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
 
 @ConfigGroup
 public interface IndexDependencyConfig {
@@ -21,5 +23,11 @@ public interface IndexDependencyConfig {
      * The maven classifier of the artifact (optional).
      */
     Optional<String> classifier();
+
+    /**
+     * The maven type of the artifact.
+     */
+    @WithDefault(ArtifactCoords.TYPE_JAR)
+    String type();
 
 }

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BeanArchiveProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BeanArchiveProcessor.java
@@ -181,7 +181,7 @@ public class BeanArchiveProcessor {
             KnownCompatibleBeanArchives knownCompatibleBeanArchives) {
         // check for occurrences of incompatible annotations - currently only @Specializes
         Collection<AnnotationInstance> annotations = index.getAnnotations(DotNames.SPECIALIZES);
-        if (!annotations.isEmpty() && !knownCompatibleBeanArchives.isKnownCompatible(archive,
+        if (!annotations.isEmpty() && !knownCompatibleBeanArchives.isKnownCompatible(archive.getKey(),
                 KnownCompatibleBeanArchiveBuildItem.Reason.SPECIALIZES_ANNOTATION)) {
             Set<String> definitionErrors = new HashSet<>();
             for (AnnotationInstance annInstance : annotations) {
@@ -241,7 +241,7 @@ public class BeanArchiveProcessor {
                         if (text.contains("bean-discovery-mode='all'")
                                 || text.contains("bean-discovery-mode=\"all\"")) {
 
-                            if (!knownCompatibleBeanArchives.isKnownCompatible(archive,
+                            if (!knownCompatibleBeanArchives.isKnownCompatible(archive.getKey(),
                                     KnownCompatibleBeanArchiveBuildItem.Reason.BEANS_XML_ALL)) {
                                 LOGGER.warnf("Detected bean archive with bean discovery mode of 'all', "
                                         + "this is not portable in CDI Lite and is treated as 'annotated' in Quarkus! "

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/KnownCompatibleBeanArchiveBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/KnownCompatibleBeanArchiveBuildItem.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.maven.dependency.ArtifactCoords;
 
 /**
  * Marks a bean archive with given coordinates (groupId, artifactId and optionally classifier)
@@ -21,6 +22,7 @@ public final class KnownCompatibleBeanArchiveBuildItem extends MultiBuildItem {
     final String groupId;
     final String artifactId;
     final String classifier;
+    final String type;
 
     /**
      * Deprecated, use {@link KnownCompatibleBeanArchiveBuildItem#builder(String, String)} method instead.
@@ -37,13 +39,15 @@ public final class KnownCompatibleBeanArchiveBuildItem extends MultiBuildItem {
      */
     @Deprecated
     public KnownCompatibleBeanArchiveBuildItem(String groupId, String artifactId, String classifier) {
-        this(groupId, artifactId, classifier, Set.of(Reason.BEANS_XML_ALL));
+        this(groupId, artifactId, classifier, ArtifactCoords.TYPE_JAR, Set.of(Reason.BEANS_XML_ALL));
     }
 
-    private KnownCompatibleBeanArchiveBuildItem(String groupId, String artifactId, String classifier, Set<Reason> reasons) {
+    private KnownCompatibleBeanArchiveBuildItem(String groupId, String artifactId, String classifier, String type,
+            Set<Reason> reasons) {
         Objects.requireNonNull(groupId, "groupId must be set");
         Objects.requireNonNull(artifactId, "artifactId must be set");
         Objects.requireNonNull(classifier, "classifier must be set");
+        Objects.requireNonNull(type, "type must be set");
         if (reasons.isEmpty()) {
             throw new IllegalStateException(
                     "KnownCompatibleBeanArchiveBuildItem.Builder needs to declare at least one compatibility reason. Artifact with following coordinates had no reason associated: "
@@ -52,6 +56,7 @@ public final class KnownCompatibleBeanArchiveBuildItem extends MultiBuildItem {
         this.groupId = groupId;
         this.artifactId = artifactId;
         this.classifier = classifier;
+        this.type = type;
         this.reasons = reasons;
     }
 
@@ -75,16 +80,23 @@ public final class KnownCompatibleBeanArchiveBuildItem extends MultiBuildItem {
         private final String artifactId;
         private final Set<Reason> reasons;
         private String classifier;
+        private String type;
 
         private Builder(String groupId, String artifactId) {
             this.groupId = groupId;
             this.artifactId = artifactId;
-            this.classifier = "";
+            this.classifier = ArtifactCoords.DEFAULT_CLASSIFIER;
+            this.type = ArtifactCoords.TYPE_JAR;
             this.reasons = new HashSet<>();
         }
 
         public Builder setClassifier(String classifier) {
             this.classifier = classifier;
+            return this;
+        }
+
+        public Builder setType(String type) {
+            this.type = type;
             return this;
         }
 
@@ -94,7 +106,7 @@ public final class KnownCompatibleBeanArchiveBuildItem extends MultiBuildItem {
         }
 
         public KnownCompatibleBeanArchiveBuildItem build() {
-            return new KnownCompatibleBeanArchiveBuildItem(groupId, artifactId, classifier, reasons);
+            return new KnownCompatibleBeanArchiveBuildItem(groupId, artifactId, classifier, type, reasons);
         }
     }
 }

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/KnownCompatibleBeanArchives.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/KnownCompatibleBeanArchives.java
@@ -1,69 +1,34 @@
 package io.quarkus.arc.deployment;
 
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
-import io.quarkus.deployment.ApplicationArchive;
 import io.quarkus.maven.dependency.ArtifactKey;
 
 final class KnownCompatibleBeanArchives {
-    static class Key {
-        final String groupId;
-        final String artifactId;
-        final String classifier;
 
-        Key(String groupId, String artifactId, String classifier) {
-            this.groupId = groupId;
-            this.artifactId = artifactId;
-            this.classifier = classifier;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (!(o instanceof Key)) {
-                return false;
-            }
-            Key key = (Key) o;
-            return Objects.equals(groupId, key.groupId)
-                    && Objects.equals(artifactId, key.artifactId)
-                    && Objects.equals(classifier, key.classifier);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(groupId, artifactId, classifier);
-        }
-    }
-
-    private final Map<KnownCompatibleBeanArchiveBuildItem.Reason, Set<Key>> compatArchivesByReason;
+    private final Map<KnownCompatibleBeanArchiveBuildItem.Reason, Set<ArtifactKey>> compatArchivesByReason;
 
     KnownCompatibleBeanArchives(List<KnownCompatibleBeanArchiveBuildItem> list) {
-        Map<KnownCompatibleBeanArchiveBuildItem.Reason, Set<Key>> allCompatArchivesMap = new HashMap<>();
+        Map<KnownCompatibleBeanArchiveBuildItem.Reason, Set<ArtifactKey>> allCompatArchivesMap = new EnumMap<>(
+                KnownCompatibleBeanArchiveBuildItem.Reason.class);
         for (KnownCompatibleBeanArchiveBuildItem item : list) {
             for (KnownCompatibleBeanArchiveBuildItem.Reason reason : item.reasons) {
                 allCompatArchivesMap.computeIfAbsent(reason, unused -> new HashSet<>())
-                        .add(new Key(item.groupId, item.artifactId, item.classifier));
+                        .add(ArtifactKey.of(item.groupId, item.artifactId, item.classifier, item.type));
             }
         }
         this.compatArchivesByReason = allCompatArchivesMap;
     }
 
-    boolean isKnownCompatible(ApplicationArchive archive, KnownCompatibleBeanArchiveBuildItem.Reason reason) {
-        ArtifactKey artifact = archive.getKey();
-        if (artifact == null) {
+    boolean isKnownCompatible(ArtifactKey artifactKey, KnownCompatibleBeanArchiveBuildItem.Reason reason) {
+        if (artifactKey == null) {
             return false;
         }
-
-        Set<Key> archives = compatArchivesByReason.get(reason);
-        return archives == null ? false
-                : archives
-                        .contains(new Key(artifact.getGroupId(), artifact.getArtifactId(), artifact.getClassifier()));
+        Set<ArtifactKey> archives = compatArchivesByReason.get(reason);
+        return archives != null && archives.contains(artifactKey);
     }
 }

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/deployment/KnownCompatibleBeanArchivesTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/deployment/KnownCompatibleBeanArchivesTest.java
@@ -1,0 +1,68 @@
+package io.quarkus.arc.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.ArtifactKey;
+
+public class KnownCompatibleBeanArchivesTest {
+
+    @Test
+    void defaultTypeMatchesJarArchive() {
+        KnownCompatibleBeanArchiveBuildItem item = KnownCompatibleBeanArchiveBuildItem
+                .builder("org.acme", "acme-lib")
+                .addReason(KnownCompatibleBeanArchiveBuildItem.Reason.BEANS_XML_ALL)
+                .build();
+        KnownCompatibleBeanArchives archives = new KnownCompatibleBeanArchives(List.of(item));
+
+        assertThat(archives.isKnownCompatible(ArtifactKey.of("org.acme", "acme-lib", "", ArtifactCoords.TYPE_JAR),
+                KnownCompatibleBeanArchiveBuildItem.Reason.BEANS_XML_ALL)).isTrue();
+    }
+
+    @Test
+    void customTypeMatchesArchive() {
+        KnownCompatibleBeanArchiveBuildItem item = KnownCompatibleBeanArchiveBuildItem
+                .builder("org.acme", "acme-lib")
+                .setType("test-jar")
+                .addReason(KnownCompatibleBeanArchiveBuildItem.Reason.BEANS_XML_ALL)
+                .build();
+        KnownCompatibleBeanArchives archives = new KnownCompatibleBeanArchives(List.of(item));
+
+        assertThat(archives.isKnownCompatible(ArtifactKey.of("org.acme", "acme-lib", "", "test-jar"),
+                KnownCompatibleBeanArchiveBuildItem.Reason.BEANS_XML_ALL)).isTrue();
+    }
+
+    @Test
+    void typeMismatchDoesNotMatch() {
+        KnownCompatibleBeanArchiveBuildItem item = KnownCompatibleBeanArchiveBuildItem
+                .builder("org.acme", "acme-lib")
+                .addReason(KnownCompatibleBeanArchiveBuildItem.Reason.BEANS_XML_ALL)
+                .build();
+        KnownCompatibleBeanArchives archives = new KnownCompatibleBeanArchives(List.of(item));
+
+        assertThat(archives.isKnownCompatible(ArtifactKey.of("org.acme", "acme-lib", "", "test-jar"),
+                KnownCompatibleBeanArchiveBuildItem.Reason.BEANS_XML_ALL)).isFalse();
+    }
+
+    @Test
+    void classifierAndTypeMatch() {
+        KnownCompatibleBeanArchiveBuildItem item = KnownCompatibleBeanArchiveBuildItem
+                .builder("org.acme", "acme-lib")
+                .setClassifier("tests")
+                .setType("test-jar")
+                .addReason(KnownCompatibleBeanArchiveBuildItem.Reason.SPECIALIZES_ANNOTATION)
+                .build();
+        KnownCompatibleBeanArchives archives = new KnownCompatibleBeanArchives(List.of(item));
+
+        assertThat(archives.isKnownCompatible(ArtifactKey.of("org.acme", "acme-lib", "tests", "test-jar"),
+                KnownCompatibleBeanArchiveBuildItem.Reason.SPECIALIZES_ANNOTATION)).isTrue();
+        assertThat(archives.isKnownCompatible(ArtifactKey.of("org.acme", "acme-lib", "", "test-jar"),
+                KnownCompatibleBeanArchiveBuildItem.Reason.SPECIALIZES_ANNOTATION)).isFalse();
+        assertThat(archives.isKnownCompatible(ArtifactKey.of("org.acme", "acme-lib", "tests", ArtifactCoords.TYPE_JAR),
+                KnownCompatibleBeanArchiveBuildItem.Reason.SPECIALIZES_ANNOTATION)).isFalse();
+    }
+}


### PR DESCRIPTION
Adds a `type` field to `KnownCompatibleBeanArchiveBuildItem` and `quarkus.index-dependency` configuration, enabling matching of dependencies with non-default Maven types.

1. **`KnownCompatibleBeanArchiveBuildItem`**: Added `setType(String)` to the builder (defaulting to `ArtifactCoords.TYPE_JAR`). `KnownCompatibleBeanArchives` now uses `ArtifactKey` directly instead of a custom `Key` class, and `isKnownCompatible()` accepts `ArtifactKey` instead of `ApplicationArchive`. Uses `EnumMap` for the reason-to-archives mapping.

2. **`quarkus.index-dependency`**: Added `type` property to `IndexDependencyConfig` and `IndexDependencyBuildItem` (defaulting to `ArtifactCoords.TYPE_JAR`). Previously the type was hardcoded to `jar` in `ApplicationArchiveBuildStep.addIndexDependencyPaths()`.

The resolver changes needed to make `test-jar` work end-to-end are in a separate PR: #54856

Fixes: #54814