### PR TITLE
Add TTL caching to DataSourceHealthCheck

### DIFF
--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -638,6 +638,25 @@ To exclude only a particular datasource from the health check:
 quarkus.datasource."datasource-name".health-exclude=true
 ----
 
+==== Health check result caching
+
+By default, health check results are cached for 10 seconds to avoid performing a JDBC validation query on every probe request.
+This is especially important in Kubernetes deployments where liveness and readiness probes can trigger frequent health checks.
+
+You can configure the cache duration per datasource:
+
+[source,properties]
+----
+# Set the TTL for the default datasource
+quarkus.datasource.health.ttl=30s
+
+# Set the TTL for a named datasource
+quarkus.datasource."datasource-name".health.ttl=5s
+
+# Disable caching (validate on every probe)
+quarkus.datasource.health.ttl=0
+----
+
 === Datasource metrics
 
 When you add the xref:telemetry-micrometer.adoc[`quarkus-micrometer`] extension, `quarkus-agroal` can publish datasource metrics to the metrics registry.

--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/DataSourceHealthCheckNoTtlTest.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/DataSourceHealthCheckNoTtlTest.java
@@ -1,0 +1,43 @@
+package io.quarkus.agroal.test;
+
+import jakarta.inject.Inject;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.agroal.api.AgroalDataSource;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+
+/**
+ * Verifies that health check results are NOT cached when {@code quarkus.datasource.health.ttl} is {@code 0}.
+ * <p>
+ * After closing the datasource, a subsequent health check must report DOWN because no cached result is available.
+ */
+public class DataSourceHealthCheckNoTtlTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withEmptyApplication()
+            .overrideConfigKey("quarkus.datasource.db-kind", "h2")
+            .overrideConfigKey("quarkus.datasource.jdbc.url", "jdbc:h2:mem:health-no-ttl-test")
+            .overrideConfigKey("quarkus.datasource.health.enabled", "true")
+            .overrideRuntimeConfigKey("quarkus.datasource.health.ttl", "0");
+
+    @Inject
+    AgroalDataSource dataSource;
+
+    @Test
+    public void testNoCachingWithZeroTtl() {
+        RestAssured.when().get("/q/health/ready")
+                .then()
+                .body("status", CoreMatchers.equalTo("UP"));
+
+        dataSource.close();
+
+        RestAssured.when().get("/q/health/ready")
+                .then()
+                .body("status", CoreMatchers.equalTo("DOWN"));
+    }
+}

--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/DataSourceHealthCheckTtlTest.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/DataSourceHealthCheckTtlTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.agroal.test;
+
+import jakarta.inject.Inject;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.agroal.api.AgroalDataSource;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+
+/**
+ * Verifies that health check results are cached when {@code quarkus.datasource.health.ttl} is set.
+ * <p>
+ * The test performs a health check (UP), then closes the datasource so that subsequent real checks
+ * would fail. A second call within the TTL window must still return UP from the cache.
+ */
+public class DataSourceHealthCheckTtlTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withEmptyApplication()
+            .overrideConfigKey("quarkus.datasource.db-kind", "h2")
+            .overrideConfigKey("quarkus.datasource.jdbc.url", "jdbc:h2:mem:health-ttl-test")
+            .overrideConfigKey("quarkus.datasource.health.enabled", "true")
+            .overrideRuntimeConfigKey("quarkus.datasource.health.ttl", "10m");
+
+    @Inject
+    AgroalDataSource dataSource;
+
+    @Test
+    public void testCachedResultReturnedWithinTtl() {
+        RestAssured.when().get("/q/health/ready")
+                .then()
+                .body("status", CoreMatchers.equalTo("UP"))
+                .body("checks[0].data.\"<default>\"", CoreMatchers.equalTo("UP"));
+
+        dataSource.close();
+
+        RestAssured.when().get("/q/health/ready")
+                .then()
+                .body("status", CoreMatchers.equalTo("UP"))
+                .body("checks[0].data.\"<default>\"", CoreMatchers.equalTo("UP"));
+    }
+}

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/health/DataSourceHealthCheck.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/health/DataSourceHealthCheck.java
@@ -24,6 +24,7 @@ import io.quarkus.agroal.runtime.AgroalDataSourceSupport;
 import io.quarkus.agroal.runtime.AgroalDataSourceUtil;
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.quarkus.datasource.runtime.DataSourceSupport;
+import io.quarkus.datasource.runtime.DataSourcesRuntimeConfig;
 
 @Readiness
 @ApplicationScoped
@@ -35,7 +36,10 @@ public class DataSourceHealthCheck implements HealthCheck {
     @Inject
     Instance<AgroalDataSourceSupport> agroalDataSourceSupport;
 
-    private final Map<String, DataSource> checkedDataSources = new HashMap<>();
+    @Inject
+    DataSourcesRuntimeConfig dataSourcesRuntimeConfig;
+
+    private final Map<String, CheckedDataSource> checkedDataSources = new HashMap<>();
 
     @PostConstruct
     protected void init() {
@@ -51,7 +55,8 @@ public class DataSourceHealthCheck implements HealthCheck {
             }
             Optional<AgroalDataSource> dataSource = AgroalDataSourceUtil.dataSourceIfActive(name);
             if (dataSource.isPresent()) {
-                checkedDataSources.put(name, dataSource.get());
+                long ttlNanos = dataSourcesRuntimeConfig.dataSources().get(name).health().ttl().toNanos();
+                checkedDataSources.put(name, new CheckedDataSource(dataSource.get(), ttlNanos));
             }
         }
     }
