### PR TITLE
Fix JSON logging with null formatter keys

### DIFF
--- a/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/runtime/JsonFormatterNullKeyTest.java
+++ b/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/runtime/JsonFormatterNullKeyTest.java
@@ -1,0 +1,60 @@
+package io.quarkus.logging.json.runtime;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Proxy;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import org.junit.jupiter.api.Test;
+
+class JsonFormatterNullKeyTest {
+
+    @Test
+    void jsonLogGeneratorAcceptsNullKeysWhenExclusionsAreConfigured() throws Exception {
+        JsonFormatter.JsonLogGenerator generator = newJsonLogGenerator(Set.of("timestamp", "sequence"));
+
+        assertThatCode(() -> {
+            generator.add(null, true);
+            generator.add(null, 1);
+            generator.add(null, 1L);
+            generator.add(null, Map.of("key", "value"));
+            generator.add(null, "value");
+            generator.startObject(null).endObject();
+            generator.startArray(null).endArray();
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    void formatterKeepsExceptionRecordsWhenExclusionsAreConfigured() {
+        JsonFormatter formatter = new JsonFormatter(null, Set.of("timestamp", "sequence"), Map.of());
+
+        LogRecord record = new LogRecord(Level.WARNING, "Something went wrong");
+        record.setThrown(new RuntimeException("boom"));
+
+        assertThatCode(() -> formatter.format(record)).doesNotThrowAnyException();
+    }
+
+    private static JsonFormatter.JsonLogGenerator newJsonLogGenerator(Set<String> excludedKeys) throws Exception {
+        Class<?> generatorClass = Class.forName("org.jboss.logmanager.formatters.StructuredFormatter$Generator");
+        Object delegate = Proxy.newProxyInstance(
+                generatorClass.getClassLoader(),
+                new Class<?>[] { generatorClass },
+                (proxy, method, args) -> {
+                    if (method.getReturnType().equals(generatorClass)) {
+                        return proxy;
+                    }
+                    if (method.getReturnType().equals(boolean.class)) {
+                        return false;
+                    }
+                    return null;
+                });
+        Constructor<JsonFormatter.JsonLogGenerator> constructor = JsonFormatter.JsonLogGenerator.class
+                .getDeclaredConstructor(generatorClass, Set.class);
+        constructor.setAccessible(true);
+        return constructor.newInstance(delegate, excludedKeys);
+    }
+}

--- a/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/runtime/JsonFormatterNullKeyTest.java
+++ b/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/runtime/JsonFormatterNullKeyTest.java
@@ -1,0 +1,74 @@
+package io.quarkus.logging.json.runtime;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import org.junit.jupiter.api.Test;
+
+class JsonFormatterNullKeyTest {
+
+    @Test
+    void jsonLogGeneratorAcceptsNullKeysWhenExclusionsAreConfigured() {
+        JsonFormatter.JsonLogGenerator generator = new TestFormatter().newJsonLogGenerator(Set.of("timestamp", "sequence"));
+
+        assertThatCode(() -> {
+            generator.add(null, true);
+            generator.add(null, 1);
+            generator.add(null, 1L);
+            generator.add(null, Map.of("key", "value"));
+            generator.add(null, "value");
+            generator.startObject(null).endObject();
+            generator.startArray(null).endArray();
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    void formatterKeepsExceptionRecordsWhenExclusionsAreConfigured() {
+        JsonFormatter formatter = new JsonFormatter(null, Set.of("timestamp", "sequence"), Map.of());
+
+        LogRecord record = new LogRecord(Level.WARNING, "Something went wrong");
+        record.setThrown(new RuntimeException("boom"));
+
+        assertThatCode(() -> formatter.format(record)).doesNotThrowAnyException();
+    }
+
+    private static final class TestFormatter extends JsonFormatter {
+
+        JsonLogGenerator newJsonLogGenerator(Set<String> excludedKeys) {
+            return new JsonLogGenerator(new TestGenerator(), excludedKeys);
+        }
+
+        private static final class TestGenerator implements Generator {
+
+            @Override
+            public Generator add(String key, Map<String, ?> value) {
+                return this;
+            }
+
+            @Override
+            public Generator add(String key, String value) {
+                return this;
+            }
+
+            @Override
+            public Generator startObject(String key) {
+                return this;
+            }
+
+            @Override
+            public Generator endObject() {
+                return this;
+            }
+
+            @Override
+            public Generator end() {
+                return this;
+            }
+        }
+    }
+
+}

--- a/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/runtime/JsonFormatterNullKeyTest.java
+++ b/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/runtime/JsonFormatterNullKeyTest.java
@@ -2,8 +2,6 @@ package io.quarkus.logging.json.runtime;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Proxy;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
@@ -14,8 +12,8 @@ import org.junit.jupiter.api.Test;
 class JsonFormatterNullKeyTest {
 
     @Test
-    void jsonLogGeneratorAcceptsNullKeysWhenExclusionsAreConfigured() throws Exception {
-        JsonFormatter.JsonLogGenerator generator = newJsonLogGenerator(Set.of("timestamp", "sequence"));
+    void jsonLogGeneratorAcceptsNullKeysWhenExclusionsAreConfigured() {
+        JsonFormatter.JsonLogGenerator generator = new TestFormatter().newJsonLogGenerator(Set.of("timestamp", "sequence"));
 
         assertThatCode(() -> {
             generator.add(null, true);
@@ -38,23 +36,39 @@ class JsonFormatterNullKeyTest {
         assertThatCode(() -> formatter.format(record)).doesNotThrowAnyException();
     }
 
-    private static JsonFormatter.JsonLogGenerator newJsonLogGenerator(Set<String> excludedKeys) throws Exception {
-        Class<?> generatorClass = Class.forName("org.jboss.logmanager.formatters.StructuredFormatter$Generator");
-        Object delegate = Proxy.newProxyInstance(
-                generatorClass.getClassLoader(),
-                new Class<?>[] { generatorClass },
-                (proxy, method, args) -> {
-                    if (method.getReturnType().equals(generatorClass)) {
-                        return proxy;
-                    }
-                    if (method.getReturnType().equals(boolean.class)) {
-                        return false;
-                    }
-                    return null;
-                });
-        Constructor<JsonFormatter.JsonLogGenerator> constructor = JsonFormatter.JsonLogGenerator.class
-                .getDeclaredConstructor(generatorClass, Set.class);
-        constructor.setAccessible(true);
-        return constructor.newInstance(delegate, excludedKeys);
+    private static final class TestFormatter extends JsonFormatter {
+
+        JsonLogGenerator newJsonLogGenerator(Set<String> excludedKeys) {
+            return new JsonLogGenerator(new TestGenerator(), excludedKeys);
+        }
+
+        private static final class TestGenerator implements Generator {
+
+            @Override
+            public Generator add(String key, Map<String, ?> value) {
+                return this;
+            }
+
+            @Override
+            public Generator add(String key, String value) {
+                return this;
+            }
+
+            @Override
+            public Generator startObject(String key) {
+                return this;
+            }
+
+            @Override
+            public Generator endObject() {
+                return this;
+            }
+
+            @Override
+            public Generator end() {
+                return this;
+            }
+        }
     }
+
 }

--- a/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/JsonFormatter.java
+++ b/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/JsonFormatter.java
@@ -245,43 +245,47 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
             this.excludedKeys = excludedKeys;
         }
 
+        private boolean isExcluded(final String key) {
+            return key != null && excludedKeys.contains(key);
+        }
+
         public JsonLogGenerator add(final String key, final boolean value) throws Exception {
-            if (skippedDepth == 0 && !excludedKeys.contains(key)) {
+            if (skippedDepth == 0 && !isExcluded(key)) {
                 delegate.add(key, String.valueOf(value));
             }
             return this;
         }
 
         public JsonLogGenerator add(final String key, final int value) throws Exception {
-            if (skippedDepth == 0 && !excludedKeys.contains(key)) {
+            if (skippedDepth == 0 && !isExcluded(key)) {
                 delegate.add(key, value);
             }
             return this;
         }
 
         public JsonLogGenerator add(final String key, final long value) throws Exception {
-            if (skippedDepth == 0 && !excludedKeys.contains(key)) {
+            if (skippedDepth == 0 && !isExcluded(key)) {
                 delegate.add(key, value);
             }
             return this;
         }
 
         public JsonLogGenerator add(final String key, final Map<String, ?> value) throws Exception {
-            if (skippedDepth == 0 && !excludedKeys.contains(key)) {
+            if (skippedDepth == 0 && !isExcluded(key)) {
                 delegate.add(key, value);
             }
             return this;
         }
 
         public JsonLogGenerator add(final String key, final String value) throws Exception {
-            if (skippedDepth == 0 && !excludedKeys.contains(key)) {
+            if (skippedDepth == 0 && !isExcluded(key)) {
                 delegate.add(key, value);
             }
             return this;
         }
 
         public JsonLogGenerator startObject(final String key) throws Exception {
-            if (skippedDepth > 0 || (key != null && excludedKeys.contains(key))) {
+            if (skippedDepth > 0 || isExcluded(key)) {
                 skippedDepth++;
             } else {
                 delegate.startObject(key);
@@ -299,7 +303,7 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
         }
 
         public JsonLogGenerator startArray(final String key) throws Exception {
-            if (skippedDepth > 0 || (key != null && excludedKeys.contains(key))) {
+            if (skippedDepth > 0 || isExcluded(key)) {
                 skippedDepth++;
             } else {
                 delegate.startArray(key);
@@ -346,6 +350,10 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
             this.flatMdc = flatMdc;
         }
 
+        private boolean isExcluded(final String key) {
+            return key != null && excludedKeys.contains(key);
+        }
+
         @Override
         public Generator begin() throws Exception {
             delegate.begin();
@@ -354,7 +362,7 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
 
         @Override
         public Generator add(final String key, final int value) throws Exception {
-            if (skippedDepth == 0 && !excludedKeys.contains(key)) {
+            if (skippedDepth == 0 && !isExcluded(key)) {
                 delegate.add(key, value);
             }
             return this;
@@ -362,7 +370,7 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
 
         @Override
         public Generator add(final String key, final long value) throws Exception {
-            if (skippedDepth == 0 && !excludedKeys.contains(key)) {
+            if (skippedDepth == 0 && !isExcluded(key)) {
                 delegate.add(key, value);
             }
             return this;
@@ -370,7 +378,7 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
 
         @Override
         public Generator add(final String key, final Map<String, ?> value) throws Exception {
-            if (skippedDepth == 0 && !excludedKeys.contains(key)) {
+            if (skippedDepth == 0 && !isExcluded(key)) {
                 if (flatMdc && value != null && !value.isEmpty()) {
                     for (Map.Entry<String, ?> entry : value.entrySet()) {
                         Object v = entry.getValue();
@@ -387,7 +395,7 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
 
         @Override
         public Generator add(final String key, final String value) throws Exception {
-            if (skippedDepth == 0 && !excludedKeys.contains(key)) {
+            if (skippedDepth == 0 && !isExcluded(key)) {
                 String actual = value;
                 // Strip the leading ": " that jboss's StackTraceFormatter prepends to the rendered
                 // stack trace string. Only applied to the specific key configured for this purpose.
@@ -407,7 +415,7 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
 
         @Override
         public Generator startObject(final String key) throws Exception {
-            if (skippedDepth > 0 || (key != null && excludedKeys.contains(key))) {
+            if (skippedDepth > 0 || isExcluded(key)) {
                 skippedDepth++;
             } else {
                 delegate.startObject(key);
@@ -427,7 +435,7 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
 
         @Override
         public Generator startArray(final String key) throws Exception {
-            if (skippedDepth > 0 || (key != null && excludedKeys.contains(key))) {
+            if (skippedDepth > 0 || isExcluded(key)) {
                 skippedDepth++;
             } else {
                 delegate.startArray(key);

--- a/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/JsonFormatter.java
+++ b/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/JsonFormatter.java
@@ -305,43 +305,47 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
             this.excludedKeys = excludedKeys;
         }
 
+        private boolean isExcluded(final String key) {
+            return key != null && excludedKeys.contains(key);
+        }
+
         public JsonLogGenerator add(final String key, final boolean value) throws Exception {
-            if (skippedDepth == 0 && !excludedKeys.contains(key)) {
+            if (skippedDepth == 0 && !isExcluded(key)) {
                 delegate.add(key, String.valueOf(value));
             }
             return this;
         }
 
         public JsonLogGenerator add(final String key, final int value) throws Exception {
-            if (skippedDepth == 0 && !excludedKeys.contains(key)) {
+            if (skippedDepth == 0 && !isExcluded(key)) {
                 delegate.add(key, value);
             }
             return this;
         }
 
         public JsonLogGenerator add(final String key, final long value) throws Exception {
-            if (skippedDepth == 0 && !excludedKeys.contains(key)) {
+            if (skippedDepth == 0 && !isExcluded(key)) {
                 delegate.add(key, value);
             }
             return this;
         }
 
         public JsonLogGenerator add(final String key, final Map<String, ?> value) throws Exception {
-            if (skippedDepth == 0 && !excludedKeys.contains(key)) {
+            if (skippedDepth == 0 && !isExcluded(key)) {
                 delegate.add(key, value);
             }
             return this;
         }
 
         public JsonLogGenerator add(final String key, final String value) throws Exception {
-            if (skippedDepth == 0 && !excludedKeys.contains(key)) {
+            if (skippedDepth == 0 && !isExcluded(key)) {
                 delegate.add(key, value);
             }
             return this;
         }
 
         public JsonLogGenerator startObject(final String key) throws Exception {
-            if (skippedDepth > 0 || (key != null && excludedKeys.contains(key))) {
+            if (skippedDepth > 0 || isExcluded(key)) {
                 skippedDepth++;
             } else {
                 delegate.startObject(key);
@@ -359,7 +363,7 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
         }
 
         public JsonLogGenerator startArray(final String key) throws Exception {
-            if (skippedDepth > 0 || (key != null && excludedKeys.contains(key))) {
+            if (skippedDepth > 0 || isExcluded(key)) {
                 skippedDepth++;
             } else {
                 delegate.startArray(key);
@@ -409,6 +413,10 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
             this.structuredAccessLog = structuredAccessLog;
         }
 
+        private boolean isExcluded(final String key) {
+            return key != null && excludedKeys.contains(key);
+        }
+
         @Override
         public Generator begin() throws Exception {
             delegate.begin();
@@ -417,7 +425,7 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
 
         @Override
         public Generator add(final String key, final int value) throws Exception {
-            if (skippedDepth == 0 && !excludedKeys.contains(key)) {
+            if (skippedDepth == 0 && !isExcluded(key)) {
                 delegate.add(key, value);
             }
             return this;
@@ -425,7 +433,7 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
 
         @Override
         public Generator add(final String key, final long value) throws Exception {
-            if (skippedDepth == 0 && !excludedKeys.contains(key)) {
+            if (skippedDepth == 0 && !isExcluded(key)) {
                 delegate.add(key, value);
             }
             return this;
@@ -433,7 +441,7 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
 
         @Override
         public Generator add(final String key, final Map<String, ?> value) throws Exception {
-            if (skippedDepth == 0 && !excludedKeys.contains(key)) {
+            if (skippedDepth == 0 && !isExcluded(key)) {
                 if (flatMdc && value != null && !value.isEmpty()) {
                     for (Map.Entry<String, ?> entry : value.entrySet()) {
                         // When structured-access-log is enabled, the __access__-prefixed MDC entries
@@ -469,7 +477,7 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
 
         @Override
         public Generator add(final String key, final String value) throws Exception {
-            if (skippedDepth == 0 && !excludedKeys.contains(key)) {
+            if (skippedDepth == 0 && !isExcluded(key)) {
                 String actual = value;
                 // Strip the leading ": " that jboss's StackTraceFormatter prepends to the rendered
                 // stack trace string. Only applied to the specific key configured for this purpose.
@@ -489,7 +497,7 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
 
         @Override
         public Generator startObject(final String key) throws Exception {
-            if (skippedDepth > 0 || (key != null && excludedKeys.contains(key))) {
+            if (skippedDepth > 0 || isExcluded(key)) {
                 skippedDepth++;
             } else {
                 delegate.startObject(key);
@@ -509,7 +517,7 @@ public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter
 
         @Override
         public Generator startArray(final String key) throws Exception {
-            if (skippedDepth > 0 || (key != null && excludedKeys.contains(key))) {
+            if (skippedDepth > 0 || isExcluded(key)) {
                 skippedDepth++;
             } else {
                 delegate.startArray(key);


### PR DESCRIPTION
## Summary

- Avoid checking `excludedKeys` with a `null` formatter key before delegating JSON generator calls.
- Reuse the same null-safe exclusion check in both JSON generator wrappers.
- Add regression coverage for null formatter keys and exception formatting when excluded keys are configured.

----

- Fixes: #54925