### PR TITLE
Reproducibility: improve the check and add recorder-time validation

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
@@ -108,6 +108,9 @@ public class BytecodeRecorderImpl implements RecorderContext {
     private static final Class<?> SINGLETON_SET_CLASS = Collections.singleton(1).getClass();
     private static final Class<?> SINGLETON_MAP_CLASS = Collections.singletonMap(1, 1).getClass();
 
+    private static final String REPRODUCIBILITY_CHECK_PROPERTY_NAME = "quarkus-internal.test.reproducibility-check";
+    private static final boolean REPRODUCIBILITY_CHECK = System.getProperty(REPRODUCIBILITY_CHECK_PROPERTY_NAME) != null;
+
     // Global counter for proxy class name suffixes. These are build time artifacts
     // that don't affect the generated output bytecode, so non-deterministic ordering is fine.
     private static final AtomicInteger COUNT = new AtomicInteger();
@@ -1150,6 +1153,30 @@ public class BytecodeRecorderImpl implements RecorderContext {
         //been deserialized
         List<SerializationStep> setupSteps = new ArrayList<>();
         List<SerializationStep> ctorSetupSteps = new ArrayList<>();
+
+        if (REPRODUCIBILITY_CHECK) {
+            try {
+                if (param instanceof Set<?> set && set.getClass() == HashSet.class) {
+                    for (Object object : set) {
+                        if (object.getClass().getMethod("hashCode").getDeclaringClass() == Object.class) {
+                            throw new IllegalArgumentException("Object of class " + object.getClass().getName()
+                                    + " has non-deterministic hash code, it cannot be passed"
+                                    + " in a HashSet through the recorder boundary: " + object);
+                        }
+                    }
+                } else if (param instanceof Map<?, ?> map && map.getClass() == HashMap.class) {
+                    for (Object object : map.keySet()) {
+                        if (object.getClass().getMethod("hashCode").getDeclaringClass() == Object.class) {
+                            throw new IllegalArgumentException("Object of class " + object.getClass().getName()
+                                    + " has non-deterministic hash code, it cannot be passed"
+                                    + " as a HashMap key through the recorder boundary: " + object);
+                        }
+                    }
+                }
+            } catch (NoSuchMethodException e) {
+                throw new RuntimeException(e);
+            }
+        }
 
         boolean relaxedOk = false;
         if (param instanceof Collection) {

--- a/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/FaultToleranceScanner.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/FaultToleranceScanner.java
@@ -4,7 +4,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -128,7 +128,7 @@ final class FaultToleranceScanner {
     }
 
     FaultToleranceMethod createFaultToleranceMethod(ClassInfo beanClass, MethodInfo method) {
-        Set<Class<? extends Annotation>> annotationsPresentDirectly = new HashSet<>();
+        Set<Class<? extends Annotation>> annotationsPresentDirectly = new LinkedHashSet<>();
 
         FaultToleranceMethod result = new FaultToleranceMethod();
 

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/multiple/MultipleBean.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/multiple/MultipleBean.java
@@ -1,0 +1,39 @@
+package io.quarkus.smallrye.faulttolerance.test.multiple;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Bulkhead;
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.faulttolerance.Retry;
+import org.eclipse.microprofile.faulttolerance.Timeout;
+
+import io.smallrye.faulttolerance.api.BeforeRetry;
+import io.smallrye.faulttolerance.api.CircuitBreakerName;
+import io.smallrye.faulttolerance.api.ExponentialBackoff;
+import io.smallrye.faulttolerance.api.RateLimit;
+import io.smallrye.faulttolerance.api.RetryWhen;
+
+@ApplicationScoped
+public class MultipleBean {
+    @Bulkhead
+    @BeforeRetry(methodName = "beforeRetry")
+    @CircuitBreaker
+    @CircuitBreakerName("hello-cb")
+    @ExponentialBackoff
+    @Fallback(fallbackMethod = "fallback")
+    @RateLimit
+    @Retry
+    @RetryWhen
+    @Timeout
+    public String hello() {
+        throw new RuntimeException();
+    }
+
+    String fallback() {
+        return "fallback";
+    }
+
+    void beforeRetry() {
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/multiple/MultipleTest.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/multiple/MultipleTest.java
@@ -1,0 +1,24 @@
+package io.quarkus.smallrye.faulttolerance.test.multiple;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class MultipleTest {
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar.addClasses(MultipleBean.class));
+
+    @Inject
+    MultipleBean bean;
+
+    @Test
+    public void test() {
+        assertEquals("fallback", bean.hello());
+    }
+}

--- a/test-framework/junit-internal/pom.xml
+++ b/test-framework/junit-internal/pom.xml
@@ -40,6 +40,11 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit-config</artifactId>
         </dependency>
@@ -71,6 +76,10 @@
         <dependency>
             <groupId>org.vineflower</groupId>
             <artifactId>vineflower</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.common</groupId>
+            <artifactId>smallrye-common-process</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/test-framework/junit-internal/src/main/java/io/quarkus/test/AbstractQuarkusExtensionTest.java
+++ b/test-framework/junit-internal/src/main/java/io/quarkus/test/AbstractQuarkusExtensionTest.java
@@ -59,6 +59,7 @@ import io.quarkus.bootstrap.classloading.ClassLoaderEventListener;
 import io.quarkus.bootstrap.classloading.ClassPathElement;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.bootstrap.util.IoUtils;
 import io.quarkus.builder.BuildChainBuilder;
 import io.quarkus.builder.BuildContext;
 import io.quarkus.builder.BuildException;
@@ -80,6 +81,8 @@ import io.quarkus.test.common.TestResourceManager;
 import io.quarkus.test.common.http.TestHTTPResourceManager;
 import io.quarkus.test.junit.common.ClearCache;
 import io.quarkus.value.registry.ValueRegistry;
+import io.smallrye.common.process.ProcessBuilder;
+import io.smallrye.common.process.ProcessUtil;
 
 /**
  * A test extension for testing Quarkus internals, not intended for end user consumption.
@@ -96,6 +99,8 @@ public abstract class AbstractQuarkusExtensionTest<S extends AbstractQuarkusExte
     public static final String THE_BUILD_WAS_EXPECTED_TO_FAIL = "The build was expected to fail";
     private static final String APP_ROOT = "app-root";
     private static final String REPRODUCIBILITY_CHECK_PROPERTY_NAME = "quarkus-internal.test.reproducibility-check";
+    private static final String REPRODUCIBILITY_CROSS_JVM_PROPERTY_NAME = "quarkus-internal.test.reproducibility-check.cross-jvm";
+    private static final String REPRODUCIBILITY_DUMP_DIR_PROPERTY_NAME = "quarkus-internal.test.reproducibility-check.dump-dir";
 
     private static final Logger rootLogger;
     private Handler[] originalHandlers;
@@ -694,9 +699,14 @@ public abstract class AbstractQuarkusExtensionTest<S extends AbstractQuarkusExte
                             .addBannedElement(ClassPathElement.fromPath(testLocation, true)).build();
                 }
 
+                String reproducibilityDumpDir = System.getProperty(REPRODUCIBILITY_DUMP_DIR_PROPERTY_NAME);
+                if (reproducibilityDumpDir != null) {
+                    runReproducibilityDump(extensionContext, testLocation, projectDir, customizers,
+                            Path.of(reproducibilityDumpDir));
+                }
+
                 if (reproducibilityCheck) {
-                    runReproducibilityCheck(extensionContext, testLocation, projectDir,
-                            reproducibilityRuns, customizers);
+                    runReproducibilityCheck(extensionContext, testLocation, projectDir, customizers, reproducibilityRuns);
                 }
 
                 // Normal path: single augmentation, start app, run tests
@@ -865,31 +875,37 @@ public abstract class AbstractQuarkusExtensionTest<S extends AbstractQuarkusExte
     }
 
     private void runReproducibilityCheck(ExtensionContext extensionContext, Path testLocation, Path projectDir,
-            int reproducibilityRuns, List<Consumer<BuildChainBuilder>> customizers) throws Exception {
+            List<Consumer<BuildChainBuilder>> customizers, int runs) throws Exception {
+        if (System.getProperty(REPRODUCIBILITY_CROSS_JVM_PROPERTY_NAME) != null) {
+            runReproducibilityCheckCrossJvm(extensionContext, runs);
+        } else {
+            runReproducibilityCheckInsideJvm(extensionContext, testLocation, projectDir, customizers, runs);
+        }
+    }
+
+    private void runReproducibilityCheckInsideJvm(ExtensionContext extensionContext, Path testLocation, Path projectDir,
+            List<Consumer<BuildChainBuilder>> customizers, int runs) throws Exception {
         String testName = extensionContext.getRequiredTestClass().getSimpleName();
-        System.out.printf("[AbstractQuarkusExtensionTest] Reproducibility check (%d runs) for %s%n",
-                reproducibilityRuns, testName);
+        System.out.printf("[AbstractQuarkusExtensionTest] Reproducibility check (%d runs) for %s%n", runs, testName);
         List<Consumer<BuildChainBuilder>> reproducibilityCustomizers = new ArrayList<>(customizers);
-        reproducibilityCustomizers.add(
-                buildChainBuilder -> buildChainBuilder
-                        .addBuildStep(context -> context.produce(new ReproducibilityCheckBuildItem()))
-                        .produces(ReproducibilityCheckBuildItem.class).build());
+        reproducibilityCustomizers.add(buildChainBuilder -> buildChainBuilder
+                .addBuildStep(context -> context.produce(new ReproducibilityCheckBuildItem()))
+                .produces(ReproducibilityCheckBuildItem.class)
+                .build());
         Map<String, byte[]> referenceInMemoryClasses = null;
-        ApplicationModel cachedApplicationModel = null;
-        for (int run = 1; run <= reproducibilityRuns; run++) {
+        ApplicationModel appModel = null;
+        for (int run = 1; run <= runs; run++) {
             CuratedApplication currentCuratedApplication = null;
             StartupActionImpl currentStartupAction = null;
             try {
                 resetLegacyGizmoFunctionCounters();
-                currentCuratedApplication = createCuratedApplication(extensionContext, testLocation, projectDir,
-                        cachedApplicationModel);
-                if (cachedApplicationModel == null) {
+                currentCuratedApplication = createCuratedApplication(extensionContext, testLocation, projectDir, appModel);
+                if (appModel == null) {
                     // Reuse the resolved model so this check focuses on repeated augmentation bytecode.
-                    cachedApplicationModel = currentCuratedApplication.getApplicationModel();
+                    appModel = currentCuratedApplication.getApplicationModel();
                 }
                 currentStartupAction = new AugmentActionImpl(currentCuratedApplication, reproducibilityCustomizers,
-                        classLoadListeners)
-                        .createInitialRuntimeApplication();
+                        classLoadListeners).createInitialRuntimeApplication();
 
                 Map<String, byte[]> currentInMemoryClasses = currentStartupAction.getClassLoader().getInMemoryClassBytes();
                 if (referenceInMemoryClasses == null) {
@@ -904,8 +920,7 @@ public abstract class AbstractQuarkusExtensionTest<S extends AbstractQuarkusExte
                         Path mismatchDumpPath = BytecodeTools.dumpReproducibilityMismatch(diff,
                                 referenceInMemoryClasses, currentInMemoryClasses, run, dumpDir);
                         throw new AssertionError("Build reproducibility check failed on run " + run + "/"
-                                + reproducibilityRuns + ": " + diff + ". Dumped to "
-                                + mismatchDumpPath);
+                                + runs + ": " + diff + ". Dumped to " + mismatchDumpPath);
                     }
                 }
             } finally {
@@ -919,18 +934,19 @@ public abstract class AbstractQuarkusExtensionTest<S extends AbstractQuarkusExte
             }
         }
         System.out.printf("[AbstractQuarkusExtensionTest] Reproducibility check passed for %s%n", testName);
-        throw new TestAbortedException(
-                "Reproducibility check passed (" + reproducibilityRuns + " runs). Test execution skipped.");
+        throw new TestAbortedException("Reproducibility check passed (" + runs + " runs). Test execution skipped.");
     }
 
     /**
-     *
-     * Legacy Gizmo createFunction() uses a static counter keyed by generated class name, which leaks between
-     * reproducibility runs in the same JVM. This affects generators that emit $$function$$ helper classes, such as
-     * {@link io.quarkus.rest.data.panache.deployment.JaxRsResourceImplementor#implement},
-     * {@link io.quarkus.hibernate.reactive.rest.data.panache.deployment.ResourceImplementor#implement},
-     * {@link io.quarkus.security.jpa.reactive.deployment.QuarkusSecurityJpaReactiveProcessor#generateIdentityProvider}
-     * {@link io.quarkus.security.jpa.reactive.deployment.QuarkusSecurityJpaReactiveProcessor#generateTrustedIdentityProvider}.
+     * Legacy Gizmo {@code createFunction()} uses a {@code static} counter keyed by generated class name,
+     * which leaks between reproducibility runs in the same JVM. This affects generators that emit {@code $$function$$}
+     * helper classes, such as:
+     * <ul>
+     * <li>{@code io.quarkus.rest.data.panache.deployment.JaxRsResourceImplementor#implement}</li>
+     * <li>{@code io.quarkus.hibernate.reactive.rest.data.panache.deployment.ResourceImplementor#implement}</li>
+     * <li>{@code io.quarkus.security.jpa.reactive.deployment.QuarkusSecurityJpaReactiveProcessor#generateIdentityProvider}</li>
+     * <li>{@code io.quarkus.security.jpa.reactive.deployment.QuarkusSecurityJpaReactiveProcessor#generateTrustedIdentityProvider}</li>
+     * </ul>
      */
     private static void resetLegacyGizmoFunctionCounters() {
         try {
@@ -943,9 +959,96 @@ public abstract class AbstractQuarkusExtensionTest<S extends AbstractQuarkusExte
         }
     }
 
+    private void runReproducibilityCheckCrossJvm(ExtensionContext extensionContext, int runs) throws Exception {
+        String testClassName = extensionContext.getRequiredTestClass().getName();
+        String testName = extensionContext.getRequiredTestClass().getSimpleName();
+        System.out.printf("[AbstractQuarkusExtensionTest] Reproducibility check (%d runs) for %s%n", runs, testName);
+
+        Path baseDir = Path.of("target", "reproducibility", testName);
+        IoUtils.recursiveDelete(baseDir);
+        Files.createDirectories(baseDir);
+
+        List<String> baseArgs = new ArrayList<>();
+        baseArgs.add("-cp");
+        baseArgs.add(System.getProperty("java.class.path"));
+        for (String key : System.getProperties().stringPropertyNames()) {
+            if (key.equals(REPRODUCIBILITY_DUMP_DIR_PROPERTY_NAME)) {
+                continue;
+            }
+            baseArgs.add("-D" + key + "=" + System.getProperty(key));
+        }
+
+        Map<String, byte[]> referenceClasses = null;
+        for (int run = 1; run <= runs; run++) {
+            Path runDumpDir = baseDir.resolve("run-" + run);
+
+            List<String> args = new ArrayList<>(baseArgs);
+            args.add("-D" + REPRODUCIBILITY_DUMP_DIR_PROPERTY_NAME + "=" + runDumpDir);
+            args.add(ReproducibilityTestLauncher.class.getName());
+            args.add(testClassName);
+
+            System.out.printf("[AbstractQuarkusExtensionTest] Starting run %d/%d for %s%n", run, runs, testName);
+            ProcessBuilder.newBuilder(ProcessUtil.pathOfJava())
+                    .arguments(args)
+                    .output().inherited()
+                    .error().inherited()
+                    .run();
+
+            if (!Files.isDirectory(runDumpDir)) {
+                // this should never happen, the dump process creates the directory before running augmentation
+                throw new AssertionError("Reproducibility run " + run + "/" + runs
+                        + " did not produce dump directory " + runDumpDir);
+            }
+
+            Map<String, byte[]> runClasses = BytecodeTools.loadClassBytes(runDumpDir);
+            if (referenceClasses == null) {
+                referenceClasses = runClasses;
+            } else {
+                var diff = BytecodeTools.diff(referenceClasses, runClasses);
+                if (!diff.isEmpty()) {
+                    Path mismatchDir = baseDir.resolve("mismatch-run-" + run);
+                    BytecodeTools.dumpReproducibilityMismatch(diff, referenceClasses, runClasses, run, mismatchDir);
+                    throw new AssertionError("Reproducibility check failed on run " + run + "/"
+                            + runs + ": " + diff + ". Dumped to " + mismatchDir);
+                }
+            }
+        }
+        System.out.printf("[AbstractQuarkusExtensionTest] Reproducibility check passed for %s%n", testName);
+        throw new TestAbortedException("Reproducibility check passed (" + runs + " runs). Test execution skipped.");
+    }
+
+    private void runReproducibilityDump(ExtensionContext extensionContext, Path testLocation, Path projectDir,
+            List<Consumer<BuildChainBuilder>> customizers, Path dumpDir) throws Exception {
+
+        IoUtils.recursiveDelete(dumpDir);
+        Files.createDirectories(dumpDir);
+
+        List<Consumer<BuildChainBuilder>> dumpCustomizers = new ArrayList<>(customizers);
+        dumpCustomizers.add(
+                buildChainBuilder -> buildChainBuilder
+                        .addBuildStep(context -> context.produce(new ReproducibilityCheckBuildItem()))
+                        .produces(ReproducibilityCheckBuildItem.class).build());
+
+        CuratedApplication curatedApplication = null;
+        StartupActionImpl startupAction = null;
+        try {
+            curatedApplication = createCuratedApplication(extensionContext, testLocation, projectDir, null);
+            startupAction = new AugmentActionImpl(curatedApplication, dumpCustomizers, classLoadListeners)
+                    .createInitialRuntimeApplication();
+            BytecodeTools.dumpClassBytes(startupAction.getClassLoader().getInMemoryClassBytes(), dumpDir);
+        } finally {
+            if (startupAction != null) {
+                startupAction.getClassLoader().close();
+            }
+            if (curatedApplication != null) {
+                curatedApplication.close();
+            }
+        }
+        throw new TestAbortedException("Reproducibility dump complete (" + dumpDir + "). Test execution skipped.");
+    }
+
     private CuratedApplication createCuratedApplication(ExtensionContext extensionContext, Path testLocation, Path projectDir,
-            ApplicationModel existingModel)
-            throws Exception {
+            ApplicationModel existingModel) throws Exception {
         QuarkusBootstrap.Builder builder = QuarkusBootstrap.builder()
                 .setBaseName(extensionContext.getDisplayName() + " (AbstractQuarkusExtensionTest)")
                 .setApplicationRoot(deploymentDir.resolve(APP_ROOT))

--- a/test-framework/junit-internal/src/main/java/io/quarkus/test/BytecodeTools.java
+++ b/test-framework/junit-internal/src/main/java/io/quarkus/test/BytecodeTools.java
@@ -3,6 +3,7 @@ package io.quarkus.test;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -70,6 +71,29 @@ class BytecodeTools {
         options.put(IFernflowerPreferences.REMOVE_SYNTHETIC, "0");
         options.put(IFernflowerPreferences.REMOVE_BRIDGE, "0");
         return Map.copyOf(options);
+    }
+
+    static void dumpClassBytes(Map<String, byte[]> classes, Path outputDir) throws IOException {
+        for (Map.Entry<String, byte[]> entry : classes.entrySet()) {
+            Path outputFile = outputDir.resolve(entry.getKey());
+            Files.createDirectories(outputFile.getParent());
+            Files.write(outputFile, entry.getValue());
+        }
+    }
+
+    static Map<String, byte[]> loadClassBytes(Path inputDir) throws IOException {
+        Map<String, byte[]> result = new HashMap<>();
+        try (var walk = Files.walk(inputDir)) {
+            walk.filter(Files::isRegularFile).forEach(file -> {
+                try {
+                    String relativePath = inputDir.relativize(file).toString();
+                    result.put(relativePath, Files.readAllBytes(file));
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+        }
+        return result;
     }
 
     static InMemoryClassDiff diff(Map<String, byte[]> reference, Map<String, byte[]> current) {

--- a/test-framework/junit-internal/src/main/java/io/quarkus/test/ReproducibilityTestLauncher.java
+++ b/test-framework/junit-internal/src/main/java/io/quarkus/test/ReproducibilityTestLauncher.java
@@ -1,0 +1,31 @@
+package io.quarkus.test;
+
+import java.io.PrintWriter;
+
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
+
+/**
+ * Minimal JUnit launcher for running a single test class in a forked JVM.
+ * Used by the reproducibility check in {@link AbstractQuarkusExtensionTest}.
+ */
+class ReproducibilityTestLauncher {
+    public static void main(String[] args) {
+        var request = LauncherDiscoveryRequestBuilder.request()
+                .selectors(DiscoverySelectors.selectClass(args[0]))
+                .build();
+
+        var summary = new SummaryGeneratingListener();
+        var launcher = LauncherFactory.create();
+        launcher.registerTestExecutionListeners(summary);
+        launcher.execute(request);
+
+        var result = summary.getSummary();
+        if (result.getTotalFailureCount() > 0) {
+            result.printFailuresTo(new PrintWriter(System.err, true));
+            System.exit(1);
+        }
+    }
+}


### PR DESCRIPTION
See commit messages for more details.

The first commit actually makes a lot of tests fail early on when running in reproducibility checking mode. One of them was SmallRye Fault Tolerance, which made me wonder why the reproducibility check didn't fail before. This led me to discover that certain sources of non-determinism were hidden in the reproducibility checks by all Quarkus builds running in the same JVM. This provoked the second commit. It probably slows down the reproducibility check considerably, but is more faithful, so I'm on the fence here.

I didn't check how many failures the second commit uncovers (maybe it's the same set as the first commit?), but with the third commit, the SmallRye Fault Tolerance extension passes :-)

CC @reaver585 