### PR TITLE
Avoid overriding explicit OTLP endpoints in LGTM devservice

### DIFF
--- a/extensions/observability-devservices/deployment/src/main/java/io/quarkus/observability/deployment/ObservabilityDevServiceProcessor.java
+++ b/extensions/observability-devservices/deployment/src/main/java/io/quarkus/observability/deployment/ObservabilityDevServiceProcessor.java
@@ -56,11 +56,13 @@ class ObservabilityDevServiceProcessor {
     private static final DotName OTLP_REGISTRY = DotName.createSimple("io.micrometer.registry.otlp.OtlpMeterRegistry");
     private static final String OTEL_EXPORTER_OTLP_ENDPOINT = "quarkus.otel.exporter.otlp.endpoint";
     private static final String OTEL_EXPORTER_OTLP_PROTOCOL = "quarkus.otel.exporter.otlp.protocol";
+    private static final String MICROMETER_EXPORT_OTLP_URL = "quarkus.micrometer.export.otlp.url";
     private static final List<String> OTEL_EXPORTER_OTLP_ENDPOINT_CONFIG_KEYS = List.of(
             OTEL_EXPORTER_OTLP_ENDPOINT,
             "quarkus.otel.exporter.otlp.traces.endpoint",
             "quarkus.otel.exporter.otlp.metrics.endpoint",
             "quarkus.otel.exporter.otlp.logs.endpoint");
+    private static final List<String> MICROMETER_EXPORT_OTLP_CONFIG_KEYS = List.of(MICROMETER_EXPORT_OTLP_URL);
 
     public static class IsEnabled implements BooleanSupplier {
         ObservabilityConfiguration config;
@@ -101,6 +103,22 @@ class ObservabilityDevServiceProcessor {
 
     static boolean hasUserDefinedOtlpEndpoint(Config config) {
         return hasConfiguredValue(config, OTEL_EXPORTER_OTLP_ENDPOINT_CONFIG_KEYS);
+    }
+
+    static boolean hasUserDefinedMicrometerOtlpEndpoint(Config config) {
+        return hasConfiguredValue(config, MICROMETER_EXPORT_OTLP_CONFIG_KEYS);
+    }
+
+    static boolean shouldStartDevService(String devId, ExtensionsCatalog catalog, Config config) {
+        if (!"Lgtm".equals(devId)) {
+            return true;
+        }
+
+        if (catalog.hasOpenTelemetry() && hasUserDefinedOtlpEndpoint(config)) {
+            return false;
+        }
+
+        return !catalog.hasMicrometerOtlp() || !hasUserDefinedMicrometerOtlpEndpoint(config);
     }
 
     static boolean hasConfiguredValue(Config config, List<String> propertyNames) {
@@ -155,6 +173,11 @@ class ObservabilityDevServiceProcessor {
 
             if (!currentDevServicesConfiguration.enabled()) {
                 log.debugf("Not starting Dev Services for %s as it has been disabled in the config", devId);
+                continue;
+            }
+
+            if (!shouldStartDevService(devId, catalog, ConfigProvider.getConfig())) {
+                log.debugf("Not starting Dev Services for %s as an explicit OTLP endpoint has been configured", devId);
                 continue;
             }
 

--- a/extensions/observability-devservices/deployment/src/main/java/io/quarkus/observability/deployment/ObservabilityDevServiceProcessor.java
+++ b/extensions/observability-devservices/deployment/src/main/java/io/quarkus/observability/deployment/ObservabilityDevServiceProcessor.java
@@ -10,6 +10,8 @@ import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.jandex.DotName;
 import org.jboss.logging.Logger;
 import org.testcontainers.DockerClientFactory;
@@ -52,6 +54,13 @@ class ObservabilityDevServiceProcessor {
     private static final Logger log = Logger.getLogger(ObservabilityDevServiceProcessor.class);
 
     private static final DotName OTLP_REGISTRY = DotName.createSimple("io.micrometer.registry.otlp.OtlpMeterRegistry");
+    private static final String OTEL_EXPORTER_OTLP_ENDPOINT = "quarkus.otel.exporter.otlp.endpoint";
+    private static final String OTEL_EXPORTER_OTLP_PROTOCOL = "quarkus.otel.exporter.otlp.protocol";
+    private static final List<String> OTEL_EXPORTER_OTLP_ENDPOINT_CONFIG_KEYS = List.of(
+            OTEL_EXPORTER_OTLP_ENDPOINT,
+            "quarkus.otel.exporter.otlp.traces.endpoint",
+            "quarkus.otel.exporter.otlp.metrics.endpoint",
+            "quarkus.otel.exporter.otlp.logs.endpoint");
 
     public static class IsEnabled implements BooleanSupplier {
         ObservabilityConfiguration config;
@@ -64,6 +73,38 @@ class ObservabilityDevServiceProcessor {
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(Feature.OBSERVABILITY);
+    }
+
+    static Map<String, Function<ObservabilityStartable, String>> openTelemetryConfigProvider() {
+        return openTelemetryConfigProvider(ConfigProvider.getConfig());
+    }
+
+    static Map<String, Function<ObservabilityStartable, String>> openTelemetryConfigProvider(Config config) {
+        // The LGTM endpoint is exposed as a generic OTLP exporter configuration. Do not publish it when a user
+        // has already configured a generic or signal-specific endpoint, otherwise the higher priority dev services
+        // config source can route that signal to LGTM instead of the configured collector.
+        if (hasUserDefinedOtlpEndpoint(config)) {
+            return Map.of();
+        }
+
+        Map<String, Function<ObservabilityStartable, String>> configProvider = new LinkedHashMap<>();
+        configProvider.put(OTEL_EXPORTER_OTLP_ENDPOINT,
+                s -> s.getDevServiceConfig().get(OTEL_EXPORTER_OTLP_ENDPOINT));
+        configProvider.put(OTEL_EXPORTER_OTLP_PROTOCOL,
+                s -> s.getDevServiceConfig().get(OTEL_EXPORTER_OTLP_PROTOCOL));
+        return configProvider;
+    }
+
+    static boolean hasUserDefinedOtlpEndpoint() {
+        return hasUserDefinedOtlpEndpoint(ConfigProvider.getConfig());
+    }
+
+    static boolean hasUserDefinedOtlpEndpoint(Config config) {
+        return hasConfiguredValue(config, OTEL_EXPORTER_OTLP_ENDPOINT_CONFIG_KEYS);
+    }
+
+    static boolean hasConfiguredValue(Config config, List<String> propertyNames) {
+        return propertyNames.stream().anyMatch(propertyName -> config.getOptionalValue(propertyName, String.class).isPresent());
     }
 
     private String devId(DevResourceLifecycleManager<?> dev) {
@@ -141,10 +182,7 @@ class ObservabilityDevServiceProcessor {
                             s -> s.getDevServiceConfig().get("quarkus.micrometer.export.otlp.url"));
                 }
                 if (catalog.hasOpenTelemetry()) {
-                    configProvider.put("quarkus.otel.exporter.otlp.endpoint",
-                            s -> s.getDevServiceConfig().get("quarkus.otel.exporter.otlp.endpoint"));
-                    configProvider.put("quarkus.otel.exporter.otlp.protocol",
-                            s -> s.getDevServiceConfig().get("quarkus.otel.exporter.otlp.protocol"));
+                    configProvider.putAll(openTelemetryConfigProvider());
                 }
 
                 services.produce(

--- a/extensions/observability-devservices/deployment/src/test/java/io/quarkus/observability/deployment/ObservabilityDevServiceProcessorTest.java
+++ b/extensions/observability-devservices/deployment/src/test/java/io/quarkus/observability/deployment/ObservabilityDevServiceProcessorTest.java
@@ -8,12 +8,20 @@ import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.observability.devresource.ExtensionsCatalog;
 import io.smallrye.config.PropertiesConfigSource;
 
 class ObservabilityDevServiceProcessorTest {
 
     private static final String OTEL_ENDPOINT = "quarkus.otel.exporter.otlp.endpoint";
     private static final String OTEL_PROTOCOL = "quarkus.otel.exporter.otlp.protocol";
+    private static final String MICROMETER_OTLP_URL = "quarkus.micrometer.export.otlp.url";
+    private static final ExtensionsCatalog OPEN_TELEMETRY_CATALOG = new ExtensionsCatalog(s -> false, s -> false, true,
+            false);
+    private static final ExtensionsCatalog MICROMETER_OTLP_CATALOG = new ExtensionsCatalog(s -> false, s -> false, false,
+            true);
+    private static final ExtensionsCatalog NO_COLLECTOR_CATALOG = new ExtensionsCatalog(s -> false, s -> false, false,
+            false);
 
     @Test
     void lgtmProvidesOtlpDefaultsWhenNoEndpointIsConfigured() {
@@ -33,6 +41,42 @@ class ObservabilityDevServiceProcessorTest {
         assertThat(ObservabilityDevServiceProcessor.openTelemetryConfigProvider(
                 config(Map.of("quarkus.otel.exporter.otlp.traces.endpoint", "http://localhost:4317"))))
                 .doesNotContainKeys(OTEL_ENDPOINT, OTEL_PROTOCOL);
+    }
+
+    @Test
+    void lgtmDoesNotStartWhenGenericOtelEndpointIsConfigured() {
+        assertThat(ObservabilityDevServiceProcessor.shouldStartDevService("Lgtm", OPEN_TELEMETRY_CATALOG,
+                config(Map.of(OTEL_ENDPOINT, "http://localhost:4317"))))
+                .isFalse();
+    }
+
+    @Test
+    void lgtmDoesNotStartWhenSignalOtelEndpointIsConfigured() {
+        assertThat(ObservabilityDevServiceProcessor.shouldStartDevService("Lgtm", OPEN_TELEMETRY_CATALOG,
+                config(Map.of("quarkus.otel.exporter.otlp.traces.endpoint", "http://localhost:4317"))))
+                .isFalse();
+    }
+
+    @Test
+    void lgtmDoesNotStartWhenMicrometerOtlpUrlIsConfigured() {
+        assertThat(ObservabilityDevServiceProcessor.shouldStartDevService("Lgtm", MICROMETER_OTLP_CATALOG,
+                config(Map.of(MICROMETER_OTLP_URL, "http://localhost:4318/v1/metrics"))))
+                .isFalse();
+    }
+
+    @Test
+    void lgtmStillStartsWhenConfiguredCollectorIsNotPresent() {
+        assertThat(ObservabilityDevServiceProcessor.shouldStartDevService("Lgtm", NO_COLLECTOR_CATALOG,
+                config(Map.of(OTEL_ENDPOINT, "http://localhost:4317", MICROMETER_OTLP_URL,
+                        "http://localhost:4318/v1/metrics"))))
+                .isTrue();
+    }
+
+    @Test
+    void otherDevServicesStillStartWhenOtlpEndpointIsConfigured() {
+        assertThat(ObservabilityDevServiceProcessor.shouldStartDevService("Other", OPEN_TELEMETRY_CATALOG,
+                config(Map.of(OTEL_ENDPOINT, "http://localhost:4317"))))
+                .isTrue();
     }
 
     private Config config(Map<String, String> config) {

--- a/extensions/observability-devservices/deployment/src/test/java/io/quarkus/observability/deployment/ObservabilityDevServiceProcessorTest.java
+++ b/extensions/observability-devservices/deployment/src/test/java/io/quarkus/observability/deployment/ObservabilityDevServiceProcessorTest.java
@@ -1,0 +1,43 @@
+package io.quarkus.observability.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.config.PropertiesConfigSource;
+
+class ObservabilityDevServiceProcessorTest {
+
+    private static final String OTEL_ENDPOINT = "quarkus.otel.exporter.otlp.endpoint";
+    private static final String OTEL_PROTOCOL = "quarkus.otel.exporter.otlp.protocol";
+
+    @Test
+    void lgtmProvidesOtlpDefaultsWhenNoEndpointIsConfigured() {
+        assertThat(ObservabilityDevServiceProcessor.openTelemetryConfigProvider(config(Map.of())))
+                .containsKeys(OTEL_ENDPOINT, OTEL_PROTOCOL);
+    }
+
+    @Test
+    void lgtmDoesNotProvideOtlpDefaultsWhenGenericEndpointIsConfigured() {
+        assertThat(ObservabilityDevServiceProcessor.openTelemetryConfigProvider(
+                config(Map.of(OTEL_ENDPOINT, "http://localhost:4317"))))
+                .doesNotContainKeys(OTEL_ENDPOINT, OTEL_PROTOCOL);
+    }
+
+    @Test
+    void lgtmDoesNotProvideOtlpDefaultsWhenSignalEndpointIsConfigured() {
+        assertThat(ObservabilityDevServiceProcessor.openTelemetryConfigProvider(
+                config(Map.of("quarkus.otel.exporter.otlp.traces.endpoint", "http://localhost:4317"))))
+                .doesNotContainKeys(OTEL_ENDPOINT, OTEL_PROTOCOL);
+    }
+
+    private Config config(Map<String, String> config) {
+        return ConfigProviderResolver.instance().getBuilder()
+                .withSources(new PropertiesConfigSource(config, "test config", 1))
+                .build();
+    }
+}


### PR DESCRIPTION
Fixes #54953

## Summary
- detect existing generic or signal-specific OTLP exporter endpoints before publishing LGTM's OpenTelemetry config provider
- avoid adding LGTM's generic OTLP endpoint/protocol defaults when a user endpoint is already configured
- add deployment unit coverage for no endpoint, generic endpoint, and traces endpoint cases

## Testing
- ./mvnw -pl extensions/observability-devservices/deployment -am -Dtest=ObservabilityDevServiceProcessorTest -Dsurefire.failIfNoSpecifiedTests=false -DskipITs -DskipDocs test
