### PR TITLE
[4.0] Align Vert.x options and Quarkus configuration for Vert.x and Vert.x HTTP

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/StaticResourcesConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/StaticResourcesConfig.java
@@ -53,4 +53,22 @@ public interface StaticResourcesConfig {
      */
     @WithDefault("UTF-8")
     Charset contentEncoding();
+
+    /**
+     * Set whether directory listing should be enabled.
+     * <p>
+     * When enabled, if a request is made to a path that maps to a directory,
+     * the server returns an HTML page listing the directory contents.
+     */
+    @WithDefault("false")
+    boolean directoryListing();
+
+    /**
+     * Set whether the {@code Vary} header should be sent in responses.
+     * <p>
+     * The {@code Vary} header indicates to caches that the response may vary
+     * based on the value of the specified request headers (e.g. {@code Accept-Encoding}).
+     */
+    @WithDefault("true")
+    boolean sendVaryHeader();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/StaticResourcesRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/StaticResourcesRecorder.java
@@ -57,7 +57,9 @@ public class StaticResourcesRecorder {
                         .setCachingEnabled(false)
                         .setIndexPage(config.indexPage())
                         .setIncludeHidden(config.includeHidden())
-                        .setEnableRangeSupport(config.enableRangeSupport());
+                        .setEnableRangeSupport(config.enableRangeSupport())
+                        .setDirectoryListing(config.directoryListing())
+                        .setSendVaryHeader(config.sendVaryHeader());
                 handlers.add(new Handler<>() {
                     @Override
                     public void handle(RoutingContext ctx) {
@@ -88,7 +90,9 @@ public class StaticResourcesRecorder {
                     .setEnableRangeSupport(config.enableRangeSupport())
                     .setMaxCacheSize(config.maxCacheSize())
                     .setCacheEntryTimeout(config.cacheEntryTimeout().toMillis())
-                    .setMaxAgeSeconds(config.maxAge().toSeconds());
+                    .setMaxAgeSeconds(config.maxAge().toSeconds())
+                    .setDirectoryListing(config.directoryListing())
+                    .setSendVaryHeader(config.sendVaryHeader());
             // normalize index page like StaticHandler because its not expose
             // TODO: create a converter to normalize filename in config.indexPage?
             final String indexPage = (config.indexPage().charAt(0) == '/')

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpConfig.java
@@ -300,10 +300,81 @@ public interface VertxHttpConfig {
     OptionalInt initialWindowSize();
 
     /**
+     * The timeout for the PROXY protocol handshake.
+     * When the PROXY protocol is enabled ({@code quarkus.http.proxy.use-proxy-protocol=true}),
+     * this configures how long the server waits for the PROXY protocol header before closing the connection.
+     */
+    @WithDefault("10s")
+    Duration proxyProtocolTimeout();
+
+    /**
+     * The maximum number of small HTTP/2 CONTINUATION frames allowed per request before the connection
+     * is closed. This protects against HTTP/2 CONTINUATION flood attacks.
+     * Setting zero or a negative value disables the protection.
+     */
+    OptionalInt http2MaxSmallContinuationFrames();
+
+    /**
+     * The initial buffer size for the HTTP/1.x decoder.
+     * <p>
+     * This is an advanced setting. The initial buffer size used by the HTTP/1.x decoder.
+     * A larger buffer can improve performance when processing large headers but increases memory usage.
+     */
+    @WithDefault("128")
+    int decoderInitialBufferSize();
+
+    /**
+     * Enable TCP keepalive.
+     * <p>
+     * This is an advanced setting. When enabled, the server sends TCP keepalive probes to detect dead connections.
+     */
+    @WithDefault("false")
+    boolean tcpKeepAlive();
+
+    /**
+     * Enable Netty-level wire logging for the HTTP server.
+     * <p>
+     * This is an advanced setting. When enabled, all bytes sent and received on the server are logged
+     * at DEBUG level using the Netty logging handler. This produces a large volume of logs.
+     */
+    @WithDefault("false")
+    boolean logActivity();
+
+    /**
+     * The format for Netty activity log data. Only used when {@code log-activity} is enabled.
+     * <p>
+     * This is an advanced setting.
+     */
+    @WithDefault("HEX_DUMP")
+    ActivityLogDataFormat activityLogDataFormat();
+
+    /**
+     * Enable address reuse on the server socket.
+     * <p>
+     * This is an advanced setting. When enabled, the {@code SO_REUSEADDR} option is set on the server socket.
+     */
+    @WithDefault("true")
+    boolean reuseAddress();
+
+    /**
+     * The value of the IP traffic class (TOS field) for outgoing packets.
+     * <p>
+     * This is an advanced setting. Valid values range from 0 to 255.
+     * A value of {@code -1} (the default) means the traffic class is not set.
+     */
+    @WithDefault("-1")
+    int trafficClass();
+
+    /**
      * Path to a unix domain socket
      */
     @WithDefault("/var/run/io.quarkus.app.socket")
     String domainSocket();
+
+    enum ActivityLogDataFormat {
+        HEX_DUMP,
+        SIMPLE
+    }
 
     /**
      * Enable listening to host:port

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementConfig.java
@@ -15,6 +15,7 @@ import io.quarkus.vertx.http.runtime.HeaderConfig;
 import io.quarkus.vertx.http.runtime.ProxyConfig;
 import io.quarkus.vertx.http.runtime.ServerLimitsConfig;
 import io.quarkus.vertx.http.runtime.ServerSslConfig;
+import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 import io.quarkus.vertx.http.runtime.WebsocketServerConfig;
 import io.quarkus.vertx.http.runtime.cors.CORSConfig;
 import io.smallrye.config.ConfigMapping;
@@ -209,6 +210,56 @@ public interface ManagementConfig {
      */
     @WithDefault("0")
     int compressionContentSizeThreshold();
+
+    /**
+     * The timeout for the PROXY protocol handshake.
+     * When the PROXY protocol is enabled ({@code quarkus.management.proxy.use-proxy-protocol=true}),
+     * this configures how long the server waits for the PROXY protocol header before closing the connection.
+     */
+    @WithDefault("10s")
+    Duration proxyProtocolTimeout();
+
+    /**
+     * Enable TCP keepalive.
+     * <p>
+     * This is an advanced setting. When enabled, the server sends TCP keepalive probes to detect dead connections.
+     */
+    @WithDefault("false")
+    boolean tcpKeepAlive();
+
+    /**
+     * Enable Netty-level wire logging for the management interface.
+     * <p>
+     * This is an advanced setting. When enabled, all bytes sent and received on the server are logged
+     * at DEBUG level using the Netty logging handler. This produces a large volume of logs.
+     */
+    @WithDefault("false")
+    boolean logActivity();
+
+    /**
+     * The format for Netty activity log data. Only used when {@code log-activity} is enabled.
+     * <p>
+     * This is an advanced setting.
+     */
+    @WithDefault("HEX_DUMP")
+    VertxHttpConfig.ActivityLogDataFormat activityLogDataFormat();
+
+    /**
+     * Enable address reuse on the server socket.
+     * <p>
+     * This is an advanced setting. When enabled, the {@code SO_REUSEADDR} option is set on the server socket.
+     */
+    @WithDefault("true")
+    boolean reuseAddress();
+
+    /**
+     * The value of the IP traffic class (TOS field) for outgoing packets.
+     * <p>
+     * This is an advanced setting. Valid values range from 0 to 255.
+     * A value of {@code -1} (the default) means the traffic class is not set.
+     */
+    @WithDefault("-1")
+    int trafficClass();
 
     default int determinePort(LaunchMode launchMode) {
         return launchMode == LaunchMode.TEST ? testPort() : port();

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtils.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtils.java
@@ -22,6 +22,7 @@ import io.netty.handler.codec.compression.BrotliOptions;
 import io.netty.handler.codec.compression.DeflateOptions;
 import io.netty.handler.codec.compression.GzipOptions;
 import io.netty.handler.codec.compression.StandardCompressionOptions;
+import io.netty.handler.logging.ByteBufFormat;
 import io.quarkus.credentials.CredentialsProvider;
 import io.quarkus.credentials.runtime.CredentialsProviderFinder;
 import io.quarkus.runtime.LaunchMode;
@@ -369,11 +370,28 @@ public class HttpServerOptionsUtils {
             if (httpConfig.http2ConnectionWindowSize().isPresent()) {
                 httpServerOptions.setHttp2ConnectionWindowSize(httpConfig.http2ConnectionWindowSize().getAsInt());
             }
+            if (httpConfig.http2MaxSmallContinuationFrames().isPresent()) {
+                httpServerOptions
+                        .setHttp2MaxSmallContinuationFrames(httpConfig.http2MaxSmallContinuationFrames().getAsInt());
+            }
         } else {
             httpServerOptions.setHttp2ClearTextEnabled(false);
         }
 
         httpServerOptions.setUseProxyProtocol(httpConfig.proxy().useProxyProtocol());
+        httpServerOptions.setProxyProtocolTimeout(httpConfig.proxyProtocolTimeout().toMillis());
+        httpServerOptions.setProxyProtocolTimeoutUnit(TimeUnit.MILLISECONDS);
+        httpServerOptions.setTcpKeepAlive(httpConfig.tcpKeepAlive());
+        httpServerOptions.setLogActivity(httpConfig.logActivity());
+        httpServerOptions.setActivityLogDataFormat(
+                httpConfig.activityLogDataFormat() == VertxHttpConfig.ActivityLogDataFormat.SIMPLE
+                        ? ByteBufFormat.SIMPLE
+                        : ByteBufFormat.HEX_DUMP);
+        httpServerOptions.setReuseAddress(httpConfig.reuseAddress());
+        if (httpConfig.trafficClass() >= 0) {
+            httpServerOptions.setTrafficClass(httpConfig.trafficClass());
+        }
+        httpServerOptions.setDecoderInitialBufferSize(httpConfig.decoderInitialBufferSize());
         configureTrafficShapingIfEnabled(httpServerOptions, httpConfig);
 
         // WebSocket options
@@ -440,6 +458,18 @@ public class HttpServerOptionsUtils {
         // options.setUseSemicolonAsQueryParamDelimiter(managementConfig.useSemicolonAsQueryParamDelimiter());
 
         options.setUseProxyProtocol(managementConfig.proxy().useProxyProtocol());
+        options.setProxyProtocolTimeout(managementConfig.proxyProtocolTimeout().toMillis());
+        options.setProxyProtocolTimeoutUnit(TimeUnit.MILLISECONDS);
+        options.setTcpKeepAlive(managementConfig.tcpKeepAlive());
+        options.setLogActivity(managementConfig.logActivity());
+        options.setActivityLogDataFormat(
+                managementConfig.activityLogDataFormat() == VertxHttpConfig.ActivityLogDataFormat.SIMPLE
+                        ? ByteBufFormat.SIMPLE
+                        : ByteBufFormat.HEX_DUMP);
+        options.setReuseAddress(managementConfig.reuseAddress());
+        if (managementConfig.trafficClass() >= 0) {
+            options.setTrafficClass(managementConfig.trafficClass());
+        }
 
         options.setTcpUserTimeout((int) managementConfig.tcpUserTimeout().toMillis());
         options.setSoLinger(managementConfig.soLinger());

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtilsTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtilsTest.java
@@ -367,6 +367,14 @@ class HttpServerOptionsUtilsTest {
         when(config.readIdleTimeout()).thenReturn(Duration.ZERO);
         when(config.writeIdleTimeout()).thenReturn(Duration.ZERO);
         when(config.compressionContentSizeThreshold()).thenReturn(0);
+        when(config.proxyProtocolTimeout()).thenReturn(Duration.ofSeconds(10));
+        when(config.http2MaxSmallContinuationFrames()).thenReturn(OptionalInt.empty());
+        when(config.decoderInitialBufferSize()).thenReturn(128);
+        when(config.tcpKeepAlive()).thenReturn(false);
+        when(config.logActivity()).thenReturn(false);
+        when(config.activityLogDataFormat()).thenReturn(VertxHttpConfig.ActivityLogDataFormat.HEX_DUMP);
+        when(config.reuseAddress()).thenReturn(true);
+        when(config.trafficClass()).thenReturn(-1);
 
         WebsocketServerConfig ws = mock(WebsocketServerConfig.class);
         when(ws.maxFrameSize()).thenReturn(Optional.empty());

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
@@ -495,12 +495,12 @@ public class VertxCoreRecorder {
     private static void setAddressResolverOptions(VertxConfiguration conf, VertxOptions options) {
         AddressResolverConfiguration ar = conf.resolver();
         AddressResolverOptions opts = new AddressResolverOptions();
-        opts.setCacheMaxTimeToLive(ar.cacheMaxTimeToLive());
-        opts.setCacheMinTimeToLive(ar.cacheMinTimeToLive());
-        opts.setCacheNegativeTimeToLive(ar.cacheNegativeTimeToLive());
+        opts.setCacheMaxTimeToLive((int) ar.cacheMaxTimeToLive().toSeconds());
+        opts.setCacheMinTimeToLive((int) ar.cacheMinTimeToLive().toSeconds());
+        opts.setCacheNegativeTimeToLive((int) ar.cacheNegativeTimeToLive().toSeconds());
         opts.setMaxQueries(ar.maxQueries());
         opts.setQueryTimeout(ar.queryTimeout().toMillis());
-        opts.setHostsRefreshPeriod(ar.hostRefreshPeriod());
+        opts.setHostsRefreshPeriod((int) ar.hostRefreshPeriod().toMillis());
         opts.setOptResourceEnabled(ar.optResourceEnabled());
         opts.setRdFlag(ar.rdFlag());
         opts.setNdots(ar.ndots());

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/config/AddressResolverConfiguration.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/config/AddressResolverConfiguration.java
@@ -11,24 +11,26 @@ import io.smallrye.config.WithDefault;
 public interface AddressResolverConfiguration {
 
     /**
-     * The maximum amount of time in seconds that a successfully resolved address will be cached.
+     * The maximum amount of time that a successfully resolved address will be cached.
      * <p>
      * If not set explicitly, resolved addresses may be cached forever.
+     * <p>
+     * The value must be a duration of at least 1 second.
      */
-    @WithDefault("2147483647")
-    int cacheMaxTimeToLive();
+    @WithDefault("2147483647S")
+    Duration cacheMaxTimeToLive();
 
     /**
-     * The minimum amount of time in seconds that a successfully resolved address will be cached.
+     * The minimum amount of time that a successfully resolved address will be cached.
      */
-    @WithDefault("0")
-    int cacheMinTimeToLive();
+    @WithDefault("0S")
+    Duration cacheMinTimeToLive();
 
     /**
-     * The amount of time in seconds that an unsuccessful attempt to resolve an address will be cached.
+     * The amount of time that an unsuccessful attempt to resolve an address will be cached.
      */
-    @WithDefault("0")
-    int cacheNegativeTimeToLive();
+    @WithDefault("0S")
+    Duration cacheNegativeTimeToLive();
 
     /**
      * The maximum number of queries to be sent during a resolution.
@@ -50,14 +52,16 @@ public interface AddressResolverConfiguration {
     Optional<String> hostsPath();
 
     /**
-     * Set the hosts configuration refresh period in millis, {@code 0} (default) disables it.
+     * The hosts configuration refresh period.
      * <p/>
      * The resolver caches the hosts configuration (configured using `quarkus.vertx.resolver.hosts-path` after it has read it.
      * When the content of this file can change, setting a positive refresh period will load the configuration
      * file again when necessary.
+     * <p/>
+     * A value of {@code 0} (the default) disables the refresh.
      */
     @WithDefault("0")
-    int hostRefreshPeriod();
+    Duration hostRefreshPeriod();
 
     /**
      * Set the list of DNS server addresses, an address is the IP of the dns server, followed by an optional

--- a/extensions/vertx/runtime/src/test/java/io/quarkus/vertx/core/runtime/VertxCoreProducerTest.java
+++ b/extensions/vertx/runtime/src/test/java/io/quarkus/vertx/core/runtime/VertxCoreProducerTest.java
@@ -57,18 +57,18 @@ public class VertxCoreProducerTest {
                     }
 
                     @Override
-                    public int cacheNegativeTimeToLive() {
-                        return 1;
+                    public Duration cacheNegativeTimeToLive() {
+                        return Duration.ofSeconds(1);
                     }
 
                     @Override
-                    public int cacheMinTimeToLive() {
-                        return 0;
+                    public Duration cacheMinTimeToLive() {
+                        return Duration.ofSeconds(0);
                     }
 
                     @Override
-                    public int cacheMaxTimeToLive() {
-                        return 3;
+                    public Duration cacheMaxTimeToLive() {
+                        return Duration.ofSeconds(3);
                     }
 
                     @Override
@@ -77,8 +77,8 @@ public class VertxCoreProducerTest {
                     }
 
                     @Override
-                    public int hostRefreshPeriod() {
-                        return 0;
+                    public Duration hostRefreshPeriod() {
+                        return Duration.ofMillis(0);
                     }
 
                     @Override
@@ -260,18 +260,18 @@ public class VertxCoreProducerTest {
                 }
 
                 @Override
-                public int cacheNegativeTimeToLive() {
-                    return 0;
+                public Duration cacheNegativeTimeToLive() {
+                    return Duration.ofSeconds(0);
                 }
 
                 @Override
-                public int cacheMinTimeToLive() {
-                    return 0;
+                public Duration cacheMinTimeToLive() {
+                    return Duration.ofSeconds(0);
                 }
 
                 @Override
-                public int cacheMaxTimeToLive() {
-                    return Integer.MAX_VALUE;
+                public Duration cacheMaxTimeToLive() {
+                    return Duration.ofSeconds(Integer.MAX_VALUE);
                 }
 
                 @Override
@@ -280,8 +280,8 @@ public class VertxCoreProducerTest {
                 }
 
                 @Override
-                public int hostRefreshPeriod() {
-                    return 0;
+                public Duration hostRefreshPeriod() {
+                    return Duration.ofMillis(0);
                 }
 
                 @Override


### PR DESCRIPTION
Align Vert.x Core and Vert.x HTTP configuration with the new options from Vert.x

Also:
 - extend our StaticHandler configuration
 - switch some our Quarkus configuration to Duration instead of "number of (milli)-seconds"

