### PR TITLE
Add shared Dev Services support for datasource containers

### DIFF
--- a/docs/src/main/asciidoc/databases-dev-services.adoc
+++ b/docs/src/main/asciidoc/databases-dev-services.adoc
@@ -82,6 +82,33 @@ By capturing the logs, they become visible amongst other log statements:
 quarkus.datasource.devservices.show-logs=true
 ----
 
+[[shared]]
+== Sharing Dev Services across applications
+
+When running multiple Quarkus applications in dev mode on the same machine,
+you can share a single database container between them,
+similar to the `quarkus.*.devservices.shared` option for Kafka, Redis, and other Dev Services.
+
+Enable sharing on each application that should use the same database:
+
+[source,properties]
+----
+quarkus.datasource.devservices.shared=true
+# optional - defaults to "default" for the default datasource:
+# quarkus.datasource.devservices.service-name=my-shared-db
+----
+
+The first application to start creates the container, with a database-specific dev service label set to the configured service name.
+Subsequent applications with matching `shared` and `service-name` configuration discover and connect to the existing container.
+
+Container sharing only applies in dev mode.
+
+[WARNING]
+====
+All applications sharing a database will use the same schema and data.
+Configure schema management (e.g. xref:flyway.adoc[Flyway]) carefully to avoid conflicts.
+====
+
 == Automatic Image Selection
 
 The container image used by Dev Services is determined by the database kind of your xref:datasource.adoc[datasource],

