### PR TITLE
Change log level of some OIDC log messages from debug to warn

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BackChannelLogoutHandler.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BackChannelLogoutHandler.java
@@ -195,7 +195,7 @@ public final class BackChannelLogoutHandler implements Handler<RoutingContext> {
                                             context.response().setStatusCode(400);
                                         }
                                     } catch (InvalidJwtException e) {
-                                        LOG.debug("Back channel logout token is invalid");
+                                        LOG.warn("Back channel logout token is invalid");
                                         context.response().setStatusCode(400);
 
                                     }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -210,7 +210,7 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
             String error = requestParams.get(OidcConstants.CODE_FLOW_ERROR);
             String errorDescription = requestParams.get(OidcConstants.CODE_FLOW_ERROR_DESCRIPTION);
 
-            LOG.debugf("Authentication has failed, error: %s, description: %s", error, errorDescription);
+            LOG.warnf("Authentication has failed, error: %s, description: %s", error, errorDescription);
 
             if (oidcTenantConfig.authentication().errorPath().isPresent()) {
                 Uni<TenantConfigContext> resolvedContext = resolver.resolveContext(context);
@@ -1490,7 +1490,7 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                                     }).onFailure().transform(new Function<Throwable, Throwable>() {
                                         @Override
                                         public Throwable apply(Throwable tInner) {
-                                            LOG.debugf("Verifying the refreshed ID token failed %s", errorMessage(tInner));
+                                            LOG.warnf("Verifying the refreshed ID token failed %s", errorMessage(tInner));
                                             return new AuthenticationFailedException(tInner, tokenMap(currentIdToken));
                                         }
                                     });

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenStateManager.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenStateManager.java
@@ -131,7 +131,7 @@ public class DefaultTokenStateManager implements TokenStateManager {
                 }
             } catch (ArrayIndexOutOfBoundsException ex) {
                 final String error = "Session cookie is malformed";
-                LOG.debug(ex);
+                LOG.error(error);
                 return Uni.createFrom().failure(new AuthenticationFailedException(error));
             } catch (AuthenticationFailedException ex) {
                 return Uni.createFrom().failure(ex);
@@ -156,7 +156,7 @@ public class DefaultTokenStateManager implements TokenStateManager {
                         }
                     } catch (ArrayIndexOutOfBoundsException ex) {
                         final String error = "Session cookie is malformed";
-                        LOG.debug(ex);
+                        LOG.error(error);
                         // Make this error message visible in the dev mode
                         return Uni.createFrom().failure(new AuthenticationFailedException(error));
                     } catch (AuthenticationFailedException ex) {
@@ -202,10 +202,9 @@ public class DefaultTokenStateManager implements TokenStateManager {
         try {
             return Long.valueOf(accessTokenExpiresInString);
         } catch (NumberFormatException ex) {
-            final String error = """
-                    Access token expires_in property in the session cookie must be a number, found %s
-                    """.formatted(accessTokenExpiresInString);
-            LOG.debug(ex);
+            final String error = "Access token expires_in property in the session cookie must be a number, found %s"
+                    .formatted(accessTokenExpiresInString);
+            LOG.error(error);
             // Make this error message visible in the dev mode
             throw new AuthenticationFailedException(error);
         }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -216,8 +216,9 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
             }
         } else {
             final boolean idToken = isIdToken(request);
-            Uni<TokenVerificationResult> result = verifyTokenUni(requestData, resolvedContext, request.getToken(), idToken,
-                    idToken, false, userInfo);
+            final TokenType tokenType = idToken ? TokenType.ID_TOKEN : TokenType.BEARER_ACCESS_TOKEN;
+            Uni<TokenVerificationResult> result = verifyTokenUni(requestData, resolvedContext, request.getToken(), tokenType,
+                    idToken, userInfo);
             if (!idToken) {
                 if (resolvedContext.oidcConfig().token().binding().certificate()) {
                     result = result.onItem().transform(new Function<TokenVerificationResult, TokenVerificationResult>() {
@@ -642,19 +643,19 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                 codeAccessToken = OidcUtils.decryptToken(resolvedContext, codeAccessToken);
                 requestData.put(OidcConstants.ACCESS_TOKEN_VALUE, codeAccessToken);
             }
-            return verifyTokenUni(requestData, resolvedContext, new AccessTokenCredential(codeAccessToken), false,
-                    false, true, userInfo);
+            return verifyTokenUni(requestData, resolvedContext, new AccessTokenCredential(codeAccessToken),
+                    TokenType.CODE_FLOW_ACCESS_TOKEN, false, userInfo);
         } else {
             return NULL_CODE_ACCESS_TOKEN_UNI;
         }
     }
 
     private Uni<TokenVerificationResult> verifyTokenUni(Map<String, Object> requestData, TenantConfigContext resolvedContext,
-            TokenCredential tokenCred, boolean idToken, boolean enforceAudienceVerification, boolean codeFlowAccessToken,
+            TokenCredential tokenCred, TokenType tokenType, boolean enforceAudienceVerification,
             UserInfo userInfo) {
         final String token = tokenCred.getToken();
         Long expiresIn = null;
-        if (codeFlowAccessToken) {
+        if (tokenType == TokenType.CODE_FLOW_ACCESS_TOKEN) {
             expiresIn = ((AuthorizationCodeTokens) requestData.get(AuthorizationCodeTokens.class.getName()))
                     .getAccessTokenExpiresIn();
         }
@@ -676,12 +677,12 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                 }
             }
             LOG.debug("Starting the opaque token introspection");
-            return introspectTokenUni(resolvedContext, token, idToken, expiresIn, false);
+            return introspectTokenUni(resolvedContext, token, tokenType, expiresIn, false);
         } else if (resolvedContext.provider().getMetadata().getJsonWebKeySetUri() == null
                 || resolvedContext.oidcConfig().token().requireJwtIntrospectionOnly()) {
             // Verify JWT token with the remote introspection
             LOG.debug("Starting the JWT token introspection");
-            return introspectTokenUni(resolvedContext, token, idToken, expiresIn, false);
+            return introspectTokenUni(resolvedContext, token, tokenType, expiresIn, false);
         } else if (resolvedContext.oidcConfig().jwks().resolveEarly()) {
             // Verify JWT token with the local JWK keys with a possible remote introspection fallback
             final String nonce = tokenCred instanceof IdTokenCredential ? (String) requestData.get(OidcConstants.NONCE) : null;
@@ -693,16 +694,15 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
             } catch (Throwable t) {
                 if (t.getCause() instanceof UnresolvableKeyException) {
                     LOG.debug("No matching JWK key is found, refreshing and repeating the token verification");
-                    return refreshJwksAndVerifyTokenUni(resolvedContext, token, idToken, enforceAudienceVerification,
+                    return refreshJwksAndVerifyTokenUni(resolvedContext, token, tokenType, enforceAudienceVerification,
                             resolvedContext.oidcConfig().token().subjectRequired(), nonce, expiresIn);
                 } else {
-                    LOG.debugf("Token verification has failed: %s", t.getMessage());
                     return Uni.createFrom().failure(t);
                 }
             }
         } else {
             final String nonce = (String) requestData.get(OidcConstants.NONCE);
-            return resolveJwksAndVerifyTokenUni(resolvedContext, tokenCred, enforceAudienceVerification,
+            return resolveJwksAndVerifyTokenUni(resolvedContext, tokenCred, tokenType, enforceAudienceVerification,
                     resolvedContext.oidcConfig().token().subjectRequired(), nonce, expiresIn);
         }
     }
@@ -717,23 +717,22 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
     }
 
     private Uni<TokenVerificationResult> refreshJwksAndVerifyTokenUni(TenantConfigContext resolvedContext, String token,
-            boolean idToken,
+            TokenType tokenType,
             boolean enforceAudienceVerification, boolean subjectRequired, String nonce, Long expiresIn) {
         return resolvedContext.provider()
                 .refreshJwksAndVerifyJwtToken(token, enforceAudienceVerification, subjectRequired, nonce)
                 .onFailure(f -> fallbackToIntrospectionIfNoMatchingKey(f, resolvedContext))
-                .recoverWithUni(f -> introspectTokenUni(resolvedContext, token, idToken, expiresIn, true));
+                .recoverWithUni(f -> introspectTokenUni(resolvedContext, token, tokenType, expiresIn, true));
     }
 
     private Uni<TokenVerificationResult> resolveJwksAndVerifyTokenUni(TenantConfigContext resolvedContext,
-            TokenCredential tokenCred,
+            TokenCredential tokenCred, TokenType tokenType,
             boolean enforceAudienceVerification, boolean subjectRequired, String nonce, Long expiresIn) {
         return resolvedContext.provider()
                 .getKeyResolverAndVerifyJwtToken(tokenCred, enforceAudienceVerification, subjectRequired, nonce,
                         (tokenCred instanceof IdTokenCredential))
                 .onFailure(f -> fallbackToIntrospectionIfNoMatchingKey(f, resolvedContext))
-                .recoverWithUni(f -> introspectTokenUni(resolvedContext, tokenCred.getToken(),
-                        isIdToken(tokenCred), expiresIn, true));
+                .recoverWithUni(f -> introspectTokenUni(resolvedContext, tokenCred.getToken(), tokenType, expiresIn, true));
     }
 
     private static boolean fallbackToIntrospectionIfNoMatchingKey(Throwable f, TenantConfigContext resolvedContext) {
@@ -751,28 +750,30 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
     }
 
     private Uni<TokenVerificationResult> introspectTokenUni(TenantConfigContext resolvedContext, final String token,
-            boolean idToken, Long expiresIn, boolean fallbackFromJwkMatch) {
+            TokenType tokenType, Long expiresIn, boolean fallbackFromJwkMatch) {
         TokenIntrospectionCache tokenIntrospectionCache = tenantResolver.getTokenIntrospectionCache();
         Uni<TokenIntrospection> tokenIntrospectionUni = tokenIntrospectionCache == null ? null
                 : tokenIntrospectionCache
                         .getIntrospection(token, resolvedContext.oidcConfig(), getIntrospectionRequestContext);
         if (tokenIntrospectionUni == null) {
-            tokenIntrospectionUni = newTokenIntrospectionUni(resolvedContext, token, idToken, expiresIn, fallbackFromJwkMatch);
+            tokenIntrospectionUni = newTokenIntrospectionUni(resolvedContext, token, tokenType, expiresIn,
+                    fallbackFromJwkMatch);
         } else {
             tokenIntrospectionUni = tokenIntrospectionUni.onItem().ifNull()
                     .switchTo(new Supplier<Uni<? extends TokenIntrospection>>() {
                         @Override
                         public Uni<TokenIntrospection> get() {
-                            return newTokenIntrospectionUni(resolvedContext, token, idToken, expiresIn, fallbackFromJwkMatch);
+                            return newTokenIntrospectionUni(resolvedContext, token, tokenType, expiresIn, fallbackFromJwkMatch);
                         }
                     });
         }
         return tokenIntrospectionUni.onItem().transform(t -> new TokenVerificationResult(null, t));
     }
 
