### PR TITLE
Fix filtering of log capture in @QuarkusTests

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
@@ -95,10 +95,42 @@ public class LoggingSetupRecorder {
     }
 
     public static void handleFailedStart(RuntimeValue<Optional<Supplier<String>>> banner) {
+        SmallRyeConfig loggingConfig = buildLoggingConfig();
+        LogBuildTimeConfig logBuildTimeConfig = loggingConfig.getConfigMapping(LogBuildTimeConfig.class);
+        LogRuntimeConfig logRuntimeConfig = loggingConfig.getConfigMapping(LogRuntimeConfig.class);
+        ConsoleRuntimeConfig consoleRuntimeConfig = loggingConfig.getConfigMapping(ConsoleRuntimeConfig.class);
+        new LoggingSetupRecorder(logBuildTimeConfig, new RuntimeValue<>(logRuntimeConfig),
+                new RuntimeValue<>(consoleRuntimeConfig)).initializeLogging(
+                        DiscoveredLogComponents.ofEmpty(), emptyMap(), false, null, emptyList(), emptyList(), emptyList(),
+                        emptyList(),
+                        emptyList(), emptyList(), emptyList(), banner, LaunchMode.DEVELOPMENT, false);
+    }
+
+    /**
+     * Sets up basic logging early in the test lifecycle, before Quarkus starts.
+     * <p>
+     * Unlike {@link #handleFailedStart}, this method uses
+     * {@link #initializeBuildTimeLogging} which installs handlers via
+     * {@code setBuildTimeHandlers()}. This ensures the {@code QuarkusDelayedHandler}
+     * returns to queuing mode after {@code buildTimeComplete()} is called,
+     * so that messages logged before the runtime logging setup can be buffered
+     * and later drained through properly configured handlers (including
+     * {@code LogCleanupFilter}).
+     */
+    public static void initializeEarlyLogging() {
+        SmallRyeConfig loggingConfig = buildLoggingConfig();
+        initializeBuildTimeLogging(
+                loggingConfig.getConfigMapping(LogRuntimeConfig.class),
+                loggingConfig.getConfigMapping(LogBuildTimeConfig.class),
+                loggingConfig.getConfigMapping(ConsoleRuntimeConfig.class),
+                emptyMap(), emptyList(), LaunchMode.DEVELOPMENT);
+    }
+
+    private static SmallRyeConfig buildLoggingConfig() {
         SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
         // There may be cases where a Config with the mappings is already available, but we can't be sure, so we wrap
         // the original Config and map the logging classes.
-        SmallRyeConfig loggingConfig = new SmallRyeConfigBuilder()
+        return new SmallRyeConfigBuilder()
                 .withCustomizers(new QuarkusConfigBuilderCustomizer())
                 .withMapping(LogBuildTimeConfig.class)
                 .withMapping(LogRuntimeConfig.class)
@@ -121,14 +153,6 @@ public class LoggingSetupRecorder {
                         return "Logging Config";
                     }
                 }).build();
