### PR TITLE
Fix gRPC server startup when using a custom proto directory

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/CodeGenProvider.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/CodeGenProvider.java
@@ -53,10 +53,13 @@ public interface CodeGenProvider {
     String inputDirectory();
 
     /**
-     * Provides the possibility for the provider to override the default input directory.
+     * Provides the possibility for the provider to override the default input directory for production sources.
      * This method is called after {@link #init(ApplicationModel, Map)}.
      * Returning {@code null} will result in the {@code inputDirectory} method being called to retrieve the default input
      * directory.
+     * <p>
+     * Custom input directories do not apply to test sources. Test code generation always uses the default location under
+     * the test sources root (for example {@code src/test/proto}).
      * <p>
      * The returned path must be an absolute path. However, pointing to a directory outside of the project structure should
      * be avoided for security purposes.

--- a/core/deployment/src/main/java/io/quarkus/deployment/CodeGenerator.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/CodeGenerator.java
@@ -69,7 +69,7 @@ public class CodeGenerator {
         Map<String, String> props = new HashMap<>();
         properties.entrySet().stream().forEach(e -> props.put((String) e.getKey(), (String) e.getValue()));
         final List<CodeGenData> generators = init(appModel, props, classLoader, sourceParentDirs, generatedSourcesDir, buildDir,
-                sourceRegistrar);
+                sourceRegistrar, test);
         if (generators.isEmpty()) {
             return;
         }
@@ -88,7 +88,8 @@ public class CodeGenerator {
             PathCollection sourceParentDirs,
             Path generatedSourcesDir,
             Path buildDir,
-            Consumer<Path> sourceRegistrar) throws CodeGenException {
+            Consumer<Path> sourceRegistrar,
+            boolean test) throws CodeGenException {
         return callWithClassloader(deploymentClassLoader, () -> {
             final List<CodeGenProvider> codeGenProviders = loadCodeGenProviders(deploymentClassLoader);
             if (codeGenProviders.isEmpty()) {
@@ -99,10 +100,7 @@ public class CodeGenerator {
                 provider.init(model, properties);
                 Path outputDir = codeGenOutDir(generatedSourcesDir, provider, sourceRegistrar);
                 for (Path sourceParentDir : sourceParentDirs) {
-                    Path in = provider.getInputDirectory();
-                    if (in == null) {
-                        in = sourceParentDir.resolve(provider.inputDirectory());
-                    }
+                    Path in = resolveInputDirectory(provider, sourceParentDir, test);
                     result.add(
                             new CodeGenData(provider, outputDir, in, buildDir));
                 }
@@ -134,10 +132,7 @@ public class CodeGenerator {
                             if (codeGens.isEmpty()) {
                                 codeGens = new ArrayList<>();
                             }
-                            Path in = provider.getInputDirectory();
-                            if (in == null) {
-                                in = sourceParentDir.resolve(provider.inputDirectory());
-                            }
+                            Path in = resolveInputDirectory(provider, sourceParentDir, isTestSourceParent(sourceParentDir));
                             codeGens.add(
                                     new CodeGenData(provider, outputDir, in,
                                             Path.of(module.getTargetDir())));
@@ -398,6 +393,24 @@ public class CodeGenerator {
         } catch (IOException e) {
             throw new CodeGenException("Failed to read " + dep.getResolvedPaths(), e);
         }
+    }
+
+    /**
+     * Resolves the input directory for a code generator.
+     * <p>
+     * A custom input directory configured by a {@link CodeGenProvider} applies to production sources only.
+     * Test sources always use the default location under the test sources root (for example {@code src/test/proto}).
+     */
+    private static Path resolveInputDirectory(CodeGenProvider provider, Path sourceParentDir, boolean test) {
+        Path customInput = provider.getInputDirectory();
+        if (customInput == null || test) {
+            return sourceParentDir.resolve(provider.inputDirectory());
+        }
+        return customInput;
+    }
+
+    private static boolean isTestSourceParent(Path sourceParentDir) {
+        return sourceParentDir != null && "test".equals(sourceParentDir.getFileName().toString());
     }
 
     private static Path codeGenOutDir(Path generatedSourcesDir,

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
@@ -27,6 +27,7 @@ import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.util.GradleVersion;
 import org.gradle.workers.WorkQueue;
@@ -41,6 +42,8 @@ public abstract class QuarkusGenerateCode extends QuarkusTaskWithExtensionView {
 
     public static final String QUARKUS_GENERATED_SOURCES = "quarkus-generated-sources";
     public static final String QUARKUS_TEST_GENERATED_SOURCES = "quarkus-test-generated-sources";
+
+    private static final String GRPC_PROTO_DIRECTORY = "quarkus.grpc.codegen.proto-directory";
 
     private Set<Path> sourcesDirectories;
     private FileCollection compileClasspath;
@@ -94,6 +97,16 @@ public abstract class QuarkusGenerateCode extends QuarkusTaskWithExtensionView {
             Path providerSrcDir = src.resolve(input);
             if (Files.exists(providerSrcDir)) {
                 inputDirectories.add(providerSrcDir.toFile());
+            }
+        }
+
+        if (SourceSet.MAIN_SOURCE_SET_NAME.equals(inputSourceSetName)) {
+            String customProtoDirectory = getExtensionView().getQuarkusBuildProperties().get().get(GRPC_PROTO_DIRECTORY);
+            if (customProtoDirectory != null && !customProtoDirectory.isBlank()) {
+                Path customProtoDirectoryPath = Path.of(customProtoDirectory);
+                if (Files.isDirectory(customProtoDirectoryPath)) {
+                    inputDirectories.add(customProtoDirectoryPath.toFile());
+                }
             }
         }
 

--- a/docs/src/main/asciidoc/grpc-generation-reference.adoc
+++ b/docs/src/main/asciidoc/grpc-generation-reference.adoc
@@ -67,6 +67,8 @@ With Maven, add the following configuration:
 </plugin>
 ----
 
+NOTE: The custom directory applies to production `\*.proto` files only. Test protos must still be placed in `src/test/proto`.
+
 With Gradle, use the following configuration:
 
 [source,gradle,subs=attributes+]
@@ -75,6 +77,8 @@ quarkus {
     quarkusBuildProperties.put("quarkus.grpc.codegen.proto-directory", "${project.projectDir}/ext/proto")
 }
 ----
+
+NOTE: The custom directory applies to production `\*.proto` files only. Test protos must still be placed in `src/test/proto`.
 
 == Generating Descriptor Set
 Protocol Buffers do not contain descriptions of their own types. Thus, given only a raw message without the corresponding .proto file defining its type, it is difficult to extract any useful data. However, the contents of a .proto file can itself be https://protobuf.dev/programming-guides/techniques/#self-description[represented using protocol buffers].

--- a/integration-tests/gradle/src/main/resources/grpc-custom-proto-directory/build.gradle
+++ b/integration-tests/gradle/src/main/resources/grpc-custom-proto-directory/build.gradle
@@ -1,0 +1,39 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+}
+
+repositories {
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+            includeGroup 'org.hibernate.orm'
+        }
+    }
+    mavenCentral()
+    gradlePluginPortal()
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-arc'
+    implementation 'io.quarkus:quarkus-grpc'
+
+    testImplementation 'io.quarkus:quarkus-junit'
+}
+
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}
+
+quarkus {
+    quarkusBuildProperties.put("quarkus.grpc.codegen.proto-directory", "${project.projectDir}/protocols/proto")
+}

