### PR TITLE
[3.33] bump otel 1.62.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -29,7 +29,7 @@
         <resteasy-microprofile.version>3.0.1.Final</resteasy-microprofile.version>
         <resteasy-spring-web.version>3.2.0.Final</resteasy-spring-web.version>
         <resteasy.version>6.2.16.Final</resteasy.version>
-        <opentelemetry-instrumentation.version>2.23.0-alpha</opentelemetry-instrumentation.version> <!-- OTel SDk 1.55.0-->
+        <opentelemetry-instrumentation.version>2.25.0-alpha</opentelemetry-instrumentation.version> <!-- OTel SDk 1.55.0-->
         <opentelemetry-semconv.version>1.37.0-alpha</opentelemetry-semconv.version>
         <quarkus-http.version>5.5.0</quarkus-http.version>
         <micrometer.version>1.16.3</micrometer.version><!-- keep in sync with hdrhistogram: https://central.sonatype.com/artifact/io.micrometer/micrometer-core -->

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -29,7 +29,7 @@
         <resteasy-microprofile.version>3.0.1.Final</resteasy-microprofile.version>
         <resteasy-spring-web.version>3.2.0.Final</resteasy-spring-web.version>
         <resteasy.version>6.2.16.Final</resteasy.version>
-        <opentelemetry-instrumentation.version>2.25.0-alpha</opentelemetry-instrumentation.version> <!-- OTel SDk 1.55.0-->
+        <opentelemetry-instrumentation.version>2.26.1-alpha</opentelemetry-instrumentation.version> <!-- OTel SDk 1.60.1-->
         <opentelemetry-semconv.version>1.37.0-alpha</opentelemetry-semconv.version>
         <quarkus-http.version>5.5.0</quarkus-http.version>
         <micrometer.version>1.16.3</micrometer.version><!-- keep in sync with hdrhistogram: https://central.sonatype.com/artifact/io.micrometer/micrometer-core -->

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AgroalOpenTelemetryWrapper.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AgroalOpenTelemetryWrapper.java
@@ -2,12 +2,23 @@ package io.quarkus.agroal.runtime;
 
 import java.util.function.Function;
 
+import jakarta.inject.Inject;
+
 import io.agroal.api.AgroalDataSource;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.instrumentation.jdbc.datasource.JdbcTelemetry;
+import io.opentelemetry.instrumentation.jdbc.datasource.OpenTelemetryDataSource;
 
 public class AgroalOpenTelemetryWrapper implements Function<AgroalDataSource, AgroalDataSource> {
 
+    @Inject
+    OpenTelemetry openTelemetry;
+
     @Override
     public AgroalDataSource apply(AgroalDataSource originalDataSource) {
-        return new OpenTelemetryAgroalDataSource(originalDataSource);
+        OpenTelemetryDataSource otelDataSource = (OpenTelemetryDataSource) JdbcTelemetry
+                .create(openTelemetry)
+                .wrap(originalDataSource);
+        return new OpenTelemetryAgroalDataSource(originalDataSource, otelDataSource);
     }
 }

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/OpenTelemetryAgroalDataSource.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/OpenTelemetryAgroalDataSource.java
@@ -1,29 +1,79 @@
 package io.quarkus.agroal.runtime;
 
+import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.sql.ShardingKeyBuilder;
 import java.util.Collection;
 import java.util.List;
+import java.util.logging.Logger;
 
 import io.agroal.api.AgroalDataSource;
 import io.agroal.api.AgroalDataSourceMetrics;
 import io.agroal.api.AgroalPoolInterceptor;
 import io.agroal.api.configuration.AgroalDataSourceConfiguration;
-import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.jdbc.datasource.OpenTelemetryDataSource;
-import io.quarkus.arc.Arc;
 
 /**
  * The {@link AgroalDataSource} wrapper that activates OpenTelemetry JDBC instrumentation.
+ * <p>
+ * Uses composition to wrap an {@link OpenTelemetryDataSource} (for instrumented connections)
+ * while delegating {@link AgroalDataSource}-specific operations to the original data source.
  */
