### PR TITLE
Use `HttpServerMetricsTagsContributor` when the connection is reset

### DIFF
--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/HttpServerMetricsTagsContributor.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/HttpServerMetricsTagsContributor.java
@@ -1,5 +1,7 @@
 package io.quarkus.micrometer.runtime;
 
+import java.util.Optional;
+
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.vertx.core.http.HttpServerRequest;
@@ -20,9 +22,18 @@ public interface HttpServerMetricsTagsContributor {
     Tags contribute(Context context);
 
     interface Context {
+
+        /**
+         * Represents the HTTP requests
+         */
         HttpServerRequest request();
 
-        HttpResponse response();
+        /**
+         * Represents the HTTP response, if one exists.
+         * This is {@link Optional} because {@link HttpServerMetricsTagsContributor#contribute(Context)} is called
+         * in both cases where the HTTP request has been completed and when the request was reset (so no respose exists)
+         */
+        Optional<HttpResponse> response();
 
         /**
          * Gives access to the contextual data that was added while the HTTP request was active.

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxHttpServerMetrics.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxHttpServerMetrics.java
@@ -3,6 +3,7 @@ package io.quarkus.micrometer.runtime.binder.vertx;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.LongAdder;
 
 import org.jboss.logging.Logger;
@@ -188,16 +189,37 @@ public class VertxHttpServerMetrics extends VertxTcpServerMetrics
         if (path != null) {
             Timer.Sample sample = requestMetric.getSample();
 
+            Tags originalTags = Tags.of(
+                    VertxMetricsTags.method(requestMetric.request().method()),
+                    HttpCommonTags.uri(path, requestMetric.getInitialPath(), 0, false),
+                    Outcome.CLIENT_ERROR.asTag(),
+                    HttpCommonTags.STATUS_RESET);
+            Tags effectiveTags = effectiveTags(requestMetric, Optional.empty(), originalTags);
+
             openTelemetryContextUnwrapper.executeInContext(
                     sample::stop,
-                    requestsTimer.withTags(Tags.of(
-                            VertxMetricsTags.method(requestMetric.request().method()),
-                            HttpCommonTags.uri(path, requestMetric.getInitialPath(), 0, false),
-                            Outcome.CLIENT_ERROR.asTag(),
-                            HttpCommonTags.STATUS_RESET)),
+                    requestsTimer.withTags(effectiveTags),
                     requestMetric.request().context());
         }
         requestMetric.requestEnded();
+    }
+
+    private Tags effectiveTags(HttpRequestMetric requestMetric, Optional<HttpResponse> httpResponse, Tags originalTags) {
+        if (!httpServerMetricsTagsContributors.isEmpty()) {
+            HttpServerMetricsTagsContributor.Context context = new DefaultContext(requestMetric.request(),
+                    httpResponse);
+            Tags allTags = originalTags;
+            for (int i = 0; i < httpServerMetricsTagsContributors.size(); i++) {
+                try {
+                    Tags additionalTags = httpServerMetricsTagsContributors.get(i).contribute(context);
+                    allTags = allTags.and(additionalTags);
+                } catch (Exception e) {
+                    log.debug("Unable to obtain additional tags", e);
+                }
+            }
+            return allTags;
+        }
+        return originalTags;
     }
 
     /**
@@ -216,27 +238,17 @@ public class VertxHttpServerMetrics extends VertxTcpServerMetrics
                 config.getServerIgnorePatterns());
         if (path != null) {
             Timer.Sample sample = requestMetric.getSample();
-            Tags allTags = Tags.of(
+            Tags originalTags = Tags.of(
                     VertxMetricsTags.method(requestMetric.request().method()),
                     HttpCommonTags.uri(path, requestMetric.getInitialPath(), response.statusCode(),
                             config.isServerSuppress4xxErrors()),
                     VertxMetricsTags.outcome(response),
                     HttpCommonTags.status(response.statusCode()));
-            if (!httpServerMetricsTagsContributors.isEmpty()) {
-                HttpServerMetricsTagsContributor.Context context = new DefaultContext(requestMetric.request(), response);
-                for (int i = 0; i < httpServerMetricsTagsContributors.size(); i++) {
-                    try {
-                        Tags additionalTags = httpServerMetricsTagsContributors.get(i).contribute(context);
-                        allTags = allTags.and(additionalTags);
-                    } catch (Exception e) {
-                        log.debug("Unable to obtain additional tags", e);
-                    }
-                }
-            }
+            Tags effectiveTags = effectiveTags(requestMetric, Optional.of(response), originalTags);
 
             openTelemetryContextUnwrapper.executeInContext(
                     sample::stop,
-                    requestsTimer.withTags(allTags),
+                    requestsTimer.withTags(effectiveTags),
                     requestMetric.request().context());
         }
         requestMetric.requestEnded();
@@ -277,7 +289,7 @@ public class VertxHttpServerMetrics extends VertxTcpServerMetrics
     }
 
     private record DefaultContext(HttpServerRequest request,
-            HttpResponse response) implements HttpServerMetricsTagsContributor.Context {
+            Optional<HttpResponse> response) implements HttpServerMetricsTagsContributor.Context {
         @Override
         public <T> T requestContextLocalData(Object key) {
             return ((HttpServerRequestInternal) request).context().getLocal(key);

--- a/integration-tests/micrometer-prometheus/src/main/java/io/quarkus/ResponseHeaderTag.java
+++ b/integration-tests/micrometer-prometheus/src/main/java/io/quarkus/ResponseHeaderTag.java
@@ -14,13 +14,12 @@ public class ResponseHeaderTag implements HttpServerMetricsTagsContributor {
     @Override
     public Tags contribute(Context context) {
         Optional<HttpResponse> response = context.response();
-        if (response.isEmpty()) {
-            return Tags.empty();
-        }
-        var headerValue = response.get().headers().get("foo-response");
         String value = "UNSET";
-        if ((headerValue != null) && !headerValue.isEmpty()) {
-            value = headerValue;
+        if (response.isPresent()) {
+            var headerValue = response.get().headers().get("foo-response");
+            if ((headerValue != null) && !headerValue.isEmpty()) {
+                value = headerValue;
+            }
         }
         return Tags.of("foo-response", value);
     }

--- a/integration-tests/micrometer-prometheus/src/main/java/io/quarkus/ResponseHeaderTag.java
+++ b/integration-tests/micrometer-prometheus/src/main/java/io/quarkus/ResponseHeaderTag.java
@@ -1,16 +1,23 @@
 package io.quarkus;
 
+import java.util.Optional;
+
 import jakarta.inject.Singleton;
 
 import io.micrometer.core.instrument.Tags;
 import io.quarkus.micrometer.runtime.HttpServerMetricsTagsContributor;
+import io.vertx.core.spi.observability.HttpResponse;
 
 @Singleton
 public class ResponseHeaderTag implements HttpServerMetricsTagsContributor {
 
     @Override
     public Tags contribute(Context context) {
-        var headerValue = context.response().headers().get("foo-response");
+        Optional<HttpResponse> response = context.response();
+        if (response.isEmpty()) {
+            return Tags.empty();
+        }
+        var headerValue = response.get().headers().get("foo-response");
         String value = "UNSET";
         if ((headerValue != null) && !headerValue.isEmpty()) {
             value = headerValue;

--- a/integration-tests/micrometer-prometheus/src/main/java/io/quarkus/it/micrometer/prometheus/SlowResource.java
+++ b/integration-tests/micrometer-prometheus/src/main/java/io/quarkus/it/micrometer/prometheus/SlowResource.java
@@ -1,0 +1,20 @@
+package io.quarkus.it.micrometer.prometheus;
+
+import java.time.Duration;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.smallrye.mutiny.Uni;
+
+@Path("/slow")
+public class SlowResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public Uni<String> slow() {
+        return Uni.createFrom().item("hello").onItem().delayIt().by(Duration.ofSeconds(10));
+    }
+}

--- a/integration-tests/micrometer-prometheus/src/test/java/io/quarkus/it/micrometer/prometheus/ConnectionResetTagsTest.java
+++ b/integration-tests/micrometer-prometheus/src/test/java/io/quarkus/it/micrometer/prometheus/ConnectionResetTagsTest.java
@@ -1,0 +1,54 @@
+package io.quarkus.it.micrometer.prometheus;
+
+import static io.restassured.RestAssured.get;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URL;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.client.WebClient;
+
+@QuarkusTest
+public class ConnectionResetTagsTest {
+
+    @Inject
+    Vertx vertx;
+
+    @TestHTTPResource
+    URL url;
+
+    @Test
+    void testConnectionResetIncludesAllContributorTags() throws Exception {
+        WebClient client = WebClient.create(vertx);
+
+        client.get(url.getPort(), url.getHost(), "/slow").send();
+
+        // wait a bit for the request to reach the server
+        Thread.sleep(500);
+
+        // close the client to trigger a connection reset
+        client.close();
+
+        // wait a bit for Vert.x to process the reset
+        Thread.sleep(500);
+
+        String metricMatch = "http_server_requests_seconds_count{dummy=\"value\"," +
+                "env=\"test\",env2=\"test\",foo=\"UNSET\",foo_response=\"UNSET\",method=\"GET\"," +
+                "outcome=\"CLIENT_ERROR\",registry=\"prometheus\",status=\"RESET\"," +
+                "uri=\"/slow\"}";
+
+        await().atMost(5, SECONDS).untilAsserted(() -> {
+            String body = get("/q/metrics").then().extract().asString();
+            assertTrue(body.contains(metricMatch),
+                    "Expected metric with all contributor tags not found. Looking for:\n" + metricMatch);
+        });
+    }
+}


### PR DESCRIPTION
Unfortunately, this is a breaking change
as we now need to account for the fact that
there might not be an HttpResponse.
In practice however, it's likely that the
breakage will be pretty minimal

- Fixes: #54870