### PR TITLE
Update Hibernate and Hibernate Reactive guides for sessions, transactions, and StatelessSession

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -1090,8 +1090,9 @@ public class PersonEndpoint {
     @GET
     @Transactional
     public Person findByIdForUpdate(Long id){
-        Person p = Person.findById(id, LockModeType.PESSIMISTIC_WRITE);
-        //do something useful, the lock will be released when the transaction ends.
+        Person person = Person.findById(id, LockModeType.PESSIMISTIC_WRITE);
+        person.status = Status.Dead;
+        // the lock will be released when the transaction ends
         return person;
     }
 
@@ -1111,8 +1112,9 @@ public class PersonEndpoint {
     @GET
     @Transactional
     public Person findByNameForUpdate(String name){
-        Person p = Person.find("name", name).withLock(LockModeType.PESSIMISTIC_WRITE).findOne();
-        //do something useful, the lock will be released when the transaction ends.
+        Person person = Person.find("name", name).withLock(LockModeType.PESSIMISTIC_WRITE).firstResult();
+        person.status = Status.Dead;
+        // the lock will be released when the transaction ends
         return person;
     }
 

--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -526,6 +526,57 @@ These components can also be injected with a specific persistence unit qualifier
 CriteriaBuilder criteriaBuilder;
 ----
 
+[[stateless-session]]
+==== Using `StatelessSession`
+
+In addition to the regular `Session` (or `EntityManager`), Quarkus supports injecting Hibernate's link:{hibernate-orm-docs-url}#stateless-sessions[`StatelessSession`].
+
+A stateless session does not maintain a first-level cache and does not perform automatic dirty checking.
+Entity changes are not persisted implicitly at transaction commit: you must call `insert()`, `update()`, or `delete()` explicitly.
+This makes stateless sessions a good fit for bulk operations or workflows where you want full control over writes.
+
+You can inject a `StatelessSession` the same way as a regular `Session`:
+
+[source,java]
+----
+@Inject
+StatelessSession statelessSession;
+
+@Inject
+@PersistenceUnit("users")
+StatelessSession usersStatelessSession;
+----
+
+Wrap methods that modify the database in `@Transactional`, as you would with a regular `Session`:
+
+[source,java]
+----
+@ApplicationScoped
+public class GiftService {
+
+    @Inject
+    StatelessSession statelessSession;
+
+    @Transactional
+    public void createGift(String giftDescription) {
+        Gift gift = new Gift();
+        gift.setName(giftDescription);
+        statelessSession.insert(gift);
+    }
+
+    @Transactional
+    public List<Gift> findAll() {
+        return statelessSession
+                .createSelectionQuery("from Gift", Gift.class)
+                .getResultList();
+    }
+}
+----
+
+It is also possible to mix a regular `Session` and a `StatelessSession` within the same transaction when needed.
+
+For more details on stateless sessions with Panache, see xref:quarkus-data-hibernate.adoc#use-stateless-sessions[Quarkus Data Hibernate].
+
 [[plugging-in-converters-entity-listeners]]
 ==== Plugging in converters and entity listeners
 
@@ -694,6 +745,34 @@ Instead, inject `InjectableInstance<Session>`.
 It selects either PostgreSQL or Oracle, depending on which persistence unit is active.
 <3> Check if a bean is active before retrieving it.
 <4> Injects the only active persistence unit.
+
+[[testing]]
+=== Testing
+
+Using Hibernate ORM in a `@QuarkusTest` is straightforward: xref:databases-dev-services.adoc[Dev Services] provides a test database automatically when no datasource is configured.
+
+To run a test in a transaction and roll back any database changes when the test completes, annotate the test method with `io.quarkus.test.TestTransaction`.
+You can inject `org.hibernate.Session` or `jakarta.persistence.EntityManager` to interact with the database directly in your tests.
+
+[source,java]
+----
+@QuarkusTest
+public class SomeTest {
+
+    @Inject
+    Session session;
+
+    @Test
+    @TestTransaction
+    void testEntity() {
+        MyEntity entity = new MyEntity();
+        session.persist(entity);
+        assertEquals(1L, session.createQuery("from MyEntity", MyEntity.class).getResultCount());
+    }
+}
+----
+
+See also xref:getting-started-testing.adoc#tests-and-transactions[Tests and Transactions] in the getting started testing guide.
 
 [[persistence-xml]]
 == Setting up and configuring Hibernate ORM with a `persistence.xml`

--- a/docs/src/main/asciidoc/hibernate-reactive-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-reactive-panache.adoc
@@ -777,68 +777,99 @@ When using multiple persistence units, Panache automatically uses the correct pe
 For configuration details on setting up multiple persistence units, refer to the xref:hibernate-orm.adoc#multiple-persistence-units[Multiple Persistence Units] section in the Hibernate ORM guide.
 
 [[transactions]]
-== Sessions and Transactions
+== Transactions
 
-First of all, most of the methods of a Panache entity must be invoked within the scope of a reactive `Mutiny.Session`.
-In some cases, the session is opened automatically on demand.
-For example, if a Panache entity method is invoked in a Jakarta REST resource method in an application that includes the `quarkus-rest` extension.
-For other cases, there are two declarative ways and a programmatic way to ensure a session is available:
+Make sure to wrap methods modifying your database (e.g. `entity.persist()`) within a transaction.
+Marking a CDI bean method `@Transactional` will do that for you and make that method a transaction boundary.
+We recommend doing so at your application entry point boundaries like your REST endpoint controllers.
 
-* The first method is to use a method annotated with `@Transactional`.
-* Alternatively, you can annotate a CDI business method that returns `Uni` with the `@WithSession` annotation.
-If you have multiple persistence units, you can specify which one to use by providing the persistence unit name as the annotation value: `@WithSession("my-persistence-unit")`. If not specified, the default persistence unit is used.
-* The programmatic way to achieve the same effect is to use the `Panache.withSession()` method.
+Here is a typical Jakarta REST resource using Panache with `@Transactional`:
 
-NOTE: Note that a Panache entity may not be used from a blocking thread. See also xref:getting-started-reactive.adoc[Getting Started With Reactive] guide that explains the basics of reactive principles in Quarkus.
+[source,java]
+----
+@Path("/persons")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class PersonResource {
 
-Also make sure to wrap methods that modify the database or involve multiple queries (e.g. `entity.persist()`) within a transaction.
+    @GET
+    public Uni<List<Person>> list() {
+        return Person.listAll();
+    }
 
-You can annotate the method with `@jakarta.transaction.Transactional` as you would in Hibernate ORM to specify declarative transaction management.
+    @GET
+    @Path("/{id}")
+    public Uni<Person> get(Long id) {
+        return Person.findById(id);
+    }
 
-You can also annotate a CDI business method that returns `Uni` with the `@WithTransaction` annotation.
-The method will be intercepted and the returned `Uni` is triggered within a transaction boundary.
-If you have multiple persistence units, you can specify which one to use by providing the persistence unit name as the annotation value: `@WithTransaction("my-persistence-unit")`. If not specified, the default persistence unit is used.
-Alternatively, you can use the `Panache.withTransaction()` method for the same effect.
+    @POST
+    @Transactional
+    public Uni<Response> create(Person person) {
+        return person.persist()
+                .replaceWith(() -> Response.created(URI.create("/persons/" + person.id)).build());
+    }
 
-[NOTE]
-====
-You should not mix `@Transactional` with Panache transaction annotations (`@WithTransaction`, `@WithSession`, `@WithSessionOnDemand`) in the same application. Choose one approach and use it consistently throughout your application. Mixing these annotations in a single reactive pipeline will result in an `UnsupportedOperationException`.
+    @PUT
+    @Path("/{id}")
+    @Transactional
+    public Uni<Person> update(Long id, Person person) {
+        return Person.<Person>findById(id)
+                .onItem().ifNull().failWith(NotFoundException::new)
+                .invoke(entity -> entity.name = person.name);
+    }
 
-See the xref:hibernate-reactive.adoc[Hibernate Reactive guide] for more details on using `@Transactional` with Hibernate Reactive.
-====
-[WARNING]
-====
-There are some limitations when using different pipelines with `@Transactional`, refer to xref:hibernate-reactive.adoc#transactional-different-pipelines[the limitations section in the Hibernate Reactive guide]
-====
+    @DELETE
+    @Path("/{id}")
+    @Transactional
+    public Uni<Void> delete(Long id) {
+        return Person.<Person>findById(id)
+                .onItem().ifNull().failWith(NotFoundException::new)
+                .chain(Person::delete);
+    }
+}
+----
+
+When a method is annotated with `@Transactional` and returns a `Uni`, the interceptor automatically opens a Hibernate Reactive session, begins a transaction, commits when the `Uni` completes successfully, and rolls back on failure.
+See xref:hibernate-reactive.adoc#hr-getting-started[Using Hibernate Reactive] for more details.
+
+In Jakarta REST endpoints with the `quarkus-rest` extension, a session may also be opened automatically for read-only Panache calls.
+For writes and for other entry points (schedulers, message consumers, etc.), use `@Transactional` to ensure both a session and a transaction are available.
 
 Hibernate Reactive batches changes you make to your entities and sends changes (it is called flush) at the end of the transaction or before a query.
 This is usually a good thing as it is more efficient.
-But if you want to check optimistic locking failures, do object validation right away or generally want to get immediate feedback, you can force the flush operation by calling `entity.flush()` or even use `entity.persistAndFlush()` to make it a single method call. This will allow you to catch any `PersistenceException` that could occur when Hibernate Reactive send those changes to the database.
+But if you want to check optimistic locking failures, do object validation right away or generally want to get immediate feedback, you can force the flush operation by calling `entity.flush()` or even use `entity.persistAndFlush()` to make it a single method call.
+This will allow you to catch any `PersistenceException` that could occur when Hibernate Reactive sends those changes to the database.
 Remember, this is less efficient so don't abuse it.
 And your transaction still has to be committed.
 
 Here is an example of the usage of the flush method to allow making a specific action in case of `PersistenceException`:
+
 [source,java]
 ----
-@WithTransaction
-public Uni<Void> create(Person person){
-    // Here we use the persistAndFlush() shorthand method on a Panache repository to persist to database then flush the changes.
+@Transactional
+public Uni<Void> create(Person person) {
     return person.persistAndFlush()
             .onFailure(PersistenceException.class)
-            .recoverWithItem(() -> {
-                LOG.error("Unable to create the parameter", pe);
-                //in case of error, I save it to disk
+            .recoverWithItem(t -> {
+                LOG.error("Unable to create the person", t);
+                // in case of error, save it to disk
                 diskPersister.save(person);
                 return null;
             });
 }
 ----
 
-The `@WithTransaction` annotation will also work for testing.
-This means that changes done during the test will be propagated to the database.
-If you want any changes made to be rolled back at the end of
-the test you can use the `io.quarkus.test.TestReactiveTransaction` annotation.
-This will run the test method in a transaction, but roll it back once the test method is complete to revert any database changes.
+=== Other session APIs
+
+If you only need a session without a transaction (for example, read-only operations outside Jakarta REST), you can use `@WithSession` or the programmatic `Panache.withSession()` method.
+Use `@Transactional` for operations that modify the database.
+
+[NOTE]
+====
+Do not mix `@Transactional` with Panache session/transaction annotations (`@WithTransaction`, `@WithSession`, `@WithSessionOnDemand`) in the same application.
+Some advanced reactive patterns such as `Uni.combine()` and `Uni.join()` do not work well with declarative transaction management — see xref:hibernate-reactive.adoc#transactional-different-pipelines[Using Declarative Transaction Management in different reactive pipelines] in the Hibernate Reactive guide.
+====
 
 == Lock management
 
@@ -850,16 +881,16 @@ The following examples are for the active record pattern, but the same can be us
 
 [source,java]
 ----
-public class PersonEndpoint {
+public class ProductEndpoint {
 
     @GET
-    public Uni<Person> findByIdForUpdate(Long id){
-        return Panache.withTransaction(() -> {
-            return Person.<Person>findById(id, LockModeType.PESSIMISTIC_WRITE)
-                    .invoke(person -> {
-                        //do something useful, the lock will be released when the transaction ends.
-                    });
-        });
+    @Transactional
+    public Uni<Product> findByIdForUpdate(Long id) {
+        return Product.<Product>findById(id, LockModeType.PESSIMISTIC_WRITE)
+                .invoke(product -> {
+                    product.stock--;
+                    // the lock will be released when the transaction ends
+                });
     }
 }
 ----
@@ -868,22 +899,22 @@ public class PersonEndpoint {
 
 [source,java]
 ----
-public class PersonEndpoint {
+public class ProductEndpoint {
 
     @GET
-    public Uni<Person> findByNameForUpdate(String name){
-        return Panache.withTransaction(() -> {
-            return Person.<Person>find("name", name).withLock(LockModeType.PESSIMISTIC_WRITE).firstResult()
-                    .invoke(person -> {
-                        //do something useful, the lock will be released when the transaction ends.
-                    });
-        });
+    @Transactional
+    public Uni<Product> findBySkuForUpdate(String sku) {
+        return Product.<Product>find("sku", sku).withLock(LockModeType.PESSIMISTIC_WRITE).firstResult()
+                .invoke(product -> {
+                    product.stock--;
+                    // the lock will be released when the transaction ends
+                });
     }
 
 }
 ----
 
-Be careful that locks are released when the transaction ends, so the method that invokes the lock query must be called within a transaction.
+Be careful that locks are released when the transaction ends, so the method that invokes the lock query must be annotated with `@Transactional`.
 
 == Custom IDs
 
@@ -922,12 +953,15 @@ public class PersonRepository implements PanacheRepositoryBase<Person,Integer> {
 }
 ----
 
+[[testing]]
 == Testing
 
 Testing reactive Panache entities in a `@QuarkusTest` is slightly more complicated than testing regular Panache entities due to the asynchronous nature of the APIs and the fact that all operations need to run on a Vert.x event loop.
 
 The `quarkus-test-vertx` dependency provides the `@io.quarkus.test.vertx.RunOnVertxContext` annotation and the `io.quarkus.test.vertx.UniAsserter` class which are intended precisely for this purpose.
 The usage is described in the xref:hibernate-reactive.adoc#testing[Hibernate Reactive] guide.
+
+To run a test in a transaction and roll back any database changes when the test completes, annotate the test class or method with `io.quarkus.test.TestReactiveTransaction`.
 
 Moreover, the `quarkus-test-hibernate-reactive-panache` dependency provides the `io.quarkus.test.hibernate.reactive.panache.TransactionalUniAsserter` that can be injected as a method parameter of a test method annotated with `@RunOnVertxContext`.
 The `TransactionalUniAsserter` is a `io.quarkus.test.vertx.UniAsserterInterceptor` that wraps each assert method within a separate reactive transaction.

--- a/docs/src/main/asciidoc/hibernate-reactive.adoc
+++ b/docs/src/main/asciidoc/hibernate-reactive.adoc
@@ -5,6 +5,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using Hibernate Reactive
 include::_attributes.adoc[]
+:categories: data
 :config-file: application.properties
 :reactive-doc-url-prefix: https://hibernate.org/reactive/documentation/1.1/reference/html_single/#getting-started
 :extension-status: preview
@@ -125,7 +126,7 @@ The dialect will be selected based on the Reactive SQL client - unless you set o
 NOTE: For more information on dialect selection and database versions,
 see xref:hibernate-orm.adoc#hibernate-dialect[the corresponding section of the Hibernate ORM guide].
 
-You can then happily inject your `Mutiny.SessionFactory`:
+You can then happily inject your `Mutiny.Session`:
 
 [source,java]
 .Example application bean using Hibernate Reactive
@@ -133,23 +134,22 @@ You can then happily inject your `Mutiny.SessionFactory`:
 @ApplicationScoped
 public class SantaClausService {
     @Inject
-    Mutiny.SessionFactory sf; <1>
+    Mutiny.Session session; <1>
 
+    @Transactional <2>
     public Uni<Void> createGift(String giftDescription) {
-	Gift gift = new Gift();
+        Gift gift = new Gift();
         gift.setName(giftDescription);
-	return sf.withTransaction(session -> session.persist(gift)) <2>
+        return session.persist(gift);
     }
 }
 ----
 
-<1> Inject your session factory and have fun
-<2> `.withTransaction()` will automatically flush at commit
-
-WARNING: Make sure to wrap methods modifying your database (e.g. `session.persist(entity)`) within a transaction.
+<1> Inject your session and have fun
+<2> Mark your CDI bean method as `@Transactional` and the session will enlist and flush at commit.
 
 [source,java]
-.Example of an Entity
+.Example Entity
 ----
 @Entity
 public class Gift {
@@ -157,8 +157,7 @@ public class Gift {
     private String name;
 
     @Id
-    @SequenceGenerator(name = "giftSeq", sequenceName = "gift_id_seq", allocationSize = 1, initialValue = 1)
-    @GeneratedValue(generator = "giftSeq")
+    @GeneratedValue
     public Long getId() {
         return id;
     }
@@ -183,69 +182,42 @@ Make sure to terminate each statement with a semicolon.
 
 This is useful to have a data set ready for your tests or demos.
 
-=== Using `@Transactional` with Hibernate Reactive
+WARNING: Make sure to wrap methods modifying your database (e.g. `session.persist(entity)`) within a transaction. Marking a
+CDI bean method `@Transactional` will do that for you and make that method a transaction boundary. We recommend doing
+so at your application entry point boundaries like your REST endpoint controllers.
 
-You can use the standard `jakarta.transaction.Transactional` annotation with Hibernate Reactive.
-This provides a more familiar programming model for developers coming from Hibernate ORM.
+[[hr-stateless-session]]
+=== Using `Mutiny.StatelessSession`
 
-While defining transaction handling using the annotation, you should inject `Mutiny.Session` or `Mutiny.StatelessSession` using CDI and use them in methods annotated with `@Transactional`.
+In addition to `Mutiny.Session`, Quarkus supports injecting Hibernate Reactive's link:{hibernate-orm-docs-url}#stateless-sessions[`Mutiny.StatelessSession`].
 
-Here's an example showing how to use `@Transactional` in a REST resource:
+Like its blocking counterpart, a stateless session does not maintain a first-level cache and does not perform automatic dirty checking.
+Entity changes must be persisted explicitly with `insert()`, `update()`, or `delete()`.
+
+Inject a `Mutiny.StatelessSession` and use it in methods annotated with `@Transactional`:
 
 [source,java]
-.Example REST resource using @Transactional
 ----
-@Path("/fruits")
-public class FruitResource {
+@ApplicationScoped
+public class GiftService {
 
     @Inject
-    Mutiny.Session session; <1>
+    Mutiny.StatelessSession session;
 
-    @GET
-    @Path("/{id}")
-    public Uni<Fruit> getFruit(Long id) {
-        return session.find(Fruit.class, id);
+    @Transactional
+    public Uni<Gift> updateName(Long id, String newName) {
+        return session.get(Gift.class, id)
+                .map(gift -> {
+                    gift.setName(newName);
+                    return gift;
+                })
+                .call(gift -> session.update(gift));
     }
-
-    @POST
-    @Transactional <2>
-    public Uni<Fruit> createFruit(Fruit fruit) {
-        return session.persist(fruit)
-                .chain(() -> session.find(Fruit.class, fruit.getId()));
-    }
-
-    @PUT
-    @Path("/{id}")
-    @Transactional <3>
-    public Uni<Fruit> updateFruit(Long id, @QueryParam("name") String newName) {
-        return session.find(Fruit.class, id)
-                .map(fruit -> {
-                    fruit.setName(newName);
-                    return fruit;
-                });
-    }
-
 }
 ----
 
-<1> Inject the reactive session directly
-<2> Use `@Transactional` for persist operations - creates new entities in the database
-<3> Use `@Transactional` for update operations - modifies existing entities
-
-The `@Transactional` interceptor will:
-
-* Lazily open a Hibernate Reactive session when first accessed
-* Begin a transaction automatically
-* Commit the transaction when the `Uni` completes successfully
-* Roll back the transaction if an exception is thrown or the `Uni` is cancelled
-* Close the session and release the database connection when the reactive chain completes
-
-[IMPORTANT]
-====
-There are some limitations when using `@Transactional` with Hibernate Reactive, in particular not being able to use a specific `TxType`, not being able to use multiple persistence units / datasources, or non-functional `Uni.combine()`/`Uni.joining()`.
-
-See <<hr-limitations>> for more information.
-====
+For the blocking variant, see xref:hibernate-orm.adoc#stateless-session[Using `StatelessSession` with Hibernate ORM].
+For more details on stateless sessions with Panache, see xref:quarkus-data-hibernate.adoc#reactive-and-stateless[Quarkus Data Hibernate].
 
 [[hr-configuration-properties]]
 === Hibernate Reactive configuration properties
@@ -315,17 +287,24 @@ Quarkus will set many Hibernate Reactive configuration settings automatically, a
 [[hr-cdi-integration]]
 ==== CDI integration
 
-If you are familiar with using Hibernate Reactive in Quarkus, you probably already have injected the `Mutiny.SessionFactory` using CDI:
+If you are familiar with using Hibernate Reactive in Quarkus, you probably already have injected `Mutiny.Session` using CDI:
+
+[source,java]
+----
+@Inject
+Mutiny.Session session;
+----
+
+This will inject the `Mutiny.Session` of the default persistence unit.
+Use it in methods annotated with `@Transactional`, as shown in <<hr-getting-started>>.
+
+You can also inject the `Mutiny.SessionFactory` of the default persistence unit:
 
 [source,java]
 ----
 @Inject
 Mutiny.SessionFactory sessionFactory;
 ----
-
-This will inject the `Mutiny.SessionFactory` of the default persistence unit.
-
-NOTE: Prior to Quarkus 3.0 it was also possible to inject a `@RequestScoped` bean for `Mutiny.Session`. However, the lifecycle of a reactive session does not fit the lifecycle of the CDI request context. Therefore, this bean is removed in Quarkus 3.0.
 
 [[persistence-unit-active]]
 === Activate/deactivate persistence units
@@ -396,31 +375,28 @@ public class SomeTest {
 
 NOTE: See the Javadoc of `UniAsserter` for a full description of the various methods that can be used for creating assertions.
 
-[TIP]
-====
-You can also extend the `io.quarkus.test.vertx.UniAsserterInterceptor` to wrap the injected `UniAsserter` and customize the default behavior. For example, the interceptor can be used to execute the assert methods within a separate database transaction.:
+To run a test in a transaction and roll back any database changes when the test completes, annotate the test class or method with `io.quarkus.test.TestReactiveTransaction`.
+`@Transactional` cannot be used on test methods yet (see https://github.com/quarkusio/quarkus/issues/55189[issue #55189]).
 
 [source,java]
 ----
 @QuarkusTest
+@TestReactiveTransaction
 public class SomeTest {
 
-   @Test
-   @RunOnVertxContext
-   public void testEntity(UniAsserter asserter) {
-      asserter = new UniAsserterInterceptor(asserter) {
-         @Override
-         protected <T> Supplier<Uni<T>> transformUni(Supplier<Uni<T>> uniSupplier) {
-            return () -> Panache.withTransaction(uniSupplier);
-         }
-      };
-      asserter.execute(() -> new MyEntity().persist());
-      asserter.assertEquals(() -> MyEntity.count(), 1l);
-      asserter.execute(() -> MyEntity.deleteAll());
-   }
+    @Inject
+    Mutiny.Session session;
+
+    @Test
+    public void testEntity(UniAsserter asserter) {
+        MyEntity entity = new MyEntity();
+        asserter.execute(() -> session.persist(entity));
+        asserter.assertEquals(() -> session.createQuery("from MyEntity", MyEntity.class).getResultCount(), 1L);
+    }
 }
 ----
-====
+
+When using Panache, you can also inject `io.quarkus.test.hibernate.reactive.panache.TransactionalUniAsserter` to wrap each assert method within a separate reactive transaction — see xref:hibernate-reactive-panache.adoc#testing[Hibernate Reactive with Panache].
 
 [[multiple-persistence-units]]
 === Multiple persistence units
@@ -480,16 +456,10 @@ xref:hibernate-orm.adoc#discriminator-approach[Discriminator-based multitenancy]
 See https://github.com/quarkusio/quarkus/issues/15959.
 * Integration with the Envers extension is not supported.
 
-=== Transaction management: choosing between `@Transactional` and Panache annotations
+=== Transaction management
 
-With the introduction of the `quarkus-reactive-transactions` extension, you now have two options for managing transactions in Hibernate Reactive applications:
-
-1. Use `jakarta.transaction.Transactional` for declarative transaction management
-2. Use Panache's transaction annotations (`@WithTransaction`, `@WithSession`, `@WithSessionOnDemand`, or the programmatic `Panache.withTransaction()`)
-
-You must choose one approach and use it consistently throughout your application.
-Mixing both transaction management styles in the same reactive pipeline is not supported and will result in an `UnsupportedOperationException`.
-In the future, we'll deprecate the previous annotations provided by Panache and and support only `@Transactional`.
+Use `jakarta.transaction.Transactional` for declarative transaction management in Hibernate Reactive applications.
+Inject `Mutiny.Session` or `Mutiny.StatelessSession` and annotate methods returning `Uni` with `@Transactional`, as shown in <<hr-getting-started>>.
 
 You can inject either `Mutiny.Session` or `Mutiny.StatelessSession`.
 Mixing both session types in the same transaction should work, but should be reserved for exotic use cases implemented by advanced users, as the (stateful) session will not be aware of changes operated through the stateless session, which could thus conflict or be silently erased by (stateful) session writes.
@@ -497,9 +467,9 @@ Mixing both session types in the same transaction should work, but should be res
 [[transactional-different-pipelines]]
 === Using Declarative Transaction Management in different reactive pipelines
 
-When using declarative transaction management with Vert.x context-based interceptors (`@Transactional`, `@WithTransaction`, `@WithSession`, `@WithSessionOnDemand`) in multiple methods and combining such methods with either `Uni.combine().all().unis()` or `Uni.join().all()` the same transaction might be shared by different reactive pipelines causing unpredictable behavior.
+When using `@Transactional` in multiple methods and combining such methods with either `Uni.combine().all().unis()` or `Uni.join().all()` the same transaction might be shared by different reactive pipelines causing unpredictable behavior.
 
-For this reason, **avoid using declarative transactional management with those methods**.
+For this reason, **avoid using `@Transactional` with those methods**.
 
 [[transactional-others]]
 === Other Declarative Transactional Management limitations


### PR DESCRIPTION
Fixes #54486

The Hibernate ORM, Hibernate Reactive, and Hibernate Reactive Panache guides
were inconsistent and missing important session APIs. The Reactive Panache
transactions section also recommended legacy `@WithTransaction` patterns that
are harder to follow than standard `@Transactional`.
This updates the guides to document `StatelessSession` and
`Mutiny.StatelessSession`, align the Hibernate Reactive getting-started flow
with the Hibernate ORM guide, simplify the Reactive Panache transactions
section with clearer REST examples, and recommend `@Transactional` as the
default transaction approach throughout.