### PR TITLE
Add nightly scheduled CI workflow to run reproducibility tests

### DIFF
--- a/.github/list-deployment-modules.sh
+++ b/.github/list-deployment-modules.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Purpose: Prints a comma-separated list of the core and extension deployment modules,
+#          suitable for passing to Maven's -pl/--projects option.
+# Note: This script is only for CI and does therefore not aim to be compatible with BSD/macOS.
+
+set -e -u -o pipefail
+shopt -s failglob
+
+# An extension can be disabled by commenting out its <module> in extensions/pom.xml
+# (e.g. smallrye-reactive-messaging-mqtt). Such a module is still tracked on disk, so
+# git ls-files would list it, but it is not part of Maven's reactor and passing it to
+# -pl fails the build. Collect the commented-out extensions and skip them.
+disabled=$(grep -oE '<!--[[:space:]]*<module>[^<]+</module>[[:space:]]*-->' extensions/pom.xml \
+           | sed -E 's|.*<module>([^<]+)</module>.*|extensions/\1/|')
+
+# Note: git's ** matches one or more path segments, never zero,
+# so core/deployment/pom.xml has to be listed explicitly.
+deployment_modules=()
+while IFS= read -r pom; do
+  module="${pom%/pom.xml}"
+  skip=
+  for d in $disabled; do
+    [[ "$module" == "$d"* ]] && { skip=1; break; }
+  done
+  if [[ -n "$skip" ]]; then
+    printf 'Skipping disabled module: %s\n' "$module" >&2
+  else
+    deployment_modules+=("$module")
+  fi
+done < <(git ls-files 'core/deployment/pom.xml' 'core/**/deployment/pom.xml' 'extensions/**/deployment/pom.xml')
+
+if (( ${#deployment_modules[@]} == 0 )); then
+  echo "No deployment module found, this is not expected." >&2
+  exit 1
+fi
+
+printf 'Found %d deployment modules:\n' "${#deployment_modules[@]}" >&2
+printf '%s\n' "${deployment_modules[@]}" >&2
+
+(IFS=,; printf '%s' "${deployment_modules[*]}")

--- a/.github/workflows/reproducibility-check.yml
+++ b/.github/workflows/reproducibility-check.yml
@@ -1,0 +1,121 @@
+name: Quarkus Reproducibility Check
+
+permissions:
+  contents: read
+  packages: read
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}"
+  cancel-in-progress: ${{ github.repository != 'quarkusio/quarkus' }}
+
+env:
+  LANG: en_US.UTF-8
+  MAVEN_OPTS: -Xmx3g -XX:MaxMetaspaceSize=1g
+  COMMON_MAVEN_ARGS: "-e -B --settings .github/mvn-settings.xml --fail-at-end"
+  QUICK_INSTALL_MAVEN_ARGS: "-Dscalpel.enabled=false -DskipTests -DskipITs -DskipDocs -Dinvoker.skip -Dskip.gradle.tests -Djbang.skip -Dtruststore.skip -Dno-format -Dno-build-cache -Dno-test-modules -Prelocations"
+  COMMON_TEST_MAVEN_ARGS: "-Dformat.skip -Denforcer.skip -DskipDocs -Dforbiddenapis.skip -DskipExtensionValidation -DskipCodestartValidation"
+  REPRODUCIBILITY_MAVEN_ARGS: "-Dno-build-cache -Dquarkus-internal.test.reproducibility-check=5"
+
+jobs:
+  reproducibility-check:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    if: github.repository == 'quarkusio/quarkus' || github.event_name == 'workflow_dispatch'
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - id: jvm
+            name: "Deployment JVM Reproducibility Check"
+            artifact-name: jvm-reproducibility
+          - id: resteasy-reactive-tck
+            name: "RESTEasy Reactive TCK Reproducibility Check"
+            artifact-name: resteasy-reactive-tck-reproducibility
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: 21
+      - name: Reclaim Disk Space
+        run: .github/ci-prerequisites.sh
+      - name: Print disk usage before build
+        run: .github/ci-disk-usage.sh
+      - name: Gradle Enterprise environment
+        run: |
+          echo "GE_TAGS=jdk-21,reproducibility-check" >> "$GITHUB_ENV"
+          echo "GE_CUSTOM_VALUES=gh-job-name=${{ matrix.name }}" >> "$GITHUB_ENV"
+      - name: Setup Develocity Build Scan capture
+        uses: gradle/develocity-actions/setup-maven@0e1f30c14ab56d0c1ecf229a0ffc3eb3e40e4642 # v2.2
+        with:
+          capture-strategy: ON_DEMAND
+          job-name: ${{ matrix.name }}
+          add-pr-comment: false
+          add-job-summary: false
+          develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          develocity-token-expiry: 6
+      - name: Build Quarkus
+        run: ./mvnw $COMMON_MAVEN_ARGS $QUICK_INSTALL_MAVEN_ARGS -pl '!docs' clean install
+      - name: Run deployment JVM reproducibility check
+        if: matrix.id == 'jvm'
+        env:
+          CAPTURE_BUILD_SCAN: true
+        run: |
+          deployment_module_list=$(.github/list-deployment-modules.sh)
+          ./mvnw $COMMON_MAVEN_ARGS $COMMON_TEST_MAVEN_ARGS $REPRODUCIBILITY_MAVEN_ARGS -pl "$deployment_module_list" -Dsurefire.timeout=1200 -Dquarkus.test.hang-detection-timeout=300 clean test
+      - name: Run RESTEasy Reactive TCK reproducibility check
+        if: matrix.id == 'resteasy-reactive-tck'
+        env:
+          CAPTURE_BUILD_SCAN: true
+        run: ./mvnw $COMMON_MAVEN_ARGS $COMMON_TEST_MAVEN_ARGS $REPRODUCIBILITY_MAVEN_ARGS -Dresteasy-reactive-testsuite.mvn.args="$REPRODUCIBILITY_MAVEN_ARGS" -Dtcks -pl tcks/resteasy-reactive -amd clean test
+      - name: Print disk usage after build
+        if: always()
+        run: .github/ci-disk-usage.sh
+      - name: Prepare failure archive
+        if: failure()
+        run: find . -name '*-reports' -type d -o -name '*.log' | tar -czf test-reports.tgz -T -
+      - name: Upload failure archive
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-reports-${{ matrix.artifact-name }}
+          path: test-reports.tgz
+          retention-days: 7
+      - name: Prepare build reports archive
+        if: always()
+        run: |
+          7z a -tzip build-reports.zip -r \
+              '**/target/*-reports/TEST-*.xml' \
+              '**/target/*-reports-*/TEST-*.xml' \
+              'target/build-report.json' \
+              'target/gradle-build-scan-url.txt' \
+              LICENSE
+      - name: Upload build reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: build-reports-${{ github.run_attempt }}-${{ matrix.name }}
+          path: build-reports.zip
+          retention-days: 7
+      - name: Upload reproducibility debug dumps
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: debug-${{ github.run_attempt }}-${{ matrix.name }}
+          path: '**/target/debug/**'
+          if-no-files-found: ignore
+          retention-days: 28
+      - name: Upload build.log
+        if: failure() || cancelled()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: build-logs-${{ matrix.name }}
+          path: '**/build.log'
+          retention-days: 7


### PR DESCRIPTION
The trigger is scheduled for 3AM UTC.

Workflow run triggered by the scheduler adds `-Dquarkus-internal.test.reproducibility-check=5` to `COMMON_TEST_MAVEN_ARGS` and updates this environment variable for every job using it. Additionally, same property/value are passed to RESTEasy Reactive TCK via `-Dresteasy-reactive-testsuite.mvn.args` property.