### PR TITLE
[4.0] Switch to Java 21 as base

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,10 +1,10 @@
-ARG VARIANT=17
+ARG VARIANT=21
 FROM mcr.microsoft.com/vscode/devcontainers/java:0-${VARIANT}
 
 ARG USER=vscode
 VOLUME /home/$USER/.m2
 VOLUME /home/$USER/.gradle
 
-ENV JAVA_VERSION=17.0.14-tem
+ENV JAVA_VERSION=21.0.5-tem
 RUN sudo mkdir /home/$USER/.m2 /home/$USER/.gradle && sudo chown $USER:$USER /home/$USER/.m2 /home/$USER/.gradle
 RUN bash -lc '. /usr/local/sdkman/bin/sdkman-init.sh && sdk install java $JAVA_VERSION && sdk use java $JAVA_VERSION'

--- a/.github/matrix-jvm-tests.json
+++ b/.github/matrix-jvm-tests.json
@@ -1,23 +1,11 @@
 [
     {
-        "name": "JVM Tests - JDK 17",
-        "category": "Runtime",
-        "tag": "jvm-tests-main",
-        "java-version": 17,
-        "java-distribution": "temurin",
-        "maven_args": "$JVM_TEST_MAVEN_ARGS",
-        "maven_opts": "-Xmx3g -XX:MaxMetaspaceSize=1g",
-        "os-name": "ubuntu-latest",
-        "runs-on": true,
-        "modules": "-pl\n!docs\n-Dno-test-modules"
-    },
-    {
         "name": "JVM Tests - JDK 21",
         "category": "Runtime",
         "tag": "jvm-tests-main",
         "java-version": 21,
         "java-distribution": "temurin",
-        "java-version-gradle": 17,
+        "java-version-gradle": 21,
         "maven_args": "$JVM_TEST_MAVEN_ARGS",
         "maven_opts": "-Xmx3g -XX:MaxMetaspaceSize=1g",
         "os-name": "ubuntu-latest",
@@ -30,7 +18,7 @@
         "tag": "jvm-tests-main",
         "java-version": 25,
         "java-distribution": "temurin",
-        "java-version-gradle": 17,
+        "java-version-gradle": 21,
         "maven_args": "$JVM_TEST_MAVEN_ARGS",
         "maven_opts": "-Xmx3g -XX:MaxMetaspaceSize=1g",
         "os-name": "ubuntu-latest",
@@ -38,10 +26,10 @@
         "modules": "-pl\n!docs\n-Dno-test-modules"
     },
     {
-        "name": "JVM Tests - JDK 17 Windows",
+        "name": "JVM Tests - JDK 21 Windows",
         "category": "Runtime",
         "tag": "jvm-tests-main",
-        "java-version": 17,
+        "java-version": 21,
         "java-distribution": "temurin",
         "maven_args": "-DskipDocs -Dformat.skip",
         "maven_opts": "-Xmx2g -XX:MaxMetaspaceSize=1g",
@@ -55,7 +43,7 @@
         "tag": "jvm-tests-main",
         "java-version": 25,
         "java-distribution": "semeru",
-        "java-version-gradle": 17,
+        "java-version-gradle": 21,
         "maven_args": "$JVM_TEST_MAVEN_ARGS",
         "maven_opts": "-Xmx3g -XX:MaxMetaspaceSize=1g",
         "os-name": "ubuntu-latest",
@@ -72,18 +60,6 @@
         "maven_opts": "-Xmx3g -XX:MaxMetaspaceSize=1g",
         "os-name": "ubuntu-latest",
         "runs-on": true,
-        "modules": "-f\nintegration-tests\n-pl\n!gradle\n-pl\n!maven\n-pl\n!devmode\n-pl\n!devtools"
-    },
-    {
-        "name": "JVM Integration Tests - JDK 21",
-        "category": "Integration",
-        "tag": "jvm-tests-integration",
-        "java-version": 21,
-        "java-distribution": "temurin",
-        "maven_args": "$JVM_TEST_MAVEN_ARGS",
-        "maven_opts": "-Xmx3g -XX:MaxMetaspaceSize=1g",
-        "os-name": "ubuntu-latest",
-        "runs-on": false,
         "modules": "-f\nintegration-tests\n-pl\n!gradle\n-pl\n!maven\n-pl\n!devmode\n-pl\n!devtools"
     },
     {
@@ -108,7 +84,7 @@
         "maven_opts": "-Xmx2g -XX:MaxMetaspaceSize=1g",
         "os-name": "windows-latest",
         "runs-on": false,
-        "modules": "-f\nintegration-tests\n-pl\n!gradle\n-pl\n!maven\n-pl\n!devmode\n-pl\n!devtools"
+        "modules": "-f\nintegration-tests\n-pl\n!gradle\n-pl\n!maven\n-pl\n!devmode\n-pl\n!devtools\n-pl\n!"
     },
     {
         "name": "JVM Integration Tests - JDK 25 Semeru",

--- a/.github/matrix-jvm-tests.json
+++ b/.github/matrix-jvm-tests.json
@@ -51,10 +51,10 @@
         "modules": "-pl\n!docs\n-Dno-test-modules"
     },
     {
-        "name": "JVM Integration Tests - JDK 17",
+        "name": "JVM Integration Tests - JDK 21",
         "category": "Integration",
         "tag": "jvm-tests-integration",
-        "java-version": 17,
+        "java-version": 21,
         "java-distribution": "temurin",
         "maven_args": "$JVM_TEST_MAVEN_ARGS",
         "maven_opts": "-Xmx3g -XX:MaxMetaspaceSize=1g",
@@ -75,10 +75,10 @@
         "modules": "-f\nintegration-tests\n-pl\n!gradle\n-pl\n!maven\n-pl\n!devmode\n-pl\n!devtools"
     },
     {
-        "name": "JVM Integration Tests - JDK 17 Windows",
+        "name": "JVM Integration Tests - JDK 21 Windows",
         "category": "Integration",
         "tag": "jvm-tests-integration",
-        "java-version": 17,
+        "java-version": 21,
         "java-distribution": "temurin",
         "maven_args": "-DskipDocs -Dformat.skip",
         "maven_opts": "-Xmx2g -XX:MaxMetaspaceSize=1g",

--- a/.github/oracle-test-pilot-jvm-tests.json
+++ b/.github/oracle-test-pilot-jvm-tests.json
@@ -5,35 +5,35 @@
             "oci-service": "base-database-service-19c",
             "timeout": 20,
             "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle",
-            "java-version": 17
+            "java-version": 21
         },
         {
             "category": "19c-atps",
             "oci-service": "autonomous-transaction-processing-serverless-19c",
             "timeout": 20,
             "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle",
-            "java-version": 17
+            "java-version": 21
         },
         {
             "category": "21c",
             "oci-service": "base-database-service-21c",
             "timeout": 20,
             "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle",
-            "java-version": 17
+            "java-version": 21
         },
         {
             "category": "26ai",
             "oci-service": "base-database-service-26ai",
             "timeout": 20,
             "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle",
-            "java-version": 17
+            "java-version": 21
         },
         {
             "category": "26ai-atps",
             "oci-service": "autonomous-transaction-processing-serverless-26ai",
             "timeout": 20,
             "test-modules": "jpa-oracle, reactive-oracle-client, hibernate-reactive-oracle",
-            "java-version": 17
+            "java-version": 21
         }
     ]
 }

--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -308,11 +308,11 @@ jobs:
           path: main-last-build-sha.txt
           retention-days: 30
 
-  build-jdk17:
-    name: "Initial JDK 17 Build"
+  build-jdk21:
+    name: "Initial JDK 21 Build"
     needs: [ configure ]
     if: needs.configure.outputs.run-ci-build == 'true'
-    runs-on: ${{ fromJson(needs.configure.outputs.config).runners['ubuntu-latest-large'].runsOn && format('{0}/tag={1}', fromJson(needs.configure.outputs.config).runners['ubuntu-latest-large'].runsOn, 'initial-jdk-17') || 'ubuntu-latest' }}
+    runs-on: ${{ fromJson(needs.configure.outputs.config).runners['ubuntu-latest-large'].runsOn && format('{0}/tag={1}', fromJson(needs.configure.outputs.config).runners['ubuntu-latest-large'].runsOn, 'initial-jdk-21') || 'ubuntu-latest' }}
     env:
       COMMON_MAVEN_ARGS: ${{ needs.configure.outputs.common-maven-args }}
       RUNS_ON_ENABLED: ${{ fromJson(needs.configure.outputs.config).runners['ubuntu-latest'].runsOn && 'true' || 'false' }}
@@ -324,8 +324,8 @@ jobs:
       - uses: runs-on/action@d141ef83eb66d096ce8afc767e09115a65c63b60 # v2.1.2
       - name: Gradle Enterprise environment
         run: |
-          echo "GE_TAGS=jdk-17" >> "$GITHUB_ENV"
-          echo "GE_CUSTOM_VALUES=gh-job-name=Initial JDK 17 Build" >> "$GITHUB_ENV"
+          echo "GE_TAGS=jdk-21" >> "$GITHUB_ENV"
+          echo "GE_CUSTOM_VALUES=gh-job-name=Initial JDK 21 Build" >> "$GITHUB_ENV"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           # this is important for Scalpel to work
@@ -336,11 +336,11 @@ jobs:
         run: .github/ci-prerequisites.sh
       - name: Print disk usage before build
         run: .github/ci-disk-usage.sh
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
       - name: Restore Maven Repository
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         if: (github.event_name != 'push' && github.event_name != 'schedule') || github.actor == 'dependabot[bot]'
@@ -367,9 +367,9 @@ jobs:
         if: github.event_name == 'pull_request' || github.event_name == 'push' && github.repository != 'quarkusio/quarkus'
         with:
           path: ~/.m2/.develocity/build-cache
