### PR TITLE
Disable observability dev services at test time

### DIFF
--- a/docs/src/main/asciidoc/observability-devservices-lgtm.adoc
+++ b/docs/src/main/asciidoc/observability-devservices-lgtm.adoc
@@ -20,7 +20,10 @@ This data can then be visualized by https://github.com/grafana/grafana[Grafana].
 
 == Configuring your project
 
-Add the Quarkus Grafana OTel LGTM sink (where data goes) extension to your build file:
+If you are using `quarkus-opentelemetry` or `quarkus-micrometer-opentelemetry` this Observability extension is already bundled and the container will start automatically in dev mode.
+
+If the mentioned extensions are not present, you can manually add the Quarkus Grafana OTel LGTM sink (where data goes)
+extension to your build file:
 
 [source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
 .pom.xml
@@ -218,16 +221,29 @@ quarkus.observability.lgtm.otel-http-port=5318
 Internal container ports stay the same; e.g. 3000 for Grafana, 4317 for OTel gRPC, 4318 for OTel HTTP, etc
 ====
 
-=== Tests
+=== Disabling observability Dev Services
 
-And for the least 'auto-magical' usage in the tests, simply disable both (Dev Resources are already disabled by default):
+Observability Dev Services are enabled by default in dev mode. To disable them entirely (both in dev and test mode), preventing the Grafana LGTM container from starting automatically, set:
 
 [source,properties]
 ----
 quarkus.observability.enabled=false
 ----
 
-And then explicitly list LGTM Dev Resource in the test as a `@QuarkusTestResource` resource:
+This also disables the Dev UI card, the shared container discovery, compose support and the OpenTelemetry override properties.
+
+=== Enabling observability Dev Services in tests
+
+By default, observability Dev Services do not start in test mode. To enable the Grafana LGTM container during tests, set:
+
+[source,properties]
+----
+quarkus.observability.enabled-in-tests=true
+----
+
+This property has no effect in dev mode, where Dev Services are controlled solely by `quarkus.observability.enabled`.
+
+For the least 'auto-magical' usage in the tests, you can explicitly list LGTM Dev Resource in the test as a `@QuarkusTestResource` resource:
 [source, java]
 ----
 @QuarkusTest
@@ -236,6 +252,21 @@ And then explicitly list LGTM Dev Resource in the test as a `@QuarkusTestResourc
 public class LgtmLifecycleTest extends LgtmTestBase {
 }
 ----
+
+=== Dev Resources mode
+
+As an alternative to full Dev Services, you can enable a simplified Dev Resources mode. In this mode, containers are started lazily at runtime via a MicroProfile `ConfigSource` instead of during the build phase. This means there is no shared container discovery, no compose support, no Dev UI card and no OpenTelemetry override properties injected.
+
+[source,properties]
+----
+quarkus.observability.enabled=false
+quarkus.observability.dev-resources=true
+----
+
+[NOTE]
+====
+`quarkus.observability.enabled` must be set to `false` when using Dev Resources mode. The two modes are mutually exclusive.
+====
 
 == Testing full Grafana OTel LGTM stack - example
 

--- a/docs/src/main/asciidoc/opentelemetry-logging.adoc
+++ b/docs/src/main/asciidoc/opentelemetry-logging.adoc
@@ -157,6 +157,10 @@ We have 2 options:
 
 ==== Grafana OTel LGTM option
 
+A Dev Service will receive your app's telemetry.
+
+The Grafana-OTel-LGTM Dev Service will start automatically on Dev Mode and data will be automatically sent to it.
+
 * Take a look at: xref:observability-devservices-lgtm.adoc[Getting Started with Grafana-OTel-LGTM].
 
 This features a Quarkus Dev service including a Grafana for visualizing data, Loki to store logs, Tempo to store traces and Prometheus to store metrics. Also provides and OTel collector to receive the data.

--- a/docs/src/main/asciidoc/opentelemetry-metrics.adoc
+++ b/docs/src/main/asciidoc/opentelemetry-metrics.adoc
@@ -165,7 +165,12 @@ First we need to start a system to visualise the OpenTelemetry data.
 === See the data
 
 ==== Grafana-OTel-LGTM Dev Service
-You can use the xref:observability-devservices-lgtm.adoc[Grafana-OTel-LGTM] devservice.
+
+A Dev Service will receive your app's telemetry.
+
+The Grafana-OTel-LGTM Dev Service will start automatically on Dev Mode and data will be automatically sent to it.
+
+* Take a look at: xref:observability-devservices-lgtm.adoc[Getting Started with Grafana-OTel-LGTM].
 
 This Dev service includes a Grafana for visualizing data, Loki to store logs, Tempo to store traces and Prometheus to store metrics.
 Also provides and OTel collector to receive the data.

--- a/docs/src/main/asciidoc/opentelemetry-tracing.adoc
+++ b/docs/src/main/asciidoc/opentelemetry-tracing.adoc
@@ -121,7 +121,9 @@ We have several options:
 * Logging exporter
 
 === Grafana OTel LGTM option
-A Dev Service that will receive your app's telemetry. Only the dependency is needed.
+A Dev Service will receive your app's telemetry.
+
+The Grafana-OTel-LGTM Dev Service will start automatically on Dev Mode and data will be automatically sent to it.
 
 * Take a look at: xref:observability-devservices-lgtm.adoc[Getting Started with Grafana-OTel-LGTM].
 

--- a/docs/src/main/asciidoc/opentelemetry.adoc
+++ b/docs/src/main/asciidoc/opentelemetry.adoc
@@ -467,9 +467,11 @@ quarkus.otel.traces.exporter=logging <3>
 
 == Visualizing the data
 
-We recommend the xref:observability-devservices-lgtm.adoc[Getting Started with Grafana-OTel-LGTM].
+A Dev Service can receive your app's telemetry.
 
-This provides a Quarkus Dev service using an "all-in-one" https://github.com/grafana/docker-otel-lgtm[Grafana OTel LGTM].
+The Grafana-OTel-LGTM Dev Service will start automatically on Dev Mode and data will be automatically sent to it.
+
+* Take a look at: xref:observability-devservices-lgtm.adoc[Getting Started with Grafana-OTel-LGTM].
 
 Grafana is used to visualize data, Loki to store logs, Tempo to store traces and Prometheus to store metrics. Also provides and OTel collector to receive the data.
 

--- a/extensions/observability-devservices/deployment/src/main/java/io/quarkus/observability/deployment/DevResourcesProcessor.java
+++ b/extensions/observability-devservices/deployment/src/main/java/io/quarkus/observability/deployment/DevResourcesProcessor.java
@@ -6,16 +6,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.quarkus.deployment.IsDevResourcesSupportedByLaunchMode;
+import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigBuilderBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.observability.runtime.DevResourceShutdownRecorder;
 import io.quarkus.observability.runtime.DevResourcesConfigBuilder;
 import io.quarkus.observability.runtime.config.ObservabilityConfiguration;
+import io.quarkus.runtime.LaunchMode;
 
 @BuildSteps(onlyIf = { IsDevResourcesSupportedByLaunchMode.class, DevResourcesProcessor.IsEnabled.class })
 class DevResourcesProcessor {
@@ -28,9 +31,16 @@ class DevResourcesProcessor {
     }
 
     @BuildStep
-    public RunTimeConfigBuilderBuildItem registerDevResourcesConfigSource() {
+    public void registerDevResourcesConfigSource(LaunchModeBuildItem launchMode,
+            ObservabilityConfiguration configuration,
+            BuildProducer<RunTimeConfigBuilderBuildItem> configBuilder) {
+        if (launchMode.getLaunchMode() == LaunchMode.TEST && !configuration.enabledInTests()) {
+            log.info("Dev resources are disabled in test mode by default. "
+                    + "Set quarkus.observability.enabled-in-tests=true to enable.");
+            return;
+        }
         log.info("Adding dev resources config builder");
-        return new RunTimeConfigBuilderBuildItem(DevResourcesConfigBuilder.class);
+        configBuilder.produce(new RunTimeConfigBuilderBuildItem(DevResourcesConfigBuilder.class));
     }
 
     @BuildStep

--- a/extensions/observability-devservices/deployment/src/main/java/io/quarkus/observability/deployment/ObservabilityDevServiceProcessor.java
+++ b/extensions/observability-devservices/deployment/src/main/java/io/quarkus/observability/deployment/ObservabilityDevServiceProcessor.java
@@ -88,6 +88,12 @@ class ObservabilityDevServiceProcessor {
             return;
         }
 
+        if (launchMode.getLaunchMode() == LaunchMode.TEST && !configuration.enabledInTests()) {
+            log.debugf("Starting new observability dev services is disabled in test mode by default. "
+                    + "Set quarkus.observability.enabled-in-tests=true to enable.");
+            return;
+        }
+
         if (!dockerStatusBuildItem.isContainerRuntimeAvailable()) {
             log.warn("Please get a working Docker instance");
             return;

--- a/extensions/observability-devservices/runtime/src/main/java/io/quarkus/observability/runtime/config/ObservabilityConfiguration.java
+++ b/extensions/observability-devservices/runtime/src/main/java/io/quarkus/observability/runtime/config/ObservabilityConfiguration.java
@@ -10,19 +10,34 @@ import io.smallrye.config.WithDefault;
 @ConfigRoot(phase = ConfigPhase.BUILD_TIME)
 public interface ObservabilityConfiguration extends ModulesConfiguration {
     /**
-     * If DevServices has been explicitly enabled or disabled. DevServices is generally enabled
-     * by default, unless there is an existing configuration present.
+     * If DevServices has been explicitly enabled.
      * <p>
-     * When DevServices is enabled Quarkus will attempt to automatically configure and start
-     * a containers when running in Dev or Test mode and when Docker is running.
+     * DevServices is generally enabled by default, unless there is an existing configuration present set to false.
+     * <p>
+     * When DevServices is enabled Quarkus will attempt to automatically configure and start observability
+     * containers when running in Dev mode, when Docker is running and in test mode,
+     * if enabled-in-tests config is enabled.
      */
     @WithDefault("true")
     boolean enabled();
 
     /**
+     * Whether to start observability Dev Services in test mode.
+     * <p>
+     * When set to {@code false} (the default), the Grafana LGTM container will not be started
+     * automatically when running tests. Set to {@code true} to enable the container in test mode.
+     * <p>
+     * This property has no effect in dev mode, where Dev Services are controlled solely
+     * by {@code enabled}.
+     */
+    @WithDefault("false")
+    boolean enabledInTests();
+
+    /**
      * Enable simplified usage of dev resources,
      * instead of full observability processing.
-     * Make sure @code{enabled} is set to false.
+     * No shared container discovery, no compose support, no Dev UI card and no override properties injected.
+     * Make sure @code{enabled} is set to false unless you know exactly what you are doing.
      */
     @WithDefault("false")
     boolean devResources();

--- a/integration-tests/observability-lgtm-fixedports/src/test/resources/application.properties
+++ b/integration-tests/observability-lgtm-fixedports/src/test/resources/application.properties
@@ -4,4 +4,5 @@ quarkus.micrometer.binder-enabled-default=false
 quarkus.log.category."io.quarkus.observability".level=DEBUG
 quarkus.log.category."io.quarkus.devservices".level=DEBUG
 
+quarkus.observability.enabled-in-tests=true
 quarkus.observability.lgtm.timeout=PT3M

--- a/integration-tests/observability-lgtm-prometheus/src/test/resources/application.properties
+++ b/integration-tests/observability-lgtm-prometheus/src/test/resources/application.properties
@@ -4,5 +4,6 @@ quarkus.micrometer.binder-enabled-default=false
 quarkus.log.category."io.quarkus.observability".level=DEBUG
 quarkus.log.category."io.quarkus.devservices".level=DEBUG
 
+quarkus.observability.enabled-in-tests=true
 quarkus.observability.lgtm.timeout=PT3M
 quarkus.observability.lgtm.scraping-interval=2

--- a/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmDisabledInTestsTest.java
+++ b/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmDisabledInTestsTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.observability.test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.config.Config;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+/**
+ * Verifies that observability Dev Services do not start in test mode
+ * when {@code quarkus.observability.enabled-in-tests} is {@code false} (the default).
+ */
+@QuarkusTest
+@TestProfile(LgtmDisabledInTestsTest.DisabledInTestsProfile.class)
+@DisabledOnOs(OS.WINDOWS)
+public class LgtmDisabledInTestsTest {
+
+    @Inject
+    Config config;
+
+    @Test
+    public void testDevServicesNotStarted() {
+        Optional<String> grafanaEndpoint = config.getOptionalValue("grafana.endpoint", String.class);
+        Assertions.assertTrue(grafanaEndpoint.isEmpty(),
+                "grafana.endpoint should not be set when enabled-in-tests is false, but was: " + grafanaEndpoint.orElse(""));
+
+        Optional<String> otelCollectorUrl = config.getOptionalValue("otel-collector.url", String.class);
+        Assertions.assertTrue(otelCollectorUrl.isEmpty(),
+                "otel-collector.url should not be set when enabled-in-tests is false, but was: "
+                        + otelCollectorUrl.orElse(""));
+    }
+
+    public static class DisabledInTestsProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("quarkus.observability.enabled-in-tests", "false");
+        }
+    }
+}

--- a/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmResourcesTest.java
+++ b/integration-tests/observability-lgtm/src/test/java/io/quarkus/observability/test/LgtmResourcesTest.java
@@ -24,7 +24,8 @@ public class LgtmResourcesTest extends LgtmConfigTestBase {
                     "quarkus.otel.exporter.otlp.protocol", "http/protobuf",
                     "quarkus.otel.exporter.otlp.endpoint", "http://${otel-collector.url}",
                     "quarkus.observability.dev-resources", "true",
-                    "quarkus.observability.enabled", "false");
+                    "quarkus.observability.enabled", "false",
+                    "quarkus.observability.enabled-in-tests", "true");
         }
     }
 }

--- a/integration-tests/observability-lgtm/src/test/resources/application.properties
+++ b/integration-tests/observability-lgtm/src/test/resources/application.properties
@@ -4,4 +4,5 @@ quarkus.micrometer.binder-enabled-default=false
 quarkus.log.category."io.quarkus.observability".level=DEBUG
 quarkus.log.category."io.quarkus.devservices".level=DEBUG
 
+quarkus.observability.enabled-in-tests=true
 quarkus.observability.lgtm.timeout=PT3M


### PR DESCRIPTION
Disable automatic start of the Grafana lgtm at test time. 
This has started after https://github.com/quarkusio/quarkus/pull/54276

#### Impact

Low because it only affects tests and I'm not aware of users using this functionality. 

#### Why?

Only extension specific tests are using this functionality but because the dev service starts automatically with `quarkus-opentelemetry`, this feature extends build time and uses more resources without need. 

### Other changes

Updated the docs to make them consistent with the automatic start of the Grafana LGTM dev service when `quarkus-opentelemetry` is present.