### PR TITLE
Fix JAX-RS client proxy generation for resolved type parameters

### DIFF
--- a/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest-client-jaxrs/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
@@ -935,7 +935,8 @@ public class JaxrsClientReactiveProcessor {
                     MethodParameter param = method.getParameters()[i];
                     javaMethodParameters[i] = param.declaredType != null ? param.declaredType : param.type;
                 }
-                MethodInfo jandexMethod = getJavaMethod(interfaceClass, method, method.getParameters(), index)
+                MethodInfo jandexMethod = getJavaMethod(interfaceClass, method, method.getParameters(), index,
+                        hierarchyIdentifierTypeLookupMap)
                         .orElseThrow(() -> new RuntimeException(
                                 "Failed to find matching java method for " + method + " on " + interfaceClass
                                         + ". It may have unresolved parameter types (generics)"));
@@ -1680,7 +1681,7 @@ public class JaxrsClientReactiveProcessor {
             int subMethodIndex = 0;
             for (ResourceMethod subMethod : method.getSubResourceMethods()) {
                 MethodInfo jandexSubMethod = getJavaMethod(subInterface, subMethod,
-                        subMethod.getParameters(), index)
+                        subMethod.getParameters(), index, hierarchyIdentifierTypeLookupMap)
                         .orElseThrow(() -> new RuntimeException(
                                 "Failed to find matching java method for " + subMethod + " on "
                                         + subInterface
@@ -2895,14 +2896,21 @@ public class JaxrsClientReactiveProcessor {
     }
 
     private Optional<MethodInfo> getJavaMethod(ClassInfo interfaceClass, ResourceMethod method,
-            MethodParameter[] parameters, IndexView index) {
+            MethodParameter[] parameters, IndexView index, Map<DotName, Map<String, Type>> hierarchyIdentifierTypeLookupMap) {
 
         for (MethodInfo methodInfo : interfaceClass.methods()) {
             if (methodInfo.name().equals(method.getName()) && methodInfo.parametersCount() == parameters.length) {
                 boolean matches = true;
+                Map<String, Type> identifierTypeLookupMap = hierarchyIdentifierTypeLookupMap
+                        .getOrDefault(methodInfo.declaringClass().name(), Collections.emptyMap());
                 for (int i = 0; i < parameters.length; i++) {
                     MethodParameter actualParam = parameters[i];
                     Type parameterType = methodInfo.parameterType(i);
+                    try {
+                        parameterType = resolveType(parameterType, identifierTypeLookupMap, methodInfo);
+                    } catch (IllegalArgumentException ignored) {
+                        // Keep the raw Jandex type and fall back to the previous matching behavior.
+                    }
                     String declaredType = actualParam.declaredType != null ? actualParam.declaredType : actualParam.type;
                     if (!declaredType.equals(parameterType.name().toString())) {
                         matches = false;
@@ -2918,7 +2926,7 @@ public class JaxrsClientReactiveProcessor {
         Optional<MethodInfo> maybeMethod = Optional.empty();
         for (DotName interfaceName : interfaceClass.interfaceNames()) {
             maybeMethod = getJavaMethod(index.getClassByName(interfaceName), method, parameters,
-                    index);
+                    index, hierarchyIdentifierTypeLookupMap);
             if (maybeMethod.isPresent()) {
                 break;
             }

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/SubResourceLocatorTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/SubResourceLocatorTest.java
@@ -64,6 +64,7 @@ public class SubResourceLocatorTest {
     public void test657() {
         Client client = ClientBuilder.newClient();
         Assertions.assertNotNull(((WebTargetImpl) client.target(uri)).proxy(SubResourceLocatorPlatformServiceResource.class));
+        Assertions.assertNotNull(((WebTargetImpl) client.target(uri)).proxy(SubResourceLocatorBaseService.class));
         WebTarget base = client.target(UriBuilder.fromUri(uri).path("/platform/users/89080/data/ada/jsanchez110"));
         Response response = base.request().get();
         String s = response.readEntity(String.class);


### PR DESCRIPTION
`SubResourceLocatorBaseService` extends a generic resource interface with a concrete type parameter, but client proxy generation failed to match inherited methods because it compared the resolved `ResourceMethod` parameter type with the raw Jandex `MethodInfo` type variable.

Now, we resolve generic method parameter types against the root client interface before matching MethodInfo candidates.