-          key: develocity-cache-Initial JDK 17 Build-${{ github.event.pull_request.number || github.event.ref }}-${{ github.event.pull_request.head.sha || github.event.head }}
+          key: develocity-cache-Initial JDK 21 Build-${{ github.event.pull_request.number || github.event.ref }}-${{ github.event.pull_request.head.sha || github.event.head }}
           restore-keys: |
-            develocity-cache-Initial JDK 17 Build-${{ github.event.pull_request.number || github.event.ref }}-
+            develocity-cache-Initial JDK 21 Build-${{ github.event.pull_request.number || github.event.ref }}-
       - name: Verify native-tests.json
         run: ./.github/verify-tests-json.sh native-tests.json integration-tests/
       - name: Verify virtual-threads-tests.json
@@ -382,7 +382,7 @@ jobs:
         uses: gradle/develocity-actions/setup-maven@974e8dbcbda40db6828fc35f349c80a7c0e71529 # v2.1
         with:
           capture-strategy: ON_DEMAND
-          job-name: "Initial JDK 17 Build"
+          job-name: "Initial JDK 21 Build"
           add-pr-comment: false
           add-job-summary: false
           develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
@@ -489,7 +489,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
-          name: "build-reports-${{ github.run_attempt }}-Initial JDK 17 Build"
+          name: "build-reports-${{ github.run_attempt }}-Initial JDK 21 Build"
           path: |
             build-reports.zip
           retention-days: 7
@@ -497,9 +497,9 @@ jobs:
   calculate-test-jobs:
     name: Calculate Test Jobs
     runs-on: ubuntu-latest
-    needs: build-jdk17
+    needs: build-jdk21
     env:
-      SCALPEL_IMPACTED_MODULES: ${{ needs.build-jdk17.outputs.scalpel_impacted }}
+      SCALPEL_IMPACTED_MODULES: ${{ needs.build-jdk21.outputs.scalpel_impacted }}
     outputs:
       native_matrix: ${{ steps.calc-native-matrix.outputs.matrix }}
       jvm_matrix: ${{ steps.calc-jvm-matrix.outputs.matrix }}
@@ -578,7 +578,7 @@ jobs:
   jvm-tests:
     name: ${{ matrix.java.name }}
     runs-on: ${{ matrix.java.runs-on && fromJson(needs.configure.outputs.config).runners[format('{0}-{1}', matrix.java.os-name, 'large')].runsOn && format('{0}/tag={1}', fromJson(needs.configure.outputs.config).runners[format('{0}-{1}', matrix.java.os-name, 'large')].runsOn, matrix.java.tag) || matrix.java.os-name }}
-    needs: [configure, build-jdk17, calculate-test-jobs]
+    needs: [configure, build-jdk21, calculate-test-jobs]
     if: needs.calculate-test-jobs.outputs.jvm_matrix
     timeout-minutes: 400
     env:
@@ -742,7 +742,7 @@ jobs:
   maven-tests:
     name: Maven Tests - JDK ${{matrix.java.name}}
     runs-on: ${{ matrix.java.runs-on && fromJson(needs.configure.outputs.config).runners[format('{0}-{1}', matrix.java.os-name, 'large')].runsOn && format('{0}/tag={1}', fromJson(needs.configure.outputs.config).runners[format('{0}-{1}', matrix.java.os-name, 'large')].runsOn, matrix.java.tag) || matrix.java.os-name }}
-    needs: [configure, build-jdk17, calculate-test-jobs]
+    needs: [configure, build-jdk21, calculate-test-jobs]
     env:
       MAVEN_OPTS: -Xmx2g -XX:MaxMetaspaceSize=1g
       COMMON_MAVEN_ARGS: ${{ needs.configure.outputs.common-maven-args }}
@@ -763,11 +763,11 @@ jobs:
             runs-on: true
           }
           - {
-            name: "17 Windows",
-            java-version: 17,
+            name: "21 Windows",
+            java-version: 21,
             java-distribution: "temurin",
             os-name: "windows-latest",
-            tag: "maven-jdk-17-windows",
+            tag: "maven-jdk-21-windows",
             runs-on: false
           }
           - {
@@ -827,7 +827,7 @@ jobs:
           CAPTURE_BUILD_SCAN: true
         # Important: keep -pl ... in sync with "Calculate run flags"!
         # Despite the pre-calculated run_maven flag, Scalpel has to be re-run here to figure out the exact submodules to build.
-        run: ./mvnw $COMMON_MAVEN_ARGS $COMMON_TEST_MAVEN_ARGS $PTS_MAVEN_ARGS $JVM_TEST_MAVEN_ARGS clean install -pl 'integration-tests/maven' -pl 'integration-tests/devmode' ${{ needs.build-jdk17.outputs.scalpel_args }}
+        run: ./mvnw $COMMON_MAVEN_ARGS $COMMON_TEST_MAVEN_ARGS $PTS_MAVEN_ARGS $JVM_TEST_MAVEN_ARGS clean install -pl 'integration-tests/maven' -pl 'integration-tests/devmode' ${{ needs.build-jdk21.outputs.scalpel_args }}
       - name: Prepare failure archive (if maven failed)
         if: failure()
         run: find . -name '*-reports' -type d -o -name '*.log' | tar -czf test-reports.tgz -T -
@@ -865,7 +865,7 @@ jobs:
   gradle-tests:
     name: Gradle Tests - JDK ${{matrix.java.name}}
     runs-on: ${{ matrix.java.runs-on && fromJson(needs.configure.outputs.config).runners[format('{0}-{1}', matrix.java.os-name, 'large')].runsOn && format('{0}/tag={1}', fromJson(needs.configure.outputs.config).runners[format('{0}-{1}', matrix.java.os-name, 'large')].runsOn, matrix.java.tag) || matrix.java.os-name }}
-    needs: [configure, build-jdk17, calculate-test-jobs]
+    needs: [configure, build-jdk21, calculate-test-jobs]
     env:
       # leave more space for the actual gradle execution (which is just wrapped by maven)
       MAVEN_OPTS: -Xmx1g
@@ -886,10 +886,10 @@ jobs:
             runs-on: true
           }
           - {
-            name: "17 Windows",
-            java-version: 17,
+            name: "21 Windows",
+            java-version: 21,
             os-name: "windows-latest",
-            tag: "gradle-jdk-17-windows",
+            tag: "gradle-jdk-21-windows",
             runs-on: false
           }
     steps:
@@ -962,7 +962,7 @@ jobs:
   devtools-tests:
     name: Devtools Tests - JDK ${{matrix.java.name}}
     runs-on: ${{ matrix.java.runs-on && fromJson(needs.configure.outputs.config).runners[format('{0}-{1}', matrix.java.os-name, 'small')].runsOn && format('{0}/tag={1}', fromJson(needs.configure.outputs.config).runners[format('{0}-{1}', matrix.java.os-name, 'small')].runsOn, matrix.java.tag) || matrix.java.os-name }}
-    needs: [configure, build-jdk17, calculate-test-jobs]
+    needs: [configure, build-jdk21, calculate-test-jobs]
     # Skip main in forks
     if: needs.calculate-test-jobs.outputs.run_devtools == 'true'
     env:
