### PR TITLE
Preserve Maven artifact type in the resolver

### DIFF
--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ArtifactCoords.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ArtifactCoords.java
@@ -23,6 +23,7 @@ public interface ArtifactCoords {
     }
 
     String TYPE_JAR = "jar";
+    String TYPE_TEST_JAR = "test-jar";
     String TYPE_POM = "pom";
     String DEFAULT_CLASSIFIER = "";
 
@@ -39,7 +40,8 @@ public interface ArtifactCoords {
     ArtifactKey getKey();
 
     default boolean isJar() {
-        return TYPE_JAR.equals(getType());
+        final String type = getType();
+        return TYPE_JAR.equals(type) || TYPE_TEST_JAR.equals(type);
     }
 
     default boolean isSnapshot() {
@@ -56,7 +58,7 @@ public interface ArtifactCoords {
         if (!getClassifier().isEmpty()) {
             b.append(getClassifier()).append(':');
         }
-        if (!isJar()) {
+        if (!TYPE_JAR.equals(getType())) {
             b.append(getType()).append(':');
         }
         b.append(getVersion());

--- a/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/maven/dependency/ArtifactCoordsTest.java
+++ b/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/maven/dependency/ArtifactCoordsTest.java
@@ -1,0 +1,36 @@
+package io.quarkus.maven.dependency;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class ArtifactCoordsTest {
+
+    @Test
+    void jarWithoutClassifier() {
+        ArtifactCoords coords = ArtifactCoords.jar("org.acme", "acme-lib", "1.0");
+        assertThat(coords.toCompactCoords()).isEqualTo("org.acme:acme-lib:1.0");
+        assertThat(coords.isJar()).isTrue();
+    }
+
+    @Test
+    void jarWithClassifier() {
+        ArtifactCoords coords = ArtifactCoords.of("org.acme", "acme-lib", "sources", "jar", "1.0");
+        assertThat(coords.toCompactCoords()).isEqualTo("org.acme:acme-lib:sources:1.0");
+        assertThat(coords.isJar()).isTrue();
+    }
+
+    @Test
+    void nonJarTypeWithoutClassifier() {
+        ArtifactCoords coords = ArtifactCoords.of("org.acme", "acme-lib", "", "pom", "1.0");
+        assertThat(coords.toCompactCoords()).isEqualTo("org.acme:acme-lib:pom:1.0");
+        assertThat(coords.isJar()).isFalse();
+    }
+
+    @Test
+    void testJarTypeIsJar() {
+        ArtifactCoords coords = ArtifactCoords.of("org.acme", "acme-lib", "tests-quarkus", "test-jar", "1.0");
+        assertThat(coords.isJar()).isTrue();
+        assertThat(coords.toCompactCoords()).isEqualTo("org.acme:acme-lib:tests-quarkus:test-jar:1.0");
+    }
+}

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/BootstrapAppModelResolver.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/BootstrapAppModelResolver.java
@@ -299,7 +299,8 @@ public class BootstrapAppModelResolver implements AppModelResolver {
                 version = constraint.getArtifact().getVersion();
             }
             directDeps.add(new Dependency(
-                    new DefaultArtifact(d.getGroupId(), d.getArtifactId(), d.getClassifier(), d.getType(), version),
+                    new DefaultArtifact(d.getGroupId(), d.getArtifactId(), d.getClassifier(), null, version,
+                            mvn.getSession().getArtifactTypeRegistry().get(d.getType())),
                     d.getScope(), d.isOptional(), toAetherExclusions(d.getExclusions())));
         }
 

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/ApplicationDependencyResolver.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/ApplicationDependencyResolver.java
@@ -234,7 +234,7 @@ public class ApplicationDependencyResolver {
                     .setGroupId(a.getGroupId())
                     .setArtifactId(a.getArtifactId())
                     .setClassifier(a.getClassifier())
-                    .setType(a.getExtension())
+                    .setType(DependencyUtils.getType(a))
                     .setVersion(a.getVersion())
                     .setScope(dep.getScope());
             var appDep = appBuilder.getDependency(depBuilder.getKey());
@@ -642,6 +642,7 @@ public class ApplicationDependencyResolver {
                 }
                 try {
                     resolvedDep = DependencyUtils.toAppArtifact(getResolvedArtifact(), module)
+                            .setType(DependencyUtils.getType(artifact))
                             .setOptional(node.getDependency().isOptional())
                             .setScope(node.getDependency().getScope())
                             .setFlags(DependencyFlags.RUNTIME_CP | DependencyFlags.DEPLOYMENT_CP);

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/util/DependencyUtils.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/util/DependencyUtils.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.ArtifactProperties;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.DependencyNode;
@@ -27,7 +28,7 @@ public class DependencyUtils {
 
     public static ArtifactKey getKey(Artifact artifact) {
         return ArtifactKey.of(artifact.getGroupId(), artifact.getArtifactId(),
-                artifact.getClassifier(), artifact.getExtension());
+                artifact.getClassifier(), getType(artifact));
     }
 
     public static ArtifactKey getKey(Exclusion exclusion) {
@@ -40,21 +41,19 @@ public class DependencyUtils {
 
     public static ArtifactCoords getCoords(Artifact artifact) {
         return new GACTV(artifact.getGroupId(), artifact.getArtifactId(),
-                artifact.getClassifier(), artifact.getExtension(), artifact.getVersion());
+                artifact.getClassifier(), getType(artifact), artifact.getVersion());
     }
 
     public static Map<ArtifactKey, Dependency> toMap(List<Dependency> deps) {
         final Map<ArtifactKey, Dependency> map = new HashMap<>(deps.size());
-        for (int i = 0; i < deps.size(); i++) {
-            final Dependency dep = deps.get(i);
+        for (Dependency dep : deps) {
             map.put(getKey(dep.getArtifact()), dep);
         }
         return map;
     }
 
     public static void putAll(Map<ArtifactKey, Dependency> map, List<Dependency> deps) {
-        for (int i = 0; i < deps.size(); i++) {
-            final Dependency dep = deps.get(i);
+        for (Dependency dep : deps) {
             map.putIfAbsent(getKey(dep.getArtifact()), dep);
         }
     }
@@ -181,9 +180,13 @@ public class DependencyUtils {
                 .setGroupId(artifact.getGroupId())
                 .setArtifactId(artifact.getArtifactId())
                 .setClassifier(artifact.getClassifier())
-                .setType(artifact.getExtension())
+                .setType(getType(artifact))
                 .setVersion(artifact.getVersion())
                 .setResolvedPaths(artifact.getFile() == null ? PathList.empty() : PathList.of(artifact.getFile().toPath()));
+    }
+
+    public static String getType(Artifact artifact) {
+        return artifact.getProperty(ArtifactProperties.TYPE, artifact.getExtension());
     }
 
     public static boolean hasWinner(DependencyNode node) {

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/util/DependencyUtils.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/util/DependencyUtils.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.ArtifactProperties;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.DependencyNode;
@@ -27,7 +28,7 @@ public class DependencyUtils {
 
     public static ArtifactKey getKey(Artifact artifact) {
         return ArtifactKey.of(artifact.getGroupId(), artifact.getArtifactId(),
-                artifact.getClassifier(), artifact.getExtension());
+                artifact.getClassifier(), getType(artifact));
     }
 
     public static ArtifactKey getKey(Exclusion exclusion) {
@@ -40,21 +41,19 @@ public class DependencyUtils {
 
     public static ArtifactCoords getCoords(Artifact artifact) {
         return new GACTV(artifact.getGroupId(), artifact.getArtifactId(),
-                artifact.getClassifier(), artifact.getExtension(), artifact.getVersion());
+                artifact.getClassifier(), getType(artifact), artifact.getVersion());
     }
 
     public static Map<ArtifactKey, Dependency> toMap(List<Dependency> deps) {
         final Map<ArtifactKey, Dependency> map = new HashMap<>(deps.size());
-        for (int i = 0; i < deps.size(); i++) {
-            final Dependency dep = deps.get(i);
+        for (Dependency dep : deps) {
             map.put(getKey(dep.getArtifact()), dep);
         }
         return map;
     }
 
     public static void putAll(Map<ArtifactKey, Dependency> map, List<Dependency> deps) {
-        for (int i = 0; i < deps.size(); i++) {
-            final Dependency dep = deps.get(i);
+        for (Dependency dep : deps) {
             map.putIfAbsent(getKey(dep.getArtifact()), dep);
         }
     }
@@ -216,9 +215,13 @@ public class DependencyUtils {
                 .setGroupId(artifact.getGroupId())
                 .setArtifactId(artifact.getArtifactId())
                 .setClassifier(artifact.getClassifier())
-                .setType(artifact.getExtension())
+                .setType(getType(artifact))
                 .setVersion(artifact.getVersion())
                 .setResolvedPaths(artifact.getFile() == null ? PathList.empty() : PathList.of(artifact.getFile().toPath()));
+    }
+
+    public static String getType(Artifact artifact) {
+        return artifact.getProperty(ArtifactProperties.TYPE, artifact.getExtension());
     }
 
     public static boolean hasWinner(DependencyNode node) {

--- a/independent-projects/bootstrap/maven-resolver/src/test/java/io/quarkus/bootstrap/util/DependencyUtilsTest.java
+++ b/independent-projects/bootstrap/maven-resolver/src/test/java/io/quarkus/bootstrap/util/DependencyUtilsTest.java
@@ -1,0 +1,50 @@
+package io.quarkus.bootstrap.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.eclipse.aether.artifact.ArtifactProperties;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.ArtifactKey;
+
+public class DependencyUtilsTest {
+
+    @Test
+    void getKeyPreservesTestJarType() {
+        var artifact = new DefaultArtifact("org.acme", "acme-lib", "tests-quarkus", ArtifactCoords.TYPE_JAR, "1.0",
+                Map.of(ArtifactProperties.TYPE, ArtifactCoords.TYPE_TEST_JAR), (org.eclipse.aether.artifact.ArtifactType) null);
+        ArtifactKey key = DependencyUtils.getKey(artifact);
+        assertThat(key.getType()).isEqualTo(ArtifactCoords.TYPE_TEST_JAR);
+        assertThat(key.getClassifier()).isEqualTo("tests-quarkus");
+    }
+
+    @Test
+    void getKeyDefaultsToExtensionWhenNoTypeProperty() {
+        var artifact = new DefaultArtifact("org.acme", "acme-lib", "", ArtifactCoords.TYPE_JAR, "1.0");
+        ArtifactKey key = DependencyUtils.getKey(artifact);
+        assertThat(key.getType()).isEqualTo(ArtifactCoords.TYPE_JAR);
+    }
+
+    @Test
+    void getCoordsPreservesTestJarType() {
+        var artifact = new DefaultArtifact("org.acme", "acme-lib", "tests-quarkus", ArtifactCoords.TYPE_JAR, "1.0",
+                Map.of(ArtifactProperties.TYPE, ArtifactCoords.TYPE_TEST_JAR), (org.eclipse.aether.artifact.ArtifactType) null);
+        ArtifactCoords coords = DependencyUtils.getCoords(artifact);
+        assertThat(coords.getType()).isEqualTo(ArtifactCoords.TYPE_TEST_JAR);
+        assertThat(coords.getClassifier()).isEqualTo("tests-quarkus");
+        assertThat(coords.getVersion()).isEqualTo("1.0");
+    }
+
+    @Test
+    void toAppArtifactPreservesTestJarType() {
+        var artifact = new DefaultArtifact("org.acme", "acme-lib", "tests-quarkus", ArtifactCoords.TYPE_JAR, "1.0",
+                Map.of(ArtifactProperties.TYPE, ArtifactCoords.TYPE_TEST_JAR), (org.eclipse.aether.artifact.ArtifactType) null);
+        var resolved = DependencyUtils.toAppArtifact(artifact, null).build();
+        assertThat(resolved.getType()).isEqualTo(ArtifactCoords.TYPE_TEST_JAR);
+        assertThat(resolved.getClassifier()).isEqualTo("tests-quarkus");
+    }
+}


### PR DESCRIPTION
The Quarkus resolver loses the original Maven artifact type (e.g. `test-jar`) at multiple points, replacing it with the Aether file extension (`jar`).

This PR preserves the original Maven type by:

1. **`DependencyUtils`**: `getKey()`, `getCoords()`, and `toAppArtifact()` now use `artifact.getProperty(ArtifactProperties.TYPE, artifact.getExtension())` instead of `artifact.getExtension()`. `getType()` is now public for use in `ApplicationDependencyResolver`. Same fix applied in `ApplicationDependencyResolver.setDirectDeps()` and `visitRuntimeDependency()`.

2. **`BootstrapAppModelResolver`**: Used `DefaultArtifact(groupId, artifactId, classifier, type, version)` which passes the Maven type as the Aether `extension` parameter. Now uses `ArtifactTypeRegistry` to properly map the type to its file extension while preserving the original type as an artifact property.

3. **`ArtifactCoords`**: Added `TYPE_TEST_JAR` constant. `isJar()` now returns `true` for `test-jar` artifacts since they are physically jar files. `toCompactCoords()` uses `TYPE_JAR.equals(getType())` instead of `isJar()` so `test-jar` type is displayed.

Related: #54814