@@ -59,30 +64,74 @@ public class DataSourceHealthCheck implements HealthCheck {
     @Override
     public HealthCheckResponse call() {
         HealthCheckResponseBuilder builder = HealthCheckResponse.named("Database connections health check").up();
-        for (Map.Entry<String, DataSource> dataSource : checkedDataSources.entrySet()) {
-            boolean isDefault = DataSourceUtil.isDefault(dataSource.getKey());
-            AgroalDataSource ads = (AgroalDataSource) dataSource.getValue();
-            String dsName = dataSource.getKey();
+        for (Map.Entry<String, CheckedDataSource> entry : checkedDataSources.entrySet()) {
+            String dsName = entry.getKey();
+            CheckedDataSource cds = entry.getValue();
+            boolean isDefault = DataSourceUtil.isDefault(dsName);
+
+            CachedResult cached = cds.cachedResult;
+            if (cached != null && cds.ttlNanos > 0 && (System.nanoTime() - cached.checkedAt()) < cds.ttlNanos) {
+                if (cached.healthy()) {
+                    builder.withData(dsName, "UP");
+                } else {
+                    builder.down().withData(dsName, cached.detail());
+                }
+                continue;
+            }
 
             try {
-                boolean valid = ads.isHealthy(false);
+                boolean valid = cds.dataSource.isHealthy(false);
                 if (!valid) {
                     String data = isDefault ? "validation check failed for the default DataSource"
-                            : "validation check failed for DataSource '" + dataSource.getKey() + "'";
+                            : "validation check failed for DataSource '" + dsName + "'";
                     builder.down().withData(dsName, data);
+                    if (cds.ttlNanos > 0) {
+                        cds.cachedResult = new CachedResult(false, data, System.nanoTime());
+                    }
                 } else {
                     builder.withData(dsName, "UP");
+                    if (cds.ttlNanos > 0) {
+                        cds.cachedResult = new CachedResult(true, null, System.nanoTime());
+                    }
                 }
             } catch (SQLException e) {
                 String data = isDefault ? "Unable to execute the validation check for the default DataSource: "
-                        : "Unable to execute the validation check for DataSource '" + dataSource.getKey() + "': ";
+                        : "Unable to execute the validation check for DataSource '" + dsName + "': ";
                 builder.down().withData(dsName, data + e.getMessage());
+                if (cds.ttlNanos > 0) {
+                    cds.cachedResult = new CachedResult(false, data + e.getMessage(), System.nanoTime());
+                }
             }
         }
         return builder.build();
     }
 
     protected Map<String, DataSource> getCheckedDataSources() {
-        return Collections.unmodifiableMap(checkedDataSources);
+        Map<String, DataSource> result = new HashMap<>();
+        for (Map.Entry<String, CheckedDataSource> entry : checkedDataSources.entrySet()) {
+            result.put(entry.getKey(), entry.getValue().dataSource);
+        }
+        return Collections.unmodifiableMap(result);
+    }
+
+    /**
+     * Immutable snapshot of a single datasource health check result.
+     * Swapped atomically via a volatile reference in {@link CheckedDataSource}.
+     */
+    record CachedResult(boolean healthy, String detail, long checkedAt) {
+    }
+
+    /**
+     * Groups a datasource with its per-datasource health check TTL and the most recent cached result.
+     */
+    static final class CheckedDataSource {
+        final AgroalDataSource dataSource;
+        final long ttlNanos;
+        volatile CachedResult cachedResult;
+
+        CheckedDataSource(AgroalDataSource dataSource, long ttlNanos) {
+            this.dataSource = dataSource;
+            this.ttlNanos = ttlNanos;
+        }
     }
 }

--- a/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DataSourceHealthRuntimeConfig.java
+++ b/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DataSourceHealthRuntimeConfig.java
@@ -1,0 +1,20 @@
+package io.quarkus.datasource.runtime;
+
+import java.time.Duration;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
+
+@ConfigGroup
+public interface DataSourceHealthRuntimeConfig {
+
+    /**
+     * Minimum interval between health check executions.
+     * <p>
+     * Health check results are cached for this duration to avoid performing a JDBC validation
+     * query on every probe request. Set to {@code 0} to disable caching and execute the
+     * validation query on every health check call.
+     */
+    @WithDefault("10s")
+    Duration ttl();
+}

--- a/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DataSourceRuntimeConfig.java
+++ b/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DataSourceRuntimeConfig.java
@@ -45,4 +45,9 @@ public interface DataSourceRuntimeConfig {
      * For Vault, the credentials provider bean name is {@code vault-credentials-provider}.
      */
     Optional<@WithConverter(TrimmedStringConverter.class) String> credentialsProviderName();
+
+    /**
+     * Health check configuration.
+     */
+    DataSourceHealthRuntimeConfig health();
 }


### PR DESCRIPTION
## Summary

- Add per-datasource `quarkus.datasource.health.ttl` config property (default `10s`) that caches health check results to avoid redundant JDBC `Connection.isValid()` round-trips on every probe request
- Agroal 3.x changed `ConnectionPool.isHealthy(false)` from a no-op to a real JDBC validation with pool lock contention, causing significant CPU regression in Kubernetes deployments with frequent liveness/readiness probes
- Document the new property in `datasource.adoc`


---

- Closes: #54955
