### PR TITLE
Fix invalid secret and ConfigMap volume item mode in Kubernetes manifests

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ConfigMapVolumeConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ConfigMapVolumeConfig.java
@@ -13,7 +13,13 @@ public interface ConfigMapVolumeConfig extends VolumeConfig {
         final var volume = new VolumeBuilder()
                 .withName(name)
                 .withNewConfigMap();
-        items().forEach((k, v) -> volume.addNewItem().withKey(k).withMode(v.mode()).withPath(v.path()).endItem());
+        items().forEach((k, v) -> {
+            final var item = volume.addNewItem().withKey(k).withPath(v.path());
+            if (v.hasExplicitMode()) {
+                item.withMode(v.mode());
+            }
+            item.endItem();
+        });
 
         return volume
                 .withName(configMapName())

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/SecretVolumeConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/SecretVolumeConfig.java
@@ -13,7 +13,13 @@ public interface SecretVolumeConfig extends VolumeConfig {
         final var volume = new VolumeBuilder()
                 .withName(name)
                 .withNewSecret();
-        items().forEach((k, v) -> volume.addNewItem().withKey(k).withMode(v.mode()).withPath(v.path()).endItem());
+        items().forEach((k, v) -> {
+            final var item = volume.addNewItem().withKey(k).withPath(v.path());
+            if (v.hasExplicitMode()) {
+                item.withMode(v.mode());
+            }
+            item.endItem();
+        });
 
         return volume
                 .withSecretName(secretName())

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/VolumeItemConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/VolumeItemConfig.java
@@ -13,4 +13,11 @@ public interface VolumeItemConfig {
      */
     @WithDefault("-1")
     int mode();
+
+    /**
+     * @return {@code true} if {@link #mode()} was explicitly configured
+     */
+    default boolean hasExplicitMode() {
+        return mode() >= 0;
+    }
 }

--- a/extensions/kubernetes/vanilla/deployment/src/test/java/io/quarkus/kubernetes/deployment/KubernetesConfigTest.java
+++ b/extensions/kubernetes/vanilla/deployment/src/test/java/io/quarkus/kubernetes/deployment/KubernetesConfigTest.java
@@ -4,6 +4,7 @@ import static io.quarkus.kubernetes.deployment.KubernetesConfigTest.Reader.read;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -180,6 +181,20 @@ class KubernetesConfigTest {
                 assertEquals("earth", items.get("key"));
                 assertEquals("earth", items.get("path"));
                 assertEquals("777", items.get("mode").toString());
+            } else if (volume.get("name").equals("lightning")) {
+                assertEquals("lightning", read(volume).asMap("secret").get("secretName"));
+                assertEquals("384", read(volume).asMap("secret").get("defaultMode").toString());
+                Map<String, Object> items = read(read(volume).asMap("secret").get("items")).list(0).asMap();
+                assertEquals("keystore", items.get("key"));
+                assertEquals("keystore.p12", items.get("path"));
+                assertNull(items.get("mode"));
+            } else if (volume.get("name").equals("rock")) {
+                assertEquals("rock", read(volume).asMap("configMap").get("name"));
+                assertEquals("384", read(volume).asMap("configMap").get("defaultMode").toString());
+                Map<String, Object> items = read(read(volume).asMap("configMap").get("items")).list(0).asMap();
+                assertEquals("rock", items.get("key"));
+                assertEquals("application.properties", items.get("path"));
+                assertNull(items.get("mode"));
             } else if (volume.get("name").equals("one")) {
                 assertNotNull(read(volume).asMap("emptyDir"));
             } else if (volume.get("name").equals("two")) {

--- a/extensions/kubernetes/vanilla/deployment/src/test/resources/application-kubernetes.properties
+++ b/extensions/kubernetes/vanilla/deployment/src/test/resources/application-kubernetes.properties
@@ -102,6 +102,12 @@ quarkus.kubernetes.config-map-volumes.earth.default-mode=0777
 quarkus.kubernetes.config-map-volumes.earth.items.earth.path=earth
 quarkus.kubernetes.config-map-volumes.earth.items.earth.mode=0777
 quarkus.kubernetes.config-map-volumes.earth.optional=true
+quarkus.kubernetes.secret-volumes.lightning.secret-name=lightning
+quarkus.kubernetes.secret-volumes.lightning.default-mode=0600
+quarkus.kubernetes.secret-volumes.lightning.items.keystore.path=keystore.p12
+quarkus.kubernetes.config-map-volumes.rock.config-map-name=rock
+quarkus.kubernetes.config-map-volumes.rock.default-mode=0600
+quarkus.kubernetes.config-map-volumes.rock.items.rock.path=application.properties
 quarkus.kubernetes.empty-dir-volumes=one,two,three
 
 # Couldn't find usages of io.quarkus.kubernetes.deployment.KubernetesConfig.getGitRepoVolumes


### PR DESCRIPTION
Deployments to Kubernetes and OpenShift fail when secret or ConfigMap volume
items specify only `path` without `mode`, because the generated manifest
contains `mode: -1`, which the API rejects. This regressed in #54245 when
volume generation moved from Dekorate decorators to direct Fabric8 builders.

When item `mode` is not set, omit it from the manifest so the volume
`defaultMode` applies, restoring pre-3.37 behavior for both
`quarkus.kubernetes.*` and `quarkus.openshift.*` secret/config-map volume
items.


- Fixes: #54784