### PR TITLE
Fix reactive Panache usage without Hibernate Reactive in Quarkus Data Hibernate

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -1617,6 +1617,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-hibernate-reactive-panache-session</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-hibernate-reactive-panache-common</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/docs/src/main/asciidoc/quarkus-data-hibernate.adoc
+++ b/docs/src/main/asciidoc/quarkus-data-hibernate.adoc
@@ -657,11 +657,6 @@ You want to start using your entities in a reactive application? Let's start by 
     <groupId>io.quarkus</groupId>
     <artifactId>quarkus-reactive-pg-client</artifactId>
 </dependency>
-<!-- FIXME: this will not be required in the future -->
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-hibernate-reactive-panache-common</artifactId>
-</dependency>
 ----
 
 [source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
@@ -671,8 +666,6 @@ You want to start using your entities in a reactive application? Let's start by 
 implementation("io.quarkus:quarkus-hibernate-reactive")
 // Pick your database reactive driver
 implementation("io.quarkus:quarkus-reactive-pg-client")
-// FIXME: this will not be required in the future
-implementation("io.quarkus:quarkus-hibernate-reactive-panache-common")
 ----
 
 TIP: You can use any of the xref:hibernate-reactive.adoc#hr-getting-started[supported reactive drivers].

--- a/extensions/data/hibernate/deployment/src/main/java/io/quarkus/data/hibernate/deployment/QuarkusDataHibernateProcessor.java
+++ b/extensions/data/hibernate/deployment/src/main/java/io/quarkus/data/hibernate/deployment/QuarkusDataHibernateProcessor.java
@@ -267,6 +267,23 @@ public final class QuarkusDataHibernateProcessor {
     }
 
     @BuildStep
+    ValidationPhaseBuildItem.ValidationErrorBuildItem validateReactivePanacheRequiresHibernateReactive(
+            CombinedIndexBuildItem index,
+            Capabilities capabilities) {
+        Set<String> offendingTypes = ReactivePanacheValidator.findOffendingReactivePanacheTypes(index.getIndex(),
+                capabilities);
+        if (offendingTypes.isEmpty()) {
+            return null;
+        }
+
+        BuildException be = new BuildException(
+                ReactivePanacheValidator.REACTIVE_PANACHE_REQUIRES_HIBERNATE_REACTIVE
+                        + " Found reactive Quarkus Data Hibernate type(s): " + String.join(", ", offendingTypes),
+                Collections.emptyList());
+        return new ValidationPhaseBuildItem.ValidationErrorBuildItem(be);
+    }
+
+    @BuildStep
     void registerPanacheRepositoryInterfacesForSecurityScanning(Capabilities capabilities,
             CombinedIndexBuildItem indexBuildItem,
             BuildProducer<SecuredTopLevelInterfaceBuildItem> interfaceBuildItemBuildProducer) {

--- a/extensions/data/hibernate/deployment/src/main/java/io/quarkus/data/hibernate/deployment/ReactivePanacheValidator.java
+++ b/extensions/data/hibernate/deployment/src/main/java/io/quarkus/data/hibernate/deployment/ReactivePanacheValidator.java
@@ -1,0 +1,114 @@
+package io.quarkus.data.hibernate.deployment;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import jakarta.persistence.Entity;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.Indexer;
+
+import io.quarkus.data.hibernate.ManagedEntity;
+import io.quarkus.data.hibernate.managed.blocking.BlockingManagedEntity;
+import io.quarkus.data.hibernate.managed.reactive.ReactiveManagedEntity;
+import io.quarkus.data.hibernate.managed.reactive.ReactiveManagedRepositoryBase;
+import io.quarkus.data.hibernate.stateless.reactive.ReactiveRecordEntity;
+import io.quarkus.data.hibernate.stateless.reactive.ReactiveRecordRepositoryBase;
+import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.Capability;
+
+final class ReactivePanacheValidator {
+
+    private static final DotName DOTNAME_ENTITY = DotName.createSimple(Entity.class.getName());
+
+    private static final DotName DOTNAME_PANACHE_MANAGED_REACTIVE_ENTITY = DotName
+            .createSimple(ReactiveManagedEntity.class.getName());
+    private static final DotName DOTNAME_PANACHE_STATELESS_REACTIVE_ENTITY = DotName
+            .createSimple(ReactiveRecordEntity.class.getName());
+    private static final DotName DOTNAME_PANACHE_MANAGED_REACTIVE_REPOSITORY_BASE = DotName
+            .createSimple(ReactiveManagedRepositoryBase.class.getName());
+    private static final DotName DOTNAME_PANACHE_STATELESS_REACTIVE_REPOSITORY_BASE = DotName
+            .createSimple(ReactiveRecordRepositoryBase.class.getName());
+
+    private static final String PANACHE_FRAMEWORK_PACKAGE = "io.quarkus.data.hibernate";
+
+    static final String REACTIVE_PANACHE_REQUIRES_HIBERNATE_REACTIVE = "Reactive Quarkus Data Hibernate types require the Hibernate Reactive extension. "
+            + "Add the 'quarkus-hibernate-reactive' extension and a reactive driver extension "
+            + "(for example 'quarkus-reactive-pg-client') to your project dependencies.";
+
+    private ReactivePanacheValidator() {
+    }
+
+    static Set<String> findOffendingReactivePanacheTypes(IndexView index, Capabilities capabilities) {
+        if (capabilities.isPresent(Capability.HIBERNATE_REACTIVE)) {
+            return Collections.emptySet();
+        }
+
+        Set<String> offendingTypes = new LinkedHashSet<>();
+
+        for (ClassInfo classInfo : index.getAllKnownImplementations(DOTNAME_PANACHE_MANAGED_REACTIVE_ENTITY)) {
+            if (isReactivePanacheFrameworkType(classInfo.name())) {
+                continue;
+            }
+            if (classInfo.declaredAnnotation(DOTNAME_ENTITY) != null) {
+                offendingTypes.add(classInfo.name().toString());
+            }
+        }
+
+        for (ClassInfo classInfo : index.getAllKnownImplementations(DOTNAME_PANACHE_STATELESS_REACTIVE_ENTITY)) {
+            if (isReactivePanacheFrameworkType(classInfo.name())) {
+                continue;
+            }
+            if (classInfo.declaredAnnotation(DOTNAME_ENTITY) != null) {
+                offendingTypes.add(classInfo.name().toString());
+            }
+        }
+
+        for (ClassInfo classInfo : index.getAllKnownSubinterfaces(DOTNAME_PANACHE_MANAGED_REACTIVE_REPOSITORY_BASE)) {
+            if (classInfo.isInterface() && isUserDefinedReactivePanacheType(classInfo)) {
+                offendingTypes.add(classInfo.name().toString());
+            }
+        }
+
+        for (ClassInfo classInfo : index.getAllKnownSubinterfaces(DOTNAME_PANACHE_STATELESS_REACTIVE_REPOSITORY_BASE)) {
+            if (classInfo.isInterface() && isUserDefinedReactivePanacheType(classInfo)) {
+                offendingTypes.add(classInfo.name().toString());
+            }
+        }
+
+        return offendingTypes;
+    }
+
+    static IndexView indexOf(Class<?>... classes) {
+        try {
+            Indexer indexer = new Indexer();
+            indexer.indexClass(BlockingManagedEntity.class);
+            indexer.indexClass(ReactiveManagedEntity.class);
+            indexer.indexClass(ReactiveRecordEntity.class);
+            indexer.indexClass(ReactiveManagedRepositoryBase.class);
+            indexer.indexClass(ReactiveRecordRepositoryBase.class);
+            indexer.indexClass(ManagedEntity.class);
+            indexer.indexClass(ManagedEntity.Reactive.class);
+            indexer.indexClass(Entity.class);
+            for (Class<?> clazz : classes) {
+                indexer.indexClass(clazz);
+            }
+            return indexer.complete();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static boolean isReactivePanacheFrameworkType(DotName name) {
+        return name.equals(DOTNAME_PANACHE_MANAGED_REACTIVE_ENTITY)
+                || name.equals(DOTNAME_PANACHE_STATELESS_REACTIVE_ENTITY);
+    }
+
+    private static boolean isUserDefinedReactivePanacheType(ClassInfo classInfo) {
+        return !classInfo.name().toString().startsWith(PANACHE_FRAMEWORK_PACKAGE);
+    }
+}

--- a/extensions/data/hibernate/runtime/pom.xml
+++ b/extensions/data/hibernate/runtime/pom.xml
@@ -22,6 +22,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-reactive-panache-session</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-reactive-panache-common</artifactId>
             <optional>true</optional>
         </dependency>

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/pom.xml
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/pom.xml
@@ -14,6 +14,10 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-reactive-panache-session</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core</artifactId>
         </dependency>
         <dependency>

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/AbstractJpaOperations.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/AbstractJpaOperations.java
@@ -367,8 +367,9 @@ public abstract class AbstractJpaOperations<PanacheQueryType, SessionType> {
     }
 
     public Uni<SessionType> getSession(String persistenceUnitName) {
-        return sessionType == Mutiny.Session.class ? (Uni<SessionType>) SessionOperations.getSession(persistenceUnitName)
-                : (Uni<SessionType>) SessionOperations.getStatelessSession(persistenceUnitName);
+        return sessionType == Mutiny.Session.class
+                ? (Uni<SessionType>) SessionOperationsDelegate.getSession(persistenceUnitName)
+                : (Uni<SessionType>) SessionOperationsDelegate.getStatelessSession(persistenceUnitName);
     }
 
     public static Mutiny.Query<?> bindParameters(Mutiny.Query<?> query, Object[] params) {

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/AbstractManagedJpaOperations.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/AbstractManagedJpaOperations.java
@@ -80,7 +80,7 @@ public abstract class AbstractManagedJpaOperations<PanacheQueryType>
 
     public Mutiny.Session getCurrentSession(Class<?> entityClass) {
         String persistenceUnitName = entityToPersistenceUnit.get(entityClass.getName());
-        return SessionOperations.getCurrentSession(persistenceUnitName);
+        return SessionOperationsDelegate.getCurrentSession(persistenceUnitName);
     }
 
     public Uni<Void> flush(Object entity) {

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/ReactiveTransactionalInterceptor.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/ReactiveTransactionalInterceptor.java
@@ -22,7 +22,7 @@ public class ReactiveTransactionalInterceptor {
     public Object intercept(InvocationContext context) throws Exception {
         // Note that intercepted methods annotated with @ReactiveTransactional are validated at build time
         // The build fails if the method does not return Uni
-        Context vertxContext = SessionOperations.vertxContext();
+        Context vertxContext = SessionOperationsDelegate.vertxContext();
         if (ContextLocals.get(vertxContext, TRANSACTIONAL_METHOD_KEY, null) != null) {
             return Uni.createFrom().failure(
                     new UnsupportedOperationException(
@@ -34,7 +34,7 @@ public class ReactiveTransactionalInterceptor {
         // Annotate current method so that we can validate mixing of @ReactiveTransactional with @Transactional
         ContextLocals.put(vertxContext, REACTIVE_TRANSACTIONAL_METHOD_KEY, true);
 
-        return SessionOperations.withTransaction(() -> proceedUni(context));
+        return SessionOperationsDelegate.withTransaction(() -> proceedUni(context));
     }
 
 }

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/SessionOperationsDelegate.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/SessionOperationsDelegate.java
@@ -29,9 +29,9 @@ import io.vertx.core.Vertx;
 /**
  * Static util methods for {@link Mutiny.Session}.
  */
-public final class SessionOperations {
+public final class SessionOperationsDelegate {
 
-    private static final Logger LOG = Logger.getLogger(SessionOperations.class);
+    private static final Logger LOG = Logger.getLogger(SessionOperationsDelegate.class);
 
     private static final String ERROR_MSG = "Hibernate Reactive Panache requires a safe (isolated) Vert.x sub-context, but the current context hasn't been flagged as such.";
 

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/TestReactiveTransactionalInterceptor.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/TestReactiveTransactionalInterceptor.java
@@ -66,7 +66,7 @@ public class TestReactiveTransactionalInterceptor {
             execute.invoke(uniAsserter, new Function<Uni<?>, Uni<?>>() {
                 @Override
                 public Uni<?> apply(Uni<?> t) {
-                    return SessionOperations.withTransaction(tx -> {
+                    return SessionOperationsDelegate.withTransaction(tx -> {
                         tx.markForRollback();
                         return t;
                     });

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/WithSessionInterceptor.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/WithSessionInterceptor.java
@@ -20,9 +20,9 @@ public class WithSessionInterceptor extends AbstractUniInterceptor {
             WithSession withSession = getAnnotation(context);
             String persistenceUnitName = withSession.value();
             if (withSession.stateless()) {
-                return SessionOperations.withStatelessSession(persistenceUnitName, s -> proceedUni(context));
+                return SessionOperationsDelegate.withStatelessSession(persistenceUnitName, s -> proceedUni(context));
             } else {
-                return SessionOperations.withSession(persistenceUnitName, s -> proceedUni(context));
+                return SessionOperationsDelegate.withSession(persistenceUnitName, s -> proceedUni(context));
             }
         }
         return context.proceed();

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/WithSessionOnDemandInterceptor.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/WithSessionOnDemandInterceptor.java
@@ -21,7 +21,7 @@ public class WithSessionOnDemandInterceptor {
         // However, a class-level binding implies that methods that do not return Uni are just a no-op
         if (reactiveInterceptorShouldRun()) {
 
-            return SessionOperations.withSessionOnDemand(() -> proceedUni(context));
+            return SessionOperationsDelegate.withSessionOnDemand(() -> proceedUni(context));
         }
         return context.proceed();
     }

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/WithTransactionInterceptor.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/WithTransactionInterceptor.java
@@ -23,7 +23,7 @@ public class WithTransactionInterceptor extends AbstractUniInterceptor {
         // Bindings are validated at build time - method-level binding declared on a method that does not return Uni results in a build failure
         // However, a class-level binding implies that methods that do not return Uni are just a no-op
         if (isUniReturnType(context)) {
-            Context vertxContext = SessionOperations.vertxContext();
+            Context vertxContext = SessionOperationsDelegate.vertxContext();
             if (ContextLocals.get(vertxContext, TRANSACTIONAL_METHOD_KEY, null) != null) {
                 return Uni.createFrom().failure(
                         new UnsupportedOperationException(
@@ -38,10 +38,10 @@ public class WithTransactionInterceptor extends AbstractUniInterceptor {
             WithTransaction withTransaction = getAnnotation(context);
             String persistenceUnitName = withTransaction.value();
             if (withTransaction.stateless()) {
-                return SessionOperations.withStatelessTransaction(persistenceUnitName, () -> proceedUni(context))
+                return SessionOperationsDelegate.withStatelessTransaction(persistenceUnitName, () -> proceedUni(context))
                         .eventually(() -> clearWithTransactionMethod(vertxContext));
             } else {
-                return SessionOperations.withTransaction(persistenceUnitName, () -> proceedUni(context))
+                return SessionOperationsDelegate.withTransaction(persistenceUnitName, () -> proceedUni(context))
                         .eventually(() -> clearWithTransactionMethod(vertxContext));
             }
         }

--- a/extensions/panache/hibernate-reactive-panache-session/pom.xml
+++ b/extensions/panache/hibernate-reactive-panache-session/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-panache-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-hibernate-reactive-panache-session-parent</artifactId>
+    <name>Quarkus - Hibernate Reactive with Panache - Session</name>
+    <packaging>pom</packaging>
+    <modules>
+        <module>runtime</module>
+    </modules>
+
+</project>

--- a/extensions/panache/hibernate-reactive-panache-session/runtime/pom.xml
+++ b/extensions/panache/hibernate-reactive-panache-session/runtime/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-hibernate-reactive-panache-session-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-hibernate-reactive-panache-session</artifactId>
+    <name>Quarkus - Hibernate Reactive with Panache - Session - Runtime</name>
+    <description>Session facade for Hibernate Reactive Panache processor generated code</description>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-mutiny</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.reactive</groupId>
+            <artifactId>hibernate-reactive-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.smallrye.reactive</groupId>
+                    <artifactId>mutiny</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+</project>

--- a/extensions/panache/hibernate-reactive-panache-session/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/SessionOperations.java
+++ b/extensions/panache/hibernate-reactive-panache-session/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/SessionOperations.java
@@ -1,0 +1,175 @@
+package io.quarkus.hibernate.reactive.panache.common.runtime;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.hibernate.reactive.mutiny.Mutiny.Transaction;
+
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Facade used by Hibernate Reactive Panache and by hibernate-processor generated metamodel code.
+ * <p>
+ * The actual implementation lives in {@code SessionOperationsDelegate}, which is only available when the
+ * Hibernate Reactive Panache common extension is on the classpath. This facade keeps processor-generated
+ * imports compiling even when Hibernate Reactive is not present; calls then fail with a clear message.
+ */
+public final class SessionOperations {
+
+    private static final String DELEGATE_CLASS_NAME = "io.quarkus.hibernate.reactive.panache.common.runtime.SessionOperationsDelegate";
+
+    private static final String MISSING_HIBERNATE_REACTIVE = "Reactive Quarkus Data Hibernate types require the Hibernate Reactive extension. "
+            + "Add the 'quarkus-hibernate-reactive' extension and a reactive driver extension "
+            + "(for example 'quarkus-reactive-pg-client') to your project dependencies.";
+
+    private SessionOperations() {
+    }
+
+    public static <T> Uni<T> withTransaction(Supplier<Uni<T>> work) {
+        return invokeDelegate("withTransaction", work);
+    }
+
+    public static <T> Uni<T> withTransaction(String persistenceUnitName, Supplier<Uni<T>> work) {
+        return invokeDelegate("withTransaction", persistenceUnitName, work);
+    }
+
+    public static <T> Uni<T> withTransaction(Function<Transaction, Uni<T>> work) {
+        return invokeDelegate("withTransaction", work);
+    }
+
+    public static <T> Uni<T> withStatelessTransaction(Supplier<Uni<T>> work) {
+        return invokeDelegate("withStatelessTransaction", work);
+    }
+
+    public static <T> Uni<T> withStatelessTransaction(String persistenceUnitName, Supplier<Uni<T>> work) {
+        return invokeDelegate("withStatelessTransaction", persistenceUnitName, work);
+    }
+
+    public static <T> Uni<T> withStatelessTransaction(Function<Transaction, Uni<T>> work) {
+        return invokeDelegate("withStatelessTransaction", work);
+    }
+
+    public static <T> Uni<T> withSession(String persistenceUnitName, Function<Mutiny.Session, Uni<T>> work) {
+        return invokeDelegate("withSession", persistenceUnitName, work);
+    }
+
+    public static <T> Uni<T> withSession(Function<Mutiny.Session, Uni<T>> work) {
+        return invokeDelegate("withSession", work);
+    }
+
+    public static <T> Uni<T> withStatelessSession(String persistenceUnitName, Function<Mutiny.StatelessSession, Uni<T>> work) {
+        return invokeDelegate("withStatelessSession", persistenceUnitName, work);
+    }
+
+    public static <T> Uni<T> withStatelessSession(Function<Mutiny.StatelessSession, Uni<T>> work) {
+        return invokeDelegate("withStatelessSession", work);
+    }
+
+    public static Uni<Mutiny.Session> getSession() {
+        return invokeDelegate("getSession");
+    }
+
+    public static Uni<Mutiny.Session> getSession(String persistenceUnitName) {
+        return invokeDelegate("getSession", persistenceUnitName);
+    }
+
+    public static Uni<Mutiny.StatelessSession> getStatelessSession() {
+        return invokeDelegate("getStatelessSession");
+    }
+
+    public static Uni<Mutiny.StatelessSession> getStatelessSession(String persistenceUnitName) {
+        return invokeDelegate("getStatelessSession", persistenceUnitName);
+    }
+
+    public static Mutiny.Session getCurrentSession(String persistenceUnitName) {
+        return invokeDelegate("getCurrentSession", persistenceUnitName);
+    }
+
+    public static Mutiny.StatelessSession getCurrentStatelessSession(String persistenceUnitName) {
+        return invokeDelegate("getCurrentStatelessSession", persistenceUnitName);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T invokeDelegate(String methodName, Object... args) {
+        try {
+            Class<?> delegateClass = Class.forName(DELEGATE_CLASS_NAME, true,
+                    Thread.currentThread().getContextClassLoader());
+            Class<?>[] parameterTypes = new Class<?>[args.length];
+            for (int i = 0; i < args.length; i++) {
+                parameterTypes[i] = args[i].getClass();
+                // unwrap lambdas - use declared interfaces
+                if (parameterTypes[i].getName().contains("$$Lambda")) {
+                    for (Class<?> iface : parameterTypes[i].getInterfaces()) {
+                        if (iface != java.io.Serializable.class) {
+                            parameterTypes[i] = iface;
+                            break;
+                        }
+                    }
+                }
+            }
+            Method method = delegateClass.getMethod(methodName, parameterTypes);
+            return (T) method.invoke(null, args);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException(MISSING_HIBERNATE_REACTIVE, e);
+        } catch (NoSuchMethodException e) {
+            try {
+                Class<?> delegateClass = Class.forName(DELEGATE_CLASS_NAME, true,
+                        Thread.currentThread().getContextClassLoader());
+                Method method = findMethod(delegateClass, methodName, args);
+                return (T) method.invoke(null, args);
+            } catch (ReflectiveOperationException ex) {
+                throw new IllegalStateException(MISSING_HIBERNATE_REACTIVE, ex);
+            }
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            if (cause instanceof Error error) {
+                throw error;
+            }
+            throw new IllegalStateException(cause);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(MISSING_HIBERNATE_REACTIVE, e);
+        }
+    }
+
+    private static Method findMethod(Class<?> delegateClass, String methodName, Object[] args)
+            throws NoSuchMethodException {
+        for (Method method : delegateClass.getMethods()) {
+            if (!method.getName().equals(methodName) || method.getParameterCount() != args.length) {
+                continue;
+            }
+            Class<?>[] parameterTypes = method.getParameterTypes();
+            boolean matches = true;
+            for (int i = 0; i < args.length; i++) {
+                if (!isCompatible(parameterTypes[i], args[i])) {
+                    matches = false;
+                    break;
+                }
+            }
+            if (matches) {
+                return method;
+            }
+        }
+        throw new NoSuchMethodException(methodName);
+    }
+
+    private static boolean isCompatible(Class<?> parameterType, Object arg) {
+        if (arg == null) {
+            return !parameterType.isPrimitive();
+        }
+        if (parameterType.isInstance(arg)) {
+            return true;
+        }
+        for (Class<?> iface : arg.getClass().getInterfaces()) {
+            if (parameterType.isAssignableFrom(iface)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/extensions/panache/pom.xml
+++ b/extensions/panache/pom.xml
@@ -21,6 +21,7 @@
         <module>hibernate-orm-panache</module>
         <module>hibernate-orm-panache-kotlin</module>
         <module>mongodb-panache-common</module>
+        <module>hibernate-reactive-panache-session</module>
         <module>hibernate-reactive-panache-common</module>
         <module>hibernate-reactive-panache</module>
         <module>hibernate-reactive-rest-data-panache</module>


### PR DESCRIPTION
Reactive Panache entities in Quarkus Data Hibernate caused a cryptic compile error when Hibernate Reactive was not on the classpath, because `hibernate-processor` generated code importing `SessionOperations` from an optional dependency.

This change adds a lightweight `SessionOperations` facade for processor-generated metamodel code, moves the real implementation to `SessionOperationsDelegate`, and fails the Quarkus build with a clear message when reactive Panache types are used without `quarkus-hibernate-reactive`.

Fixes #53139

