### PR TITLE
Fix gRPC Stork load balancer subchannel lifecycle

### DIFF
--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/stork/GrpcLoadBalancerProvider.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/stork/GrpcLoadBalancerProvider.java
@@ -5,14 +5,15 @@ import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
 import static io.quarkus.grpc.runtime.stork.StorkMeasuringCollector.STORK_MEASURE_TIME;
 import static io.quarkus.grpc.runtime.stork.StorkMeasuringCollector.STORK_SERVICE_INSTANCE;
 
-import java.util.Collections;
+import java.net.SocketAddress;
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.jboss.logging.Logger;
 
@@ -77,6 +78,11 @@ public class GrpcLoadBalancerProvider extends LoadBalancerProvider {
     public LoadBalancer newLoadBalancer(LoadBalancer.Helper helper) {
         return new LoadBalancer() {
 
+            final Map<AddressKey, ManagedSubchannel> subchannelsByAddress = new LinkedHashMap<>();
+            final Map<ServiceInstance, Subchannel> subchannelsByServiceInstance = new TreeMap<>(
+                    Comparator.comparingLong(ServiceInstance::getId));
+            final Set<ServiceInstance> activeServiceInstances = new HashSet<>();
+
             String serviceName;
 
             @Override
@@ -90,70 +96,189 @@ public class GrpcLoadBalancerProvider extends LoadBalancerProvider {
 
                 StorkLoadBalancerConfig config = (StorkLoadBalancerConfig) loadBalancerConfig;
 
-                Map<ServiceInstance, Subchannel> subChannels = new TreeMap<>(Comparator.comparingLong(ServiceInstance::getId));
-                Set<ServiceInstance> activeSubchannels = Collections.newSetFromMap(new ConcurrentHashMap<>());
-                AtomicReference<ConnectivityState> state = new AtomicReference<>(ConnectivityState.CONNECTING);
-
                 serviceName = config.serviceName;
 
-                final StorkSubchannelPicker picker = new StorkSubchannelPicker(subChannels, serviceName, activeSubchannels);
+                Map<AddressKey, EquivalentAddressGroup> desiredAddresses = new LinkedHashMap<>();
+                Map<ServiceInstance, Subchannel> desiredSubchannelsByServiceInstance = new TreeMap<>(
+                        Comparator.comparingLong(ServiceInstance::getId));
 
                 for (EquivalentAddressGroup addressGroup : addresses) {
                     ServiceInstance serviceInstance = addressGroup.getAttributes()
                             .get(GrpcStorkServiceDiscovery.SERVICE_INSTANCE);
-                    CreateSubchannelArgs subChannelArgs = CreateSubchannelArgs.newBuilder()
-                            .setAddresses(addressGroup)
-                            .setAttributes(addressGroup.getAttributes())
-                            .build();
-
-                    Subchannel subchannel = helper.createSubchannel(subChannelArgs);
-                    subchannel.start(new SubchannelStateListener() {
-                        @Override
-                        public void onSubchannelState(ConnectivityStateInfo stateInfo) {
-                            if (stateInfo.getState() == TRANSIENT_FAILURE || stateInfo.getState() == IDLE) {
-                                Status status = stateInfo.getStatus();
-                                log.error("gRPC Sub Channel failed", status == null ? null : status.getCause());
-                                helper.refreshNameResolution();
-                            }
-                            log.debugf("subchannel changed state to %s for %s", stateInfo.getState(),
-                                    serviceInstance.getId());
-                            switch (stateInfo.getState()) {
-                                case READY:
-                                    activeSubchannels.add(serviceInstance);
-                                    if (state.getAndSet(ConnectivityState.READY) != ConnectivityState.READY) {
-                                        helper.updateBalancingState(state.get(), picker);
-                                    }
-                                    break;
-                                case CONNECTING:
-                                case TRANSIENT_FAILURE:
-                                case IDLE:
-                                case SHUTDOWN:
-                                    activeSubchannels.remove(serviceInstance);
-                                    if (activeSubchannels.isEmpty()
-                                            && state.compareAndSet(ConnectivityState.READY, stateInfo.getState())) {
-                                        helper.updateBalancingState(state.get(), picker);
-                                    }
-                                    break;
-                            }
-                        }
-                    });
-                    if (requestConnections) {
-                        subchannel.requestConnection();
+                    if (serviceInstance == null) {
+                        log.warn("Ignoring gRPC Stork address group without a service instance");
+                        continue;
                     }
-                    subChannels.put(serviceInstance, subchannel);
+                    AddressKey addressKey = AddressKey.from(addressGroup);
+                    desiredAddresses.put(addressKey, addressGroup);
+                    ManagedSubchannel managedSubchannel = subchannelsByAddress.get(addressKey);
+                    if (managedSubchannel == null) {
+                        managedSubchannel = createManagedSubchannel(addressKey, addressGroup, serviceInstance, helper);
+                        subchannelsByAddress.put(addressKey, managedSubchannel);
+                    } else {
+                        managedSubchannel.update(addressGroup, serviceInstance);
+                    }
+                    desiredSubchannelsByServiceInstance.put(serviceInstance, managedSubchannel.subchannel);
                 }
 
-                helper.updateBalancingState(state.get(), picker);
+                shutdownRemovedSubchannels(desiredAddresses.keySet());
+                subchannelsByServiceInstance.clear();
+                subchannelsByServiceInstance.putAll(desiredSubchannelsByServiceInstance);
+                rebuildActiveServiceInstances();
+                updateBalancingState(helper);
             }
 
             @Override
             public void handleNameResolutionError(Status error) {
                 log.errorf("Name resolution failed for service '%s'", serviceName);
+                if (activeServiceInstances.isEmpty()) {
+                    helper.updateBalancingState(TRANSIENT_FAILURE, new GrpcLoadBalancerProvider.ErrorPicker(error));
+                }
             }
 
             @Override
             public void shutdown() {
                 log.debugf("Shutting down load balancer for service '%s'", serviceName);
+                for (ManagedSubchannel managedSubchannel : subchannelsByAddress.values()) {
+                    managedSubchannel.shutdown();
+                }
+                subchannelsByAddress.clear();
+                subchannelsByServiceInstance.clear();
+                activeServiceInstances.clear();
+            }
+
+            private ManagedSubchannel createManagedSubchannel(AddressKey addressKey, EquivalentAddressGroup addressGroup,
+                    ServiceInstance serviceInstance, LoadBalancer.Helper helper) {
+                CreateSubchannelArgs subChannelArgs = CreateSubchannelArgs.newBuilder()
+                        .setAddresses(addressGroup)
+                        .setAttributes(addressGroup.getAttributes())
+                        .build();
+
+                Subchannel subchannel = helper.createSubchannel(subChannelArgs);
+                ManagedSubchannel managedSubchannel = new ManagedSubchannel(addressKey, subchannel, addressGroup,
+                        serviceInstance);
+                subchannel.start(new SubchannelStateListener() {
+                    @Override
+                    public void onSubchannelState(ConnectivityStateInfo stateInfo) {
+                        handleSubchannelState(managedSubchannel, stateInfo, helper);
+                    }
+                });
+                if (requestConnections) {
+                    subchannel.requestConnection();
+                }
+                return managedSubchannel;
+            }
+
+            private void handleSubchannelState(ManagedSubchannel managedSubchannel,
+                    ConnectivityStateInfo stateInfo, LoadBalancer.Helper helper) {
+                if (subchannelsByAddress.get(managedSubchannel.addressKey) != managedSubchannel) {
+                    return;
+                }
+                if (stateInfo.getState() == ConnectivityState.SHUTDOWN) {
+                    return;
+                }
+
+                if (stateInfo.getState() == TRANSIENT_FAILURE) {
+                    Status status = stateInfo.getStatus();
+                    log.error("gRPC Sub Channel failed", status == null ? null : status.getCause());
+                    helper.refreshNameResolution();
+                } else if (stateInfo.getState() == IDLE) {
+                    helper.refreshNameResolution();
+                    if (requestConnections) {
+                        managedSubchannel.subchannel.requestConnection();
+                    }
+                }
+                log.debugf("subchannel changed state to %s for %s", stateInfo.getState(),
+                        managedSubchannel.serviceInstance.getId());
+
+                managedSubchannel.state = stateInfo.getState();
+                managedSubchannel.status = stateInfo.getStatus();
+                rebuildActiveServiceInstances();
+                updateBalancingState(helper);
+            }
+
+            private void shutdownRemovedSubchannels(Set<AddressKey> desiredAddresses) {
+                List<AddressKey> removedAddresses = new ArrayList<>();
+                for (AddressKey addressKey : subchannelsByAddress.keySet()) {
+                    if (!desiredAddresses.contains(addressKey)) {
+                        removedAddresses.add(addressKey);
+                    }
+                }
+                for (AddressKey addressKey : removedAddresses) {
+                    ManagedSubchannel removed = subchannelsByAddress.remove(addressKey);
+                    if (removed != null) {
+                        removed.shutdown();
+                    }
+                }
+            }
+
+            private void rebuildActiveServiceInstances() {
+                activeServiceInstances.clear();
+                for (ManagedSubchannel managedSubchannel : subchannelsByAddress.values()) {
+                    if (managedSubchannel.state == ConnectivityState.READY
+                            && subchannelsByServiceInstance.containsKey(managedSubchannel.serviceInstance)) {
+                        activeServiceInstances.add(managedSubchannel.serviceInstance);
+                    }
+                }
+            }
+
+            private void updateBalancingState(LoadBalancer.Helper helper) {
+                if (subchannelsByServiceInstance.isEmpty()) {
+                    helper.updateBalancingState(TRANSIENT_FAILURE,
+                            new GrpcLoadBalancerProvider.ErrorPicker(
+                                    Status.UNAVAILABLE.withDescription("No Stork service instances available")));
+                    return;
+                }
+
+                ConnectivityState state = calculateState();
+                if (state == TRANSIENT_FAILURE) {
+                    helper.updateBalancingState(state, new GrpcLoadBalancerProvider.ErrorPicker(lastFailure()));
+                } else {
+                    helper.updateBalancingState(state, new StorkSubchannelPicker(
+                            copySubchannelsByServiceInstance(),
+                            serviceName,
+                            new HashSet<>(activeServiceInstances)));
+                }
+            }
+
+            private Map<ServiceInstance, Subchannel> copySubchannelsByServiceInstance() {
+                Map<ServiceInstance, Subchannel> copy = new TreeMap<>(Comparator.comparingLong(ServiceInstance::getId));
+                copy.putAll(subchannelsByServiceInstance);
+                return copy;
+            }
+
+            private ConnectivityState calculateState() {
+                if (!activeServiceInstances.isEmpty()) {
+                    return ConnectivityState.READY;
+                }
+                boolean connectingOrIdle = false;
+                boolean transientFailure = false;
+                for (ManagedSubchannel managedSubchannel : subchannelsByAddress.values()) {
+                    switch (managedSubchannel.state) {
+                        case CONNECTING:
+                        case IDLE:
+                            connectingOrIdle = true;
+                            break;
+                        case TRANSIENT_FAILURE:
+                            transientFailure = true;
+                            break;
+                        default:
+                            break;
+                    }
+                }
+                if (connectingOrIdle) {
+                    return ConnectivityState.CONNECTING;
+                }
+                return transientFailure ? TRANSIENT_FAILURE : ConnectivityState.CONNECTING;
+            }
+
+            private Status lastFailure() {
+                for (ManagedSubchannel managedSubchannel : subchannelsByAddress.values()) {
+                    if (managedSubchannel.state == TRANSIENT_FAILURE) {
+                        return managedSubchannel.status;
+                    }
+                }
+                return Status.UNAVAILABLE;
             }
         };
     }
@@ -163,6 +288,62 @@ public class GrpcLoadBalancerProvider extends LoadBalancerProvider {
 
         StorkLoadBalancerConfig(String serviceName) {
             this.serviceName = serviceName;
+        }
+    }
+
+    static final class AddressKey {
+        private final List<SocketAddress> addresses;
+
+        private AddressKey(List<SocketAddress> addresses) {
+            this.addresses = addresses;
+        }
+
+        static AddressKey from(EquivalentAddressGroup addressGroup) {
+            return new AddressKey(List.copyOf(addressGroup.getAddresses()));
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof AddressKey)) {
+                return false;
+            }
+            AddressKey that = (AddressKey) o;
+            return addresses.equals(that.addresses);
+        }
+
+        @Override
+        public int hashCode() {
+            return addresses.hashCode();
+        }
+    }
+
+    static class ManagedSubchannel {
+        final AddressKey addressKey;
+        final LoadBalancer.Subchannel subchannel;
+        EquivalentAddressGroup addressGroup;
+        ServiceInstance serviceInstance;
+        ConnectivityState state = ConnectivityState.CONNECTING;
+        Status status = Status.OK;
+
+        ManagedSubchannel(AddressKey addressKey, LoadBalancer.Subchannel subchannel,
+                EquivalentAddressGroup addressGroup, ServiceInstance serviceInstance) {
+            this.addressKey = addressKey;
+            this.subchannel = subchannel;
+            this.addressGroup = addressGroup;
+            this.serviceInstance = serviceInstance;
+        }
+
+        void update(EquivalentAddressGroup addressGroup, ServiceInstance serviceInstance) {
+            this.addressGroup = addressGroup;
+            this.serviceInstance = serviceInstance;
+            subchannel.updateAddresses(List.of(addressGroup));
+        }
+
+        void shutdown() {
+            subchannel.shutdown();
         }
     }
 