@@ -982,11 +982,11 @@ jobs:
             runs-on: true
           }
           - {
-            name: "17 Windows",
-            java-version: 17,
+            name: "21 Windows",
+            java-version: 21,
             java-distribution: "temurin",
             os-name: "windows-latest",
-            tag: "devtools-jdk-17-windows",
+            tag: "devtools-jdk-21-windows",
             runs-on: false
           }
           - {
@@ -1071,7 +1071,7 @@ jobs:
   kubernetes-tests:
     name: Kubernetes Tests - JDK ${{matrix.java.name}}
     runs-on: ${{ matrix.java.runs-on && fromJson(needs.configure.outputs.config).runners[format('{0}-{1}', matrix.java.os-name, 'large')].runsOn && format('{0}/tag={1}', fromJson(needs.configure.outputs.config).runners[format('{0}-{1}', matrix.java.os-name, 'large')].runsOn, matrix.java.tag) || matrix.java.os-name }}
-    needs: [configure, build-jdk17, calculate-test-jobs]
+    needs: [configure, build-jdk21, calculate-test-jobs]
     # Skip main in forks
     if: needs.calculate-test-jobs.outputs.run_kubernetes == 'true'
     env:
@@ -1091,8 +1091,8 @@ jobs:
             runs-on: true
           }
           - {
-            name: "17 Windows",
-            java-version: 17,
+            name: "25 Windows",
+            java-version: 25,
             java-distribution: "temurin",
             os-name: "windows-latest",
             tag: "kubernetes-jdk-25-windows",
@@ -1180,7 +1180,7 @@ jobs:
 #  quickstarts-tests:
 #    name: Quickstarts - JDK ${{matrix.java.name}}
 #    runs-on: ${{ matrix.java.runs-on && fromJson(needs.configure.outputs.config).runners[format('{0}-{1}', matrix.java.os-name, 'large')].runsOn && format('{0}/tag={1}', fromJson(needs.configure.outputs.config).runners[format('{0}-{1}', matrix.java.os-name, 'large')].runsOn, matrix.java.tag) || matrix.java.os-name }}
-#    needs: [configure, build-jdk17, calculate-test-jobs]
+#    needs: [configure, build-jdk21, calculate-test-jobs]
 #    # Skip main in forks
 #    if: needs.calculate-test-jobs.outputs.run_quickstarts == 'true'
 #    env:
@@ -1264,7 +1264,7 @@ jobs:
 #        working-directory: quarkus-quickstarts
 #        env:
 #          CAPTURE_BUILD_SCAN: true
-#          SCALPEL_IMPACTED_GAV: ${{ needs.build-jdk17.outputs.scalpel_impacted_gav }}
+#          SCALPEL_IMPACTED_GAV: ${{ needs.build-jdk21.outputs.scalpel_impacted_gav }}
 #        run: |
 #          echo "=== SCALPEL_IMPACTED_GAV ==="
 #          echo "$SCALPEL_IMPACTED_GAV"
@@ -1296,7 +1296,7 @@ jobs:
   platform-tests:
     name: Platform Tests - JDK ${{matrix.java.name}}
     runs-on: ${{ matrix.java.runs-on && fromJson(needs.configure.outputs.config).runners[format('{0}-{1}', matrix.java.os-name, 'large')].runsOn && format('{0}/tag={1}', fromJson(needs.configure.outputs.config).runners[format('{0}-{1}', matrix.java.os-name, 'large')].runsOn, matrix.java.tag) || matrix.java.os-name }}
-    needs: [configure, build-jdk17, calculate-test-jobs]
+    needs: [configure, build-jdk21, calculate-test-jobs]
     # Skip main in forks
     if: ${{ contains( github.event.pull_request.labels.*.name, 'ci/test-platform') }}
     env:
@@ -1395,7 +1395,7 @@ jobs:
   virtual-thread-native-tests:
     name: Native Tests - Virtual Thread - ${{matrix.category}}
     runs-on: ${{ fromJson(needs.configure.outputs.config).runners[format('{0}-{1}', matrix.os-name, 'large')].runsOn && format('{0}/tag={1}', fromJson(needs.configure.outputs.config).runners[format('{0}-{1}', matrix.os-name, 'large')].runsOn, matrix.tag) || matrix.os-name }}
-    needs: [configure, build-jdk17, calculate-test-jobs]
+    needs: [configure, build-jdk21, calculate-test-jobs]
     # Skip main in forks
     if: needs.calculate-test-jobs.outputs.virtual_threads_matrix != '{}'
     env:
@@ -1475,7 +1475,7 @@ jobs:
 
   tcks-test:
     name: MicroProfile TCKs Tests
-    needs: [configure, build-jdk17, calculate-test-jobs]
+    needs: [configure, build-jdk21, calculate-test-jobs]
     # Skip main in forks
     if: needs.calculate-test-jobs.outputs.run_tcks == 'true'
     runs-on: ${{ fromJson(needs.configure.outputs.config).runners['ubuntu-latest-large'].runsOn && format('{0}/tag={1}', fromJson(needs.configure.outputs.config).runners['ubuntu-latest-large'].runsOn, 'microprofile-tcks') || 'ubuntu-latest' }}
@@ -1531,7 +1531,7 @@ jobs:
           CAPTURE_BUILD_SCAN: true
         # Important: keep -pl ... in sync with "Calculate run flags"!
         # Despite the pre-calculated run_tcks flag, Scalpel has to be re-run here to figure out the exact tcks submodules to build.
-        run: ./mvnw $COMMON_MAVEN_ARGS $COMMON_TEST_MAVEN_ARGS $PTS_MAVEN_ARGS -Dtcks -pl tcks -amd clean install ${{ needs.build-jdk17.outputs.scalpel_args }}
+        run: ./mvnw $COMMON_MAVEN_ARGS $COMMON_TEST_MAVEN_ARGS $PTS_MAVEN_ARGS -Dtcks -pl tcks -amd clean install ${{ needs.build-jdk21.outputs.scalpel_args }}
       - name: Verify resteasy-reative dependencies
         # note: ideally, this would be run _before_ mvnw but that would required building tcks/resteasy-reactive in two steps
         run: ./tcks/resteasy-reactive/update-dependencies.sh $COMMON_MAVEN_ARGS
@@ -1565,7 +1565,7 @@ jobs:
 
   native-tests:
     name: Native Tests - ${{matrix.category}}
-    needs: [configure, build-jdk17, calculate-test-jobs]
+    needs: [configure, build-jdk21, calculate-test-jobs]
     runs-on: ${{ fromJson(needs.configure.outputs.config).runners[format('{0}-{1}', matrix.os-name, 'large')].runsOn && format('{0}/tag={1}', fromJson(needs.configure.outputs.config).runners[format('{0}-{1}', matrix.os-name, 'large')].runsOn, matrix.tag) || matrix.os-name }}
     env:
       # leave more space for the actual native compilation and execution
@@ -1772,7 +1772,7 @@ jobs:
     # Shared environment: make extra sure not to leak a GitHub token with any permission.
     permissions:
       contents: read
-    needs: [configure, build-jdk17, calculate-test-jobs]
+    needs: [configure, build-jdk21, calculate-test-jobs]
     if: github.repository == 'quarkusio/quarkus' && needs.calculate-test-jobs.outputs.otp_jvm_matrix != '{}'
     env:
       COMMON_MAVEN_ARGS: ${{ needs.configure.outputs.common-maven-args }}
@@ -1803,11 +1803,11 @@ jobs:
           path: .
       - name: Extract previously uploaded .m2 content
         run: tar -xzf m2-content.tgz -C ~
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
       - name: Setup Develocity Build Scan capture
         uses: gradle/develocity-actions/setup-maven@974e8dbcbda40db6828fc35f349c80a7c0e71529 # v2.1
         with:
@@ -1881,7 +1881,7 @@ jobs:
     # Shared environment: make extra sure not to leak a GitHub token with any permission.
     permissions:
       contents: read
-    needs: [configure, build-jdk17, calculate-test-jobs]
+    needs: [configure, build-jdk21, calculate-test-jobs]
     if: github.repository == 'quarkusio/quarkus' && needs.calculate-test-jobs.outputs.otp_native_matrix != '{}'
     env:
       COMMON_MAVEN_ARGS: ${{ needs.configure.outputs.common-maven-args }}
@@ -1999,8 +1999,8 @@ jobs:
   build-report:
     runs-on: ubuntu-latest
     name: Build report
-    # needs: [configure,build-jdk17,jvm-tests,maven-tests,gradle-tests,devtools-tests,kubernetes-tests,quickstarts-tests,platform-tests,tcks-test,native-tests,virtual-thread-native-tests,oracle-test-pilot-jvm-tests,oracle-test-pilot-native-tests]
-    needs: [configure,build-jdk17,jvm-tests,maven-tests,gradle-tests,devtools-tests,kubernetes-tests,platform-tests,tcks-test,native-tests,virtual-thread-native-tests,oracle-test-pilot-jvm-tests,oracle-test-pilot-native-tests]
+    # needs: [configure,build-jdk21,jvm-tests,maven-tests,gradle-tests,devtools-tests,kubernetes-tests,quickstarts-tests,platform-tests,tcks-test,native-tests,virtual-thread-native-tests,oracle-test-pilot-jvm-tests,oracle-test-pilot-native-tests]
+    needs: [configure,build-jdk21,jvm-tests,maven-tests,gradle-tests,devtools-tests,kubernetes-tests,platform-tests,tcks-test,native-tests,virtual-thread-native-tests,oracle-test-pilot-jvm-tests,oracle-test-pilot-native-tests]
     if: always() && needs.configure.outputs.run-ci-build == 'true'
     steps:
       - uses: runs-on/action@d141ef83eb66d096ce8afc767e09115a65c63b60 # v2.1.2

--- a/.github/workflows/ci-istio.yml.disabled
+++ b/.github/workflows/ci-istio.yml.disabled
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - name: Install artifacts
         run: ./mvnw ${MAVEN_ARGS} -DskipTests -DskipITs -Dinvoker.skip clean install -pl :quarkus-integration-test-istio-invoker -am
       - name: Tar Maven repository
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - name: Download Maven repository
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/ci-kubernetes.yml.disabled
+++ b/.github/workflows/ci-kubernetes.yml.disabled
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - name: Install artifacts
         run: ./mvnw ${MAVEN_ARGS} -DskipTests -DskipITs -Dinvoker.skip clean install -pl :quarkus-integration-test-kubernetes-invoker -am
       - name: Tar Maven repository
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - name: Download Maven repository
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -118,7 +118,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - name: Download Maven repository
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/ci-openshift.yml.disabled
+++ b/.github/workflows/ci-openshift.yml.disabled
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - name: Install artifacts
         run: ./mvnw ${MAVEN_ARGS} -DskipTests -DskipITs -Dinvoker.skip clean install -pl :quarkus-integration-test-kubernetes-invoker -am
       - name: Tar Maven repository
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - name: Download Maven repository
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/codeql-analysis.yml.disabled
+++ b/.github/workflows/codeql-analysis.yml.disabled
@@ -27,7 +27,7 @@ jobs:
       uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         distribution: temurin
-        java-version: 17
+        java-version: 21
     - name: Generate cache key
       id: cache-key
       run: |

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -62,11 +62,11 @@ jobs:
     if: github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
       - name: Generate cache key
         id: cache-key
         run: |

--- a/.github/workflows/native-it-selected-graalvm.yml
+++ b/.github/workflows/native-it-selected-graalvm.yml
@@ -29,7 +29,6 @@ permissions:
 #        default: '25'
 #        type: choice
 #        options:
-#          - '17'
 #          - '21'
 #          - '25'
 on: [workflow_dispatch]
@@ -50,8 +49,8 @@ defaults:
     shell: bash
 
 jobs:
-  build-jdk17:
-    name: "Initial JDK 17 Build - ${{ inputs.BRANCH }}"
+  build-jdk21:
+    name: "Initial JDK 21 Build - ${{ inputs.BRANCH }}"
     runs-on: ubuntu-latest
     outputs:
       scalpel_args: ${{ steps.get-scalpel-args.outputs.scalpel_args }}
@@ -64,8 +63,8 @@ jobs:
     steps:
       - name: Gradle Enterprise environment
         run: |
-          echo "GE_TAGS=jdk-17" >> "$GITHUB_ENV"
-          echo "GE_CUSTOM_VALUES=gh-job-name=Initial JDK 17 Build" >> "$GITHUB_ENV"
+          echo "GE_TAGS=jdk-21" >> "$GITHUB_ENV"
+          echo "GE_CUSTOM_VALUES=gh-job-name=Initial JDK 21 Build" >> "$GITHUB_ENV"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.BRANCH }}
@@ -75,11 +74,11 @@ jobs:
         run: git remote show quarkusio &> /dev/null || git remote add quarkusio https://github.com/quarkusio/quarkus.git
       - name: Reclaim Disk Space
         run: .github/ci-prerequisites.sh
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
       - name: Generate cache key
         id: cache-key
         run: |