--- a/integration-tests/gradle/src/main/resources/grpc-custom-proto-directory/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/grpc-custom-proto-directory/gradle.properties
@@ -1,0 +1,2 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus

--- a/integration-tests/gradle/src/main/resources/grpc-custom-proto-directory/protocols/proto/protocol/v1/game.proto
+++ b/integration-tests/gradle/src/main/resources/grpc-custom-proto-directory/protocols/proto/protocol/v1/game.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package protocol.v1;
+
+option java_multiple_files = true;
+option java_outer_classname = "GameProto";
+option java_package = "org.acme.protocol";
+
+message HelloRequest {}
+
+message HelloResponse {
+  string message = 1;
+}
+
+service GameService {
+  rpc Hello(HelloRequest) returns (HelloResponse);
+}

--- a/integration-tests/gradle/src/main/resources/grpc-custom-proto-directory/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/grpc-custom-proto-directory/settings.gradle
@@ -1,0 +1,16 @@
+pluginManagement {
+    repositories {
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+                includeGroup 'org.hibernate.orm'
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+        id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+rootProject.name = 'grpc-custom-proto-directory'

--- a/integration-tests/gradle/src/main/resources/grpc-custom-proto-directory/src/main/java/org/acme/GameServiceImpl.java
+++ b/integration-tests/gradle/src/main/resources/grpc-custom-proto-directory/src/main/java/org/acme/GameServiceImpl.java
@@ -1,0 +1,16 @@
+package org.acme;
+
+import io.quarkus.grpc.GrpcService;
+import io.smallrye.mutiny.Uni;
+import org.acme.protocol.GameService;
+import org.acme.protocol.HelloRequest;
+import org.acme.protocol.HelloResponse;
+
+@GrpcService
+public class GameServiceImpl implements GameService {
+
+    @Override
+    public Uni<HelloResponse> hello(HelloRequest request) {
+        return Uni.createFrom().item(HelloResponse.newBuilder().setMessage("Hello from gRPC service!").build());
+    }
+}

--- a/integration-tests/gradle/src/main/resources/grpc-custom-proto-directory/src/main/resources/application.properties
+++ b/integration-tests/gradle/src/main/resources/grpc-custom-proto-directory/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.grpc.server.use-separate-server=false

--- a/integration-tests/gradle/src/main/resources/grpc-custom-proto-directory/src/test/java/org/acme/GameServiceTest.java
+++ b/integration-tests/gradle/src/main/resources/grpc-custom-proto-directory/src/test/java/org/acme/GameServiceTest.java
@@ -1,0 +1,28 @@
+package org.acme;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.acme.protocol.GameService;
+import org.acme.protocol.HelloRequest;
+import org.acme.protocol.HelloResponse;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.grpc.GrpcClient;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class GameServiceTest {
+
+    @GrpcClient("game-service")
+    GameService gameService;
+
+    @Test
+    void testHello() {
+        HelloRequest request = HelloRequest.newBuilder().build();
+        HelloResponse response = gameService.hello(request).await().indefinitely();
+
+        assertNotNull(response);
+        assertEquals("Hello from gRPC service!", response.getMessage());
+    }
+}

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/GrpcCustomProtoDirectoryBuildTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/GrpcCustomProtoDirectoryBuildTest.java
@@ -1,0 +1,25 @@
+package io.quarkus.gradle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+public class GrpcCustomProtoDirectoryBuildTest extends QuarkusGradleWrapperTestBase {
+
+    @Test
+    public void testGrpcServerWithCustomProtoDirectory() throws Exception {
+        final File projectDir = getProjectDir("grpc-custom-proto-directory");
+
+        final BuildResult buildResult = runGradleWrapper(projectDir, "clean", "test");
+
+        assertThat(BuildResult.isSuccessful(buildResult.getTasks().get(":test"))).isTrue();
+        assertThat(buildResult.getOutput()).contains("grpc-server");
+
+        final Path testGeneratedBean = projectDir.toPath()
+                .resolve("build/classes/java/test/org/acme/protocol/GameServiceBean.class");
+        assertThat(testGeneratedBean).doesNotExist();
+    }
+}


### PR DESCRIPTION
When `quarkus.grpc.codegen.proto-directory` is configured, test code generation was also reading from that custom location instead of `src/test/proto`. That duplicated gRPC service classes on the test classpath and prevented the gRPC server from starting during `@QuarkusTest`, resulting in `UNIMPLEMENTED` / HTTP 404 responses.

This change limits custom proto directories to production code generation only and includes the custom directory in Gradle build cache inputs for `quarkusGenerateCode`.

Fixes #51788

