### PR TITLE
Make `WebJarProcessor#processWebJarDevMode` aware of reproducibility checks

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/webjar/WebJarProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/webjar/WebJarProcessor.java
@@ -7,13 +7,16 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
+import io.quarkus.bootstrap.util.IoUtils;
 import io.quarkus.deployment.IsProduction;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
+import io.quarkus.deployment.builditem.ReproducibilityCheckBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
@@ -29,11 +32,12 @@ public class WebJarProcessor {
     WebJarResultsBuildItem processWebJarDevMode(WebJarRecorder recorder, List<WebJarBuildItem> webJars,
             CurateOutcomeBuildItem curateOutcomeBuildItem,
             ShutdownContextBuildItem shutdownContext,
+            Optional<ReproducibilityCheckBuildItem> reproducibilityCheckBuildItem,
             ApplicationConfig applicationConfig) throws IOException {
 
         Map<GACT, WebJarResultsBuildItem.WebJarResult> results = new HashMap<>();
 
-        Path deploymentBasePath = Files.createTempDirectory("quarkus-webjar");
+        Path deploymentBasePath = getDeploymentBasePath(applicationConfig, reproducibilityCheckBuildItem.isPresent());
         recorder.shutdownTask(shutdownContext, deploymentBasePath.toString());
 
         for (WebJarBuildItem webJar : webJars) {
@@ -60,6 +64,22 @@ public class WebJarProcessor {
         }
 
         return new WebJarResultsBuildItem(results);
+    }
+
+    private static Path getDeploymentBasePath(ApplicationConfig applicationConfig, boolean isReproducibilityCheck)
+            throws IOException {
+        if (!isReproducibilityCheck) {
+            return Files.createTempDirectory("quarkus-webjar");
+        }
+        Path deploymentBasePath = Path.of(
+                System.getProperty("java.io.tmpdir"),
+                "quarkus-webjar-" + applicationConfig.name().orElse("app"));
+
+        if (Files.exists(deploymentBasePath)) {
+            IoUtils.recursiveDelete(deploymentBasePath);
+        }
+        Files.createDirectories(deploymentBasePath);
+        return deploymentBasePath;
     }
 
     @BuildStep(onlyIf = IsProduction.class)

--- a/test-framework/junit-internal/src/main/java/io/quarkus/test/BytecodeTools.java
+++ b/test-framework/junit-internal/src/main/java/io/quarkus/test/BytecodeTools.java
@@ -26,21 +26,10 @@ import org.jetbrains.java.decompiler.main.extern.IResultSaver;
 class BytecodeTools {
 
     private static final Map<String, Object> VINEFLOWER_OPTIONS = createVineflowerOptions();
-
-    // Known non-deterministic classes. Each extension should fix its non-determinism;
-    // entries here are temporary workarounds.
-    // TODO: allow extensions to declare exclusions dynamically via a build item
-    private static final Set<String> DEFAULT_EXCLUDED = Set.of(
-            // DevUI handler classes that embed non-deterministic data
-            "io/quarkus/runner/recorded/WebJarProcessor$processWebJarDevMode",
-            "io/quarkus/runner/recorded/SmallRyeHealthProcessor$registerHealthUiHandler",
-            "io/quarkus/runner/recorded/SmallRyeGraphQLProcessor$registerGraphQLUiHandler",
-            "io/quarkus/runner/recorded/SwaggerUiProcessor$registerSwaggerUiHandler");
-
     private static final Set<String> EXCLUDED = loadExclusions();
 
     private static Set<String> loadExclusions() {
-        Set<String> result = new TreeSet<>(DEFAULT_EXCLUDED);
+        Set<String> result = new TreeSet<>();
         String additional = System.getProperty("quarkus-internal.test.reproducibility-check.excludes");
         if (additional != null && !additional.isBlank()) {
             for (String prefix : additional.split(",")) {

--- a/test-framework/junit-internal/src/test/java/io/quarkus/test/BytecodeToolsTest.java
+++ b/test-framework/junit-internal/src/test/java/io/quarkus/test/BytecodeToolsTest.java
@@ -62,18 +62,6 @@ class BytecodeToolsTest {
     }
 
     @Test
-    void excludedClassIsNotReportedAsChanged() {
-        String excluded = "io/quarkus/runner/recorded/WebJarProcessor$processWebJarDevMode";
-        String resource = excluded + ".class";
-        Map<String, byte[]> reference = Map.of(resource, new byte[] { 1, 2, 3 });
-        Map<String, byte[]> current = Map.of(resource, new byte[] { 4, 5, 6 });
-
-        var diff = BytecodeTools.diff(reference, current);
-
-        assertThat(diff.isEmpty()).isTrue();
-    }
-
-    @Test
     void dumpCreatesExpectedFileStructure(@TempDir Path tempDir) throws Exception {
         Map<String, byte[]> reference = generateClassWithField("com.example.Foo", "fieldA");
         Map<String, byte[]> current = generateClassWithField("com.example.Foo", "fieldB");


### PR DESCRIPTION
Instead of hardcoding several processors that fail reproducibility checks in `BytecodeTools`, we now avoid generating unstable bytecode when producing `WebJarResultsBuildItem` while reproducibility tests are run.

We can do this because this such bytecode generation never happens in prod mode.