### PR TITLE
Fix wrong subresource parameter type lookup in `JaxrsClientReactiveProcessor`

### DIFF
--- a/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
@@ -1809,7 +1809,7 @@ public class JaxrsClientReactiveProcessor {
                             // just store the index of parameter used to create the body, we'll use it later
                             bodyParameterValue = paramValue;
                         } else if (param.parameterType == ParameterType.HEADER) {
-                            Type paramType = jandexSubMethod.parameterType(subParamField.paramIndex);
+                            Type paramType = subParamField.type;
                             Type effectiveParamType = paramType;
                             boolean isOptional = isOptional(paramType, index);
                             if (isOptional) {
@@ -3146,7 +3146,7 @@ public class JaxrsClientReactiveProcessor {
         BranchResult isParamNull = methodCreator.ifNull(queryParamHandle);
         BytecodeCreator notNullParam = isParamNull.falseBranch();
         if (isMap(type, index)) {
-            var resolvesTypes = resolveMapTypes(type, index, jandexMethod);
+            var resolvesTypes = resolveMapTypes(type, jandexMethod);
             var keyType = resolvesTypes.getKey();
             if (!ResteasyReactiveDotNames.STRING.equals(keyType.name())) {
                 throw new IllegalArgumentException(
@@ -3287,7 +3287,7 @@ public class JaxrsClientReactiveProcessor {
         return result;
     }
 
-    private Map.Entry<Type, Type> resolveMapTypes(Type type, IndexView index, MethodInfo jandexMethod) {
+    private Map.Entry<Type, Type> resolveMapTypes(Type type, MethodInfo jandexMethod) {
         if (type.name().equals(ResteasyReactiveDotNames.MAP)) {
             if (type.kind() != PARAMETERIZED_TYPE) {
                 throw new IllegalArgumentException(
@@ -3354,7 +3354,7 @@ public class JaxrsClientReactiveProcessor {
         BytecodeCreator notNullValue = invoBuilderEnricher.ifNull(headerValueHandle).falseBranch();
 
         if (isMap(paramType, index)) {
-            Map.Entry<Type, Type> resolvesTypes = resolveMapTypes(paramType, index, jandexMethod);
+            Map.Entry<Type, Type> resolvesTypes = resolveMapTypes(paramType, jandexMethod);
             Type keyType = resolvesTypes.getKey();
             if (!ResteasyReactiveDotNames.STRING.equals(keyType.name())) {
                 throw new IllegalArgumentException(
@@ -3480,7 +3480,7 @@ public class JaxrsClientReactiveProcessor {
                 creator.invokeInterfaceMethod(MULTIVALUED_MAP_ADD_ALL, formParams,
                         creator.load(paramName), convertedParamArray);
             } else if (isMap(parameterType, index)) {
-                var resolvesTypes = resolveMapTypes(parameterType, index, jandexMethod);
+                var resolvesTypes = resolveMapTypes(parameterType, jandexMethod);
                 var keyType = resolvesTypes.getKey();
                 if (!ResteasyReactiveDotNames.STRING.equals(keyType.name())) {
                     throw new IllegalArgumentException(

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/SubResourceLocatorTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/SubResourceLocatorTest.java
@@ -9,6 +9,7 @@ import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriBuilder;
 
+import org.jboss.resteasy.reactive.client.impl.WebTargetImpl;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Assertions;
@@ -62,6 +63,7 @@ public class SubResourceLocatorTest {
     @DisplayName("Test 657")
     public void test657() {
         Client client = ClientBuilder.newClient();
+        Assertions.assertNotNull(((WebTargetImpl) client.target(uri)).proxy(SubResourceLocatorPlatformServiceResource.class));
         WebTarget base = client.target(UriBuilder.fromUri(uri).path("/platform/users/89080/data/ada/jsanchez110"));
         Response response = base.request().get();
         String s = response.readEntity(String.class);


### PR DESCRIPTION
When generating a REST client subresource method, inherited parameters from the parent locator method were stored in `subParamFields` with their original parameter index and type.

For header parameters, we later used that parent parameter index to look up the type on the current subresource method's `MethodInfo`. That was wrong because the index belongs to the parent locator method, not to the subresource method.

Depending on the subresource method, this could either use the wrong type or lead to "Array index out of range" error being thrown when running `io.quarkus.resteasy.reactive.server.test.resource.basic.SubResourceLocatorTest`.

The test did not fail because `JaxrsClientReactiveProcessor` doesn't explode on exceptions (some of which could be legitimate unsupported cases) but rather records them in the `failures` map.

We now use `subParamField.type` instead.