### PR TITLE
OIDC client: migrate from Gizmo 1 to Gizmo 2

### DIFF
--- a/extensions/oidc-client/deployment/src/main/java/io/quarkus/oidc/client/deployment/OidcClientBuildStep.java
+++ b/extensions/oidc-client/deployment/src/main/java/io/quarkus/oidc/client/deployment/OidcClientBuildStep.java
@@ -2,7 +2,6 @@ package io.quarkus.oidc.client.deployment;
 
 import static io.quarkus.oidc.client.deployment.OidcClientFilterDeploymentHelper.sanitize;
 
-import java.lang.reflect.Modifier;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -10,6 +9,7 @@ import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
 
 import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Singleton;
 
 import org.jboss.jandex.ClassType;
@@ -18,7 +18,7 @@ import org.jboss.jandex.DotName;
 import io.quarkus.arc.BeanDestroyer;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
-import io.quarkus.arc.deployment.GeneratedBeanGizmoAdaptor;
+import io.quarkus.arc.deployment.GeneratedBeanGizmo2Adaptor;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeansRuntimeInitBuildItem;
 import io.quarkus.arc.processor.DotNames;
@@ -36,11 +36,10 @@ import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigBuilderBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
-import io.quarkus.gizmo.ClassCreator;
-import io.quarkus.gizmo.ClassOutput;
-import io.quarkus.gizmo.MethodCreator;
-import io.quarkus.gizmo.MethodDescriptor;
-import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo2.Const;
+import io.quarkus.gizmo2.Gizmo;
+import io.quarkus.gizmo2.desc.ConstructorDesc;
+import io.quarkus.gizmo2.desc.MethodDesc;
 import io.quarkus.oidc.client.NamedOidcClient;
 import io.quarkus.oidc.client.OidcClient;
 import io.quarkus.oidc.client.OidcClients;
@@ -133,13 +132,13 @@ public class OidcClientBuildStep {
             BuildProducer<GeneratedBeanBuildItem> generatedBean,
             OidcClientNamesBuildItem oidcClientNames) {
 
-        ClassOutput classOutput = new GeneratedBeanGizmoAdaptor(generatedBean);
+        Gizmo gizmo = Gizmo.create(new GeneratedBeanGizmo2Adaptor(generatedBean));
 
         String targetPackage = DotNames
-                .internalPackageNameWithTrailingSlash(DotName.createSimple(TokensProducer.class.getName()));
+                .packagePrefix(DotName.createSimple(TokensProducer.class));
 
         for (String oidcClientName : oidcClientNames.oidcClientNames()) {
-            createNamedTokensProducerFor(classOutput, targetPackage, oidcClientName);
+            createNamedTokensProducerFor(gizmo, targetPackage, oidcClientName);
         }
     }
 
@@ -183,52 +182,57 @@ public class OidcClientBuildStep {
      * }
      * </pre>
      */
