### PR TITLE
SmallRye Reactive Messaging: migrate from Gizmo 1 to Gizmo 2

### DIFF
--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/JacksonSerdeGenerator.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/JacksonSerdeGenerator.java
@@ -2,13 +2,14 @@ package io.quarkus.smallrye.reactivemessaging.kafka.deployment;
 
 import org.jboss.jandex.Type;
 
-import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
+import io.quarkus.deployment.GeneratedClassGizmo2Adaptor;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
-import io.quarkus.gizmo.ClassCreator;
-import io.quarkus.gizmo.ClassOutput;
-import io.quarkus.gizmo.MethodCreator;
-import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
+import io.quarkus.deployment.builditem.GeneratedServiceProviderBuildItem;
+import io.quarkus.gizmo2.Const;
+import io.quarkus.gizmo2.Gizmo;
+import io.quarkus.gizmo2.desc.ConstructorDesc;
 import io.quarkus.kafka.client.serialization.ObjectMapperDeserializer;
 import io.quarkus.kafka.client.serialization.ObjectMapperSerializer;
 import io.quarkus.runtime.util.HashUtil;
@@ -19,35 +20,41 @@ public class JacksonSerdeGenerator {
         // Avoid direct instantiation
     }
 
-    public static String generateSerializer(BuildProducer<GeneratedClassBuildItem> generatedClass, Type type) {
-        ClassOutput classOutput = new GeneratedClassGizmoAdaptor(generatedClass, true);
+    public static String generateSerializer(BuildProducer<GeneratedClassBuildItem> generatedClass,
+            BuildProducer<GeneratedResourceBuildItem> generatedResources,
+            BuildProducer<GeneratedServiceProviderBuildItem> generatedServiceProviders, Type type) {
+        var classOutput = new GeneratedClassGizmo2Adaptor(generatedClass, generatedResources, generatedServiceProviders, true);
+        var gizmo = Gizmo.create(classOutput);
         String baseName = type.name().withoutPackagePrefix();
-        String targetPackage = io.quarkus.arc.processor.DotNames
-                .internalPackageNameWithTrailingSlash(type.name());
         String out = baseName + "_Serializer_" + HashUtil.sha1(type.name().toString());
-        String generatedName = targetPackage + out;
-        ClassCreator creator = ClassCreator.builder().classOutput(classOutput).className(generatedName)
-                .superClass(ObjectMapperSerializer.class).build();
-        creator.close();
-        return type.name().packagePrefix() + "." + out;
+        String className = type.name().packagePrefix() + "." + out;
+        gizmo.class_(className, cc -> {
+            cc.extends_(ObjectMapperSerializer.class);
+            cc.defaultConstructor();
+        });
+        return className;
     }
 
-    public static String generateDeserializer(BuildProducer<GeneratedClassBuildItem> generatedClass, Type type) {
-        ClassOutput classOutput = new GeneratedClassGizmoAdaptor(generatedClass, true);
+    public static String generateDeserializer(BuildProducer<GeneratedClassBuildItem> generatedClass,
+            BuildProducer<GeneratedResourceBuildItem> generatedResources,
+            BuildProducer<GeneratedServiceProviderBuildItem> generatedServiceProviders, Type type) {
+        var classOutput = new GeneratedClassGizmo2Adaptor(generatedClass, generatedResources, generatedServiceProviders, true);
+        var gizmo = Gizmo.create(classOutput);
         String baseName = type.name().withoutPackagePrefix();
-        String targetPackage = io.quarkus.arc.processor.DotNames
-                .internalPackageNameWithTrailingSlash(type.name());
         String out = baseName + "_Deserializer_" + HashUtil.sha1(type.name().toString());
-        String generatedName = targetPackage + out;
-        ClassCreator creator = ClassCreator.builder().classOutput(classOutput).className(generatedName)
-                .superClass(ObjectMapperDeserializer.class).build();
-        MethodCreator constructor = creator.getMethodCreator("<init>", void.class);
-        MethodDescriptor superConstructor = MethodDescriptor.ofConstructor(ObjectMapperDeserializer.class, Class.class);
-        constructor.invokeSpecialMethod(superConstructor, constructor.getThis(),
-                constructor.loadClassFromTCCL(type.name().toString()));
-        constructor.returnValue(null);
-        constructor.close();
-        creator.close();
-        return type.name().packagePrefix() + "." + out;
+        String className = type.name().packagePrefix() + "." + out;
+        gizmo.class_(className, cc -> {
+            cc.extends_(ObjectMapperDeserializer.class);
+            cc.constructor(ctc -> {
+                ctc.public_();
+                ctc.body(bc -> {
+                    ConstructorDesc superCtor = ConstructorDesc.of(ObjectMapperDeserializer.class, Class.class);
+                    bc.invokeSpecial(superCtor, cc.this_(),
+                            bc.classForName(Const.of(type.name().toString())));
+                    bc.return_();
+                });
+            });
+        });
+        return className;
     }
 }

--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/SmallRyeReactiveMessagingKafkaProcessor.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/SmallRyeReactiveMessagingKafkaProcessor.java
@@ -38,6 +38,8 @@ import io.quarkus.deployment.annotations.Consume;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
+import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
+import io.quarkus.deployment.builditem.GeneratedServiceProviderBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
 import io.quarkus.deployment.builditem.RuntimeConfigSetupCompleteBuildItem;
@@ -188,12 +190,15 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
             List<ConnectorManagedChannelBuildItem> channelsManagedByConnectors,
             BuildProducer<RunTimeConfigurationDefaultBuildItem> defaultConfigProducer,
             BuildProducer<GeneratedClassBuildItem> generatedClass,
+            BuildProducer<GeneratedResourceBuildItem> generatedResources,
+            BuildProducer<GeneratedServiceProviderBuildItem> generatedServiceProviders,
             BuildProducer<ReflectiveClassBuildItem> reflection) {
 
         DefaultSerdeDiscoveryState discoveryState = new DefaultSerdeDiscoveryState(combinedIndex.getIndex());
         if (buildTimeConfig.serializerAutodetectionEnabled()) {
             discoverDefaultSerdeConfig(discoveryState, channelsManagedByConnectors, defaultConfigProducer,
-                    buildTimeConfig.serializerGenerationEnabled() ? generatedClass : null, reflection);
+                    buildTimeConfig.serializerGenerationEnabled() ? generatedClass : null,
+                    generatedResources, generatedServiceProviders, reflection);
         }
 
         if (launchMode.getLaunchMode().isDevOrTest()) {
@@ -224,6 +229,8 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
             List<ConnectorManagedChannelBuildItem> channelsManagedByConnectors,
             BuildProducer<RunTimeConfigurationDefaultBuildItem> config,
             BuildProducer<GeneratedClassBuildItem> generatedClass,
+            BuildProducer<GeneratedResourceBuildItem> generatedResources,
+            BuildProducer<GeneratedServiceProviderBuildItem> generatedServiceProviders,
             BuildProducer<ReflectiveClassBuildItem> reflection) {
         Map<String, String> alreadyGeneratedSerializers = new HashMap<>();
         Map<String, String> alreadyGeneratedDeserializers = new HashMap<>();
@@ -237,8 +244,8 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
 
             Type incomingType = getIncomingTypeFromMethod(method);
 
-            processIncomingType(discovery, config, incomingType, channelName, generatedClass, reflection,
-                    alreadyGeneratedDeserializers, alreadyGeneratedSerializers);
+            processIncomingType(discovery, config, incomingType, channelName, generatedClass, generatedResources,
+                    generatedServiceProviders, reflection, alreadyGeneratedDeserializers, alreadyGeneratedSerializers);
         }
 
         for (AnnotationInstance annotation : discovery.findRepeatableAnnotationsOnMethods(DotNames.OUTGOING)) {
@@ -257,7 +264,7 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
                         getChannelOutgoingPropertyName(channelName, "value.serializer"), valueSerializer);
 
                 handleAdditionalProperties(channelName, false, discovery, config, keySerializer, valueSerializer);
