### PR TITLE
Automatically add @Transactional to blocking GraphQL resolvers

### DIFF
--- a/extensions/smallrye-graphql/deployment/pom.xml
+++ b/extensions/smallrye-graphql/deployment/pom.xml
@@ -79,6 +79,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-narayana-jta-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-elytron-security-deployment</artifactId>
             <scope>test</scope>
         </dependency>

--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
@@ -31,10 +31,12 @@ import org.jboss.jandex.Indexer;
 import org.jboss.logging.Logger;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.deployment.AnnotationsTransformerBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.arc.deployment.BeanDefiningAnnotationBuildItem;
 import io.quarkus.arc.deployment.KnownCompatibleBeanArchiveBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
+import io.quarkus.arc.processor.AnnotationsTransformer;
 import io.quarkus.arc.processor.BuiltinScope;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.Capabilities;
@@ -207,6 +209,63 @@ public class SmallRyeGraphQLProcessor {
         // Make ArC discover the beans marked with the @GraphQLApi qualifier
         beanDefiningAnnotationProducer
                 .produce(new BeanDefiningAnnotationBuildItem(Annotations.GRAPHQL_API, BuiltinScope.SINGLETON.getName()));
+    }
+
+    @BuildStep
+    void autoTransactional(Capabilities capabilities,
+            BuildProducer<AnnotationsTransformerBuildItem> annotationsTransformer) {
+        if (!capabilities.isPresent(Capability.TRANSACTIONS)) {
+            return;
+        }
+
+        DotName transactional = DotName.createSimple("jakarta.transaction.Transactional");
+
+        Set<DotName> reactiveTypes = Set.of(
+                DotName.createSimple("io.smallrye.mutiny.Uni"),
+                DotName.createSimple("io.smallrye.mutiny.Multi"),
+                DotName.createSimple("java.util.concurrent.CompletionStage"),
+                DotName.createSimple("java.util.concurrent.CompletableFuture"),
+                DotName.createSimple("org.reactivestreams.Publisher"));
+
+        annotationsTransformer.produce(new AnnotationsTransformerBuildItem(new AnnotationsTransformer() {
+            @Override
+            public boolean appliesTo(org.jboss.jandex.AnnotationTarget.Kind kind) {
+                return kind == org.jboss.jandex.AnnotationTarget.Kind.METHOD;
+            }
+
+            @Override
+            public void transform(TransformationContext ctx) {
+                var method = ctx.getTarget().asMethod();
+
+                if (!method.declaringClass().hasAnnotation(Annotations.GRAPHQL_API)) {
+                    return;
+                }
+
+                boolean isGraphQLMethod = method.hasAnnotation(Annotations.QUERY)
+                        || method.hasAnnotation(Annotations.MUTATION)
+                        || method.hasAnnotation(Annotations.SUBCRIPTION)
+                        || method.hasAnnotation(Annotations.NAME)
+                        || method.hasAnnotation(Annotations.RESOLVER)
+                        || method.hasAnnotation(Annotations.SOURCE);
+                if (!isGraphQLMethod) {
+                    return;
+                }
+
+                if (reactiveTypes.contains(method.returnType().name())) {
+                    return;
+                }
+
+                if (method.hasAnnotation(transactional)) {
+                    return;
+                }
+
+                if (method.hasAnnotation(Annotations.NON_BLOCKING)) {
+                    return;
+                }
+
+                ctx.transform().add(transactional).done();
+            }
+        }));
     }
 
     @BuildStep

--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
@@ -218,6 +218,12 @@ public class SmallRyeGraphQLProcessor {
             return;
         }
 
