### PR TITLE
Work around for HHH90001002 log filter being ignored in HibernateOrmNoWarningsTest

### DIFF
--- a/integration-tests/jpa-db2/src/test/java/io/quarkus/it/jpa/db2/HibernateOrmNoWarningsTest.java
+++ b/integration-tests/jpa-db2/src/test/java/io/quarkus/it/jpa/db2/HibernateOrmNoWarningsTest.java
@@ -25,7 +25,9 @@ import io.quarkus.test.junit.QuarkusTest;
         // Ignore logs about schema management:
         // they are unfortunate (https://github.com/quarkusio/quarkus/issues/16204)
         // but for now we have to live with them.
-        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*")
+        // Ignore logs about JCache region factory being closed "twice", too: the log filter is apparently ignored,
+        // see https://github.com/quarkusio/quarkus/issues/48346
+        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*,org\\.hibernate\\.orm\\.cache.*")
 })
 public class HibernateOrmNoWarningsTest {
     @Test

--- a/integration-tests/jpa-h2-embedded/src/test/java/io/quarkus/it/jpa/h2/HibernateOrmNoWarningsTest.java
+++ b/integration-tests/jpa-h2-embedded/src/test/java/io/quarkus/it/jpa/h2/HibernateOrmNoWarningsTest.java
@@ -25,7 +25,9 @@ import io.quarkus.test.junit.QuarkusTest;
         // Ignore logs about schema management:
         // they are unfortunate (https://github.com/quarkusio/quarkus/issues/16204)
         // but for now we have to live with them.
-        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*")
+        // Ignore logs about JCache region factory being closed "twice", too: the log filter is apparently ignored,
+        // see https://github.com/quarkusio/quarkus/issues/48346
+        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*,org\\.hibernate\\.orm\\.cache.*")
 })
 public class HibernateOrmNoWarningsTest {
     @Test

--- a/integration-tests/jpa-h2/src/test/java/io/quarkus/it/jpa/h2/HibernateOrmNoWarningsTest.java
+++ b/integration-tests/jpa-h2/src/test/java/io/quarkus/it/jpa/h2/HibernateOrmNoWarningsTest.java
@@ -23,7 +23,9 @@ import io.quarkus.test.junit.QuarkusTest;
         @ResourceArg(name = LogCollectingTestResource.LEVEL, value = "WARNING"),
         @ResourceArg(name = LogCollectingTestResource.INCLUDE, value = "org\\.hibernate\\..*"),
         //We actually have a single warning, caused by the intentional peculiarities of io.quarkus.it.jpa.h2.CompanyCustomer:
-        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.metamodel\\.internal\\.EntityRepresentationStrategyPojoStandard"),
+        // Ignore logs about JCache region factory being closed "twice", too: the log filter is apparently ignored,
+        // see https://github.com/quarkusio/quarkus/issues/48346
+        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.metamodel\\.internal\\.EntityRepresentationStrategyPojoStandard,org\\.hibernate\\.orm\\.cache.*"),
 })
 public class HibernateOrmNoWarningsTest {
     @Test

--- a/integration-tests/jpa-mariadb/src/test/java/io/quarkus/it/jpa/mariadb/HibernateOrmNoWarningsTest.java
+++ b/integration-tests/jpa-mariadb/src/test/java/io/quarkus/it/jpa/mariadb/HibernateOrmNoWarningsTest.java
@@ -25,7 +25,9 @@ import io.quarkus.test.junit.QuarkusTest;
         // Ignore logs about schema management:
         // they are unfortunate (https://github.com/quarkusio/quarkus/issues/16204)
         // but for now we have to live with them.
-        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*")
+        // Ignore logs about JCache region factory being closed "twice", too: the log filter is apparently ignored,
+        // see https://github.com/quarkusio/quarkus/issues/48346
+        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*,org\\.hibernate\\.orm\\.cache.*")
 })
 public class HibernateOrmNoWarningsTest {
     @Test

--- a/integration-tests/jpa-mssql/src/test/java/io/quarkus/it/jpa/mssql/HibernateOrmNoWarningsTest.java
+++ b/integration-tests/jpa-mssql/src/test/java/io/quarkus/it/jpa/mssql/HibernateOrmNoWarningsTest.java
@@ -25,7 +25,9 @@ import io.quarkus.test.junit.QuarkusTest;
         // Ignore logs about schema management:
         // they are unfortunate (https://github.com/quarkusio/quarkus/issues/16204)
         // but for now we have to live with them.
-        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*")
+        // Ignore logs about JCache region factory being closed "twice", too: the log filter is apparently ignored,
+        // see https://github.com/quarkusio/quarkus/issues/48346
+        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*,org\\.hibernate\\.orm\\.cache.*")
 })
 public class HibernateOrmNoWarningsTest {
     @Test

--- a/integration-tests/jpa-mysql/src/test/java/io/quarkus/it/jpa/mysql/HibernateOrmNoWarningsTest.java
+++ b/integration-tests/jpa-mysql/src/test/java/io/quarkus/it/jpa/mysql/HibernateOrmNoWarningsTest.java
@@ -25,7 +25,9 @@ import io.quarkus.test.junit.QuarkusTest;
         // Ignore logs about schema management:
         // they are unfortunate (https://github.com/quarkusio/quarkus/issues/16204)
         // but for now we have to live with them.
-        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*")
+        // Ignore logs about JCache region factory being closed "twice", too: the log filter is apparently ignored,
+        // see https://github.com/quarkusio/quarkus/issues/48346
+        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*,org\\.hibernate\\.orm\\.cache.*")
 })
 public class HibernateOrmNoWarningsTest {
     @Test

--- a/integration-tests/jpa-oracle/src/test/java/io/quarkus/it/jpa/oracle/HibernateOrmNoWarningsTest.java
+++ b/integration-tests/jpa-oracle/src/test/java/io/quarkus/it/jpa/oracle/HibernateOrmNoWarningsTest.java
@@ -25,7 +25,9 @@ import io.quarkus.test.junit.QuarkusTest;
         // Ignore logs about schema management:
         // they are unfortunate (https://github.com/quarkusio/quarkus/issues/16204)
         // but for now we have to live with them.
-        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*")
+        // Ignore logs about JCache region factory being closed "twice", too: the log filter is apparently ignored,
+        // see https://github.com/quarkusio/quarkus/issues/48346
+        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*,org\\.hibernate\\.orm\\.cache.*")
 })
 public class HibernateOrmNoWarningsTest {
     @Test

--- a/integration-tests/jpa-postgresql/src/test/java/io/quarkus/it/jpa/postgresql/HibernateOrmNoWarningsTest.java
+++ b/integration-tests/jpa-postgresql/src/test/java/io/quarkus/it/jpa/postgresql/HibernateOrmNoWarningsTest.java
@@ -25,7 +25,9 @@ import io.quarkus.test.junit.QuarkusTest;
         // Ignore logs about schema management:
         // they are unfortunate (https://github.com/quarkusio/quarkus/issues/16204)
         // but for now we have to live with them.
-        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*")
+        // Ignore logs about JCache region factory being closed "twice", too: the log filter is apparently ignored,
+        // see https://github.com/quarkusio/quarkus/issues/48346
+        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*,org\\.hibernate\\.orm\\.cache.*")
 })
 public class HibernateOrmNoWarningsTest {
     @Test


### PR DESCRIPTION
Extends the workaround from 701b753839 to all HibernateOrmNoWarningsTest copies across integration tests, excluding org.hibernate.orm.cache.* logs that slip through despite the log filter.

See https://github.com/quarkusio/quarkus/issues/48346, #54891 