### PR TITLE
Update chappie extension link to quarkus.io extensions

### DIFF
--- a/docs/src/main/asciidoc/assistant.adoc
+++ b/docs/src/main/asciidoc/assistant.adoc
@@ -42,7 +42,7 @@ To enable the Dev Assistant in your Quarkus project, add the `quarkus-chappie` e
     <version>${chappie-extension-version}</version> // <1>
 </dependency>
 ----
-<1> Replace `${chappie-extension-version}` with the latest available version. You can find the latest version on https://search.maven.org/artifact/io.quarkiverse.chappie/quarkus-chappie[search.maven.org].
+<1> Replace `${chappie-extension-version}` with the latest available version. You can find the latest version on https://quarkus.io/extensions/io.quarkiverse.chappie/quarkus-chappie/[extensions.quarkus.io].
 
 Once added, open the Dev UI to start using the assistant.
 


### PR DESCRIPTION
I don't have strong feelings about this, but search.maven.org can be a bit unreliable as an endpoint, and the extensions site has the required information (plus some extra, too).