@@ -110,7 +109,7 @@ jobs:
         uses: gradle/develocity-actions/setup-maven@974e8dbcbda40db6828fc35f349c80a7c0e71529 # v2.1
         with:
           capture-strategy: ON_DEMAND
-          job-name: "Initial JDK 17 Build"
+          job-name: "Initial JDK 21 Build"
           add-pr-comment: false
           add-job-summary: false
           develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
@@ -183,7 +182,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
-          name: "build-reports-Initial JDK 17 Build"
+          name: "build-reports-Initial JDK 21 Build"
           path: |
             build-reports.zip
           retention-days: 7
@@ -191,9 +190,9 @@ jobs:
   calculate-test-jobs:
     name: Calculate Test Jobs
     runs-on: ubuntu-latest
-    needs: build-jdk17
+    needs: build-jdk21
     env:
-      SCALPEL_IMPACTED_MODULES: ${{ needs.build-jdk17.outputs.scalpel_impacted }}
+      SCALPEL_IMPACTED_MODULES: ${{ needs.build-jdk21.outputs.scalpel_impacted }}
     outputs:
       native_matrix: ${{ steps.calc-native-matrix.outputs.matrix }}
       virtual_threads_matrix: ${{ steps.calc-virtual-threads-matrix.outputs.matrix }}
@@ -223,7 +222,7 @@ jobs:
   virtual-thread-native-tests:
     name: Native Tests - Virtual Thread - ${{matrix.category}} - ${{inputs.NATIVE_COMPILER}} ${{inputs.NATIVE_COMPILER_VERSION}} - ${{inputs.BRANCH}}
     runs-on: ${{matrix.os-name}}
-    needs: [build-jdk17, calculate-test-jobs]
+    needs: [build-jdk21, calculate-test-jobs]
     timeout-minutes: ${{matrix.timeout}}
     strategy:
       max-parallel: 12
@@ -240,10 +239,10 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.m2/repository
-          key: ${{ needs.build-jdk17.outputs.m2-cache-key }}
+          key: ${{ needs.build-jdk21.outputs.m2-cache-key }}
           restore-keys: |
-            ${{ needs.build-jdk17.outputs.m2-monthly-branch-cache-key }}-
-            ${{ needs.build-jdk17.outputs.m2-monthly-cache-key }}-
+            ${{ needs.build-jdk21.outputs.m2-monthly-branch-cache-key }}-
+            ${{ needs.build-jdk21.outputs.m2-monthly-cache-key }}-
       - name: Download .m2/repository/io/quarkus
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -303,7 +302,7 @@ jobs:
 
   native-tests:
     name: Native Tests - ${{matrix.category}} - ${{inputs.NATIVE_COMPILER}} ${{inputs.NATIVE_COMPILER_VERSION}} - ${{inputs.BRANCH}}
-    needs: [build-jdk17, calculate-test-jobs]
+    needs: [build-jdk21, calculate-test-jobs]
     runs-on: ${{matrix.os-name}}
     env:
       # leave more space for the actual native compilation and execution
@@ -323,11 +322,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Reclaim Disk Space
         run: .github/ci-prerequisites.sh
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
       - name: Setup GraalVM
         id: setup-graalvm
         uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f # v1.5.3
@@ -345,10 +344,10 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.m2/repository
-          key: ${{ needs.build-jdk17.outputs.m2-cache-key }}
+          key: ${{ needs.build-jdk21.outputs.m2-cache-key }}
           restore-keys: |
-            ${{ needs.build-jdk17.outputs.m2-monthly-branch-cache-key }}-
-            ${{ needs.build-jdk17.outputs.m2-monthly-cache-key }}-
+            ${{ needs.build-jdk21.outputs.m2-monthly-branch-cache-key }}-
+            ${{ needs.build-jdk21.outputs.m2-monthly-cache-key }}-
       - name: Download .m2/repository/io/quarkus
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -369,9 +368,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: '**/.quarkus/quarkus-prod-config-dump'
-          key: ${{ needs.build-jdk17.outputs.quarkus-metadata-cache-key }}
+          key: ${{ needs.build-jdk21.outputs.quarkus-metadata-cache-key }}
           # The key is restored from default branch if not found, but still branch specific to override the default after first run
-          restore-keys: ${{ needs.build-jdk17.outputs.quarkus-metadata-cache-key-default }}
+          restore-keys: ${{ needs.build-jdk21.outputs.quarkus-metadata-cache-key-default }}
       - name: Build
         env:
           TEST_MODULES: ${{matrix.test-modules}}
@@ -408,17 +407,17 @@ jobs:
   build-report:
     runs-on: ubuntu-latest
     name: Build report - ${{inputs.NATIVE_COMPILER}} ${{inputs.NATIVE_COMPILER_VERSION}} - ${{inputs.BRANCH}}
-    needs: [build-jdk17,native-tests,virtual-thread-native-tests]
+    needs: [build-jdk21,native-tests,virtual-thread-native-tests]
     if: always()
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: build-reports-artifacts
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
       - name: Produce report and add it as job summary
         uses: quarkusio/action-build-reporter@main
         with:

--- a/.github/workflows/owasp-check.yml
+++ b/.github/workflows/owasp-check.yml
@@ -30,7 +30,7 @@ jobs:
       uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         distribution: temurin
-        java-version: 17
+        java-version: 21
 
     - name: Generate cache key
       id: cache-key

--- a/.github/workflows/podman-build.yml
+++ b/.github/workflows/podman-build.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   build-all-the-things:
-    name: "JDK 17 Build"
+    name: "JDK 21 Build"
     runs-on: ubuntu-latest
     env:
       MAVEN_OPTS: "-Xmx2g -XX:MaxMetaspaceSize=1g"
@@ -54,11 +54,11 @@ jobs:
       - name: Reclaim Disk Space
         if: "!startsWith(matrix.java.os-name, 'windows') && !startsWith(matrix.java.os-name, 'macos')"
         run: .github/ci-prerequisites.sh
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
       - name: Get Date
         id: get-date
         run: |

--- a/.github/workflows/populate-cache.yml
+++ b/.github/workflows/populate-cache.yml
@@ -47,11 +47,11 @@ jobs:
     needs: [ configure ]
     runs-on: ubuntu-latest
     steps:
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -31,11 +31,11 @@ jobs:
           echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       - name: Reclaim Disk Space
         run: .github/ci-prerequisites.sh
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
       - name: Create maven repo
         run: mkdir -p $HOME/release/repository
       - name: Build and Test

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -21,11 +21,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
       - name: Generate cache key
         id: cache-key
         run: |

--- a/.gitpod/Dockerfile
+++ b/.gitpod/Dockerfile
@@ -1,6 +1,6 @@
-FROM gitpod/workspace-java-17
+FROM gitpod/workspace-java-21
 
-ENV JAVA_VERSION=17.0.14-tem
+ENV JAVA_VERSION=21.0.5-tem
 
 RUN bash -c ". /home/gitpod/.sdkman/bin/sdkman-init.sh && \
     sdk install java ${JAVA_VERSION} && \

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -851,12 +851,12 @@
                             </execution>
                         </executions>
                         <configuration>
-                            <jdkVersion>17</jdkVersion>
+                            <jdkVersion>21</jdkVersion>
                             <outputFormat>html</outputFormat>
                             <externalDocumentationLinks>
                                 <link>
                                     <!-- Root URL of the generated documentation to link with. The trailing slash is required! -->