-public class OpenTelemetryAgroalDataSource extends OpenTelemetryDataSource implements AgroalDataSource {
+public class OpenTelemetryAgroalDataSource implements AgroalDataSource {
 
     private final AgroalDataSource delegate;
+    private final OpenTelemetryDataSource otelDataSource;
 
-    public OpenTelemetryAgroalDataSource(AgroalDataSource delegate) {
-        super(delegate, Arc.container().instance(OpenTelemetry.class).get());
+    public OpenTelemetryAgroalDataSource(AgroalDataSource delegate, OpenTelemetryDataSource otelDataSource) {
         this.delegate = delegate;
+        this.otelDataSource = otelDataSource;
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        return otelDataSource.getConnection();
+    }
+
+    @Override
+    public Connection getConnection(String username, String password) throws SQLException {
+        return otelDataSource.getConnection(username, password);
+    }
+
+    @Override
+    public PrintWriter getLogWriter() throws SQLException {
+        return delegate.getLogWriter();
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter out) throws SQLException {
+        delegate.setLogWriter(out);
+    }
+
+    @Override
+    public int getLoginTimeout() throws SQLException {
+        return delegate.getLoginTimeout();
+    }
+
+    @Override
+    public void setLoginTimeout(int seconds) throws SQLException {
+        delegate.setLoginTimeout(seconds);
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        return delegate.getParentLogger();
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        return delegate.unwrap(iface);
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        return delegate.isWrapperFor(iface);
     }
 
     @Override

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/JvmMetricsTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/JvmMetricsTest.java
@@ -85,13 +85,16 @@ public class JvmMetricsTest extends BaseJvmMetricsTest {
             allMetrics.add(new MetricToAssert("jvm.network.io", "Network read/write bytes.", "By", HISTOGRAM));
             allMetrics.add(new MetricToAssert("jvm.network.time", "Network read/write duration.", "s", HISTOGRAM));
         }
-        // Recommended sdk metrics
+        // SDK self-diagnostics metrics
         allMetrics.add(new MetricToAssert("otel.sdk.span.live",
                 "The number of created spans with recording=true for which the end operation has not been called yet.",
                 "{span}", LONG_SUM));
         allMetrics.add(new MetricToAssert("otel.sdk.span.started",
                 "The number of created spans.",
                 "{span}", LONG_SUM));
+        allMetrics.add(new MetricToAssert("otel.sdk.metric_reader.collection.duration",
+                "The duration of the collect operation of the metric reader.",
+                "s", HISTOGRAM));
 
         // Force GC to run
         System.gc();

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/JvmMetricsTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/JvmMetricsTest.java
@@ -85,6 +85,13 @@ public class JvmMetricsTest extends BaseJvmMetricsTest {
             allMetrics.add(new MetricToAssert("jvm.network.io", "Network read/write bytes.", "By", HISTOGRAM));
             allMetrics.add(new MetricToAssert("jvm.network.time", "Network read/write duration.", "s", HISTOGRAM));
         }
+        // Recommended sdk metrics
+        allMetrics.add(new MetricToAssert("otel.sdk.span.live",
+                "The number of created spans with recording=true for which the end operation has not been called yet.",
+                "{span}", LONG_SUM));
+        allMetrics.add(new MetricToAssert("otel.sdk.span.started",
+                "The number of created spans.",
+                "{span}", LONG_SUM));
 
         // Force GC to run
         System.gc();

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/AutoConfiguredOpenTelemetrySdkBuilderCustomizer.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/AutoConfiguredOpenTelemetrySdkBuilderCustomizer.java
@@ -1,6 +1,6 @@
 package io.quarkus.opentelemetry.runtime;
 
-import static io.opentelemetry.sdk.internal.ScopeConfiguratorBuilder.nameEquals;
+import static io.opentelemetry.sdk.common.internal.ScopeConfiguratorBuilder.nameEquals;
 import static java.lang.Boolean.TRUE;
 import static java.util.Collections.emptyList;
 

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/AutoConfiguredOpenTelemetrySdkBuilderCustomizer.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/AutoConfiguredOpenTelemetrySdkBuilderCustomizer.java
@@ -291,7 +291,8 @@ public interface AutoConfiguredOpenTelemetrySdkBuilderCustomizer {
                                 // In the future we can inject scopes here.
                                 Set<String> dropInstrumentationScopes = Set.of(
                                         "io.opentelemetry.sdk.trace",
-                                        "io.opentelemetry.sdk.logs");
+                                        "io.opentelemetry.sdk.logs",
+                                        "io.opentelemetry.sdk.metrics");
                                 for (String target : dropInstrumentationScopes) {
                                     SdkMeterProviderUtil.addMeterConfiguratorCondition(
                                             meterProviderBuilder,

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/OTelRuntimeConfig.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/OTelRuntimeConfig.java
@@ -99,6 +99,20 @@ public interface OTelRuntimeConfig {
     InstrumentRuntimeConfig instrument();
 
     /**
+     * Controls the OpenTelemetry SDK internal telemetry version.
+     * <p>
+     * When set to <code>latest</code>, the SDK emits self-diagnostics metrics for spans
+     * (<code>otel.sdk.span.live</code>, <code>otel.sdk.span.started</code>) in addition to
+     * metric reader diagnostics (<code>otel.sdk.metric_reader.collection.duration</code>).
+     * When set to <code>legacy</code>, only metric reader diagnostics are emitted.
+     * <p>
+     * Defaults to <code>latest</code>.
+     */
+    @WithName("experimental.sdk.telemetry.version")
+    @WithDefault("latest")
+    String experimentalSdkTelemetryVersion();
+
+    /**
      * Prioritize OpenTelemetry configuration <code>otel.</code> on top of Quarkus OpenTelemetry configuration
      * <code>quarkus.otel</code>.
      * <p>

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/OTelExporterRecorder.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/OTelExporterRecorder.java
@@ -1,6 +1,6 @@
 package io.quarkus.opentelemetry.runtime.exporter.otlp;
 
-import static io.opentelemetry.sdk.internal.StandardComponentId.ExporterType.OTLP_GRPC_METRIC_EXPORTER;
+import static io.opentelemetry.sdk.common.internal.StandardComponentId.ExporterType.OTLP_GRPC_METRIC_EXPORTER;
 import static io.quarkus.opentelemetry.runtime.config.runtime.exporter.OtlpExporterConfig.Protocol.GRPC;
 import static io.quarkus.opentelemetry.runtime.config.runtime.exporter.OtlpExporterConfig.Protocol.HTTP_PROTOBUF;
 import static io.quarkus.opentelemetry.runtime.config.runtime.exporter.OtlpExporterRuntimeConfig.DEFAULT_GRPC_BASE_URI;
@@ -22,14 +22,11 @@ import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.exporter.internal.ExporterBuilderUtil;
 import io.opentelemetry.exporter.internal.grpc.GrpcExporter;
 import io.opentelemetry.exporter.internal.http.HttpExporter;
-import io.opentelemetry.exporter.internal.otlp.logs.LogsRequestMarshaler;
-import io.opentelemetry.exporter.internal.otlp.metrics.MetricsRequestMarshaler;
-import io.opentelemetry.exporter.internal.otlp.traces.TraceRequestMarshaler;
 import io.opentelemetry.exporter.otlp.internal.OtlpUserAgent;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import io.opentelemetry.sdk.common.InternalTelemetryVersion;
-import io.opentelemetry.sdk.internal.ComponentId;
-import io.opentelemetry.sdk.internal.StandardComponentId;
+import io.opentelemetry.sdk.common.internal.ComponentId;
+import io.opentelemetry.sdk.common.internal.StandardComponentId;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 import io.opentelemetry.sdk.metrics.Aggregation;
 import io.opentelemetry.sdk.metrics.InstrumentType;
@@ -166,7 +163,7 @@ public class OTelExporterRecorder {
 
                 OtlpExporterTracesConfig tracesConfig = exporterRuntimeConfig.traces();
 
-                return new VertxGrpcSpanExporter(new GrpcExporter<TraceRequestMarshaler>(
+                return new VertxGrpcSpanExporter(new GrpcExporter(
                         new VertxGrpcSender(
                                 baseUri,
                                 VertxGrpcSender.GRPC_TRACE_SERVICE_NAME,
@@ -178,7 +175,7 @@ public class OTelExporterRecorder {
                         InternalTelemetryVersion.LATEST,
                         ComponentId.generateLazy(StandardComponentId.ExporterType.OTLP_GRPC_SPAN_EXPORTER), // use the same as OTel does
                         MeterProvider::noop,
-                        baseUri.toASCIIString()));
+                        baseUri));
             }
 
             private SpanExporter createHttpSpanExporter(OtlpExporterRuntimeConfig exporterRuntimeConfig, Vertx vertx,
@@ -189,7 +186,7 @@ public class OTelExporterRecorder {
 
                 boolean exportAsJson = false; //TODO: this will be enhanced in the future
 
-                return new VertxHttpSpanExporter(new HttpExporter<TraceRequestMarshaler>(
+                return new VertxHttpSpanExporter(new HttpExporter(
                         ComponentId.generateLazy(StandardComponentId.ExporterType.OTLP_HTTP_SPAN_EXPORTER),
                         new VertxHttpSender(
                                 baseUri,
@@ -202,7 +199,8 @@ public class OTelExporterRecorder {
                                 vertx),
                         MeterProvider::noop,
                         InternalTelemetryVersion.LATEST,
-                        baseUri.toASCIIString()));
+                        baseUri,
+                        false));
             }
         };
     }
@@ -233,7 +231,7 @@ public class OTelExporterRecorder {
                     String protocol = metricsConfig.protocol().get();
                     if (GRPC.equals(protocol)) {
                         metricExporter = new VertxGrpcMetricExporter(
-                                new GrpcExporter<MetricsRequestMarshaler>(
+                                new GrpcExporter(
                                         new VertxGrpcSender(
                                                 baseUri,
                                                 VertxGrpcSender.GRPC_METRIC_SERVICE_NAME,
@@ -245,13 +243,13 @@ public class OTelExporterRecorder {
                                         InternalTelemetryVersion.LATEST,
                                         ComponentId.generateLazy(OTLP_GRPC_METRIC_EXPORTER), // use the same as OTel does
                                         MeterProvider::noop,
-                                        baseUri.toASCIIString()),
+                                        baseUri),
                                 aggregationTemporalityResolver(metricsConfig),
                                 aggregationResolver(metricsConfig));
                     } else if (HTTP_PROTOBUF.equals(protocol)) {
                         boolean exportAsJson = false; //TODO: this will be enhanced in the future
                         metricExporter = new VertxHttpMetricsExporter(
-                                new HttpExporter<MetricsRequestMarshaler>(
+                                new HttpExporter(
                                         ComponentId.generateLazy(
                                                 StandardComponentId.ExporterType.OTLP_HTTP_METRIC_EXPORTER),
                                         new VertxHttpSender(
@@ -265,7 +263,8 @@ public class OTelExporterRecorder {
                                                 vertx.get()),
                                         MeterProvider::noop,
                                         InternalTelemetryVersion.LATEST,
-                                        baseUri.toASCIIString()),
+                                        baseUri,
+                                        false),
                                 aggregationTemporalityResolver(metricsConfig),
                                 aggregationResolver(metricsConfig));
                     } else {
@@ -307,7 +306,7 @@ public class OTelExporterRecorder {
                     String protocol = logsConfig.protocol().get();
                     if (GRPC.equals(protocol)) {
                         logRecordExporter = new VertxGrpcLogRecordExporter(
-                                new GrpcExporter<LogsRequestMarshaler>(
+                                new GrpcExporter(
                                         new VertxGrpcSender(
                                                 baseUri,
                                                 VertxGrpcSender.GRPC_LOG_SERVICE_NAME,
@@ -320,11 +319,11 @@ public class OTelExporterRecorder {
                                         ComponentId.generateLazy(
                                                 StandardComponentId.ExporterType.OTLP_GRPC_LOG_EXPORTER), // use the same as OTel does
                                         MeterProvider::noop,
-                                        baseUri.toASCIIString()));
+                                        baseUri));
                     } else if (HTTP_PROTOBUF.equals(protocol)) {
                         boolean exportAsJson = false; //TODO: this will be enhanced in the future
                         logRecordExporter = new VertxHttpLogRecordExporter(
-                                new HttpExporter<LogsRequestMarshaler>(
+                                new HttpExporter(
                                         ComponentId.generateLazy(
                                                 StandardComponentId.ExporterType.OTLP_HTTP_LOG_EXPORTER),
                                         new VertxHttpSender(
@@ -338,7 +337,8 @@ public class OTelExporterRecorder {
                                                 vertx.get()),
                                         MeterProvider::noop,
                                         InternalTelemetryVersion.LATEST,
-                                        baseUri.toASCIIString()));
+                                        baseUri,
+                                        false));
                     } else {
                         throw new IllegalArgumentException(String.format("Unsupported OTLP protocol %s specified. " +
                                 "Please check `quarkus.otel.exporter.otlp.logs.protocol` property", protocol));

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/logs/VertxGrpcLogRecordExporter.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/logs/VertxGrpcLogRecordExporter.java
@@ -9,9 +9,9 @@ import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 
 public class VertxGrpcLogRecordExporter implements LogRecordExporter {
-    private final GrpcExporter<LogsRequestMarshaler> delegate;
+    private final GrpcExporter delegate;
 
-    public VertxGrpcLogRecordExporter(GrpcExporter<LogsRequestMarshaler> delegate) {
+    public VertxGrpcLogRecordExporter(GrpcExporter delegate) {
         this.delegate = delegate;
     }
 

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/logs/VertxHttpLogRecordExporter.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/logs/VertxHttpLogRecordExporter.java
@@ -9,9 +9,9 @@ import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 
 public class VertxHttpLogRecordExporter implements LogRecordExporter {
-    private final HttpExporter<LogsRequestMarshaler> delegate;
+    private final HttpExporter delegate;
 
-    public VertxHttpLogRecordExporter(HttpExporter<LogsRequestMarshaler> delegate) {
+    public VertxHttpLogRecordExporter(HttpExporter delegate) {
         this.delegate = delegate;
     }
 

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/metrics/VertxGrpcMetricExporter.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/metrics/VertxGrpcMetricExporter.java
@@ -16,11 +16,11 @@ import io.opentelemetry.sdk.metrics.export.MetricExporter;
 
 public class VertxGrpcMetricExporter implements MetricExporter {
 
-    private final GrpcExporter<MetricsRequestMarshaler> delegate;
+    private final GrpcExporter delegate;
     private final AggregationTemporalitySelector aggregationTemporalitySelector;
     private final DefaultAggregationSelector defaultAggregationSelector;
 
-    public VertxGrpcMetricExporter(GrpcExporter<MetricsRequestMarshaler> grpcExporter,
+    public VertxGrpcMetricExporter(GrpcExporter grpcExporter,
             AggregationTemporalitySelector aggregationTemporalitySelector,
             DefaultAggregationSelector defaultAggregationSelector) {
         this.delegate = grpcExporter;

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/metrics/VertxHttpMetricsExporter.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/metrics/VertxHttpMetricsExporter.java
@@ -16,11 +16,11 @@ import io.opentelemetry.sdk.metrics.export.MetricExporter;
 
 public class VertxHttpMetricsExporter implements MetricExporter {
 
-    private final HttpExporter<MetricsRequestMarshaler> delegate;
+    private final HttpExporter delegate;
     private final AggregationTemporalitySelector aggregationTemporalitySelector;
     private final DefaultAggregationSelector defaultAggregationSelector;
 
-    public VertxHttpMetricsExporter(HttpExporter<MetricsRequestMarshaler> delegate,
+    public VertxHttpMetricsExporter(HttpExporter delegate,
             AggregationTemporalitySelector aggregationTemporalitySelector,
             DefaultAggregationSelector defaultAggregationSelector) {
         this.delegate = delegate;

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxGrpcSender.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxGrpcSender.java
@@ -17,16 +17,19 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import io.netty.handler.codec.http.QueryStringDecoder;
-import io.opentelemetry.exporter.internal.grpc.GrpcResponse;
-import io.opentelemetry.exporter.internal.grpc.GrpcSender;
-import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.internal.ThrottlingLogger;
+import io.opentelemetry.sdk.common.export.GrpcResponse;
+import io.opentelemetry.sdk.common.export.GrpcSender;
+import io.opentelemetry.sdk.common.export.GrpcStatusCode;
+import io.opentelemetry.sdk.common.export.MessageWriter;
+import io.opentelemetry.sdk.common.internal.ThrottlingLogger;
 import io.quarkus.opentelemetry.runtime.exporter.otlp.OTelExporterUtil;
 import io.quarkus.vertx.core.runtime.BufferOutputStream;
 import io.smallrye.common.annotation.SuppressForbidden;
 import io.smallrye.mutiny.Uni;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientOptions;
@@ -88,15 +91,17 @@ public final class VertxGrpcSender implements GrpcSender {
     }
 
     @Override
-    public void send(Marshaler request, Consumer onSuccess, Consumer onError) {
+    public void send(MessageWriter messageWriter,
+            Consumer<GrpcResponse> onResponse,
+            Consumer<Throwable> onError) {
         if (isShutdown.get()) {
             return;
         }
 
-        final String marshalerType = request.getClass().getSimpleName();
+        final String marshalerType = messageWriter.getClass().getSimpleName();
         var onSuccessHandler = new ClientRequestOnSuccessHandler(client, server, headers, compressionEnabled,
-                request,
-                loggedUnimplemented, logger, marshalerType, onSuccess, onError, 1, grpcEndpointPath,
+                messageWriter,
+                loggedUnimplemented, logger, marshalerType, onResponse, onError, 1, grpcEndpointPath,
                 isShutdown::get, exportTimeout);
 
         initiateSend(client, server, MAX_ATTEMPTS, onSuccessHandler, exportTimeout, new Consumer<>() {
@@ -195,11 +200,11 @@ public final class VertxGrpcSender implements GrpcSender {
         private final Map<String, String> headers;
         private final boolean compressionEnabled;
 
-        private final Marshaler marshaler;
+        private final MessageWriter messageWriter;
         private final AtomicBoolean loggedUnimplemented;
         private final ThrottlingLogger logger;
         private final String type;
-        private final Consumer<GrpcResponse> onSuccess;
+        private final Consumer<GrpcResponse> onResponse;
         private final Consumer<Throwable> onError;
         private final String grpcEndpointPath;
 
@@ -211,11 +216,11 @@ public final class VertxGrpcSender implements GrpcSender {
                 SocketAddress server,
                 Map<String, String> headers,
                 boolean compressionEnabled,
-                Marshaler marshaler,
+                MessageWriter messageWriter,
                 AtomicBoolean loggedUnimplemented,
                 ThrottlingLogger logger,
                 String type,
-                Consumer<GrpcResponse> onSuccess,
+                Consumer<GrpcResponse> onResponse,
                 Consumer<Throwable> onError,
                 int attemptNumber,
                 String grpcEndpointPath,
@@ -226,11 +231,11 @@ public final class VertxGrpcSender implements GrpcSender {
             this.grpcEndpointPath = grpcEndpointPath;
             this.headers = headers;
             this.compressionEnabled = compressionEnabled;
-            this.marshaler = marshaler;
+            this.messageWriter = messageWriter;
             this.loggedUnimplemented = loggedUnimplemented;
             this.logger = logger;
             this.type = type;
-            this.onSuccess = onSuccess;
+            this.onResponse = onResponse;
             this.onError = onError;
             this.attemptNumber = attemptNumber;
             this.isShutdown = isShutdown;
@@ -255,10 +260,10 @@ public final class VertxGrpcSender implements GrpcSender {
             }
 
             try {
-                int messageSize = marshaler.getBinarySerializedSize();
+                int messageSize = messageWriter.getContentLength();
                 Buffer buffer = Buffer.buffer(messageSize);
                 var os = new BufferOutputStream(buffer);
-                marshaler.writeBinaryTo(os);
+                messageWriter.writeMessage(os);
                 request.send(buffer).onSuccess(new Handler<>() {
                     @Override
                     public void handle(GrpcClientResponse<Buffer, Buffer> response) {
@@ -291,7 +296,44 @@ public final class VertxGrpcSender implements GrpcSender {
                             public void handle(Void ignored) {
                                 GrpcStatus status = getStatus(response);
                                 if (status == GrpcStatus.OK) {
-                                    onSuccess.accept(GrpcResponse.create(status.code, status.toString()));
+                                    // onResponse.accept(GrpcResponse.create(status.code, status.toString()));
+                                    onResponse.accept(new GrpcResponse() {
+                                        @Override
+                                        public GrpcStatusCode getStatusCode() {
+                                            return GrpcStatusCode.fromValue(status.code);
+                                        }
+
+                                        @Override
+                                        public String getStatusDescription() {
+                                            return status.name();
+                                        }
+
+                                        @Override
+                                        public byte[] getResponseMessage() {
+                                            if (response == null) {
+                                                return null;
+                                            }
+                                            Promise<String> promise = Promise.promise();
+                                            StringBuilder sb = new StringBuilder();
+                                            response.handler(msg -> {
+                                                sb.append(msg.toString());
+                                            });
+                                            response.endHandler(v -> {
+                                                // Done reading stream
+                                                promise.complete(sb.toString());
+                                            });
+                                            response.exceptionHandler(promise::fail);
+                                            String result = promise.future()
+                                                    .timeout(exportTimeout.toMillis(), MILLISECONDS)
+                                                    .recover(throwable -> Future.succeededFuture(
+                                                            "Response error: " + throwable.getMessage()))
+                                                    .result();
+                                            if (result == null || result.isEmpty()) {
+                                                return null;
+                                            }
+                                            return result.getBytes(StandardCharsets.UTF_8);
+                                        }
+                                    });
                                 } else {
                                     handleError(status, response);
                                 }
@@ -447,8 +489,8 @@ public final class VertxGrpcSender implements GrpcSender {
         }
 
         public ClientRequestOnSuccessHandler newAttempt() {
-            return new ClientRequestOnSuccessHandler(client, server, headers, compressionEnabled, marshaler,
-                    loggedUnimplemented, logger, type, onSuccess, onError, attemptNumber + 1,
+            return new ClientRequestOnSuccessHandler(client, server, headers, compressionEnabled, messageWriter,
+                    loggedUnimplemented, logger, type, onResponse, onError, attemptNumber + 1,
                     grpcEndpointPath, isShutdown, exportTimeout);
         }
     }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxHttpSender.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxHttpSender.java
@@ -14,13 +14,15 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.zip.GZIPOutputStream;
 
-import io.opentelemetry.exporter.internal.http.HttpSender;
-import io.opentelemetry.exporter.internal.marshal.Marshaler;
+import org.jboss.logging.Logger;
+
 import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.internal.ThrottlingLogger;
+import io.opentelemetry.sdk.common.export.HttpResponse;
+import io.opentelemetry.sdk.common.export.HttpSender;
+import io.opentelemetry.sdk.common.export.MessageWriter;
+import io.opentelemetry.sdk.common.internal.ThrottlingLogger;
 import io.quarkus.vertx.core.runtime.BufferOutputStream;
 import io.smallrye.common.annotation.SuppressForbidden;
 import io.smallrye.mutiny.Uni;
@@ -33,6 +35,8 @@ import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.impl.HttpClientBuilderImpl;
+import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.tracing.TracingPolicy;
 
 public final class VertxHttpSender implements HttpSender {
@@ -41,8 +45,10 @@ public final class VertxHttpSender implements HttpSender {
     public static final String METRICS_PATH = "/v1/metrics";
     public static final String LOGS_PATH = "/v1/logs";
 
-    private static final Logger internalLogger = Logger.getLogger(VertxHttpSender.class.getName());
-    private static final ThrottlingLogger logger = new ThrottlingLogger(internalLogger);
+    private static final Logger log = Logger.getLogger(VertxHttpSender.class.getName());
+
+    private static final ThrottlingLogger throttlingLogger = new ThrottlingLogger(
+            java.util.logging.Logger.getLogger(VertxHttpSender.class.getName()));
 
     private static final int MAX_ATTEMPTS = 3;
 
@@ -73,7 +79,15 @@ public final class VertxHttpSender implements HttpSender {
                 .setDefaultPort(getPort(baseUri))
                 .setTracingPolicy(TracingPolicy.IGNORE); // needed to avoid tracing the calls from this http client
         clientOptionsCustomizer.accept(httpClientOptions);
-        this.client = vertx.createHttpClient(httpClientOptions);
+        this.client = (new HttpClientBuilderImpl((VertxInternal) vertx))
+                .with(httpClientOptions)
+                .with(httpClientOptions.getPoolOptions())
+                .withConnectHandler(connection -> {
+                    connection.exceptionHandler(thw -> {
+                        throttlingLogger.log(Level.WARNING, "Connection handler exception: ", thw);
+                    });
+                })
+                .build();
     }
 
     private final AtomicBoolean isShutdown = new AtomicBoolean();
@@ -94,24 +108,23 @@ public final class VertxHttpSender implements HttpSender {
     }
 
     @Override
-    public void send(Marshaler marshaler,
-            int contentLength,
-            Consumer<Response> onHttpResponseRead,
+    public void send(MessageWriter requestBodyWriter,
+            Consumer<HttpResponse> onHttpResponseRead,
             Consumer<Throwable> onError) {
         if (isShutdown.get()) {
             return;
         }
 
-        String marshalerType = marshaler.getClass().getSimpleName();
+        String writerType = requestBodyWriter.getClass().getSimpleName();
         String requestURI = basePath + signalPath;
         var clientRequestSuccessHandler = new ClientRequestSuccessHandler(client, requestURI, headers, compressionEnabled,
                 contentType,
-                contentLength, onHttpResponseRead,
-                onError, marshaler, 1, isShutdown::get);
+                onHttpResponseRead,
+                onError, requestBodyWriter, 1, isShutdown::get);
         initiateSend(client, requestURI, MAX_ATTEMPTS, clientRequestSuccessHandler, new Consumer<>() {
             @Override
             public void accept(Throwable throwable) {
-                failOnClientRequest(marshalerType, throwable, onError);
+                failOnClientRequest(writerType, throwable, onError);
             }
         });
     }
@@ -122,7 +135,7 @@ public final class VertxHttpSender implements HttpSender {
                 + type
                 + ". The request could not be executed. Full error message: "
                 + (t.getMessage() == null ? t.getClass().getName() : t.getMessage());
-        logger.log(Level.WARNING, message);
+        throttlingLogger.log(Level.WARNING, message);
         onError.accept(t);
     }
 
@@ -167,7 +180,7 @@ public final class VertxHttpSender implements HttpSender {
     @SuppressForbidden(reason = "The use of ThrottlingLogger mandates the use of java.util.logging")
     public CompletableResultCode shutdown() {
         if (!isShutdown.compareAndSet(false, true)) {
-            logger.log(Level.FINE, "Calling shutdown() multiple times.");
+            throttlingLogger.log(Level.FINE, "Calling shutdown() multiple times.");
             return shutdownResult;
         }
 
@@ -187,7 +200,7 @@ public final class VertxHttpSender implements HttpSender {
                         }
                     });
         } catch (RejectedExecutionException e) {
-            internalLogger.log(Level.FINE, "Unable to complete shutdown", e);
+            log.debug("Unable to complete shutdown", e);
             // if Netty's ThreadPool has been closed, this onSuccess() will immediately throw RejectedExecutionException
             // which we need to handle
             shutdownResult.fail();
@@ -201,10 +214,9 @@ public final class VertxHttpSender implements HttpSender {
         private final Map<String, String> headers;
         private final boolean compressionEnabled;
         private final String contentType;
-        private final int contentLength;
-        private final Consumer<Response> onHttpResponseRead;
+        private final Consumer<HttpResponse> onHttpResponseRead;
         private final Consumer<Throwable> onError;
-        private final Marshaler marshaler;
+        private final MessageWriter requestBodyWriter;
 
         private final int attemptNumber;
         private final Supplier<Boolean> isShutdown;
@@ -213,10 +225,9 @@ public final class VertxHttpSender implements HttpSender {
                 String requestURI, Map<String, String> headers,
                 boolean compressionEnabled,
                 String contentType,
-                int contentLength,
-                Consumer<Response> onHttpResponseRead,
+                Consumer<HttpResponse> onHttpResponseRead,
                 Consumer<Throwable> onError,
-                Marshaler marshaler,
+                MessageWriter requestBodyWriter,
                 int attemptNumber,
                 Supplier<Boolean> isShutdown) {
             this.client = client;
@@ -224,10 +235,9 @@ public final class VertxHttpSender implements HttpSender {
             this.headers = headers;
             this.compressionEnabled = compressionEnabled;
             this.contentType = contentType;
-            this.contentLength = contentLength;
             this.onHttpResponseRead = onHttpResponseRead;
             this.onError = onError;
-            this.marshaler = marshaler;
+            this.requestBodyWriter = requestBodyWriter;
             this.attemptNumber = attemptNumber;
             this.isShutdown = isShutdown;
         }
@@ -255,19 +265,19 @@ public final class VertxHttpSender implements HttpSender {
                                             return;
                                         }
                                     }
-                                    onHttpResponseRead.accept(new Response() {
+                                    onHttpResponseRead.accept(new HttpResponse() {
                                         @Override
-                                        public int statusCode() {
+                                        public int getStatusCode() {
                                             return clientResponse.statusCode();
                                         }
 
                                         @Override
-                                        public String statusMessage() {
+                                        public String getStatusMessage() {
                                             return clientResponse.statusMessage();
                                         }
 
                                         @Override
-                                        public byte[] responseBody() {
+                                        public byte[] getResponseBody() {
                                             return bodyResult.result().getBytes();
                                         }
                                     });
@@ -299,18 +309,18 @@ public final class VertxHttpSender implements HttpSender {
             })
                     .putHeader("Content-Type", contentType);
 
-            Buffer buffer = Buffer.buffer(contentLength);
+            Buffer buffer = Buffer.buffer(requestBodyWriter.getContentLength());
             OutputStream os = new BufferOutputStream(buffer);
             if (compressionEnabled) {
                 clientRequest.putHeader("Content-Encoding", "gzip");
                 try (var gzos = new GZIPOutputStream(os)) {
-                    marshaler.writeBinaryTo(gzos);
+                    requestBodyWriter.writeMessage(gzos);
                 } catch (IOException e) {
                     throw new IllegalStateException(e);
                 }
             } else {
                 try {
-                    marshaler.writeBinaryTo(os);
+                    requestBodyWriter.writeMessage(os);
                 } catch (IOException e) {
                     throw new IllegalStateException(e);
                 }
@@ -327,8 +337,8 @@ public final class VertxHttpSender implements HttpSender {
 
         public ClientRequestSuccessHandler newAttempt() {
             return new ClientRequestSuccessHandler(client, requestURI, headers, compressionEnabled,
-                    contentType, contentLength, onHttpResponseRead,
-                    onError, marshaler, attemptNumber + 1, isShutdown);
+                    contentType, onHttpResponseRead,
+                    onError, requestBodyWriter, attemptNumber + 1, isShutdown);
         }
     }
 }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/tracing/VertxGrpcSpanExporter.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/tracing/VertxGrpcSpanExporter.java
@@ -10,9 +10,9 @@ import io.opentelemetry.sdk.trace.export.SpanExporter;
 
 public final class VertxGrpcSpanExporter implements SpanExporter {
 
-    private final GrpcExporter<TraceRequestMarshaler> delegate;
+    private final GrpcExporter delegate;
 
-    public VertxGrpcSpanExporter(GrpcExporter<TraceRequestMarshaler> delegate) {
+    public VertxGrpcSpanExporter(GrpcExporter delegate) {
         this.delegate = delegate;
     }
 

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/tracing/VertxHttpSpanExporter.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/tracing/VertxHttpSpanExporter.java
@@ -10,9 +10,9 @@ import io.opentelemetry.sdk.trace.export.SpanExporter;
 
 public final class VertxHttpSpanExporter implements SpanExporter {
 
-    private final HttpExporter<TraceRequestMarshaler> delegate;
+    private final HttpExporter delegate;
 
-    public VertxHttpSpanExporter(HttpExporter<TraceRequestMarshaler> delegate) {
+    public VertxHttpSpanExporter(HttpExporter delegate) {
         this.delegate = delegate;
     }
 

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/graal/RandomSupplier.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/graal/RandomSupplier.java
@@ -7,7 +7,7 @@ import java.util.function.Supplier;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 
-@TargetClass(className = "io.opentelemetry.sdk.internal.RandomSupplier")
+@TargetClass(className = "io.opentelemetry.sdk.common.internal.RandomSupplier")
 final class RandomSupplier {
 
     @Substitute

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/grpc/GrpcAttributesGetter.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/grpc/GrpcAttributesGetter.java
@@ -1,8 +1,9 @@
 package io.quarkus.opentelemetry.runtime.tracing.instrumentation.grpc;
 
+import io.grpc.Status;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcAttributesGetter;
 
-enum GrpcAttributesGetter implements RpcAttributesGetter<GrpcRequest> {
+enum GrpcAttributesGetter implements RpcAttributesGetter<GrpcRequest, Status> {
     INSTANCE;
 
     @Override
@@ -15,8 +16,20 @@ enum GrpcAttributesGetter implements RpcAttributesGetter<GrpcRequest> {
         return grpcRequest.getMethodDescriptor().getServiceName();
     }
 
+    /**
+     * Marked as Deprecated upstream
+     *
+     * @param grpcRequest
+     * @return
+     */
+    @Deprecated
     @Override
     public String getMethod(final GrpcRequest grpcRequest) {
+        return grpcRequest.getMethodDescriptor().getBareMethodName();
+    }
+
+    @Override
+    public String getRpcMethod(final GrpcRequest grpcRequest) {
         return grpcRequest.getMethodDescriptor().getBareMethodName();
     }
 }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/RedisClientInstrumenterVertxTracer.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/RedisClientInstrumenterVertxTracer.java
@@ -181,7 +181,7 @@ public class RedisClientInstrumenterVertxTracer implements
         }
 
         @Override
-        public String getDbSystem(final CommandTrace commandTrace) {
+        public String getDbSystemName(final CommandTrace commandTrace) {
             return REDIS;
         }
 
@@ -194,7 +194,7 @@ public class RedisClientInstrumenterVertxTracer implements
 
         @Override
         public String getDbNamespace(CommandTrace commandTrace) {
-            return null;
+            return commandTrace.dbIndex();
         }
 
         // kept for compatibility reasons

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/RedisClientInstrumenterVertxTracer.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/RedisClientInstrumenterVertxTracer.java
@@ -1,6 +1,6 @@
 package io.quarkus.opentelemetry.runtime.tracing.instrumentation.vertx;
 
-import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAMESPACE;
+import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.REDIS;
 import static io.quarkus.opentelemetry.runtime.config.build.OTelBuildConfig.INSTRUMENTATION_NAME;
 
@@ -16,7 +16,6 @@ import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
-import io.opentelemetry.instrumentation.api.internal.AttributesExtractorUtil;
 import io.opentelemetry.instrumentation.api.semconv.network.NetworkAttributesExtractor;
 import io.opentelemetry.instrumentation.api.semconv.network.NetworkAttributesGetter;
 import io.quarkus.opentelemetry.runtime.config.runtime.OTelRuntimeConfig;
@@ -231,7 +230,9 @@ public class RedisClientInstrumenterVertxTracer implements
         @Override
         public void onStart(AttributesBuilder attributes, io.opentelemetry.context.Context parentContext,
                 CommandTrace request) {
-            AttributesExtractorUtil.internalSet(attributes, DB_NAMESPACE, request.dbIndex());
+            if (request.dbIndex() != null) {
+                attributes.put(DB_NAMESPACE, request.dbIndex());
+            }
         }
 
         @Override

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/SqlClientInstrumenterVertxTracer.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/SqlClientInstrumenterVertxTracer.java
@@ -1,16 +1,20 @@
 package io.quarkus.opentelemetry.runtime.tracing.instrumentation.vertx;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlDialect.DOUBLE_QUOTES_ARE_IDENTIFIERS;
+import static io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlDialect.DOUBLE_QUOTES_ARE_STRING_LITERALS;
 import static io.quarkus.opentelemetry.runtime.config.build.OTelBuildConfig.INSTRUMENTATION_NAME;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiConsumer;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlClientAttributesExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlDialect;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.semconv.network.NetworkAttributesExtractor;
@@ -143,6 +147,54 @@ public class SqlClientInstrumenterVertxTracer implements
     static class SqlClientAttributesGetter implements
             io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlClientAttributesGetter<QueryTrace, Object>,
             NetworkAttributesGetter<QueryTrace, Object> {
+
+        // Databases where double quotes are exclusively identifiers and cannot be string literals.
+        private static final Set<String> DOUBLE_QUOTES_FOR_IDENTIFIERS_SYSTEMS = Set.of(
+                // "A string constant in SQL is an arbitrary sequence of characters
+                // bounded by single quotes (')"
+                // https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-STRINGS
+                "postgresql",
+                // "Text, character, and string literals are always surrounded
+                // by single quotation marks."
+                // https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/Literals.html
+                "oracle",
+                // "A sequence of characters that starts and ends with a string delimiter,
+                // which is an apostrophe (')"
+                // https://www.ibm.com/docs/en/db2/12.1?topic=elements-constants
+                "db2",
+                // "Single quotation marks delimit character strings."
+                // "Double quotation marks delimit special identifiers"
+                // https://db.apache.org/derby/docs/10.17/ref/rrefsqlj28468.html
+                "derby",
+                // "names of objects are enclosed in double-quotes"
+                // (double quotes are exclusively for identifiers; follows SQL standard strictly)
+                // https://hsqldb.org/doc/2.0/guide/sqlgeneral-chapt.html
+                "hsqldb",
+                // <string_literal> ::= <single_quote>[<any_character>...]<single_quote>
+                // <special_identifier> ::= <double_quotes><any_character>...<double_quotes>
+                // https://help.sap.com/docs/hana-cloud-database/sap-hana-cloud-sap-hana-database-sql-reference-guide/sql-notation-conventions
+                "hanadb",
+                // "String literals must be enclosed in single quotes.
+                // Double quotes are not supported."
+                // https://clickhouse.com/docs/en/sql-reference/syntax#string
+                "clickhouse",
+                // PostgreSQL-compatible fork, inherits PG string literal rules
+                "polardb");
+
+        /**
+         * Same as in
+         * io.opentelemetry.instrumentation.jdbc.internal.JdbcAttributesGetter#getSqlDialect(io.opentelemetry.instrumentation.jdbc.internal.DbRequest)
+         */
+        @Override
+        public SqlDialect getSqlDialect(QueryTrace queryTrace) {
+            String system = queryTrace.system();
+            if (system != null && DOUBLE_QUOTES_FOR_IDENTIFIERS_SYSTEMS.contains(system)) {
+                return DOUBLE_QUOTES_ARE_IDENTIFIERS;
+            }
+            // default to treating double-quoted tokens as string literals for safety, ensuring that
+            // potentially sensitive values are not captured
+            return DOUBLE_QUOTES_ARE_STRING_LITERALS;
+        }
 
         @Override
         public Collection<String> getRawQueryTexts(final QueryTrace queryTrace) {

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/SqlClientInstrumenterVertxTracer.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/instrumentation/vertx/SqlClientInstrumenterVertxTracer.java
@@ -152,7 +152,7 @@ public class SqlClientInstrumenterVertxTracer implements
         }
 
         @Override
-        public String getDbSystem(final QueryTrace queryTrace) {
+        public String getDbSystemName(final QueryTrace queryTrace) {
             return queryTrace.system();
         }
 

--- a/integration-tests/opentelemetry-redis-instrumentation/src/test/java/io/quarkus/it/opentelemetry/QuarkusOpenTelemetryRedisTest.java
+++ b/integration-tests/opentelemetry-redis-instrumentation/src/test/java/io/quarkus/it/opentelemetry/QuarkusOpenTelemetryRedisTest.java
@@ -1,11 +1,11 @@
 package io.quarkus.it.opentelemetry;
 
+import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_LOCAL_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_LOCAL_PORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CONNECTION_STRING;
-import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAMESPACE;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.REDIS;
@@ -60,8 +60,8 @@ class QuarkusOpenTelemetryRedisTest {
     @Test
     public void syncValidOperation() {
         String path = String.format("redis/sync/%s", getKey(SYNC_KEY));
-        String getCommand = Command.GET.toString();
-        String setCommand = Command.SET.toString();
+        String getCommand = Command.GET.toString() + " 0";
+        String setCommand = Command.SET.toString() + " 0";
 
         RestAssured.given()
                 .body(SYNC_VALUE)
@@ -91,7 +91,7 @@ class QuarkusOpenTelemetryRedisTest {
 
         // SET
         assertEquals(setCommand, setSpan.get("name"));
-        assertEquals(setCommand, setAttributes.get(DB_OPERATION.getKey()));
+        assertEquals("set", setAttributes.get(DB_OPERATION.getKey()));
         assertEquals(REDIS, setAttributes.get(DB_SYSTEM.getKey()));
         assertEquals("0", setAttributes.get(DB_NAMESPACE.getKey()));
         assertEquals(CONNECTION_STRING, setAttributes.get(DB_CONNECTION_STRING.getKey()));
@@ -101,7 +101,7 @@ class QuarkusOpenTelemetryRedisTest {
         assertEquals(16379, setAttributes.get(NETWORK_LOCAL_PORT.getKey()));
         // GET
         assertEquals(getCommand, getSpan.get("name"));
-        assertEquals(getCommand, getAttributes.get(DB_OPERATION.getKey()));
+        assertEquals("get", getAttributes.get(DB_OPERATION.getKey()));
         assertEquals(REDIS, getAttributes.get(DB_SYSTEM.getKey()));
         assertEquals("0", setAttributes.get(DB_NAMESPACE.getKey()));
         assertEquals(CONNECTION_STRING, setAttributes.get(DB_CONNECTION_STRING.getKey()));
@@ -127,7 +127,7 @@ class QuarkusOpenTelemetryRedisTest {
         Map<String, Object> event = ((List<Map<String, Object>>) span.get("events")).get(0);
         Map<String, Object> exception = (Map<String, Object>) event.get("exception");
 
-        assertEquals("bazinga", span.get("name"));
+        assertEquals("bazinga 0", span.get("name"));
         assertEquals("ERROR", status.get("statusCode"));
         assertEquals("exception", event.get("name"));
 
@@ -142,8 +142,8 @@ class QuarkusOpenTelemetryRedisTest {
     @Test
     public void reactiveValidOperation() {
         String path = String.format("redis/reactive/%s", getKey(REACTIVE_KEY));
-        String getCommand = Command.GET.toString();
-        String setCommand = Command.SET.toString();
+        String getCommand = Command.GET.toString() + " 0";
+        String setCommand = Command.SET.toString() + " 0";
 
         RestAssured.given()
                 .body(REACTIVE_VALUE)
@@ -173,7 +173,7 @@ class QuarkusOpenTelemetryRedisTest {
 
         // SET
         assertEquals(setCommand, setSpan.get("name"));
-        assertEquals(setCommand, setAttributes.get(DB_OPERATION.getKey()));
+        assertEquals("set", setAttributes.get(DB_OPERATION.getKey()));
         assertEquals(REDIS, setAttributes.get(DB_SYSTEM.getKey()));
         assertEquals("0", setAttributes.get(DB_NAMESPACE.getKey()));
         assertEquals(CONNECTION_STRING, setAttributes.get(DB_CONNECTION_STRING.getKey()));
@@ -183,7 +183,7 @@ class QuarkusOpenTelemetryRedisTest {
         assertEquals(16379, setAttributes.get(NETWORK_LOCAL_PORT.getKey()));
         // GET
         assertEquals(getCommand, getSpan.get("name"));
-        assertEquals(getCommand, getAttributes.get(DB_OPERATION.getKey()));
+        assertEquals("get", getAttributes.get(DB_OPERATION.getKey()));
         assertEquals(REDIS, getAttributes.get(DB_SYSTEM.getKey()));
         assertEquals("0", getAttributes.get(DB_NAMESPACE.getKey()));
         assertEquals(CONNECTION_STRING, setAttributes.get(DB_CONNECTION_STRING.getKey()));
@@ -209,7 +209,7 @@ class QuarkusOpenTelemetryRedisTest {
         Map<String, Object> event = ((List<Map<String, Object>>) span.get("events")).get(0);
         Map<String, Object> exception = (Map<String, Object>) event.get("exception");
 
-        assertEquals("bazinga", span.get("name"));
+        assertEquals("bazinga 0", span.get("name"));
         assertEquals("ERROR", status.get("statusCode"));
         assertEquals("exception", event.get("name"));
 


### PR DESCRIPTION
Relates to https://github.com/quarkusio/quarkus/issues/54670.

Includes backports for:
- https://github.com/quarkusio/quarkus/pull/54794 (not yet)
- https://github.com/quarkusio/quarkus/pull/53476
- https://github.com/quarkusio/quarkus/pull/51143

Provides fix for CVE-2026-45292 - unbounded memory allocation in W3CBaggagePropagator when parsing crafted baggage headers.