### PR TITLE
Fix cross-application Dev Services discovery in ContainerLocator

### DIFF
--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ContainerLocator.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ContainerLocator.java
@@ -11,6 +11,7 @@ import java.util.stream.Stream;
 import org.jboss.logging.Logger;
 import org.testcontainers.DockerClientFactory;
 
+import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.model.Container;
 import com.github.dockerjava.api.model.ContainerPort;
 
@@ -41,26 +42,38 @@ public class ContainerLocator {
 
     private final BiPredicate<Container, String> filter;
     private final int port;
+    private final boolean inspect;
 
     public ContainerLocator(String devServiceLabel, int port) {
-        this((container, expectedLabel) -> expectedLabel.equals(container.getLabels().get(devServiceLabel)), port);
+        this((container, expectedLabel) -> expectedLabel.equals(container.getLabels().get(devServiceLabel)), port, false);
     }
 
-    public ContainerLocator(BiPredicate<Container, String> filter, int port) {
+    public ContainerLocator(BiPredicate<Container, String> filter, int port, boolean inspect) {
         // Always tack on an extra filter to rule out containers which were clearly created by this process
         this.filter = filter.and(IS_NOT_CREATED_BY_US_SELECTOR);
         this.port = port;
+        this.inspect = inspect;
     }
 
     public static ContainerLocator locateContainerWithLabels(int port, String... devServiceLabels) {
         return new ContainerLocator(
                 (container, expectedLabel) -> hasDevServiceLabels(container, expectedLabel::equals, devServiceLabels),
-                port);
+                port, false);
+    }
+
+    public static ContainerLocator locateContainerWithLabels(int port, boolean inspect, String... devServiceLabels) {
+        return new ContainerLocator(
+                (container, expectedLabel) -> hasDevServiceLabels(container, expectedLabel::equals, devServiceLabels),
+                port, inspect);
     }
 
     private Stream<Container> lookup(String expectedLabelValue) {
         return DockerClientFactory.lazyClient().listContainersCmd().exec().stream()
                 .filter(container -> filter.test(container, expectedLabelValue));
+    }
+
+    private InspectContainerResponse inspect(Container container) {
+        return DockerClientFactory.lazyClient().inspectContainerCmd(container.getId()).exec();
     }
 
     private Optional<ContainerPort> getMappedPort(Container container, int port) {
@@ -79,10 +92,19 @@ public class ContainerLocator {
                     .flatMap(container -> getMappedPort(container, port).stream()
                             .flatMap(containerPort -> Optional.ofNullable(containerPort.getPublicPort())
                                     .map(port -> {
-                                        final ContainerAddress containerAddress = new ContainerAddress(
-                                                container.getId(),
-                                                DockerClientFactory.instance().dockerHostIpAddress(),
-                                                containerPort.getPublicPort());
+                                        final ContainerAddress containerAddress;
+                                        if (inspect) {
+                                            InspectContainerResponse containerInfo = inspect(container);
+                                            containerAddress = new ContainerAddress(
+                                                    ContainerUtil.toRunningContainer(containerInfo),
+                                                    DockerClientFactory.instance().dockerHostIpAddress(),
+                                                    containerPort.getPublicPort());
+                                        } else {
+                                            containerAddress = new ContainerAddress(
+                                                    container.getId(),
+                                                    DockerClientFactory.instance().dockerHostIpAddress(),
+                                                    containerPort.getPublicPort());
+                                        }
                                         log.infof("Dev Services container found: %s (%s). Connecting to: %s.",
                                                 container.getId(),
                                                 container.getImage(),

--- a/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/amqp/deployment/AmqpDevServicesProcessor.java
+++ b/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/amqp/deployment/AmqpDevServicesProcessor.java
@@ -51,7 +51,9 @@ public class AmqpDevServicesProcessor {
     private static final int AMQP_PORT = 5672;
     private static final int AMQP_CONSOLE_PORT = 8161;
 
-    private static final ContainerLocator amqpContainerLocator = locateContainerWithLabels(AMQP_PORT, DEV_SERVICE_LABEL);
+    private static final ContainerLocator amqpContainerLocator = locateContainerWithLabels(AMQP_PORT, true,
+            DEV_SERVICE_LABEL);
+
     private static final String AMQP_HOST_PROP = "amqp-host";
     private static final String AMQP_PORT_PROP = "amqp-port";
     private static final String AMQP_MAPPED_PORT_PROP = "amqp-mapped-port";
@@ -105,6 +107,7 @@ public class AmqpDevServicesProcessor {
                 })
                 .orElseGet(() -> DevServicesResultBuildItem.owned()
                         .feature(Feature.MESSAGING_AMQP)
+                        .serviceName(config.serviceName())
                         .serviceConfig(config)
                         .startable(() -> new ArtemisContainer(
                                 DockerImageName.parse(config.imageName().orElse(getDefaultImageNameFor("amqp")))

--- a/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/RabbitMQDevServicesProcessor.java
+++ b/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/RabbitMQDevServicesProcessor.java
@@ -49,7 +49,7 @@ public class RabbitMQDevServicesProcessor {
     private static final int RABBITMQ_PORT = 5672;
     private static final int RABBITMQ_HTTP_PORT = 15672;
 
-    private static final ContainerLocator rabbitmqContainerLocator = locateContainerWithLabels(RABBITMQ_PORT,
+    private static final ContainerLocator rabbitmqContainerLocator = locateContainerWithLabels(RABBITMQ_PORT, true,
             DEV_SERVICE_LABEL);
 
     private static final String RABBITMQ_HOST_PROP = "rabbitmq-host";
@@ -101,6 +101,7 @@ public class RabbitMQDevServicesProcessor {
                 })
                 .orElseGet(() -> DevServicesResultBuildItem.owned()
                         .feature(Feature.MESSAGING_RABBITMQ)
+                        .serviceName(config.serviceName())
                         .serviceConfig(config)
                         .startable(() -> {
                             ConfiguredRabbitMQContainer container = new ConfiguredRabbitMQContainer(


### PR DESCRIPTION
Fixes a regression introduced when Dev Services processors were refactored to use `DevServicesResultBuildItem.discovered()`, which requires a `RunningContainer` to read environment variables and port mappings.

`ComposeLocator` was updated for this API, but `ContainerLocator` was not. It still used the legacy `ContainerAddress(id, host, port)` constructor, leaving `runningContainer` null. Processors such as AMQP and RabbitMQ guard against that and fall through to starting a new container, so a second Quarkus app in dev mode fails to reuse the broker started by the first (port conflict with a fixed port, or an unnecessary duplicate broker otherwise).

This change inspects containers found via label lookup and builds `ContainerAddress` with a `RunningContainer`, consistent with `ComposeLocator`. No extension-specific changes are required.

- Fixes: #53350