### PR TITLE
Security JPA: migrate from Gizmo 1 to Gizmo 2

### DIFF
--- a/extensions/security-jpa-common/deployment/src/main/java/io/quarkus/security/jpa/common/deployment/JpaSecurityDefinition.java
+++ b/extensions/security-jpa-common/deployment/src/main/java/io/quarkus/security/jpa/common/deployment/JpaSecurityDefinition.java
@@ -11,13 +11,12 @@ import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.Index;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
+import org.jboss.jandex.gizmo2.Jandex2Gizmo;
 
 import io.quarkus.arc.processor.DotNames;
 import io.quarkus.deployment.bean.JavaBeanUtil;
-import io.quarkus.gizmo.BytecodeCreator;
-import io.quarkus.gizmo.FieldDescriptor;
-import io.quarkus.gizmo.MethodDescriptor;
-import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo2.Expr;
+import io.quarkus.gizmo2.creator.BlockCreator;
 
 public class JpaSecurityDefinition {
 
@@ -53,12 +52,12 @@ public class JpaSecurityDefinition {
             return JavaBeanUtil.getPropertyNameFromGetter(getter.name());
         }
 
-        public ResultHandle readValue(BytecodeCreator bytecodeCreator, ResultHandle userVar) {
+        public Expr readValue(BlockCreator bc, Expr userVar) {
             // favour the getter
             if (getter != null) {
-                return bytecodeCreator.invokeVirtualMethod(MethodDescriptor.of(getter), userVar);
+                return bc.invokeVirtual(Jandex2Gizmo.methodDescOf(getter), userVar);
             }
-            return bytecodeCreator.readInstanceField(FieldDescriptor.of(field), userVar);
+            return bc.get(userVar.field(Jandex2Gizmo.fieldDescOf(field)));
         }
 
         public Type type() {

--- a/extensions/security-jpa-common/deployment/src/main/java/io/quarkus/security/jpa/common/deployment/JpaSecurityIdentityUtil.java
+++ b/extensions/security-jpa-common/deployment/src/main/java/io/quarkus/security/jpa/common/deployment/JpaSecurityIdentityUtil.java
@@ -1,10 +1,9 @@
 package io.quarkus.security.jpa.common.deployment;
 
+import java.lang.constant.ClassDesc;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import java.util.function.BiConsumer;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
@@ -13,15 +12,17 @@ import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.Index;
 import org.jboss.jandex.Type;
+import org.wildfly.security.password.Password;
 
 import io.quarkus.arc.processor.DotNames;
-import io.quarkus.gizmo.AssignableResultHandle;
-import io.quarkus.gizmo.BranchResult;
-import io.quarkus.gizmo.BytecodeCreator;
-import io.quarkus.gizmo.FieldDescriptor;
-import io.quarkus.gizmo.MethodCreator;
-import io.quarkus.gizmo.MethodDescriptor;
-import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo2.Const;
+import io.quarkus.gizmo2.Expr;
+import io.quarkus.gizmo2.LocalVar;
+import io.quarkus.gizmo2.creator.BlockCreator;
+import io.quarkus.gizmo2.desc.ClassMethodDesc;
+import io.quarkus.gizmo2.desc.ConstructorDesc;
+import io.quarkus.gizmo2.desc.FieldDesc;
+import io.quarkus.gizmo2.desc.MethodDesc;
 import io.quarkus.security.AuthenticationFailedException;
 import io.quarkus.security.identity.request.TrustedAuthenticationRequest;
 import io.quarkus.security.identity.request.UsernamePasswordAuthenticationRequest;
@@ -42,89 +43,88 @@ public final class JpaSecurityIdentityUtil {
 
     public static void buildIdentity(Index index, JpaSecurityDefinition jpaSecurityDefinition,
             AnnotationValue passwordTypeValue, AnnotationValue passwordProviderValue,
-            PanacheEntityPredicateBuildItem panacheEntityPredicate, FieldDescriptor passwordProviderField,
-            MethodCreator outerMethod, ResultHandle userVar, BytecodeCreator innerMethod) {
+            PanacheEntityPredicateBuildItem panacheEntityPredicate, FieldDesc passwordProviderField,
+            Expr thisRef, Expr requestParam, Expr userVar, BlockCreator bc) {
         // if(user == null) throw new AuthenticationFailedException();
 
         PasswordType passwordType = passwordTypeValue != null ? PasswordType.valueOf(passwordTypeValue.asEnum())
                 : PasswordType.MCF;
 
-        try (BytecodeCreator trueBranch = innerMethod.ifNull(userVar).trueBranch()) {
-
-            ResultHandle exceptionInstance = trueBranch
-                    .newInstance(MethodDescriptor.ofConstructor(AuthenticationFailedException.class));
-            trueBranch.invokeStaticMethod(passwordActionMethod(), trueBranch.load(passwordType));
-            trueBranch.throwException(exceptionInstance);
-        }
+        bc.if_(bc.isNull(userVar), trueBranch -> {
+            Expr exceptionInstance = trueBranch
+                    .new_(ConstructorDesc.of(AuthenticationFailedException.class));
+            trueBranch.invokeStatic(passwordActionMethod(), Const.of(passwordType));
+            trueBranch.throw_(exceptionInstance);
+        });
 
         // :pass = user.pass | user.getPass()
-        ResultHandle pass = jpaSecurityDefinition.password.readValue(innerMethod, userVar);
+        LocalVar pass = bc.localVar("pass", jpaSecurityDefinition.password.readValue(bc, userVar));
 
         if (passwordType == PasswordType.CUSTOM && passwordProviderValue == null) {
             throw new RuntimeException("Missing password provider for password type: " + passwordType);
         }
 
-        ResultHandle storedPassword;
+        Expr storedPassword;
         switch (passwordType) {
             case CUSTOM:
                 String passwordProviderClassStr = passwordProviderValue.asString();
                 String passwordProviderMethod = "getPassword";
-                ResultHandle passwordProviderInstanceField = innerMethod.readInstanceField(passwordProviderField,
-                        outerMethod.getThis());
-                BytecodeCreator trueBranch = innerMethod.ifNull(passwordProviderInstanceField).trueBranch();
-                ResultHandle passwordProviderInstance = trueBranch
-                        .newInstance(MethodDescriptor.ofConstructor(passwordProviderClassStr));
-                trueBranch.writeInstanceField(passwordProviderField, outerMethod.getThis(), passwordProviderInstance);
-                trueBranch.close();
-                ResultHandle objectToInvokeOn = innerMethod.readInstanceField(passwordProviderField, outerMethod.getThis());
+                LocalVar passwordProviderInstanceField = bc.localVar("ppField",
+                        bc.get(thisRef.field(passwordProviderField)));
+                bc.if_(bc.isNull(passwordProviderInstanceField), trueBranch -> {
+                    Expr passwordProviderInstance = trueBranch
+                            .new_(ConstructorDesc.of(ClassDesc.of(passwordProviderClassStr)));
+                    trueBranch.set(thisRef.field(passwordProviderField), passwordProviderInstance);
+                });
+                LocalVar objectToInvokeOn = bc.localVar("ppObj",
+                        bc.get(thisRef.field(passwordProviderField)));
 
                 // :getPasswordMethod(:pass);
-                storedPassword = innerMethod.invokeVirtualMethod(
-                        MethodDescriptor.ofMethod(passwordProviderClassStr, passwordProviderMethod,
-                                org.wildfly.security.password.Password.class,
+                storedPassword = bc.invokeVirtual(
+                        ClassMethodDesc.of(ClassDesc.of(passwordProviderClassStr),
+                                passwordProviderMethod,
+                                Password.class,
                                 String.class),
-                        objectToInvokeOn, pass);
+                        bc.cast(objectToInvokeOn, ClassDesc.of(passwordProviderClassStr)), pass);
                 break;
             case CLEAR:
-                storedPassword = innerMethod.invokeStaticMethod(getUtilMethod("getClearPassword"), pass);
+                storedPassword = bc.invokeStatic(getUtilMethod("getClearPassword"), pass);
                 break;
             case MCF:
-                storedPassword = innerMethod.invokeStaticMethod(getUtilMethod("getMcfPassword"), pass);
+                storedPassword = bc.invokeStatic(getUtilMethod("getMcfPassword"), pass);
                 break;
             default:
                 throw new RuntimeException("Unknown password type: " + passwordType);
         }
 
         // Builder builder = JpaIdentityProviderUtil.checkPassword(storedPassword, request);
-        ResultHandle builder = innerMethod.invokeStaticMethod(
-                MethodDescriptor.ofMethod(JpaIdentityProviderUtil.class, "checkPassword",
+        Expr builder = bc.invokeStatic(
+                MethodDesc.of(JpaIdentityProviderUtil.class, "checkPassword",
                         QuarkusSecurityIdentity.Builder.class,
-                        org.wildfly.security.password.Password.class,
+                        Password.class,
                         UsernamePasswordAuthenticationRequest.class),
-                storedPassword, outerMethod.getMethodParam(1));
-        AssignableResultHandle builderVar = innerMethod.createVariable(QuarkusSecurityIdentity.Builder.class);
-        innerMethod.assign(builderVar, builder);
+                storedPassword, requestParam);
+        LocalVar builderVar = bc.localVar("builder", QuarkusSecurityIdentity.Builder.class, builder);
 
-        setupRoles(index, jpaSecurityDefinition, panacheEntityPredicate, userVar, builderVar, innerMethod);
+        setupRoles(index, jpaSecurityDefinition, panacheEntityPredicate, userVar, builderVar, bc);
     }
 
     public static void buildTrustedIdentity(Index index, JpaSecurityDefinition jpaSecurityDefinition,
-            PanacheEntityPredicateBuildItem panacheEntityPredicate, MethodCreator outerMethod, ResultHandle userVar,
-            BytecodeCreator innerMethod) {
+            PanacheEntityPredicateBuildItem panacheEntityPredicate, Expr requestParam, Expr userVar,
+            BlockCreator bc) {
         // if(user == null) return null;
-        try (BytecodeCreator trueBranch = innerMethod.ifNull(userVar).trueBranch()) {
-            trueBranch.returnValue(trueBranch.loadNull());
-        }
+        bc.if_(bc.isNull(userVar), trueBranch -> {
+            trueBranch.returnNull();
+        });
         // Builder builder = JpaIdentityProviderUtil.trusted(request);
-        ResultHandle builder = innerMethod.invokeStaticMethod(MethodDescriptor.ofMethod(JpaIdentityProviderUtil.class,
+        Expr builder = bc.invokeStatic(MethodDesc.of(JpaIdentityProviderUtil.class,
                 "trusted",
                 QuarkusSecurityIdentity.Builder.class,
                 TrustedAuthenticationRequest.class),
-                outerMethod.getMethodParam(1));
-        AssignableResultHandle builderVar = innerMethod.createVariable(QuarkusSecurityIdentity.Builder.class);
-        innerMethod.assign(builderVar, builder);
+                requestParam);
+        LocalVar builderVar = bc.localVar("builder", QuarkusSecurityIdentity.Builder.class, builder);
 
-        setupRoles(index, jpaSecurityDefinition, panacheEntityPredicate, userVar, builderVar, innerMethod);
+        setupRoles(index, jpaSecurityDefinition, panacheEntityPredicate, userVar, builderVar, bc);
     }
 
     static AnnotationTarget getSingleAnnotatedElement(Index index, DotName annotation) {
@@ -138,9 +138,9 @@ public final class JpaSecurityIdentityUtil {
     }
 
     private static void setupRoles(Index index, JpaSecurityDefinition jpaSecurityDefinition,
-            PanacheEntityPredicateBuildItem panacheEntityPredicate, ResultHandle userVar,
-            AssignableResultHandle builderVar, BytecodeCreator innerMethod) {
-        ResultHandle role = jpaSecurityDefinition.roles.readValue(innerMethod, userVar);
+            PanacheEntityPredicateBuildItem panacheEntityPredicate, Expr userVar,
+            LocalVar builderVar, BlockCreator bc) {
+        Expr role = jpaSecurityDefinition.roles.readValue(bc, userVar);
         // role: user.getRole()
         boolean handledRole = false;
         Type rolesType = jpaSecurityDefinition.roles.type();
@@ -151,8 +151,8 @@ public final class JpaSecurityIdentityUtil {
             case CLASS:
                 if (rolesType.name().equals(DotNames.STRING)) {
                     // JpaIdentityProviderUtil.addRoles(builder, :role)
-                    innerMethod.invokeStaticMethod(
-                            MethodDescriptor.ofMethod(JpaIdentityProviderUtil.class, "addRoles", void.class,
+                    bc.invokeStatic(
+                            MethodDesc.of(JpaIdentityProviderUtil.class, "addRoles", void.class,
                                     QuarkusSecurityIdentity.Builder.class, String.class),
                             builderVar, role);
                     handledRole = true;
@@ -164,8 +164,6 @@ public final class JpaSecurityIdentityUtil {
                         || roleType.equals(DOTNAME_COLLECTION)
                         || roleType.equals(DOTNAME_SET)) {
                     Type elementType = rolesType.asParameterizedType().arguments().get(0);
-                    String elementClassName = elementType.name().toString();
-                    String elementClassTypeDescriptor = "L" + elementClassName.replace('.', '/') + ";";
                     JpaSecurityDefinition.FieldOrMethod rolesFieldOrMethod;
                     if (!elementType.name().equals(DotNames.STRING)) {
                         ClassInfo roleClass = index.getClassByName(elementType.name());
@@ -188,15 +186,15 @@ public final class JpaSecurityIdentityUtil {
                     //    // or for String collections:
                     //    JpaIdentityProviderUtil.addRoles(:role);
                     // }
-                    foreach(innerMethod, role, elementClassTypeDescriptor, (creator, var) -> {
-                        ResultHandle roleElement;
+                    bc.forEach(role, (loopBody, var) -> {
+                        Expr roleElement;
                         if (rolesFieldOrMethod != null) {
-                            roleElement = rolesFieldOrMethod.readValue(creator, var);
+                            roleElement = rolesFieldOrMethod.readValue(loopBody, var);
                         } else {
                             roleElement = var;
                         }
-                        creator.invokeStaticMethod(
-                                MethodDescriptor.ofMethod(JpaIdentityProviderUtil.class, "addRoles", void.class,
+                        loopBody.invokeStatic(
+                                MethodDesc.of(JpaIdentityProviderUtil.class, "addRoles", void.class,
                                         QuarkusSecurityIdentity.Builder.class, String.class),
                                 builderVar, roleElement);
                     });
@@ -209,47 +207,19 @@ public final class JpaSecurityIdentityUtil {
         }
 
         // return builder.build()
-        innerMethod.returnValue(innerMethod.invokeVirtualMethod(
-                MethodDescriptor.ofMethod(QuarkusSecurityIdentity.Builder.class,
+        bc.return_(bc.invokeVirtual(
+                MethodDesc.of(QuarkusSecurityIdentity.Builder.class,
                         "build",
                         QuarkusSecurityIdentity.class),
                 builderVar));
     }
 
-    private static void foreach(BytecodeCreator bytecodeCreator, ResultHandle iterable, String type,
-            BiConsumer<BytecodeCreator, AssignableResultHandle> body) {
-        ResultHandle iterator = bytecodeCreator.invokeInterfaceMethod(
-                MethodDescriptor.ofMethod(Iterable.class, "iterator", Iterator.class),
-                iterable);
-        try (BytecodeCreator loop = bytecodeCreator.createScope()) {
-            ResultHandle hasNextValue = loop.invokeInterfaceMethod(
-                    MethodDescriptor.ofMethod(Iterator.class, "hasNext", boolean.class),
-                    iterator);
-
-            BranchResult hasNextBranch = loop.ifNonZero(hasNextValue);
-            try (BytecodeCreator hasNext = hasNextBranch.trueBranch()) {
-                ResultHandle next = hasNext.invokeInterfaceMethod(
-                        MethodDescriptor.ofMethod(Iterator.class, "next", Object.class),
-                        iterator);
-
-                AssignableResultHandle var = hasNext.createVariable(type);
-                hasNext.assign(var, next);
-
-                body.accept(hasNext, var);
-                hasNext.continueScope(loop);
-            }
-            try (BytecodeCreator doesNotHaveNext = hasNextBranch.falseBranch()) {
-                doesNotHaveNext.breakScope(loop);
-            }
-        }
+    private static MethodDesc getUtilMethod(String passwordProviderMethod) {
+        return MethodDesc.of(JpaIdentityProviderUtil.class, passwordProviderMethod,
+                Password.class, String.class);
     }
 
-    private static MethodDescriptor getUtilMethod(String passwordProviderMethod) {
-        return MethodDescriptor.ofMethod(JpaIdentityProviderUtil.class, passwordProviderMethod,
-                org.wildfly.security.password.Password.class, String.class);
-    }
-
-    private static MethodDescriptor passwordActionMethod() {
-        return MethodDescriptor.ofMethod(JpaIdentityProviderUtil.class, "passwordAction", void.class, PasswordType.class);
+    private static MethodDesc passwordActionMethod() {
+        return MethodDesc.of(JpaIdentityProviderUtil.class, "passwordAction", void.class, PasswordType.class);
     }
 }

--- a/extensions/security-jpa-reactive/deployment/src/main/java/io/quarkus/security/jpa/reactive/deployment/QuarkusSecurityJpaReactiveProcessor.java
+++ b/extensions/security-jpa-reactive/deployment/src/main/java/io/quarkus/security/jpa/reactive/deployment/QuarkusSecurityJpaReactiveProcessor.java
@@ -1,15 +1,12 @@
 package io.quarkus.security.jpa.reactive.deployment;
 
-import static io.quarkus.gizmo.MethodDescriptor.ofMethod;
 import static io.quarkus.security.jpa.common.deployment.JpaSecurityIdentityUtil.buildIdentity;
 import static io.quarkus.security.jpa.common.deployment.JpaSecurityIdentityUtil.buildTrustedIdentity;
 
-import java.lang.reflect.Modifier;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 import jakarta.inject.Singleton;
@@ -27,19 +24,20 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.Index;
 
 import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
-import io.quarkus.arc.deployment.GeneratedBeanGizmoAdaptor;
+import io.quarkus.arc.deployment.GeneratedBeanGizmo2Adaptor;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ApplicationIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
-import io.quarkus.gizmo.BytecodeCreator;
-import io.quarkus.gizmo.ClassCreator;
-import io.quarkus.gizmo.FieldDescriptor;
-import io.quarkus.gizmo.FunctionCreator;
-import io.quarkus.gizmo.MethodCreator;
-import io.quarkus.gizmo.MethodDescriptor;
-import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo2.Const;
+import io.quarkus.gizmo2.Expr;
+import io.quarkus.gizmo2.Gizmo;
+import io.quarkus.gizmo2.LocalVar;
+import io.quarkus.gizmo2.Var;
+import io.quarkus.gizmo2.creator.BlockCreator;
+import io.quarkus.gizmo2.desc.FieldDesc;
+import io.quarkus.gizmo2.desc.MethodDesc;
 import io.quarkus.panache.common.deployment.PanacheEntityClassesBuildItem;
 import io.quarkus.security.identity.request.TrustedAuthenticationRequest;
 import io.quarkus.security.identity.request.UsernamePasswordAuthenticationRequest;
@@ -93,106 +91,127 @@ class QuarkusSecurityJpaReactiveProcessor {
     private static void generateIdentityProvider(Index index, JpaSecurityDefinition jpaSecurityDefinition,
             AnnotationValue passwordTypeValue, AnnotationValue passwordProviderValue,
             BuildProducer<GeneratedBeanBuildItem> beanProducer, PanacheEntityPredicateBuildItem panacheEntityPredicate) {
-        GeneratedBeanGizmoAdaptor gizmoAdaptor = new GeneratedBeanGizmoAdaptor(beanProducer);
+        GeneratedBeanGizmo2Adaptor gizmoAdaptor = new GeneratedBeanGizmo2Adaptor(beanProducer);
 
         String name = jpaSecurityDefinition.annotatedClass.name() + "__JpaReactiveIdentityProviderImpl";
-        try (ClassCreator classCreator = ClassCreator.builder()
-                .className(name)
-                .superClass(JpaReactiveIdentityProvider.class)
-                .classOutput(gizmoAdaptor)
-                .build()) {
-            classCreator.addAnnotation(Singleton.class);
-            FieldDescriptor passwordProviderField = classCreator.getFieldCreator("passwordProvider", PasswordProvider.class)
-                    .setModifiers(0) // removes default modifier => makes field package-private
-                    .getFieldDescriptor();
+        Gizmo.create(gizmoAdaptor).class_(name, cc -> {
+            cc.extends_(JpaReactiveIdentityProvider.class);
+            cc.addAnnotation(Singleton.class);
+            cc.defaultConstructor();
+            FieldDesc passwordProviderField = cc.field("passwordProvider", ifc -> {
+                ifc.setType(PasswordProvider.class);
+                ifc.packagePrivate();
+            });
 
-            MethodDescriptor methodToImpl = MethodDescriptor.ofMethod(JpaReactiveIdentityProvider.class, "authenticate",
-                    Uni.class, Mutiny.Session.class, UsernamePasswordAuthenticationRequest.class);
-            try (MethodCreator methodCreator = classCreator.getMethodCreator(methodToImpl)) {
-                methodCreator.setModifiers(Modifier.PUBLIC);
+            cc.method("authenticate", mc -> {
+                mc.public_();
+                mc.returning(Uni.class);
+                var sessionParam = mc.parameter("session", Mutiny.Session.class);
+                var requestParam = mc.parameter("request", UsernamePasswordAuthenticationRequest.class);
+                mc.body(bc -> {
+                    LocalVar username = bc.localVar("username", bc.invokeVirtual(
+                            MethodDesc.of(UsernamePasswordAuthenticationRequest.class, "getUsername", String.class),
+                            requestParam));
 
-                ResultHandle username = methodCreator.invokeVirtualMethod(
-                        ofMethod(UsernamePasswordAuthenticationRequest.class, "getUsername", String.class),
-                        methodCreator.getMethodParam(1));
+                    Expr userUni = lookupUserById(jpaSecurityDefinition, bc, sessionParam, username);
 
-                ResultHandle userUni = lookupUserById(jpaSecurityDefinition, methodCreator, username);
+                    // .map(user -> { /* build identity */ })
+                    Expr identityUni = bc.invokeInterface(
+                            MethodDesc.of(Uni.class, "map", Uni.class, Function.class),
+                            userUni, bc.lambda(Function.class, lc -> {
+                                Var thisCapture = lc.capture("this", cc.this_());
+                                Var reqCapture = lc.capture("request", requestParam);
+                                Expr user = lc.parameter("user", 0);
+                                lc.body(lbc -> {
+                                    buildIdentity(index, jpaSecurityDefinition, passwordTypeValue, passwordProviderValue,
+                                            panacheEntityPredicate, passwordProviderField, thisCapture, reqCapture,
+                                            user, lbc);
+                                });
+                            }));
 
-                // .map(user -> { /* build identity */ })
-                ResultHandle identityUni = uniMap(methodCreator, userUni,
-                        (body, user) -> buildIdentity(index, jpaSecurityDefinition, passwordTypeValue, passwordProviderValue,
-                                panacheEntityPredicate, passwordProviderField, methodCreator, user, body));
-
-                methodCreator.returnValue(identityUni);
-            }
-        }
+                    bc.return_(identityUni);
+                });
+            });
+        });
     }
 
     private static void generateTrustedIdentityProvider(Index index, JpaSecurityDefinition jpaSecurityDefinition,
             BuildProducer<GeneratedBeanBuildItem> beanProducer, PanacheEntityPredicateBuildItem panacheEntityPredicate) {
-        GeneratedBeanGizmoAdaptor gizmoAdaptor = new GeneratedBeanGizmoAdaptor(beanProducer);
+        GeneratedBeanGizmo2Adaptor gizmoAdaptor = new GeneratedBeanGizmo2Adaptor(beanProducer);
 
         String name = jpaSecurityDefinition.annotatedClass.name() + "__JpaReactiveTrustedIdentityProviderImpl";
-        try (ClassCreator classCreator = ClassCreator.builder()
-                .className(name)
-                .superClass(JpaReactiveTrustedIdentityProvider.class)
-                .classOutput(gizmoAdaptor)
-                .build()) {
-            classCreator.addAnnotation(Singleton.class);
+        Gizmo.create(gizmoAdaptor).class_(name, cc -> {
+            cc.extends_(JpaReactiveTrustedIdentityProvider.class);
+            cc.addAnnotation(Singleton.class);
+            cc.defaultConstructor();
 
-            MethodDescriptor methodToImpl = MethodDescriptor.ofMethod(JpaReactiveTrustedIdentityProvider.class, "authenticate",
-                    Uni.class, Mutiny.Session.class, TrustedAuthenticationRequest.class);
-            try (MethodCreator methodCreator = classCreator.getMethodCreator(methodToImpl)) {
-                methodCreator.setModifiers(Modifier.PUBLIC);
+            cc.method("authenticate", mc -> {
+                mc.public_();
+                mc.returning(Uni.class);
+                var sessionParam = mc.parameter("session", Mutiny.Session.class);
+                var requestParam = mc.parameter("request", TrustedAuthenticationRequest.class);
+                mc.body(bc -> {
+                    LocalVar username = bc.localVar("username", bc.invokeVirtual(
+                            MethodDesc.of(TrustedAuthenticationRequest.class, "getPrincipal", String.class),
+                            requestParam));
 
-                ResultHandle username = methodCreator.invokeVirtualMethod(
-                        ofMethod(TrustedAuthenticationRequest.class, "getPrincipal", String.class),
-                        methodCreator.getMethodParam(1));
+                    Expr userUni = lookupUserById(jpaSecurityDefinition, bc, sessionParam, username);
 
-                ResultHandle userUni = lookupUserById(jpaSecurityDefinition, methodCreator, username);
+                    // .map(user -> { /* build identity */ })
+                    Expr identityUni = bc.invokeInterface(
+                            MethodDesc.of(Uni.class, "map", Uni.class, Function.class),
+                            userUni, bc.lambda(Function.class, lc -> {
+                                Var reqCapture = lc.capture("request", requestParam);
+                                Expr user = lc.parameter("user", 0);
+                                lc.body(lbc -> {
+                                    buildTrustedIdentity(index, jpaSecurityDefinition, panacheEntityPredicate,
+                                            reqCapture, user, lbc);
+                                });
+                            }));
 
-                // .map(user -> { /* build identity */ })
-                ResultHandle identityUni = uniMap(methodCreator, userUni,
-                        (body, user) -> buildTrustedIdentity(index, jpaSecurityDefinition, panacheEntityPredicate,
-                                methodCreator, user, body));
-
-                methodCreator.returnValue(identityUni);
-            }
-        }
+                    bc.return_(identityUni);
+                });
+            });
+        });
     }
 
-    private static ResultHandle lookupUserById(JpaSecurityDefinition jpaSecurityDefinition, MethodCreator methodCreator,
-            ResultHandle username) {
+    private static Expr lookupUserById(JpaSecurityDefinition jpaSecurityDefinition, BlockCreator bc,
+            Expr session, Expr username) {
 
         // two strategies, depending on whether the username is natural id
         AnnotationInstance naturalIdAnnotation = jpaSecurityDefinition.username.annotation(NATURAL_ID);
 
         // PlainUserEntity.class
         String userEntityClassName = jpaSecurityDefinition.annotatedClass.name().toString();
-        var userEntityClass = methodCreator.loadClass(userEntityClassName);
-
-        // 'Mutiny.Session' session
-        ResultHandle session = methodCreator.getMethodParam(0);
+        Expr userEntityClass = bc.classForName(Const.of(userEntityClassName));
 
         boolean fetchJoinRoles = shouldFetchJoinRoles(jpaSecurityDefinition);
-        ResultHandle user;
+        Expr user;
         if (naturalIdAnnotation != null) {
 
             // Identifier.id("name", username)
-            ResultHandle id = methodCreator.invokeStaticMethod(
-                    ofMethod(Identifier.class, "id", Identifier.Id.class, String.class, Object.class),
-                    methodCreator.load(jpaSecurityDefinition.username.name()), username);
+            Expr id = bc.invokeStatic(
+                    MethodDesc.of(Identifier.class, "id", Identifier.Id.class, String.class, Object.class),
+                    Const.of(jpaSecurityDefinition.username.name()), username);
 
             // session.find(PlainUserEntity.class, Identifier.id("name", username))
-            user = methodCreator.invokeInterfaceMethod(
-                    ofMethod(Mutiny.Session.class, "find", Uni.class, Class.class, Identifier.class),
+            user = bc.invokeInterface(
+                    MethodDesc.of(Mutiny.Session.class, "find", Uni.class, Class.class, Identifier.class),
                     session, userEntityClass, id);
 
             if (fetchJoinRoles) {
                 // .flatMap(user -> session.fetch(user))
-                String userClassName = jpaSecurityDefinition.annotatedClass.name().toString();
-                user = uniFlatMap(methodCreator, user, (body, user1) -> body.invokeInterfaceMethod(
-                        ofMethod(Mutiny.Session.class, "fetch", Uni.class, userClassName),
-                        session, user1));
+                user = bc.invokeInterface(
+                        MethodDesc.of(Uni.class, "flatMap", Uni.class, Function.class),
+                        user, bc.lambda(Function.class, lc -> {
+                            Var sessionCapture = lc.capture("session", session);
+                            Expr user1 = lc.parameter("user1", 0);
+                            lc.body(lbc -> {
+                                lbc.return_(lbc.invokeInterface(
+                                        MethodDesc.of(Mutiny.Session.class, "fetch", Uni.class, Object.class),
+                                        sessionCapture, user1));
+                            });
+                        }));
             }
         } else {
 
@@ -209,19 +228,19 @@ class QuarkusSecurityJpaReactiveProcessor {
             }
 
             // session.createQuery("<<HQL>>", UserEntity.class)
-            ResultHandle query1 = methodCreator.invokeInterfaceMethod(
-                    ofMethod(Mutiny.Session.class, "createQuery", Mutiny.SelectionQuery.class, String.class, Class.class),
-                    session, methodCreator.load(hql), userEntityClass);
+            Expr query1 = bc.invokeInterface(
+                    MethodDesc.of(Mutiny.Session.class, "createQuery", Mutiny.SelectionQuery.class, String.class, Class.class),
+                    session, Const.of(hql), userEntityClass);
 
             // .setParameter("name", username)
-            ResultHandle query2 = methodCreator.invokeInterfaceMethod(
-                    ofMethod(Mutiny.SelectionQuery.class, "setParameter", Mutiny.SelectionQuery.class, String.class,
+            Expr query2 = bc.invokeInterface(
+                    MethodDesc.of(Mutiny.SelectionQuery.class, "setParameter", Mutiny.SelectionQuery.class, String.class,
                             Object.class),
-                    query1, methodCreator.load("name"), username);
+                    query1, Const.of("name"), username);
 
             // .getSingleResultOrNull()
-            user = methodCreator.invokeInterfaceMethod(
-                    ofMethod(Mutiny.SelectionQuery.class, "getSingleResultOrNull", Uni.class),
+            user = bc.invokeInterface(
+                    MethodDesc.of(Mutiny.SelectionQuery.class, "getSingleResultOrNull", Uni.class),
                     query2);
         }
 
@@ -234,26 +253,5 @@ class QuarkusSecurityJpaReactiveProcessor {
                 DotName.createSimple(ManyToMany.class),
                 DotName.createSimple(OneToMany.class),
                 DotName.createSimple(ManyToOne.class));
-    }
-
-    private static ResultHandle uniMap(MethodCreator creator, ResultHandle uniInstance,
-            BiConsumer<BytecodeCreator, ResultHandle> fun) {
-        return uniLambda(creator, uniInstance, fun, "map");
-    }
-
-    private static ResultHandle uniFlatMap(BytecodeCreator creator, ResultHandle uniInstance,
-            BiConsumer<BytecodeCreator, ResultHandle> fun) {
-        return uniLambda(creator, uniInstance, fun, "flatMap");
-    }
-
-    private static ResultHandle uniLambda(BytecodeCreator creator, ResultHandle uniInstance,
-            BiConsumer<BytecodeCreator, ResultHandle> function, String name) {
-        FunctionCreator lambda = creator.createFunction(Function.class);
-        BytecodeCreator body = lambda.getBytecode();
-        ResultHandle user = body.getMethodParam(0);
-        function.accept(body, user);
-
-        return creator.invokeInterfaceMethod(ofMethod(Uni.class, name, Uni.class, Function.class),
-                uniInstance, lambda.getInstance());
     }
 }

--- a/extensions/security-jpa/deployment/src/main/java/io/quarkus/security/jpa/deployment/QuarkusSecurityJpaProcessor.java
+++ b/extensions/security-jpa/deployment/src/main/java/io/quarkus/security/jpa/deployment/QuarkusSecurityJpaProcessor.java
@@ -4,7 +4,7 @@ import static io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil.DEFAULT_PERSI
 import static io.quarkus.security.jpa.common.deployment.JpaSecurityIdentityUtil.buildIdentity;
 import static io.quarkus.security.jpa.common.deployment.JpaSecurityIdentityUtil.buildTrustedIdentity;
 
-import java.lang.reflect.Modifier;
+import java.lang.constant.ClassDesc;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -27,7 +27,7 @@ import org.jboss.jandex.Index;
 import org.jboss.jandex.Type;
 
 import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
-import io.quarkus.arc.deployment.GeneratedBeanGizmoAdaptor;
+import io.quarkus.arc.deployment.GeneratedBeanGizmo2Adaptor;
 import io.quarkus.arc.deployment.InjectionPointTransformerBuildItem;
 import io.quarkus.arc.processor.InjectionPointsTransformer;
 import io.quarkus.deployment.Feature;
@@ -35,12 +35,14 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ApplicationIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
-import io.quarkus.gizmo.AssignableResultHandle;
-import io.quarkus.gizmo.ClassCreator;
-import io.quarkus.gizmo.FieldDescriptor;
-import io.quarkus.gizmo.MethodCreator;
-import io.quarkus.gizmo.MethodDescriptor;
-import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo2.Const;
+import io.quarkus.gizmo2.Expr;
+import io.quarkus.gizmo2.Gizmo;
+import io.quarkus.gizmo2.LocalVar;
+import io.quarkus.gizmo2.creator.BlockCreator;
+import io.quarkus.gizmo2.creator.ClassCreator;
+import io.quarkus.gizmo2.desc.FieldDesc;
+import io.quarkus.gizmo2.desc.MethodDesc;
 import io.quarkus.hibernate.orm.PersistenceUnit;
 import io.quarkus.hibernate.orm.deployment.PersistenceUnitDescriptorBuildItem;
 import io.quarkus.hibernate.orm.runtime.migration.MultiTenancyStrategy;
@@ -130,131 +132,139 @@ class QuarkusSecurityJpaProcessor {
             AnnotationValue passwordTypeValue, AnnotationValue passwordProviderValue,
             BuildProducer<GeneratedBeanBuildItem> beanProducer, PanacheEntityPredicateBuildItem panacheEntityPredicate,
             boolean requireActiveCDIRequestContext) {
-        GeneratedBeanGizmoAdaptor gizmoAdaptor = new GeneratedBeanGizmoAdaptor(beanProducer);
+        GeneratedBeanGizmo2Adaptor gizmoAdaptor = new GeneratedBeanGizmo2Adaptor(beanProducer);
 
         String name = jpaSecurityDefinition.annotatedClass.name() + "__JpaIdentityProviderImpl";
-        try (ClassCreator classCreator = ClassCreator.builder()
-                .className(name)
-                .superClass(JpaIdentityProvider.class)
-                .classOutput(gizmoAdaptor)
-                .build()) {
-            classCreator.addAnnotation(Singleton.class);
-            FieldDescriptor passwordProviderField = classCreator.getFieldCreator("passwordProvider", PasswordProvider.class)
-                    .setModifiers(Modifier.PRIVATE)
-                    .getFieldDescriptor();
+        Gizmo.create(gizmoAdaptor)
+                .class_(name, cc -> {
+                    cc.extends_(JpaIdentityProvider.class);
+                    cc.addAnnotation(Singleton.class);
+                    cc.defaultConstructor();
+                    FieldDesc passwordProviderField = cc.field("passwordProvider", ifc -> {
+                        ifc.setType(PasswordProvider.class);
+                        ifc.private_();
+                    });
 
-            if (requireActiveCDIRequestContext) {
-                activateCDIRequestContext(classCreator);
-            }
+                    if (requireActiveCDIRequestContext) {
+                        activateCDIRequestContext(cc);
+                    }
 
-            try (MethodCreator methodCreator = classCreator.getMethodCreator("authenticate", SecurityIdentity.class,
-                    EntityManager.class, UsernamePasswordAuthenticationRequest.class)) {
-                methodCreator.setModifiers(Modifier.PUBLIC);
+                    cc.method("authenticate", mc -> {
+                        mc.public_();
+                        mc.returning(SecurityIdentity.class);
+                        var emParam = mc.parameter("entityManager", EntityManager.class);
+                        var requestParam = mc.parameter("request", UsernamePasswordAuthenticationRequest.class);
+                        mc.body(bc -> {
+                            LocalVar username = bc.localVar("username", bc.invokeVirtual(
+                                    MethodDesc.of(UsernamePasswordAuthenticationRequest.class, "getUsername", String.class),
+                                    requestParam));
 
-                ResultHandle username = methodCreator.invokeVirtualMethod(
-                        MethodDescriptor.ofMethod(UsernamePasswordAuthenticationRequest.class, "getUsername", String.class),
-                        methodCreator.getMethodParam(1));
+                            // two strategies, depending on whether the username is natural id
+                            AnnotationInstance naturalIdAnnotation = jpaSecurityDefinition.username
+                                    .annotation(DOTNAME_NATURAL_ID);
+                            Expr user = lookupUserById(jpaSecurityDefinition, name, bc, cc.this_(), emParam, username,
+                                    naturalIdAnnotation, JpaIdentityProvider.class);
 
-                // two strategies, depending on whether the username is natural id
-                AnnotationInstance naturalIdAnnotation = jpaSecurityDefinition.username.annotation(DOTNAME_NATURAL_ID);
-                ResultHandle user = lookupUserById(jpaSecurityDefinition, name, methodCreator, username, naturalIdAnnotation);
+                            String declaringClassName = jpaSecurityDefinition.annotatedClass.name().toString();
+                            LocalVar userVar = bc.localVar("user",
+                                    bc.cast(user, ClassDesc.of(declaringClassName)));
 
-                String declaringClassName = jpaSecurityDefinition.annotatedClass.name().toString();
-                String declaringClassTypeDescriptor = "L" + declaringClassName.replace('.', '/') + ";";
-                AssignableResultHandle userVar = methodCreator.createVariable(declaringClassTypeDescriptor);
-                methodCreator.assign(userVar, methodCreator.checkCast(user, declaringClassName));
-
-                buildIdentity(index, jpaSecurityDefinition, passwordTypeValue, passwordProviderValue, panacheEntityPredicate,
-                        passwordProviderField, methodCreator, userVar, methodCreator);
-            }
-        }
+                            buildIdentity(index, jpaSecurityDefinition, passwordTypeValue, passwordProviderValue,
+                                    panacheEntityPredicate,
+                                    passwordProviderField, cc.this_(), requestParam, userVar, bc);
+                        });
+                    });
+                });
     }
 
     private void generateTrustedIdentityProvider(Index index, JpaSecurityDefinition jpaSecurityDefinition,
             BuildProducer<GeneratedBeanBuildItem> beanProducer, PanacheEntityPredicateBuildItem panacheEntityPredicate,
             boolean requireActiveCDIRequestContext) {
-        GeneratedBeanGizmoAdaptor gizmoAdaptor = new GeneratedBeanGizmoAdaptor(beanProducer);
+        GeneratedBeanGizmo2Adaptor gizmoAdaptor = new GeneratedBeanGizmo2Adaptor(beanProducer);
 
         String name = jpaSecurityDefinition.annotatedClass.name() + "__JpaTrustedIdentityProviderImpl";
-        try (ClassCreator classCreator = ClassCreator.builder()
-                .className(name)
-                .superClass(JpaTrustedIdentityProvider.class)
-                .classOutput(gizmoAdaptor)
-                .build()) {
-            classCreator.addAnnotation(Singleton.class);
-            try (MethodCreator methodCreator = classCreator.getMethodCreator("authenticate", SecurityIdentity.class,
-                    EntityManager.class, TrustedAuthenticationRequest.class)) {
-                methodCreator.setModifiers(Modifier.PUBLIC);
+        Gizmo.create(gizmoAdaptor).class_(name, cc -> {
+            cc.extends_(JpaTrustedIdentityProvider.class);
+            cc.addAnnotation(Singleton.class);
+            cc.defaultConstructor();
 
-                if (requireActiveCDIRequestContext) {
-                    activateCDIRequestContext(classCreator);
-                }
-
-                ResultHandle username = methodCreator.invokeVirtualMethod(
-                        MethodDescriptor.ofMethod(TrustedAuthenticationRequest.class, "getPrincipal", String.class),
-                        methodCreator.getMethodParam(1));
-
-                // two strategies, depending on whether the username is natural id
-                AnnotationInstance naturalIdAnnotation = jpaSecurityDefinition.username.annotation(DOTNAME_NATURAL_ID);
-                ResultHandle user = lookupUserById(jpaSecurityDefinition, name, methodCreator, username, naturalIdAnnotation);
-
-                String declaringClassName = jpaSecurityDefinition.annotatedClass.name().toString();
-                String declaringClassTypeDescriptor = "L" + declaringClassName.replace('.', '/') + ";";
-                AssignableResultHandle userVar = methodCreator.createVariable(declaringClassTypeDescriptor);
-                methodCreator.assign(userVar, methodCreator.checkCast(user, declaringClassName));
-
-                buildTrustedIdentity(index, jpaSecurityDefinition, panacheEntityPredicate, methodCreator, userVar,
-                        methodCreator);
+            if (requireActiveCDIRequestContext) {
+                activateCDIRequestContext(cc);
             }
-        }
+
+            cc.method("authenticate", mc -> {
+                mc.public_();
+                mc.returning(SecurityIdentity.class);
+                var emParam = mc.parameter("entityManager", EntityManager.class);
+                var requestParam = mc.parameter("request", TrustedAuthenticationRequest.class);
+                mc.body(bc -> {
+                    LocalVar username = bc.localVar("username", bc.invokeVirtual(
+                            MethodDesc.of(TrustedAuthenticationRequest.class, "getPrincipal", String.class),
+                            requestParam));
+
+                    // two strategies, depending on whether the username is natural id
+                    AnnotationInstance naturalIdAnnotation = jpaSecurityDefinition.username.annotation(DOTNAME_NATURAL_ID);
+                    Expr user = lookupUserById(jpaSecurityDefinition, name, bc, cc.this_(), emParam, username,
+                            naturalIdAnnotation, JpaTrustedIdentityProvider.class);
+
+                    String declaringClassName = jpaSecurityDefinition.annotatedClass.name().toString();
+                    LocalVar userVar = bc.localVar("user",
+                            bc.cast(user, ClassDesc.of(declaringClassName)));
+
+                    buildTrustedIdentity(index, jpaSecurityDefinition, panacheEntityPredicate, requestParam,
+                            userVar, bc);
+                });
+            });
+        });
     }
 
-    private ResultHandle lookupUserById(JpaSecurityDefinition jpaSecurityDefinition, String name, MethodCreator methodCreator,
-            ResultHandle username, AnnotationInstance naturalIdAnnotation) {
-        ResultHandle user;
+    private Expr lookupUserById(JpaSecurityDefinition jpaSecurityDefinition, String name, BlockCreator bc,
+            Expr thisRef, Expr emParam, Expr username, AnnotationInstance naturalIdAnnotation,
+            Class<?> identityProviderClass) {
         if (naturalIdAnnotation != null) {
             // Session session = em.unwrap(Session.class);
-            ResultHandle session = methodCreator.invokeInterfaceMethod(
-                    MethodDescriptor.ofMethod(EntityManager.class, "unwrap", Object.class, Class.class),
-                    methodCreator.getMethodParam(0),
-                    methodCreator.loadClassFromTCCL(Session.class));
+            Expr session = bc.invokeInterface(
+                    MethodDesc.of(EntityManager.class, "unwrap", Object.class, Class.class),
+                    emParam,
+                    Const.of(Session.class));
             // SimpleNaturalIdLoadAccess<PlainUserEntity> naturalIdLoadAccess = session.bySimpleNaturalId(PlainUserEntity.class);
-            ResultHandle naturalIdLoadAccess = methodCreator.invokeInterfaceMethod(
-                    MethodDescriptor.ofMethod(Session.class, "bySimpleNaturalId",
+            Expr naturalIdLoadAccess = bc.invokeInterface(
+                    MethodDesc.of(Session.class, "bySimpleNaturalId",
                             SimpleNaturalIdLoadAccess.class, Class.class),
-                    methodCreator.checkCast(session, Session.class),
-                    methodCreator.loadClassFromTCCL(jpaSecurityDefinition.annotatedClass.name().toString()));
+                    bc.cast(session, Session.class),
+                    bc.classForName(Const.of(jpaSecurityDefinition.annotatedClass.name().toString())));
             // PlainUserEntity user = naturalIdLoadAccess.load(request.getUsername());
-            user = methodCreator.invokeInterfaceMethod(
-                    MethodDescriptor.ofMethod(SimpleNaturalIdLoadAccess.class, "load",
+            return bc.invokeInterface(
+                    MethodDesc.of(SimpleNaturalIdLoadAccess.class, "load",
                             Object.class, Object.class),
                     naturalIdLoadAccess, username);
         } else {
             // Query query = entityManager.createQuery("FROM Entity WHERE field = :name")
             String hql = "FROM " + jpaSecurityDefinition.annotatedClass.simpleName() + " WHERE "
                     + jpaSecurityDefinition.username.name() + " = :name";
-            ResultHandle query = methodCreator.invokeInterfaceMethod(
-                    MethodDescriptor.ofMethod(EntityManager.class, "createQuery", Query.class, String.class),
-                    methodCreator.getMethodParam(0), methodCreator.load(hql));
+            Expr query = bc.invokeInterface(
+                    MethodDesc.of(EntityManager.class, "createQuery", Query.class, String.class),
+                    emParam, Const.of(hql));
             // query.setParameter("name", request.getUsername())
-            ResultHandle query2 = methodCreator.invokeInterfaceMethod(
-                    MethodDescriptor.ofMethod(Query.class, "setParameter", Query.class, String.class, Object.class),
-                    query, methodCreator.load("name"), username);
+            Expr query2 = bc.invokeInterface(
+                    MethodDesc.of(Query.class, "setParameter", Query.class, String.class, Object.class),
+                    query, Const.of("name"), username);
 
             // UserEntity user = getSingleUser(query2);
-            user = methodCreator.invokeVirtualMethod(
-                    MethodDescriptor.ofMethod(name, "getSingleUser", Object.class, Query.class),
-                    methodCreator.getThis(), query2);
+            return bc.invokeVirtual(
+                    MethodDesc.of(identityProviderClass, "getSingleUser", Object.class, Query.class),
+                    thisRef, query2);
         }
-        return user;
     }
 
-    private static void activateCDIRequestContext(ClassCreator classCreator) {
-        try (MethodCreator methodCreator = classCreator.getMethodCreator("requireActiveCDIRequestContext",
-                DotName.createSimple(boolean.class.getName()).toString())) {
-            methodCreator.setModifiers(Modifier.PROTECTED);
-            methodCreator.returnBoolean(true);
-        }
+    private static void activateCDIRequestContext(ClassCreator cc) {
+        cc.method("requireActiveCDIRequestContext", mc -> {
+            mc.protected_();
+            mc.returning(boolean.class);
+            mc.body(bc -> {
+                bc.return_(true);
+            });
+        });
     }
 
     private static boolean shouldActivateCDIReqCtx(List<PersistenceUnitDescriptorBuildItem> puDescriptors,


### PR DESCRIPTION
Migrate the JPA security identity provider generation to use the Gizmo 2 API across security-jpa-common, security-jpa, and security-jpa-reactive modules.

Assisted-By: Claude (claude-opus-4-6)