-    private String createNamedTokensProducerFor(ClassOutput classOutput, String targetPackage, String oidcClientName) {
-        String generatedName = targetPackage + "TokensProducer_" + sanitize(oidcClientName);
+    private String createNamedTokensProducerFor(Gizmo gizmo, String targetPackage, String oidcClientName) {
+        String generatedName = targetPackage + ".TokensProducer_" + sanitize(oidcClientName);
 
-        try (ClassCreator tokensProducer = ClassCreator.builder().classOutput(classOutput).className(generatedName)
-                .superClass(AbstractTokensProducer.class)
-                .build()) {
-            tokensProducer.addAnnotation(DotNames.SINGLETON.toString());
+        gizmo.class_(generatedName, cc -> {
+            cc.extends_(AbstractTokensProducer.class);
+            cc.addAnnotation(Singleton.class);
+            cc.defaultConstructor();
 
-            try (MethodCreator produceMethod = tokensProducer.getMethodCreator("produceTokens", Tokens.class)) {
-                produceMethod.setModifiers(Modifier.PUBLIC);
+            cc.method("produceTokens", mc -> {
+                mc.public_();
+                mc.returning(Tokens.class);
 
-                produceMethod.addAnnotation(DotNames.PRODUCES.toString());
-                produceMethod.addAnnotation(NamedOidcClient.class.getName()).addValue("value", oidcClientName);
-                produceMethod.addAnnotation(RequestScoped.class.getName());
+                mc.addAnnotation(Produces.class);
+                mc.addAnnotation(NamedOidcClient.class, ac -> ac.add("value", oidcClientName));
+                mc.addAnnotation(RequestScoped.class);
 
-                ResultHandle tokensResult = produceMethod.invokeVirtualMethod(
-                        MethodDescriptor.ofMethod(AbstractTokensProducer.class, "awaitTokens", Tokens.class),
-                        produceMethod.getThis());
+                mc.body(bc -> {
+                    bc.return_(bc.invokeVirtual(
+                            MethodDesc.of(AbstractTokensProducer.class, "awaitTokens", Tokens.class),
+                            cc.this_()));
+                });
+            });
 
-                produceMethod.returnValue(tokensResult);
-            }
+            cc.method("produceTokenProvider", mc -> {
+                mc.public_();
+                mc.returning(TokenProvider.class);
 
-            try (MethodCreator produceMethod = tokensProducer.getMethodCreator("produceTokenProvider", TokenProvider.class)) {
-                produceMethod.setModifiers(Modifier.PUBLIC);
+                mc.addAnnotation(Produces.class);
+                mc.addAnnotation(NamedOidcClient.class, ac -> ac.add("value", oidcClientName));
+                mc.addAnnotation(RequestScoped.class);
 
-                produceMethod.addAnnotation(DotNames.PRODUCES.toString());
-                produceMethod.addAnnotation(NamedOidcClient.class.getName()).addValue("value", oidcClientName);
-                produceMethod.addAnnotation(RequestScoped.class.getName());
+                mc.body(bc -> {
+                    bc.return_(bc.new_(
+                            ConstructorDesc.of(TokenProviderImpl.class, AbstractTokensProducer.class),
+                            cc.this_()));
+                });
+            });
 
-                ResultHandle newTokenProvider = produceMethod.newInstance(
-                        MethodDescriptor.ofConstructor(TokenProviderImpl.class, AbstractTokensProducer.class),
-                        produceMethod.getThis());
+            cc.method("clientId", mc -> {
+                mc.protected_();
+                mc.returning(Optional.class);
 
-                produceMethod.returnValue(newTokenProvider);
-            }
+                mc.body(bc -> {
+                    bc.return_(bc.invokeStatic(
+                            MethodDesc.of(Optional.class, "of", Optional.class, Object.class),
+                            Const.of(oidcClientName)));
+                });
+            });
+        });
 
-            try (MethodCreator clientIdMethod = tokensProducer.getMethodCreator("clientId", Optional.class)) {
-                clientIdMethod.setModifiers(Modifier.PROTECTED);
-
-                clientIdMethod.returnValue(clientIdMethod.invokeStaticMethod(
-                        MethodDescriptor.ofMethod(Optional.class, "of", Optional.class, Object.class),
-                        clientIdMethod.load(oidcClientName)));
-            }
-        }
-
-        return generatedName.replace('/', '.');
+        return generatedName;
     }
 
     public static class IsEnabled implements BooleanSupplier {

--- a/extensions/oidc-client/deployment/src/main/java/io/quarkus/oidc/client/deployment/OidcClientFilterDeploymentHelper.java
+++ b/extensions/oidc-client/deployment/src/main/java/io/quarkus/oidc/client/deployment/OidcClientFilterDeploymentHelper.java
@@ -1,7 +1,7 @@
 package io.quarkus.oidc.client.deployment;
 
 import java.lang.annotation.RetentionPolicy;
-import java.lang.reflect.Modifier;
+import java.lang.constant.ClassDesc;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -11,6 +11,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
+import jakarta.inject.Singleton;
+
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.AnnotationValue;
@@ -19,15 +21,15 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
 
+import io.quarkus.arc.Unremovable;
 import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
-import io.quarkus.arc.deployment.GeneratedBeanGizmoAdaptor;
+import io.quarkus.arc.deployment.GeneratedBeanGizmo2Adaptor;
 import io.quarkus.arc.processor.DotNames;
 import io.quarkus.deployment.annotations.BuildProducer;
-import io.quarkus.gizmo.ClassCreator;
-import io.quarkus.gizmo.ClassOutput;
-import io.quarkus.gizmo.MethodCreator;
-import io.quarkus.gizmo.MethodDescriptor;
-import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo2.Const;
+import io.quarkus.gizmo2.Gizmo;
+import io.quarkus.gizmo2.desc.ConstructorDesc;
+import io.quarkus.gizmo2.desc.MethodDesc;
 import io.quarkus.oidc.client.filter.OidcClientFilter;
 import io.quarkus.oidc.client.runtime.AbstractTokensProducer;
 import io.quarkus.oidc.client.runtime.MethodDescription;
@@ -41,7 +43,7 @@ public class OidcClientFilterDeploymentHelper<T extends AbstractTokensProducer> 
     private final Map<TokensProducerKey, String> clientNameToGeneratedClass = new HashMap<>();
     private final Map<String, Boolean> restClientToIsMethodAnnotated = new HashMap<>();
     private final Class<T> baseClass;
-    private final ClassOutput classOutput;
+    private final Gizmo gizmo;
     private final String targetPackage;
     private final boolean refreshOnUnauthorized;
 
@@ -51,9 +53,9 @@ public class OidcClientFilterDeploymentHelper<T extends AbstractTokensProducer> 
     public OidcClientFilterDeploymentHelper(Class<T> baseClass, BuildProducer<GeneratedBeanBuildItem> generatedBean,
             boolean refreshOnUnauthorized) {
         this.baseClass = baseClass;
-        this.classOutput = new GeneratedBeanGizmoAdaptor(generatedBean);
+        this.gizmo = Gizmo.create(new GeneratedBeanGizmo2Adaptor(generatedBean));
         this.targetPackage = DotNames
-                .internalPackageNameWithTrailingSlash(DotName.createSimple(baseClass.getName()));
+                .packagePrefix(DotName.createSimple(baseClass));
         this.refreshOnUnauthorized = refreshOnUnauthorized;
     }
 
@@ -84,33 +86,41 @@ public class OidcClientFilterDeploymentHelper<T extends AbstractTokensProducer> 
                 new Function<TokensProducerKey, String>() {
                     @Override
                     public String apply(TokensProducerKey key) {
-                        final String generatedName = targetPackage + baseClass.getSimpleName() + "_" + sanitize(oidcClientName)
+                        final String generatedName = targetPackage + "." + baseClass.getSimpleName() + "_"
+                                + sanitize(oidcClientName)
                                 + possiblyTargetMethodSuffix(targetMethod);
 
-                        try (ClassCreator creator = ClassCreator.builder().classOutput(classOutput).className(generatedName)
-                                .superClass(baseClass).build()) {
-                            creator.addAnnotation(DotNames.SINGLETON.toString());
-                            creator.addAnnotation(DotNames.UNREMOVABLE.toString());
+                        gizmo.class_(generatedName, cc -> {
+                            cc.extends_(baseClass);
+                            cc.addAnnotation(Singleton.class);
+                            cc.addAnnotation(Unremovable.class);
+                            cc.defaultConstructor();
 
                             if (!DEFAULT_OIDC_REQUEST_FILTER_NAME.equals(oidcClientName)) {
-                                try (MethodCreator clientIdMethod = creator.getMethodCreator("clientId", Optional.class)) {
-                                    clientIdMethod.setModifiers(Modifier.PROTECTED);
+                                cc.method("clientId", mc -> {
+                                    mc.protected_();
+                                    mc.returning(Optional.class);
 
-                                    clientIdMethod.returnValue(clientIdMethod.invokeStaticMethod(
-                                            MethodDescriptor.ofMethod(Optional.class, "of", Optional.class, Object.class),
-                                            clientIdMethod.load(oidcClientName)));
-                                }
+                                    mc.body(bc -> {
+                                        bc.return_(bc.invokeStatic(
+                                                MethodDesc.of(Optional.class, "of", Optional.class, Object.class),
+                                                Const.of(oidcClientName)));
+                                    });
+                                });
                             }
 
                             if (refreshOnUnauthorized) {
                                 // protected boolean refreshOnUnauthorized() {
                                 //  return true;
                                 // }
-                                try (MethodCreator methodCreator = creator.getMethodCreator("refreshOnUnauthorized",
-                                        boolean.class)) {
-                                    methodCreator.setModifiers(Modifier.PROTECTED);
-                                    methodCreator.returnBoolean(true);
-                                }
+                                cc.method("refreshOnUnauthorized", mc -> {
+                                    mc.protected_();
+                                    mc.returning(boolean.class);
+
+                                    mc.body(bc -> {
+                                        bc.return_(true);
+                                    });
+                                });
                             }
 
                             /*
@@ -119,34 +129,32 @@ public class OidcClientFilterDeploymentHelper<T extends AbstractTokensProducer> 
                              * }
                              */
                             if (targetMethod != null) {
-                                try (var methodCreator = creator.getMethodCreator("getMethodDescription",
-                                        MethodDescription.class)) {
-                                    methodCreator.addAnnotation(Override.class.getName(), RetentionPolicy.CLASS);
-                                    methodCreator.setModifiers(Modifier.PROTECTED);
+                                cc.method("getMethodDescription", mc -> {
+                                    mc.addAnnotation(ClassDesc.of(Override.class.getName()), RetentionPolicy.CLASS, ac -> {
+                                    });
+                                    mc.protected_();
+                                    mc.returning(MethodDescription.class);
 
-                                    // String methodName
-                                    var methodName = methodCreator.load(targetMethod.name());
-                                    // String declaringClassName
-                                    var declaringClassName = methodCreator
-                                            .load(targetMethod.declaringClass().name().toString());
-                                    // String[] paramTypes
-                                    var paramTypes = methodCreator.marshalAsArray(String[].class,
-                                            targetMethod.parameterTypes().stream()
-                                                    .map(pt -> pt.name().toString()).map(methodCreator::load)
-                                                    .toArray(ResultHandle[]::new));
-                                    // new MethodDescription(declaringClassName, methodName, parameterTypes)
-                                    var methodDescriptionCtor = MethodDescriptor.ofConstructor(MethodDescription.class,
-                                            String.class, String.class, String[].class);
-                                    var newMethodDescription = methodCreator.newInstance(methodDescriptionCtor,
-                                            declaringClassName,
-                                            methodName, paramTypes);
-                                    // return new MethodDescription(declaringClassName, methodName, parameterTypes);
-                                    methodCreator.returnValue(newMethodDescription);
-                                }
+                                    mc.body(bc -> {
+                                        // String[] paramTypes
+                                        var paramTypes = bc.newArray(String.class,
+                                                targetMethod.parameterTypes(),
+                                                pt -> Const.of(pt.name().toString()));
+                                        // new MethodDescription(declaringClassName, methodName, parameterTypes)
+                                        var newMethodDescription = bc.new_(
+                                                ConstructorDesc.of(MethodDescription.class,
+                                                        String.class, String.class, String[].class),
+                                                Const.of(targetMethod.declaringClass().name().toString()),
+                                                Const.of(targetMethod.name()),
+                                                paramTypes);
+                                        // return new MethodDescription(declaringClassName, methodName, parameterTypes);
+                                        bc.return_(newMethodDescription);
+                                    });
+                                });
                             }
-                        }
+                        });
 
-                        return generatedName.replace('/', '.');
+                        return generatedName;
                     }
                 });
 


### PR DESCRIPTION
Migrate the named tokens producer and OIDC client filter generation to use the Gizmo 2 API.

Assisted-By: Claude (claude-opus-4-6)