### PR TITLE
Disable filtering for quarkus-devui-resources

### DIFF
--- a/extensions/devui/resources/pom.xml
+++ b/extensions/devui/resources/pom.xml
@@ -11,6 +11,15 @@
     <name>Quarkus - Dev UI - Resources</name>
     <description>Quarkus Dev UI Resources (Javascript, CSS and HTML)</description>
     
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+            </resource>
+        </resources>
+    </build>
+
     <dependencies>
         <!-- Vaadin Router -->
         <dependency>


### PR DESCRIPTION
We don't use filtering there and, if filtering is enabled, and a file is 1MB+, Scalpel doesn't analyze the file to check if the property is used and consider it is used.

This led to the following in https://github.com/quarkusio/quarkus/pull/54842 when updating unboundid-ldapsdk:

```
Scalpel: 1 changed files detected
Scalpel: 2 modules directly affected: [io.quarkus:quarkus-test-ldap, io.quarkus:quarkus-devui-resources]
Scalpel: Building 1335 of 1394 modules:
```