### PR TITLE
QuarkusTestProfile#getConfigOverrides to have priority over QuarkusTestResourceLifecycleManager#start() configuration

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigSourceOrdinal.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigSourceOrdinal.java
@@ -6,12 +6,18 @@ import io.smallrye.config.common.utils.StringUtil;
  * Keep generated {@code ConfigSource} ordinals centralized, so it is easier to know {@code ConfigSource} order.
  */
 public enum ConfigSourceOrdinal {
+    /** Configuration used by build time and available at runtime */
     BUILD_TIME_RUNTIME_FIXED(Integer.MAX_VALUE),
-    STARTUP_OVERRIDE(Integer.MAX_VALUE - 500),
-    DEV_TEST(Integer.MAX_VALUE - 500),
-    INTEGRATION_TEST(Integer.MAX_VALUE - 500),
-    DEV_SERVICES_OVERRIDE(Integer.MAX_VALUE - 1000),
-    TEST_PROFILE(Integer.MAX_VALUE - 1500),
+    /** Configuration provided by io.quarkus.test.junit.QuarkusTestProfile#getConfigOverrides() */
+    TEST_PROFILE(Integer.MAX_VALUE - 500),
+    /** Configuration provided by io.quarkus.test.common.QuarkusTestResourceLifecycleManager#start() */
+    STARTUP_OVERRIDE(Integer.MAX_VALUE - 1000),
+    /** Configuration provided by io.quarkus.test.common.QuarkusTestResourceLifecycleManager#start() in Dev Mode */
+    DEV_TEST(Integer.MAX_VALUE - 1000),
+    /** Configuration provided by io.quarkus.test.common.QuarkusTestResourceLifecycleManager#start() in Int Test Mode */
+    INTEGRATION_TEST(Integer.MAX_VALUE - 1000),
+    /** Configuration provided by io.quarkus.deployment.builditem.DevServicesRegistryBuildItem.DevServicesStartResult */
+    DEV_SERVICES_OVERRIDE(Integer.MAX_VALUE - 1500),
     ;
 
     private final int ordinal;

--- a/extensions/amazon-lambda/common-runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AbstractLambdaPollLoop.java
+++ b/extensions/amazon-lambda/common-runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AbstractLambdaPollLoop.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.SocketException;
+import java.net.URI;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -18,6 +19,8 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import io.quarkus.runtime.Application;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.ShutdownContext;
+import io.quarkus.value.registry.ValueRegistry;
+import io.quarkus.value.registry.ValueRegistry.RuntimeKey;
 
 public abstract class AbstractLambdaPollLoop {
     private static final Logger log = Logger.getLogger(AbstractLambdaPollLoop.class);
@@ -51,13 +54,17 @@ public abstract class AbstractLambdaPollLoop {
 
     protected HttpURLConnection requestConnection = null;
 
-    public void startPollLoop(ShutdownContext context) {
+    private static final RuntimeKey<URI> LOCAL_BASE_URI = RuntimeKey.key("quarkus.http.local-base-uri");
+
+    public void startPollLoop(ValueRegistry valueRegistry, ShutdownContext context) {
         final AtomicBoolean running = new AtomicBoolean(true);
         // flag to check whether to interrupt.
         final AtomicBoolean shouldInterrupt = new AtomicBoolean(true);
         String baseUrl = AmazonLambdaApi.baseUrl();
+        URI lambdaBase = URI.create(AmazonLambdaApi.baseUrl());
+        valueRegistry.register(LOCAL_BASE_URI,
+                URI.create(lambdaBase.getScheme() + "://" + lambdaBase.getHost() + ":" + lambdaBase.getPort()));
         final Thread pollingThread = new Thread(new Runnable() {
-            @SuppressWarnings("unchecked")
             @Override
             public void run() {
                 try {

--- a/extensions/amazon-lambda/runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaRecorder.java
+++ b/extensions/amazon-lambda/runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaRecorder.java
@@ -22,6 +22,7 @@ import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
+import io.quarkus.value.registry.ValueRegistry;
 
 /**
  * Used for Amazon Lambda java runtime
@@ -37,9 +38,13 @@ public class AmazonLambdaRecorder {
     protected static Set<Class<?>> expectedExceptionClasses;
 
     private final RuntimeValue<LambdaConfig> runtimeConfig;
+    private final RuntimeValue<ValueRegistry> valueRegistry;
 
-    public AmazonLambdaRecorder(RuntimeValue<LambdaConfig> runtimeConfig) {
+    public AmazonLambdaRecorder(
+            RuntimeValue<LambdaConfig> runtimeConfig,
+            RuntimeValue<ValueRegistry> valueRegistry) {
         this.runtimeConfig = runtimeConfig;
+        this.valueRegistry = valueRegistry;
     }
 
     public void setStreamHandlerClass(Class<? extends RequestStreamHandler> handler) {
@@ -185,8 +190,7 @@ public class AmazonLambdaRecorder {
                 return expectedExceptionClasses.stream().noneMatch(clazz -> clazz.isAssignableFrom(e.getClass()));
             }
         };
-        loop.startPollLoop(context);
-
+        loop.startPollLoop(valueRegistry.getValue(), context);
     }
 
     public record RequestHandlerDefinition(Class<? extends RequestHandler<?, ?>> handlerClass,

--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/FunqyLambdaBindingRecorder.java
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/java/io/quarkus/funqy/lambda/FunqyLambdaBindingRecorder.java
@@ -34,6 +34,7 @@ import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
+import io.quarkus.value.registry.ValueRegistry;
 
 /**
  * Provides the runtime methods to bootstrap Quarkus Funq
@@ -49,14 +50,17 @@ public class FunqyLambdaBindingRecorder {
     private final RuntimeValue<FunqyConfig> runtimeConfig;
     private final FunqyAmazonBuildTimeConfig amazonBuildTimeConfig;
     private final RuntimeValue<FunqyAmazonConfig> amazonRuntimeConfig;
+    private final RuntimeValue<ValueRegistry> valueRegistry;
 
     public FunqyLambdaBindingRecorder(
             final RuntimeValue<FunqyConfig> runtimeConfig,
             final FunqyAmazonBuildTimeConfig amazonBuildTimeConfig,
-            final RuntimeValue<FunqyAmazonConfig> amazonRuntimeConfig) {
+            final RuntimeValue<FunqyAmazonConfig> amazonRuntimeConfig,
+            final RuntimeValue<ValueRegistry> valueRegistry) {
         this.runtimeConfig = runtimeConfig;
         this.amazonBuildTimeConfig = amazonBuildTimeConfig;
         this.amazonRuntimeConfig = amazonRuntimeConfig;
+        this.valueRegistry = valueRegistry;
     }
 
     public void init(BeanContainer bc) {
@@ -181,8 +185,7 @@ public class FunqyLambdaBindingRecorder {
                 throw new RuntimeException("Unreachable!");
             }
         };
-        loop.startPollLoop(context);
-
+        loop.startPollLoop(valueRegistry.getValue(), context);
     }
 
     private static FunqyServerResponse dispatch(Object input, Context context) throws IOException {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -1315,8 +1315,8 @@ public class VertxHttpRecorder {
                         }
                     });
                 }
-                setupTcpHttpServer(httpServer, httpOptions, false, startFuture, remainingCount, connectionCount,
-                        container, notifyStartObservers);
+                setupTcpHttpServer(httpServer, httpOptions, false, insecureRequests, startFuture, remainingCount,
+                        connectionCount, container, notifyStartObservers);
             }
 
             if (domainSocketOptions != null) {
@@ -1329,8 +1329,8 @@ public class VertxHttpRecorder {
             if (httpsOptions != null) {
                 httpsServer = vertx.createHttpServer(httpsOptions);
                 httpsServer.requestHandler(ACTUAL_ROOT);
-                setupTcpHttpServer(httpsServer, httpsOptions, true, startFuture, remainingCount, connectionCount,
-                        container, notifyStartObservers);
+                setupTcpHttpServer(httpsServer, httpsOptions, true, insecureRequests, startFuture, remainingCount,
+                        connectionCount, container, notifyStartObservers);
             }
         }
 
@@ -1366,8 +1366,8 @@ public class VertxHttpRecorder {
         }
 
         private void setupTcpHttpServer(HttpServer httpServer, HttpServerOptions options, boolean https,
-                Promise<Void> startFuture, AtomicInteger remainingCount, AtomicInteger currentConnectionCount,
-                ArcContainer container, boolean notifyStartObservers) {
+                InsecureRequests insecureRequests, Promise<Void> startFuture, AtomicInteger remainingCount,
+                AtomicInteger currentConnectionCount, ArcContainer container, boolean notifyStartObservers) {
 
             if (httpConfig.limits().maxConnections().isPresent() && httpConfig.limits().maxConnections().getAsInt() > 0) {
                 var tracker = vertx.isMetricsEnabled()
@@ -1421,6 +1421,13 @@ public class VertxHttpRecorder {
                                 actualHttpsPort = actualPort;
                                 validateHttpPorts(actualHttpPort, actualHttpsPort);
                                 valueRegistry.register(HTTPS_PORT, actualPort);
+                                URI localBaseUri = localBaseUri("https", actualPort);
+                                // Someone else may register the local base uri first (lambda extension)
+                                // The implemented behaviour is that lambda has priority, but we may want to review that
+                                if (!insecureRequests.equals(InsecureRequests.ENABLED)
+                                        && !valueRegistry.containsKey(LOCAL_BASE_URI)) {
+                                    valueRegistry.register(LOCAL_BASE_URI, localBaseUri);
+                                }
                                 if (launchMode.isDevOrTest()) {
                                     valueRegistry.register(HTTPS_TEST_PORT, actualPort);
                                     // TODO - Should we register test.url.ssl? We don't use it, or have tests for it
@@ -1434,7 +1441,12 @@ public class VertxHttpRecorder {
                                 validateHttpPorts(actualHttpPort, actualHttpsPort);
                                 valueRegistry.register(HTTP_PORT, actualPort);
                                 URI localBaseUri = localBaseUri("http", actualPort);
-                                valueRegistry.register(LOCAL_BASE_URI, localBaseUri);
+                                // Someone else may register the local base uri first (lambda extension)
+                                // The implemented behaviour is that lambda has priority, but we may want to review that
+                                if (insecureRequests.equals(InsecureRequests.ENABLED)
+                                        && !valueRegistry.containsKey(LOCAL_BASE_URI)) {
+                                    valueRegistry.register(LOCAL_BASE_URI, localBaseUri);
+                                }
                                 if (launchMode.isDevOrTest()) {
                                     valueRegistry.register(HTTP_TEST_PORT, actualPort);
                                     // Compatibility with test.url

--- a/integration-tests/elytron-undertow/src/test/java/io/quarkus/it/undertow/elytron/BaseAuthRestTest.java
+++ b/integration-tests/elytron-undertow/src/test/java/io/quarkus/it/undertow/elytron/BaseAuthRestTest.java
@@ -23,7 +23,7 @@ class BaseAuthRestTest extends HttpsSetup {
                 .body("Bill")
                 .contentType(ContentType.TEXT)
                 .when()
-                .post("/foo/mapped/rest")
+                .post("/mapped/rest")
                 .then()
                 .statusCode(200)
                 .body(is("post success"));
@@ -34,7 +34,7 @@ class BaseAuthRestTest extends HttpsSetup {
         given()
                 .header("Authorization", "Basic am9objpqb2hu")
                 .when()
-                .get("/foo/mapped/rest")
+                .get("/mapped/rest")
                 .then()
                 .statusCode(200)
                 .body(is("get success"));

--- a/integration-tests/elytron-undertow/src/test/java/io/quarkus/it/undertow/elytron/BaseAuthTest.java
+++ b/integration-tests/elytron-undertow/src/test/java/io/quarkus/it/undertow/elytron/BaseAuthTest.java
@@ -22,7 +22,7 @@ public class BaseAuthTest extends HttpsSetup {
                 .body("Bill")
                 .contentType(ContentType.TEXT)
                 .when()
-                .post("/foo/")
+                .post()
                 .then()
                 .statusCode(200)
                 .body(is("hello Bill"));
@@ -33,7 +33,7 @@ public class BaseAuthTest extends HttpsSetup {
         given()
                 .header("Authorization", "Basic am9objpqb2hu")
                 .when()
-                .get("/foo/")
+                .get()
                 .then()
                 .statusCode(200)
                 .body(is("hello"));

--- a/integration-tests/elytron-undertow/src/test/java/io/quarkus/it/undertow/elytron/ServletSecurityAnnotationPermissionsTestCase.java
+++ b/integration-tests/elytron-undertow/src/test/java/io/quarkus/it/undertow/elytron/ServletSecurityAnnotationPermissionsTestCase.java
@@ -14,7 +14,7 @@ class ServletSecurityAnnotationPermissionsTestCase extends HttpsSetup {
         given()
                 .header("Authorization", "Basic am9objpqb2hu")
                 .when()
-                .get("/foo/annotation-secure")
+                .get("/annotation-secure")
                 .then()
                 .statusCode(403);
     }
@@ -23,12 +23,12 @@ class ServletSecurityAnnotationPermissionsTestCase extends HttpsSetup {
     void testSecuredServletWithNoAuth() {
         given()
                 .when()
-                .get("/foo/annotation-secure")
+                .get("/annotation-secure")
                 .then()
                 .statusCode(401);
         given()
                 .when()
-                .get("/foo/bar/../annotation-secure")
+                .get("/bar/../annotation-secure")
                 .then()
                 .statusCode(401);
     }
@@ -39,7 +39,7 @@ class ServletSecurityAnnotationPermissionsTestCase extends HttpsSetup {
                 .auth()
                 .basic("mary", "mary")
                 .when()
-                .get("/foo/annotation-secure")
+                .get("/annotation-secure")
                 .then()
                 .statusCode(200);
     }
@@ -48,7 +48,7 @@ class ServletSecurityAnnotationPermissionsTestCase extends HttpsSetup {
     void testEmptyRolesPermit() {
         given()
                 .when()
-                .put("/foo/annotation-secure")
+                .put("/annotation-secure")
                 .then()
                 .statusCode(200);
     }
@@ -57,7 +57,7 @@ class ServletSecurityAnnotationPermissionsTestCase extends HttpsSetup {
     void testEmptyRolesDeny() {
         given()
                 .when()
-                .delete("/foo/annotation-secure")
+                .delete("/annotation-secure")
                 .then()
                 .statusCode(401);
     }
@@ -68,7 +68,7 @@ class ServletSecurityAnnotationPermissionsTestCase extends HttpsSetup {
                 .auth()
                 .basic("mary", "mary")
                 .when()
-                .post("/foo/annotation-secure")
+                .post("/annotation-secure")
                 .then()
                 .statusCode(403);
     }
@@ -80,7 +80,7 @@ class ServletSecurityAnnotationPermissionsTestCase extends HttpsSetup {
                 .body("tmp")
                 .auth()
                 .basic("poul", "poul")
-                .post("/foo/annotation-secure")
+                .post("/annotation-secure")
                 .then()
                 .statusCode(200);
     }

--- a/integration-tests/elytron-undertow/src/test/java/io/quarkus/it/undertow/elytron/WebXmlPermissionsTestCase.java
+++ b/integration-tests/elytron-undertow/src/test/java/io/quarkus/it/undertow/elytron/WebXmlPermissionsTestCase.java
@@ -21,7 +21,7 @@ class WebXmlPermissionsTestCase extends HttpsSetup {
                 .body("Bill")
                 .contentType(ContentType.TEXT)
                 .when()
-                .post("/foo/")
+                .post()
                 .then()
                 .statusCode(200)
                 .body(is("hello Bill"));
@@ -31,22 +31,22 @@ class WebXmlPermissionsTestCase extends HttpsSetup {
     void testOpenApiNoPermissions() {
         given()
                 .when()
-                .get("/foo/openapi")
+                .get("/openapi")
                 .then()
                 .statusCode(401);
         given()
                 .when()
-                .get("/r/../foo/openapi")
+                .get("/r/../openapi")
                 .then()
                 .statusCode(401);
         given()
                 .when()
-                .get("/foo/bar/../openapi")
+                .get("/bar/../openapi")
                 .then()
                 .statusCode(401);
         given()
                 .when()
-                .get("/foo/bar/../openapi/;a")
+                .get("/bar/../openapi/;a")
                 .then()
                 .statusCode(401);
     }
@@ -56,7 +56,7 @@ class WebXmlPermissionsTestCase extends HttpsSetup {
         given()
                 .header("Authorization", "Basic am9objpqb2hu")
                 .when()
-                .get("/foo/openapi")
+                .get("/openapi")
                 .then()
                 .statusCode(403);
     }
@@ -67,7 +67,7 @@ class WebXmlPermissionsTestCase extends HttpsSetup {
                 .auth()
                 .basic("mary", "mary")
                 .when()
-                .get("/foo/openapi")
+                .get("/openapi")
                 .then()
                 .statusCode(200);
     }
@@ -77,7 +77,7 @@ class WebXmlPermissionsTestCase extends HttpsSetup {
         given()
                 .header("Authorization", "Basic am9objpqb2hu")
                 .when()
-                .get("/foo/secure/a")
+                .get("/secure/a")
                 .then()
                 .statusCode(403);
     }
@@ -86,7 +86,7 @@ class WebXmlPermissionsTestCase extends HttpsSetup {
     void testSecuredServletWithNoAuth() {
         given()
                 .when()
-                .get("/foo/secure/a")
+                .get("/secure/a")
                 .then()
                 .statusCode(401);
     }
@@ -97,7 +97,7 @@ class WebXmlPermissionsTestCase extends HttpsSetup {
                 .auth()
                 .basic("mary", "mary")
                 .when()
-                .get("/foo/secure/a")
+                .get("/secure/a")
                 .then()
                 .statusCode(200);
     }

--- a/integration-tests/google-cloud-functions/src/test/java/io/quarkus/gcp/function/test/HttpFunctionRandomPortTestCase.java
+++ b/integration-tests/google-cloud-functions/src/test/java/io/quarkus/gcp/function/test/HttpFunctionRandomPortTestCase.java
@@ -3,22 +3,21 @@ package io.quarkus.gcp.function.test;
 import static io.restassured.RestAssured.when;
 import static org.hamcrest.Matchers.is;
 
-import org.junit.jupiter.api.BeforeAll;
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.gcp.function.test.HttpFunctionRandomPortTestCase.Profile;
 import io.quarkus.google.cloud.functions.test.FunctionType;
 import io.quarkus.google.cloud.functions.test.WithFunction;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
 @WithFunction(FunctionType.HTTP)
+@TestProfile(Profile.class)
 class HttpFunctionRandomPortTestCase {
-
-    @BeforeAll
-    public static void setup() {
-        System.setProperty("quarkus.http.test-port", "0");
-    }
-
     @Test
     public void test() {
         // test the function using RestAssured
@@ -27,5 +26,14 @@ class HttpFunctionRandomPortTestCase {
                 .then()
                 .statusCode(200)
                 .body(is("Hello Quarkus!"));
+    }
+
+    public static class Profile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.http.port", "0",
+                    "quarkus.http.test-port", "0");
+        }
     }
 }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/ListeningAddress.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/ListeningAddress.java
@@ -1,9 +1,11 @@
 package io.quarkus.test.common;
 
+import static io.quarkus.test.common.http.TestHTTPResourceManager.*;
+import static io.quarkus.test.common.http.TestHTTPResourceManager.testUrlSsl;
+
 import java.net.URI;
 import java.util.Optional;
 
-import io.quarkus.test.common.http.TestHTTPResourceManager;
 import io.quarkus.value.registry.ValueRegistry;
 import io.quarkus.value.registry.ValueRegistry.RuntimeKey;
 import io.smallrye.config.Config;
@@ -17,7 +19,8 @@ public record ListeningAddress(Integer port, String protocol) {
     public void register(ValueRegistry valueRegistry, Config config) {
         valueRegistry.register(isSsl() ? HTTPS_PORT : HTTP_PORT, port);
         valueRegistry.register(isSsl() ? HTTPS_TEST_PORT : HTTP_TEST_PORT, port);
-        valueRegistry.register(LOCAL_BASE_URI, URI.create(TestHTTPResourceManager.testUrl(valueRegistry, config)));
+        valueRegistry.register(LOCAL_BASE_URI,
+                URI.create(isSsl() ? testUrlSsl(valueRegistry, config) : testUrl(valueRegistry, config)));
     }
 
     // Compatibility with Config and io.quarkus.vertx.http.HttpServer

--- a/test-framework/common/src/main/java/io/quarkus/test/common/QuarkusTestResourceLifecycleManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/QuarkusTestResourceLifecycleManager.java
@@ -5,6 +5,8 @@ import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.function.Predicate;
 
+import io.quarkus.value.registry.ValueRegistry;
+
 /**
  * Manage the lifecycle of a test resource, for instance a H2 test server.
  * <p>
@@ -104,6 +106,12 @@ public interface QuarkusTestResourceLifecycleManager {
      * {@link QuarkusTestResourceLifecycleManager#inject(TestInjector)}
      */
     interface TestInjector {
+        /**
+         * Gets this test {@link ValueRegistry}.
+         *
+         * @return this test {@link ValueRegistry}.
+         */
+        ValueRegistry valueRegistry();
 
         /**
          * @param fieldValue The actual value to inject into a test field

--- a/test-framework/common/src/main/java/io/quarkus/test/common/RestAssuredStateManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/RestAssuredStateManager.java
@@ -1,5 +1,6 @@
 package io.quarkus.test.common;
 
+import java.net.URI;
 import java.time.Duration;
 import java.util.Optional;
 
@@ -10,6 +11,7 @@ import io.restassured.config.HttpClientConfig;
 import io.restassured.config.RestAssuredConfig;
 import io.restassured.path.json.JsonPath;
 import io.restassured.specification.RequestSpecification;
+import io.smallrye.config.Config;
 
 /**
  * Utility class that sets the rest assured port to the default test port and meaningful timeouts.
@@ -55,18 +57,22 @@ public class RestAssuredStateManager {
         return defaultValue;
     }
 
+    @Deprecated(forRemoval = true, since = "3.36")
     public static void setURL(boolean useSecureConnection) {
         setURL(useSecureConnection, null, null);
     }
 
+    @Deprecated(forRemoval = true, since = "3.36")
     public static void setURL(boolean useSecureConnection, String additionalPath) {
         setURL(useSecureConnection, null, additionalPath);
     }
 
+    @Deprecated(forRemoval = true, since = "3.36")
     public static void setURL(boolean useSecureConnection, Integer port) {
         setURL(useSecureConnection, port, null);
     }
 
+    @Deprecated(forRemoval = true, since = "3.36")
     public static void setURL(boolean useSecureConnection, Integer port, String additionalPath) {
         if (!REST_ASSURED_PRESENT) {
             return;
@@ -124,6 +130,52 @@ public class RestAssuredStateManager {
 
         oldRequestSpecification = RestAssured.requestSpecification;
         if (ConfigProvider.getConfig()
+                .getOptionalValue("quarkus.test.rest-assured.enable-logging-on-failure", Boolean.class).orElse(true)) {
+            RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+        }
+    }
+
+    public static void setTestUri(URI baseUri, String additionalPath) {
+        if (!REST_ASSURED_PRESENT) {
+            return;
+        }
+
+        oldPort = RestAssured.port;
+        RestAssured.port = baseUri.getPort();
+
+        oldBaseURI = RestAssured.baseURI;
+        RestAssured.baseURI = baseUri.getScheme() + "://" + baseUri.getHost();
+
+        oldBasePath = RestAssured.basePath;
+        StringBuilder bp = new StringBuilder();
+        if (baseUri.getPath().startsWith("/")) {
+            bp.append(baseUri.getPath().substring(1));
+        } else {
+            bp.append(baseUri.getPath());
+        }
+        if (bp.toString().endsWith("/")) {
+            bp.setLength(bp.length() - 1);
+        }
+        if (additionalPath != null) {
+            if (!additionalPath.startsWith("/")) {
+                bp.append("/");
+            }
+            bp.append(additionalPath);
+            if (bp.toString().endsWith("/")) {
+                bp.setLength(bp.length() - 1);
+            }
+        }
+        RestAssured.basePath = bp.toString();
+
+        oldRestAssuredConfig = RestAssured.config();
+
+        // TODO - This configuration can be set a single time at start
+        Duration timeout = Config.get()
+                .getOptionalValue("quarkus.http.test-timeout", Duration.class).orElse(Duration.ofSeconds(30));
+        configureTimeouts(timeout);
+
+        oldRequestSpecification = RestAssured.requestSpecification;
+        if (Config.get()
                 .getOptionalValue("quarkus.test.rest-assured.enable-logging-on-failure", Boolean.class).orElse(true)) {
             RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
         }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
@@ -40,6 +40,8 @@ import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 
+import io.quarkus.value.registry.ValueRegistry;
+
 /**
  * Manages {@link QuarkusTestResourceLifecycleManager}
  */
@@ -194,12 +196,12 @@ public class TestResourceManager implements Closeable {
         return allProps;
     }
 
-    public void inject(Object testInstance) {
+    public void inject(ValueRegistry valueRegistry, Object testInstance) {
         injectTestContext(testInstance, devServicesContext);
         for (TestResourceStartInfo entry : allTestResources) {
             QuarkusTestResourceLifecycleManager quarkusTestResourceLifecycleManager = entry.getTestResource();
             quarkusTestResourceLifecycleManager.inject(testInstance);
-            quarkusTestResourceLifecycleManager.inject(new DefaultTestInjector(testInstance));
+            quarkusTestResourceLifecycleManager.inject(new DefaultTestInjector(valueRegistry, testInstance));
         }
     }
 
@@ -730,10 +732,17 @@ public class TestResourceManager implements Closeable {
     static class DefaultTestInjector implements QuarkusTestResourceLifecycleManager.TestInjector {
 
         // visible for testing
+        final ValueRegistry valueRegistry;
         final Object testInstance;
 
-        private DefaultTestInjector(Object testInstance) {
+        private DefaultTestInjector(ValueRegistry valueRegistry, Object testInstance) {
+            this.valueRegistry = valueRegistry;
             this.testInstance = testInstance;
+        }
+
+        @Override
+        public ValueRegistry valueRegistry() {
+            return valueRegistry;
         }
 
         @Override

--- a/test-framework/common/src/test/java/io/quarkus/test/common/TestResourceManagerInjectorTest.java
+++ b/test-framework/common/src/test/java/io/quarkus/test/common/TestResourceManagerInjectorTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import io.quarkus.runtime.ValueRegistryImpl;
+
 public class TestResourceManagerInjectorTest {
 
     @ParameterizedTest
@@ -21,7 +23,7 @@ public class TestResourceManagerInjectorTest {
         manager.start();
 
         Foo foo = new Foo();
-        manager.inject(foo);
+        manager.inject(ValueRegistryImpl.builder().build(), foo);
 
         Assertions.assertNotNull(foo.bar);
         Assertions.assertEquals("bar", foo.bar.value);

--- a/test-framework/common/src/test/java/io/quarkus/test/common/TestResourceManagerTest.java
+++ b/test-framework/common/src/test/java/io/quarkus/test/common/TestResourceManagerTest.java
@@ -16,6 +16,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import io.quarkus.runtime.ValueRegistryImpl;
+
 public class TestResourceManagerTest {
 
     private static final String OVERRIDEN_KEY = "overridenKey";
@@ -26,7 +28,7 @@ public class TestResourceManagerTest {
     void testRepeatableAnnotationsAreIndexed(Class<?> clazz) {
         AtomicInteger counter = new AtomicInteger();
         TestResourceManager manager = new TestResourceManager(clazz);
-        manager.inject(counter);
+        manager.inject(ValueRegistryImpl.builder().build(), counter);
         assertThat(counter.intValue()).isEqualTo(2);
     }
 

--- a/test-framework/google-cloud-functions/src/main/java/io/quarkus/google/cloud/functions/test/CloudFunctionTestResource.java
+++ b/test-framework/google-cloud-functions/src/main/java/io/quarkus/google/cloud/functions/test/CloudFunctionTestResource.java
@@ -4,9 +4,9 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.eclipse.microprofile.config.ConfigProvider;
-
+import io.quarkus.test.common.ListeningAddress;
 import io.quarkus.test.common.QuarkusTestResourceConfigurableLifecycleManager;
+import io.smallrye.config.Config;
 
 /**
  * Test resource that starts a Google Cloud Function invoker at the beginning of the test and stops it at the end.
@@ -35,8 +35,10 @@ public class CloudFunctionTestResource implements QuarkusTestResourceConfigurabl
         if (started.compareAndSet(false, true)) {
             // This is a hack, we cannot start the invoker in the start() method as Quarkus is not yet initialized,
             // so we start it here as this method is called later (the same for reading the test port).
-            int port = ConfigProvider.getConfig().getOptionalValue("quarkus.http.test-port", Integer.class).orElse(8081);
+            Config config = Config.get();
+            int port = config.getOptionalValue("quarkus.http.test-port", int.class).orElse(8081);
             this.invoker = new CloudFunctionsInvoker(functionType, port);
+            new ListeningAddress(this.invoker.actualPort(), "http").register(testInjector.valueRegistry(), config);
             try {
                 this.invoker.start();
             } catch (Exception e) {

--- a/test-framework/google-cloud-functions/src/main/java/io/quarkus/google/cloud/functions/test/CloudFunctionsInvoker.java
+++ b/test-framework/google-cloud-functions/src/main/java/io/quarkus/google/cloud/functions/test/CloudFunctionsInvoker.java
@@ -5,21 +5,20 @@ import com.google.cloud.functions.invoker.runner.Invoker;
 class CloudFunctionsInvoker {
 
     private final Invoker invoker;
-
-    CloudFunctionsInvoker(FunctionType functionType) {
-        this(functionType, 8081);
-    }
+    private final int port;
 
     CloudFunctionsInvoker(FunctionType functionType, int port) {
         int realPort = port == 0 ? SocketUtil.findAvailablePort() : port;
-        if (realPort != port) {
-            System.setProperty("quarkus.http.test-port", String.valueOf(realPort));
-        }
         this.invoker = new Invoker(
                 realPort,
                 functionType.getTarget(),
                 functionType.getSignatureType(),
                 Thread.currentThread().getContextClassLoader());
+        this.port = realPort;
+    }
+
+    public int actualPort() {
+        return port;
     }
 
     void start() throws Exception {

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
@@ -120,7 +120,7 @@ public final class IntegrationTestUtil {
             throw new RuntimeException(
                     "An unexpected situation occurred while trying to instantiate the testing infrastructure. Have you perhaps mixed @QuarkusTest and @QuarkusIntegrationTest in the same test run?");
         }
-        ((TestResourceManager) state.getTestResourceManager()).inject(testInstance);
+        ((TestResourceManager) state.getTestResourceManager()).inject(valueRegistry, testInstance);
     }
 
     static Optional<ListeningAddress> startLauncher(ArtifactLauncher<?> launcher, Map<String, String> additionalProperties)

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
@@ -3,6 +3,7 @@ package io.quarkus.test.junit;
 import static io.quarkus.runtime.LaunchMode.NORMAL;
 import static io.quarkus.runtime.configuration.ConfigSourceOrdinal.INTEGRATION_TEST;
 import static io.quarkus.test.common.ListeningAddress.LISTENING_ADDRESS;
+import static io.quarkus.test.common.ListeningAddress.LOCAL_BASE_URI;
 import static io.quarkus.test.junit.ArtifactTypeUtil.isContainer;
 import static io.quarkus.test.junit.ArtifactTypeUtil.isJar;
 import static io.quarkus.test.junit.IntegrationTestUtil.activateLogging;
@@ -15,7 +16,6 @@ import static io.quarkus.test.junit.IntegrationTestUtil.handleDevServices;
 import static io.quarkus.test.junit.IntegrationTestUtil.readQuarkusArtifactProperties;
 import static io.quarkus.test.junit.IntegrationTestUtil.startLauncher;
 import static io.quarkus.test.junit.TestResourceUtil.TestResourceManagerReflections.copyEntriesFromProfile;
-import static java.util.Optional.empty;
 
 import java.io.Closeable;
 import java.io.File;
@@ -140,7 +140,8 @@ public class QuarkusIntegrationTestExtension extends AbstractQuarkusTestWithCont
             listeningAddress.ifPresent(new Consumer<ListeningAddress>() {
                 @Override
                 public void accept(ListeningAddress listeningAddress) {
-                    RestAssuredStateManager.setURL(listeningAddress.isSsl(), listeningAddress.port(),
+                    RestAssuredStateManager.setTestUri(
+                            valueRegistry.get(LOCAL_BASE_URI),
                             QuarkusTestExtension.getEndpointPath(context, testHttpEndpointProviders));
                 }
             });
@@ -293,12 +294,12 @@ public class QuarkusIntegrationTestExtension extends AbstractQuarkusTestWithCont
                 }
             }
 
-            // Properties set by @TestProfile
-            additionalProperties.putAll(testProfileAndProperties.properties());
             // Make the dev services config accessible from the test itself
             additionalProperties.putAll(devServicesLaunchResult.properties());
             // Allow override of dev services props by integration test extensions
             additionalProperties.putAll(testResourceManager.start());
+            // Properties set by @TestProfile
+            additionalProperties.putAll(testProfileAndProperties.properties());
 
             // Create the ValueRegistry with the current Config and test config
             ConfigSource integrationTestSource = new PropertiesConfigSource(

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusMainIntegrationTestExtension.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusMainIntegrationTestExtension.java
@@ -167,12 +167,12 @@ public class QuarkusMainIntegrationTestExtension extends AbstractQuarkusTestWith
                     }
                 }
 
-                // Properties set by @TestProfile
-                additionalProperties.putAll(testProfileAndProperties.properties());
                 // Make the dev services config accessible from the test itself
                 additionalProperties.putAll(devServicesLaunchResult.properties());
                 // Allow override of dev services props by integration test extensions
                 additionalProperties.putAll(testResourceManager.start());
+                // Properties set by @TestProfile
+                additionalProperties.putAll(testProfileAndProperties.properties());
 
                 // Create the ValueRegistry with the current Config and test config
                 ConfigSource integrationTestSource = new PropertiesConfigSource(
@@ -208,7 +208,7 @@ public class QuarkusMainIntegrationTestExtension extends AbstractQuarkusTestWith
                             "Artifact type + '" + artifactType + "' is not supported by @QuarkusMainIntegrationTest");
                 }
 
-                testResourceManager.inject(context.getRequiredTestInstance());
+                testResourceManager.inject(valueRegistry, context.getRequiredTestInstance());
 
                 activateLogging();
 

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusMainTestExtension.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusMainTestExtension.java
@@ -42,12 +42,14 @@ import io.quarkus.bootstrap.logging.QuarkusDelayedHandler;
 import io.quarkus.deployment.dev.testing.LogCapturingOutputFilter;
 import io.quarkus.dev.console.QuarkusConsole;
 import io.quarkus.dev.testing.TracingHandler;
+import io.quarkus.runtime.ValueRegistryImpl;
 import io.quarkus.runtime.configuration.ConfigSourceOrdinal;
 import io.quarkus.test.common.TestResourceManager;
 import io.quarkus.test.junit.main.Launch;
 import io.quarkus.test.junit.main.LaunchResult;
 import io.quarkus.test.junit.main.QuarkusMainIntegrationTest;
 import io.quarkus.test.junit.main.QuarkusMainLauncher;
+import io.quarkus.value.registry.ValueRegistry;
 
 public class QuarkusMainTestExtension extends AbstractJvmQuarkusTestExtension
         implements InvocationInterceptor, BeforeEachCallback, AfterEachCallback, ParameterResolver, BeforeAllCallback,
@@ -244,8 +246,8 @@ public class QuarkusMainTestExtension extends AbstractJvmQuarkusTestExtension
             startupAction.overrideConfig(properties);
 
             testResourceManager.getClass()
-                    .getMethod("inject", Object.class)
-                    .invoke(testResourceManager, context.getRequiredTestInstance());
+                    .getMethod("inject", ValueRegistry.class, Object.class)
+                    .invoke(testResourceManager, ValueRegistryImpl.builder().build(), context.getRequiredTestInstance());
 
             var result = startupAction.runMainClassBlocking(arguments);
             flushAllLoggers();

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -1,6 +1,7 @@
 package io.quarkus.test.junit;
 
 import static io.quarkus.runtime.LaunchMode.NORMAL;
+import static io.quarkus.test.common.ListeningAddress.LOCAL_BASE_URI;
 import static io.quarkus.test.common.PathTestHelper.getTestClassesLocation;
 import static io.quarkus.test.junit.IntegrationTestUtil.activateLogging;
 import static io.quarkus.test.junit.TestResourceUtil.TestResourceManagerReflections.copyEntriesFromProfile;
@@ -21,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -396,19 +396,11 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
             Map.Entry<Class<?>, ?> tuple = createQuarkusTestMethodContextTuple(context);
             invokeBeforeEachCallbacks(tuple.getKey(), tuple.getValue());
             String endpointPath = getEndpointPath(context, testHttpEndpointProviders);
-            if (runningQuarkusApplication != null) {
-                boolean secure = false;
-                Optional<String> insecureAllowed = runningQuarkusApplication
-                        .getConfigValue("quarkus.http.insecure-requests", String.class);
-                if (insecureAllowed.isPresent()) {
-                    secure = !insecureAllowed.get().toLowerCase(Locale.ENGLISH).equals("enabled");
-                }
-                runningQuarkusApplication.getClassLoader().loadClass(RestAssuredStateManager.class.getName())
-                        .getDeclaredMethod("setURL", boolean.class, String.class).invoke(null, secure, endpointPath);
-                runningQuarkusApplication.getClassLoader().loadClass(TestScopeManager.class.getName())
-                        .getDeclaredMethod("setup", boolean.class).invoke(null, false);
+            ValueRegistry valueRegistry = ValueRegistryInjector.get(context);
+            if (valueRegistry.containsKey(LOCAL_BASE_URI)) {
+                RestAssuredStateManager.setTestUri(valueRegistry.get(LOCAL_BASE_URI), endpointPath);
             }
-
+            TestScopeManager.setup(false);
         } else {
             throwBootFailureException();
         }
@@ -809,8 +801,7 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
         }
     }
 
-    private Object createActualTestInstance(Class<?> testClass, ExtensionContext context, QuarkusTestExtensionState state)
-            throws IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+    private Object createActualTestInstance(Class<?> testClass, ExtensionContext context, QuarkusTestExtensionState state) {
         Object testInstance = runningQuarkusApplication.instance(testClass);
 
         ValueRegistry valueRegistry = runningQuarkusApplication.valueRegistry();
@@ -818,8 +809,7 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
         ValueRegistryInjector.inject(testInstance, valueRegistry);
         ConfigInjector.inject(testInstance, config);
         TestHTTPResourceManager.inject(testInstance, valueRegistry, config, testHttpEndpointProviders);
-
-        state.testResourceManager.getClass().getMethod("inject", Object.class).invoke(state.testResourceManager, testInstance);
+        ((TestResourceManager) state.getTestResourceManager()).inject(valueRegistry, testInstance);
         return testInstance;
     }
 

--- a/test-framework/oidc-server/src/test/java/io/quarkus/test/oidc/server/OidcWiremockTestResourceInjectionTest.java
+++ b/test-framework/oidc-server/src/test/java/io/quarkus/test/oidc/server/OidcWiremockTestResourceInjectionTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 
+import io.quarkus.runtime.ValueRegistryImpl;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.TestResourceManager;
 
@@ -20,7 +21,7 @@ class OidcWiremockTestResourceInjectionTest {
         manager.start();
 
         CustomTest test = new CustomTest();
-        manager.inject(test);
+        manager.inject(ValueRegistryImpl.builder().build(), test);
         assertNotNull(test.server);
     }
 


### PR DESCRIPTION
Before https://github.com/quarkusio/quarkus/pull/52919, the test resource config was being propagated with SystemProperties, which caused all sorts of issues. So, when I removed that, I used the order we were already using for integration tests (the order is test resource first, then `QuarkusTestProfile#getConfigOverride` later). This has been reported in #54290.

Now, it seems to make sense to make `io.quarkus.test.junit.QuarkusTestProfile#getConfigOverrides` take priority over test resources (previous behavior for `@QuarkusTest` before #52919), but a breaking change for integration tests.

The changes I made didn't seem to break the tests in that scenario. On the other hand, it required some fixes in how the test URL is set in REST Assured. It now uses `ValueRegistry`, which was also required to expand the usage into Lambda and Funqy.

In Undertow, REST Assured was not taking into account `quarkus.servlet.context-path`, but `@TestHTTPResource` correctly takes it into account, meaning that in some cases you have to use the `context-path` as part of the path to invoke, and in other cases you don't. I've changed it so it always takes into account the `quarkus.servlet.context-path`, so this is a breaking change.

- Fixes #54290