### PR TITLE
[4.0] Unix Domain Socket support works without native transports

### DIFF
--- a/docs/src/main/asciidoc/deploying-to-google-cloud.adoc
+++ b/docs/src/main/asciidoc/deploying-to-google-cloud.adoc
@@ -267,24 +267,11 @@ due to issue link:https://github.com/quarkusio/quarkus/issues/15782[#15782].
 === Using Cloud SQL with a reactive SQL client
 
 You can also use one of our reactive SQL client instead of the JDBC client.
-To do so with Cloud SQL, add the following dependency
-(adjust the classifier depending on your platform):
-
-[source, xml]
-----
-<dependency>
-    <groupId>io.netty</groupId>
-    <artifactId>netty-transport-native-epoll</artifactId>
-    <classifier>linux-x86_64</classifier>
-</dependency>
-----
-
-Then configure your reactive datasource with no hostname and with the Netty native transport:
+Configure your reactive datasource with no hostname:
 
 [source, properties]
 ----
 quarkus.datasource.reactive.url=postgresql://:5432/db-name?host=/cloudsql/project-id:zone:db-name
-quarkus.vertx.prefer-native-transport=true
 ----
 
 WARNING: This only works when your application is running inside a Google Cloud managed runtime like App Engine.

--- a/docs/src/main/asciidoc/reactive-sql-clients.adoc
+++ b/docs/src/main/asciidoc/reactive-sql-clients.adoc
@@ -690,13 +690,13 @@ Pool additional2Client;
 <1> Injecting the client for the default datasource does not require anything special.
 <2> For a named datasource, you use the `@ReactiveDataSource` CDI qualifier with the datasource name as its value.
 
-== UNIX Domain Socket connections
+== Unix Domain Socket connections
 
-The PostgreSQL and MariaDB/MySQL clients can be configured to connect to the server through a UNIX domain socket.
+The PostgreSQL and MariaDB/MySQL clients can be configured to connect to the server through a Unix Domain Socket.
 
-First make sure that xref:vertx-reference.adoc#native-transport[native transport support] is enabled.
+Unix Domain Sockets are supported in both JVM and native modes.
 
-Then configure the database connection url.
+Configure the database connection url as described below.
 This step depends on the database type.
 
 === PostgreSQL

