### PR TITLE
Upgrade Hibernate Reactive to 3.4.2.Final

### DIFF
--- a/integration-tests/hibernate-reactive-panache/src/main/java/io/quarkus/it/panache/reactive/TransactionalTestEndpoint.java
+++ b/integration-tests/hibernate-reactive-panache/src/main/java/io/quarkus/it/panache/reactive/TransactionalTestEndpoint.java
@@ -1,0 +1,60 @@
+package io.quarkus.it.panache.reactive;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.hibernate.reactive.mutiny.Mutiny;
+
+import io.quarkus.hibernate.reactive.panache.Panache;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Endpoint to verify that both {@code session.currentTransaction()} and
+ * {@code Panache.currentTransaction()} detect the externally-opened transaction
+ * inside a {@code @Transactional} method.
+ *
+ * @see <a href="https://github.com/hibernate/hibernate-reactive/issues/2852">HR #2852</a>
+ */
+@Path("test-transactional")
+public class TransactionalTestEndpoint {
+
+    @Inject
+    TransactionalService service;
+
+    @GET
+    @Path("current-transaction")
+    public Uni<String> testCurrentTransaction() {
+        return service.persistAndCheckTransaction();
+    }
+
+    @ApplicationScoped
+    public static class TransactionalService {
+
+        @Inject
+        Mutiny.Session session;
+
+        @Transactional
+        public Uni<String> persistAndCheckTransaction() {
+            Person p = new Person();
+            p.name = "currentTransaction";
+            return session.persist(p)
+                    .chain(session::flush)
+                    .chain(() -> Panache.currentTransaction())
+                    .map(panacheTx -> {
+                        Mutiny.Transaction sessionTx = session.currentTransaction();
+                        assertNotNull(sessionTx, "session.currentTransaction() should not be null");
+                        assertNotNull(panacheTx, "Panache.currentTransaction() should not be null");
+                        assertSame(sessionTx, panacheTx,
+                                "Panache.currentTransaction() and session.currentTransaction() should return the same transaction");
+                        return "OK";
+                    })
+                    .eventually(() -> session.remove(p));
+        }
+    }
+}

--- a/integration-tests/hibernate-reactive-panache/src/test/java/io/quarkus/it/panache/reactive/PanacheFunctionalityTest.java
+++ b/integration-tests/hibernate-reactive-panache/src/test/java/io/quarkus/it/panache/reactive/PanacheFunctionalityTest.java
@@ -312,6 +312,18 @@ public class PanacheFunctionalityTest {
         asserter.assertFailedWith(() -> Panache.withTransaction(() -> new Person().delete()), IllegalArgumentException.class);
     }
 
+    /**
+     * Verifies that both {@code session.currentTransaction()} and
+     * {@code Panache.currentTransaction()} return non-null inside a
+     * {@code @Transactional} method after a DB operation.
+     *
+     * @see <a href="https://github.com/hibernate/hibernate-reactive/issues/2852">HR #2852</a>
+     */
+    @Test
+    public void testCurrentTransactionWithJakartaTransactional() {
+        RestAssured.when().get("/test-transactional/current-transaction").then().body(is("OK"));
+    }
+
     @Test
     public void testBeerRepository() {
         RestAssured.when().get("/test-repo/beers").then().body(is("OK"));

--- a/integration-tests/hibernate-reactive-postgresql/src/main/java/io/quarkus/it/hibernate/reactive/postgresql/HibernateReactiveTransactionalTestEndpoint.java
+++ b/integration-tests/hibernate-reactive-postgresql/src/main/java/io/quarkus/it/hibernate/reactive/postgresql/HibernateReactiveTransactionalTestEndpoint.java
@@ -50,6 +50,18 @@ public class HibernateReactiveTransactionalTestEndpoint {
         return updatePigRollback(pigId, name);
     }
 
+    @POST
+    @Path("/currentTransaction/{id}")
+    @Transactional(Transactional.TxType.REQUIRED)
+    public Uni<String> currentTransaction(int id) {
+        return session.persist(new GuineaPig(id, "currentTransaction"))
+                .chain(session::flush)
+                .map(v -> {
+                    Mutiny.Transaction tx = session.currentTransaction();
+                    return tx != null ? "active" : "null";
+                });
+    }
+
     @Transactional(Transactional.TxType.REQUIRED)
     public Uni<GuineaPig> transactionalFind(int pigId) {
         return session.find(GuineaPig.class, pigId);

--- a/integration-tests/hibernate-reactive-postgresql/src/test/java/io/quarkus/it/hibernate/reactive/postgresql/HibernateReactiveTransactionalIntegrationTest.java
+++ b/integration-tests/hibernate-reactive-postgresql/src/test/java/io/quarkus/it/hibernate/reactive/postgresql/HibernateReactiveTransactionalIntegrationTest.java
@@ -22,6 +22,35 @@ import io.restassured.RestAssured;
 @TestHTTPEndpoint(HibernateReactiveTransactionalTestEndpoint.class)
 public class HibernateReactiveTransactionalIntegrationTest {
 
+    /**
+     * Verifies that {@code session.currentTransaction()} returns a non-null transaction
+     * when called inside a {@code @Transactional} method after a DB operation has been
+     * performed, and that the transaction commits the data successfully.
+     * <p>
+     * The DB operation (persist) is necessary because {@code TransactionalContextPool}
+     * opens the transaction lazily when the connection is first used.
+     *
+     * @see <a href="https://github.com/hibernate/hibernate-reactive/issues/2852">HR #2852</a>
+     */
+    @Test
+    public void testCurrentTransactionInTransactionalMethod() {
+        // Persist a pig inside @Transactional and check currentTransaction()
+        RestAssured.given().when()
+                .auth().preemptive().basic("scott", "jb0ss")
+                .post("/currentTransaction/50")
+                .then()
+                .statusCode(200)
+                .body(equalTo("active"));
+
+        // Verify the pig was actually committed by the external transaction
+        RestAssured.given().when()
+                .auth().preemptive().basic("scott", "jb0ss")
+                .get("/findPig/50")
+                .then()
+                .body("id", equalTo(50))
+                .body("name", equalTo("currentTransaction"));
+    }
+
     @Test
     public void testTransactionalUpdate() {
         RestAssured.given().when()

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <bytebuddy.version>1.18.8</bytebuddy.version> <!-- version controlled by Hibernate ORM's needs; checked by maven-enforcer-plugin in bom -->
         <geolatte.version>1.11</geolatte.version> <!-- version controlled by Hibernate ORM's needs; checked by maven-enforcer-plugin in bom -->
         <hibernate-models.version>1.1.1</hibernate-models.version> <!-- version controlled by Hibernate ORM's needs; checked by maven-enforcer-plugin in bom -->
-        <hibernate-reactive.version>3.4.1.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
+        <hibernate-reactive.version>3.4.2.Final</hibernate-reactive.version> <!-- highly sensitive to Hibernate ORM upgrades -->
         <hibernate-validator.version>9.1.0.Final</hibernate-validator.version>
         <hibernate-search.version>8.4.0.Final</hibernate-search.version>
 


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
and the AI/LLM usage policy at https://github.com/quarkusio/quarkus/blob/main/AI_POLICY.md
-->

This upgrade contains a fix for #54537.

Upgrades to Hibernate Reactive 3.4.2.Final that contains the [external transactions detection when calling session.currentTransaction](https://github.com/hibernate/hibernate-reactive/issues/2852)

@lucamolteni, I still need to flush the operations, but I think you fixed this already in your other PR, right?

/cc @lucamolteni, @FroMage 

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