--- a/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceContainerConfig.java
+++ b/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceContainerConfig.java
@@ -23,6 +23,8 @@ public class DevServicesDatasourceContainerConfig {
     private final Map<String, String> volumes;
     private final boolean reuse;
     private final boolean showLogs;
+    private final boolean shared;
+    private final String serviceName;
     private final String datasourceName;
     private final Set<DatabaseFeature> requiredFeatures;
 
@@ -40,6 +42,8 @@ public class DevServicesDatasourceContainerConfig {
             Map<String, String> volumes,
             boolean reuse,
             boolean showLogs,
+            boolean shared,
+            String serviceName,
             String datasourceName,
             Set<DatabaseFeature> requiredFeatures) {
         this.imageName = imageName;
@@ -56,6 +60,8 @@ public class DevServicesDatasourceContainerConfig {
         this.volumes = volumes;
         this.reuse = reuse;
         this.showLogs = showLogs;
+        this.shared = shared;
+        this.serviceName = serviceName;
         this.datasourceName = datasourceName;
         this.requiredFeatures = requiredFeatures != null ? requiredFeatures : Collections.emptySet();
     }
@@ -114,6 +120,14 @@ public class DevServicesDatasourceContainerConfig {
 
     public boolean isReuse() {
         return reuse;
+    }
+
+    public boolean isShared() {
+        return shared;
+    }
+
+    public String getServiceName() {
+        return serviceName;
     }
 
     public String getDatasourceName() {

--- a/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceProvider.java
+++ b/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceProvider.java
@@ -30,6 +30,11 @@ public interface DevServicesDatasourceProvider {
             boolean useSharedNetwork, DevServicesDatasourceContainerConfig containerConfig,
             DevServicesComposeProjectBuildItem composeProjectBuildItem);
 
+    default Optional<DevServicesDatasourceProvider.RunningDevServicesDatasource> findRunningSharedDatasource(
+            LaunchMode launchMode, DevServicesDatasourceContainerConfig containerConfig) {
+        return Optional.empty();
+    }
+
     default boolean isDockerRequired() {
         return true;
     }

--- a/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesDatasourceProcessor.java
+++ b/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesDatasourceProcessor.java
@@ -141,6 +141,8 @@ public class DevServicesDatasourceProcessor {
             res.put(name + ".devservices.port", config.devservices().port());
             res.put(name + ".devservices.properties", config.devservices().properties());
             res.put(name + ".devservices.reuse", config.devservices().reuse());
+            res.put(name + ".devservices.shared", config.devservices().shared());
+            res.put(name + ".devservices.service-name", config.devservices().serviceName());
             res.put(name + ".devservices.username", config.devservices().username());
             res.put(name + ".devservices.volumes", config.devservices().volumes());
             Optional<String> username = ConfigUtils.getFirstOptionalValue(
@@ -223,7 +225,10 @@ public class DevServicesDatasourceProcessor {
             String feature = devDbProvider.getFeature();
 
             DevServicesResultBuildItem buildItem = devDbProvider
-                    .findRunningComposeDatasource(launchMode, useSharedNetwork, containerConfig, composeProjectBuildItem)
+                    .findRunningSharedDatasource(launchMode, containerConfig)
+                    .or(() -> devDbProvider
+                            .findRunningComposeDatasource(launchMode, useSharedNetwork, containerConfig,
+                                    composeProjectBuildItem))
                     .map(datasource -> DevServicesResultBuildItem.discovered().feature(feature).containerId(datasource.id())
                             .config(makeConfigMapForRunningDatasource(dbName, capabilities, configHandlers, datasource))
                             .build())
@@ -414,6 +419,8 @@ public class DevServicesDatasourceProcessor {
             DataSourceBuildTimeConfig dataSourceBuildTimeConfig,
             String datasourceName,
             Set<DatabaseFeature> requiredFeatures) {
+        String serviceName = dataSourceBuildTimeConfig.devservices().serviceName()
+                .orElse(DataSourceUtil.isDefault(datasourceName) ? "default" : datasourceName);
         return new DevServicesDatasourceContainerConfig(
                 dataSourceBuildTimeConfig.devservices().imageName(),
                 dataSourceBuildTimeConfig.devservices().containerEnv(),
@@ -429,6 +436,8 @@ public class DevServicesDatasourceProcessor {
                 dataSourceBuildTimeConfig.devservices().volumes(),
                 dataSourceBuildTimeConfig.devservices().reuse(),
                 dataSourceBuildTimeConfig.devservices().showLogs(),
+                dataSourceBuildTimeConfig.devservices().shared(),
+                serviceName,
                 datasourceName,
                 requiredFeatures);
     }

--- a/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DevServicesBuildTimeConfig.java
+++ b/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DevServicesBuildTimeConfig.java
@@ -127,6 +127,37 @@ public interface DevServicesBuildTimeConfig {
     Map<String, String> volumes();
 
     /**
+     * Indicates if the database Dev Service managed by Quarkus is shared.
+     * When shared, Quarkus looks for running containers using label-based service discovery.
+     * If a matching container is found, it is used, and so a second one is not started.
+     * Otherwise, Dev Services starts a new container.
+     * <p>
+     * The discovery uses a database-specific dev service label.
+     * The value is configured using the {@code service-name} property.
+     * <p>
+     * Container sharing is only used in dev mode.
+     *
+     * @asciidoclet
+     */
+    @WithDefault("false")
+    boolean shared();
+
+    /**
+     * The value of the dev service label attached to the started container.
+     * This property is used when {@code shared} is set to {@code true}.
+     * In this case, before starting a container, Dev Services looks for a container with the label
+     * set to the configured value. If found, it will use this container instead of starting a new one.
+     * Otherwise, it starts a new container with the label set to the specified value.
+     * <p>
+     * This property is used when you need multiple shared database Dev Services.
+     * <p>
+     * If not set, the datasource name is used ({@code default} for the default datasource).
+     *
+     * @asciidoclet
+     */
+    Optional<@WithConverter(TrimmedStringConverter.class) String> serviceName();
+
+    /**
      * Whether to keep Dev Service containers running *after a dev mode session or test suite execution*
      * to reuse them in the next dev mode session or test suite execution.
      *

--- a/extensions/devservices/common/pom.xml
+++ b/extensions/devservices/common/pom.xml
@@ -39,5 +39,9 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-datasource-common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-datasource-deployment-spi</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ContainerLocator.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ContainerLocator.java
@@ -11,9 +11,11 @@ import java.util.stream.Stream;
 import org.jboss.logging.Logger;
 import org.testcontainers.DockerClientFactory;
 
+import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.model.Container;
 import com.github.dockerjava.api.model.ContainerPort;
 
+import io.quarkus.deployment.dev.devservices.RunningContainer;
 import io.quarkus.devservices.crossclassloader.runtime.RunningDevServicesRegistry;
 import io.quarkus.runtime.LaunchMode;
 
@@ -78,17 +80,7 @@ public class ContainerLocator {
             return lookup(serviceName)
                     .flatMap(container -> getMappedPort(container, port).stream()
                             .flatMap(containerPort -> Optional.ofNullable(containerPort.getPublicPort())
-                                    .map(port -> {
-                                        final ContainerAddress containerAddress = new ContainerAddress(
-                                                container.getId(),
-                                                DockerClientFactory.instance().dockerHostIpAddress(),
-                                                containerPort.getPublicPort());
-                                        log.infof("Dev Services container found: %s (%s). Connecting to: %s.",
-                                                container.getId(),
-                                                container.getImage(),
-                                                containerAddress.getUrl());
-                                        return containerAddress;
-                                    }).stream()))
+                                    .map(publicPort -> toContainerAddress(container, containerPort)).stream()))
                     .findFirst();
         } else {
             return Optional.empty();
@@ -109,18 +101,28 @@ public class ContainerLocator {
 
                         Arrays.stream(container.getPorts())
                                 .filter(cp -> Objects.nonNull(cp.getPublicPort()) && Objects.nonNull(cp.getPrivatePort()))
-                                .forEach(cp -> {
-                                    ContainerAddress containerAddress = new ContainerAddress(
-                                            container.getId(),
-                                            DockerClientFactory.instance().dockerHostIpAddress(),
-                                            cp.getPublicPort());
-                                    consumer.accept(cp.getPrivatePort(), containerAddress);
-                                });
+                                .forEach(cp -> consumer.accept(cp.getPrivatePort(), toContainerAddress(container, cp)));
                         return container.getId();
                     });
         } else {
             return Optional.empty();
         }
+    }
+
+    private ContainerAddress toContainerAddress(Container container, ContainerPort containerPort) {
+        InspectContainerResponse inspectContainer = DockerClientFactory.lazyClient()
+                .inspectContainerCmd(container.getId())
+                .exec();
+        RunningContainer runningContainer = ContainerUtil.toRunningContainer(inspectContainer);
+        ContainerAddress containerAddress = new ContainerAddress(
+                runningContainer,
+                DockerClientFactory.instance().dockerHostIpAddress(),
+                containerPort.getPublicPort());
+        log.infof("Dev Services container found: %s (%s). Connecting to: %s.",
+                container.getId(),
+                container.getImage(),
+                containerAddress.getUrl());
+        return containerAddress;
     }
 
     public Optional<Integer> locatePublicPort(String serviceName, boolean shared, LaunchMode launchMode, int privatePort) {

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/DatasourceServiceConfigurator.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/DatasourceServiceConfigurator.java
@@ -2,9 +2,14 @@ package io.quarkus.devservices.common;
 
 import java.util.Map;
 
+import io.quarkus.datasource.deployment.spi.DevServicesDatasourceContainerConfig;
+import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProvider.RunningDevServicesDatasource;
 import io.quarkus.runtime.util.StringUtil;
 
 public interface DatasourceServiceConfigurator {
+
+    RunningDevServicesDatasource composeRunningService(ContainerAddress containerAddress,
+            DevServicesDatasourceContainerConfig containerConfig);
 
     default String getReactiveUrl(String jdbcUrl) {
         return jdbcUrl.replaceFirst("jdbc:", "vertx-reactive:");

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/SharedDatasourceLocator.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/SharedDatasourceLocator.java
@@ -1,0 +1,35 @@
+package io.quarkus.devservices.common;
+
+import java.util.Optional;
+
+import org.testcontainers.containers.GenericContainer;
+
+import io.quarkus.datasource.deployment.spi.DevServicesDatasourceContainerConfig;
+import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProvider.RunningDevServicesDatasource;
+import io.quarkus.runtime.LaunchMode;
+
+public final class SharedDatasourceLocator {
+
+    private SharedDatasourceLocator() {
+    }
+
+    public static Optional<RunningDevServicesDatasource> locate(ContainerLocator containerLocator,
+            LaunchMode launchMode, DevServicesDatasourceContainerConfig containerConfig,
+            DatasourceServiceConfigurator configurator) {
+        if (!containerConfig.isShared()) {
+            return Optional.empty();
+        }
+        return containerLocator
+                .locateContainer(containerConfig.getServiceName(), true, launchMode)
+                .map(address -> configurator.composeRunningService(address, containerConfig));
+    }
+
+    public static <T extends GenericContainer<T>> T configureSharedLabel(T container, LaunchMode launchMode,
+            String devServiceLabel, DevServicesDatasourceContainerConfig containerConfig) {
+        if (containerConfig.isShared()) {
+            return ConfigureUtil.configureSharedServiceLabel(container, launchMode, devServiceLabel,
+                    containerConfig.getServiceName());
+        }
+        return container;
+    }
+}

--- a/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
+++ b/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
@@ -31,14 +31,20 @@ import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.deployment.util.ContainerRuntimeUtil;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.devservices.common.ContainerLocator;
 import io.quarkus.devservices.common.JBossLoggingConsumer;
 import io.quarkus.devservices.common.Labels;
+import io.quarkus.devservices.common.SharedDatasourceLocator;
 import io.quarkus.devservices.common.Volumes;
 import io.quarkus.runtime.LaunchMode;
 
 public class DB2DevServicesProcessor {
 
     private static final Logger LOG = Logger.getLogger(DB2DevServicesProcessor.class);
+
+    static final String DEV_SERVICE_LABEL = "quarkus-dev-service-db2";
+    private static final ContainerLocator containerLocator = ContainerLocator.locateContainerWithLabels(DB2_PORT,
+            DEV_SERVICE_LABEL);
 
     private static final DB2DatasourceServiceConfigurator configurator = new DB2DatasourceServiceConfigurator();
 
@@ -129,7 +135,15 @@ public class DB2DevServicesProcessor {
                     container.withLogConsumer(new JBossLoggingConsumer(LOG));
                 }
 
+                SharedDatasourceLocator.configureSharedLabel(container, launchMode, DEV_SERVICE_LABEL, containerConfig);
+
                 return container;
+            }
+
+            @Override
+            public Optional<DevServicesDatasourceProvider.RunningDevServicesDatasource> findRunningSharedDatasource(
+                    LaunchMode launchMode, DevServicesDatasourceContainerConfig containerConfig) {
+                return SharedDatasourceLocator.locate(containerLocator, launchMode, containerConfig, configurator);
             }
 
             @Override

--- a/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDevServicesProcessor.java
+++ b/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDevServicesProcessor.java
@@ -24,8 +24,10 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.DevServicesComposeProjectBuildItem;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.devservices.common.ContainerLocator;
 import io.quarkus.devservices.common.JBossLoggingConsumer;
 import io.quarkus.devservices.common.Labels;
+import io.quarkus.devservices.common.SharedDatasourceLocator;
 import io.quarkus.devservices.common.Volumes;
 import io.quarkus.runtime.LaunchMode;
 
@@ -35,6 +37,10 @@ public class MariaDBDevServicesProcessor {
 
     public static final Integer PORT = 3306;
     public static final String MY_CNF_CONFIG_OVERRIDE_PARAM_NAME = "TC_MY_CNF";
+
+    static final String DEV_SERVICE_LABEL = "quarkus-dev-service-mariadb";
+    private static final ContainerLocator containerLocator = ContainerLocator.locateContainerWithLabels(PORT,
+            DEV_SERVICE_LABEL);
 
     private static final MariaDBDatasourceServiceConfigurator configurator = new MariaDBDatasourceServiceConfigurator();
 
@@ -84,7 +90,15 @@ public class MariaDBDevServicesProcessor {
                     container.withLogConsumer(new JBossLoggingConsumer(LOG));
                 }
 
+                SharedDatasourceLocator.configureSharedLabel(container, launchMode, DEV_SERVICE_LABEL, containerConfig);
+
                 return container;
+            }
+
+            @Override
+            public Optional<DevServicesDatasourceProvider.RunningDevServicesDatasource> findRunningSharedDatasource(
+                    LaunchMode launchMode, DevServicesDatasourceContainerConfig containerConfig) {
+                return SharedDatasourceLocator.locate(containerLocator, launchMode, containerConfig, configurator);
             }
 
             @Override

--- a/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
+++ b/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
@@ -23,8 +23,10 @@ import io.quarkus.deployment.builditem.DevServicesComposeProjectBuildItem;
 import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.devservices.common.ContainerLocator;
 import io.quarkus.devservices.common.JBossLoggingConsumer;
 import io.quarkus.devservices.common.Labels;
+import io.quarkus.devservices.common.SharedDatasourceLocator;
 import io.quarkus.devservices.common.Volumes;
 import io.quarkus.runtime.LaunchMode;
 
@@ -36,6 +38,10 @@ public class MSSQLDevServicesProcessor {
      * Using SA doesn't work with all collations so let's use the lowercase version instead.
      */
     private static final String DEFAULT_USERNAME = "sa";
+
+    static final String DEV_SERVICE_LABEL = "quarkus-dev-service-mssql";
+    private static final ContainerLocator containerLocator = ContainerLocator.locateContainerWithLabels(MS_SQL_SERVER_PORT,
+            DEV_SERVICE_LABEL);
 
     private static final MSSQLDatasourceServiceConfigurator configurator = new MSSQLDatasourceServiceConfigurator();
 
@@ -79,7 +85,15 @@ public class MSSQLDevServicesProcessor {
                     container.withLogConsumer(new JBossLoggingConsumer(LOG));
                 }
 
+                SharedDatasourceLocator.configureSharedLabel(container, launchMode, DEV_SERVICE_LABEL, containerConfig);
+
                 return container;
+            }
+
+            @Override
+            public Optional<DevServicesDatasourceProvider.RunningDevServicesDatasource> findRunningSharedDatasource(
+                    LaunchMode launchMode, DevServicesDatasourceContainerConfig containerConfig) {
+                return SharedDatasourceLocator.locate(containerLocator, launchMode, containerConfig, configurator);
             }
 
             @Override

--- a/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/mysql/deployment/MySQLDevServicesProcessor.java
+++ b/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/mysql/deployment/MySQLDevServicesProcessor.java
@@ -25,8 +25,10 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.DevServicesComposeProjectBuildItem;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.devservices.common.ContainerLocator;
 import io.quarkus.devservices.common.JBossLoggingConsumer;
 import io.quarkus.devservices.common.Labels;
+import io.quarkus.devservices.common.SharedDatasourceLocator;
 import io.quarkus.devservices.common.Volumes;
 import io.quarkus.runtime.LaunchMode;
 
@@ -35,6 +37,10 @@ public class MySQLDevServicesProcessor {
     private static final Logger LOG = Logger.getLogger(MySQLDevServicesProcessor.class);
 
     public static final String MY_CNF_CONFIG_OVERRIDE_PARAM_NAME = "TC_MY_CNF";
+
+    static final String DEV_SERVICE_LABEL = "quarkus-dev-service-mysql";
+    private static final ContainerLocator containerLocator = ContainerLocator.locateContainerWithLabels(MYSQL_PORT,
+            DEV_SERVICE_LABEL);
 
     private static final MySQLDatasourceServiceConfigurator configurator = new MySQLDatasourceServiceConfigurator();
 
@@ -84,8 +90,16 @@ public class MySQLDevServicesProcessor {
                     container.withLogConsumer(new JBossLoggingConsumer(LOG));
                 }
 
+                SharedDatasourceLocator.configureSharedLabel(container, launchMode, DEV_SERVICE_LABEL, containerConfig);
+
                 return container;
 
+            }
+
+            @Override
+            public Optional<DevServicesDatasourceProvider.RunningDevServicesDatasource> findRunningSharedDatasource(
+                    LaunchMode launchMode, DevServicesDatasourceContainerConfig containerConfig) {
+                return SharedDatasourceLocator.locate(containerLocator, launchMode, containerConfig, configurator);
             }
 
             @Override

--- a/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
+++ b/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
@@ -25,8 +25,10 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.DevServicesComposeProjectBuildItem;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.devservices.common.ContainerLocator;
 import io.quarkus.devservices.common.JBossLoggingConsumer;
 import io.quarkus.devservices.common.Labels;
+import io.quarkus.devservices.common.SharedDatasourceLocator;
 import io.quarkus.devservices.common.Volumes;
 import io.quarkus.runtime.LaunchMode;
 
@@ -40,6 +42,10 @@ public class OracleDevServicesProcessor {
      */
     public static final String ORIGINAL_IMAGE_NAME = "gvenzl/oracle-xe";
     public static final int PORT = 1521;
+
+    static final String DEV_SERVICE_LABEL = "quarkus-dev-service-oracle";
+    private static final ContainerLocator containerLocator = ContainerLocator.locateContainerWithLabels(PORT,
+            DEV_SERVICE_LABEL);
 
     private static final OracleDatasourceServiceConfigurator configurator = new OracleDatasourceServiceConfigurator();
 
@@ -100,7 +106,15 @@ public class OracleDevServicesProcessor {
                     container.withLogConsumer(new JBossLoggingConsumer(LOG));
                 }
 
+                SharedDatasourceLocator.configureSharedLabel(container, launchMode, DEV_SERVICE_LABEL, containerConfig);
+
                 return container;
+            }
+
+            @Override
+            public Optional<DevServicesDatasourceProvider.RunningDevServicesDatasource> findRunningSharedDatasource(
+                    LaunchMode launchMode, DevServicesDatasourceContainerConfig containerConfig) {
+                return SharedDatasourceLocator.locate(containerLocator, launchMode, containerConfig, configurator);
             }
 
             @Override

--- a/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
+++ b/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
@@ -30,8 +30,10 @@ import io.quarkus.deployment.builditem.DevServicesComposeProjectBuildItem;
 import io.quarkus.deployment.builditem.DevServicesLauncherConfigResultBuildItem;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.devservices.common.ContainerLocator;
 import io.quarkus.devservices.common.JBossLoggingConsumer;
 import io.quarkus.devservices.common.Labels;
+import io.quarkus.devservices.common.SharedDatasourceLocator;
 import io.quarkus.devservices.common.Volumes;
 import io.quarkus.runtime.LaunchMode;
 import io.smallrye.common.cpu.CPU;
@@ -42,6 +44,10 @@ public class PostgresqlDevServicesProcessor {
 
     private static final String MAX_PREPARED_TRANSACTIONS = "max_prepared_transactions";
     private static final String DEFAULT_MAX_PREPARED_TRANSACTIONS = "--" + MAX_PREPARED_TRANSACTIONS + "=100";
+
+    static final String DEV_SERVICE_LABEL = "quarkus-dev-service-postgresql";
+    private static final ContainerLocator containerLocator = ContainerLocator.locateContainerWithLabels(POSTGRESQL_PORT,
+            DEV_SERVICE_LABEL);
 
     private static final PostgresDatasourceServiceConfigurator configurator = new PostgresDatasourceServiceConfigurator();
 
@@ -106,7 +112,15 @@ public class PostgresqlDevServicesProcessor {
                     container.withLogConsumer(new JBossLoggingConsumer(LOG));
                 }
 
+                SharedDatasourceLocator.configureSharedLabel(container, launchMode, DEV_SERVICE_LABEL, containerConfig);
+
                 return container;
+            }
+
+            @Override
+            public Optional<DevServicesDatasourceProvider.RunningDevServicesDatasource> findRunningSharedDatasource(
+                    LaunchMode launchMode, DevServicesDatasourceContainerConfig containerConfig) {
+                return SharedDatasourceLocator.locate(containerLocator, launchMode, containerConfig, configurator);
             }
 
             @Override


### PR DESCRIPTION
Fixes #26215

When running multiple Quarkus applications in dev mode on the same machine, each application currently starts its own database Dev Service container. Other Dev Services (Kafka, Redis, Keycloak, etc.) already support sharing a single container across applications via label-based discovery; datasource Dev Services did not.

This change adds `quarkus.datasource.<name>.devservices.shared` and `quarkus.datasource.<name>.devservices.service-name` configuration properties, aligned with the existing Dev Services sharing model. When sharing is enabled, the first application starts the database container with a database-specific Docker label; subsequent applications with matching configuration discover and reuse that container instead of starting a new one. Sharing applies only in dev mode.



Release note: Datasource Dev Services now support sharing a single database container across multiple Quarkus applications in dev mode via `quarkus.datasource.devservices.shared=true`.