### PR TITLE
[4.0] Remove clustered Vert.x event bus support

### DIFF
--- a/docs/src/main/asciidoc/vertx-reference.adoc
+++ b/docs/src/main/asciidoc/vertx-reference.adoc
@@ -732,7 +732,7 @@ Read xref:./virtual-threads.adoc[the virtual thread guide] for more details.
 
 The link:++https://vertx.io/docs/vertx-core/java/#event_bus++[Vert.x Event Bus] uses link:++https://vertx.io/docs/vertx-core/java/#_message_codecs++[codecs] to _serialize_ and _deserialize_ message objects.
 Quarkus provides a default codec for local delivery.
-This codec is automatically used for return types and message body parameters of local consumers, i.e. methods annotated with `@ConsumeEvent` where `ConsumeEvent#local() == true` (which is the default).
+This codec is automatically used for return types and message body parameters of methods annotated with `@ConsumeEvent`.
 
 So that you can exchange the message objects as follows:
 

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
@@ -93,7 +93,6 @@ class VertxCoreProcessor {
         return NativeImageConfigBuildItem.builder()
                 .addRuntimeInitializedClass("io.vertx.core.impl.buffer.VertxByteBufAllocator")
                 .addRuntimeInitializedClass("io.vertx.core.http.impl.tcp.VertxHttp2ClientUpgradeCodec")
-                .addRuntimeInitializedClass("io.vertx.core.eventbus.impl.clustered.InboundConnection")
                 .addNativeImageSystemProperty(SysProps.DISABLE_DNS_RESOLVER.name, "true")
                 .addNativeImageSystemProperty("vertx.logger-delegate-factory-class-name",
                         VertxLogDelegateFactory.class.getName())

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/EventBusCodecProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/EventBusCodecProcessor.java
@@ -63,8 +63,6 @@ public class EventBusCodecProcessor {
             if (typeTarget.kind() != AnnotationTarget.Kind.METHOD) {
                 throw new IllegalStateException("@ConsumeEvent annotation must target a method");
             }
-            AnnotationValue local = consumeEventAnnotationInstance.value("local");
-            boolean isLocal = local == null || local.asBoolean();
             MethodInfo method = typeTarget.asMethod();
 
             Type codecTargetFromParameter = extractPayloadTypeFromParameter(method);
@@ -77,13 +75,7 @@ public class EventBusCodecProcessor {
                 codecByTypes.put(codecTargetFromParameter.name(), codec.asClass().asClassType().name());
             } else if (codecTargetFromParameter != null && !hasBuiltInCodec(codecTargetFromParameter)) {
                 // Codec is not set and built-in codecs cannot be used
-                if (!isLocal) {
-                    throw new IllegalStateException(
-                            "The Local Message Codec can only be used for local delivery,"
-                                    + " you will need to implement a message codec for " + codecTargetFromParameter.name()
-                                            .toString()
-                                    + " and make use of @ConsumeEvent#codec()");
-                } else if (!codecByTypes.containsKey(codecTargetFromParameter.name())) {
+                if (!codecByTypes.containsKey(codecTargetFromParameter.name())) {
                     if (isConcreteClass(codecTargetFromParameter, index)) {
                         // The default codec makes only sense for concrete classes
                         LOGGER.debugf("Local Message Codec registered for type %s",
@@ -98,14 +90,7 @@ public class EventBusCodecProcessor {
 
             Type codecTargetFromReturnType = extractPayloadTypeFromReturn(method);
             if (codecTargetFromReturnType != null && !hasBuiltInCodec(codecTargetFromReturnType)) {
-                if (!isLocal) {
-                    throw new IllegalStateException(
-                            "The Local Message Codec can only be used for local delivery,"
-                                    + " you will need to modify the method to consume io.vertx.core.eventbus.Message, implement a message codec for "
-                                    + codecTargetFromReturnType.name()
-                                            .toString()
-                                    + " and make use of io.vertx.core.eventbus.DeliveryOptions");
-                } else if (!codecByTypes.containsKey(codecTargetFromReturnType.name())) {
+                if (!codecByTypes.containsKey(codecTargetFromReturnType.name())) {
                     if (isConcreteClass(codecTargetFromReturnType, index)) {
                         // The default codec makes only sense for concrete classes
                         LOGGER.debugf("Local Message Codec registered for type %s", codecTargetFromReturnType);

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/EventBusCodecTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/EventBusCodecTest.java
@@ -28,19 +28,12 @@ public class EventBusCodecTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .setArchiveProducer(() -> ShrinkWrap
-                    .create(JavaArchive.class).addClasses(MyBean.class, MyNonLocalBean.class,
+                    .create(JavaArchive.class).addClasses(MyBean.class,
                             MyPetCodec.class, Person.class, Pet.class,
                             Event.class, SubclassEvent.class));
 
     @Inject
     MyBean bean;
-
-    /**
-     * Bean setting the consumption to be non-local.
-     * So, the user must configure the codec explicitly.
-     */
-    @Inject
-    MyNonLocalBean nonLocalBean;
 
     @Inject
     Vertx vertx;
@@ -59,14 +52,6 @@ public class EventBusCodecTest {
                 .onItem().transform(Message::body)
                 .await().indefinitely();
         assertThat(hello.getMessage()).isEqualTo("Hello NEO");
-    }
-
-    @Test
-    public void testWithUserCodecNonLocal() {
-        String hello = vertx.eventBus().<String> request("nl-pet", new Pet("neo", "rabbit"))
-                .onItem().transform(Message::body)
-                .await().indefinitely();
-        assertEquals("Non Local Hello NEO", hello);
     }
 
     @Test
@@ -147,12 +132,4 @@ public class EventBusCodecTest {
             };
         }
     }
-
-    static class MyNonLocalBean {
-        @ConsumeEvent(value = "nl-pet", codec = MyPetCodec.class, local = false)
-        public CompletionStage<String> hello(Pet p) {
-            return CompletableFuture.completedFuture("Non Local Hello " + p.getName());
-        }
-    }
-
 }

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/MutinyCodecTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/MutinyCodecTest.java
@@ -1,7 +1,6 @@
 package io.quarkus.vertx;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import jakarta.inject.Inject;
 
@@ -21,18 +20,11 @@ public class MutinyCodecTest {
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .setArchiveProducer(() -> ShrinkWrap
-                    .create(JavaArchive.class).addClasses(MyBean.class, MyNonLocalBean.class,
+                    .create(JavaArchive.class).addClasses(MyBean.class,
                             MyPetCodec.class, Person.class, Pet.class));
 
     @Inject
     MyBean bean;
-
-    /**
-     * Bean setting the consumption to be non-local.
-     * So, the user must configure the codec explicitly.
-     */
-    @Inject
-    MyNonLocalBean nonLocalBean;
 
     @Inject
     Vertx vertx;
@@ -51,14 +43,6 @@ public class MutinyCodecTest {
                 .onItem().transform(Message::body)
                 .await().indefinitely();
         assertThat(hello.getMessage()).isEqualTo("Hello NEO");
-    }
-
-    @Test
-    public void testWithUserCodecNonLocal() {
-        String hello = vertx.eventBus().<String> request("nl-pet", new Pet("neo", "rabbit"))
-                .onItem().transform(Message::body)
-                .await().indefinitely();
-        assertEquals("Non Local Hello NEO", hello);
     }
 
     static class Greeting {
@@ -88,14 +72,4 @@ public class MutinyCodecTest {
                     .emitOn(Infrastructure.getDefaultExecutor());
         }
     }
-
-    static class MyNonLocalBean {
-        @ConsumeEvent(value = "nl-pet", codec = MyPetCodec.class, local = false)
-        public Uni<String> hello(Pet p) {
-            return Uni.createFrom().item(
-                    () -> "Non Local Hello " + p.getName())
-                    .emitOn(Infrastructure.getDefaultExecutor());
-        }
-    }
-
 }

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/ConsumeEvent.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/ConsumeEvent.java
@@ -105,14 +105,6 @@ public @interface ConsumeEvent {
     String value() default "";
 
     /**
-     *
-     * @return {@code true} if the address should not be propagated across the cluster
-     * @see io.vertx.core.eventbus.EventBus#localConsumer(String)
-     */
-    boolean local() default true;
-
-    /**
-     *
      * @return {@code true} if the consumer should be invoked as a blocking operation using a worker thread
      * @see io.vertx.core.Vertx#executeBlocking(Callable, boolean)
      */

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/LocalEventBusCodec.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/LocalEventBusCodec.java
@@ -6,8 +6,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.MessageCodec;
 
 /**
- * An implementation of {@link MessageCodec} for local delivery only.
- * It does not support the clustered event bus.
+ * An implementation of {@link MessageCodec} for local delivery.
  * <p>
  * The {@link #transform(Object)} method returns the passed instance. So make sure it's immutable.
  *
@@ -30,12 +29,12 @@ public class LocalEventBusCodec<T> implements MessageCodec<T, T> {
 
     @Override
     public void encodeToWire(Buffer buffer, T t) {
-        throw new UnsupportedOperationException("LocalEventBusCodec cannot only be used for local delivery");
+        throw new UnsupportedOperationException("LocalEventBusCodec can only be used for local delivery");
     }
 
     @Override
     public T decodeFromWire(int pos, Buffer buffer) {
-        throw new UnsupportedOperationException("LocalEventBusCodec cannot only be used for local delivery");
+        throw new UnsupportedOperationException("LocalEventBusCodec can only be used for local delivery");
     }
 
     @Override

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/VertxEventBusConsumerRecorder.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/VertxEventBusConsumerRecorder.java
@@ -99,7 +99,6 @@ public class VertxEventBusConsumerRecorder {
             for (EventConsumerInfo info : messageConsumerConfigurations) {
                 EventConsumerInvoker invoker = new EventConsumerInvoker(info.invoker.getValue(), info.splitHeadersBodyParams);
                 String address = lookUpPropertyValue(info.annotation.value());
-                boolean local = info.annotation.local();
                 boolean blocking = info.annotation.blocking() || info.blockingAnnotation || info.runOnVirtualThreadAnnotation;
                 boolean runOnVirtualThread = info.runOnVirtualThreadAnnotation;
                 boolean ordered = info.annotation.ordered();
@@ -110,12 +109,7 @@ public class VertxEventBusConsumerRecorder {
                 context.runOnContext(new Handler<Void>() {
                     @Override
                     public void handle(Void x) {
-                        MessageConsumer<Object> consumer;
-                        if (local) {
-                            consumer = eventBus.localConsumer(address);
-                        } else {
-                            consumer = eventBus.consumer(address);
-                        }
+                        MessageConsumer<Object> consumer = eventBus.localConsumer(address);
 
                         consumer.handler(new Handler<Message<Object>>() {
                             @Override

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/jackson/JsonUtil.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/jackson/JsonUtil.java
@@ -90,7 +90,7 @@ public final class JsonUtil {
             val = val.toString();
         } else if (val instanceof Shareable) {
             // Shareable objects know how to copy themselves, this covers:
-            // JsonObject, JsonArray or any user defined type that can shared across the cluster
+            // JsonObject, JsonArray or any user defined Shareable type
             val = ((Shareable) val).copy();
         } else if (val instanceof Map) {
             val = (new JsonObject((Map) val)).copy();

--- a/extensions/vertx/runtime/src/test/java/io/quarkus/vertx/runtime/VertxProducerTest.java
+++ b/extensions/vertx/runtime/src/test/java/io/quarkus/vertx/runtime/VertxProducerTest.java
@@ -1,7 +1,6 @@
 package io.quarkus.vertx.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.util.List;
 
@@ -38,7 +37,6 @@ public class VertxProducerTest {
         assertThat(producer.eventbus(v)).isNotNull();
 
         assertThat(producer.mutiny(v)).isNotNull();
-        assertFalse(producer.mutiny(v).isClustered());
         assertThat(producer.mutinyEventBus(producer.mutiny(v))).isNotNull();
 
     }


### PR DESCRIPTION
Quarkus does not support clustered Vert.x instances.

Removed the remaining code that allowed configuring non-local event bus consumers and updated docs.