-        LogBuildTimeConfig logBuildTimeConfig = loggingConfig.getConfigMapping(LogBuildTimeConfig.class);
-        LogRuntimeConfig logRuntimeConfig = loggingConfig.getConfigMapping(LogRuntimeConfig.class);
-        ConsoleRuntimeConfig consoleRuntimeConfig = loggingConfig.getConfigMapping(ConsoleRuntimeConfig.class);
-        new LoggingSetupRecorder(logBuildTimeConfig, new RuntimeValue<>(logRuntimeConfig),
-                new RuntimeValue<>(consoleRuntimeConfig)).initializeLogging(
-                        DiscoveredLogComponents.ofEmpty(), emptyMap(), false, null, emptyList(), emptyList(), emptyList(),
-                        emptyList(),
-                        emptyList(), emptyList(), emptyList(), banner, LaunchMode.DEVELOPMENT, false);
     }
 
     public ShutdownListener initializeLogging(

--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/config/packages/ConfigEntityPUAssigmentUsingOnlyPanacheEntityBaseTest.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/config/packages/ConfigEntityPUAssigmentUsingOnlyPanacheEntityBaseTest.java
@@ -32,10 +32,7 @@ public class ConfigEntityPUAssigmentUsingOnlyPanacheEntityBaseTest {
             // In a real-world scenario, this would be used only if there are multiple PUs,
             // but this is simpler and enough to reproduce the issue.
             .overrideConfigKey("quarkus.hibernate-orm.packages", EntityExtendingOnlyPanacheEntityBase.class.getPackageName())
-            .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue()
-                    // Ignore logs about JCache region factory being closed "twice": the log filter is apparently ignored,
-                    // see https://github.com/quarkusio/quarkus/issues/48346
-                    && !record.getMessage().contains("HHH90001002"))
+            .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue())
             // We don't expect any warning, in particular not:
             // "Could not find a suitable persistence unit for model classes:"
             .assertLogRecords(records -> assertThat(records).extracting(LOG_FORMATTER::format).isEmpty());

--- a/integration-tests/jpa/src/test/java/io/quarkus/it/jpa/proxy/ProxyTest.java
+++ b/integration-tests/jpa/src/test/java/io/quarkus/it/jpa/proxy/ProxyTest.java
@@ -19,9 +19,7 @@ import io.restassured.RestAssured;
         // Ignore logs about schema management:
         // they are unfortunate (https://github.com/quarkusio/quarkus/issues/16204)
         // but for now we have to live with them.
-        // Ignore logs about JCache region factory being closed "twice", too: the log filter is apparently ignored,
-        // see https://github.com/quarkusio/quarkus/issues/48346
-        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*,org\\.hibernate\\.orm\\.cache.*")
+        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*")
 })
 public class ProxyTest {
 

--- a/test-framework/junit-config/src/main/java/io/quarkus/test/config/LoggingSetupExtension.java
+++ b/test-framework/junit-config/src/main/java/io/quarkus/test/config/LoggingSetupExtension.java
@@ -12,6 +12,6 @@ import io.quarkus.runtime.logging.LoggingSetupRecorder;
  */
 public class LoggingSetupExtension implements Extension {
     public LoggingSetupExtension() {
-        LoggingSetupRecorder.handleFailedStart();
+        LoggingSetupRecorder.initializeEarlyLogging();
     }
 }

--- a/test-framework/junit-internal/src/main/java/io/quarkus/test/InMemoryLogHandler.java
+++ b/test-framework/junit-internal/src/main/java/io/quarkus/test/InMemoryLogHandler.java
@@ -3,6 +3,7 @@ package io.quarkus.test;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Predicate;
+import java.util.logging.Filter;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
@@ -22,8 +23,20 @@ public class InMemoryLogHandler extends ExtHandler {
 
     @Override
     public void publish(LogRecord record) {
-        if (predicate.test(record)) {
+        if (isLoggable(record) && predicate.test(record)) {
             records.add(record);
+        }
+    }
+
+    /**
+     * Retroactively filters already-captured records when a new filter is installed,
+     * so that records captured before the filter was set are also filtered.
+     */
+    @Override
+    public void setFilter(Filter newFilter) throws SecurityException {
+        super.setFilter(newFilter);
+        if (newFilter != null) {
+            records.removeIf(record -> !newFilter.isLoggable(record));
         }
     }
 


### PR DESCRIPTION
Filtering wasn't exactly working properly, which could lead to issues when doing some assumptions about the log records.

Handle this a bit better to try to prevent the issue as much as possible.

The concurrency in InMemoryLogHandler#setFilter might not be strong enough but I think it should work fine.

@yrodiere this approach seems to fix the issue. It's not exactly pretty but I haven't found a better way that doesn't require to completely change the way things are done (which might be a good thing for the future though).