### PR TITLE
Avoid dragging the whole test classpath to Virtual Threads ITs

### DIFF
--- a/integration-tests/virtual-threads/amqp-virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/amqp-virtual-threads/pom.xml
@@ -52,10 +52,16 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- Use the "compile" scope because we need to include the VirtualThreadsAssertions in the app -->
+        <!-- Use the "compile" scope but exclude all transitive dependencies because we only need to include the VirtualThreadsAssertions in the app -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-test-vertx</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/virtual-threads/graphql-virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/graphql-virtual-threads/pom.xml
@@ -18,10 +18,16 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-graphql</artifactId>
         </dependency>
-        <!-- Use the "compile" scope because we need to include the VirtualThreadsAssertions in the app -->
+        <!-- Use the "compile" scope but exclude all transitive dependencies because we only need to include the VirtualThreadsAssertions in the app -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-test-vertx</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/virtual-threads/grpc-virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/grpc-virtual-threads/pom.xml
@@ -22,10 +22,16 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-grpc</artifactId>
         </dependency>
-        <!-- Use the "compile" scope because we need to include the VirtualThreadsAssertions in the app -->
+        <!-- Use the "compile" scope but exclude all transitive dependencies because we only need to include the VirtualThreadsAssertions in the app -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-test-vertx</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/virtual-threads/jms-virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/jms-virtual-threads/pom.xml
@@ -82,10 +82,16 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- Use the "compile" scope because we need to include the VirtualThreadsAssertions in the app -->
+        <!-- Use the "compile" scope but exclude all transitive dependencies because we only need to include the VirtualThreadsAssertions in the app -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-test-vertx</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/virtual-threads/kafka-virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/kafka-virtual-threads/pom.xml
@@ -51,10 +51,16 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- Use the "compile" scope because we need to include the VirtualThreadsAssertions in the app -->
+        <!-- Use the "compile" scope but exclude all transitive dependencies because we only need to include the VirtualThreadsAssertions in the app -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-test-vertx</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/virtual-threads/mailer-virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/mailer-virtual-threads/pom.xml
@@ -22,10 +22,16 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-mailer</artifactId>
         </dependency>
-        <!-- Use the "compile" scope because we need to include the VirtualThreadsAssertions in the app -->
+        <!-- Use the "compile" scope but exclude all transitive dependencies because we only need to include the VirtualThreadsAssertions in the app -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-test-vertx</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/virtual-threads/metrics-virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/metrics-virtual-threads/pom.xml
@@ -30,10 +30,16 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
         </dependency>
-        <!-- Use the "compile" scope because we need to include the VirtualThreadsAssertions in the app -->
+        <!-- Use the "compile" scope but exclude all transitive dependencies because we only need to include the VirtualThreadsAssertions in the app -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-test-vertx</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/virtual-threads/quartz-virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/quartz-virtual-threads/pom.xml
@@ -22,10 +22,16 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-quartz</artifactId>
         </dependency>
-        <!-- Use the "compile" scope because we need to include the VirtualThreadsAssertions in the app -->
+        <!-- Use the "compile" scope but exclude all transitive dependencies because we only need to include the VirtualThreadsAssertions in the app -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-test-vertx</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/virtual-threads/reactive-routes-virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/reactive-routes-virtual-threads/pom.xml
@@ -18,10 +18,16 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-reactive-routes</artifactId>
         </dependency>
-        <!-- Use the "compile" scope because we need to include the VirtualThreadsAssertions in the app -->
+        <!-- Use the "compile" scope but exclude all transitive dependencies because we only need to include the VirtualThreadsAssertions in the app -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-test-vertx</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/virtual-threads/redis-virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/redis-virtual-threads/pom.xml
@@ -26,10 +26,16 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-redis-client</artifactId>
         </dependency>
-        <!-- Use the "compile" scope because we need to include the VirtualThreadsAssertions in the app -->
+        <!-- Use the "compile" scope but exclude all transitive dependencies because we only need to include the VirtualThreadsAssertions in the app -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-test-vertx</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/virtual-threads/rest-client-reactive-virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/rest-client-reactive-virtual-threads/pom.xml
@@ -22,10 +22,16 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-client-jackson</artifactId>
         </dependency>
-        <!-- Use the "compile" scope because we need to include the VirtualThreadsAssertions in the app -->
+        <!-- Use the "compile" scope but exclude all transitive dependencies because we only need to include the VirtualThreadsAssertions in the app -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-test-vertx</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/virtual-threads/resteasy-reactive-virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/resteasy-reactive-virtual-threads/pom.xml
@@ -18,10 +18,16 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-jackson</artifactId>
         </dependency>
-        <!-- Use the "compile" scope because we need to include the VirtualThreadsAssertions in the app -->
+        <!-- Use the "compile" scope but exclude all transitive dependencies because we only need to include the VirtualThreadsAssertions in the app -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-test-vertx</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/virtual-threads/scheduler-virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/scheduler-virtual-threads/pom.xml
@@ -22,10 +22,16 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-scheduler</artifactId>
         </dependency>
-        <!-- Use the "compile" scope because we need to include the VirtualThreadsAssertions in the app -->
+        <!-- Use the "compile" scope but exclude all transitive dependencies because we only need to include the VirtualThreadsAssertions in the app -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-test-vertx</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/virtual-threads/security-webauthn-virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/security-webauthn-virtual-threads/pom.xml
@@ -22,10 +22,16 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-security-webauthn</artifactId>
         </dependency>
-        <!-- Use the "compile" scope because we need to include the VirtualThreadsAssertions in the app -->
+        <!-- Use the "compile" scope but exclude all transitive dependencies because we only need to include the VirtualThreadsAssertions in the app -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-test-vertx</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/virtual-threads/vertx-event-bus-virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/vertx-event-bus-virtual-threads/pom.xml
@@ -18,10 +18,16 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-jackson</artifactId>
         </dependency>
-        <!-- Use the "compile" scope because we need to include the VirtualThreadsAssertions in the app -->
+        <!-- Use the "compile" scope but exclude all transitive dependencies because we only need to include the VirtualThreadsAssertions in the app -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-test-vertx</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/virtual-threads/virtual-threads-disabled/pom.xml
+++ b/integration-tests/virtual-threads/virtual-threads-disabled/pom.xml
@@ -18,10 +18,16 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-jackson</artifactId>
         </dependency>
-        <!-- Use the "compile" scope because we need to include the VirtualThreadsAssertions in the app -->
+        <!-- Use the "compile" scope but exclude all transitive dependencies because we only need to include the VirtualThreadsAssertions in the app -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-test-vertx</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Per discussion with Stale, this was discovered by his Aesh work.

The main purpose of this change is to not drag the whole test classpath into the native executables when testing native.