### PR TITLE
Fix Testcontainers reuse broken by process-uuid label

### DIFF
--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ConfigureUtil.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ConfigureUtil.java
@@ -19,6 +19,7 @@ import java.util.function.Consumer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.utility.Base58;
+import org.testcontainers.utility.TestcontainersConfiguration;
 
 import com.github.dockerjava.api.command.CreateNetworkCmd;
 
@@ -58,9 +59,23 @@ public final class ConfigureUtil {
         return container;
     }
 
+    /**
+     * The process UUID label marks containers as owned by the current JVM so that
+     * {@link ContainerLocator} does not rediscover them; reuse within a process is
+     * handled by {@link io.quarkus.deployment.builditem.DevServicesRegistryBuildItem}.
+     * <p>
+     * When Testcontainers reuse is enabled for a container, the label must be omitted
+     * so the Docker create command hash stays stable across JVM restarts.
+     */
+    public static boolean shouldConfigureProcessUuidLabel(GenericContainer<?> container) {
+        return !(TestcontainersConfiguration.getInstance().environmentSupportsReuse()
+                && container.isShouldBeReused());
+    }
+
     public static void configureLabels(GenericContainer<?> container, LaunchMode launchMode) {
-        // Configure the labels for the container
-        container.withLabel(QUARKUS_PROCESS_UUID, RunningDevServicesRegistry.APPLICATION_UUID);
+        if (shouldConfigureProcessUuidLabel(container)) {
+            container.withLabel(QUARKUS_PROCESS_UUID, RunningDevServicesRegistry.APPLICATION_UUID);
+        }
         container.withLabel(QUARKUS_LAUNCH_MODE, launchMode.toString());
     }
 

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/Labels.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/Labels.java
@@ -35,9 +35,12 @@ public final class Labels {
 
     /**
      * Label which indicates that this dev service was started by this process, and therefore should not be discovered for
-     * re-use;
+     * re-use by {@link ContainerLocator};
      * instead reuse should be managed by the DevServicesRegistry, so that config updates apply.
      * We use a UUID as the value so that we don't filter out dev services from other processes.
+     * <p>
+     * This label is omitted when Testcontainers reuse is enabled for the container, so the Docker create command hash
+     * stays stable across JVM restarts.
      */
     public static final String QUARKUS_PROCESS_UUID = QUARKUS_DEV_SERVICE + ".process-uuid";
 

--- a/integration-tests/jpa-postgresql/src/test/java/io/quarkus/it/jpa/postgresql/DevServicesPostgresqlContainerReuseTest.java
+++ b/integration-tests/jpa-postgresql/src/test/java/io/quarkus/it/jpa/postgresql/DevServicesPostgresqlContainerReuseTest.java
@@ -9,7 +9,6 @@ import java.util.Map;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.DockerClientFactory;
 
@@ -25,18 +24,17 @@ import io.quarkus.maven.it.verifier.RunningInvoker;
  * reuse the container from the first run. If it cannot (because the process-uuid label
  * changed), the second run fails with a port conflict.
  * <p>
- * This test is disabled until the issue is fixed.
  */
-@Disabled("https://github.com/quarkusio/quarkus/issues/53312 - process-uuid label prevents container reuse")
 class DevServicesPostgresqlContainerReuseTest extends MojoTestBase {
 
     private static final int FIXED_PORT = 55432;
 
     @BeforeAll
-    static void checkPortIsClear() {
-        assertThat(findContainerOnPort(FIXED_PORT))
-                .as("Port %d must not be in use before the test starts", FIXED_PORT)
-                .isNull();
+    static void ensurePortIsClear() {
+        String containerId = findContainerOnPort(FIXED_PORT);
+        if (containerId != null) {
+            DockerClientFactory.lazyClient().removeContainerCmd(containerId).withForce(true).exec();
+        }
     }
 
     @AfterAll

--- a/integration-tests/jpa-postgresql/src/test/resources-filtered/projects/devservices-postgresql-fixed-port/pom.xml
+++ b/integration-tests/jpa-postgresql/src/test/resources-filtered/projects/devservices-postgresql-fixed-port/pom.xml
@@ -4,7 +4,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.acme</groupId>
-    <artifactId>devservices-postgresql-reuse</artifactId>
+    <artifactId>devservices-postgresql-fixed-port</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/integration-tests/jpa-postgresql/src/test/resources-filtered/projects/devservices-postgresql-reuse/src/main/resources/application.properties
+++ b/integration-tests/jpa-postgresql/src/test/resources-filtered/projects/devservices-postgresql-reuse/src/main/resources/application.properties
@@ -3,3 +3,5 @@ quarkus.datasource.db-kind=postgresql
 # The specific value is arbitrary.
 quarkus.datasource.devservices.port=55432
 quarkus.hibernate-orm.database.generation=drop-and-create
+# Fresh port to avoid conflicts with other tests
+quarkus.http.test-port=8086


### PR DESCRIPTION
When `testcontainers.reuse.enable=true` is set, Dev Services containers
should be reused across separate JVM runs (second `mvn verify`, re-running
a test in the IDE, etc.). Since 3.32, every container was labeled with
`io.quarkus.devservice.process-uuid` using a random per-JVM UUID. That
label is part of the Docker create command Testcontainers hashes for
reuse lookup, so each run produced a different hash, failed to find the
existing container, and often failed with a port conflict when a fixed
devservices port was configured.

Skip the `process-uuid` label when both `testcontainers.reuse.enable`
and the container's `.withReuse(true)` flag are active (e.g.
`quarkus.datasource.devservices.reuse`, which defaults to `true`). The
label is still applied otherwise, so in-process reuse continues to be
managed by `DevServicesRegistry` and `ContainerLocator` behavior is
unchanged for non-reuse scenarios.

Also re-enables `DevServicesPostgresqlContainerReuseTest`, cleans up
leftover containers on the fixed test port before the run, assigns a
dedicated HTTP test port to the reproducer project, and fixes a
copy-paste error in the fixed-port test `pom.xml` artifact ID.

- Fixes: #53312