### PR TITLE
Rename trusted proxy Subject DN property 

### DIFF
--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -645,13 +645,12 @@ When no configured DN matches, forwarded headers are ignored and the original co
 
 [source,properties]
 ----
-quarkus.http.proxy.trusted-proxy-dns[0]=CN=my-proxy <1> <2> <3>
-quarkus.http.proxy.trusted-proxy-dns[1]=CN=envoy-client,O=MyOrg <4>
+quarkus.http.proxy.trusted-proxy[0].subject-dn=CN=my-proxy <1> <2> <3>
+quarkus.http.proxy.trusted-proxy[1].subject-dn=CN=envoy-client,O=MyOrg
 ----
 <1> DNs must be in RFC 2253 format.
 <2> This option cannot be combined with `quarkus.http.proxy.trusted-proxies`.
 <3> TLS client authentication must be enabled via `quarkus.http.ssl.client-auth` set to `request` or `required`.
-<4> Use indexed format to avoid multi-component DNs being split on commas.
 
 NOTE: Configure enough DN components to uniquely identify your proxy. Using only `CN=my-proxy` will match any certificate with that CN, regardless of issuing organization.
 

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/AbstractTrustedProxyDnTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/AbstractTrustedProxyDnTest.java
@@ -44,8 +44,8 @@ abstract class AbstractTrustedProxyDnTest {
                 quarkus.http.proxy.enable-trusted-proxy-header=true
                 """.formatted(CERTS_DIR + CERT_NAME, PASSWORD, clientAuth));
         for (int i = 0; i < trustedProxyDns.length; i++) {
-            sb.append("quarkus.http.proxy.trusted-proxy-dns[").append(i).append("]=").append(trustedProxyDns[i])
-                    .append("\n");
+            sb.append("quarkus.http.proxy.trusted-proxy[").append(i).append("].subject-dn=")
+                    .append(trustedProxyDns[i]).append("\n");
         }
 
         return new QuarkusExtensionTest()

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedProxyDnAndIpValidationFailureTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedProxyDnAndIpValidationFailureTest.java
@@ -16,7 +16,7 @@ class TrustedProxyDnAndIpValidationFailureTest {
             quarkus.http.proxy.proxy-address-forwarding=true
             quarkus.http.proxy.allow-forwarded=true
             quarkus.http.proxy.trusted-proxies=localhost
-            quarkus.http.proxy.trusted-proxy-dns=CN=my-trusted-proxy
+            quarkus.http.proxy.trusted-proxy[0].subject-dn=CN=my-trusted-proxy
             """;
 
     @RegisterExtension
@@ -25,7 +25,7 @@ class TrustedProxyDnAndIpValidationFailureTest {
                     .addClasses(ForwardedHandlerInitializer.class)
                     .addAsResource(new StringAsset(configuration), "application.properties"))
             .assertException(t -> assertThat(t).hasMessageContaining("quarkus.http.proxy.trusted-proxies")
-                    .hasMessageContaining("quarkus.http.proxy.trusted-proxy-dns"));
+                    .hasMessageContaining("quarkus.http.proxy.trusted-proxy[*].subject-dn"));
 
     @Test
     void testStartupFails() {

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedProxyDnNoClientAuthValidationFailureTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedProxyDnNoClientAuthValidationFailureTest.java
@@ -15,7 +15,7 @@ class TrustedProxyDnNoClientAuthValidationFailureTest {
     private static final String configuration = """
             quarkus.http.proxy.proxy-address-forwarding=true
             quarkus.http.proxy.allow-forwarded=true
-            quarkus.http.proxy.trusted-proxy-dns=CN=my-trusted-proxy
+            quarkus.http.proxy.trusted-proxy[0].subject-dn=CN=my-trusted-proxy
             """;
 
     @RegisterExtension
@@ -23,7 +23,7 @@ class TrustedProxyDnNoClientAuthValidationFailureTest {
             .withApplicationRoot(jar -> jar
                     .addClasses(ForwardedHandlerInitializer.class)
                     .addAsResource(new StringAsset(configuration), "application.properties"))
-            .assertException(t -> assertThat(t).hasMessageContaining("quarkus.http.proxy.trusted-proxy-dns")
+            .assertException(t -> assertThat(t).hasMessageContaining("quarkus.http.proxy.trusted-proxy[*].subject-dn")
                     .hasMessageContaining("quarkus.http.ssl.client-auth"));
 
     @Test

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedProxyDnNoForwardedHeadersValidationFailureTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedProxyDnNoForwardedHeadersValidationFailureTest.java
@@ -17,7 +17,7 @@ class TrustedProxyDnNoForwardedHeadersValidationFailureTest {
             quarkus.http.proxy.proxy-address-forwarding=true
             quarkus.http.proxy.allow-forwarded=false
             quarkus.http.proxy.allow-x-forwarded=false
-            quarkus.http.proxy.trusted-proxy-dns[0]=CN=my-trusted-proxy
+            quarkus.http.proxy.trusted-proxy[0].subject-dn=CN=my-trusted-proxy
             """;
 
     @RegisterExtension
@@ -25,7 +25,7 @@ class TrustedProxyDnNoForwardedHeadersValidationFailureTest {
             .withApplicationRoot(jar -> jar
                     .addClasses(ForwardedHandlerInitializer.class)
                     .addAsResource(new StringAsset(configuration), "application.properties"))
-            .assertException(t -> assertThat(t).hasMessageContaining("quarkus.http.proxy.trusted-proxy-dns")
+            .assertException(t -> assertThat(t).hasMessageContaining("quarkus.http.proxy.trusted-proxy[*].subject-dn")
                     .hasMessageContaining("quarkus.http.proxy.allow-forwarded")
                     .hasMessageContaining("quarkus.http.proxy.allow-x-forwarded"));
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardingProxyOptions.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardingProxyOptions.java
@@ -82,25 +82,27 @@ public class ForwardingProxyOptions {
 
     private static List<List<Rdn>> collectAndValidateTrustedProxyDns(ProxyConfig proxyConfig, ClientAuth clientAuth,
             List<TrustedProxyCheckPart> parts, boolean allowXForwarded, boolean allowForwarded) {
-        final List<String> dnStrings = proxyConfig.trustedProxyDns().orElse(List.of());
+        final List<String> dnStrings = proxyConfig.trustedProxy().stream()
+                .map(ProxyConfig.TrustedProxyConfig::subjectDn)
+                .toList();
         if (dnStrings.isEmpty()) {
             return null;
         }
 
         if (!parts.isEmpty()) {
             throw new ConfigurationException(
-                    "'quarkus.http.proxy.trusted-proxies' and 'quarkus.http.proxy.trusted-proxy-dns' are mutually exclusive");
+                    "'quarkus.http.proxy.trusted-proxies' and 'quarkus.http.proxy.trusted-proxy[*].subject-dn' are mutually exclusive");
         }
 
         if (clientAuth == ClientAuth.NONE) {
             throw new ConfigurationException(
-                    "'quarkus.http.proxy.trusted-proxy-dns' requires 'quarkus.http.ssl.client-auth' to be set "
+                    "'quarkus.http.proxy.trusted-proxy[*].subject-dn' requires 'quarkus.http.ssl.client-auth' to be set "
                             + "to 'request' or 'required'");
         }
 
         if (!allowXForwarded && !allowForwarded) {
             throw new ConfigurationException(
-                    "'quarkus.http.proxy.trusted-proxy-dns' requires 'quarkus.http.proxy.allow-forwarded' "
+                    "'quarkus.http.proxy.trusted-proxy[*].subject-dn' requires 'quarkus.http.proxy.allow-forwarded' "
                             + "or 'quarkus.http.proxy.allow-x-forwarded' to be enabled");
         }
 
@@ -109,7 +111,7 @@ public class ForwardingProxyOptions {
                 var x500PrincipalName = new X500Principal(dn).getName(); // force DN validation
                 return List.copyOf(new LdapName(x500PrincipalName).getRdns());
             } catch (IllegalArgumentException | InvalidNameException e) {
-                throw new ConfigurationException("Invalid 'quarkus.http.proxy.trusted-proxy-dns' value '" + dn
+                throw new ConfigurationException("Invalid 'quarkus.http.proxy.trusted-proxy[*].subject-dn' value '" + dn
                         + "': not a valid RFC 2253 Distinguished Name", e);
             }
         }).toList();

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ProxyConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ProxyConfig.java
@@ -148,17 +148,28 @@ public interface ProxyConfig {
     Optional<List<@WithConverter(TrustedProxyCheckPartConverter.class) TrustedProxyCheckPart>> trustedProxies();
 
     /**
-     * Configure the list of trusted proxy Distinguished Names (DNs).
-     * The proxy is trusted when its TLS client certificate's Subject DN contains all
-     * the components specified in any single configured value. For example, configuring
-     * {@code CN=my-proxy,O=MyOrg} matches a certificate with Subject DN {@code CN=my-proxy,O=MyOrg,C=US}.
-     * <p>
-     * DNs must be in RFC 2253 format.
-     * Use the indexed property format to avoid multi-component DN values being split on commas:
-     * {@code quarkus.http.proxy.trusted-proxy-dns[0]=CN=envoy-client,O=MyOrg}.
+     * Identify trusted proxies by their TLS client certificate Subject DN.
+     * Each entry defines a trusted proxy whose forwarded headers are honored when the client certificate matches.
+     * Use the indexed property format to configure multiple trusted proxies:
+     * {@code quarkus.http.proxy.trusted-proxy[0].subject-dn=CN=my-proxy,O=MyOrg}.
      * <p>
      * This option is mutually exclusive with {@link #trustedProxies()} and requires
      * {@code quarkus.http.ssl.client-auth} to be set to {@code REQUEST} or {@code REQUIRED}.
      */
-    Optional<List<@WithConverter(TrimmedStringConverter.class) String>> trustedProxyDns();
+    List<TrustedProxyConfig> trustedProxy();
+
+    /**
+     * Trusted proxy configuration.
+     */
+    interface TrustedProxyConfig {
+
+        /**
+         * The trusted proxy's Subject Distinguished Name (DN) in RFC 2253 format.
+         * The proxy is trusted when its TLS client certificate's Subject DN contains all
+         * the components specified in this value. For example, configuring
+         * {@code CN=my-proxy,O=MyOrg} matches a certificate with Subject DN {@code CN=my-proxy,O=MyOrg,C=US}.
+         */
+        @WithConverter(TrimmedStringConverter.class)
+        String subjectDn();
+    }
 }


### PR DESCRIPTION
https://github.com/quarkusio/quarkus/pull/54517 will need to rename this configuration property. The property was only added in the 3.37 https://github.com/quarkusio/quarkus/pull/54054, hence if this is backported to 3.37 before the platform release, we avoid breaking changes in 3.38 if the other PR ever makes it.