### PR TITLE
Exempt quarkus-devservices from bootstrap deployment-depends-on-runtime validation

### DIFF
--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/ApplicationDependencyResolver.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/ApplicationDependencyResolver.java
@@ -1005,6 +1005,13 @@ public class ApplicationDependencyResolver {
 
             replaceRuntimeExtensionNodes(deploymentNode);
             if (!presentInTargetGraph) {
+                // quarkus-devservices-deployment intentionally does not depend on the quarkus-devservices
+                // runtime module to avoid execution-time failures in modules that provide dev services.
+                // See https://github.com/quarkusio/quarkus/pull/49025 for details.
+                if ("io.quarkus".equals(info.runtimeArtifact.getGroupId())
+                        && "quarkus-devservices".equals(info.runtimeArtifact.getArtifactId())) {
+                    return;
+                }
                 throw new RuntimeException(
                         "Quarkus extension deployment artifact " + deploymentNode.getArtifact()
                                 + " does not appear to depend on the corresponding runtime artifact "

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/ApplicationDependencyTreeResolver.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/ApplicationDependencyTreeResolver.java
@@ -636,6 +636,13 @@ public class ApplicationDependencyTreeResolver {
 
         extDep.replaceRuntimeExtensionNodes(deploymentNode);
         if (!extDep.presentInTargetGraph) {
+            // quarkus-devservices-deployment intentionally does not depend on the quarkus-devservices
+            // runtime module to avoid execution-time failures in modules that provide dev services.
+            // See https://github.com/quarkusio/quarkus/pull/49025 for details.
+            if ("io.quarkus".equals(extDep.info.runtimeArtifact.getGroupId())
+                    && "quarkus-devservices".equals(extDep.info.runtimeArtifact.getArtifactId())) {
+                return;
+            }
             throw new BootstrapDependencyProcessingException(
                     "Quarkus extension deployment artifact " + deploymentNode.getArtifact()
                             + " does not appear to depend on the corresponding runtime artifact "


### PR DESCRIPTION
Fixes #54572

When an extension's runtime module declares a dependency on `quarkus-devservices`
and also uses a code-generation extension (e.g. `quarkus-openapi-generator`) that
triggers the `generate-code` goal, the build fails with:

    java.lang.RuntimeException: Quarkus extension deployment artifact
    io.quarkus:quarkus-devservices-deployment does not appear to depend on the
    corresponding runtime artifact io.quarkus:quarkus-devservices

The bootstrap resolver validates that every deployment artifact transitively depends
on its corresponding runtime artifact. This check fails for `quarkus-devservices`
because `quarkus-devservices-deployment` intentionally omits that dependency to avoid
execution-time classloading failures — a deliberate design decision documented in #49025.

This PR mirrors the exemption already present in `StartupActionImpl`, which tolerates
the absence of `quarkus-devservices` runtime classes for the same reason. The exemption
is applied to both places in the bootstrap resolver that perform this validation:

- `ApplicationDependencyResolver` — the current default resolver
- `ApplicationDependencyTreeResolver` — the legacy resolver, active when
  `-Dquarkus.bootstrap.legacy-model-resolver=true`

Both resolvers are patched to avoid repeating the regression from #52695, where only
the legacy resolver was fixed and the bug resurfaced when the new resolver became
the default.