### PR TITLE
Work around for HHH90001002 log filter being ignored in integration tests

### DIFF
--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/config/packages/ConfigEntityPUAssigmentUsingOnlyPanacheEntityBaseTest.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/config/packages/ConfigEntityPUAssigmentUsingOnlyPanacheEntityBaseTest.java
@@ -32,7 +32,10 @@ public class ConfigEntityPUAssigmentUsingOnlyPanacheEntityBaseTest {
             // In a real-world scenario, this would be used only if there are multiple PUs,
             // but this is simpler and enough to reproduce the issue.
             .overrideConfigKey("quarkus.hibernate-orm.packages", EntityExtendingOnlyPanacheEntityBase.class.getPackageName())
-            .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue())
+            .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue()
+                    // Ignore logs about JCache region factory being closed "twice": the log filter is apparently ignored,
+                    // see https://github.com/quarkusio/quarkus/issues/48346
+                    && !record.getMessage().contains("HHH90001002"))
             // We don't expect any warning, in particular not:
             // "Could not find a suitable persistence unit for model classes:"
             .assertLogRecords(records -> assertThat(records).extracting(LOG_FORMATTER::format).isEmpty());

--- a/integration-tests/jpa/src/test/java/io/quarkus/it/jpa/proxy/ProxyTest.java
+++ b/integration-tests/jpa/src/test/java/io/quarkus/it/jpa/proxy/ProxyTest.java
@@ -19,7 +19,9 @@ import io.restassured.RestAssured;
         // Ignore logs about schema management:
         // they are unfortunate (https://github.com/quarkusio/quarkus/issues/16204)
         // but for now we have to live with them.
-        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*")
+        // Ignore logs about JCache region factory being closed "twice", too: the log filter is apparently ignored,
+        // see https://github.com/quarkusio/quarkus/issues/48346
+        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*,org\\.hibernate\\.orm\\.cache.*")
 })
 public class ProxyTest {
 


### PR DESCRIPTION
Note this should not be necessary because there is a log filter there: https://github.com/quarkusio/quarkus/blob/97bc0a3f2a3287f10087d8b4912b36712de505ff/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateLogFilterBuildStep.java#L48-L50

But we need to work around #48346 