-            }, generatedClass, reflection, alreadyGeneratedSerializers);
+            }, generatedClass, generatedResources, generatedServiceProviders, reflection, alreadyGeneratedSerializers);
         }
 
         for (AnnotationInstance annotation : discovery.findAnnotationsOnInjectionPoints(DotNames.CHANNEL)) {
@@ -274,8 +281,8 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
 
             Type incomingType = getIncomingTypeFromChannelInjectionPoint(injectionPointType);
 
-            processIncomingType(discovery, config, incomingType, channelName, generatedClass, reflection,
-                    alreadyGeneratedDeserializers, alreadyGeneratedSerializers);
+            processIncomingType(discovery, config, incomingType, channelName, generatedClass, generatedResources,
+                    generatedServiceProviders, reflection, alreadyGeneratedDeserializers, alreadyGeneratedSerializers);
 
             processKafkaTransactions(discovery, config, channelName, injectionPointType);
 
@@ -287,11 +294,13 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
                             getChannelOutgoingPropertyName(channelName, "key.serializer"), keySerializer);
                     produceRuntimeConfigurationDefaultBuildItem(discovery, config,
                             getChannelOutgoingPropertyName(channelName, "value.serializer"), valueSerializer);
-                }, generatedClass, reflection, alreadyGeneratedSerializers);
+                }, generatedClass, generatedResources, generatedServiceProviders, reflection, alreadyGeneratedSerializers);
                 extractKeyValueType(replyType, (key, value, isBatchType) -> {
-                    Result keyDeserializer = deserializerFor(discovery, key, true, channelName, generatedClass, reflection,
+                    Result keyDeserializer = deserializerFor(discovery, key, true, channelName, generatedClass,
+                            generatedResources, generatedServiceProviders, reflection,
                             alreadyGeneratedDeserializers, alreadyGeneratedSerializers);
-                    Result valueDeserializer = deserializerFor(discovery, value, false, channelName, generatedClass, reflection,
+                    Result valueDeserializer = deserializerFor(discovery, value, false, channelName, generatedClass,
+                            generatedResources, generatedServiceProviders, reflection,
                             alreadyGeneratedDeserializers, alreadyGeneratedSerializers);
 
                     produceRuntimeConfigurationDefaultBuildItem(discovery, config,
@@ -309,7 +318,7 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
                             getChannelOutgoingPropertyName(channelName, "value.serializer"), valueSerializer);
 
                     handleAdditionalProperties(channelName, false, discovery, config, keySerializer, valueSerializer);
-                }, generatedClass, reflection, alreadyGeneratedSerializers);
+                }, generatedClass, generatedResources, generatedServiceProviders, reflection, alreadyGeneratedSerializers);
             }
         }
     }
