### PR TITLE
fix #54869 and partially rolls back #54425

### DIFF
--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/stork/GrpcLoadBalancerProvider.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/stork/GrpcLoadBalancerProvider.java
@@ -77,6 +77,8 @@ public class GrpcLoadBalancerProvider extends LoadBalancerProvider {
     public LoadBalancer newLoadBalancer(LoadBalancer.Helper helper) {
         return new LoadBalancer() {
 
+            Map<ServiceInstance, Subchannel> previousSubChannels = new TreeMap<>(
+                    Comparator.comparingLong(ServiceInstance::getId));
             String serviceName;
 
             @Override
@@ -101,6 +103,7 @@ public class GrpcLoadBalancerProvider extends LoadBalancerProvider {
                 for (EquivalentAddressGroup addressGroup : addresses) {
                     ServiceInstance serviceInstance = addressGroup.getAttributes()
                             .get(GrpcStorkServiceDiscovery.SERVICE_INSTANCE);
+                    previousSubChannels.remove(serviceInstance);
                     CreateSubchannelArgs subChannelArgs = CreateSubchannelArgs.newBuilder()
                             .setAddresses(addressGroup)
                             .setAttributes(addressGroup.getAttributes())
@@ -143,6 +146,11 @@ public class GrpcLoadBalancerProvider extends LoadBalancerProvider {
                     subChannels.put(serviceInstance, subchannel);
                 }
 
+                for (Subchannel value : previousSubChannels.values()) {
+                    log.info("shutting down subchannel");
+                    value.shutdown();
+                }
+                previousSubChannels = subChannels;
                 helper.updateBalancingState(state.get(), picker);
             }
 

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/stork/GrpcStorkServiceDiscovery.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/stork/GrpcStorkServiceDiscovery.java
@@ -6,8 +6,10 @@ import java.net.SocketAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.jboss.logging.Logger;
 
@@ -58,6 +60,7 @@ public class GrpcStorkServiceDiscovery extends NameResolverProvider {
             volatile boolean resolving, shutdown;
             ServiceDiscovery serviceDiscovery;
             String serviceName;
+            volatile Set<Long> serviceInstanceIds = new HashSet<>();
 
             @Override
             public String getServiceAuthority() {
@@ -108,6 +111,15 @@ public class GrpcStorkServiceDiscovery extends NameResolverProvider {
                 resolve();
             }
 
+            private boolean areServicesRemoved(List<ServiceInstance> instances) {
+                for (ServiceInstance instance : instances) {
+                    if (!serviceInstanceIds.contains(instance.getId())) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
             private void informListener(List<ServiceInstance> instances) {
                 try {
                     if (shutdown) {
@@ -128,40 +140,48 @@ public class GrpcStorkServiceDiscovery extends NameResolverProvider {
                         return;
                     }
 
-                    // Always notify the listener for a non-empty resolution, even when the
-                    // instance set is unchanged. Skipping onResult/onError when nothing
-                    // changed can leave a refresh() with no callback and the channel stuck
-                    // waiting for re-resolution (same class of bug as the empty-list case).
-                    ArrayList<EquivalentAddressGroup> addresses = new ArrayList<>();
-                    for (ServiceInstance instance : instances) {
-                        List<SocketAddress> socketAddresses = new ArrayList<>();
-                        try {
-                            for (InetAddress inetAddress : InetAddress.getAllByName(instance.getHost())) {
-                                socketAddresses.add(new InetSocketAddress(inetAddress, instance.getPort()));
+                    if (serviceInstanceIds.size() != instances.size() || areServicesRemoved(instances)) {
+                        HashSet<Long> serviceInstanceIds = new HashSet<>();
+                        for (ServiceInstance instance : instances) {
+                            serviceInstanceIds.add(instance.getId());
+                        }
+                        this.serviceInstanceIds = serviceInstanceIds;
+
+                        // Always notify the listener for a non-empty resolution, even when the
+                        // instance set is unchanged. Skipping onResult/onError when nothing
+                        // changed can leave a refresh() with no callback and the channel stuck
+                        // waiting for re-resolution (same class of bug as the empty-list case).
+                        ArrayList<EquivalentAddressGroup> addresses = new ArrayList<>();
+                        for (ServiceInstance instance : instances) {
+                            List<SocketAddress> socketAddresses = new ArrayList<>();
+                            try {
+                                for (InetAddress inetAddress : InetAddress.getAllByName(instance.getHost())) {
+                                    socketAddresses.add(new InetSocketAddress(inetAddress, instance.getPort()));
+                                }
+                            } catch (UnknownHostException e) {
+                                log.warnf(e, "Ignoring wrong host: '%s' for service name '%s'", instance.getHost(),
+                                        serviceName);
                             }
-                        } catch (UnknownHostException e) {
-                            log.warnf(e, "Ignoring wrong host: '%s' for service name '%s'", instance.getHost(),
-                                    serviceName);
+
+                            if (!socketAddresses.isEmpty()) {
+                                Attributes attributes = Attributes.newBuilder()
+                                        .set(SERVICE_INSTANCE, instance)
+                                        .build();
+                                EquivalentAddressGroup addressGroup = new EquivalentAddressGroup(socketAddresses, attributes);
+                                addresses.add(addressGroup);
+                            }
                         }
 
-                        if (!socketAddresses.isEmpty()) {
-                            Attributes attributes = Attributes.newBuilder()
-                                    .set(SERVICE_INSTANCE, instance)
-                                    .build();
-                            EquivalentAddressGroup addressGroup = new EquivalentAddressGroup(socketAddresses, attributes);
-                            addresses.add(addressGroup);
+                        if (addresses.isEmpty()) {
+                            log.error("Failed to determine working socket addresses for service-name: " + serviceName);
+                            listener.onError(Status.FAILED_PRECONDITION);
+                        } else {
+                            ConfigOrError serviceConfig = configParser.parseServiceConfig(mapConfigForServiceName());
+                            listener.onResult(ResolutionResult.newBuilder()
+                                    .setAddresses(addresses)
+                                    .setServiceConfig(serviceConfig)
+                                    .build());
                         }
-                    }
-
-                    if (addresses.isEmpty()) {
-                        log.error("Failed to determine working socket addresses for service-name: " + serviceName);
-                        listener.onError(Status.FAILED_PRECONDITION);
-                    } else {
-                        ConfigOrError serviceConfig = configParser.parseServiceConfig(mapConfigForServiceName());
-                        listener.onResult(ResolutionResult.newBuilder()
-                                .setAddresses(addresses)
-                                .setServiceConfig(serviceConfig)
-                                .build());
                     }
                 } finally {
                     resolving = false;

--- a/extensions/grpc/runtime/src/test/java/io/quarkus/grpc/runtime/stork/GrpcStorkServiceDiscoveryTest.java
+++ b/extensions/grpc/runtime/src/test/java/io/quarkus/grpc/runtime/stork/GrpcStorkServiceDiscoveryTest.java
@@ -45,19 +45,30 @@ class GrpcStorkServiceDiscoveryTest {
         Stork.shutdown();
     }
 
-    @Test
-    void refreshNotifiesListenerWhenInstancesUnchanged() {
-        defineService(staticDiscovery());
-        CountingListener listener = new CountingListener();
-        NameResolver resolver = createResolver();
-
-        resolver.start(listener);
-        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> assertThat(listener.results.get()).isEqualTo(1));
-
-        resolver.refresh();
-        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> assertThat(listener.results.get()).isEqualTo(2));
-        assertThat(listener.errors.get()).isZero();
-    }
+    /*
+     * We actually want to skip sometimes
+     * If the backend is unreachable, this leads us to:
+     * 1. Subchannel enters TRANSIENT_FAILURE → refreshNameResolution()
+     * 2. resolve() → Stork returns same non-empty list (pod still exists in k8s)
+     * 3. we don't skip when instances have not changed → listener.onResult() fires
+     * 4. handleResolvedAddresses → creates new subchannel to same dead IP → fails immediately (backoff=0)
+     * 5. → refreshNameResolution() → back to step 2
+     *
+     * This tight loop can crash the client. SKipping when instances don't change removes the problem
+     */
+    //    @Test
+    //    void refreshNotifiesListenerWhenInstancesUnchanged() {
+    //        defineService(staticDiscovery());
+    //        CountingListener listener = new CountingListener();
+    //        NameResolver resolver = createResolver();
+    //
+    //        resolver.start(listener);
+    //        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> assertThat(listener.results.get()).isEqualTo(1));
+    //
+    //        resolver.refresh();
+    //        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> assertThat(listener.results.get()).isEqualTo(2));
+    //        assertThat(listener.errors.get()).isZero();
+    //    }
 
     @Test
     void refreshAfterDiscoveryFailureNotifiesListener() {


### PR DESCRIPTION
partially rolls back #54425 and fixes #54869.

#54869 noticed that 
> gRPC stork `LoadBalancerProvider` never shutdown removed subchannels (endless gRPC Sub Channel failed after an backend pod is replaced). 

When reproducing the error, it became clear that things were actually worse because of #54425. When backend is unreachable, client crashed because of:

1. Subchannel enters TRANSIENT_FAILURE → refreshNameResolution()
2. resolve() → Stork returns same non-empty list (pod still exists in k8s)
3. we don't skip when instances have not changed → listener.onResult() fires
4. handleResolvedAddresses → creates new subchannel to same dead IP → fails immediately (backoff=0)
5. → refreshNameResolution() → back to step 2
 
I rolled back some changes made by #54425 and followed @magnus-gustafsson lead to actually remove subchannels for old ip.