### PR TITLE
Allow the use of `@Cancellable` on `ContainerResponseFilter`

### DIFF
--- a/docs/src/main/asciidoc/rest.adoc
+++ b/docs/src/main/asciidoc/rest.adoc
@@ -1005,6 +1005,11 @@ when the client isn't going to use the response anyway.
 If instead of cancelling the pipeline, it should be completed regardless of the state of the HTTP connection, Quarkus REST provides the `org.jboss.resteasy.reactive.server.Cancellable` annotation
 which can be applied to REST classes or methods to control the cancellation behavior.
 
+NOTE: When a client drops the connection, `ContainerResponseFilter` implementations are normally skipped.
+If you need a `ContainerResponseFilter` to run even when the connection is closed, annotate the filter class with `@Cancellable(false)`.
+Only filters explicitly marked as non-cancellable will run; other response filters are still skipped.
+For declarative response filters, use `@ServerResponseFilter(cancellable = false)` to achieve the same effect.
+
 === Streaming support
 
 If you want to stream your response element by element, you can make your endpoint method return a

--- a/extensions/resteasy-reactive/rest-common/deployment/src/main/java/io/quarkus/resteasy/reactive/common/deployment/ResteasyReactiveCommonProcessor.java
+++ b/extensions/resteasy-reactive/rest-common/deployment/src/main/java/io/quarkus/resteasy/reactive/common/deployment/ResteasyReactiveCommonProcessor.java
@@ -221,11 +221,12 @@ public class ResteasyReactiveCommonProcessor {
             if (filterSourceMethod != null) {
                 interceptor.metadata = Map.of(FILTER_SOURCE_METHOD_METADATA_KEY, filterSourceMethod);
             }
-        } else if (filterItem instanceof ContainerResponseFilterBuildItem) {
-            MethodInfo filterSourceMethod = ((ContainerResponseFilterBuildItem) filterItem).getFilterSourceMethod();
+        } else if (filterItem instanceof ContainerResponseFilterBuildItem crfbi) {
+            MethodInfo filterSourceMethod = crfbi.getFilterSourceMethod();
             if (filterSourceMethod != null) {
                 interceptor.metadata = Map.of(FILTER_SOURCE_METHOD_METADATA_KEY, filterSourceMethod);
             }
+            interceptor.setCancellable(crfbi.isCancellable());
         }
         if (interceptors instanceof PreMatchInterceptorContainer
                 && ((ContainerRequestFilterBuildItem) filterItem).isPreMatching()) {

--- a/extensions/resteasy-reactive/rest-common/spi-deployment/src/main/java/io/quarkus/resteasy/reactive/spi/ContainerResponseFilterBuildItem.java
+++ b/extensions/resteasy-reactive/rest-common/spi-deployment/src/main/java/io/quarkus/resteasy/reactive/spi/ContainerResponseFilterBuildItem.java
@@ -5,19 +5,26 @@ import org.jboss.jandex.MethodInfo;
 public final class ContainerResponseFilterBuildItem extends AbstractInterceptorBuildItem {
 
     private final MethodInfo filterSourceMethod;
+    private final boolean cancellable;
 
     protected ContainerResponseFilterBuildItem(ContainerResponseFilterBuildItem.Builder builder) {
         super(builder);
         this.filterSourceMethod = builder.filterSourceMethod;
+        this.cancellable = builder.cancellable;
     }
 
     public MethodInfo getFilterSourceMethod() {
         return filterSourceMethod;
     }
 
+    public boolean isCancellable() {
+        return cancellable;
+    }
+
     public static final class Builder extends AbstractInterceptorBuildItem.Builder<ContainerResponseFilterBuildItem, Builder> {
 
         private MethodInfo filterSourceMethod = null;
+        private boolean cancellable = true;
 
         public Builder(String className) {
             super(className);
@@ -25,6 +32,11 @@ public final class ContainerResponseFilterBuildItem extends AbstractInterceptorB
 
         public Builder setFilterSourceMethod(MethodInfo filterSourceMethod) {
             this.filterSourceMethod = filterSourceMethod;
+            return this;
+        }
+
+        public Builder setCancellable(boolean cancellable) {
+            this.cancellable = cancellable;
             return this;
         }
 

--- a/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveScanningProcessor.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveScanningProcessor.java
@@ -35,6 +35,7 @@ import org.jboss.resteasy.reactive.common.model.ResourceParamConverterProvider;
 import org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames;
 import org.jboss.resteasy.reactive.common.processor.scanning.ApplicationScanningResult;
 import org.jboss.resteasy.reactive.common.processor.scanning.ResteasyReactiveInterceptorScanner;
+import org.jboss.resteasy.reactive.server.Cancellable;
 import org.jboss.resteasy.reactive.server.ExceptionUnwrapStrategy;
 import org.jboss.resteasy.reactive.server.UnwrapException;
 import org.jboss.resteasy.reactive.server.core.ExceptionMapping;
@@ -91,6 +92,7 @@ public class ResteasyReactiveScanningProcessor {
     private static final DotName RUNTIME_EXCEPTION = DotName.createSimple(RuntimeException.class);
 
     public static final Set<DotName> CONDITIONAL_BEAN_ANNOTATIONS;
+    private static final DotName CANCELLABLE = DotName.createSimple(Cancellable.class);
 
     static {
         CONDITIONAL_BEAN_ANNOTATIONS = new HashSet<>(BuildTimeEnabledProcessor.BUILD_TIME_ENABLED_BEAN_ANNOTATIONS);
@@ -120,7 +122,16 @@ public class ResteasyReactiveScanningProcessor {
             public void accept(ResourceInterceptors interceptors) {
                 ResteasyReactiveInterceptorScanner.scanForContainerRequestFilters(interceptors,
                         combinedIndexBuildItem.getIndex(),
-                        applicationResultBuildItem.getResult());
+                        applicationResultBuildItem.getResult(),
+                        (filterClass, interceptor) -> {
+                            AnnotationInstance cancellableAnnotation = filterClass.declaredAnnotation(CANCELLABLE);
+                            if (cancellableAnnotation != null) {
+                                AnnotationValue value = cancellableAnnotation.value();
+                                if (value != null) {
+                                    interceptor.setCancellable(value.asBoolean());
+                                }
+                            }
+                        });
             }
         });
     }
@@ -458,6 +469,7 @@ public class ResteasyReactiveScanningProcessor {
                         generated.getGeneratedClassName())
                         .setRegisterAsBean(false)// it has already been made a bean
                         .setPriority(generated.getPriority())
+                        .setCancellable(generated.isCancellable())
                         .setFilterSourceMethod(generated.getFilterSourceMethod());
                 if (!generated.getNameBindingNames().isEmpty()) {
                     builder.setNameBindingNames(generated.getNameBindingNames());

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/CancellableBlockingResponseFilterTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/CancellableBlockingResponseFilterTest.java
@@ -1,0 +1,180 @@
+package io.quarkus.resteasy.reactive.server.test;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.net.URL;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.reactive.RestQuery;
+import org.jboss.resteasy.reactive.server.Cancellable;
+import org.jboss.resteasy.reactive.server.ServerResponseFilter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.smallrye.common.annotation.Blocking;
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.client.WebClient;
+
+public class CancellableBlockingResponseFilterTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar.addClasses(Resource.class,
+                    NonCancellableResponseFilter.class, OtherResponseFilter.class, Filters.class));
+
+    @BeforeEach
+    void setUp() {
+        Resource.COUNT.set(0);
+        NonCancellableResponseFilter.COUNT.set(0);
+        OtherResponseFilter.COUNT.set(0);
+        Filters.NON_CANCELLABLE_COUNT.set(0);
+    }
+
+    @Inject
+    Vertx vertx;
+
+    @TestHTTPResource
+    URL url;
+
+    @Test
+    public void testFilterRunsOnConnectionClose() {
+        WebClient client = WebClient.create(vertx);
+
+        client.get(url.getPort(), url.getHost(), "/test/hello").send();
+
+        try {
+            // make sure we did make the proper request
+            await().atMost(Duration.ofSeconds(2)).untilAtomic(Resource.COUNT, equalTo(1));
+
+            // this will effectively close the connection
+            client.close();
+
+            // make sure we wait until the request could have completed
+            Thread.sleep(7_000);
+
+            // the blocking method completed
+            assertEquals(2, Resource.COUNT.get());
+
+            // the non-cancellable filters should have run
+            assertEquals(1, NonCancellableResponseFilter.COUNT.get());
+            assertEquals(1, Filters.NON_CANCELLABLE_COUNT.get());
+
+            // the cancellable filter should NOT run when the connection is closed
+            assertEquals(0, OtherResponseFilter.COUNT.get());
+        } catch (InterruptedException ignored) {
+
+        } finally {
+            try {
+                client.close();
+            } catch (Exception ignored) {
+
+            }
+        }
+    }
+
+    @Test
+    public void testFilterRunsNormally() {
+        WebClient client = WebClient.create(vertx);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        client.get(url.getPort(), url.getHost(), "/test/hello?sleep=0").send()
+                .onComplete(ar -> {
+                    latch.countDown();
+                });
+
+        try {
+            latch.await(10, java.util.concurrent.TimeUnit.SECONDS);
+
+            // all filters run on a normal request
+            assertEquals(1, NonCancellableResponseFilter.COUNT.get());
+            assertEquals(1, OtherResponseFilter.COUNT.get());
+            assertEquals(1, Filters.NON_CANCELLABLE_COUNT.get());
+            assertEquals(2, Resource.COUNT.get());
+        } catch (InterruptedException ignored) {
+
+        } finally {
+            try {
+                client.close();
+            } catch (Exception ignored) {
+
+            }
+        }
+    }
+
+    @Path("test")
+    public static class Resource {
+
+        public static final AtomicInteger COUNT = new AtomicInteger(0);
+
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        @Path("hello")
+        @Blocking
+        public String hello(@RestQuery @DefaultValue("5000") Integer sleep) {
+            COUNT.incrementAndGet();
+            if ((sleep != null) && (sleep > 0)) {
+                try {
+                    Thread.sleep(sleep);
+                } catch (InterruptedException ignored) {
+
+                }
+            }
+            COUNT.incrementAndGet();
+            return "Hello, world";
+        }
+    }
+
+    @Provider
+    @Cancellable(false)
+    public static class NonCancellableResponseFilter implements ContainerResponseFilter {
+
+        public static final AtomicInteger COUNT = new AtomicInteger(0);
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+                throws IOException {
+            COUNT.incrementAndGet();
+        }
+    }
+
+    @Provider
+    public static class OtherResponseFilter implements ContainerResponseFilter {
+
+        public static final AtomicInteger COUNT = new AtomicInteger(0);
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+                throws IOException {
+            COUNT.incrementAndGet();
+        }
+    }
+
+    public static class Filters {
+
+        public static final AtomicInteger NON_CANCELLABLE_COUNT = new AtomicInteger(0);
+
+        @ServerResponseFilter(cancellable = false)
+        public void nonCancellableFilter(ContainerResponseContext responseContext) {
+            NON_CANCELLABLE_COUNT.incrementAndGet();
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/CancellableCompletionStageTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/CancellableCompletionStageTest.java
@@ -3,11 +3,15 @@ package io.quarkus.resteasy.reactive.server.test;
 import static io.restassured.RestAssured.when;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URL;
 import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
@@ -15,18 +19,16 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
-import org.jboss.resteasy.reactive.server.Cancellable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusExtensionTest;
 import io.quarkus.test.common.http.TestHTTPResource;
-import io.smallrye.mutiny.Uni;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.client.WebClient;
 
-public class CancelableUniTest {
+public class CancellableCompletionStageTest {
 
     @RegisterExtension
     static QuarkusExtensionTest runner = new QuarkusExtensionTest()
@@ -45,35 +47,17 @@ public class CancelableUniTest {
 
     @Test
     public void testNormal() {
-        doTestNormal("1");
-    }
-
-    @Test
-    public void testDefaultCancellable() {
-        doTestCancel("1", Resource.COUNT, 1);
-    }
-
-    @Test
-    public void testUnCancellable() {
-        doTestCancel("2", Resource.COUNT, 2);
-    }
-
-    @Test
-    public void testCancellable() {
-        doTestCancel("3", Resource.COUNT, 1);
-    }
-
-    private void doTestNormal(String path) {
-        when().get("test/" + path)
+        when().get("test")
                 .then()
                 .statusCode(200)
                 .body(equalTo("Hello, world"));
     }
 
-    private void doTestCancel(String path, AtomicInteger count, int expected) {
+    @Test
+    public void testCancel() {
         WebClient client = WebClient.create(vertx);
 
-        client.get(url.getPort(), url.getHost(), "/test/" + path).send();
+        client.get(url.getPort(), url.getHost(), "/test").send();
 
         try {
             // make sure we did make the proper request
@@ -86,7 +70,7 @@ public class CancelableUniTest {
             Thread.sleep(7_000);
 
             // if the count did not increase, it means that Uni was cancelled
-            assertEquals(expected, count.get());
+            assertEquals(1, Resource.COUNT.get());
         } catch (InterruptedException ignored) {
 
         } finally {
@@ -96,6 +80,7 @@ public class CancelableUniTest {
 
             }
         }
+
     }
 
     @Path("test")
@@ -105,31 +90,17 @@ public class CancelableUniTest {
 
         @GET
         @Produces(MediaType.TEXT_PLAIN)
-        @Path("1")
-        public Uni<String> defaultCancelableHello() {
+        public CompletionStage<String> hello() {
             COUNT.incrementAndGet();
-            return Uni.createFrom().item("Hello, world").onItem().delayIt().by(Duration.ofSeconds(5)).onItem().invoke(
-                    COUNT::incrementAndGet);
-        }
-
-        @GET
-        @Produces(MediaType.TEXT_PLAIN)
-        @Cancellable(false)
-        @Path("2")
-        public Uni<String> uncancellableHello() {
-            COUNT.incrementAndGet();
-            return Uni.createFrom().item("Hello, world").onItem().delayIt().by(Duration.ofSeconds(5)).onItem().invoke(
-                    COUNT::incrementAndGet);
-        }
-
-        @GET
-        @Produces(MediaType.TEXT_PLAIN)
-        @Cancellable
-        @Path("3")
-        public Uni<String> cancellableHello() {
-            COUNT.incrementAndGet();
-            return Uni.createFrom().item("Hello, world").onItem().delayIt().by(Duration.ofSeconds(5)).onItem().invoke(
-                    COUNT::incrementAndGet);
+            return CompletableFuture.supplyAsync(
+                    new Supplier<>() {
+                        @Override
+                        public String get() {
+                            COUNT.incrementAndGet();
+                            return "Hello, world";
+                        }
+                    },
+                    CompletableFuture.delayedExecutor(5, TimeUnit.SECONDS));
         }
     }
 }

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/CancellableResponseFilterTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/CancellableResponseFilterTest.java
@@ -1,0 +1,152 @@
+package io.quarkus.resteasy.reactive.server.test;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.net.URL;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.reactive.server.Cancellable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.client.WebClient;
+
+public class CancellableResponseFilterTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar.addClasses(Resource.class,
+                    NonCancellableResponseFilter.class, OtherResponseFilter.class));
+
+    @BeforeEach
+    void setUp() {
+        Resource.COUNT.set(0);
+        NonCancellableResponseFilter.COUNT.set(0);
+        OtherResponseFilter.COUNT.set(0);
+    }
+
+    @Inject
+    Vertx vertx;
+
+    @TestHTTPResource
+    URL url;
+
+    @Test
+    public void testFilterRunsOnConnectionClose() {
+        WebClient client = WebClient.create(vertx);
+
+        client.get(url.getPort(), url.getHost(), "/test/slow").send();
+
+        try {
+            // make sure we did make the proper request
+            await().atMost(Duration.ofSeconds(2)).untilAtomic(Resource.COUNT, equalTo(1));
+
+            // this will effectively close the connection
+            client.close();
+
+            // make sure we wait until the request could have completed
+            Thread.sleep(7_000);
+
+            // the Uni was not cancelled because @Cancellable(false) is on the method,
+            // so the count should have been incremented again by the Uni completion
+            assertEquals(2, Resource.COUNT.get());
+
+            // the non-cancellable filter should have run
+            assertEquals(1, NonCancellableResponseFilter.COUNT.get());
+
+            // the cancellable filter should NOT run when the connection is closed
+            assertEquals(0, OtherResponseFilter.COUNT.get());
+        } catch (InterruptedException ignored) {
+
+        } finally {
+            try {
+                client.close();
+            } catch (Exception ignored) {
+
+            }
+        }
+    }
+
+    @Test
+    public void testFilterRunsNormally() {
+        WebClient client = WebClient.create(vertx);
+
+        client.get(url.getPort(), url.getHost(), "/test/slow").send()
+                .onComplete(ar -> {
+                });
+
+        try {
+            // both filters run on a normal request
+            await().atMost(Duration.ofSeconds(10)).untilAtomic(NonCancellableResponseFilter.COUNT, equalTo(1));
+            await().atMost(Duration.ofSeconds(10)).untilAtomic(OtherResponseFilter.COUNT, equalTo(1));
+            assertEquals(2, Resource.COUNT.get());
+        } finally {
+            try {
+                client.close();
+            } catch (Exception ignored) {
+
+            }
+        }
+    }
+
+    @Path("test")
+    public static class Resource {
+
+        public static final AtomicInteger COUNT = new AtomicInteger(0);
+
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        @Path("slow")
+        @Cancellable(false)
+        public Uni<String> slowHello() {
+            COUNT.incrementAndGet();
+            return Uni.createFrom().item("Hello, world")
+                    .onItem().delayIt().by(Duration.ofSeconds(5))
+                    .onItem().invoke(() -> COUNT.incrementAndGet());
+        }
+    }
+
+    @Provider
+    @Cancellable(false)
+    public static class NonCancellableResponseFilter implements ContainerResponseFilter {
+
+        public static final AtomicInteger COUNT = new AtomicInteger(0);
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+                throws IOException {
+            COUNT.incrementAndGet();
+        }
+    }
+
+    @Provider
+    public static class OtherResponseFilter implements ContainerResponseFilter {
+
+        public static final AtomicInteger COUNT = new AtomicInteger(0);
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+                throws IOException {
+            COUNT.incrementAndGet();
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/CancellableUniTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/CancellableUniTest.java
@@ -3,15 +3,11 @@ package io.quarkus.resteasy.reactive.server.test;
 import static io.restassured.RestAssured.when;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.net.URL;
 import java.time.Duration;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Supplier;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
@@ -19,16 +15,18 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
+import org.jboss.resteasy.reactive.server.Cancellable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusExtensionTest;
 import io.quarkus.test.common.http.TestHTTPResource;
+import io.smallrye.mutiny.Uni;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.client.WebClient;
 
-public class CancelableCompletionStageTest {
+public class CancellableUniTest {
 
     @RegisterExtension
     static QuarkusExtensionTest runner = new QuarkusExtensionTest()
@@ -47,17 +45,35 @@ public class CancelableCompletionStageTest {
 
     @Test
     public void testNormal() {
-        when().get("test")
+        doTestNormal("1");
+    }
+
+    @Test
+    public void testDefaultCancellable() {
+        doTestCancel("1", Resource.COUNT, 1);
+    }
+
+    @Test
+    public void testUnCancellable() {
+        doTestCancel("2", Resource.COUNT, 2);
+    }
+
+    @Test
+    public void testCancellable() {
+        doTestCancel("3", Resource.COUNT, 1);
+    }
+
+    private void doTestNormal(String path) {
+        when().get("test/" + path)
                 .then()
                 .statusCode(200)
                 .body(equalTo("Hello, world"));
     }
 
-    @Test
-    public void testCancel() {
+    private void doTestCancel(String path, AtomicInteger count, int expected) {
         WebClient client = WebClient.create(vertx);
 
-        client.get(url.getPort(), url.getHost(), "/test").send();
+        client.get(url.getPort(), url.getHost(), "/test/" + path).send();
 
         try {
             // make sure we did make the proper request
@@ -70,7 +86,7 @@ public class CancelableCompletionStageTest {
             Thread.sleep(7_000);
 
             // if the count did not increase, it means that Uni was cancelled
-            assertEquals(1, Resource.COUNT.get());
+            assertEquals(expected, count.get());
         } catch (InterruptedException ignored) {
 
         } finally {
@@ -80,7 +96,6 @@ public class CancelableCompletionStageTest {
 
             }
         }
-
     }
 
     @Path("test")
@@ -90,17 +105,31 @@ public class CancelableCompletionStageTest {
 
         @GET
         @Produces(MediaType.TEXT_PLAIN)
-        public CompletionStage<String> hello() {
+        @Path("1")
+        public Uni<String> defaultCancelableHello() {
             COUNT.incrementAndGet();
-            return CompletableFuture.supplyAsync(
-                    new Supplier<>() {
-                        @Override
-                        public String get() {
-                            COUNT.incrementAndGet();
-                            return "Hello, world";
-                        }
-                    },
-                    CompletableFuture.delayedExecutor(5, TimeUnit.SECONDS));
+            return Uni.createFrom().item("Hello, world").onItem().delayIt().by(Duration.ofSeconds(5)).onItem().invoke(
+                    COUNT::incrementAndGet);
+        }
+
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        @Cancellable(false)
+        @Path("2")
+        public Uni<String> uncancellableHello() {
+            COUNT.incrementAndGet();
+            return Uni.createFrom().item("Hello, world").onItem().delayIt().by(Duration.ofSeconds(5)).onItem().invoke(
+                    COUNT::incrementAndGet);
+        }
+
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        @Cancellable
+        @Path("3")
+        public Uni<String> cancellableHello() {
+            COUNT.incrementAndGet();
+            return Uni.createFrom().item("Hello, world").onItem().delayIt().by(Duration.ofSeconds(5)).onItem().invoke(
+                    COUNT::incrementAndGet);
         }
     }
 }

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/scanning/ResteasyReactiveInterceptorScanner.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/scanning/ResteasyReactiveInterceptorScanner.java
@@ -9,6 +9,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 import jakarta.ws.rs.RuntimeType;
@@ -60,6 +61,12 @@ public class ResteasyReactiveInterceptorScanner {
 
     public static void scanForContainerRequestFilters(ResourceInterceptors interceptors, IndexView index,
             ApplicationScanningResult applicationScanningResult) {
+        scanForContainerRequestFilters(interceptors, index, applicationScanningResult, null);
+    }
+
+    public static void scanForContainerRequestFilters(ResourceInterceptors interceptors, IndexView index,
+            ApplicationScanningResult applicationScanningResult,
+            BiConsumer<ClassInfo, ResourceInterceptor<ContainerResponseFilter>> responseFilterConsumer) {
         //the quarkus version of these filters will not be in the index
         //so you need an explicit check for both
 
@@ -90,6 +97,9 @@ public class ResteasyReactiveInterceptorScanner {
                 continue;
             }
             setFilterMethodSourceForRespFilter(index, specRespFilters, filterClass, interceptor);
+            if (responseFilterConsumer != null) {
+                responseFilterConsumer.accept(filterClass, interceptor);
+            }
         }
     }
 

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ResourceInterceptor.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ResourceInterceptor.java
@@ -18,6 +18,7 @@ public class ResourceInterceptor<T>
     private int priority = Priorities.USER; // default priority as defined by spec
     private boolean nonBlockingRequired; // whether or not @NonBlocking was specified on the class
     private boolean withFormRead; // whether or not '@WithFormRead' was set on this filter
+    private boolean cancellable = true;
 
     /**
      * The class names of the {@code @NameBinding} annotations that the method is annotated with.
@@ -85,6 +86,14 @@ public class ResourceInterceptor<T>
 
     public void setWithFormRead(boolean withFormRead) {
         this.withFormRead = withFormRead;
+    }
+
+    public boolean isCancellable() {
+        return cancellable;
+    }
+
+    public void setCancellable(boolean cancellable) {
+        this.cancellable = cancellable;
     }
 
     public RuntimeType getRuntimeType() {

--- a/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/generation/filters/FilterGeneration.java
+++ b/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/generation/filters/FilterGeneration.java
@@ -106,6 +106,11 @@ public class FilterGeneration {
             if (priorityValue != null) {
                 priority = priorityValue.asInt();
             }
+            boolean cancellable = true;
+            AnnotationValue cancellableValue = instance.value("cancellable");
+            if (cancellableValue != null) {
+                cancellable = cancellableValue.asBoolean();
+            }
             List<AnnotationInstance> annotations = methodInfo.annotations();
             for (AnnotationInstance annotation : annotations) {
                 if (SERVER_REQUEST_FILTER.equals(annotation.name())) {
@@ -122,7 +127,7 @@ public class FilterGeneration {
             }
 
             ret.add(new GeneratedFilter(output.getOutput(), generatedClassName, methodInfo.declaringClass().name().toString(),
-                    false, priority, false, false, nameBindingNames, false, methodInfo));
+                    false, priority, false, false, nameBindingNames, false, methodInfo, cancellable));
 
         }
         return ret;
@@ -138,13 +143,22 @@ public class FilterGeneration {
         final boolean nonBlocking;
         final Set<String> nameBindingNames;
         final boolean withFormRead;
-
         final MethodInfo filterSourceMethod;
+        final boolean cancellable;
 
         public GeneratedFilter(List<GeneratedClass> generatedClasses, String generatedClassName,
                 String declaringClassName,
                 boolean requestFilter, Integer priority, boolean preMatching, boolean nonBlocking,
                 Set<String> nameBindingNames, boolean withFormRead, MethodInfo filterSourceMethod) {
+            this(generatedClasses, generatedClassName, declaringClassName, requestFilter, priority, preMatching,
+                    nonBlocking, nameBindingNames, withFormRead, filterSourceMethod, true);
+        }
+
+        public GeneratedFilter(List<GeneratedClass> generatedClasses, String generatedClassName,
+                String declaringClassName,
+                boolean requestFilter, Integer priority, boolean preMatching, boolean nonBlocking,
+                Set<String> nameBindingNames, boolean withFormRead, MethodInfo filterSourceMethod,
+                boolean cancellable) {
             this.generatedClasses = generatedClasses;
             this.generatedClassName = generatedClassName;
             this.declaringClassName = declaringClassName;
@@ -155,6 +169,7 @@ public class FilterGeneration {
             this.nameBindingNames = nameBindingNames;
             this.withFormRead = withFormRead;
             this.filterSourceMethod = filterSourceMethod;
+            this.cancellable = cancellable;
         }
 
         public String getGeneratedClassName() {
@@ -195,6 +210,10 @@ public class FilterGeneration {
 
         public MethodInfo getFilterSourceMethod() {
             return filterSourceMethod;
+        }
+
+        public boolean isCancellable() {
+            return cancellable;
         }
     }
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/Cancellable.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/Cancellable.java
@@ -6,13 +6,19 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.concurrent.CompletionStage;
 
+import jakarta.ws.rs.container.ContainerResponseFilter;
+
 import io.smallrye.mutiny.Uni;
 
 /**
  * Used on a method that returns a single item async return type (such as {@link Uni} or {@link CompletionStage or Kotlin
  * suspend function})
  * to control whether to cancel the subscription to the result if the connection is closed before the result is ready.
- * By default, Quarkus will cancel the subscription
+ * By default, Quarkus will cancel the subscription.
+ * <p>
+ * Can also be placed on a {@link ContainerResponseFilter} class with {@code value = false}
+ * to ensure the filter is still executed even when the client closes the connection before the response is completed.
+ * Only filters explicitly marked as non-cancellable will run; other response filters are still skipped.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE })

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/ServerResponseFilter.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/ServerResponseFilter.java
@@ -66,4 +66,11 @@ public @interface ServerResponseFilter {
      * The priority with which this response filter will be executed
      */
     int priority() default Priorities.USER;
+
+    /**
+     * Whether the filter can be cancelled when the client drops the connection.
+     * Set to {@code false} to ensure this filter runs even when the client closes
+     * the connection before the response is completed.
+     */
+    boolean cancellable() default true;
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
@@ -213,8 +213,7 @@ public abstract class ResteasyReactiveRequestContext
     public void setupInitialMatchAndRestart(RequestMapper.RequestMatch<RestInitialHandler.InitialMatch> initialMatch) {
         this.initialMatch = initialMatch;
 
-        // add a default close handler that simply discards whatever REST handlers still remain to be run
-        serverResponse().addCloseHandler(new DiscardRemainingRunner(this));
+        serverResponse().addCloseHandler(new ConnectionCloseHandler(this));
 
         restart(initialMatch.value.handlers);
         setMaxPathParams(initialMatch.value.maxPathParams);
@@ -1345,17 +1344,38 @@ public abstract class ResteasyReactiveRequestContext
 
     }
 
-    private static class DiscardRemainingRunner implements Runnable {
+    /**
+     * The idea of this class is to prevent the execution of the remaining handlers
+     * that are cancellable (which all are by default)
+     */
+    private static class ConnectionCloseHandler implements Runnable {
 
         private ResteasyReactiveRequestContext context;
 
-        private DiscardRemainingRunner(ResteasyReactiveRequestContext context) {
+        private ConnectionCloseHandler(ResteasyReactiveRequestContext context) {
             this.context = context;
         }
 
         @Override
         public void run() {
-            context.discardRemaining();
+            ServerRestHandler[] handlers = context.getHandlers();
+            int pos = context.getPosition();
+            List<ServerRestHandler> nonCancellable = new ArrayList<>();
+            for (int i = pos; i < handlers.length; i++) {
+                if (!handlers[i].isCancellable()) {
+                    nonCancellable.add(handlers[i]);
+                }
+            }
+            if (nonCancellable.isEmpty()) {
+                context.discardRemaining();
+            } else {
+                ServerRestHandler[] newHandlers = new ServerRestHandler[pos + nonCancellable.size()];
+                System.arraycopy(handlers, 0, newHandlers, 0, pos);
+                for (int i = 0; i < nonCancellable.size(); i++) {
+                    newHandlers[pos + i] = nonCancellable.get(i);
+                }
+                context.handlers = newHandlers;
+            }
             context = null;
         }
     }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeInterceptorDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeInterceptorDeployment.java
@@ -89,10 +89,11 @@ public class RuntimeInterceptorDeployment {
         preMatchContainerRequestFilters = createInterceptorInstances(
                 interceptors.getContainerRequestFilters().getPreMatchInterceptors(), closeTaskHandler);
 
-        Collection<ContainerResponseFilter> responseFilters = globalResponseInterceptorsMap.values();
-        globalResponseInterceptorHandlers = new ArrayList<>(responseFilters.size());
-        for (ContainerResponseFilter responseFilter : responseFilters) {
-            globalResponseInterceptorHandlers.add(new ResourceResponseFilterHandler(responseFilter));
+        globalResponseInterceptorHandlers = new ArrayList<>(globalResponseInterceptorsMap.size());
+        for (Map.Entry<ResourceInterceptor<ContainerResponseFilter>, ContainerResponseFilter> entry : globalResponseInterceptorsMap
+                .entrySet()) {
+            globalResponseInterceptorHandlers
+                    .add(new ResourceResponseFilterHandler(entry.getValue(), entry.getKey().isCancellable()));
         }
         globalRequestInterceptorHandlers = new ArrayList<>(globalRequestInterceptorsMap.size());
         for (Map.Entry<ResourceInterceptor<ContainerRequestFilter>, ContainerRequestFilter> entry : globalRequestInterceptorsMap
@@ -268,7 +269,8 @@ public class RuntimeInterceptorDeployment {
                         true);
                 for (Map.Entry<ResourceInterceptor<ContainerResponseFilter>, ContainerResponseFilter> entry : interceptorsToUse
                         .entrySet()) {
-                    responseFilterHandlers.add(new ResourceResponseFilterHandler(entry.getValue()));
+                    responseFilterHandlers
+                            .add(new ResourceResponseFilterHandler(entry.getValue(), entry.getKey().isCancellable()));
                 }
             }
             return responseFilterHandlers;

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/ResourceResponseFilterHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/ResourceResponseFilterHandler.java
@@ -10,9 +10,15 @@ import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;
 public class ResourceResponseFilterHandler implements ServerRestHandler {
 
     private final ContainerResponseFilter filter;
+    private final boolean cancellable;
 
-    public ResourceResponseFilterHandler(ContainerResponseFilter filter) {
+    public ResourceResponseFilterHandler(ContainerResponseFilter filter, boolean cancellable) {
         this.filter = filter;
+        this.cancellable = cancellable;
+    }
+
+    public boolean isCancellable() {
+        return cancellable;
     }
 
     @Override

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/ServerRestHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/ServerRestHandler.java
@@ -7,4 +7,8 @@ public interface ServerRestHandler extends RestHandler<ResteasyReactiveRequestCo
 
     void handle(ResteasyReactiveRequestContext requestContext) throws Exception;
 
+    default boolean isCancellable() {
+        return true;
+    }
+
 }

--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -67,6 +68,7 @@ public class VertxResteasyReactiveRequestContext extends ResteasyReactiveRequest
     private final Executor contextExecutor;
     private final ClassLoader devModeTccl;
     protected Consumer<ResteasyReactiveRequestContext> preCommitTask;
+    private List<Runnable> closeHandlers;
     ContinueState continueState = ContinueState.NONE;
 
     public VertxResteasyReactiveRequestContext(Deployment deployment,
@@ -100,12 +102,18 @@ public class VertxResteasyReactiveRequestContext extends ResteasyReactiveRequest
 
     @Override
     public ServerHttpResponse addCloseHandler(Runnable onClose) {
-        this.response.closeHandler(new Handler<Void>() {
-            @Override
-            public void handle(Void v) {
-                onClose.run();
-            }
-        });
+        if (closeHandlers == null) {
+            closeHandlers = new ArrayList<>(1);
+            this.response.closeHandler(new Handler<>() {
+                @Override
+                public void handle(Void v) {
+                    for (Runnable handler : closeHandlers) {
+                        handler.run();
+                    }
+                }
+            });
+        }
+        closeHandlers.add(onClose);
         return this;
     }
 


### PR DESCRIPTION
This is done in order to give users a way to always have
`ContainerResponseFilter`, regardless of whether the connection
is still open

- Closes: #54889