@@ -202,6 +383,19 @@ public class GrpcLoadBalancerProvider extends LoadBalancerProvider {
                 log.debugf("no active service instances, using all subChannels: %s", toChooseFrom);
             }
             return service.selectInstanceAndRecordStart(toChooseFrom, measureTime);
+        }
+    }
+
+    static class ErrorPicker extends LoadBalancer.SubchannelPicker {
+        private final Status status;
+
+        ErrorPicker(Status status) {
+            this.status = status;
+        }
+
+        @Override
+        public LoadBalancer.PickResult pickSubchannel(LoadBalancer.PickSubchannelArgs args) {
+            return LoadBalancer.PickResult.withError(status);
         }
     }
 }

--- a/extensions/grpc/runtime/src/test/java/io/quarkus/grpc/runtime/stork/GrpcLoadBalancerProviderTest.java
+++ b/extensions/grpc/runtime/src/test/java/io/quarkus/grpc/runtime/stork/GrpcLoadBalancerProviderTest.java
@@ -1,0 +1,366 @@
+package io.quarkus.grpc.runtime.stork;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import io.grpc.Attributes;
+import io.grpc.ConnectivityState;
+import io.grpc.ConnectivityStateInfo;
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.LoadBalancer;
+import io.grpc.Status;
+import io.smallrye.stork.api.ServiceInstance;
+import io.smallrye.stork.impl.DefaultServiceInstance;
+
+class GrpcLoadBalancerProviderTest {
+
+    private static final String SERVICE_NAME = "hello-service";
+
+    @Test
+    void reusesSubchannelWhenEndpointIsUnchanged() {
+        LoadBalancer.Helper helper = mock(LoadBalancer.Helper.class);
+        List<LoadBalancer.SubchannelStateListener> listeners = new ArrayList<>();
+        LoadBalancer.Subchannel subchannel = subchannel(listeners);
+        when(helper.createSubchannel(any())).thenReturn(subchannel);
+
+        LoadBalancer loadBalancer = new GrpcLoadBalancerProvider(true).newLoadBalancer(helper);
+        loadBalancer.handleResolvedAddresses(resolvedAddresses(addressGroup(instance(1, 9001), 9001)));
+        loadBalancer.handleResolvedAddresses(resolvedAddresses(addressGroup(instance(2, 9001), 9001)));
+
+        verify(helper, times(1)).createSubchannel(any());
+        verify(subchannel).updateAddresses(any());
+        verify(subchannel, never()).shutdown();
+    }
+
+    @Test
+    void shutsDownSubchannelWhenEndpointIsRemoved() {
+        LoadBalancer.Helper helper = mock(LoadBalancer.Helper.class);
+        List<LoadBalancer.SubchannelStateListener> listeners = new ArrayList<>();
+        LoadBalancer.Subchannel first = subchannel(listeners);
+        LoadBalancer.Subchannel second = subchannel(listeners);
+        when(helper.createSubchannel(any())).thenReturn(first, second);
+
+        LoadBalancer loadBalancer = new GrpcLoadBalancerProvider(true).newLoadBalancer(helper);
+        loadBalancer.handleResolvedAddresses(resolvedAddresses(
+                addressGroup(instance(1, 9001), 9001),
+                addressGroup(instance(2, 9002), 9002)));
+        loadBalancer.handleResolvedAddresses(resolvedAddresses(addressGroup(instance(2, 9002), 9002)));
+
+        verify(first).shutdown();
+        verify(second, never()).shutdown();
+    }
+
+    @Test
+    void shutsDownSubchannelWhenEndpointChangesForSameServiceInstance() {
+        LoadBalancer.Helper helper = mock(LoadBalancer.Helper.class);
+        List<LoadBalancer.SubchannelStateListener> listeners = new ArrayList<>();
+        LoadBalancer.Subchannel first = subchannel(listeners);
+        LoadBalancer.Subchannel second = subchannel(listeners);
+        when(helper.createSubchannel(any())).thenReturn(first, second);
+
+        LoadBalancer loadBalancer = new GrpcLoadBalancerProvider(true).newLoadBalancer(helper);
+        loadBalancer.handleResolvedAddresses(resolvedAddresses(addressGroup(instance(1, 9001), 9001)));
+        loadBalancer.handleResolvedAddresses(resolvedAddresses(addressGroup(instance(1, 9002), 9002)));
+
+        verify(helper, times(2)).createSubchannel(any());
+        verify(first).shutdown();
+        verify(second, never()).shutdown();
+    }
+
+    @Test
+    void shutdownClosesManagedSubchannels() {
+        LoadBalancer.Helper helper = mock(LoadBalancer.Helper.class);
+        List<LoadBalancer.SubchannelStateListener> listeners = new ArrayList<>();
+        LoadBalancer.Subchannel first = subchannel(listeners);
+        LoadBalancer.Subchannel second = subchannel(listeners);
+        when(helper.createSubchannel(any())).thenReturn(first, second);
+
+        LoadBalancer loadBalancer = new GrpcLoadBalancerProvider(true).newLoadBalancer(helper);
+        loadBalancer.handleResolvedAddresses(resolvedAddresses(
+                addressGroup(instance(1, 9001), 9001),
+                addressGroup(instance(2, 9002), 9002)));
+        loadBalancer.shutdown();
+
+        verify(first).shutdown();
+        verify(second).shutdown();
+    }
+
+    @Test
+    void transientFailureRefreshesNameResolutionWithoutDuplicatingSubchannels() {
+        LoadBalancer.Helper helper = mock(LoadBalancer.Helper.class);
+        List<LoadBalancer.SubchannelStateListener> listeners = new ArrayList<>();
+        LoadBalancer.Subchannel subchannel = subchannel(listeners);
+        when(helper.createSubchannel(any())).thenReturn(subchannel);
+
+        LoadBalancer loadBalancer = new GrpcLoadBalancerProvider(true).newLoadBalancer(helper);
+        EquivalentAddressGroup addressGroup = addressGroup(instance(1, 9001), 9001);
+        loadBalancer.handleResolvedAddresses(resolvedAddresses(addressGroup));
+        clearInvocations(helper);
+
+        listeners.get(0).onSubchannelState(ConnectivityStateInfo.forTransientFailure(Status.UNAVAILABLE));
+        loadBalancer.handleResolvedAddresses(resolvedAddresses(addressGroup(instance(1, 9001), 9001)));
+
+        verify(helper).refreshNameResolution();
+        verify(helper, never()).createSubchannel(any());
+    }
+
+    @Test
+    void transientFailureUsesErrorPickerWhenNoSubchannelIsReady() {
+        LoadBalancer.Helper helper = mock(LoadBalancer.Helper.class);
+        List<LoadBalancer.SubchannelStateListener> listeners = new ArrayList<>();
+        LoadBalancer.Subchannel subchannel = subchannel(listeners);
+        when(helper.createSubchannel(any())).thenReturn(subchannel);
+
+        LoadBalancer loadBalancer = new GrpcLoadBalancerProvider(true).newLoadBalancer(helper);
+        loadBalancer.handleResolvedAddresses(resolvedAddresses(addressGroup(instance(1, 9001), 9001)));
+        clearInvocations(helper);
+
+        listeners.get(0).onSubchannelState(ConnectivityStateInfo.forTransientFailure(Status.UNAVAILABLE));
+
+        ArgumentCaptor<LoadBalancer.SubchannelPicker> picker = ArgumentCaptor.forClass(LoadBalancer.SubchannelPicker.class);
+        verify(helper).updateBalancingState(eq(ConnectivityState.TRANSIENT_FAILURE), picker.capture());
+        assertThat(picker.getValue()).isInstanceOf(GrpcLoadBalancerProvider.ErrorPicker.class);
+    }
+
+    @Test
+    void transientFailureKeepsReadyStateWhenAnotherSubchannelIsReady() {
+        LoadBalancer.Helper helper = mock(LoadBalancer.Helper.class);
+        List<LoadBalancer.SubchannelStateListener> listeners = new ArrayList<>();
+        LoadBalancer.Subchannel first = subchannel(listeners);
+        LoadBalancer.Subchannel second = subchannel(listeners);
+        when(helper.createSubchannel(any())).thenReturn(first, second);
+
+        LoadBalancer loadBalancer = new GrpcLoadBalancerProvider(true).newLoadBalancer(helper);
+        loadBalancer.handleResolvedAddresses(resolvedAddresses(
+                addressGroup(instance(1, 9001), 9001),
+                addressGroup(instance(2, 9002), 9002)));
+        listeners.get(0).onSubchannelState(ConnectivityStateInfo.forNonError(ConnectivityState.READY));
+        clearInvocations(helper);
+
+        listeners.get(1).onSubchannelState(ConnectivityStateInfo.forTransientFailure(Status.UNAVAILABLE));
+
+        verify(helper).refreshNameResolution();
+        verify(helper).updateBalancingState(eq(ConnectivityState.READY), any());
+    }
+
+    @Test
+    void idleRefreshesNameResolutionAndRequestsConnectionWhenEnabled() {
+        LoadBalancer.Helper helper = mock(LoadBalancer.Helper.class);
+        List<LoadBalancer.SubchannelStateListener> listeners = new ArrayList<>();
+        LoadBalancer.Subchannel subchannel = subchannel(listeners);
+        when(helper.createSubchannel(any())).thenReturn(subchannel);
+
+        LoadBalancer loadBalancer = new GrpcLoadBalancerProvider(true).newLoadBalancer(helper);
+        loadBalancer.handleResolvedAddresses(resolvedAddresses(addressGroup(instance(1, 9001), 9001)));
+        clearInvocations(helper, subchannel);
+
+        listeners.get(0).onSubchannelState(ConnectivityStateInfo.forNonError(ConnectivityState.IDLE));
+
+        verify(helper).refreshNameResolution();
+        verify(subchannel).requestConnection();
+        verify(helper).updateBalancingState(eq(ConnectivityState.CONNECTING), any());
+    }
+
+    @Test
+    void idleDoesNotRequestConnectionWhenDisabled() {
+        LoadBalancer.Helper helper = mock(LoadBalancer.Helper.class);
+        List<LoadBalancer.SubchannelStateListener> listeners = new ArrayList<>();
+        LoadBalancer.Subchannel subchannel = subchannel(listeners);
+        when(helper.createSubchannel(any())).thenReturn(subchannel);
+
+        LoadBalancer loadBalancer = new GrpcLoadBalancerProvider(false).newLoadBalancer(helper);
+        loadBalancer.handleResolvedAddresses(resolvedAddresses(addressGroup(instance(1, 9001), 9001)));
+        clearInvocations(helper, subchannel);
+
+        listeners.get(0).onSubchannelState(ConnectivityStateInfo.forNonError(ConnectivityState.IDLE));
+
+        verify(helper).refreshNameResolution();
+        verify(subchannel, never()).requestConnection();
+    }
+
+    @Test
+    void shutdownStateFromActiveSubchannelIsIgnored() {
+        LoadBalancer.Helper helper = mock(LoadBalancer.Helper.class);
+        List<LoadBalancer.SubchannelStateListener> listeners = new ArrayList<>();
+        LoadBalancer.Subchannel subchannel = subchannel(listeners);
+        when(helper.createSubchannel(any())).thenReturn(subchannel);
+
+        LoadBalancer loadBalancer = new GrpcLoadBalancerProvider(true).newLoadBalancer(helper);
+        loadBalancer.handleResolvedAddresses(resolvedAddresses(addressGroup(instance(1, 9001), 9001)));
+        clearInvocations(helper);
+
+        listeners.get(0).onSubchannelState(ConnectivityStateInfo.forNonError(ConnectivityState.SHUTDOWN));
+
+        verify(helper, never()).updateBalancingState(any(), any());
+        verify(helper, never()).refreshNameResolution();
+    }
+
+    @Test
+    void ignoresStateChangesFromRemovedSubchannels() {
+        LoadBalancer.Helper helper = mock(LoadBalancer.Helper.class);
+        List<LoadBalancer.SubchannelStateListener> listeners = new ArrayList<>();
+        LoadBalancer.Subchannel first = subchannel(listeners);
+        LoadBalancer.Subchannel second = subchannel(listeners);
+        when(helper.createSubchannel(any())).thenReturn(first, second);
+
+        LoadBalancer loadBalancer = new GrpcLoadBalancerProvider(true).newLoadBalancer(helper);
+        loadBalancer.handleResolvedAddresses(resolvedAddresses(addressGroup(instance(1, 9001), 9001)));
+        LoadBalancer.SubchannelStateListener removedListener = listeners.get(0);
+        loadBalancer.handleResolvedAddresses(resolvedAddresses(addressGroup(instance(2, 9002), 9002)));
+        clearInvocations(helper);
+
+        removedListener.onSubchannelState(ConnectivityStateInfo.forNonError(ConnectivityState.READY));
+
+        verify(helper, never()).updateBalancingState(any(), any());
+        verify(helper, never()).refreshNameResolution();
+    }
+
+    @Test
+    void ignoresTransientFailureFromRemovedSubchannel() {
+        LoadBalancer.Helper helper = mock(LoadBalancer.Helper.class);
+        List<LoadBalancer.SubchannelStateListener> listeners = new ArrayList<>();
+        LoadBalancer.Subchannel first = subchannel(listeners);
+        LoadBalancer.Subchannel second = subchannel(listeners);
+        when(helper.createSubchannel(any())).thenReturn(first, second);
+
+        LoadBalancer loadBalancer = new GrpcLoadBalancerProvider(true).newLoadBalancer(helper);
+        loadBalancer.handleResolvedAddresses(resolvedAddresses(addressGroup(instance(1, 9001), 9001)));
+        LoadBalancer.SubchannelStateListener removedListener = listeners.get(0);
+        loadBalancer.handleResolvedAddresses(resolvedAddresses(addressGroup(instance(2, 9002), 9002)));
+        clearInvocations(helper);
+
+        removedListener.onSubchannelState(ConnectivityStateInfo.forTransientFailure(Status.UNAVAILABLE));
+
+        verify(helper, never()).updateBalancingState(any(), any());
+        verify(helper, never()).refreshNameResolution();
+    }
+
+    @Test
+    void emptyResolutionShutsDownExistingSubchannelsAndReportsUnavailable() {
+        LoadBalancer.Helper helper = mock(LoadBalancer.Helper.class);
+        List<LoadBalancer.SubchannelStateListener> listeners = new ArrayList<>();
+        LoadBalancer.Subchannel subchannel = subchannel(listeners);
+        when(helper.createSubchannel(any())).thenReturn(subchannel);
+
+        LoadBalancer loadBalancer = new GrpcLoadBalancerProvider(true).newLoadBalancer(helper);
+        loadBalancer.handleResolvedAddresses(resolvedAddresses(addressGroup(instance(1, 9001), 9001)));
+        clearInvocations(helper);
+
+        loadBalancer.handleResolvedAddresses(resolvedAddresses());
+
+        verify(subchannel).shutdown();
+        verify(helper).updateBalancingState(eq(ConnectivityState.TRANSIENT_FAILURE),
+                any(GrpcLoadBalancerProvider.ErrorPicker.class));
+    }
+
+    @Test
+    void addressGroupWithoutServiceInstanceIsIgnored() {
+        LoadBalancer.Helper helper = mock(LoadBalancer.Helper.class);
+        LoadBalancer loadBalancer = new GrpcLoadBalancerProvider(true).newLoadBalancer(helper);
+
+        loadBalancer.handleResolvedAddresses(resolvedAddresses(new EquivalentAddressGroup(
+                List.of(new InetSocketAddress("127.0.0.1", 9001)))));
+
+        verify(helper, never()).createSubchannel(any());
+        verify(helper).updateBalancingState(eq(ConnectivityState.TRANSIENT_FAILURE),
+                any(GrpcLoadBalancerProvider.ErrorPicker.class));
+    }
+
+    @Test
+    void nameResolutionErrorReportsFailureWhenNoSubchannelIsReady() {
+        LoadBalancer.Helper helper = mock(LoadBalancer.Helper.class);
+        LoadBalancer loadBalancer = new GrpcLoadBalancerProvider(true).newLoadBalancer(helper);
+
+        loadBalancer.handleNameResolutionError(Status.UNAVAILABLE);
+
+        verify(helper).updateBalancingState(eq(ConnectivityState.TRANSIENT_FAILURE),
+                any(GrpcLoadBalancerProvider.ErrorPicker.class));
+    }
+
+    @Test
+    void nameResolutionErrorDoesNotOverrideReadySubchannel() {
+        LoadBalancer.Helper helper = mock(LoadBalancer.Helper.class);
+        List<LoadBalancer.SubchannelStateListener> listeners = new ArrayList<>();
+        LoadBalancer.Subchannel subchannel = subchannel(listeners);
+        when(helper.createSubchannel(any())).thenReturn(subchannel);
+
+        LoadBalancer loadBalancer = new GrpcLoadBalancerProvider(true).newLoadBalancer(helper);
+        loadBalancer.handleResolvedAddresses(resolvedAddresses(addressGroup(instance(1, 9001), 9001)));
+        listeners.get(0).onSubchannelState(ConnectivityStateInfo.forNonError(ConnectivityState.READY));
+        clearInvocations(helper);
+
+        loadBalancer.handleNameResolutionError(Status.UNAVAILABLE);
+
+        verify(helper, never()).updateBalancingState(any(), any());
+    }
+
+    @Test
+    void sameEndpointUpdatesServiceInstanceMetadataWithoutLosingReadyState() {
+        LoadBalancer.Helper helper = mock(LoadBalancer.Helper.class);
+        List<LoadBalancer.SubchannelStateListener> listeners = new ArrayList<>();
+        LoadBalancer.Subchannel subchannel = subchannel(listeners);
+        when(helper.createSubchannel(any())).thenReturn(subchannel);
+
+        LoadBalancer loadBalancer = new GrpcLoadBalancerProvider(true).newLoadBalancer(helper);
+        loadBalancer.handleResolvedAddresses(resolvedAddresses(addressGroup(instance(1, 9001), 9001)));
+        listeners.get(0).onSubchannelState(ConnectivityStateInfo.forNonError(ConnectivityState.READY));
+        clearInvocations(helper);
+
+        loadBalancer.handleResolvedAddresses(resolvedAddresses(addressGroup(instance(2, 9001), 9001)));
+        loadBalancer.handleNameResolutionError(Status.UNAVAILABLE);
+
+        verify(helper, times(1)).updateBalancingState(eq(ConnectivityState.READY), any());
+        verify(helper, never()).updateBalancingState(eq(ConnectivityState.TRANSIENT_FAILURE), any());
+        verify(helper, never()).createSubchannel(any());
+    }
+
+    @Test
+    void pickerReturnsErrorStatus() {
+        LoadBalancer.PickResult result = new GrpcLoadBalancerProvider.ErrorPicker(Status.UNAVAILABLE)
+                .pickSubchannel(mock(LoadBalancer.PickSubchannelArgs.class));
+
+        assertThat(result.getStatus().getCode()).isEqualTo(Status.Code.UNAVAILABLE);
+    }
+
+    private static LoadBalancer.Subchannel subchannel(List<LoadBalancer.SubchannelStateListener> listeners) {
+        LoadBalancer.Subchannel subchannel = mock(LoadBalancer.Subchannel.class);
+        doAnswer(invocation -> {
+            listeners.add(invocation.getArgument(0));
+            return null;
+        }).when(subchannel).start(any());
+        return subchannel;
+    }
+
+    private static LoadBalancer.ResolvedAddresses resolvedAddresses(EquivalentAddressGroup... addressGroups) {
+        return LoadBalancer.ResolvedAddresses.newBuilder()
+                .setAddresses(List.of(addressGroups))
+                .setLoadBalancingPolicyConfig(new GrpcLoadBalancerProvider.StorkLoadBalancerConfig(SERVICE_NAME))
+                .build();
+    }
+
+    private static EquivalentAddressGroup addressGroup(ServiceInstance instance, int port) {
+        Attributes attributes = Attributes.newBuilder()
+                .set(GrpcStorkServiceDiscovery.SERVICE_INSTANCE, instance)
+                .build();
+        return new EquivalentAddressGroup(List.of(new InetSocketAddress("127.0.0.1", port)), attributes);
+    }
+
+    private static DefaultServiceInstance instance(long id, int port) {
+        return new DefaultServiceInstance(id, "127.0.0.1", port, false);
+    }
+}


### PR DESCRIPTION
The gRPC Stork load balancer previously lacked proper subchannel lifecycle management, leading to unnecessary channel churn when endpoints remained unchanged and potential connection leaks when endpoints were removed. 

This introduces an `EndpointKey` to reliably map subchannels to their resolved socket addresses, ensuring they are correctly reused, updated, or shut down as needed. It also properly synchronizes state updates to prevent race conditions with helper callbacks and ensures we accurately fallback to an `ErrorPicker` reporting `TRANSIENT_FAILURE` when no active Stork instances remain.
