### PR TITLE
Treat empty registry offering as unset

### DIFF
--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/config/RegistriesConfigLocator.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/config/RegistriesConfigLocator.java
@@ -67,7 +67,7 @@ public class RegistriesConfigLocator {
             if (config == null) { // empty file
                 config = new RegistriesConfigImpl.Builder();
             }
-            return config.setSource(new ConfigSource.FileConfigSource(configYaml)).build();
+            return validate(config.setSource(new ConfigSource.FileConfigSource(configYaml)).build());
         } catch (IOException e) {
             throw new IllegalStateException("Failed to parse config file " + configYaml, e);
         }
@@ -83,7 +83,7 @@ public class RegistriesConfigLocator {
         try {
             RegistriesConfigImpl.Builder instance = RegistriesConfigMapperHelper.deserializeYaml(configYaml,
                     RegistriesConfigImpl.Builder.class);
-            return instance == null ? null : instance.build();
+            return instance == null ? null : validate(instance.build());
         } catch (IOException e) {
             throw new IllegalStateException("Failed to parse config file " + configYaml, e);
         }
@@ -99,10 +99,23 @@ public class RegistriesConfigLocator {
         try {
             RegistriesConfigImpl.Builder instance = RegistriesConfigMapperHelper.deserializeYaml(configYaml,
                     RegistriesConfigImpl.Builder.class);
-            return instance == null ? null : instance.build();
+            return instance == null ? null : validate(instance.build());
         } catch (IOException e) {
             throw new IllegalStateException("Failed to parse config file " + configYaml, e);
         }
+    }
+
+    private static RegistriesConfig validate(RegistriesConfig config) {
+        for (RegistryConfig registry : config.getRegistries()) {
+            Object offering = registry.getExtra().get(Constants.OFFERING);
+            if (offering == null && registry.getExtra().containsKey(Constants.OFFERING)
+                    || offering instanceof String offeringValue && offeringValue.isBlank()) {
+                throw new IllegalStateException(
+                        "Registry '" + registry.getId() + "' config option '" + Constants.OFFERING
+                                + "' must not be empty");
+            }
+        }
+        return config;
     }
 
     /**

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/json/JsonBuilder.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/json/JsonBuilder.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -74,7 +75,7 @@ public interface JsonBuilder<T> {
         if (map == null || map.isEmpty()) {
             return Collections.emptyMap();
         }
-        return Map.copyOf(map);
+        return Collections.unmodifiableMap(new LinkedHashMap<>(map));
     }
 
     static <T> T buildIfBuilder(T o) {

--- a/independent-projects/tools/registry-client/src/test/java/io/quarkus/registry/config/RegistriesConfigLocatorTest.java
+++ b/independent-projects/tools/registry-client/src/test/java/io/quarkus/registry/config/RegistriesConfigLocatorTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.registry.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.StringReader;
 import java.io.StringWriter;
@@ -162,17 +163,17 @@ public class RegistriesConfigLocatorTest {
     }
 
     @Test
-    void testRegistryOfferingWithoutValueFromYaml() {
-        final RegistriesConfig config = RegistriesConfigLocator.load(new StringReader("""
+    void testRegistryOfferingWithoutValueFromYamlThrows() {
+        assertThatThrownBy(() -> RegistriesConfigLocator.load(new StringReader("""
                 ---
                 registries:
                 - registry.acme.org:
                     offering:
-                """));
-
-        assertThat(config.getRegistries())
-                .singleElement()
-                .satisfies(registry -> assertThat(registry.getExtra()).containsEntry(Constants.OFFERING, null));
+                """)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("registry.acme.org")
+                .hasMessageContaining(Constants.OFFERING)
+                .hasMessageContaining("must not be empty");
     }
 
     @Test

--- a/independent-projects/tools/registry-client/src/test/java/io/quarkus/registry/config/RegistriesConfigLocatorTest.java
+++ b/independent-projects/tools/registry-client/src/test/java/io/quarkus/registry/config/RegistriesConfigLocatorTest.java
@@ -162,6 +162,20 @@ public class RegistriesConfigLocatorTest {
     }
 
     @Test
+    void testRegistryOfferingWithoutValueFromYaml() {
+        final RegistriesConfig config = RegistriesConfigLocator.load(new StringReader("""
+                ---
+                registries:
+                - registry.acme.org:
+                    offering:
+                """));
+
+        assertThat(config.getRegistries())
+                .singleElement()
+                .satisfies(registry -> assertThat(registry.getExtra()).containsEntry(Constants.OFFERING, null));
+    }
+
+    @Test
     void testRecommendStreamsFrom() throws Exception {
         final Map<String, String> env = new HashMap<>();
         env.put(RegistriesConfigLocator.QUARKUS_REGISTRIES, "registry.acme.org,registry.other.io");


### PR DESCRIPTION
An empty YAML value such as `offering:` is deserialized as null. Treat a blank registry offering as an incomplete registry config and fail with a clear registry configuration error after deserialization instead of letting the config load continue ambiguously.

Tests:
- `./mvnw -pl independent-projects/tools/registry-client -Dtest=RegistriesConfigLocatorTest#testRegistryOfferingWithoutValueFromYamlThrows -DskipITs -DskipDocs test`
- `./mvnw -pl independent-projects/tools/registry-client -DskipITs -DskipDocs test`

Fixes #50480
