### PR TITLE
[3.27] Upgrade Micrometer to 1.16.6

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -32,7 +32,7 @@
         <opentelemetry-instrumentation.version>2.10.0-alpha</opentelemetry-instrumentation.version>
         <opentelemetry-semconv.version>1.29.0-alpha</opentelemetry-semconv.version>
         <quarkus-http.version>5.5.0</quarkus-http.version>
-        <micrometer.version>1.14.7</micrometer.version><!-- keep in sync with hdrhistogram: https://central.sonatype.com/artifact/io.micrometer/micrometer-core -->
+        <micrometer.version>1.16.6</micrometer.version><!-- keep in sync with hdrhistogram: https://central.sonatype.com/artifact/io.micrometer/micrometer-core -->
         <hdrhistogram.version>2.2.2</hdrhistogram.version><!-- keep in sync with micrometer -->
         <google-auth.version>0.22.0</google-auth.version>
         <graphql-java.version>22.2</graphql-java.version> <!-- keep in sync with smallrye-graphql -->


### PR DESCRIPTION
Fixes the following CVEs:
https://spring.io/security/cve-2026-40983
https://spring.io/security/cve-2026-40984

This will include new features, especially from:
https://github.com/micrometer-metrics/micrometer/releases/tag/v1.15.0
https://github.com/micrometer-metrics/micrometer/releases/tag/v1.16.0

