### PR TITLE
Fix managed repository flush for Jakarta Data repositories

### DIFF
--- a/extensions/data/hibernate/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/FirstTest.java
+++ b/extensions/data/hibernate/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/FirstTest.java
@@ -31,6 +31,19 @@ public class FirstTest {
     }
 
     @Transactional
+    void flushManagedBlockingRepository() {
+        Assertions.assertEquals(0, MyEntity_.managedBlocking().count());
+
+        MyEntity.ManagedBlockingQueries repository = MyEntity_.managedBlockingQueries();
+        MyEntity entity = new MyEntity();
+        entity.foo = "flush";
+        repository.persist(entity);
+
+        Assertions.assertDoesNotThrow(repository::flush);
+        Assertions.assertEquals(1, repository.count());
+    }
+
+    @Transactional
     void modifyOne() {
         Assertions.assertEquals(1, MyEntity_.managedBlocking().count());
 
@@ -151,6 +164,8 @@ public class FirstTest {
 
     @Test
     void testRepositories() {
+        clear();
+        flushManagedBlockingRepository();
         clear();
         createOne();
         modifyOne();

--- a/extensions/data/hibernate/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/ReactiveTest.java
+++ b/extensions/data/hibernate/deployment/src/test/java/io/quarkus/hibernate/panache/deployment/test/ReactiveTest.java
@@ -36,6 +36,22 @@ public class ReactiveTest {
     }
 
     @WithTransaction
+    Uni<Void> flushManagedReactiveRepository() {
+        return MyReactiveEntity_.managedReactive().count()
+                .flatMap(count -> {
+                    Assertions.assertEquals(0l, count);
+                    MyReactiveEntity.ManagedReactiveQueries repository = MyReactiveEntity_.managedReactiveQueries();
+                    MyReactiveEntity entity = new MyReactiveEntity();
+                    entity.foo = "flush";
+                    return repository.persist(entity)
+                            .flatMap(v -> repository.flush())
+                            .flatMap(v -> repository.count());
+                })
+                .onItem().invoke(count -> Assertions.assertEquals(1l, count))
+                .replaceWithVoid();
+    }
+
+    @WithTransaction
     Uni<Void> modifyOne() {
         return MyReactiveEntity_.managedReactive().listAll()
                 .onItem().invoke(list -> {
@@ -186,6 +202,8 @@ public class ReactiveTest {
     @RunOnVertxContext
     @Test
     void testRepositories(UniAsserter asserter) {
+        asserter.execute(() -> clear());
+        asserter.execute(() -> flushManagedReactiveRepository());
         asserter.execute(() -> clear());
         asserter.execute(() -> createOne());
         asserter.execute(() -> modifyOne());

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/hr/ManagedReactiveOperations.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/hr/ManagedReactiveOperations.java
@@ -72,10 +72,12 @@ public class ManagedReactiveOperations implements PanacheReactiveOperations {
 
     @Override
     public Uni<Void> flush(Object entity) {
-        if (entity instanceof Class<?> clazz) {
-            return DELEGATE.flush(clazz);
-        }
         return DELEGATE.flush(entity);
+    }
+
+    @Override
+    public Uni<Void> flush(Class<?> entityClass) {
+        return DELEGATE.flush(entityClass);
     }
 
     @Override

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/hr/ManagedReactiveOperations.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/hr/ManagedReactiveOperations.java
@@ -72,6 +72,9 @@ public class ManagedReactiveOperations implements PanacheReactiveOperations {
 
     @Override
     public Uni<Void> flush(Object entity) {
+        if (entity instanceof Class<?> clazz) {
+            return DELEGATE.flush(clazz);
+        }
         return DELEGATE.flush(entity);
     }
 

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/hr/StatelessReactiveOperations.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/hr/StatelessReactiveOperations.java
@@ -75,6 +75,11 @@ public class StatelessReactiveOperations implements PanacheReactiveOperations {
     }
 
     @Override
+    public Uni<Void> flush(Class<?> entityClass) {
+        throw new UnsupportedOperationException("Managed operations not supported");
+    }
+
+    @Override
     public Uni<Void> persist(Iterable<?> entities) {
         throw new UnsupportedOperationException("Managed operations not supported");
     }

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/orm/ManagedBlockingOperations.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/orm/ManagedBlockingOperations.java
@@ -75,11 +75,13 @@ public class ManagedBlockingOperations implements PanacheBlockingOperations {
 
     @Override
     public Void flush(Object entity) {
-        if (entity instanceof Class<?> clazz) {
-            DELEGATE.flush(clazz);
-        } else {
-            DELEGATE.flush(entity);
-        }
+        DELEGATE.flush(entity);
+        return null;
+    }
+
+    @Override
+    public Void flush(Class<?> entityClass) {
+        DELEGATE.flush(entityClass);
         return null;
     }
 

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/orm/ManagedBlockingOperations.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/orm/ManagedBlockingOperations.java
@@ -75,7 +75,11 @@ public class ManagedBlockingOperations implements PanacheBlockingOperations {
 
     @Override
     public Void flush(Object entity) {
-        DELEGATE.flush(entity);
+        if (entity instanceof Class<?> clazz) {
+            DELEGATE.flush(clazz);
+        } else {
+            DELEGATE.flush(entity);
+        }
         return null;
     }
 

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/orm/StatelessBlockingOperations.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/orm/StatelessBlockingOperations.java
@@ -79,6 +79,11 @@ public class StatelessBlockingOperations implements PanacheBlockingOperations {
     }
 
     @Override
+    public Void flush(Class<?> entityClass) {
+        throw new UnsupportedOperationException("Managed operations not supported");
+    }
+
+    @Override
     public Void persist(Iterable<?> entities) {
         throw new UnsupportedOperationException("Managed operations not supported");
     }

--- a/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/spi/PanacheOperations.java
+++ b/extensions/data/hibernate/runtime/src/main/java/io/quarkus/hibernate/panache/runtime/spi/PanacheOperations.java
@@ -47,6 +47,8 @@ public interface PanacheOperations<One, Many, Query, Count, Completion, Confirma
 
     Completion flush(Object entity);
 
+    Completion flush(Class<?> entityClass);
+
     Completion persist(Iterable<?> entities);
 
     Completion persist(Stream<?> entities);

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/AbstractManagedJpaOperations.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/AbstractManagedJpaOperations.java
@@ -87,6 +87,10 @@ public abstract class AbstractManagedJpaOperations<PanacheQueryType>
         return getSession(entity.getClass()).chain(Mutiny.Session::flush);
     }
 
+    public Uni<Void> flush(Class<?> clazz) {
+        return getSession(clazz).chain(Mutiny.Session::flush);
+    }
+
     @Override
     public Uni<Void> delete(Mutiny.Session session, Object entity) {
         return session.remove(entity);


### PR DESCRIPTION
Fixes #54965

This updates managed blocking/reactive flush handling so repository default `flush()` calls that pass an entity class flush the session for that entity class instead of treating the `Class` object as an entity instance.

Added coverage for generated Jakarta Data repository interfaces in both blocking and reactive tests.

Verification:
- `./mvnw -pl extensions/data/hibernate/deployment -am -DskipTests -DskipITs -DskipDocs -DskipExtensionValidation -Dtruststore.skip install`
- `./mvnw -pl extensions/data/hibernate/deployment -Dtest=io.quarkus.hibernate.panache.deployment.test.FirstTest#testRepositories -Dtest-containers -DskipTests=false -Dmaven.test.skip=false -DskipSurefireTests=false -DskipITs -DskipDocs -DskipExtensionValidation -Dtruststore.skip test`
- `./mvnw -pl extensions/data/hibernate/deployment -Dtest=io.quarkus.hibernate.panache.deployment.test.ReactiveTest#testRepositories -Dtest-containers -DskipTests=false -Dmaven.test.skip=false -DskipSurefireTests=false -DskipITs -DskipDocs -DskipExtensionValidation -Dtruststore.skip test`
- `git diff --check`
