### PR TITLE
Use EnumMap for enum-keyed maps

### DIFF
--- a/docs/src/main/java/io/quarkus/docs/generation/YamlMetadataGenerator.java
+++ b/docs/src/main/java/io/quarkus/docs/generation/YamlMetadataGenerator.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -468,7 +469,7 @@ public class YamlMetadataGenerator {
     }
 
     public static class Index {
-        Map<Type, IndexByType> types = new HashMap<>();
+        Map<Type, IndexByType> types = new EnumMap<>(Type.class);
 
         public List<Map<String, String>> getCategories() {
             return Stream.of(Category.values())

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BuildTimeEnabledProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BuildTimeEnabledProcessor.java
@@ -9,6 +9,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -306,6 +307,7 @@ public class BuildTimeEnabledProcessor {
                 .map(BuildTimeConditionBuildItem::getTarget)
                 .collect(groupingBy(
                         AnnotationTarget::kind,
+                        () -> new EnumMap<>(Kind.class),
                         Collectors.mapping(BuildExclusionsBuildItem::targetMapper, Collectors.toSet())));
         return new BuildExclusionsBuildItem(
                 map.getOrDefault(AnnotationTarget.Kind.CLASS, Collections.emptySet()),

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -17,6 +17,7 @@ import java.security.PrivateKey;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -808,7 +809,7 @@ public class OidcCommonUtils {
     private static <T> Map<OidcEndpoint.Type, List<T>> getOidcFilters(Class<T> filterClass, Predicate<Class<?>> appliesTo) {
         ArcContainer container = Arc.container();
         if (container != null) {
-            Map<OidcEndpoint.Type, List<T>> map = new HashMap<>();
+            Map<OidcEndpoint.Type, List<T>> map = new EnumMap<>(OidcEndpoint.Type.class);
             for (T filter : container.listAll(filterClass).stream().map(handle -> handle.get())
                     .collect(Collectors.toList())) {
                 var actualBeanClass = ClientProxy.unwrap(filter).getClass();

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -932,7 +933,7 @@ public class BeanInfo implements InjectionTargetInfo {
 
     private Map<InterceptionType, InterceptionInfo> initLifecycleInterceptors() {
         if (!isInterceptor() && isClassBean()) {
-            Map<InterceptionType, InterceptionInfo> lifecycleInterceptors = new HashMap<>();
+            Map<InterceptionType, InterceptionInfo> lifecycleInterceptors = new EnumMap<>(InterceptionType.class);
             Set<AnnotationInstance> classLevelBindings = new HashSet<>();
             Set<AnnotationInstance> constructorLevelBindings = new HashSet<>();
             addClassLevelBindings(target.get().asClass(), classLevelBindings);


### PR DESCRIPTION
## Summary

- Replace `HashMap` with `EnumMap` in four locations where the map key is an enum type, improving memory efficiency and lookup performance:
  - `BeanInfo.initLifecycleInterceptors()` — `InterceptionType` key (ArC processor)
  - `OidcCommonUtils.getOidcFilters()` — `OidcEndpoint.Type` key (OIDC common runtime)
  - `YamlMetadataGenerator.Index` — `Type` key (docs generation)
  - `BuildTimeEnabledProcessor.buildExclusions()` — `AnnotationTarget.Kind` key (ArC deployment)

## Test plan

- [x] ArC processor module builds successfully
- [x] ArC deployment module builds successfully
- [x] OIDC common runtime module builds successfully
- [x] Docs module compiles successfully