### PR TITLE
Preserve Maven artifact type in DependencyUtils

### DIFF
--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/util/DependencyUtils.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/util/DependencyUtils.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.ArtifactProperties;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.DependencyNode;
@@ -26,12 +27,12 @@ public class DependencyUtils {
 
     public static ArtifactKey getKey(Artifact artifact) {
         return ArtifactKey.of(artifact.getGroupId(), artifact.getArtifactId(),
-                artifact.getClassifier(), artifact.getExtension());
+                artifact.getClassifier(), getType(artifact));
     }
 
     public static ArtifactCoords getCoords(Artifact artifact) {
         return new GACTV(artifact.getGroupId(), artifact.getArtifactId(),
-                artifact.getClassifier(), artifact.getExtension(), artifact.getVersion());
+                artifact.getClassifier(), getType(artifact), artifact.getVersion());
     }
 
     public static Map<ArtifactKey, Dependency> toMap(List<Dependency> deps) {
@@ -166,9 +167,13 @@ public class DependencyUtils {
                 .setGroupId(artifact.getGroupId())
                 .setArtifactId(artifact.getArtifactId())
                 .setClassifier(artifact.getClassifier())
-                .setType(artifact.getExtension())
+                .setType(getType(artifact))
                 .setVersion(artifact.getVersion())
                 .setResolvedPaths(artifact.getFile() == null ? PathList.empty() : PathList.of(artifact.getFile().toPath()));
+    }
+
+    private static String getType(Artifact artifact) {
+        return artifact.getProperty(ArtifactProperties.TYPE, artifact.getExtension());
     }
 
     public static boolean hasWinner(DependencyNode node) {

--- a/independent-projects/bootstrap/maven-resolver/src/test/java/io/quarkus/bootstrap/util/DependencyUtilsTest.java
+++ b/independent-projects/bootstrap/maven-resolver/src/test/java/io/quarkus/bootstrap/util/DependencyUtilsTest.java
@@ -1,0 +1,50 @@
+package io.quarkus.bootstrap.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.eclipse.aether.artifact.ArtifactProperties;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.ArtifactKey;
+
+public class DependencyUtilsTest {
+
+    @Test
+    void getKeyPreservesTestJarType() {
+        var artifact = new DefaultArtifact("org.acme", "acme-lib", "tests-quarkus", "jar", "1.0",
+                Map.of(ArtifactProperties.TYPE, "test-jar"), (org.eclipse.aether.artifact.ArtifactType) null);
+        ArtifactKey key = DependencyUtils.getKey(artifact);
+        assertThat(key.getType()).isEqualTo("test-jar");
+        assertThat(key.getClassifier()).isEqualTo("tests-quarkus");
+    }
+
+    @Test
+    void getKeyDefaultsToExtensionWhenNoTypeProperty() {
+        var artifact = new DefaultArtifact("org.acme", "acme-lib", "", "jar", "1.0");
+        ArtifactKey key = DependencyUtils.getKey(artifact);
+        assertThat(key.getType()).isEqualTo("jar");
+    }
+
+    @Test
+    void getCoordsPreservesTestJarType() {
+        var artifact = new DefaultArtifact("org.acme", "acme-lib", "tests-quarkus", "jar", "1.0",
+                Map.of(ArtifactProperties.TYPE, "test-jar"), (org.eclipse.aether.artifact.ArtifactType) null);
+        ArtifactCoords coords = DependencyUtils.getCoords(artifact);
+        assertThat(coords.getType()).isEqualTo("test-jar");
+        assertThat(coords.getClassifier()).isEqualTo("tests-quarkus");
+        assertThat(coords.getVersion()).isEqualTo("1.0");
+    }
+
+    @Test
+    void toAppArtifactPreservesTestJarType() {
+        var artifact = new DefaultArtifact("org.acme", "acme-lib", "tests-quarkus", "jar", "1.0",
+                Map.of(ArtifactProperties.TYPE, "test-jar"), (org.eclipse.aether.artifact.ArtifactType) null);
+        var resolved = DependencyUtils.toAppArtifact(artifact, null).build();
+        assertThat(resolved.getType()).isEqualTo("test-jar");
+        assertThat(resolved.getClassifier()).isEqualTo("tests-quarkus");
+    }
+}


### PR DESCRIPTION
`DependencyUtils.getKey()`, `getCoords()`, and `toAppArtifact()` use Aether's `artifact.getExtension()` which returns the file extension (e.g., `jar`) rather than the original Maven type (e.g., `test-jar`). This causes type information loss for dependencies declared with logical types like `test-jar`.

Aether preserves the original type as a property (`ArtifactProperties.TYPE`). This change uses `artifact.getProperty(ArtifactProperties.TYPE, artifact.getExtension())` to retain the original Maven type, falling back to the file extension when no type property is set.

Related: #54814