### PR TITLE
Add shared command-line capability, fix docs, and cleanups

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/Capability.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/Capability.java
@@ -8,6 +8,13 @@ public interface Capability {
     String QUARKUS_PREFIX = "io.quarkus";
 
     /**
+     * A command-line framework that controls command parsing and the
+     * application entry point. Mutually exclusive -- only one CLI
+     * framework extension (e.g. aesh or picocli) can be active.
+     */
+    String COMMAND_LINE = QUARKUS_PREFIX + ".command-line";
+
+    /**
      * Aesh CLI framework
      */
     String AESH = QUARKUS_PREFIX + ".aesh";

--- a/docs/src/main/asciidoc/aesh.adoc
+++ b/docs/src/main/asciidoc/aesh.adoc
@@ -57,17 +57,16 @@ eliminating reflection-based annotation scanning at runtime:
                 <groupId>org.aesh</groupId>
                 <artifactId>aesh-processor</artifactId>
             </path>
-            <path>
-                <groupId>org.aesh</groupId>
-                <artifactId>aesh</artifactId>
-            </path>
         </annotationProcessorPaths>
     </configuration>
 </plugin>
 ----
 
-NOTE: The annotation processor is optional. Without it, Aesh falls back to runtime
+[NOTE]
+====
+The annotation processor is optional. Without it, Aesh falls back to runtime
 reflection for command metadata, which works correctly but is slower at startup.
+====
 
 == Building a command line application
 
@@ -282,9 +281,12 @@ class GreetingService {
 }
 ----
 
-IMPORTANT: Beans annotated with `@CommandDefinition` should not use proxied scopes (e.g. do not use `@ApplicationScoped`)
+[IMPORTANT]
+====
+Beans annotated with `@CommandDefinition` should not use proxied scopes (e.g. do not use `@ApplicationScoped`)
 because Aesh sets field values directly via reflection.
 By default, the Aesh extension registers command classes with the `@Dependent` scope.
+====
 
 ==== Grouped commands with subcommands
 
@@ -639,8 +641,11 @@ quarkus.aesh.websocket.roles-allowed=admin,operator
 
 When `roles-allowed` is set, `authenticated` is ignored since role-based access implies authentication.
 
-NOTE: The extension will log a warning at build time if the WebSocket terminal is enabled
+[NOTE]
+====
+The extension will log a warning at build time if the WebSocket terminal is enabled
 in production without authentication configured.
+====
 
 === SSH terminal
 
@@ -690,8 +695,11 @@ quarkus.aesh.ssh.enabled=true
 Password and public key authentication can be used simultaneously. When both are configured,
 clients can authenticate with either method. If neither is configured, any password is accepted.
 
-NOTE: The extension will log a warning at startup if the SSH server is running without
+[NOTE]
+====
+The extension will log a warning at startup if the SSH server is running without
 any authentication configured (no password, no authorized-keys-file).
+====
 
 === Connection management
 
@@ -807,9 +815,12 @@ In production, always configure authentication:
 Additionally, restrict network access to these endpoints using firewalls or bind addresses.
 Use `idle-timeout` to automatically close abandoned sessions and `max-connections` to limit concurrent sessions and prevent resource exhaustion. Health checks (when `quarkus-smallrye-health` is present) provide visibility into the number of active sessions.
 
-NOTE: WebSocket connections are not protected by the browser's same-origin policy.
+[NOTE]
+====
+WebSocket connections are not protected by the browser's same-origin policy.
 If the WebSocket terminal is exposed on a network, consider configuring CORS via the
 `quarkus.http.cors` settings to restrict which origins can connect.
+====
 
 == Providing your own QuarkusMain
 
@@ -847,8 +858,14 @@ public class CustomMain implements QuarkusApplication {
 
 == Development Mode
 
-In the development mode, i.e. when running `mvn quarkus:dev`, the application is executed and restarted every time the `Space bar` key is pressed. You can also pass arguments to your command line app via the `quarkus.args` system property, e.g. `mvn quarkus:dev -Dquarkus.args='--help'` and `mvn quarkus:dev -Dquarkus.args='-n Quarkus'`.
-For Gradle projects, arguments can be passed using `--quarkus-args`.
+In development mode (`mvn quarkus:dev`), the Quarkus dev console takes control of the terminal for its interactive features (live reload, test output, etc.).
+This means the local terminal is not available for aesh CLI interaction.
+
+To test your CLI commands during development, you have the following options:
+
+* **WebSocket terminal**: Add the `quarkus-aesh-websocket` dependency and access the CLI via browser at `http://localhost:8080/aesh/index.html`. The dev console stays on the local terminal while the aesh CLI runs in the browser.
+* **Pass arguments**: Use `mvn quarkus:dev -Dquarkus.args='--help'` or `mvn quarkus:dev -Dquarkus.args='-n Quarkus'` to pass arguments directly. The application is re-executed every time the `Space bar` key is pressed. For Gradle projects, use `--quarkus-args`.
+* **Build and run**: Build the application with `mvn package -DskipTests` and run it directly with `java -jar target/quarkus-app/quarkus-run.jar <command> [options]`.
 
 === Dev UI
 
@@ -856,6 +873,7 @@ The Aesh extension provides Dev UI pages accessible at `http://localhost:8080/q/
 
 ==== Commands page
 
+Always available. Shows a table of all discovered CLI commands with their name, description, type (Group or regular), class name, and sub-commands for group commands. The resolved execution mode (console or runtime) is displayed at the top. A search field allows filtering commands by name, description, or class name.
 
 ==== Sessions page
 

--- a/extensions/aesh/deployment/src/main/java/io/quarkus/aesh/deployment/AeshProcessor.java
+++ b/extensions/aesh/deployment/src/main/java/io/quarkus/aesh/deployment/AeshProcessor.java
@@ -32,8 +32,6 @@ import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.arc.deployment.ValidationPhaseBuildItem.ValidationErrorBuildItem;
 import io.quarkus.arc.processor.BuiltinScope;
-import io.quarkus.deployment.Capabilities;
-import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -54,12 +52,7 @@ class AeshProcessor {
     private static final DotName PARENT_COMMAND = DotName.createSimple("org.aesh.command.option.ParentCommand");
 
     @BuildStep
-    FeatureBuildItem feature(Capabilities capabilities) {
-        if (capabilities.isPresent(Capability.PICOCLI)) {
-            throw new IllegalStateException(
-                    "The Aesh and Picocli extensions cannot be used together. "
-                            + "Remove either quarkus-aesh or quarkus-picocli from your dependencies.");
-        }
+    FeatureBuildItem feature() {
         return new FeatureBuildItem(Feature.AESH);
     }
 

--- a/extensions/aesh/runtime/pom.xml
+++ b/extensions/aesh/runtime/pom.xml
@@ -47,6 +47,7 @@
                 <artifactId>quarkus-extension-maven-plugin</artifactId>
                 <configuration>
                     <capabilities>
+                        <provides>io.quarkus.command-line</provides>
                         <provides>io.quarkus.aesh</provides>
                     </capabilities>
                     <conditionalDevDependencies>

--- a/extensions/picocli/runtime/pom.xml
+++ b/extensions/picocli/runtime/pom.xml
@@ -35,6 +35,7 @@
                 <artifactId>quarkus-extension-maven-plugin</artifactId>
                 <configuration>
                     <capabilities>
+                        <provides>io.quarkus.command-line</provides>
                         <provides>io.quarkus.picocli</provides>
                     </capabilities>
                 </configuration>

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle-kotlin-dsl/base/build-layout.include.qute
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle-kotlin-dsl/base/build-layout.include.qute
@@ -47,7 +47,6 @@ dependencies {
 {/if}
 {#if input.selected-extensions-ga.contains('io.quarkus:quarkus-aesh')}
     annotationProcessor("org.aesh:aesh-processor")
-    annotationProcessor("org.aesh:aesh")
 {/if}
     testImplementation("io.quarkus:quarkus-junit")
 {#for dep in test-dependencies}

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle/base/build-layout.include.qute
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle/base/build-layout.include.qute
@@ -43,7 +43,6 @@ dependencies {
 {/if}
 {#if input.selected-extensions-ga.contains('io.quarkus:quarkus-aesh')}
     annotationProcessor 'org.aesh:aesh-processor'
-    annotationProcessor 'org.aesh:aesh'
 {/if}
 {#if quarkus.version == null || quarkus.version.compareVersionTo("3.30.999") > 0}
     testImplementation 'io.quarkus:quarkus-junit'

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/maven/base/pom.tpl.qute.xml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/maven/base/pom.tpl.qute.xml
@@ -187,10 +187,6 @@
                                     <groupId>org.aesh</groupId>
                                     <artifactId>aesh-processor</artifactId>
                                 </annotationProcessorPath>
-                                <annotationProcessorPath>
-                                    <groupId>org.aesh</groupId>
-                                    <artifactId>aesh</artifactId>
-                                </annotationProcessorPath>
                                 {/if}
                             </annotationProcessorPaths>
                         </configuration>

--- a/integration-tests/aesh-native/pom.xml
+++ b/integration-tests/aesh-native/pom.xml
@@ -68,11 +68,6 @@
                             <artifactId>aesh-processor</artifactId>
                             <version>${aesh.version}</version>
                         </path>
-                        <path>
-                            <groupId>org.aesh</groupId>
-                            <artifactId>aesh</artifactId>
-                            <version>${aesh.version}</version>
-                        </path>
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>

--- a/integration-tests/aesh-ssh-native/pom.xml
+++ b/integration-tests/aesh-ssh-native/pom.xml
@@ -69,11 +69,6 @@
                             <artifactId>aesh-processor</artifactId>
                             <version>${aesh.version}</version>
                         </path>
-                        <path>
-                            <groupId>org.aesh</groupId>
-                            <artifactId>aesh</artifactId>
-                            <version>${aesh.version}</version>
-                        </path>
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>

--- a/integration-tests/aesh-websocket-native/pom.xml
+++ b/integration-tests/aesh-websocket-native/pom.xml
@@ -69,11 +69,6 @@
                             <artifactId>aesh-processor</artifactId>
                             <version>${aesh.version}</version>
                         </path>
-                        <path>
-                            <groupId>org.aesh</groupId>
-                            <artifactId>aesh</artifactId>
-                            <version>${aesh.version}</version>
-                        </path>
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>

--- a/integration-tests/aesh/pom.xml
+++ b/integration-tests/aesh/pom.xml
@@ -62,11 +62,6 @@
                             <artifactId>aesh-processor</artifactId>
                             <version>${aesh.version}</version>
                         </path>
-                        <path>
-                            <groupId>org.aesh</groupId>
-                            <artifactId>aesh</artifactId>
-                            <version>${aesh.version}</version>
-                        </path>
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>


### PR DESCRIPTION
… processor config

Use the Quarkus capabilities mechanism for aesh/picocli mutual exclusion instead of manual build step detection. Both extensions now provide the shared 'io.quarkus.command-line' capability, so the build automatically fails when both are present without needing custom code.

Also:
- Fix multiline admonitions to use block format for downstream doc compatibility
- Fill in empty Commands page section in Dev UI docs
- Document dev mode limitation: local terminal is controlled by the Quarkus dev console, so aesh CLI interaction requires WebSocket transport or direct execution
- Remove unnecessary aesh dependency from annotationProcessorPaths (aesh-processor works standalone without aesh on the processor classpath)

<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
and the AI/LLM usage policy at https://github.com/quarkusio/quarkus/blob/main/AI_POLICY.md
-->

[Please describe here what your change is about]

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