--- a/docs/src/main/asciidoc/vertx-reference.adoc
+++ b/docs/src/main/asciidoc/vertx-reference.adoc
@@ -1078,22 +1078,18 @@ class MyVerticle extends AbstractVerticle {
 In this example a scheduler is created by capturing the context of the Vert.x event-loop that calls `asyncStart()`.
 The `delayIt` operator uses that scheduler, and we can check that the context that we get in `invoke` is a Vert.x duplicated context where the data for key `"foo"` has been propagated.
 
-== Use a Unix domain socket
+== Use a Unix Domain Socket
 
-Listening on a Unix domain socket allows us to dispense with the overhead of TCP
+Listening on a Unix Domain Socket allows us to dispense with the overhead of TCP
 if the connection to the quarkus service is established from the same host.
 This can happen if access to the service goes through a proxy which is often the case
 if you're setting up a service mesh with a proxy like Envoy.
 
-IMPORTANT: This will only work on platforms that support <<native-transport>>.
-
-Enable the appropriate <<native-transport>> and set the following environment property:
+Unix Domain Sockets are supported in both JVM and native modes.
 
 ----
 quarkus.http.domain-socket=/var/run/io.quarkus.app.socket
 quarkus.http.domain-socket-enabled=true
-
-quarkus.vertx.prefer-native-transport=true
 ----
 
 By itself this will not disable the tcp socket which by default will open on
@@ -1105,9 +1101,6 @@ quarkus.http.host-enabled=false
 
 These properties can be set through Java's `-D` command line parameter or
 on `application.properties`.
-
-IMPORTANT: Do not forget to add the native transport dependency.
-See <<native-transport>> for details.
 
 IMPORTANT: Make sure your application has the right permissions to write to the socket.
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/DomainSocketServerStart.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/DomainSocketServerStart.java
@@ -3,15 +3,15 @@ package io.quarkus.vertx.http;
 import io.vertx.core.http.HttpServerOptions;
 
 /**
- * Quarkus fires a CDI event of this type asynchronously when the domain socket server starts listening
- * on the configured host and port.
+ * Quarkus fires a CDI event of this type asynchronously when the Unix Domain Socket server starts listening
+ * on the configured socket path.
  *
  * <pre>
  * &#064;ApplicationScoped
  * public class MyListener {
  *
  *     void domainSocketStarted(&#064;ObservesAsync DomainSocketServerStart start) {
- *         // ...notified when the domain socket server starts listening
+ *         // ...notified when the Unix Domain Socket server starts listening
  *     }
  * }
  * </pre>

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/HttpServerOptionsCustomizer.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/HttpServerOptionsCustomizer.java
@@ -28,7 +28,7 @@ public interface HttpServerOptionsCustomizer {
     }
 
     /**
-     * Allows customizing the server listening on a domain socket if any.
+     * Allows customizing the server listening on a Unix Domain Socket if any.
      */
     default void customizeDomainSocketServer(HttpServerOptions options) {
         // NO-OP

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpConfig.java
@@ -366,7 +366,7 @@ public interface VertxHttpConfig {
     int trafficClass();
 
     /**
-     * Path to a unix domain socket
+     * Path to a Unix Domain Socket.
      */
     @WithDefault("/var/run/io.quarkus.app.socket")
     String domainSocket();
@@ -377,7 +377,7 @@ public interface VertxHttpConfig {
     }
 
     /**
-     * Enable listening to host:port
+     * Enable listening on a Unix Domain Socket.
      */
     @WithDefault("false")
     boolean domainSocketEnabled();

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -1368,7 +1368,7 @@ public class VertxHttpRecorder {
                             && event.cause().getMessage().contains("Permission denied")) {
                         startFuture.fail(new IllegalStateException(
                                 String.format(
-                                        "Unable to bind to Unix domain socket (%s) as the application does not have the permission to write in the directory.",
+                                        "Unable to bind to Unix Domain Socket (%s) as the application does not have the permission to write in the directory.",
                                         domainSocketOptions.getHost())));
                     } else if (event.cause() instanceof IllegalArgumentException) {
                         startFuture.fail(new IllegalArgumentException(

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementConfig.java
@@ -138,7 +138,7 @@ public interface ManagementConfig {
     int acceptBacklog();
 
     /**
-     * Path to a unix domain socket
+     * Path to a Unix Domain Socket.
      */
     @WithDefault("/var/run/io.quarkus.management.socket")
     String domainSocket();

--- a/integration-tests/vertx-http/src/main/java/io/quarkus/it/vertx/UnixDomainSocketResource.java
+++ b/integration-tests/vertx-http/src/main/java/io/quarkus/it/vertx/UnixDomainSocketResource.java
@@ -1,0 +1,17 @@
+package io.quarkus.it.vertx;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/uds")
+public class UnixDomainSocketResource {
+
+    @GET
+    @Path("/test")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String test() {
+        return "Unix Domain Socket Test";
+    }
+}

--- a/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/UnixDomainSocketIT.java
+++ b/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/UnixDomainSocketIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.vertx;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class UnixDomainSocketIT extends UnixDomainSocketTest {
+}

--- a/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/UnixDomainSocketTest.java
+++ b/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/UnixDomainSocketTest.java
@@ -1,0 +1,62 @@
+package io.quarkus.it.vertx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.vertx.core.http.RequestOptions;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.mutiny.core.Vertx;
+import io.vertx.mutiny.core.http.HttpClient;
+import io.vertx.mutiny.core.http.HttpClientResponse;
+
+@QuarkusTest
+@WithTestResource(UnixDomainSocketTestResource.class)
+@DisabledOnOs(OS.WINDOWS)
+public class UnixDomainSocketTest {
+
+    Vertx vertx;
+    HttpClient httpClient;
+
+    @BeforeEach
+    void setUp() {
+        vertx = Vertx.vertx();
+        httpClient = vertx.createHttpClient();
+    }
+
+    @Test
+    public void testUnixDomainSocketHttpExchange() {
+        String address = ConfigProvider.getConfig().getValue("quarkus.http.domain-socket", String.class);
+        SocketAddress socketAddress = SocketAddress.domainSocketAddress(address);
+
+        RequestOptions requestOptions = new RequestOptions()
+                .setAbsoluteURI("http://localhost:8080/uds/test")
+                .setServer(socketAddress);
+
+        HttpClientResponse response = httpClient.request(requestOptions).onItem().transformToUni(req -> {
+            return req.send().onItem().transformToUni(resp -> resp.body().replaceWith(resp));
+        }).await().atMost(Duration.ofSeconds(10));
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.bodyAndAwait().toString()).isEqualTo("Unix Domain Socket Test");
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (httpClient != null) {
+            httpClient.close().await().atMost(Duration.ofSeconds(10));
+        }
+        if (vertx != null) {
+            vertx.close().await().atMost(Duration.ofSeconds(10));
+        }
+    }
+}

--- a/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/UnixDomainSocketTestResource.java
+++ b/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/UnixDomainSocketTestResource.java
@@ -1,0 +1,41 @@
+package io.quarkus.it.vertx;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+public class UnixDomainSocketTestResource implements QuarkusTestResourceLifecycleManager {
+
+    private Path udsPath;
+
+    @Override
+    public void init(Map<String, String> initArgs) {
+        try {
+            udsPath = Files.createTempFile(Path.of("/tmp"), "quarkus-test", ".sock");
+            Files.delete(udsPath); // Let Quarkus create a proper UDS with same path
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Map<String, String> start() {
+        return Map.of(
+                "quarkus.http.domain-socket-enabled", "true",
+                "quarkus.http.domain-socket", udsPath.toAbsolutePath().toString(),
+                "quarkus.http.host-enabled", "false",
+                "quarkus.vertx.prefer-native-transport", "false");
+    }
+
+    @Override
+    public void stop() {
+        try {
+            Files.deleteIfExists(udsPath);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Closes #54528

With Vert.x 5, it's possible to connect or listen to Unix Domain Sockets without native transports, if the runtime version is at least 16+, which is always true for Quarkus.

We should clarify in the docs that UDS work in both JVM and native mode, and remove instructions to add native dependencies.