### PR TITLE
Version Gradle file dependencies by content hash instead of `lastModified`

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusApplicationModelTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusApplicationModelTask.java
@@ -23,7 +23,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javax.inject.Inject;
 
@@ -263,7 +262,7 @@ public abstract class QuarkusApplicationModelTask extends DefaultTask {
                 }
             }
             // content-based version: stable across rebuilds, unlike a timestamp
-            final String version = contentHash(f);
+            final String version = ToolingUtils.contentHash(f);
             final ResolvedDependencyBuilder artifactBuilder = ResolvedDependencyBuilder.newInstance()
                     .setGroupId(group)
                     .setArtifactId(name)
@@ -275,25 +274,6 @@ public abstract class QuarkusApplicationModelTask extends DefaultTask {
                     .setDeploymentCp();
             processQuarkusDependency(artifactBuilder, modelBuilder);
             modelBuilder.addDependency(artifactBuilder);
-        }
-    }
-
-    private static String contentHash(File file) {
-        try {
-            if (file.isDirectory()) {
-                final Path root = file.toPath();
-                final StringBuilder sb = new StringBuilder();
-                try (Stream<Path> stream = Files.walk(root)) {
-                    for (Path p : stream.filter(Files::isRegularFile).sorted().collect(toList())) {
-                        sb.append(root.relativize(p).toString().replace('\\', '/')).append(':')
-                                .append(HashUtil.sha1(Files.readAllBytes(p))).append('\n');
-                    }
-                }
-                return HashUtil.sha1(sb.toString());
-            }
-            return HashUtil.sha1(Files.readAllBytes(file.toPath()));
-        } catch (IOException e) {
-            throw new UncheckedIOException("Failed to hash content of " + file, e);
         }
     }
 

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusApplicationModelTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusApplicationModelTask.java
@@ -23,6 +23,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.inject.Inject;
 
@@ -261,8 +262,8 @@ public abstract class QuarkusApplicationModelTask extends DefaultTask {
                     type = f.getName().substring(dot + 1);
                 }
             }
-            // hash could be a better way to represent the version
-            final String version = String.valueOf(f.lastModified());
+            // content-based version: stable across rebuilds, unlike a timestamp
+            final String version = contentHash(f);
             final ResolvedDependencyBuilder artifactBuilder = ResolvedDependencyBuilder.newInstance()
                     .setGroupId(group)
                     .setArtifactId(name)
@@ -274,6 +275,25 @@ public abstract class QuarkusApplicationModelTask extends DefaultTask {
                     .setDeploymentCp();
             processQuarkusDependency(artifactBuilder, modelBuilder);
             modelBuilder.addDependency(artifactBuilder);
+        }
+    }
+
+    private static String contentHash(File file) {
+        try {
+            if (file.isDirectory()) {
+                final Path root = file.toPath();
+                final StringBuilder sb = new StringBuilder();
+                try (Stream<Path> stream = Files.walk(root)) {
+                    for (Path p : stream.filter(Files::isRegularFile).sorted().collect(toList())) {
+                        sb.append(root.relativize(p).toString().replace('\\', '/')).append(':')
+                                .append(HashUtil.sha1(Files.readAllBytes(p))).append('\n');
+                    }
+                }
+                return HashUtil.sha1(sb.toString());
+            }
+            return HashUtil.sha1(Files.readAllBytes(file.toPath()));
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to hash content of " + file, e);
         }
     }
 

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/GradleApplicationModelBuilder.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/GradleApplicationModelBuilder.java
@@ -405,8 +405,8 @@ public class GradleApplicationModelBuilder implements ParameterizedToolingModelB
                         type = f.getName().substring(dot + 1);
                     }
                 }
-                // hash could be a better way to represent the version
-                final String version = String.valueOf(f.lastModified());
+                // content-based version: stable across rebuilds, unlike a timestamp
+                final String version = ToolingUtils.contentHash(f);
                 final ResolvedDependencyBuilder artifactBuilder = ResolvedDependencyBuilder.newInstance()
                         .setGroupId(group)
                         .setArtifactId(name)

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/ToolingUtils.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/ToolingUtils.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
@@ -11,6 +12,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.HexFormat;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
@@ -31,7 +33,6 @@ import io.quarkus.bootstrap.model.gradle.ModelParameter;
 import io.quarkus.bootstrap.model.gradle.impl.ModelParameterImpl;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.runtime.LaunchMode;