-    private Uni<TokenIntrospection> newTokenIntrospectionUni(TenantConfigContext resolvedContext, String token, boolean idToken,
+    private Uni<TokenIntrospection> newTokenIntrospectionUni(TenantConfigContext resolvedContext, String token,
+            TokenType tokenType,
             Long expiresIn, boolean fallbackFromJwkMatch) {
-        Uni<TokenIntrospection> tokenIntrospectionUni = resolvedContext.provider().introspectToken(token, idToken, expiresIn,
+        Uni<TokenIntrospection> tokenIntrospectionUni = resolvedContext.provider().introspectToken(token, tokenType, expiresIn,
                 fallbackFromJwkMatch);
         if (tenantResolver.getTokenIntrospectionCache() == null
                 || !resolvedContext.oidcConfig().allowTokenIntrospectionCache()) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
@@ -203,10 +203,10 @@ public class OidcProvider implements Closeable {
             if (exp != null) {
                 final long secondsAfterExpiry = now() / 1000 - (exp + getLifespanGrace());
                 if (secondsAfterExpiry > 0) {
-                    String error = """
-                            Logout token issued to client %s expired %d seconds ago""".formatted(oidcConfig.clientId().get(),
+                    String error = "Logout token issued to client %s expired %d seconds ago".formatted(
+                            oidcConfig.clientId().get(),
                             secondsAfterExpiry);
-                    LOG.debug(error);
+                    LOG.warn(error);
                     throw new InvalidJwtException(error, List.of(new ErrorCodeValidator.Error(ErrorCodes.EXPIRED, error)),
                             null);
                 }
@@ -291,13 +291,13 @@ public class OidcProvider implements Closeable {
                 detail = details.get(0).getErrorMessage();
             }
             if (oidcConfig.clientId().isPresent()) {
-                LOG.debugf("Verification of the token issued to client %s has failed: %s.", oidcConfig.clientId().get(),
+                LOG.warnf("Verification of the token issued to client %s has failed: %s.", oidcConfig.clientId().get(),
                         detail);
                 if (oidcConfig.clientName().isPresent()) {
-                    LOG.debugf(" Client name: %s", oidcConfig.clientName().get());
+                    LOG.warnf(" Client name: %s", oidcConfig.clientName().get());
                 }
             } else {
-                LOG.debugf("Token verification has failed: %s", detail);
+                LOG.warnf("Token verification has failed: %s", detail);
             }
             throw ex;
         }
@@ -338,7 +338,7 @@ public class OidcProvider implements Closeable {
 
             if (now - iat > oidcConfig.token().age().get().toSeconds() + getLifespanGrace()) {
                 final String errorMessage = "Token age exceeds the configured token age property";
-                LOG.debugf(errorMessage);
+                LOG.warn(errorMessage);
                 throw new InvalidJwtException(errorMessage,
                         List.of(new ErrorCodeValidator.Error(ErrorCodes.ISSUED_AT_INVALID_PAST, errorMessage)), null);
             }
@@ -387,7 +387,7 @@ public class OidcProvider implements Closeable {
                 });
     }
 
-    public Uni<TokenIntrospection> introspectToken(String token, boolean idToken, Long expiresIn,
+    public Uni<TokenIntrospection> introspectToken(String token, TokenType tokenType, Long expiresIn,
             boolean fallbackFromJwkMatch) {
         if (client.getMetadata().getIntrospectionUri() == null) {
             String errorMessage = String.format("Token issued to client %s "
@@ -396,7 +396,7 @@ public class OidcProvider implements Closeable {
                     + "please check if your OpenId Connect Provider supports the token introspection",
                     oidcConfig.clientId().get());
 
-            throw new AuthenticationFailedException(errorMessage, tokenMap(token, idToken));
+            throw new AuthenticationFailedException(errorMessage, tokenMap(token, tokenType));
         }
         return client.introspectAccessToken(token).onItemOrFailure()
                 .transform(new BiFunction<TokenIntrospection, Throwable, TokenIntrospection>() {
@@ -404,7 +404,7 @@ public class OidcProvider implements Closeable {
                     @Override
                     public TokenIntrospection apply(TokenIntrospection introspectionResult, Throwable t) {
                         if (t != null) {
-                            throw new AuthenticationFailedException(t, tokenMap(token, idToken));
+                            throw new AuthenticationFailedException(t, tokenMap(token, tokenType));
                         }
                         Long introspectionExpiresIn = introspectionResult.getLong(OidcConstants.INTROSPECTION_TOKEN_EXP);
                         if (introspectionExpiresIn == null && expiresIn != null) {
@@ -412,16 +412,16 @@ public class OidcProvider implements Closeable {
                             introspectionExpiresIn = now() + expiresIn;
                         }
                         if (!introspectionResult.isActive()) {
-                            verifyTokenExpiry(token, idToken, introspectionExpiresIn);
+                            verifyTokenExpiry(token, tokenType, introspectionExpiresIn);
                             throw new AuthenticationFailedException(
                                     String.format("Token issued to client %s is not active", oidcConfig.clientId().get()),
-                                    tokenMap(token, idToken));
+                                    tokenMap(token, tokenType));
                         }
-                        verifyTokenExpiry(token, idToken, introspectionExpiresIn);
+                        verifyTokenExpiry(token, tokenType, introspectionExpiresIn);
                         try {
                             verifyTokenAge(introspectionResult.getLong(OidcConstants.INTROSPECTION_TOKEN_IAT));
                         } catch (InvalidJwtException ex) {
-                            throw new AuthenticationFailedException(ex, tokenMap(token, idToken));
+                            throw new AuthenticationFailedException(ex, tokenMap(token, tokenType));
                         }
 
                         if (requiredClaims != null) {
@@ -429,7 +429,7 @@ public class OidcProvider implements Closeable {
                                 final String requiredClaimName = requiredClaim.getKey();
                                 if (!introspectionResult.contains(requiredClaimName)) {
                                     LOG.debugf("Introspection claim %s is missing", requiredClaimName);
-                                    throw new AuthenticationFailedException(tokenMap(token, idToken));
+                                    throw new AuthenticationFailedException(tokenMap(token, tokenType));
                                 }
                                 final Set<String> requiredClaimValues = requiredClaim.getValue();
                                 if (requiredClaimValues.size() == 1) {
@@ -449,7 +449,7 @@ public class OidcProvider implements Closeable {
                                     actualClaimValueArray = requireNonNull(introspectionResult.getArray(requiredClaimName));
                                 } catch (Exception ignored) {
                                     LOG.debugf("Introspection claim %s is neither string nor array", requiredClaimName);
-                                    throw new AuthenticationFailedException(tokenMap(token, idToken));
+                                    throw new AuthenticationFailedException(tokenMap(token, tokenType));
                                 }
                                 requiredClaimValuesLoop: for (String requiredClaimValue : requiredClaimValues) {
                                     for (int i = 0; i < actualClaimValueArray.size(); i++) {
@@ -464,7 +464,7 @@ public class OidcProvider implements Closeable {
                                     }
                                     LOG.debugf("Value of the introspection claim %s does not match required value of %s",
                                             requiredClaimName, requiredClaimValue);
-                                    throw new AuthenticationFailedException(tokenMap(token, idToken));
+                                    throw new AuthenticationFailedException(tokenMap(token, tokenType));
                                 }
                             }
                         }
@@ -475,20 +475,23 @@ public class OidcProvider implements Closeable {
                 });
     }
 
-    private void verifyTokenExpiry(String token, boolean idToken, Long exp) {
+    private void verifyTokenExpiry(String token, TokenType tokenType, Long exp) {
         if (exp == null) {
             return;
         }
         final long secondsAfterExpiry = now() / 1000 - (exp + getLifespanGrace());
         if (secondsAfterExpiry > 0) {
-            String error = """
-                    Token issued to client %s expired %d seconds ago""".formatted(oidcConfig.clientId().get(),
+            String error = "Token issued to client %s expired %d seconds ago".formatted(oidcConfig.clientId().get(),
                     secondsAfterExpiry);
-            LOG.debug(error);
+            if (tokenType == TokenType.BEARER_ACCESS_TOKEN) {
+                LOG.warn(error);
+            } else {
+                LOG.debug(error);
+            }
             throw new AuthenticationFailedException(
                     new InvalidJwtException(error,
                             List.of(new ErrorCodeValidator.Error(ErrorCodes.EXPIRED, error)), null),
-                    tokenMap(token, idToken));
+                    tokenMap(token, tokenType));
         }
     }
 
@@ -759,8 +762,9 @@ public class OidcProvider implements Closeable {
         }
     }
 
-    private static Map<String, Object> tokenMap(String token, boolean idToken) {
-        return Map.of(idToken ? OidcConstants.ID_TOKEN_VALUE : OidcConstants.ACCESS_TOKEN_VALUE, token);
+    private static Map<String, Object> tokenMap(String token, TokenType tokenType) {
+        return Map.of(tokenType == TokenType.ID_TOKEN ? OidcConstants.ID_TOKEN_VALUE : OidcConstants.ACCESS_TOKEN_VALUE,
+                token);
     }
 
     private static final class CatchingErrorCodeValidator extends ErrorCodeValidatorAdapter {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClientImpl.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClientImpl.java
@@ -192,7 +192,7 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
                                         return oidcProvider.refreshJwksAndVerifyJwtToken(response.data(), true, false, null)
                                                 .onItem().transform(v -> new UserInfo(v.localVerificationResult().encode()));
                                     } else {
-                                        LOG.debugf("Signed UserInfo verification has failed: %s", t.getMessage());
+                                        LOG.warnf("Signed UserInfo verification has failed: %s", t.getMessage());
                                         return Uni.createFrom().failure(t);
                                     }
                                 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -966,7 +966,7 @@ public final class OidcUtils {
             try {
                 return OidcUtils.decryptString(token, decryptionKey, encryptionAlgorithm);
             } catch (JoseException ex) {
-                LOG.debugf("Failed to decrypt a token: %s", ex.getMessage());
+                LOG.warnf("Failed to decrypt a token: %s", ex.getMessage());
             }
         }
         return token;

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TokenType.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TokenType.java
@@ -1,0 +1,21 @@
+package io.quarkus.oidc.runtime;
+
+/**
+ * Represents the type of token being verified during OIDC authentication.
+ */
+enum TokenType {
+    /**
+     * Bearer access token from HTTP Authorization header.
+     */
+    BEARER_ACCESS_TOKEN,
+
+    /**
+     * Access token obtained via authorization code flow.
+     */
+    CODE_FLOW_ACCESS_TOKEN,
+
+    /**
+     * ID token from authorization code flow.
+     */
+    ID_TOKEN
+}


### PR DESCRIPTION
Customers would like to see some log messages that lead to OIDC authentication failures not at the debug but at least at the warning level to have them visible in prod.

This PR does the following:
- Does change a log level of some OIDC log messages from debug to warn
- Does some minor refactoring to pass a runtime package `TokenType` enum to 1) avoid passing multiple booleans like code flow access token or id token ones, and 2) use this enum to decide how to log a token expiry exception - for the code flow related tokens it should remain at the debug level since it is a normal state that requires a user reauthentication due to a session expiry but for the bearer access token that leads to 401 it should be a warning

Some other tuning of log messages may follow later