### PR TITLE
Log Dev MCP endpoint path at startup when enabled

### DIFF
--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/MCPProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/MCPProcessor.java
@@ -8,6 +8,7 @@ import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.devui.runtime.DevUIRecorder;
 import io.quarkus.devui.runtime.mcp.McpDevUIJsonRpcService;
@@ -78,6 +79,18 @@ public class MCPProcessor {
                         .handler(recorder.mcpStreamableHTTPHandler(Version.getVersion()))
                         .build());
 
+    }
+
+    @BuildStep(onlyIf = IsDevelopment.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void logDevMcpEndpoint(DevUIRecorder recorder,
+            NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
+            LaunchModeBuildItem launchModeBuildItem) {
+        if (launchModeBuildItem.isNotLocalDevModeType()) {
+            return;
+        }
+        String path = nonApplicationRootPathBuildItem.resolvePath(DEVMCP);
+        recorder.logDevMcpEndpoint(path);
     }
 
     @BuildStep(onlyIf = IsDevelopment.class)

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/DevUIRecorder.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/DevUIRecorder.java
@@ -15,6 +15,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import jakarta.enterprise.inject.spi.CDI;
+
 import org.jboss.logging.Logger;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -26,6 +28,7 @@ import io.quarkus.devui.runtime.jsonrpc.JsonRpcMethod;
 import io.quarkus.devui.runtime.jsonrpc.json.JsonMapper;
 import io.quarkus.devui.runtime.jsonrpc.json.JsonTypeAdapter;
 import io.quarkus.devui.runtime.mcp.McpHttpHandler;
+import io.quarkus.devui.runtime.spi.McpServerConfiguration;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.vertx.http.runtime.devmode.FileSystemStaticHandler;
@@ -80,6 +83,13 @@ public class DevUIRecorder {
 
     public Handler<RoutingContext> devUIWebSocketHandler() {
         return new DevUIWebSocketHandler();
+    }
+
+    public void logDevMcpEndpoint(String path) {
+        McpServerConfiguration config = CDI.current().select(McpServerConfiguration.class).get();
+        if (config.isEnabled()) {
+            LOG.infof("Dev MCP available at: %s", path);
+        }
     }
 
     public Handler<RoutingContext> mcpStreamableHTTPHandler(String quarkusVersion) {


### PR DESCRIPTION
When the Dev MCP server is enabled, the resolved endpoint path (e.g. `/q/dev-mcp`) is now logged during application startup. This allows external tools like [quarkus-agent-mcp](https://github.com/quarkusio/quarkus-agent-mcp) to discover the correct endpoint path by parsing the startup log — the same way they already discover the HTTP port from the `Listening on:` line.

Without this, tools had to guess or hardcode `/q/dev-mcp`, which breaks when users configure `quarkus.http.non-application-root-path` to a different value via any config source (application.properties, env vars, system properties, etc.).

Fixes https://github.com/quarkusio/quarkus-agent-mcp/issues/194