-import io.quarkus.runtime.util.HashUtil;
 
 public class ToolingUtils {
 
@@ -227,31 +228,52 @@ public class ToolingUtils {
         try {
             if (file.isDirectory()) {
                 final Path root = file.toPath();
-                final StringBuilder sb = new StringBuilder();
+                final MessageDigest digest = sha1Digest();
                 try (Stream<Path> stream = Files.walk(root)) {
                     // normalize separators and sort so the hash is identical across operating systems
                     stream.filter(Files::isRegularFile)
                             .map(p -> Map.entry(root.relativize(p).toString().replace('\\', '/'), p))
                             .sorted(Map.Entry.comparingByKey())
-                            .forEach(e -> sb.append(e.getKey()).append(':')
-                                    .append(sha1(e.getValue())).append('\n'));
+                            .forEach(e -> {
+                                String fileEntry = e.getKey() + ':' + cachedSha1(e.getValue()) + '\n';
+                                digest.update(fileEntry.getBytes(StandardCharsets.UTF_8));
+                            });
                 }
-                return HashUtil.sha1(sb.toString());
+                return HexFormat.of().formatHex(digest.digest());
             }
-            return sha1(file.toPath());
+            return cachedSha1(file.toPath());
         } catch (IOException | UncheckedIOException e) {
             // never fail the model build on an unreadable file, like lastModified() never did
             return String.valueOf(file.lastModified());
         }
     }
 
-    private static String sha1(Path file) {
-        final MessageDigest digest;
-        try {
-            digest = MessageDigest.getInstance("SHA-1");
-        } catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException(e);
+    private static final Map<String, FileDigest> DIGEST_CACHE = new ConcurrentHashMap<>();
+
+    private record FileDigest(long lastModified, long length, String hash) {
+    }
+
+    /**
+     * Returns the SHA-1 of a file's content, reusing the cached digest while the file's metadata is unchanged.
+     */
+    private static String cachedSha1(Path file) {
+        final File f = file.toFile();
+        final long lastModified = f.lastModified();
+        final long length = f.length();
+        final FileDigest cached = DIGEST_CACHE.get(f.getAbsolutePath());
+        if (cached != null && cached.lastModified() == lastModified && cached.length() == length) {
+            return cached.hash();
         }
+        final String hash = sha1(file);
+        DIGEST_CACHE.put(f.getAbsolutePath(), new FileDigest(lastModified, length, hash));
+        return hash;
+    }
+
+    /**
+     * Computes the hex-encoded SHA-1 of a file's content, streaming it without loading it into memory.
+     */
+    private static String sha1(Path file) {
+        final MessageDigest digest = sha1Digest();
         try (InputStream in = Files.newInputStream(file)) {
             final byte[] buffer = new byte[8192];
             for (int read = in.read(buffer); read >= 0; read = in.read(buffer)) {
@@ -261,5 +283,13 @@ public class ToolingUtils {
             throw new UncheckedIOException("Failed to hash content of " + file, e);
         }
         return HexFormat.of().formatHex(digest.digest());
+    }
+
+    private static MessageDigest sha1Digest() {
+        try {
+            return MessageDigest.getInstance("SHA-1");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
     }
 }

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/ToolingUtils.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/ToolingUtils.java
@@ -2,9 +2,16 @@ package io.quarkus.gradle.tooling;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
 
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -23,6 +30,7 @@ import io.quarkus.bootstrap.model.gradle.ModelParameter;
 import io.quarkus.bootstrap.model.gradle.impl.ModelParameterImpl;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.runtime.LaunchMode;
+import io.quarkus.runtime.util.HashUtil;
 
 public class ToolingUtils {
 
@@ -209,5 +217,47 @@ public class ToolingUtils {
             return result.get();
         }
         return null;
+    }
+
+    /**
+     * Hash of the content of a file or directory, used as a stable version of a file dependency.
+     */
+    public static String contentHash(File file) {
+        try {
+            if (file.isDirectory()) {
+                final Path root = file.toPath();
+                final StringBuilder sb = new StringBuilder();
+                try (Stream<Path> stream = Files.walk(root)) {
+                    // normalize separators and sort so the hash is identical across operating systems
+                    stream.filter(Files::isRegularFile)
+                            .map(p -> root.relativize(p).toString().replace('\\', '/'))
+                            .sorted()
+                            .forEach(relativePath -> sb.append(relativePath).append(':')
+                                    .append(sha1(root.resolve(relativePath))).append('\n'));
+                }
+                return HashUtil.sha1(sb.toString());
+            }
+            return sha1(file.toPath());
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to hash content of " + file, e);
+        }
+    }
+
+    private static String sha1(Path file) {
+        final MessageDigest digest;
+        try {
+            digest = MessageDigest.getInstance("SHA-1");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+        try (InputStream in = Files.newInputStream(file)) {
+            final byte[] buffer = new byte[8192];
+            for (int read = in.read(buffer); read >= 0; read = in.read(buffer)) {
+                digest.update(buffer, 0, read);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to hash content of " + file, e);
+        }
+        return HexFormat.of().formatHex(digest.digest());
     }
 }

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/ToolingUtils.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/ToolingUtils.java
@@ -9,6 +9,7 @@ import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HexFormat;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
@@ -230,16 +231,17 @@ public class ToolingUtils {
                 try (Stream<Path> stream = Files.walk(root)) {
                     // normalize separators and sort so the hash is identical across operating systems
                     stream.filter(Files::isRegularFile)
-                            .map(p -> root.relativize(p).toString().replace('\\', '/'))
-                            .sorted()
-                            .forEach(relativePath -> sb.append(relativePath).append(':')
-                                    .append(sha1(root.resolve(relativePath))).append('\n'));
+                            .map(p -> Map.entry(root.relativize(p).toString().replace('\\', '/'), p))
+                            .sorted(Map.Entry.comparingByKey())
+                            .forEach(e -> sb.append(e.getKey()).append(':')
+                                    .append(sha1(e.getValue())).append('\n'));
                 }
                 return HashUtil.sha1(sb.toString());
             }
             return sha1(file.toPath());
-        } catch (IOException e) {
-            throw new UncheckedIOException("Failed to hash content of " + file, e);
+        } catch (IOException | UncheckedIOException e) {
+            // never fail the model build on an unreadable file, like lastModified() never did
+            return String.valueOf(file.lastModified());
         }
     }
 


### PR DESCRIPTION
The Gradle application model represents file-collection dependencies (e.g. `implementation(sourceSets["generated"].output)`) with a synthetic version derived from the file's last-modified time:

```java
// hash could be a better way to represent the version
final String version = String.valueOf(f.lastModified());
```

`clean` recreates source-set output directories with fresh mtimes, so the serialized model changes on every clean rebuild even when every output is byte-identical. The model file is a content-hashed input of every `Test` task (and of `quarkusGenerateCode*`), so their build-cache keys change on every clean rebuild and stored entries never match: tests always re-run after a clean in any project that wires file collections as dependencies.

Confirmed by diffing the test task's input fingerprints across two identical clean builds: the only changed input was the serialized model, and the only differing bytes in it were the digits of the mtime version.

### Fix

Version such dependencies by a SHA-1 of their content instead (for directories, a hash over relative paths and per-file hashes). The model and dependent cache keys stay stable while content is unchanged, and still change when content changes. Content changes also reach the consuming tasks through their regular classpath fingerprints, so no change is masked.

This matches how Gradle itself fingerprints inputs (content hashes, not timestamps, see docs [here](https://docs.gradle.org/current/userguide/incremental_build.html#sec:how_does_it_work)); the Gradle build-cache docs name timestamp-derived versions as a canonical unstable input ([here](https://docs.gradle.org/current/userguide/build_cache_concepts.html#stable_task_inputs)).

### Cost

Hashing applies only to file-collection dependencies — projects without them are unaffected. For typical generated source-set outputs it is in the low milliseconds per model task, and Gradle already content-hashes the same files for its own fingerprinting.

---

I did this analysis and wrote the patch with the help of Claude Code. Shoutout to @TSFenwick for analyzing this in our codebase. 

Relates to #11406, #30852.