### PR TITLE
Produce ServiceStartBuildItem for OTel

### DIFF
--- a/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/OpenTelemetryProcessor.java
+++ b/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/OpenTelemetryProcessor.java
@@ -66,6 +66,7 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.RemovedResourceBuildItem;
+import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveMethodBuildItem;
@@ -184,7 +185,8 @@ public class OpenTelemetryProcessor {
             LaunchModeBuildItem launchMode,
             OTelBuildConfig oTelBuildConfig,
             BuildProducer<SyntheticBeanBuildItem> syntheticProducer,
-            BuildProducer<OpenTelemetrySdkBuildItem> openTelemetrySdkBuildItemBuildProducer) {
+            BuildProducer<OpenTelemetrySdkBuildItem> openTelemetrySdkBuildItemBuildProducer,
+            BuildProducer<ServiceStartBuildItem> serviceStart) {
         syntheticProducer.produce(SyntheticBeanBuildItem.configure(OpenTelemetry.class)
                 .defaultBean()
                 .setRuntimeInit()
@@ -223,6 +225,8 @@ public class OpenTelemetryProcessor {
 
         recorder.eagerlyCreateContextStorage();
         recorder.storeVertxOnContextStorage(vertx.getVertx());
+
+        serviceStart.produce(new ServiceStartBuildItem("OpenTelemetry"));
     }
 
     @BuildStep


### PR DESCRIPTION
No test is being added because the original error could not be reproduced anymore. Adding the `ServiceStartBuildItem` still makes sense, regardless. 

- Fixes: https://github.com/quarkusio/quarkus/issues/49524