### PR TITLE
For missing and invalid nonces, return 401/use_dpop_nonce

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BearerAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BearerAuthenticationMechanism.java
@@ -130,16 +130,24 @@ public class BearerAuthenticationMechanism extends AbstractOidcAuthenticationMec
             if (dPoPNonceProvider != null) {
                 String proofNonce = proofJwtClaims.getString(OidcConstants.NONCE);
                 if (proofNonce == null) {
+                    /*
+                     * Set HTTP error status to `401` and the error code value to `use_dpop_nonce`.
+                     * See https://www.rfc-editor.org/rfc/rfc9449.html#section-9
+                     */
                     LOG.debug("Required DPoP proof nonce claim is missing");
                     throw new AuthenticationFailedException(Map.of(
                             OidcConstants.ACCESS_TOKEN_VALUE, token,
                             OidcConstants.USE_DPOP_NONCE, Boolean.TRUE));
                 }
                 if (!dPoPNonceProvider.isValid(proofNonce)) {
+                    /*
+                     * This same error code is used when supplying a new nonce value when there was a nonce mismatch.
+                     * See https://www.rfc-editor.org/rfc/rfc9449.html#section-9
+                     */
                     LOG.tracef("DPoP proof nonce claim '%s' is invalid", proofNonce);
                     throw new AuthenticationFailedException(Map.of(
                             OidcConstants.ACCESS_TOKEN_VALUE, token,
-                            OidcConstants.INVALID_DPOP_PROOF, Boolean.TRUE));
+                            OidcConstants.USE_DPOP_NONCE, Boolean.TRUE));
                 }
             }
 

--- a/integration-tests/oidc-dpop/src/test/java/io/quarkus/it/keycloak/OidcDPopNonceTest.java
+++ b/integration-tests/oidc-dpop/src/test/java/io/quarkus/it/keycloak/OidcDPopNonceTest.java
@@ -76,8 +76,8 @@ public class OidcDPopNonceTest {
             String wwwAuthenticate = textPage.getWebResponse()
                     .getResponseHeaderValue(HttpHeaderNames.WWW_AUTHENTICATE.toString());
             assertNotNull(wwwAuthenticate);
-            assertTrue(wwwAuthenticate.contains("DPoP error=\"invalid_dpop_proof\""),
-                    () -> "Expected 'DPoP error=\"invalid_dpop_proof\"', but got: " + wwwAuthenticate);
+            assertTrue(wwwAuthenticate.contains("DPoP error=\"use_dpop_nonce\""),
+                    () -> "Expected 'DPoP error=\"use_dpop_nonce\"', but got: " + wwwAuthenticate);
             String dpopNonce = textPage.getWebResponse().getResponseHeaderValue(OidcConstants.DPOP_NONCE);
             assertEquals(expectedNonce, dpopNonce);
             String cacheControl = textPage.getWebResponse().getResponseHeaderValue(HttpHeaders.CACHE_CONTROL.toString());


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
and the AI/LLM usage policy at https://github.com/quarkusio/quarkus/blob/main/AI_POLICY.md
-->

This aligns the DPoP responses for missing and invalid nonces with the RFC spec. 

Status: Modified test is green when run locally. Waiting for CI to finish in my cloned repo: https://github.com/ahus1/quarkus/actions/runs/27917264180

- Closes: #54854