@@ -333,12 +342,17 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
 
     private void processIncomingType(DefaultSerdeDiscoveryState discovery,
             BuildProducer<RunTimeConfigurationDefaultBuildItem> config, Type incomingType, String channelName,
-            BuildProducer<GeneratedClassBuildItem> generatedClass, BuildProducer<ReflectiveClassBuildItem> reflection,
+            BuildProducer<GeneratedClassBuildItem> generatedClass,
+            BuildProducer<GeneratedResourceBuildItem> generatedResources,
+            BuildProducer<GeneratedServiceProviderBuildItem> generatedServiceProviders,
+            BuildProducer<ReflectiveClassBuildItem> reflection,
             Map<String, String> alreadyGeneratedDeserializers, Map<String, String> alreadyGeneratedSerializers) {
         extractKeyValueType(incomingType, (key, value, isBatchType) -> {
-            Result keyDeserializer = deserializerFor(discovery, key, true, channelName, generatedClass, reflection,
+            Result keyDeserializer = deserializerFor(discovery, key, true, channelName, generatedClass,
+                    generatedResources, generatedServiceProviders, reflection,
                     alreadyGeneratedDeserializers, alreadyGeneratedSerializers);
-            Result valueDeserializer = deserializerFor(discovery, value, false, channelName, generatedClass, reflection,
+            Result valueDeserializer = deserializerFor(discovery, value, false, channelName, generatedClass,
+                    generatedResources, generatedServiceProviders, reflection,
                     alreadyGeneratedDeserializers, alreadyGeneratedSerializers);
 
             produceRuntimeConfigurationDefaultBuildItem(discovery, config,
@@ -552,11 +566,14 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
 
     private void processOutgoingType(DefaultSerdeDiscoveryState discovery, Type outgoingType,
             BiConsumer<Result, Result> serializerAcceptor, BuildProducer<GeneratedClassBuildItem> generatedClass,
+            BuildProducer<GeneratedResourceBuildItem> generatedResources,
+            BuildProducer<GeneratedServiceProviderBuildItem> generatedServiceProviders,
             BuildProducer<ReflectiveClassBuildItem> reflection, Map<String, String> alreadyGeneratedSerializer) {
         extractKeyValueType(outgoingType, (key, value, isBatch) -> {
-            Result keySerializer = serializerFor(discovery, key, generatedClass, reflection,
-                    alreadyGeneratedSerializer);
-            Result valueSerializer = serializerFor(discovery, value, generatedClass, reflection,
+            Result keySerializer = serializerFor(discovery, key, generatedClass, generatedResources,
+                    generatedServiceProviders, reflection, alreadyGeneratedSerializer);
+            Result valueSerializer = serializerFor(discovery, value, generatedClass, generatedResources,
+                    generatedServiceProviders, reflection,
                     alreadyGeneratedSerializer);
             serializerAcceptor.accept(keySerializer, valueSerializer);
         });
@@ -871,6 +888,8 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
             boolean key,
             String channelName,
             BuildProducer<GeneratedClassBuildItem> generatedClass,
+            BuildProducer<GeneratedResourceBuildItem> generatedResources,
+            BuildProducer<GeneratedServiceProviderBuildItem> generatedServiceProviders,
             BuildProducer<ReflectiveClassBuildItem> reflection,
             Map<String, String> alreadyGeneratedDeserializers,
             Map<String, String> alreadyGeneratedSerializers) {
@@ -885,7 +904,8 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
             // Check if already generated
             String generatedDeserializerClassName = alreadyGeneratedDeserializers.get(type.name().toString());
             if (generatedDeserializerClassName == null) {
-                generatedDeserializerClassName = JacksonSerdeGenerator.generateDeserializer(generatedClass, type);
+                generatedDeserializerClassName = JacksonSerdeGenerator.generateDeserializer(generatedClass, generatedResources,
+                        generatedServiceProviders, type);
                 alreadyGeneratedDeserializers.put(type.name().toString(), generatedDeserializerClassName);
                 LOGGER.infof("Generating Jackson deserializer for type %s", type.name().toString());
                 // Deserializers are access by reflection.
@@ -896,7 +916,8 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
             }
             // if the channel has a DLQ config generate a serializer as well
             if (hasDLQConfig(channelName, discovery.getConfig())) {
-                Result serializer = serializerFor(discovery, type, generatedClass, reflection, alreadyGeneratedSerializers);
+                Result serializer = serializerFor(discovery, type, generatedClass, generatedResources,
+                        generatedServiceProviders, reflection, alreadyGeneratedSerializers);
                 if (serializer != null) {
                     result = Result.of(generatedDeserializerClassName)
                             .with(key, "dead-letter-queue.key.serializer", serializer.value)
@@ -911,6 +932,8 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
 
     private Result serializerFor(DefaultSerdeDiscoveryState discovery, Type type,
             BuildProducer<GeneratedClassBuildItem> generatedClass,
+            BuildProducer<GeneratedResourceBuildItem> generatedResources,
+            BuildProducer<GeneratedServiceProviderBuildItem> generatedServiceProviders,
             BuildProducer<ReflectiveClassBuildItem> reflection,
             Map<String, String> alreadyGeneratedSerializers) {
         Result result = serializerDeserializerFor(discovery, type, true);
@@ -924,7 +947,8 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
             // Check if already generated
             String generatedSerializerClassName = alreadyGeneratedSerializers.get(type.name().toString());
             if (generatedSerializerClassName == null) {
-                generatedSerializerClassName = JacksonSerdeGenerator.generateSerializer(generatedClass, type);
+                generatedSerializerClassName = JacksonSerdeGenerator.generateSerializer(generatedClass, generatedResources,
+                        generatedServiceProviders, type);
                 alreadyGeneratedSerializers.put(type.name().toString(), generatedSerializerClassName);
                 LOGGER.infof("Generating Jackson serializer for type %s", type.name().toString());
                 // Serializers are access by reflection.

--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/DefaultSerdeConfigTest.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/DefaultSerdeConfigTest.java
@@ -109,6 +109,7 @@ public class DefaultSerdeConfigTest {
             new SmallRyeReactiveMessagingKafkaProcessor().discoverDefaultSerdeConfig(discovery, Collections.emptyList(),
                     configs::add,
                     (generatedNames == null) ? null : generated::add,
+                    null, null,
                     (reflectiveNames == null) ? null : reflective::add);
 
             assertThat(configs)

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/SmallRyeReactiveMessagingProcessor.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/SmallRyeReactiveMessagingProcessor.java
@@ -5,7 +5,7 @@ import static io.quarkus.smallrye.reactivemessaging.deployment.ReactiveMessaging
 import static io.quarkus.smallrye.reactivemessaging.deployment.ReactiveMessagingDotNames.INCOMINGS;
 import static io.quarkus.smallrye.reactivemessaging.deployment.ReactiveMessagingDotNames.RUN_ON_VIRTUAL_THREAD;
 
-import java.lang.reflect.Modifier;
+import java.lang.constant.ClassDesc;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -29,6 +29,7 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
+import org.jboss.jandex.gizmo2.Jandex2Gizmo;
 import org.jboss.logging.Logger;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
@@ -45,7 +46,7 @@ import io.quarkus.arc.processor.KotlinUtils;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.builder.item.SimpleBuildItem;
 import io.quarkus.deployment.Feature;
-import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
+import io.quarkus.deployment.GeneratedClassGizmo2Adaptor;
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -53,18 +54,21 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
+import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
+import io.quarkus.deployment.builditem.GeneratedServiceProviderBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.metrics.MetricsCapabilityBuildItem;
 import io.quarkus.deployment.recording.RecorderContext;
-import io.quarkus.gizmo.ClassCreator;
-import io.quarkus.gizmo.ClassOutput;
-import io.quarkus.gizmo.FieldDescriptor;
-import io.quarkus.gizmo.MethodCreator;
-import io.quarkus.gizmo.MethodDescriptor;
-import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo2.Const;
+import io.quarkus.gizmo2.Expr;
+import io.quarkus.gizmo2.Gizmo;
+import io.quarkus.gizmo2.LocalVar;
+import io.quarkus.gizmo2.ParamVar;
+import io.quarkus.gizmo2.desc.ConstructorDesc;
+import io.quarkus.gizmo2.desc.FieldDesc;
 import io.quarkus.runtime.metrics.MetricsFactory;
 import io.quarkus.runtime.util.HashUtil;
 import io.quarkus.smallrye.health.deployment.spi.HealthBuildItem;
@@ -269,11 +273,14 @@ public class SmallRyeReactiveMessagingProcessor {
             List<InjectedEmitterBuildItem> emitterFields,
             List<InjectedChannelBuildItem> channelFields,
             BuildProducer<GeneratedClassBuildItem> generatedClass,
+            BuildProducer<GeneratedResourceBuildItem> generatedResources,
+            BuildProducer<GeneratedServiceProviderBuildItem> generatedServiceProviders,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<RunTimeConfigurationDefaultBuildItem> defaultConfig,
             ReactiveMessagingConfiguration conf) {
 
-        ClassOutput classOutput = new GeneratedClassGizmoAdaptor(generatedClass, true);
+        Gizmo gizmo = Gizmo
+                .create(new GeneratedClassGizmo2Adaptor(generatedClass, generatedResources, generatedServiceProviders, true));
 
         Set<String> connectorManagedIncomingChannels = connectorManagedChannels.stream()
                 .filter(c -> c.getDirection() == ChannelDirection.INCOMING)
@@ -330,7 +337,7 @@ public class SmallRyeReactiveMessagingProcessor {
                 mediatorConfigurations.add(mediatorConfiguration);
 
                 String generatedInvokerName = generateInvoker(bean, methodInfo, isSuspendMethod, mediatorConfiguration,
-                        classOutput);
+                        gizmo);
                 /*
                  * We need to register the invoker's constructor for reflection since it will be called inside smallrye.
                  * We could potentially lift this restriction with some extra CDI bean generation, but it's probably not worth
@@ -394,7 +401,7 @@ public class SmallRyeReactiveMessagingProcessor {
      */
     private String generateInvoker(BeanInfo bean, MethodInfo method, boolean isSuspendMethod,
             QuarkusMediatorConfiguration mediatorConfiguration,
-            ClassOutput classOutput) {
+            Gizmo gizmo) {
         String baseName;
         if (bean.getImplClazz().enclosingClass() != null) {
             baseName = DotNames.simpleName(bean.getImplClazz().enclosingClass()) + "_"
@@ -420,91 +427,105 @@ public class SmallRyeReactiveMessagingProcessor {
         }
 
         if (!isSuspendMethod) {
-            generateStandardInvoker(method, classOutput, generatedName);
+            generateStandardInvoker(method, gizmo, generatedName);
         } else if (!mediatorConfiguration.getIncoming().isEmpty()) {
-            generateSubscribingCoroutineInvoker(method, classOutput, generatedName);
+            generateSubscribingCoroutineInvoker(method, gizmo, generatedName);
         }
 
         return generatedName.replace('/', '.');
     }
 
-    private void generateStandardInvoker(MethodInfo method, ClassOutput classOutput, String generatedName) {
-        try (ClassCreator invoker = ClassCreator.builder().classOutput(classOutput).className(generatedName)
-                .interfaces(Invoker.class)
-                .build()) {
+    private void generateStandardInvoker(MethodInfo method, Gizmo gizmo, String generatedName) {
+        String dotName = generatedName.replace('/', '.');
+        gizmo.class_(dotName, cc -> {
+            cc.implements_(Invoker.class);
 
             String beanInstanceType = method.declaringClass().name().toString();
-            FieldDescriptor beanInstanceField = invoker.getFieldCreator("beanInstance", beanInstanceType)
-                    .getFieldDescriptor();
+            FieldDesc beanInstanceField = cc.field("beanInstance", fc -> {
+                fc.setType(ClassDesc.of(beanInstanceType));
+            });
 
             // generate a constructor that takes the bean instance as an argument
             // the method parameter needs to be of type Object because that is what is used as the call site in SmallRye
             // Reactive Messaging
-            try (MethodCreator ctor = invoker.getMethodCreator("<init>", void.class, Object.class)) {
-                ctor.setModifiers(Modifier.PUBLIC);
-                ctor.invokeSpecialMethod(MethodDescriptor.ofConstructor(Object.class), ctor.getThis());
-                ResultHandle self = ctor.getThis();
-                ResultHandle beanInstance = ctor.getMethodParam(0);
-                ctor.writeInstanceField(beanInstanceField, self, beanInstance);
-                ctor.returnValue(null);
-            }
+            cc.constructor(ctc -> {
+                ctc.public_();
+                ParamVar beanParam = ctc.parameter("arg0", pc -> pc.setType(Object.class));
+                ctc.body(bc -> {
+                    bc.invokeSpecial(ConstructorDesc.of(Object.class), cc.this_());
+                    bc.set(cc.this_().field(beanInstanceField), beanParam);
+                    bc.return_();
+                });
+            });
 
-            try (MethodCreator invoke = invoker.getMethodCreator(
-                    MethodDescriptor.ofMethod(generatedName, "invoke", Object.class, Object[].class))) {
-
-                int parametersCount = method.parametersCount();
-                String[] argTypes = new String[parametersCount];
-                ResultHandle[] args = new ResultHandle[parametersCount];
-                for (int i = 0; i < parametersCount; i++) {
-                    // the only method argument of io.smallrye.reactive.messaging.Invoker is an object array, so we need to pull out
-                    // each argument and put it in the target method arguments array
-                    args[i] = invoke.readArrayValue(invoke.getMethodParam(0), i);
-                    argTypes[i] = method.parameterType(i).name().toString();
-                }
-                ResultHandle result = invoke.invokeVirtualMethod(
-                        MethodDescriptor.ofMethod(beanInstanceType, method.name(),
-                                method.returnType().name().toString(), argTypes),
-                        invoke.readInstanceField(beanInstanceField, invoke.getThis()), args);
-                if (ReactiveMessagingDotNames.VOID.equals(method.returnType().name())) {
-                    invoke.returnValue(invoke.loadNull());
-                } else {
-                    invoke.returnValue(result);
-                }
-            }
-        }
+            cc.method("invoke", mc -> {
+                mc.public_();
+                mc.returning(Object.class);
+                ParamVar argsParam = mc.parameter("args", pc -> pc.setType(Object[].class));
+                mc.body(bc -> {
+                    int parametersCount = method.parametersCount();
+                    LocalVar[] args = new LocalVar[parametersCount];
+                    for (int i = 0; i < parametersCount; i++) {
+                        args[i] = bc.localVar("arg" + i, bc.get(argsParam.elem(i)));
+                    }
+                    LocalVar beanInstance = bc.localVar("beanInstance",
+                            bc.get(cc.this_().field(beanInstanceField)));
+                    Expr result = bc.invokeVirtual(
+                            Jandex2Gizmo.methodDescOf(method),
+                            beanInstance, List.of(args));
+                    if (ReactiveMessagingDotNames.VOID.equals(method.returnType().name())) {
+                        bc.return_(Const.ofNull(Object.class));
+                    } else {
+                        bc.return_(result);
+                    }
+                });
+            });
+        });
     }
 
-    private void generateSubscribingCoroutineInvoker(MethodInfo method, ClassOutput classOutput, String generatedName) {
-        try (ClassCreator invoker = ClassCreator.builder().classOutput(classOutput).className(generatedName)
-                .superClass(ReactiveMessagingDotNames.ABSTRACT_SUBSCRIBING_COROUTINE_INVOKER.toString())
-                .build()) {
+    private void generateSubscribingCoroutineInvoker(MethodInfo method, Gizmo gizmo, String generatedName) {
+        String dotName = generatedName.replace('/', '.');
+        String superClassName = ReactiveMessagingDotNames.ABSTRACT_SUBSCRIBING_COROUTINE_INVOKER.toString();
+        String continuationType = ReactiveMessagingDotNames.CONTINUATION.toString();
+        gizmo.class_(dotName, cc -> {
+            cc.extends_(ClassDesc.of(superClassName));
 
             // generate a constructor that takes the bean instance as an argument
             // the method parameter type needs to be Object, because that is what is used as the call site in SmallRye
             // Reactive Messaging
-            try (MethodCreator ctor = invoker.getMethodCreator("<init>", void.class, Object.class)) {
-                ctor.setModifiers(Modifier.PUBLIC);
-                ctor.invokeSpecialMethod(
-                        MethodDescriptor.ofConstructor(
-                                ReactiveMessagingDotNames.ABSTRACT_SUBSCRIBING_COROUTINE_INVOKER.toString(),
-                                Object.class.getName()),
-                        ctor.getThis(),
-                        ctor.getMethodParam(0));
-                ctor.returnValue(null);
-            }
+            cc.constructor(ctc -> {
+                ctc.public_();
+                ParamVar beanParam = ctc.parameter("arg0", pc -> pc.setType(Object.class));
+                ctc.body(bc -> {
+                    bc.invokeSpecial(
+                            ConstructorDesc.of(ClassDesc.of(superClassName), Object.class),
+                            cc.this_(),
+                            beanParam);
+                    bc.return_();
+                });
+            });
 
-            try (MethodCreator invoke = invoker.getMethodCreator("invokeBean", Object.class, Object.class, Object[].class,
-                    ReactiveMessagingDotNames.CONTINUATION.toString())) {
-                ResultHandle[] args = new ResultHandle[method.parametersCount()];
-                ResultHandle array = invoke.getMethodParam(1);
-                for (int i = 0; i < method.parametersCount() - 1; ++i) {
-                    args[i] = invoke.readArrayValue(array, i);
-                }
-                args[args.length - 1] = invoke.getMethodParam(2);
-                ResultHandle result = invoke.invokeVirtualMethod(method, invoke.getMethodParam(0), args);
-                invoke.returnValue(result);
-            }
-        }
+            cc.method("invokeBean", mc -> {
+                mc.public_();
+                mc.returning(Object.class);
+                ParamVar beanInstanceParam = mc.parameter("beanInstance", pc -> pc.setType(Object.class));
+                ParamVar arrayParam = mc.parameter("args", pc -> pc.setType(Object[].class));
+                ParamVar continuationParam = mc.parameter("continuation",
+                        pc -> pc.setType(ClassDesc.of(continuationType)));
+                mc.body(bc -> {
+                    int parametersCount = method.parametersCount();
+                    LocalVar[] args = new LocalVar[parametersCount];
+                    for (int i = 0; i < parametersCount - 1; ++i) {
+                        args[i] = bc.localVar("arg" + i, bc.get(arrayParam.elem(i)));
+                    }
+                    args[args.length - 1] = bc.localVar("continuation", continuationParam);
+                    Expr result = bc.invokeVirtual(
+                            Jandex2Gizmo.methodDescOf(method),
+                            beanInstanceParam, List.of(args));
+                    bc.return_(result);
+                });
+            });
+        });
     }
 
     @BuildStep(onlyIf = IsDevelopment.class)


### PR DESCRIPTION
Migrate the invoker generation and Jackson serde generation to use the Gizmo 2 API.

Assisted-By: Claude (claude-opus-4-6)