-                                    <url>https://docs.oracle.com/en/java/javase/17/docs/api/</url>
+                                    <url>https://docs.oracle.com/en/java/javase/21/docs/api/</url>
                                 </link>
                             </externalDocumentationLinks>
                         </configuration>

--- a/core/deployment/src/main/java/io/quarkus/deployment/images/ContainerImages.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/images/ContainerImages.java
@@ -77,20 +77,10 @@ public class ContainerImages {
     private static final Pattern RUN_JAVA_IMAGE_MATCHER = Pattern
             .compile("^registry\\.access\\.redhat\\.com/ubi\\d+/openjdk-\\d+-runtime(?::[\\w.\\-]+)?$");
 
-    // UBI 8 OpenJDK 17 Runtime - https://catalog.redhat.com/software/containers/ubi8/openjdk-17-runtime/618bdc5f843af1624c4e4ba8
-    public static final String UBI8_JAVA_17_IMAGE_NAME = "registry.access.redhat.com/ubi8/openjdk-17-runtime";
-    public static final String UBI8_JAVA_17_VERSION = UBI8_JAVA_VERSION;
-    public static final String UBI8_JAVA_17 = UBI8_JAVA_17_IMAGE_NAME + ":" + UBI8_JAVA_17_VERSION;
-
     // UBI 8 OpenJDK 21 Runtime - https://catalog.redhat.com/software/containers/ubi8/openjdk-21-runtime/653fd184292263c0a2f14d69
     public static final String UBI8_JAVA_21_IMAGE_NAME = "registry.access.redhat.com/ubi8/openjdk-21-runtime";
     public static final String UBI8_JAVA_21_VERSION = UBI8_JAVA_VERSION;
     public static final String UBI8_JAVA_21 = UBI8_JAVA_21_IMAGE_NAME + ":" + UBI8_JAVA_21_VERSION;
-
-    // UBI 9 OpenJDK 17 Runtime - https://catalog.redhat.com/software/containers/ubi9/openjdk-17-runtime/61ee7d45384a3eb331996bee
-    public static final String UBI9_JAVA_17_IMAGE_NAME = "registry.access.redhat.com/ubi9/openjdk-17-runtime";
-    public static final String UBI9_JAVA_17_VERSION = UBI9_JAVA_VERSION;
-    public static final String UBI9_JAVA_17 = UBI9_JAVA_17_IMAGE_NAME + ":" + UBI9_JAVA_17_VERSION;
 
     // UBI 9 OpenJDK 21 Runtime - https://catalog.redhat.com/software/containers/ubi9/openjdk-21-runtime/6501ce769a0d86945c422d5f
     public static final String UBI9_JAVA_21_IMAGE_NAME = "registry.access.redhat.com/ubi9/openjdk-21-runtime";
@@ -120,11 +110,6 @@ public class ContainerImages {
     public static final String QUARKUS_BINARY_S2I_IMAGE_NAME = UBI9_QUARKUS_BINARY_S2I_IMAGE_NAME;
     public static final String QUARKUS_BINARY_S2I_VERSION = UBI9_QUARKUS_BINARY_S2I_VERSION;
     public static final String QUARKUS_BINARY_S2I = UBI9_QUARKUS_BINARY_S2I;
-
-    // Java 17 Source To Image - https://catalog.redhat.com/software/containers/ubi9/openjdk-17/61ee7c26ed74b2ffb22b07f6
-    public static final String S2I_JAVA_17_IMAGE_NAME = "registry.access.redhat.com/ubi9/openjdk-17";
-    public static final String S2I_JAVA_17_VERSION = UBI9_JAVA_VERSION;
-    public static final String S2I_JAVA_17 = S2I_JAVA_17_IMAGE_NAME + ":" + S2I_JAVA_17_VERSION;
 
     // Java Source To Image - https://catalog.redhat.com/software/containers/ubi9/openjdk-21/6501cdb5c34ae048c44f7814
     public static final String S2I_JAVA_21_IMAGE_NAME = "registry.access.redhat.com/ubi9/openjdk-21";
@@ -167,7 +152,7 @@ public class ContainerImages {
             return UBI9_JAVA_21;
         }
 
-        return UBI9_JAVA_17;
+        return UBI9_JAVA_25;
     }
 
     public static boolean containsRunJava(String baseJvmImage) {

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliProjectGradleTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliProjectGradleTest.java
@@ -407,22 +407,6 @@ public class CliProjectGradleTest {
     }
 
     @Test
-    public void testCreateArgJava17() throws Exception {
-        CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--gradle",
-                "-e", "-B", "--verbose",
-                "--java", "17");
-
-        // We don't need to retest this, just need to make sure all the arguments were passed through
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
-
-        Path buildGradle = project.resolve("build.gradle");
-        String buildGradleContent = CliDriver.readFileAsString(buildGradle);
-
-        Assertions.assertTrue(buildGradleContent.contains("sourceCompatibility = JavaVersion.VERSION_17"),
-                "Java 17 should be used when specified. Found:\n" + buildGradleContent);
-    }
-
-    @Test
     public void testCreateArgJava21() throws Exception {
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--gradle",
                 "-e", "-B", "--verbose",

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliProjectJBangTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliProjectJBangTest.java
@@ -168,21 +168,6 @@ public class CliProjectJBangTest {
     }
 
     @Test
-    public void testCreateArgJava17() throws Exception {
-        CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--jbang",
-                "-e", "-B", "--verbose",
-                "--java", "17");
-
-        // We don't need to retest this, just need to make sure all the arguments were passed through
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
-
-        Path javaMain = validateJBangSourcePackage(project, ""); // no package name
-        String source = CliDriver.readFileAsString(javaMain);
-        Assertions.assertTrue(source.contains("//JAVA 17"),
-                "Generated source should contain //JAVA 17. Found:\n" + source);
-    }
-
-    @Test
     public void testCreateArgJava21() throws Exception {
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--jbang",
                 "-e", "-B", "--verbose",

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliProjectMavenTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliProjectMavenTest.java
@@ -360,22 +360,6 @@ public class CliProjectMavenTest {
     }
 
     @Test
-    public void testCreateArgJava17() throws Exception {
-        CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app",
-                "-e", "-B", "--verbose",
-                "--java", "17");
-
-        // We don't need to retest this, just need to make sure all the arguments were passed through
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
-
-        Path pom = project.resolve("pom.xml");
-        String pomContent = CliDriver.readFileAsString(pom);
-
-        Assertions.assertTrue(pomContent.contains("maven.compiler.release>17<"),
-                "Java 17 should be used when specified. Found:\n" + pomContent);
-    }
-
-    @Test
     public void testCreateArgJava21() throws Exception {
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app",
                 "-e", "-B", "--verbose",

--- a/extensions/amazon-lambda-http/maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/extensions/amazon-lambda-http/maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -10,8 +10,8 @@
         <assembly-plugin.version>3.1.0</assembly-plugin.version>
         <compiler-plugin.version>3.15.0</compiler-plugin.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.target>17</maven.compiler.target>
-        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus-plugin.version>4.0.999-SNAPSHOT</quarkus-plugin.version>

--- a/extensions/amazon-lambda-rest/maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/extensions/amazon-lambda-rest/maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -10,8 +10,8 @@
         <assembly-plugin.version>3.1.0</assembly-plugin.version>
         <compiler-plugin.version>3.15.0</compiler-plugin.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.target>17</maven.compiler.target>
-        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus-plugin.version>4.0.999-SNAPSHOT</quarkus-plugin.version>

--- a/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -9,8 +9,8 @@
     <properties>
         <compiler-plugin.version>3.15.0</compiler-plugin.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.target>17</maven.compiler.target>
-        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus-plugin.version>4.0.999-SNAPSHOT</quarkus-plugin.version>

--- a/extensions/container-image/container-image-docker-common/deployment/src/test/java/io/quarkus/container/image/docker/common/deployment/UbiMinimalBaseProviderTest.java
+++ b/extensions/container-image/container-image-docker-common/deployment/src/test/java/io/quarkus/container/image/docker/common/deployment/UbiMinimalBaseProviderTest.java
@@ -40,9 +40,7 @@ class UbiMinimalBaseProviderTest {
 
     static Stream<Arguments> imageCombinations() {
         return Stream.of(
-                Arguments.of(8, 17, ContainerImages.UBI8_MINIMAL_VERSION),
                 Arguments.of(8, 21, ContainerImages.UBI8_MINIMAL_VERSION),
-                Arguments.of(9, 17, ContainerImages.UBI9_MINIMAL_VERSION),
                 Arguments.of(9, 21, ContainerImages.UBI9_MINIMAL_VERSION));
     }
 

--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/ContainerImageOpenshiftConfig.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/ContainerImageOpenshiftConfig.java
@@ -35,7 +35,7 @@ public interface ContainerImageOpenshiftConfig {
         if (version.isJava21OrHigher() == CompiledJavaVersionBuildItem.JavaVersion.Status.TRUE) {
             return ContainerImages.S2I_JAVA_21;
         }
-        return ContainerImages.S2I_JAVA_17;
+        throw new IllegalArgumentException("Unsupported Java version: " + version);
     }
 
     /**

--- a/extensions/funqy/funqy-amazon-lambda/maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/extensions/funqy/funqy-amazon-lambda/maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -9,8 +9,8 @@
     <properties>
         <compiler-plugin.version>3.15.0</compiler-plugin.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.target>17</maven.compiler.target>
-        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus-plugin.version>4.0.999-SNAPSHOT</quarkus-plugin.version>

--- a/independent-projects/parent/pom.xml
+++ b/independent-projects/parent/pom.xml
@@ -49,7 +49,7 @@
 
         <!-- Default properties -->
         <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.release>21</maven.compiler.release>
         <maven.compiler.source>${maven.compiler.release}</maven.compiler.source>
         <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
         <maven.compiler.testTarget>${maven.compiler.target}</maven.compiler.testTarget>

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateDefault/pom.xml
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateDefault/pom.xml
@@ -8,7 +8,7 @@
 
     <properties>
         <compiler-plugin.version>3.8.1-MOCK</compiler-plugin.version>
-        <maven.compiler.release>21</maven.compiler.release>
+        <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-mock-bom</quarkus.platform.artifact-id>

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateDefault/pom.xml
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateDefault/pom.xml
@@ -8,7 +8,7 @@
 
     <properties>
         <compiler-plugin.version>3.8.1-MOCK</compiler-plugin.version>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-mock-bom</quarkus.platform.artifact-id>

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateDefaultWithWrapper/pom.xml
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateDefaultWithWrapper/pom.xml
@@ -8,7 +8,7 @@
 
     <properties>
         <compiler-plugin.version>3.8.1-MOCK</compiler-plugin.version>
-        <maven.compiler.release>21</maven.compiler.release>
+        <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-mock-bom</quarkus.platform.artifact-id>

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateDefaultWithWrapper/pom.xml
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateDefaultWithWrapper/pom.xml
@@ -8,7 +8,7 @@
 
     <properties>
         <compiler-plugin.version>3.8.1-MOCK</compiler-plugin.version>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-mock-bom</quarkus.platform.artifact-id>

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateMavenWithCustomDep/pom.xml
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateMavenWithCustomDep/pom.xml
@@ -8,7 +8,7 @@
 
     <properties>
         <compiler-plugin.version>3.8.1-MOCK</compiler-plugin.version>
-        <maven.compiler.release>21</maven.compiler.release>
+        <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-mock-bom</quarkus.platform.artifact-id>

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateMavenWithCustomDep/pom.xml
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateMavenWithCustomDep/pom.xml
@@ -8,7 +8,7 @@
 
     <properties>
         <compiler-plugin.version>3.8.1-MOCK</compiler-plugin.version>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-mock-bom</quarkus.platform.artifact-id>

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-docker-aot/pom.xml
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-docker-aot/pom.xml
@@ -8,9 +8,9 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.5.4</surefire-plugin.version>
-    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.source>21</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.target>21</maven.compiler.target>
     <maven.main.skip>true</maven.main.skip>
     <maven.test.skip>true</maven.test.skip>
   </properties>

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-docker/pom.xml
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-docker/pom.xml
@@ -8,9 +8,9 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.5.4</surefire-plugin.version>
-    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.source>21</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.target>21</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-aot/pom.xml
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-aot/pom.xml
@@ -8,9 +8,9 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.5.4</surefire-plugin.version>
-    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.source>21</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.target>21</maven.compiler.target>
     <maven.main.skip>true</maven.main.skip>
     <maven.test.skip>true</maven.test.skip>
   </properties>

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-inherit/pom.xml
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-inherit/pom.xml
@@ -8,9 +8,9 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.5.4</surefire-plugin.version>
-    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.source>21</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.target>21</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib/pom.xml
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib/pom.xml
@@ -8,9 +8,9 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.5.4</surefire-plugin.version>
-    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.source>21</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.target>21</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-multiple-tags-docker/pom.xml
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-multiple-tags-docker/pom.xml
@@ -8,9 +8,9 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.5.4</surefire-plugin.version>
-    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.source>21</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.target>21</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-multiple-tags-jib/pom.xml
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-multiple-tags-jib/pom.xml
@@ -8,9 +8,9 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.5.4</surefire-plugin.version>
-    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.source>21</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.target>21</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-image-push/pom.xml
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-image-push/pom.xml
@@ -8,9 +8,9 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.5.4</surefire-plugin.version>
-    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.source>21</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.target>21</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-native-main/pom.xml
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-native-main/pom.xml
@@ -8,9 +8,9 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.5.4</surefire-plugin.version>
-    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.source>21</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.target>21</maven.compiler.target>
     <skipITs>false</skipITs>
   </properties>
   <dependencyManagement>

--- a/integration-tests/devtools/src/test/resources/__snapshots__/KotlinSerializationCodestartTest/testMavenContent/pom.xml
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/KotlinSerializationCodestartTest/testMavenContent/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <compiler-plugin.version>3.8.1-MOCK</compiler-plugin.version>
         <kotlin.version>1.4.28-MOCK</kotlin.version>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-mock-bom</quarkus.platform.artifact-id>
@@ -149,7 +149,7 @@
                 </dependencies>
                 <configuration>
                     <javaParameters>true</javaParameters>
-                    <jvmTarget>17</jvmTarget>
+                    <jvmTarget>21</jvmTarget>
                     <compilerPlugins>
                         <plugin>all-open</plugin>
                         <plugin>kotlinx-serialization</plugin>

--- a/integration-tests/devtools/src/test/resources/__snapshots__/KotlinSerializationCodestartTest/testMavenContent/pom.xml
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/KotlinSerializationCodestartTest/testMavenContent/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <compiler-plugin.version>3.8.1-MOCK</compiler-plugin.version>
         <kotlin.version>1.4.28-MOCK</kotlin.version>
-        <maven.compiler.release>21</maven.compiler.release>
+        <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-mock-bom</quarkus.platform.artifact-id>
@@ -149,7 +149,7 @@
                 </dependencies>
                 <configuration>
                     <javaParameters>true</javaParameters>
-                    <jvmTarget>21</jvmTarget>
+                    <jvmTarget>17</jvmTarget>
                     <compilerPlugins>
                         <plugin>all-open</plugin>
                         <plugin>kotlinx-serialization</plugin>

--- a/integration-tests/gradle/src/main/resources/add-extension-multi-module-kts/build.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/add-extension-multi-module-kts/build.gradle.kts
@@ -26,8 +26,8 @@ subprojects {
     apply(plugin = "java")
 
     java {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
 
     tasks {

--- a/integration-tests/gradle/src/main/resources/add-extension-multi-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/add-extension-multi-module/build.gradle
@@ -24,8 +24,8 @@ subprojects {
     apply plugin: 'java'
 
     java {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
 
     test {

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies-kotlin/build.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies-kotlin/build.gradle.kts
@@ -34,8 +34,8 @@ group = "org.acme"
 version = "1.0.0-SNAPSHOT"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 allOpen {
@@ -47,7 +47,7 @@ allOpen {
 
 kotlin {
     compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21
         javaParameters = true
     }
 }

--- a/integration-tests/gradle/src/main/resources/declared-deps-minimal/producer-maven/pom.xml
+++ b/integration-tests/gradle/src/main/resources/declared-deps-minimal/producer-maven/pom.xml
@@ -17,8 +17,8 @@
     </modules>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/integration-tests/gradle/src/main/resources/grpc-descriptor-set-alternate-output-dir/build.gradle
+++ b/integration-tests/gradle/src/main/resources/grpc-descriptor-set-alternate-output-dir/build.gradle
@@ -24,8 +24,8 @@ group = 'org.acme'
 version = '1.0.0-SNAPSHOT'
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 test {

--- a/integration-tests/gradle/src/main/resources/grpc-descriptor-set-alternate-output/build.gradle
+++ b/integration-tests/gradle/src/main/resources/grpc-descriptor-set-alternate-output/build.gradle
@@ -24,8 +24,8 @@ group = 'org.acme'
 version = '1.0.0-SNAPSHOT'
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 test {

--- a/integration-tests/gradle/src/main/resources/grpc-descriptor-set/build.gradle
+++ b/integration-tests/gradle/src/main/resources/grpc-descriptor-set/build.gradle
@@ -24,8 +24,8 @@ group = 'org.acme'
 version = '1.0.0-SNAPSHOT'
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 test {

--- a/integration-tests/gradle/src/main/resources/grpc-include-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/grpc-include-project/build.gradle
@@ -24,8 +24,8 @@ group = 'org.acme'
 version = '1.0.0-SNAPSHOT'
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 test {

--- a/integration-tests/gradle/src/main/resources/test-selection/build.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/test-selection/build.gradle.kts
@@ -29,8 +29,8 @@ group = "com.example"
 version = "1.0.0-SNAPSHOT"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 tasks.withType<JavaCompile> {

--- a/integration-tests/hibernate-orm-compatibility-5.6/database-generator/pom.xml
+++ b/integration-tests/hibernate-orm-compatibility-5.6/database-generator/pom.xml
@@ -8,7 +8,7 @@
     <version>1.0.0-SNAPSHOT</version>
     <properties>
         <compiler-plugin.version>3.10.1</compiler-plugin.version>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>

--- a/integration-tests/istio/maven-invoker-way/src/it/xds-grpc/pom.xml
+++ b/integration-tests/istio/maven-invoker-way/src/it/xds-grpc/pom.xml
@@ -8,9 +8,9 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.5.4</surefire-plugin.version>
-    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.source>21</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.target>21</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/integration-tests/kotlin-maven-invoker/src/test/resources/projects/classic-kotlin/pom.xml
+++ b/integration-tests/kotlin-maven-invoker/src/test/resources/projects/classic-kotlin/pom.xml
@@ -9,9 +9,9 @@
     <version>1.0-SNAPSHOT</version>
     <properties>
         <quarkus.version>@project.version@</quarkus.version>
-        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.source>21</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.target>21</maven.compiler.target>
         <kotlin.version>@kotlin.version@</kotlin.version>
     </properties>
     <dependencyManagement>

--- a/integration-tests/kotlin-maven-invoker/src/test/resources/projects/external-reloadable-artifacts/app/pom.xml
+++ b/integration-tests/kotlin-maven-invoker/src/test/resources/projects/external-reloadable-artifacts/app/pom.xml
@@ -9,9 +9,9 @@
 
     <properties>
         <quarkus.version>@project.version@</quarkus.version>
-        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.source>21</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.target>21</maven.compiler.target>
         <kotlin.version>@kotlin.version@</kotlin.version>
     </properties>
 

--- a/integration-tests/kotlin-maven-invoker/src/test/resources/projects/external-reloadable-artifacts/external-lib/pom.xml
+++ b/integration-tests/kotlin-maven-invoker/src/test/resources/projects/external-reloadable-artifacts/external-lib/pom.xml
@@ -8,9 +8,9 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.source>21</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.target>21</maven.compiler.target>
         <maven.jar.plugin.version>3.2.2</maven.jar.plugin.version>
         <kotlin.version>@kotlin.version@</kotlin.version>
     </properties>

--- a/integration-tests/kotlin-maven-invoker/src/test/resources/projects/kotlin-compiler-args/pom.xml
+++ b/integration-tests/kotlin-maven-invoker/src/test/resources/projects/kotlin-compiler-args/pom.xml
@@ -9,9 +9,9 @@
     <version>1.0-SNAPSHOT</version>
     <properties>
         <quarkus.version>@project.version@</quarkus.version>
-        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.source>21</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.target>21</maven.compiler.target>
         <kotlin.version>@kotlin.version@</kotlin.version>
     </properties>
     <dependencyManagement>

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/knative-jib-build-and-deploy/pom.xml
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/knative-jib-build-and-deploy/pom.xml
@@ -8,9 +8,9 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.5.4</surefire-plugin.version>
-    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.source>21</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.target>21</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-docker-build-and-deploy-deployment/pom.xml
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-docker-build-and-deploy-deployment/pom.xml
@@ -8,9 +8,9 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.5.4</surefire-plugin.version>
-    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.source>21</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.target>21</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-docker-build-and-deploy-statefulset/pom.xml
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-docker-build-and-deploy-statefulset/pom.xml
@@ -8,9 +8,9 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.5.4</surefire-plugin.version>
-    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.source>21</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.target>21</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-jib-build-and-deploy/pom.xml
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-jib-build-and-deploy/pom.xml
@@ -8,9 +8,9 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.5.4</surefire-plugin.version>
-    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.source>21</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.target>21</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-with-existing-selectorless-manifest/pom.xml
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-with-existing-selectorless-manifest/pom.xml
@@ -9,9 +9,9 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.5.4</surefire-plugin.version>
-    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.source>21</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.target>21</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-with-grpc-same-server/pom.xml
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-with-grpc-same-server/pom.xml
@@ -8,9 +8,9 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.5.4</surefire-plugin.version>
-    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.source>21</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.target>21</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-with-grpc/pom.xml
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-with-grpc/pom.xml
@@ -8,9 +8,9 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.5.4</surefire-plugin.version>
-    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.source>21</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.target>21</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/minikube-with-existing-manifest/pom.xml
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/minikube-with-existing-manifest/pom.xml
@@ -8,9 +8,9 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.5.4</surefire-plugin.version>
-    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.source>21</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.target>21</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/openshift-docker-build-and-deploy/pom.xml
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/openshift-docker-build-and-deploy/pom.xml
@@ -8,9 +8,9 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.5.4</surefire-plugin.version>
-    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.source>21</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.target>21</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/openshift-s2i-build-and-deploy/pom.xml
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/openshift-s2i-build-and-deploy/pom.xml
@@ -8,9 +8,9 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.5.4</surefire-plugin.version>
-    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.source>21</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.target>21</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/openshift-with-output-directory-build-and-deploy/pom.xml
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/openshift-with-output-directory-build-and-deploy/pom.xml
@@ -8,9 +8,9 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.5.4</surefire-plugin.version>
-    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.source>21</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.target>21</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithQuarkusAppNameTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithQuarkusAppNameTest.java
@@ -53,7 +53,7 @@ public class KubernetesWithQuarkusAppNameTest {
         List<HasMetadata> openshiftList = DeserializationUtil
                 .deserializeAsList(kubernetesDir.resolve("openshift.yml"));
         assertThat(openshiftList).allSatisfy(h -> {
-            assertThat(h.getMetadata().getName()).isIn("ofoo", "foo", "openjdk-17");
+            assertThat(h.getMetadata().getName()).isIn("ofoo", "foo", "openjdk-21");
             assertThat(h.getMetadata().getLabels()).contains(entry("app.kubernetes.io/name", "ofoo"),
                     entry("app.kubernetes.io/version", "1.0-openshift"));
         });

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithSpecifiedContainerNameTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithSpecifiedContainerNameTest.java
@@ -82,7 +82,7 @@ public class KubernetesWithSpecifiedContainerNameTest {
                 });
             });
 
-            assertThat(h.getMetadata().getName()).isIn("ofoo", "foo", "openjdk-17");
+            assertThat(h.getMetadata().getName()).isIn("ofoo", "foo", "openjdk-21");
             assertThat(h.getMetadata().getLabels()).contains(entry("app.kubernetes.io/name", "ofoo"));
         });
     }

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/CreateProjectMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/CreateProjectMojoIT.java
@@ -460,24 +460,6 @@ public class CreateProjectMojoIT extends QuarkusPlatformAwareMojoTestBase {
     }
 
     @Test
-    public void testProjectGenerationFromScratchWithJava17() throws MavenInvocationException, IOException {
-        testDir = initEmptyProject("projects/project-generation-with-java17");
-        assertThat(testDir).isDirectory();
-        invoker = initInvoker(testDir);
-
-        Properties properties = new Properties();
-        properties.put("javaVersion", "17");
-
-        InvocationResult result = setup(properties);
-        assertThat(result.getExitCode()).isZero();
-
-        testDir = new File(testDir, "code-with-quarkus");
-        assertThat(new File(testDir, "pom.xml")).isFile();
-        assertThat(FileUtils.readFileToString(new File(testDir, "pom.xml"), "UTF-8"))
-                .contains("maven.compiler.release>17<");
-    }
-
-    @Test
     public void testProjectGenerationFromScratchWithJava21() throws MavenInvocationException, IOException {
         testDir = initEmptyProject("projects/project-generation-with-java21");
         assertThat(testDir).isDirectory();
@@ -493,25 +475,6 @@ public class CreateProjectMojoIT extends QuarkusPlatformAwareMojoTestBase {
         assertThat(new File(testDir, "pom.xml")).isFile();
         assertThat(FileUtils.readFileToString(new File(testDir, "pom.xml"), "UTF-8"))
                 .contains("maven.compiler.release>21<");
-    }
-
-    @Test
-    public void testProjectGenerationFromScratchWithGradleJava17() throws MavenInvocationException, IOException {
-        testDir = initEmptyProject("projects/project-generation-with-gradle-java17");
-        assertThat(testDir).isDirectory();
-        invoker = initInvoker(testDir);
-
-        Properties properties = new Properties();
-        properties.put("javaVersion", "17");
-        properties.put("buildTool", "gradle");
-
-        InvocationResult result = setup(properties);
-        assertThat(result.getExitCode()).isZero();
-
-        testDir = new File(testDir, "code-with-quarkus");
-        assertThat(new File(testDir, "build.gradle")).isFile();
-        assertThat(FileUtils.readFileToString(new File(testDir, "build.gradle"), "UTF-8"))
-                .contains("sourceCompatibility = JavaVersion.VERSION_17");
     }
 
     @Test

--- a/integration-tests/maven/src/test/resources-filtered/expected/create-extension-pom-add-to-bom/add-to-bom/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/expected/create-extension-pom-add-to-bom/add-to-bom/pom.xml
@@ -17,8 +17,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <maven.compiler.parameters>true</maven.compiler.parameters>
     </properties>
 

--- a/integration-tests/maven/src/test/resources-filtered/expected/create-extension-pom-itest/itest/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/expected/create-extension-pom-itest/itest/pom.xml
@@ -17,8 +17,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <maven.compiler.parameters>true</maven.compiler.parameters>
     </properties>
 

--- a/integration-tests/maven/src/test/resources-filtered/expected/create-extension-pom-minimal/minimal-extension/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/expected/create-extension-pom-minimal/minimal-extension/pom.xml
@@ -17,8 +17,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <maven.compiler.parameters>true</maven.compiler.parameters>
     </properties>
 

--- a/integration-tests/maven/src/test/resources-filtered/expected/create-extension-pom-with-grand-parent/with-grand-parent/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/expected/create-extension-pom-with-grand-parent/with-grand-parent/pom.xml
@@ -18,8 +18,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <maven.compiler.parameters>true</maven.compiler.parameters>
     </properties>
 

--- a/integration-tests/maven/src/test/resources-filtered/expected/new-extension-current-directory-project/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/expected/new-extension-current-directory-project/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.release>21</maven.compiler.release>
         <quarkus.version>\${project.version}</quarkus.version>
         <compiler-plugin.version>\${compiler-plugin.version}</compiler-plugin.version>
     </properties>

--- a/integration-tests/maven/src/test/resources-filtered/expected/new-extension-project-with-jboss-parent/my-ext/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/expected/new-extension-project-with-jboss-parent/my-ext/pom.xml
@@ -19,8 +19,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <quarkus.version>\${project.version}</quarkus.version>
         <compiler-plugin.version>\${compiler-plugin.version}</compiler-plugin.version>

--- a/integration-tests/maven/src/test/resources-filtered/expected/new-extension-project/my-ext/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/expected/new-extension-project/my-ext/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.release>21</maven.compiler.release>
         <quarkus.version>\${project.version}</quarkus.version>
         <compiler-plugin.version>\${compiler-plugin.version}</compiler-plugin.version>
     </properties>

--- a/integration-tests/maven/src/test/resources-filtered/projects/codegen-config-factory/app/src/main/docker/Dockerfile.jvm
+++ b/integration-tests/maven/src/test/resources-filtered/projects/codegen-config-factory/app/src/main/docker/Dockerfile.jvm
@@ -75,7 +75,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/integration-tests/maven/src/test/resources-filtered/projects/codegen-config-factory/app/src/main/docker/Dockerfile.legacy-jar
+++ b/integration-tests/maven/src/test/resources-filtered/projects/codegen-config-factory/app/src/main/docker/Dockerfile.legacy-jar
@@ -75,7 +75,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.23
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/integration-tests/maven/src/test/resources-filtered/projects/custom-packaging-plugin/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/custom-packaging-plugin/pom.xml
@@ -40,7 +40,10 @@
       </plugin>
       <plugin>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.7.1</version>
+        <version>3.15.2</version>
+        <configuration>
+            <goalPrefix>acme</goalPrefix>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/integration-tests/maven/src/test/resources-filtered/projects/mockito-non-public-inner-class/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/mockito-non-public-inner-class/pom.xml
@@ -8,7 +8,7 @@
   <packaging>quarkus</packaging>
   <properties>
     <compiler-plugin.version>3.12.1</compiler-plugin.version>
-    <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>

--- a/integration-tests/maven/src/test/resources-filtered/projects/non-parent-aggregator/model/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/non-parent-aggregator/model/pom.xml
@@ -12,9 +12,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.release>21</maven.compiler.release>
         <maven.compiler.parameters>true</maven.compiler.parameters>
     </properties>
 

--- a/integration-tests/maven/src/test/resources-filtered/projects/non-parent-aggregator/service/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/non-parent-aggregator/service/pom.xml
@@ -12,10 +12,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-        <maven.compiler.release>17</maven.compiler.release>
-        <maven.compiler.parameters>17</maven.compiler.parameters>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.release>21</maven.compiler.release>
+        <maven.compiler.parameters>true</maven.compiler.parameters>
     </properties>
 
     <dependencyManagement>

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-selection/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-selection/pom.xml
@@ -13,9 +13,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.release>21</maven.compiler.release>
         <maven.compiler.parameters>true</maven.compiler.parameters>
     </properties>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -443,7 +443,6 @@
                 <module>management-interface</module>
                 <module>management-interface-auth</module>
                 <module>mtls-certificates</module>
-                <!-- Virtual threads test -->
                 <module>virtual-threads</module>
                 <module>mutiny-native-jctools</module>
             </modules>

--- a/integration-tests/scala/src/test/resources/projects/classic-scala/pom.xml
+++ b/integration-tests/scala/src/test/resources/projects/classic-scala/pom.xml
@@ -8,9 +8,9 @@
     <version>1.0-SNAPSHOT</version>
     <properties>
         <quarkus.version>@project.version@</quarkus.version>
-        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.source>21</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.target>21</maven.compiler.target>
         <scala.version>@scala.version@</scala.version>
         <scala-maven-plugin.version>@scala-maven-plugin.version@</scala-maven-plugin.version>
         <surefire-plugin.version>@version.surefire.plugin@</surefire-plugin.version>

--- a/integration-tests/scala/src/test/resources/projects/external-reloadable-artifacts/app/pom.xml
+++ b/integration-tests/scala/src/test/resources/projects/external-reloadable-artifacts/app/pom.xml
@@ -10,9 +10,9 @@
 
     <properties>
         <quarkus.version>@project.version@</quarkus.version>
-        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.source>21</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.target>21</maven.compiler.target>
         <scala.version>@scala.version@</scala.version>
         <scala-maven-plugin.version>@scala-maven-plugin.version@</scala-maven-plugin.version>
         <surefire-plugin.version>@version.surefire.plugin@</surefire-plugin.version>

--- a/integration-tests/scala/src/test/resources/projects/external-reloadable-artifacts/external-lib/pom.xml
+++ b/integration-tests/scala/src/test/resources/projects/external-reloadable-artifacts/external-lib/pom.xml
@@ -10,9 +10,9 @@
 
     <properties>
         <quarkus.version>@project.version@</quarkus.version>
-        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.source>21</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.target>21</maven.compiler.target>
         <scala.version>@scala.version@</scala.version>
         <scala-maven-plugin.version>@scala-maven-plugin.version@</scala-maven-plugin.version>
         <maven.jar.plugin.version>3.2.2</maven.jar.plugin.version>

--- a/integration-tests/test-extension/tests/src/test/resources-filtered/projects/avro-multimodule-project/pom.xml
+++ b/integration-tests/test-extension/tests/src/test/resources-filtered/projects/avro-multimodule-project/pom.xml
@@ -12,7 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.release>21</maven.compiler.release>
 
         <version.maven-compiler-plugin>${compiler-plugin.version}</version.maven-compiler-plugin>
         <version.maven-surefire-plugin>3.5.4</version.maven-surefire-plugin>

--- a/integration-tests/test-extension/tests/src/test/resources-filtered/projects/project-using-test-callback-from-extension/pom.xml
+++ b/integration-tests/test-extension/tests/src/test/resources-filtered/projects/project-using-test-callback-from-extension/pom.xml
@@ -9,7 +9,7 @@
     <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
     <failsafe.useModulePath>false</failsafe.useModulePath>
     <quarkus.bom.artifact-id>quarkus-bom</quarkus.bom.artifact-id>
-    <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.5.4</surefire-plugin.version>

--- a/integration-tests/test-extension/tests/src/test/resources-filtered/projects/project-using-test-parameter-injection/pom.xml
+++ b/integration-tests/test-extension/tests/src/test/resources-filtered/projects/project-using-test-parameter-injection/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
     <failsafe.useModulePath>false</failsafe.useModulePath>
-    <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.bom.artifact-id>quarkus-bom</quarkus.bom.artifact-id>

--- a/integration-tests/test-extension/tests/src/test/resources-filtered/projects/project-using-test-template-from-extension-with-bytecode-changes/pom.xml
+++ b/integration-tests/test-extension/tests/src/test/resources-filtered/projects/project-using-test-template-from-extension-with-bytecode-changes/pom.xml
@@ -9,7 +9,7 @@
     <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
     <failsafe.useModulePath>false</failsafe.useModulePath>
     <quarkus.bom.artifact-id>quarkus-bom</quarkus.bom.artifact-id>
-    <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.5.4</surefire-plugin.version>

--- a/integration-tests/test-extension/tests/src/test/resources-filtered/projects/project-using-test-template-from-extension/pom.xml
+++ b/integration-tests/test-extension/tests/src/test/resources-filtered/projects/project-using-test-template-from-extension/pom.xml
@@ -9,7 +9,7 @@
     <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
     <failsafe.useModulePath>false</failsafe.useModulePath>
     <quarkus.bom.artifact-id>quarkus-bom</quarkus.bom.artifact-id>
-    <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.5.4</surefire-plugin.version>

--- a/integration-tests/virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/pom.xml
@@ -213,17 +213,6 @@
             </properties>
         </profile>
         <profile>
-            <id>run-virtual-thread-tests</id>
-            <activation>
-                <jdk>[20,)</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>20</maven.compiler.release>
-                <impsort.skip>true</impsort.skip> <!-- impsort does not handle java 20 -->
-            </properties>
-        </profile>
-
-        <profile>
             <id>native</id>
             <activation>
                 <property>

--- a/integration-tests/virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/pom.xml
@@ -202,9 +202,11 @@
 
     <profiles>
         <profile>
-            <id>skip-test-on-jdk-17</id>
+            <id>skip-test-on-windows</id>
             <activation>
-                <jdk>[, 20)</jdk>
+                <os>
+                    <family>Windows</family>
+                </os>
             </activation>
             <properties>
                 <skipTests>true</skipTests>


### PR DESCRIPTION
This PR switches Quarkus 4.0 to Java 2q as base:

- Reworked CI to use 21 as base (so drop Java 17 builds)
- Cleanup images and constants that were used for Java 17
- Simplify profiles that were enabled for 21 
- Update tests specific to Java 17

Fix https://github.com/quarkusio/quarkus/issues/51951