### PR TITLE
Preserve read body request filter order

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customproviders/ReadBodyRequestFilterOrderTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customproviders/ReadBodyRequestFilterOrderTest.java
@@ -1,0 +1,68 @@
+package io.quarkus.resteasy.reactive.server.test.customproviders;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.HttpHeaders;
+
+import org.hamcrest.Matchers;
+import org.jboss.resteasy.reactive.RestForm;
+import org.jboss.resteasy.reactive.server.ServerRequestFilter;
+import org.jboss.resteasy.reactive.server.WithFormRead;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+
+public class ReadBodyRequestFilterOrderTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(HelloResource.class, Filters.class);
+                }
+            });
+
+    @Test
+    public void readBodyRequestFiltersKeepPriorityOrder() {
+        RestAssured.with()
+                .formParam("name", "Quarkus")
+                .post("/hello")
+                .then().body(Matchers.equalTo("first,second:Quarkus"));
+    }
+
+    @Path("hello")
+    public static class HelloResource {
+
+        @POST
+        public String hello(@RestForm String name, HttpHeaders headers) {
+            List<String> order = headers.getRequestHeader("filter-order");
+            return String.join(",", order) + ":" + name;
+        }
+    }
+
+    public static class Filters {
+
+        @WithFormRead
+        @ServerRequestFilter(priority = Priorities.USER + 1)
+        public void first(ContainerRequestContext requestContext) {
+            requestContext.getHeaders().add("filter-order", "first");
+        }
+
+        @WithFormRead
+        @ServerRequestFilter(priority = Priorities.USER + 2)
+        public void second(ContainerRequestContext requestContext) {
+            requestContext.getHeaders().add("filter-order", "second");
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
@@ -301,7 +301,7 @@ public class RuntimeResourceDeployment {
                 if (serverRestHandler instanceof ResourceRequestFilterHandler) {
                     ResourceRequestFilterHandler resourceRequestFilterHandler = (ResourceRequestFilterHandler) serverRestHandler;
                     if (resourceRequestFilterHandler.isWithFormRead()) {
-                        readBodyRequestFilters.add(handlers.remove(i));
+                        readBodyRequestFilters.add(0, handlers.remove(i));
                     }
                 }
             }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
@@ -296,14 +296,16 @@ public class RuntimeResourceDeployment {
         if (checkWithFormReadRequestFilters && hasWithFormReadRequestFilters) {
             // we need to remove the corresponding filters from the handlers list and add them to its end in the same order
             List<ServerRestHandler> readBodyRequestFilters = new ArrayList<>(1);
-            for (int i = handlers.size() - 2; i >= 0; i--) {
+            for (int i = 0; i < handlers.size() - 1;) {
                 var serverRestHandler = handlers.get(i);
                 if (serverRestHandler instanceof ResourceRequestFilterHandler) {
                     ResourceRequestFilterHandler resourceRequestFilterHandler = (ResourceRequestFilterHandler) serverRestHandler;
                     if (resourceRequestFilterHandler.isWithFormRead()) {
-                        readBodyRequestFilters.add(0, handlers.remove(i));
+                        readBodyRequestFilters.add(handlers.remove(i));
+                        continue;
                     }
                 }
+                i++;
             }
             handlers.addAll(readBodyRequestFilters);
         }


### PR DESCRIPTION
`@ServerRequestFilter` handlers that require the request body are temporarily removed from the handler chain and appended after the body handler. The scan walks the existing chain backwards, so appending each removed filter to the temporary list also reversed their priority order.

This preserves the original priority order when collecting those filters and adds a regression test that exercises two `@WithFormRead` filters on a form request.


- Fixes: #54947
