### PR TITLE
Use release version tag in all-builditems GitHub links

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -3479,6 +3479,7 @@
                                 <argument>${generated-dir}/infra/quarkus-all-build-items.adoc</argument>
                                 <argument>${project.basedir}/../core/deployment</argument>
                                 <argument>${project.basedir}/../extensions</argument>
+                                <argument>${project.version}</argument>
                             </arguments>
                             <environmentVariables>
                                 <MAVEN_CMD_LINE_ARGS>${env.MAVEN_CMD_LINE_ARGS}</MAVEN_CMD_LINE_ARGS>

--- a/docs/src/main/java/io/quarkus/docs/generation/QuarkusBuildItemDoc.java
+++ b/docs/src/main/java/io/quarkus/docs/generation/QuarkusBuildItemDoc.java
@@ -35,10 +35,11 @@ public class QuarkusBuildItemDoc {
 
     public Path outputFile;
     public List<Path> paths;
+    public String gitRef = "main";
 
     private PrintStream out = System.out;
 
-    // target/asciidoc/generated/config/quarkus-all-build-items.adoc core/deployment core/test-extension extensions
+    // target/asciidoc/generated/config/quarkus-all-build-items.adoc core/deployment core/test-extension extensions [version]
     public static void main(String[] args) throws Exception {
         if (args.length < 2) {
             System.err.println("Must specify output file (first) followed by at least one source directory");
@@ -47,7 +48,16 @@ public class QuarkusBuildItemDoc {
         QuarkusBuildItemDoc buildItemDoc = new QuarkusBuildItemDoc();
 
         buildItemDoc.outputFile = Path.of(args[0]);
-        buildItemDoc.paths = Arrays.stream(args).skip(1)
+
+        int sourceArgCount = args.length;
+        String lastArg = args[args.length - 1];
+        if (!Files.isDirectory(Path.of(lastArg))) {
+            sourceArgCount--;
+            if (!lastArg.endsWith("-SNAPSHOT")) {
+                buildItemDoc.gitRef = lastArg;
+            }
+        }
+        buildItemDoc.paths = Arrays.stream(args, 1, sourceArgCount)
                 .map(Path::of)
                 .collect(Collectors.toList());
 
@@ -179,9 +189,8 @@ public class QuarkusBuildItemDoc {
     }
 
     private void printTableRow(Pair<Path, JavaClassSource> pair) {
-        //TODO: Use tagged version?
         Path root = Paths.get(".").toAbsolutePath().normalize();
-        String link = "https://github.com/quarkusio/quarkus/blob/main/" + root.relativize(pair.getOne().normalize());
+        String link = "https://github.com/quarkusio/quarkus/blob/" + gitRef + "/" + root.relativize(pair.getOne().normalize());
         JavaClassSource source = pair.getTwo();
         String className = source.getQualifiedName();
         String attributes = buildAttributes(source);

--- a/docs/src/test/java/io/quarkus/docs/generation/QuarkusBuildItemDocTest.java
+++ b/docs/src/test/java/io/quarkus/docs/generation/QuarkusBuildItemDocTest.java
@@ -1,0 +1,88 @@
+package io.quarkus.docs.generation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class QuarkusBuildItemDocTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    public void gitRefDefaultsToMain() {
+        QuarkusBuildItemDoc doc = new QuarkusBuildItemDoc();
+        assertEquals("main", doc.gitRef);
+    }
+
+    @Test
+    public void releaseVersionArgSetsGitRef() throws Exception {
+        Path sourceDir = Files.createDirectory(tempDir.resolve("extensions"));
+        Path outputFile = tempDir.resolve("output.adoc");
+
+        QuarkusBuildItemDoc doc = parseArgs(outputFile.toString(), sourceDir.toString(), "3.21.0");
+
+        assertEquals("3.21.0", doc.gitRef);
+        assertEquals(List.of(sourceDir), doc.paths);
+    }
+
+    @Test
+    public void snapshotVersionKeepsMainAsGitRef() throws Exception {
+        Path sourceDir = Files.createDirectory(tempDir.resolve("extensions"));
+        Path outputFile = tempDir.resolve("output.adoc");
+
+        QuarkusBuildItemDoc doc = parseArgs(outputFile.toString(), sourceDir.toString(), "999-SNAPSHOT");
+
+        assertEquals("main", doc.gitRef);
+        assertEquals(List.of(sourceDir), doc.paths);
+    }
+
+    @Test
+    public void noVersionArgKeepsMainAsGitRef() throws Exception {
+        Path sourceDir = Files.createDirectory(tempDir.resolve("extensions"));
+        Path outputFile = tempDir.resolve("output.adoc");
+
+        QuarkusBuildItemDoc doc = parseArgs(outputFile.toString(), sourceDir.toString());
+
+        assertEquals("main", doc.gitRef);
+        assertEquals(List.of(sourceDir), doc.paths);
+    }
+
+    @Test
+    public void multipleSourceDirsWithVersion() throws Exception {
+        Path dir1 = Files.createDirectory(tempDir.resolve("core"));
+        Path dir2 = Files.createDirectory(tempDir.resolve("extensions"));
+        Path outputFile = tempDir.resolve("output.adoc");
+
+        QuarkusBuildItemDoc doc = parseArgs(outputFile.toString(), dir1.toString(), dir2.toString(), "3.21.0");
+
+        assertEquals("3.21.0", doc.gitRef);
+        assertEquals(List.of(dir1, dir2), doc.paths);
+    }
+
+    private static QuarkusBuildItemDoc parseArgs(String... args) {
+        QuarkusBuildItemDoc doc = new QuarkusBuildItemDoc();
+        doc.outputFile = Path.of(args[0]);
+
+        int sourceArgCount = args.length;
+        String lastArg = args[args.length - 1];
+        if (!Files.isDirectory(Path.of(lastArg))) {
+            sourceArgCount--;
+            if (!lastArg.endsWith("-SNAPSHOT")) {
+                doc.gitRef = lastArg;
+            }
+        }
+        doc.paths = Arrays.stream(args, 1, sourceArgCount)
+                .map(Path::of)
+                .collect(Collectors.toList());
+
+        return doc;
+    }
+}


### PR DESCRIPTION
We've got some dead links in the generated build items pages on the site. They're for old versions, so it's kind of expected, but I think we can avoid it by using tags. In fact, there's a TODO suggesting we use tags. 

I was a bit worried about whether the tag would be available when the generator runs, but Claude says that it runs after any tagging in the release. For snapshot builds, we default to main. 

The 'non-snapshot' case is hard to test in CI without doing a release, but Claude's attempted to simulate it locally and run through to validate. 