### PR TITLE
Fix dev mode startup when LGTM observability dev services are disabled

### DIFF
--- a/extensions/observability-devservices/deployment/src/main/java/io/quarkus/observability/deployment/devui/ObservabilityDevUIProcessor.java
+++ b/extensions/observability-devservices/deployment/src/main/java/io/quarkus/observability/deployment/devui/ObservabilityDevUIProcessor.java
@@ -1,5 +1,7 @@
 package io.quarkus.observability.deployment.devui;
 
+import java.util.function.BooleanSupplier;
+
 import io.quarkus.arc.processor.BuiltinScope;
 import io.quarkus.deployment.IsDevServicesSupportedByLaunchMode;
 import io.quarkus.deployment.IsDevelopment;
@@ -14,12 +16,23 @@ import io.quarkus.devui.spi.page.FooterPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
 import io.quarkus.devui.spi.page.WebComponentPageBuilder;
 import io.quarkus.observability.runtime.ObservabilityJsonRPCService;
+import io.quarkus.observability.runtime.config.ObservabilityConfiguration;
 
 /**
  * Dev UI card for displaying important details such LGTM embedded UI.
  */
-@BuildSteps(onlyIf = { IsDevServicesSupportedByLaunchMode.class, DevServicesConfig.Enabled.class })
+@BuildSteps(onlyIf = { IsDevServicesSupportedByLaunchMode.class, DevServicesConfig.Enabled.class,
+        ObservabilityDevUIProcessor.IsLgtmDevUiEnabled.class })
 public class ObservabilityDevUIProcessor {
+
+    public static class IsLgtmDevUiEnabled implements BooleanSupplier {
+        ObservabilityConfiguration config;
+
+        @Override
+        public boolean getAsBoolean() {
+            return config.enabled() && !config.devResources() && config.lgtm().enabled();
+        }
+    }
 
     @BuildStep(onlyIf = IsDevelopment.class)
     void createVersion(BuildProducer<CardPageBuildItem> cardPageBuildItemBuildProducer,


### PR DESCRIPTION

Fix #54759


Since the observability dev services migration (#54388), `ObservabilityJsonRPCService` is always registered as a Dev UI JsonRPC provider in dev mode. That bean requires `grafana.endpoint` and `otel-collector.url`, which are only set when the LGTM container starts.

When `quarkus.observability.lgtm.enabled=false`, the container is correctly skipped but the JsonRPC bean is still created, causing startup to fail with config resolution errors.

Gate `ObservabilityDevUIProcessor` on observability dev services and LGTM being enabled, so Dev UI pages and the JsonRPC provider are only registered when LGTM will actually run.