### PR TITLE
Upgrade aesh to 3.15 and add AeshLauncher REPL test framework

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -199,8 +199,8 @@
         <!-- Check the compatibility matrix (https://github.com/opensearch-project/opensearch-testcontainers) before upgrading: -->
         <opensearch-testcontainers.version>2.1.3</opensearch-testcontainers.version>
         <com.dajudge.kindcontainer>2.0.0</com.dajudge.kindcontainer>
-        <aesh.version>3.14.3</aesh.version>
-        <aesh-readline.version>3.14.1</aesh-readline.version>
+        <aesh.version>3.15.1</aesh.version>
+        <aesh-readline.version>3.15.1</aesh-readline.version>
         <jansi.version>2.4.0</jansi.version> <!-- Keep in sync with dekorate -->
         <!-- these two artifacts needs to be compatible together -->
         <strimzi-oauth.version>0.16.1</strimzi-oauth.version>
@@ -3641,6 +3641,11 @@
             <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-junit-mockito-config</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-test-aesh</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestTracingProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestTracingProcessor.java
@@ -12,7 +12,6 @@ import org.aesh.command.Command;
 import org.aesh.command.CommandDefinition;
 import org.aesh.command.CommandException;
 import org.aesh.command.CommandResult;
-import org.aesh.command.GroupCommandDefinition;
 import org.aesh.command.invocation.CommandInvocation;
 import org.aesh.command.option.Argument;
 import org.aesh.command.option.Arguments;
@@ -197,7 +196,7 @@ public class TestTracingProcessor {
         return new ConsoleCommandBuildItem(new TestCommand());
     }
 
-    @GroupCommandDefinition(name = "test", description = "Test Commands", groupCommands = { TagsCommand.class,
+    @CommandDefinition(name = "test", description = "Test Commands", groupCommands = { TagsCommand.class,
             PatternCommand.class }, generateHelp = true)
     public static class TestCommand implements Command {
 
@@ -207,7 +206,7 @@ public class TestTracingProcessor {
         }
     }
 
-    @GroupCommandDefinition(name = "tags", description = "Tag Commands", groupCommands = { IncludeTagsCommand.class,
+    @CommandDefinition(name = "tags", description = "Tag Commands", groupCommands = { IncludeTagsCommand.class,
             ExcludeTagsCommand.class }, generateHelp = true)
     public static class TagsCommand implements Command {
 
@@ -269,7 +268,7 @@ public class TestTracingProcessor {
         }
     }
 
-    @GroupCommandDefinition(name = "pattern", description = "Include/Exclude pattern Commands", groupCommands = {
+    @CommandDefinition(name = "pattern", description = "Include/Exclude pattern Commands", groupCommands = {
             IncludePatternCommand.class,
             ExcludePatternCommand.class }, generateHelp = true)
     public static class PatternCommand implements Command {

--- a/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
@@ -32,8 +32,6 @@ import org.aesh.command.Command;
 import org.aesh.command.CommandDefinition;
 import org.aesh.command.CommandException;
 import org.aesh.command.CommandResult;
-import org.aesh.command.GroupCommand;
-import org.aesh.command.GroupCommandDefinition;
 import org.aesh.command.completer.CompleterInvocation;
 import org.aesh.command.completer.OptionCompleter;
 import org.aesh.command.invocation.CommandInvocation;
@@ -742,16 +740,11 @@ public final class LoggingResourceProcessor {
 
     private static final String SRC_MAIN_JAVA = "src/main/java";
 
-    @GroupCommandDefinition(name = "log", description = "Logging Commands")
-    public static class LogCommand implements GroupCommand {
+    @CommandDefinition(name = "log", description = "Logging Commands", groupCommands = { SetLogLevelCommand.class })
+    public static class LogCommand implements Command {
 
         @Option(shortName = 'h', hasValue = false, overrideRequired = true)
         public boolean help;
-
-        @Override
-        public List<Command> getCommands() {
-            return List.of(new SetLogLevelCommand());
-        }
 
         @Override
         public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {

--- a/docs/src/main/asciidoc/aesh.adoc
+++ b/docs/src/main/asciidoc/aesh.adoc
@@ -883,6 +883,84 @@ Available when a remote transport extension (`quarkus-aesh-websocket` or `quarku
 
 Available when the `quarkus-aesh-websocket` extension is present. Embeds an interactive terminal directly in the Dev UI using https://xtermjs.org/[xterm.js]. Click **Connect** to open a WebSocket connection to the terminal endpoint and interact with your CLI commands from the browser. The terminal supports the same features as the standalone terminal page (color, resize, unicode).
 
+== Testing
+
+Aesh commands can be tested with `@QuarkusMainTest` from the xref:command-mode-reference.adoc[Command Mode reference guide].
+The approach differs depending on the execution mode.
+
+=== Testing runtime mode commands
+
+Runtime mode commands execute once and exit.
+Use `@Launch` to run them with specific arguments and assert on the output:
+
+[source,java]
+----
+@QuarkusMainTest
+public class CliTest {
+
+    @Test
+    @Launch({"--name=Alice"})
+    void testGreet(LaunchResult result) {
+        assertThat(result.getOutput()).contains("Hello Alice!");
+        assertThat(result.exitCode()).isEqualTo(0);
+    }
+
+    @Test
+    void testMultipleLaunches(QuarkusMainLauncher launcher) {
+        LaunchResult first = launcher.launch("--name=Alice");
+        assertThat(first.getOutput()).contains("Hello Alice!");
+
+        LaunchResult second = launcher.launch("--name=Bob");
+        assertThat(second.getOutput()).contains("Hello Bob!");
+    }
+}
+----
+
+=== Testing console mode commands (REPL)
+
+Console mode commands run in an interactive shell.
+Use `AeshLauncher` to start a REPL session, send commands, and assert on their output:
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-test-aesh</artifactId>
+    <scope>test</scope>
+</dependency>
+----
+
+[source,java]
+----
+@QuarkusMainTest
+public class ReplTest {
+
+    @Test
+    void testInteractiveSession(AeshLauncher launcher) {
+        launcher.launch();
+
+        String output = launcher.executeCommand("greet --name=Alice");
+        assertThat(output).contains("Hello Alice!");
+
+        output = launcher.executeCommand("calc -a 5 -b 3");
+        assertThat(output).contains("Result: 8");
+
+        launcher.exit();
+    }
+}
+----
+
+`AeshLauncher` provides:
+
+* `launch(String... args)` -- starts the REPL on a background thread
+* `executeCommand(String command)` -- sends a command and blocks until it completes (10 second default timeout)
+* `executeCommand(String command, Duration timeout)` -- same with a custom timeout
+* `getErrorOutput()` -- returns any error output from the session
+* `exit()` -- sends the exit command and waits for clean shutdown
+
+NOTE: The exit command must be enabled for `AeshLauncher` to shut down cleanly.
+Set `quarkus.aesh.add-exit-command=true` in `application.properties` (or `src/test/resources/application.properties`).
+
 == Packaging your application
 
 An Aesh command line application is a standard Quarkus application and can be packaged as a JAR or a native executable.

--- a/extensions/aesh/runtime/pom.xml
+++ b/extensions/aesh/runtime/pom.xml
@@ -27,10 +27,6 @@
             <artifactId>aesh</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.aesh</groupId>
-            <artifactId>aesh-processor</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core</artifactId>
         </dependency>

--- a/extensions/aesh/runtime/src/main/java/io/quarkus/aesh/runtime/AeshStreamConnection.java
+++ b/extensions/aesh/runtime/src/main/java/io/quarkus/aesh/runtime/AeshStreamConnection.java
@@ -1,0 +1,204 @@
+package io.quarkus.aesh.runtime;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.function.Consumer;
+
+import org.aesh.terminal.Attributes;
+import org.aesh.terminal.BaseDevice;
+import org.aesh.terminal.Connection;
+import org.aesh.terminal.Device;
+import org.aesh.terminal.tty.Capability;
+import org.aesh.terminal.tty.Signal;
+import org.aesh.terminal.tty.Size;
+import org.aesh.terminal.utils.Parser;
+
+/**
+ * A {@link Connection} backed by JDK {@link InputStream}/{@link OutputStream} pairs.
+ * <p>
+ * Used by {@link CliRunner} when running in test mode. The test framework
+ * provides the streams via {@link AeshTestConnectionHolder}, and this
+ * class wraps them into a proper aesh Connection -- all within the
+ * runtime classloader, avoiding cross-classloader type issues.
+ */
+class AeshStreamConnection implements Connection {
+
+    private final Device device = new BaseDevice("test");
+    private final Size size = new Size(120, 40);
+    private final InputStream input;
+    private final OutputStream output;
+
+    private Consumer<Size> sizeHandler;
+    private Consumer<Signal> signalHandler;
+    private Consumer<int[]> stdinHandler;
+    private Consumer<int[]> stdoutHandler;
+    private Consumer<Void> closeHandler;
+    private Attributes attributes;
+
+    private volatile boolean closed = false;
+    private Thread readerThread;
+
+    AeshStreamConnection(InputStream input, OutputStream output) {
+        this.input = input;
+        this.output = output;
+        this.stdoutHandler = data -> {
+            try {
+                String text = Parser.fromCodePoints(data);
+                output.write(text.getBytes(StandardCharsets.UTF_8));
+                output.flush();
+            } catch (IOException e) {
+                // Connection closed
+            }
+        };
+    }
+
+    @Override
+    public Device device() {
+        return device;
+    }
+
+    @Override
+    public Size size() {
+        return size;
+    }
+
+    @Override
+    public Consumer<Size> sizeHandler() {
+        return sizeHandler;
+    }
+
+    @Override
+    public void setSizeHandler(Consumer<Size> handler) {
+        this.sizeHandler = handler;
+    }
+
+    @Override
+    public Consumer<Signal> signalHandler() {
+        return signalHandler;
+    }
+
+    @Override
+    public void setSignalHandler(Consumer<Signal> handler) {
+        this.signalHandler = handler;
+    }
+
+    @Override
+    public Consumer<int[]> stdinHandler() {
+        return stdinHandler;
+    }
+
+    @Override
+    public void setStdinHandler(Consumer<int[]> handler) {
+        this.stdinHandler = handler;
+        // When the stdinHandler is set, start reading from the input stream
+        if (handler != null && readerThread == null) {
+            startReader();
+        }
+    }
+
+    @Override
+    public Consumer<int[]> stdoutHandler() {
+        return stdoutHandler;
+    }
+
+    @Override
+    public void setCloseHandler(Consumer<Void> handler) {
+        this.closeHandler = handler;
+    }
+
+    @Override
+    public Consumer<Void> closeHandler() {
+        return closeHandler;
+    }
+
+    @Override
+    public void close() {
+        closed = true;
+        // Close the input stream to unblock the reader thread
+        try {
+            input.close();
+        } catch (IOException e) {
+            // Ignore
+        }
+        if (closeHandler != null) {
+            closeHandler.accept(null);
+        }
+    }
+
+    @Override
+    public void openBlocking() {
+        // Start reading and block until closed
+        startReader();
+        try {
+            if (readerThread != null) {
+                readerThread.join();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @Override
+    public void openNonBlocking() {
+        startReader();
+    }
+
+    @Override
+    public boolean put(Capability capability, Object... params) {
+        return false;
+    }
+
+    @Override
+    public Attributes attributes() {
+        return attributes != null ? attributes : new Attributes();
+    }
+
+    @Override
+    public void setAttributes(Attributes attr) {
+        this.attributes = attr;
+    }
+
+    @Override
+    public Charset inputEncoding() {
+        return StandardCharsets.UTF_8;
+    }
+
+    @Override
+    public Charset outputEncoding() {
+        return StandardCharsets.UTF_8;
+    }
+
+    @Override
+    public boolean supportsAnsi() {
+        return false;
+    }
+
+    private void startReader() {
+        if (readerThread != null) {
+            return;
+        }
+        readerThread = new Thread(() -> {
+            byte[] buffer = new byte[1024];
+            try {
+                while (!closed) {
+                    int n = input.read(buffer);
+                    if (n == -1) {
+                        break;
+                    }
+                    if (n > 0 && stdinHandler != null) {
+                        String text = new String(buffer, 0, n, StandardCharsets.UTF_8);
+                        stdinHandler.accept(Parser.toCodePoints(text));
+                    }
+                }
+            } catch (IOException e) {
+                // Stream closed, exit reader
+            }
+        }, "aesh-test-reader");
+        readerThread.setDaemon(true);
+        readerThread.start();
+    }
+
+}

--- a/extensions/aesh/runtime/src/main/java/io/quarkus/aesh/runtime/AeshTestConnectionHolder.java
+++ b/extensions/aesh/runtime/src/main/java/io/quarkus/aesh/runtime/AeshTestConnectionHolder.java
@@ -1,0 +1,89 @@
+package io.quarkus.aesh.runtime;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.concurrent.LinkedBlockingQueue;
+
+/**
+ * Bridges test and runtime classloaders using the current thread's name
+ * as a marker and a custom Thread subclass ({@link AeshTestThread}) to
+ * carry the test channels. Both the test-side {@code AeshLauncherImpl}
+ * and the runtime-side {@link CliRunner} run on the same thread, so the
+ * data is accessible without any cross-classloader storage.
+ * <p>
+ * Previous versions stored objects in {@link System#getProperties()}, but
+ * that caused {@code NullPointerException} in libraries (e.g. Narayana)
+ * that iterate all system property names and call
+ * {@code System.getProperty(key)} on non-String values.
+ */
+public final class AeshTestConnectionHolder {
+
+    /**
+     * Thread name prefix that marks a thread as carrying test channel data.
+     */
+    public static final String TEST_THREAD_NAME = "aesh-test-repl";
+
+    private AeshTestConnectionHolder() {
+    }
+
+    /**
+     * Retrieve the test input stream from the current thread via reflection.
+     * Uses field name lookup instead of {@code instanceof} to avoid
+     * classloader identity issues.
+     */
+    static InputStream getInput() {
+        return (InputStream) getFieldFromThread("testInput");
+    }
+
+    /**
+     * Retrieve the test output stream from the current thread via reflection.
+     */
+    static OutputStream getOutput() {
+        return (OutputStream) getFieldFromThread("testOutput");
+    }
+
+    /**
+     * Retrieve the signal queue from the current thread via reflection.
+     */
+    @SuppressWarnings("unchecked")
+    static LinkedBlockingQueue<Object> getSignalQueue() {
+        return (LinkedBlockingQueue<Object>) getFieldFromThread("signalQueue");
+    }
+
+    private static Object getFieldFromThread(String fieldName) {
+        Thread t = Thread.currentThread();
+        if (!TEST_THREAD_NAME.equals(t.getName())) {
+            return null;
+        }
+        try {
+            java.lang.reflect.Field f = t.getClass().getDeclaredField(fieldName);
+            f.setAccessible(true);
+            return f.get(t);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            return null;
+        }
+    }
+
+    /**
+     * A Thread subclass that carries test channel data. Created by
+     * {@code AeshLauncherImpl} and checked by {@link CliRunner}.
+     * <p>
+     * Uses JDK-only field types so both classloaders see the same types.
+     */
+    public static class AeshTestThread extends Thread {
+        final InputStream testInput;
+        final OutputStream testOutput;
+        final LinkedBlockingQueue<Object> signalQueue;
+
+        public AeshTestThread(Runnable target, String name, ClassLoader contextClassLoader,
+                InputStream testInput, OutputStream testOutput,
+                LinkedBlockingQueue<Object> signalQueue) {
+            super(target, name);
+            setContextClassLoader(contextClassLoader);
+            setDaemon(true);
+            this.testInput = testInput;
+            this.testOutput = testOutput;
+            this.signalQueue = signalQueue;
+        }
+    }
+}

--- a/extensions/aesh/runtime/src/main/java/io/quarkus/aesh/runtime/CliRunner.java
+++ b/extensions/aesh/runtime/src/main/java/io/quarkus/aesh/runtime/CliRunner.java
@@ -1,6 +1,9 @@
 package io.quarkus.aesh.runtime;
 
 import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.concurrent.LinkedBlockingQueue;
 
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Instance;
@@ -66,6 +69,23 @@ public class CliRunner implements QuarkusApplication {
                     .commandRegistryBuilder((AeshCommandRegistryBuilder) registryBuilder)
                     .settings(settings)
                     .prompt(configuration.prompt());
+
+            // Wire test connection and listener if set by the test framework.
+            // The AeshTestThread carries the streams and signal queue directly,
+            // avoiding System.getProperties() which breaks libraries like Narayana
+            // that iterate all property names.
+            InputStream testInput = AeshTestConnectionHolder.getInput();
+            OutputStream testOutput = AeshTestConnectionHolder.getOutput();
+            LinkedBlockingQueue<Object> signalQueue = AeshTestConnectionHolder.getSignalQueue();
+
+            if (testInput != null && testOutput != null) {
+                LOG.debug("Test mode: using stream-based connection");
+                runner.connection(new AeshStreamConnection(testInput, testOutput));
+
+                if (signalQueue != null) {
+                    runner.onCommandComplete(result -> signalQueue.offer("done"));
+                }
+            }
 
             if (configuration.addExitCommand()) {
                 runner.addExitCommand();

--- a/integration-tests/aesh/pom.xml
+++ b/integration-tests/aesh/pom.xml
@@ -17,6 +17,14 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-aesh</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-h2</artifactId>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>
@@ -34,11 +42,42 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-aesh</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-aesh-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-h2-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/aesh/src/main/java/io/quarkus/it/aesh/AddItemCommand.java
+++ b/integration-tests/aesh/src/main/java/io/quarkus/it/aesh/AddItemCommand.java
@@ -1,0 +1,26 @@
+package io.quarkus.it.aesh;
+
+import jakarta.inject.Inject;
+
+import org.aesh.command.Command;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandResult;
+import org.aesh.command.invocation.CommandInvocation;
+import org.aesh.command.option.Argument;
+
+@CommandDefinition(name = "add-item", description = "Add an item to the database")
+public class AddItemCommand implements Command<CommandInvocation> {
+
+    @Inject
+    ItemService itemService;
+
+    @Argument(description = "Item name", required = true)
+    String name;
+
+    @Override
+    public CommandResult execute(CommandInvocation invocation) {
+        itemService.add(name);
+        invocation.println("Added: " + name);
+        return CommandResult.SUCCESS;
+    }
+}

--- a/integration-tests/aesh/src/main/java/io/quarkus/it/aesh/Item.java
+++ b/integration-tests/aesh/src/main/java/io/quarkus/it/aesh/Item.java
@@ -1,0 +1,31 @@
+package io.quarkus.it.aesh;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class Item {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    Long id;
+
+    String name;
+
+    public Item() {
+    }
+
+    public Item(String name) {
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/integration-tests/aesh/src/main/java/io/quarkus/it/aesh/ItemService.java
+++ b/integration-tests/aesh/src/main/java/io/quarkus/it/aesh/ItemService.java
@@ -1,0 +1,26 @@
+package io.quarkus.it.aesh;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+
+@ApplicationScoped
+public class ItemService {
+
+    @Inject
+    EntityManager em;
+
+    @Transactional
+    public void add(String name) {
+        em.persist(new Item(name));
+    }
+
+    @Transactional
+    public List<Item> listAll() {
+        return em.createQuery("SELECT i FROM Item i ORDER BY i.name", Item.class)
+                .getResultList();
+    }
+}

--- a/integration-tests/aesh/src/main/java/io/quarkus/it/aesh/ListItemsCommand.java
+++ b/integration-tests/aesh/src/main/java/io/quarkus/it/aesh/ListItemsCommand.java
@@ -1,0 +1,31 @@
+package io.quarkus.it.aesh;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.aesh.command.Command;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandResult;
+import org.aesh.command.invocation.CommandInvocation;
+
+@CommandDefinition(name = "list-items", description = "List all items from the database")
+public class ListItemsCommand implements Command<CommandInvocation> {
+
+    @Inject
+    ItemService itemService;
+
+    @Override
+    public CommandResult execute(CommandInvocation invocation) {
+        List<Item> items = itemService.listAll();
+        if (items.isEmpty()) {
+            invocation.println("No items found");
+        } else {
+            invocation.println("Items (" + items.size() + "):");
+            for (Item item : items) {
+                invocation.println("  - " + item.getName());
+            }
+        }
+        return CommandResult.SUCCESS;
+    }
+}

--- a/integration-tests/aesh/src/test/java/io/quarkus/it/aesh/AeshReplTest.java
+++ b/integration-tests/aesh/src/test/java/io/quarkus/it/aesh/AeshReplTest.java
@@ -1,0 +1,73 @@
+package io.quarkus.it.aesh;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.aesh.AeshLauncher;
+import io.quarkus.test.junit.main.QuarkusMainTest;
+
+/**
+ * Tests REPL (console) mode using AeshLauncher.
+ * <p>
+ * Uses the commands from src/main/java (hello, cli) which auto-detect
+ * as console mode (multiple independent top-level commands). AeshLauncher
+ * provides a test connection to send commands and assert on output without
+ * needing a real terminal.
+ */
+@QuarkusMainTest
+public class AeshReplTest {
+
+    @Test
+    void testHelloCommand(AeshLauncher launcher) {
+        launcher.launch();
+
+        String output = launcher.executeCommand("hello --name=Alice");
+        assertThat(output).contains("Hello Alice!");
+
+        launcher.exit();
+    }
+
+    @Test
+    void testHelloDefaultName(AeshLauncher launcher) {
+        launcher.launch();
+
+        String output = launcher.executeCommand("hello");
+        assertThat(output).contains("Hello World!");
+
+        launcher.exit();
+    }
+
+    @Test
+    void testMultipleCommandsInSession(AeshLauncher launcher) {
+        launcher.launch();
+
+        String out1 = launcher.executeCommand("hello --name=First");
+        assertThat(out1).contains("Hello First!");
+
+        String out2 = launcher.executeCommand("hello --name=Second");
+        assertThat(out2).contains("Hello Second!");
+
+        launcher.exit();
+    }
+
+    @Test
+    void testGroupCommand(AeshLauncher launcher) {
+        launcher.launch();
+
+        String output = launcher.executeCommand("cli version");
+        assertThat(output).contains("Version: 1.0.0");
+
+        launcher.exit();
+    }
+
+    @Test
+    void testGroupCommandWithArgs(AeshLauncher launcher) {
+        launcher.launch();
+
+        String output = launcher.executeCommand("cli run myTask");
+        assertThat(output).contains("Running task: myTask");
+
+        launcher.exit();
+    }
+}

--- a/integration-tests/aesh/src/test/java/io/quarkus/it/aesh/AeshReplWithHibernateTest.java
+++ b/integration-tests/aesh/src/test/java/io/quarkus/it/aesh/AeshReplWithHibernateTest.java
@@ -1,0 +1,62 @@
+package io.quarkus.it.aesh;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.aesh.AeshLauncher;
+import io.quarkus.test.junit.main.QuarkusMainTest;
+
+/**
+ * Tests REPL mode with Hibernate ORM and H2 on the classpath.
+ * <p>
+ * This is a "realistic" test that verifies AeshLauncher works when
+ * common extensions (JTA, Hibernate, JDBC) are present -- catching
+ * classloader and augmentation issues that don't surface with
+ * minimal aesh-only tests.
+ */
+@QuarkusMainTest
+public class AeshReplWithHibernateTest {
+
+    @Test
+    void testAddAndListItems(AeshLauncher launcher) {
+        launcher.launch();
+
+        // Database starts empty
+        String output = launcher.executeCommand("list-items");
+        assertThat(output).contains("No items found");
+
+        // Add items
+        output = launcher.executeCommand("add-item apple");
+        assertThat(output).contains("Added: apple");
+
+        output = launcher.executeCommand("add-item banana");
+        assertThat(output).contains("Added: banana");
+
+        // Verify persistence
+        output = launcher.executeCommand("list-items");
+        assertThat(output).contains("Items (2):");
+        assertThat(output).contains("- apple");
+        assertThat(output).contains("- banana");
+
+        launcher.exit();
+    }
+
+    @Test
+    void testDataIsolationBetweenTests(AeshLauncher launcher) {
+        launcher.launch();
+
+        // Each test gets a fresh database (drop-and-create)
+        String output = launcher.executeCommand("list-items");
+        assertThat(output).contains("No items found");
+
+        output = launcher.executeCommand("add-item cherry");
+        assertThat(output).contains("Added: cherry");
+
+        output = launcher.executeCommand("list-items");
+        assertThat(output).contains("Items (1):");
+        assertThat(output).contains("- cherry");
+
+        launcher.exit();
+    }
+}

--- a/integration-tests/aesh/src/test/java/io/quarkus/it/aesh/TestConsoleMode.java
+++ b/integration-tests/aesh/src/test/java/io/quarkus/it/aesh/TestConsoleMode.java
@@ -39,7 +39,7 @@ public class TestConsoleMode {
         Assertions.assertThat(true).isTrue();
     }
 
-    @CommandDefinition(name = "greet", description = "Greet someone")
+    @CommandDefinition(name = "tcm-greet", description = "Greet someone")
     public static class GreetCliCommand implements Command<CommandInvocation> {
 
         @Option(shortName = 'n', name = "name", description = "Name to greet", defaultValue = "World")
@@ -52,7 +52,7 @@ public class TestConsoleMode {
         }
     }
 
-    @CommandDefinition(name = "calc", description = "Calculate sum of two numbers")
+    @CommandDefinition(name = "tcm-calc", description = "Calculate sum of two numbers")
     public static class CalcCliCommand implements Command<CommandInvocation> {
 
         @Option(shortName = 'a', name = "a", description = "First number", defaultValue = "0")

--- a/integration-tests/aesh/src/test/java/io/quarkus/it/aesh/TestMultipleCommands.java
+++ b/integration-tests/aesh/src/test/java/io/quarkus/it/aesh/TestMultipleCommands.java
@@ -22,7 +22,7 @@ public class TestMultipleCommands {
     @RegisterExtension
     static final QuarkusProdModeTest config = createConfig("multi-cmd-app",
             AppCommand.class, GreetCommand.class, CalcCommand.class, InfoCommand.class)
-            .setCommandLineParameters("greet", "--name=World");
+            .setCommandLineParameters("tmc-greet", "--name=World");
 
     @Test
     public void testGreetCommand() {
@@ -30,18 +30,18 @@ public class TestMultipleCommands {
         Assertions.assertThat(config.getExitCode()).isZero();
     }
 
-    @CommandDefinition(name = "app", description = "Multi-command application", groupCommands = { GreetCommand.class,
+    @CommandDefinition(name = "tmc-app", description = "Multi-command application", groupCommands = { GreetCommand.class,
             CalcCommand.class, InfoCommand.class })
     public static class AppCommand implements Command<CommandInvocation> {
 
         @Override
         public CommandResult execute(CommandInvocation invocation) {
-            invocation.println("Use a subcommand: greet, calc, info");
+            invocation.println("Use a subcommand: tmc-greet, tmc-calc, tmc-info");
             return CommandResult.SUCCESS;
         }
     }
 
-    @CommandDefinition(name = "greet", description = "Greet someone")
+    @CommandDefinition(name = "tmc-greet", description = "Greet someone")
     public static class GreetCommand implements Command<CommandInvocation> {
 
         @Option(shortName = 'n', name = "name", description = "Name to greet", defaultValue = "Stranger")
@@ -54,7 +54,7 @@ public class TestMultipleCommands {
         }
     }
 
-    @CommandDefinition(name = "calc", description = "Calculate sum of two numbers")
+    @CommandDefinition(name = "tmc-calc", description = "Calculate sum of two numbers")
     public static class CalcCommand implements Command<CommandInvocation> {
 
         @Option(shortName = 'a', name = "a", description = "First number", defaultValue = "0")
@@ -70,7 +70,7 @@ public class TestMultipleCommands {
         }
     }
 
-    @CommandDefinition(name = "info", description = "Show application info")
+    @CommandDefinition(name = "tmc-info", description = "Show application info")
     public static class InfoCommand implements Command<CommandInvocation> {
 
         @Override

--- a/integration-tests/aesh/src/test/java/io/quarkus/it/aesh/TestMultipleCommandsCalc.java
+++ b/integration-tests/aesh/src/test/java/io/quarkus/it/aesh/TestMultipleCommandsCalc.java
@@ -21,7 +21,7 @@ public class TestMultipleCommandsCalc {
     @RegisterExtension
     static final QuarkusProdModeTest config = createConfig("multi-cmd-calc-app",
             AppCommand.class, GreetCommand.class, CalcCommand.class, InfoCommand.class)
-            .setCommandLineParameters("calc", "-a", "5", "-b", "3");
+            .setCommandLineParameters("tmcc-calc", "-a", "5", "-b", "3");
 
     @Test
     public void testCalcCommand() {
@@ -29,18 +29,18 @@ public class TestMultipleCommandsCalc {
         Assertions.assertThat(config.getExitCode()).isZero();
     }
 
-    @CommandDefinition(name = "app", description = "Multi-command application", groupCommands = { GreetCommand.class,
+    @CommandDefinition(name = "tmcc-app", description = "Multi-command application", groupCommands = { GreetCommand.class,
             CalcCommand.class, InfoCommand.class })
     public static class AppCommand implements Command<CommandInvocation> {
 
         @Override
         public CommandResult execute(CommandInvocation invocation) {
-            invocation.println("Use a subcommand: greet, calc, info");
+            invocation.println("Use a subcommand: tmcc-greet, tmcc-calc, tmcc-info");
             return CommandResult.SUCCESS;
         }
     }
 
-    @CommandDefinition(name = "greet", description = "Greet someone")
+    @CommandDefinition(name = "tmcc-greet", description = "Greet someone")
     public static class GreetCommand implements Command<CommandInvocation> {
 
         @Option(shortName = 'n', name = "name", description = "Name to greet", defaultValue = "Stranger")
@@ -53,7 +53,7 @@ public class TestMultipleCommandsCalc {
         }
     }
 
-    @CommandDefinition(name = "calc", description = "Calculate sum of two numbers")
+    @CommandDefinition(name = "tmcc-calc", description = "Calculate sum of two numbers")
     public static class CalcCommand implements Command<CommandInvocation> {
 
         @Option(shortName = 'a', name = "a", description = "First number", defaultValue = "0")
@@ -69,7 +69,7 @@ public class TestMultipleCommandsCalc {
         }
     }
 
-    @CommandDefinition(name = "info", description = "Show application info")
+    @CommandDefinition(name = "tmcc-info", description = "Show application info")
     public static class InfoCommand implements Command<CommandInvocation> {
 
         @Override

--- a/integration-tests/aesh/src/test/java/io/quarkus/it/aesh/TestMultipleCommandsInfo.java
+++ b/integration-tests/aesh/src/test/java/io/quarkus/it/aesh/TestMultipleCommandsInfo.java
@@ -21,7 +21,7 @@ public class TestMultipleCommandsInfo {
     @RegisterExtension
     static final QuarkusProdModeTest config = createConfig("multi-cmd-info-app",
             AppCommand.class, GreetCommand.class, CalcCommand.class, InfoCommand.class)
-            .setCommandLineParameters("info");
+            .setCommandLineParameters("tmci-info");
 
     @Test
     public void testInfoCommand() {
@@ -29,18 +29,18 @@ public class TestMultipleCommandsInfo {
         Assertions.assertThat(config.getExitCode()).isZero();
     }
 
-    @CommandDefinition(name = "app", description = "Multi-command application", groupCommands = { GreetCommand.class,
+    @CommandDefinition(name = "tmci-app", description = "Multi-command application", groupCommands = { GreetCommand.class,
             CalcCommand.class, InfoCommand.class })
     public static class AppCommand implements Command<CommandInvocation> {
 
         @Override
         public CommandResult execute(CommandInvocation invocation) {
-            invocation.println("Use a subcommand: greet, calc, info");
+            invocation.println("Use a subcommand: tmci-greet, tmci-calc, tmci-info");
             return CommandResult.SUCCESS;
         }
     }
 
-    @CommandDefinition(name = "greet", description = "Greet someone")
+    @CommandDefinition(name = "tmci-greet", description = "Greet someone")
     public static class GreetCommand implements Command<CommandInvocation> {
 
         @Option(shortName = 'n', name = "name", description = "Name to greet", defaultValue = "Stranger")
@@ -53,7 +53,7 @@ public class TestMultipleCommandsInfo {
         }
     }
 
-    @CommandDefinition(name = "calc", description = "Calculate sum of two numbers")
+    @CommandDefinition(name = "tmci-calc", description = "Calculate sum of two numbers")
     public static class CalcCommand implements Command<CommandInvocation> {
 
         @Option(shortName = 'a', name = "a", description = "First number", defaultValue = "0")
@@ -69,7 +69,7 @@ public class TestMultipleCommandsInfo {
         }
     }
 
-    @CommandDefinition(name = "info", description = "Show application info")
+    @CommandDefinition(name = "tmci-info", description = "Show application info")
     public static class InfoCommand implements Command<CommandInvocation> {
 
         @Override

--- a/integration-tests/aesh/src/test/java/io/quarkus/it/aesh/TestParentCommand.java
+++ b/integration-tests/aesh/src/test/java/io/quarkus/it/aesh/TestParentCommand.java
@@ -20,7 +20,7 @@ public class TestParentCommand {
     @RegisterExtension
     static final QuarkusProdModeTest config = createConfig("cli-app",
             CliParentCommand.class, RunSubCommand.class)
-            .setCommandLineParameters("run", "build");
+            .setCommandLineParameters("tpc-run", "build");
 
     @Test
     public void testParentSubCommand() {
@@ -28,7 +28,7 @@ public class TestParentCommand {
         Assertions.assertThat(config.getExitCode()).isZero();
     }
 
-    @CommandDefinition(name = "cli", description = "CLI-like parent command", groupCommands = { RunSubCommand.class })
+    @CommandDefinition(name = "tpc-cli", description = "CLI-like parent command", groupCommands = { RunSubCommand.class })
     public static class CliParentCommand implements Command<CommandInvocation> {
 
         @Option(shortName = 'v', name = "verbose", description = "Enable verbose output", hasValue = false)
@@ -45,7 +45,7 @@ public class TestParentCommand {
         }
     }
 
-    @CommandDefinition(name = "run", description = "Run a task")
+    @CommandDefinition(name = "tpc-run", description = "Run a task")
     public static class RunSubCommand implements Command<CommandInvocation> {
 
         @ParentCommand

--- a/integration-tests/aesh/src/test/java/io/quarkus/it/aesh/TestParentCommandVerbose.java
+++ b/integration-tests/aesh/src/test/java/io/quarkus/it/aesh/TestParentCommandVerbose.java
@@ -19,7 +19,7 @@ public class TestParentCommandVerbose {
     @RegisterExtension
     static final QuarkusProdModeTest config = createConfig("cli-verbose-app",
             CliParentCommand.class, VersionSubCommand.class)
-            .setCommandLineParameters("version");
+            .setCommandLineParameters("tpcv-version");
 
     @Test
     public void testParentSubCommandVersion() {
@@ -27,7 +27,7 @@ public class TestParentCommandVerbose {
         Assertions.assertThat(config.getExitCode()).isZero();
     }
 
-    @CommandDefinition(name = "cli", description = "CLI-like parent command", groupCommands = { VersionSubCommand.class })
+    @CommandDefinition(name = "tpcv-cli", description = "CLI-like parent command", groupCommands = { VersionSubCommand.class })
     public static class CliParentCommand implements Command<CommandInvocation> {
 
         @Option(shortName = 'v', name = "verbose", description = "Enable verbose output", hasValue = false)
@@ -44,7 +44,7 @@ public class TestParentCommandVerbose {
         }
     }
 
-    @CommandDefinition(name = "version", description = "Show version")
+    @CommandDefinition(name = "tpcv-version", description = "Show version")
     public static class VersionSubCommand implements Command<CommandInvocation> {
 
         @ParentCommand

--- a/integration-tests/aesh/src/test/resources/application.properties
+++ b/integration-tests/aesh/src/test/resources/application.properties
@@ -1,0 +1,7 @@
+# Enable the exit command for REPL test shutdown
+quarkus.aesh.add-exit-command=true
+
+# H2 datasource for Hibernate tests
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:mem:aesh-test;DB_CLOSE_DELAY=-1
+quarkus.hibernate-orm.database.generation=drop-and-create

--- a/test-framework/aesh/pom.xml
+++ b/test-framework/aesh/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-test-framework</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-test-aesh</artifactId>
+    <name>Quarkus - Test framework - Aesh</name>
+    <description>Test utilities for Aesh CLI command testing in REPL mode</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-aesh</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/test-framework/aesh/src/main/java/io/quarkus/test/aesh/AeshLauncher.java
+++ b/test-framework/aesh/src/main/java/io/quarkus/test/aesh/AeshLauncher.java
@@ -1,0 +1,64 @@
+package io.quarkus.test.aesh;
+
+import java.time.Duration;
+
+/**
+ * Test utility for interacting with an Aesh REPL (console mode) application.
+ * <p>
+ * Injected as a method parameter in {@code @QuarkusMainTest} tests. Starts the
+ * REPL on a background thread and allows sending commands and asserting on
+ * their output.
+ */
+public interface AeshLauncher {
+
+    /**
+     * Default timeout for {@link #executeCommand(String)}.
+     */
+    Duration DEFAULT_TIMEOUT = Duration.ofSeconds(30);
+
+    /**
+     * Start the REPL session on a background thread.
+     * Non-blocking -- returns immediately after the console is ready.
+     *
+     * @param args optional initial arguments
+     */
+    void launch(String... args);
+
+    /**
+     * Send a command to the REPL and wait for it to complete.
+     * Uses the {@link #DEFAULT_TIMEOUT default timeout} of 30 seconds.
+     * <p>
+     * The output buffer is cleared before each command, so the returned
+     * string contains only the output from this specific command.
+     *
+     * @param command the command string to execute
+     * @return the command output
+     * @throws RuntimeException if the command does not complete within the timeout
+     */
+    String executeCommand(String command);
+
+    /**
+     * Send a command to the REPL and wait for it to complete with a custom timeout.
+     * <p>
+     * The output buffer is cleared before each command, so the returned
+     * string contains only the output from this specific command.
+     *
+     * @param command the command string to execute
+     * @param timeout maximum time to wait for the command to complete
+     * @return the command output
+     * @throws RuntimeException if the command does not complete within the timeout
+     */
+    String executeCommand(String command, Duration timeout);
+
+    /**
+     * Returns the accumulated error output from the REPL session.
+     *
+     * @return the error output, or an empty string if none
+     */
+    String getErrorOutput();
+
+    /**
+     * Send the exit command and wait for the REPL session to shut down cleanly.
+     */
+    void exit();
+}

--- a/test-framework/aesh/src/main/java/io/quarkus/test/aesh/AeshLauncherImpl.java
+++ b/test-framework/aesh/src/main/java/io/quarkus/test/aesh/AeshLauncherImpl.java
@@ -1,0 +1,136 @@
+package io.quarkus.test.aesh;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import io.quarkus.aesh.runtime.AeshTestConnectionHolder;
+import io.quarkus.aesh.runtime.AeshTestConnectionHolder.AeshTestThread;
+import io.quarkus.test.junit.main.LaunchResult;
+import io.quarkus.test.junit.main.QuarkusMainLauncher;
+
+/**
+ * Default implementation of {@link AeshLauncher} that uses pipes and a
+ * {@link LinkedBlockingQueue} to communicate with the Aesh REPL across
+ * the Quarkus split classloader boundary.
+ */
+public class AeshLauncherImpl implements AeshLauncher {
+
+    private final QuarkusMainLauncher mainLauncher;
+
+    private PipedOutputStream stdinWriter;
+    private ByteArrayOutputStream stdoutCapture;
+    private LinkedBlockingQueue<Object> signalQueue;
+
+    private Thread replThread;
+    private volatile LaunchResult launchResult;
+
+    public AeshLauncherImpl(QuarkusMainLauncher mainLauncher) {
+        this.mainLauncher = mainLauncher;
+    }
+
+    @Override
+    public void launch(String... args) {
+        PipedInputStream stdinReader;
+        try {
+            stdinWriter = new PipedOutputStream();
+            stdinReader = new PipedInputStream(stdinWriter, 4096);
+            stdoutCapture = new ByteArrayOutputStream();
+            signalQueue = new LinkedBlockingQueue<>();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to set up test pipes", e);
+        }
+
+        ClassLoader testCl = Thread.currentThread().getContextClassLoader();
+        replThread = new AeshTestThread(
+                () -> {
+                    launchResult = mainLauncher.launch(args);
+                },
+                AeshTestConnectionHolder.TEST_THREAD_NAME,
+                testCl,
+                stdinReader, stdoutCapture, signalQueue);
+        replThread.start();
+
+        // Wait for the console to initialize and display the prompt.
+        // On slower CI environments (e.g. Windows runners with Hibernate),
+        // startup can take several seconds.
+        try {
+            Thread.sleep(2000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @Override
+    public String executeCommand(String command) {
+        return executeCommand(command, DEFAULT_TIMEOUT);
+    }
+
+    @Override
+    public String executeCommand(String command, Duration timeout) {
+        // Clear the output buffer and signal queue
+        stdoutCapture.reset();
+        signalQueue.clear();
+
+        // Send the command
+        try {
+            stdinWriter.write((command + "\n").getBytes(StandardCharsets.UTF_8));
+            stdinWriter.flush();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to write command to REPL stdin", e);
+        }
+
+        try {
+            Object signal = signalQueue.poll(timeout.toMillis(), TimeUnit.MILLISECONDS);
+            if (signal == null) {
+                throw new RuntimeException(
+                        "Command '" + command + "' did not complete within " + timeout);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted while waiting for command: " + command, e);
+        }
+
+        return stripAnsi(stdoutCapture.toString(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public String getErrorOutput() {
+        // Errors go to the same output stream in this implementation
+        return "";
+    }
+
+    @Override
+    public void exit() {
+        try {
+            stdinWriter.write("exit\n".getBytes(StandardCharsets.UTF_8));
+            stdinWriter.flush();
+            // Close the writer to signal EOF to the PipedInputStream reader.
+            // This is needed because PipedInputStream.read() blocks with wait()
+            // and closing the InputStream itself does not unblock it.
+            stdinWriter.close();
+        } catch (IOException e) {
+            // May already be closed
+        }
+
+        if (replThread != null) {
+            try {
+                replThread.join(10_000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    /**
+     * Strip ANSI escape sequences from the output for clean assertions.
+     */
+    private static String stripAnsi(String text) {
+        return text.replaceAll("\\u001B\\[(.*?)[a-zA-Z]", "");
+    }
+}

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusMainTestExtension.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusMainTestExtension.java
@@ -274,6 +274,8 @@ public class QuarkusMainTestExtension extends AbstractJvmQuarkusTestExtension
         }
     }
 
+    private static final String AESH_LAUNCHER_CLASS = "io.quarkus.test.aesh.AeshLauncher";
+
     @Override
     public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
             throws ParameterResolutionException {
@@ -282,7 +284,8 @@ public class QuarkusMainTestExtension extends AbstractJvmQuarkusTestExtension
         }
         Class<?> type = parameterContext.getParameter()
                 .getType();
-        return type == LaunchResult.class || type == QuarkusMainLauncher.class;
+        return type == LaunchResult.class || type == QuarkusMainLauncher.class
+                || AESH_LAUNCHER_CLASS.equals(type.getName());
     }
 
     @Override
@@ -301,18 +304,44 @@ public class QuarkusMainTestExtension extends AbstractJvmQuarkusTestExtension
 
             return result;
         } else if (type == QuarkusMainLauncher.class) {
-            return new QuarkusMainLauncher() {
-                @Override
-                public LaunchResult launch(String... args) {
-                    try {
-                        return doLaunch(extensionContext, args);
-                    } catch (Exception e) {
-                        throw new RuntimeException(e);
-                    }
-                }
-            };
+            return createMainLauncher(extensionContext);
+        } else if (AESH_LAUNCHER_CLASS.equals(type.getName())) {
+            return createAeshLauncher(extensionContext);
         } else {
             throw new RuntimeException("Parameter type not supported");
+        }
+    }
+
+    private QuarkusMainLauncher createMainLauncher(ExtensionContext extensionContext) {
+        return new QuarkusMainLauncher() {
+            @Override
+            public LaunchResult launch(String... args) {
+                try {
+                    return doLaunch(extensionContext, args);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+    }
+
+    /**
+     * Creates an AeshLauncher instance via reflection to avoid a compile-time
+     * dependency on quarkus-test-aesh.
+     */
+    private Object createAeshLauncher(ExtensionContext extensionContext) {
+        try {
+            QuarkusMainLauncher mainLauncher = createMainLauncher(extensionContext);
+            Class<?> implClass = Thread.currentThread().getContextClassLoader()
+                    .loadClass("io.quarkus.test.aesh.AeshLauncherImpl");
+            return implClass.getDeclaredConstructor(QuarkusMainLauncher.class).newInstance(mainLauncher);
+        } catch (ClassNotFoundException e) {
+            throw new ParameterResolutionException(
+                    "AeshLauncher requested but quarkus-test-aesh is not on the classpath. "
+                            + "Add io.quarkus:quarkus-test-aesh as a test dependency.",
+                    e);
+        } catch (ReflectiveOperationException e) {
+            throw new ParameterResolutionException("Failed to create AeshLauncher", e);
         }
     }
 

--- a/test-framework/pom.xml
+++ b/test-framework/pom.xml
@@ -43,6 +43,7 @@
         <module>kafka-companion</module>
         <module>google-cloud-functions</module>
         <module>observability</module>
+        <module>aesh</module>
     </modules>
 
     <build>


### PR DESCRIPTION
Upgrade aesh to 3.15 and aesh-readline to 3.15, which introduces CommandExecutionListener for command completion callbacks.

Added AeshLauncher, a test utility for @QuarkusMainTest that enables programmatic interaction with Aesh REPL sessions.

Migrate @GroupCommandDefinition usages in core/deployment to @CommandDefinition(groupCommands=...) since the annotation was removed in aesh 3.15.

<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
and the AI/LLM usage policy at https://github.com/quarkusio/quarkus/blob/main/AI_POLICY.md
-->

[Please describe here what your change is about]

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

