### PR TITLE
Drop trailing slash that causes a 404 

### DIFF
--- a/docs/src/main/asciidoc/podman.adoc
+++ b/docs/src/main/asciidoc/podman.adoc
@@ -22,7 +22,7 @@ The Homebrew package manager on Mac (*brew*) *should not be used to install Podm
 
 On Linux, Podman is integrated as part of the operating system, and installed through the system's packager manager. As with Mac, and Windows, Podman Desktop can also be installed to supplement the Podman CLI. However, on Linux, Podman Desktop acts as a client to the native Podman integration, and does not manage the underlying Podman installation.
 
-See https://podman-desktop.io/downloads/ for the latest version of Podman Desktop.
+See https://podman-desktop.io/downloads for the latest version of Podman Desktop.
 
 Additionally, if you are using Linux, see the Podman https://podman.io/docs/installation#installing-on-linux[Linux installation documentation] for instructions installing Podman to your specific Linux distribution.
 


### PR DESCRIPTION
Link still renders, but it's a bit ugly to have the 404 status. 

See https://github.com/podman-desktop/podman-desktop/issues/17851