+        // Don't add @Transactional when Hibernate Reactive is present — it would
+        // interfere with reactive session management
+        if (capabilities.isPresent(Capability.HIBERNATE_REACTIVE)) {
+            return;
+        }
+
         DotName transactional = DotName.createSimple("jakarta.transaction.Transactional");
 
         Set<DotName> reactiveTypes = Set.of(

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLAutoTransactionTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLAutoTransactionTest.java
@@ -1,5 +1,9 @@
 package io.quarkus.smallrye.graphql.deployment;
 
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
 import jakarta.inject.Inject;
 import jakarta.transaction.TransactionManager;
 
@@ -125,6 +129,49 @@ public class GraphQLAutoTransactionTest extends AbstractGraphQLTest {
                 .body("data.greeting.inTransaction", Matchers.is(true));
     }
 
+    @Test
+    void concurrentSourceResolversShouldEachHaveTransaction() {
+        TransactionCheckApi.sourceTransactionResults.clear();
+
+        String request = getPayload("{ greetings { message inTransaction } }");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(request)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .body("data.greetings[0].inTransaction", Matchers.is(true))
+                .body("data.greetings[1].inTransaction", Matchers.is(true))
+                .body("data.greetings[2].inTransaction", Matchers.is(true));
+
+        org.junit.jupiter.api.Assertions.assertFalse(TransactionCheckApi.sourceTransactionResults.isEmpty(),
+                "Source resolvers should have recorded transaction results");
+        org.junit.jupiter.api.Assertions.assertTrue(
+                TransactionCheckApi.sourceTransactionResults.stream().allMatch(b -> b),
+                "All concurrent source resolvers should have had an active transaction");
+    }
+
+    @Test
+    void multipleBlockingFieldsShouldEachHaveTransaction() {
+        String request = getPayload("{ blockingQuery blockingQuery2 }");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(request)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .body("data.blockingQuery", Matchers.is(true))
+                .body("data.blockingQuery2", Matchers.is(true));
+    }
+
     public static class Greeting {
         private String message;
 
@@ -147,11 +194,18 @@ public class GraphQLAutoTransactionTest extends AbstractGraphQLTest {
     @GraphQLApi
     public static class TransactionCheckApi {
 
+        static final Set<Boolean> sourceTransactionResults = ConcurrentHashMap.newKeySet();
+
         @Inject
         TransactionManager tm;
 
         @Query
         public boolean blockingQuery() {
+            return isTransactionActive();
+        }
+
+        @Query
+        public boolean blockingQuery2() {
             return isTransactionActive();
         }
 
@@ -182,8 +236,15 @@ public class GraphQLAutoTransactionTest extends AbstractGraphQLTest {
             return new Greeting("hello");
         }
 
+        @Query
+        public List<Greeting> greetings() {
+            return List.of(new Greeting("hello"), new Greeting("world"), new Greeting("test"));
+        }
+
         public boolean inTransaction(@Source Greeting greeting) {
-            return isTransactionActive();
+            boolean active = isTransactionActive();
+            sourceTransactionResults.add(active);
+            return active;
         }
 
         private boolean isTransactionActive() {

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLAutoTransactionTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLAutoTransactionTest.java
@@ -1,0 +1,197 @@
+package io.quarkus.smallrye.graphql.deployment;
+
+import jakarta.inject.Inject;
+import jakarta.transaction.TransactionManager;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Mutation;
+import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.graphql.Source;
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+import io.smallrye.common.annotation.NonBlocking;
+import io.smallrye.mutiny.Uni;
+
+public class GraphQLAutoTransactionTest extends AbstractGraphQLTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot((JavaArchive jar) -> jar
+                    .addClasses(TransactionCheckApi.class, Greeting.class)
+                    .addAsResource(new StringAsset("quarkus.smallrye-graphql.nonblocking.enabled=false"),
+                            "application.properties")
+                    .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"));
+
+    @Test
+    void blockingQueryShouldHaveTransaction() {
+        String request = getPayload("{ blockingQuery }");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(request)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .body("data.blockingQuery", Matchers.is(true));
+    }
+
+    @Test
+    void blockingMutationShouldHaveTransaction() {
+        String request = getPayload("mutation { blockingMutation }");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(request)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .body("data.blockingMutation", Matchers.is(true));
+    }
+
+    @Test
+    void reactiveQueryShouldNotHaveTransaction() {
+        String request = getPayload("{ reactiveQuery }");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(request)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .body("data.reactiveQuery", Matchers.is(false));
+    }
+
+    @Test
+    void nonBlockingQueryShouldNotHaveTransaction() {
+        String request = getPayload("{ nonBlockingQuery }");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(request)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .body("data.nonBlockingQuery", Matchers.is(false));
+    }
+
+    @Test
+    void explicitTransactionalShouldBePreserved() {
+        String request = getPayload("{ explicitTransactional }");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(request)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .body("data.explicitTransactional", Matchers.is(false));
+    }
+
+    @Test
+    void sourceResolverShouldHaveTransaction() {
+        String request = getPayload("{ greeting { message inTransaction } }");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(request)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .body("data.greeting.inTransaction", Matchers.is(true));
+    }
+
+    public static class Greeting {
+        private String message;
+
+        public Greeting() {
+        }
+
+        public Greeting(String message) {
+            this.message = message;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public void setMessage(String message) {
+            this.message = message;
+        }
+    }
+
+    @GraphQLApi
+    public static class TransactionCheckApi {
+
+        @Inject
+        TransactionManager tm;
+
+        @Query
+        public boolean blockingQuery() {
+            return isTransactionActive();
+        }
+
+        @Mutation
+        public boolean blockingMutation() {
+            return isTransactionActive();
+        }
+
+        @Query
+        public Uni<Boolean> reactiveQuery() {
+            return Uni.createFrom().item(isTransactionActive());
+        }
+
+        @NonBlocking
+        @Query
+        public boolean nonBlockingQuery() {
+            return isTransactionActive();
+        }
+
+        @jakarta.transaction.Transactional(jakarta.transaction.Transactional.TxType.NOT_SUPPORTED)
+        @Query
+        public boolean explicitTransactional() {
+            return isTransactionActive();
+        }
+
+        @Query
+        public Greeting greeting() {
+            return new Greeting("hello");
+        }
+
+        public boolean inTransaction(@Source Greeting greeting) {
+            return isTransactionActive();
+        }
+
+        private boolean isTransactionActive() {
+            try {
+                return tm.getStatus() == jakarta.transaction.Status.STATUS_ACTIVE;
+            } catch (Exception e) {
+                return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
With unordered `executeBlocking` (from #54927), blocking query resolvers can run in parallel on different threads within the same request. If a resolver uses Hibernate/Panache without `@Transactional`, the parallel threads share the same request-scoped `Session` — which is not thread-safe. Users shouldn't need to know about this threading detail to write a correct `@Query` method.

This adds a build-time `AnnotationsTransformer` that automatically applies `@Transactional` to blocking GraphQL resolver methods when JTA is on the classpath. The transformer skips methods that already have `@Transactional` and methods with reactive return types (`Uni`, `Multi`, `CompletionStage`, etc.) since those don't go through the blocking dispatch path.

Users who explicitly don't want a transaction can annotate with `@Transactional(NOT_SUPPORTED)`.

Fixes #54971