### PR TITLE
Do not use Hibernate's schema-management.strategy=drop-and-create in documentation examples

### DIFF
--- a/docs/src/main/asciidoc/config-yaml.adoc
+++ b/docs/src/main/asciidoc/config-yaml.adoc
@@ -85,8 +85,8 @@ quarkus:
       url: jdbc:postgresql://localhost:5432/quarkus_test
 
   hibernate-orm:
-    database:
-      generation: drop-and-create
+    schema-management:
+      strategy: create
 
   oidc:
     enabled: true

--- a/docs/src/main/asciidoc/getting-started-reactive.adoc
+++ b/docs/src/main/asciidoc/getting-started-reactive.adoc
@@ -151,11 +151,16 @@ Before going further, open the `src/main/resources/application.properties` file 
 
 [source, properties]
 ----
-quarkus.datasource.db-kind=postgresql
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
-----
+quarkus.datasource.db-kind = postgresql <1>
 
-It instructs the application to use PostgreSQL for the database and to handle the database schema generation.
+%prod.quarkus.datasource.username = hibernate
+%prod.quarkus.datasource.password = hibernate
+%prod.quarkus.datasource.reactive.url = vertx-reactive:postgresql://localhost/quarkus_test <2>
+%prod.quarkus.hibernate-orm.schema-management.strategy=create <3>
+----
+<1> xref:datasource.adoc[Configure the datasource] for production, relying on xref:datasource#dev-services[Dev Services] for connection information in tests / dev mode.
+<2> The only different property from a Hibernate ORM configuration
+<3> Configure Hibernate ORM to create the schema on startup in production, which is useful for experimentation, but rely on xref:hibernate-orm.adoc#dev-mode[convenient defaults in tests / dev mode].
 
 In the same directory, create an `import.sql` file, which inserts a few fruits, so we don't start with an empty database in dev mode:
 

--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -121,14 +121,14 @@ Then add the relevant configuration properties in `{config-file}`.
 [source,properties]
 ----
 # configure your datasource
-quarkus.datasource.db-kind = postgresql
-quarkus.datasource.username = sarah
-quarkus.datasource.password = connor
-quarkus.datasource.jdbc.url = jdbc:postgresql://localhost:5432/mydatabase
-
-# drop and create the database at startup (use `update` to only update the schema)
-quarkus.hibernate-orm.schema-management.strategy = drop-and-create
+quarkus.datasource.db-kind = postgresql <1>
+%prod.quarkus.datasource.username = sarah
+%prod.quarkus.datasource.password = connor
+%prod.quarkus.datasource.jdbc.url = jdbc:postgresql://localhost:5432/mydatabase
+%prod.quarkus.hibernate-orm.schema-management.strategy=create <2>
 ----
+<1> xref:datasource.adoc[Configure the datasource] for production, relying on xref:datasource#dev-services[Dev Services] for connection information in tests / dev mode.
+<2> Configure Hibernate ORM to create the schema on startup in production, which is useful for experimentation, but rely on xref:hibernate-orm.adoc#dev-mode[convenient defaults in tests / dev mode].
 
 == Solution 1: using the active record pattern
 
@@ -593,7 +593,7 @@ INSERT INTO person (id, birth, name, status) VALUES (1, '1995-09-12', 'Emily Bro
 ALTER SEQUENCE person_seq RESTART WITH 2;
 ----
 
-NOTE: If you would like to initialize the DB when you start the Quarkus app in your production environment, add `quarkus.hibernate-orm.schema-management.strategy=drop-and-create` to the Quarkus startup options in addition to `import.sql`.
+NOTE: If you would like to initialize the DB when you start the Quarkus app in your demo ("production") environment, add `quarkus.hibernate-orm.schema-management.strategy=drop-and-create` to the Quarkus startup options in addition to `import.sql`.
 
 After that, you can see the people list and add new person as followings:
 

--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -85,16 +85,15 @@ then add the relevant configuration properties in `{config-file}`.
 ----
 quarkus.datasource.db-kind = postgresql <1>
 
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create <2>
-
 %prod.quarkus.datasource.username = hibernate
 %prod.quarkus.datasource.password = hibernate
 %prod.quarkus.datasource.jdbc.url = jdbc:postgresql://localhost:5432/hibernate_db
+%prod.quarkus.hibernate-orm.schema-management.strategy=create <2>
 ----
-<1> xref:datasource.adoc[Configure the datasource].
-<2> Drop and create the database at startup (use `update` to only update the schema).
+<1> xref:datasource.adoc[Configure the datasource] for production, relying on xref:datasource#dev-services[Dev Services] for connection information in tests / dev mode.
+<2> Configure Hibernate ORM to create the schema on startup in production, which is useful for experimentation, but rely on <<dev-mode,convenient defaults in tests / dev mode>>.
 
-Note that these configuration properties are not the same ones as in your typical Hibernate ORM configuration file.
+Note that configuration properties for the Hibernate ORM Quarkus extension are not the same ones as in your typical Hibernate ORM configuration file.
 They will often map to Hibernate ORM configuration properties but could have different names and don't necessarily map 1:1 to each other.
 
 Also, Quarkus will set many Hibernate ORM configuration settings automatically, and will often use more modern defaults.
@@ -326,7 +325,7 @@ For instance, the following snippet defines a default datasource and a default p
 quarkus.datasource.db-kind=h2
 quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1
 
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
+quarkus.hibernate-orm.schema-management.strategy=validate
 ----
 
 Using a map based approach, it is possible to define named persistence units:
@@ -339,20 +338,17 @@ quarkus.datasource."users".jdbc.url=jdbc:h2:mem:users;DB_CLOSE_DELAY=-1
 quarkus.datasource."inventory".db-kind=h2 <2>
 quarkus.datasource."inventory".jdbc.url=jdbc:h2:mem:inventory;DB_CLOSE_DELAY=-1
 
-quarkus.hibernate-orm."users".schema-management.strategy=drop-and-create <3>
-quarkus.hibernate-orm."users".datasource=users <4>
-quarkus.hibernate-orm."users".packages=org.acme.model.user <5>
+quarkus.hibernate-orm."users".datasource=users <3>
+quarkus.hibernate-orm."users".packages=org.acme.model.user <4>
 
-quarkus.hibernate-orm."inventory".schema-management.strategy=drop-and-create <6>
-quarkus.hibernate-orm."inventory".datasource=inventory
+quarkus.hibernate-orm."inventory".datasource=inventory <5>
 quarkus.hibernate-orm."inventory".packages=org.acme.model.inventory
 ----
 <1> Define a datasource named `users`.
 <2> Define a datasource named `inventory`.
-<3> Define a persistence unit called `users`.
-<4> Define the datasource used by the persistence unit.
-<5> This configuration property is important, but we will discuss it a bit later.
-<6> Define a persistence unit called `inventory` pointing to the `inventory` datasource.
+<3> Define a persistence unit called `users` pointing to the `users` datasource.
+<4> This configuration property is important, but we will discuss it a bit later.
+<5> Define a persistence unit called `inventory` pointing to the `inventory` datasource.
 
 [NOTE]
 ====
@@ -383,10 +379,8 @@ Using the `packages` configuration property is simple:
 
 [source,properties]
 ----
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.packages=org.acme.model.defaultpu
 
-quarkus.hibernate-orm."users".schema-management.strategy=drop-and-create
 quarkus.hibernate-orm."users".datasource=users
 quarkus.hibernate-orm."users".packages=org.acme.model.user
 ----
@@ -590,7 +584,6 @@ For example, with the following configuration:
 ----
 quarkus.hibernate-orm."pg".packages=org.acme.model.shared
 quarkus.hibernate-orm."pg".datasource=pg
-quarkus.hibernate-orm."pg".schema-management.strategy=drop-and-create
 quarkus.hibernate-orm."pg".active=false
 quarkus.datasource."pg".db-kind=h2
 quarkus.datasource."pg".active=false
@@ -598,7 +591,6 @@ quarkus.datasource."pg".active=false
 
 quarkus.hibernate-orm."oracle".packages=org.acme.model.shared
 quarkus.hibernate-orm."oracle".datasource=oracle
-quarkus.hibernate-orm."oracle".schema-management.strategy=drop-and-create
 quarkus.hibernate-orm."oracle".active=false
 quarkus.datasource."oracle".db-kind=oracle
 quarkus.datasource."oracle".active=false
@@ -754,11 +746,8 @@ difference is that you would specify your Hibernate ORM configuration in `META-I
             <property name="hibernate.show_sql" value="true"/>
             <property name="hibernate.format_sql" value="true"/>
 
-            <!--
-                Optimistically create the tables;
-                will cause background errors being logged if they already exist,
-                but is practical to retain existing data across runs (or create as needed) -->
-            <property name="jakarta.persistence.schema-generation.database.action" value="drop-and-create"/>
+            <!-- Schema generation on startup -->
+            <property name="jakarta.persistence.schema-generation.database.action" value="create"/>
 
             <property name="jakarta.persistence.validation.mode" value="NONE"/>
         </properties>
@@ -806,25 +795,28 @@ This will allow Quarkus to index and enhance your entities as if they were insid
 [[dev-mode]]
 == Hibernate ORM in development mode
 
-Quarkus development mode is really useful for applications that mix front end or services and database access.
+During tests and in xref:dev-mode-differences.adoc[development mode], Hibernate ORM benefits from xref:datasource.adoc#dev-services[datasource Dev Services],
+making configuration of database connections unnecessary.
 
-There are a few common approaches to make the best of it.
+The main remaining question is how to initialize that database.
 
-The first choice is to use `quarkus.hibernate-orm.schema-management.strategy=drop-and-create` in conjunction with `import.sql`.
-
+1. The first choice is to use `quarkus.hibernate-orm.schema-management.strategy=drop-and-create` in conjunction with `import.sql`.
++
 That way for every change to your app and in particular to your entities, the database schema will be properly recreated
 and your data fixture (stored in `import.sql`) will be used to repopulate it from scratch.
++
 This is best to perfectly control your environment and works magic with Quarkus live reload mode:
 your entity changes or any change to your `import.sql` is immediately picked up and the schema updated without restarting the application!
-
+In fact, this is the default when using xref:dev-services.adoc[Dev Services].
++
 [TIP]
 ====
-By default, in `dev` and `test` modes, Hibernate ORM, upon boot, will read and execute the SQL statements in the `/import.sql` file (if present).
-You can change the file name by changing the property `quarkus.hibernate-orm.sql-load-script` in `application.properties`.
+You can use a file with a different name than `import.sql` by setting the property `quarkus.hibernate-orm.sql-load-script` in `application.properties`.
 You can also provide a `.zip` file in the same way which should contain only the files containing the SQL statements to be executed.
 ====
 
-The second approach is to use `quarkus.hibernate-orm.schema-management.strategy=update`.
+2. The second approach is to use `quarkus.hibernate-orm.schema-management.strategy=update`.
++
 This approach is best when you do many entity changes but
 still need to work on a copy of the production data
 or if you want to reproduce a bug that is based on specific database entries.
@@ -833,14 +825,15 @@ including altering your database structure which could lead to data loss.
 For example if you change structures which violate a foreign key constraint, Hibernate ORM might have to bail out.
 But for development, these limitations are acceptable.
 
-The third approach is to use `quarkus.hibernate-orm.schema-management.strategy=none`.
+3. The third approach is to use `quarkus.hibernate-orm.schema-management.strategy=none`.
++
 This approach is best when you are working on a copy of the production data but want to fully control the schema evolution.
 Or if you use a database schema migration tool like xref:flyway.adoc[Flyway] or xref:liquibase.adoc[Liquibase].
-
++
 With this approach when making changes to an entity, make sure to adapt the database schema accordingly;
 you could also use `validate` to have Hibernate verify the schema matches its expectations.
 
-WARNING: Do not use `quarkus.hibernate-orm.schema-management.strategy` `drop-and-create` and `update` in your production environment.
+WARNING: Do not set `quarkus.hibernate-orm.schema-management.strategy` to `drop-and-create` or `update` in your production environment.
 
 
 These approaches become really powerful when combined with Quarkus configuration profiles.

--- a/docs/src/main/asciidoc/hibernate-reactive-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-reactive-panache.adoc
@@ -118,15 +118,15 @@ Then add the relevant configuration properties in `{config-file}`.
 
 [source,properties]
 ----
-# configure your datasource
-quarkus.datasource.db-kind = postgresql
-quarkus.datasource.username = sarah
-quarkus.datasource.password = connor
-quarkus.datasource.reactive.url = vertx-reactive:postgresql://localhost:5432/mydatabase
+quarkus.datasource.db-kind = postgresql <1>
 
-# drop and create the database at startup (use `update` to only update the schema)
-quarkus.hibernate-orm.schema-management.strategy = drop-and-create
+%prod.quarkus.datasource.username = hibernate
+%prod.quarkus.datasource.password = hibernate
+%prod.quarkus.datasource.reactive.url = vertx-reactive:postgresql://localhost/quarkus_test
+%prod.quarkus.hibernate-orm.schema-management.strategy=create <2>
 ----
+<1> xref:datasource.adoc[Configure the datasource] for production, relying on xref:datasource#dev-services[Dev Services] for connection information in tests / dev mode.
+<2> Configure Hibernate ORM to create the schema on startup in production, which is useful for experimentation, but rely on xref:hibernate-orm.adoc#dev-mode[convenient defaults in tests / dev mode].
 
 == Solution 1: using the active record pattern
 

--- a/docs/src/main/asciidoc/hibernate-reactive.adoc
+++ b/docs/src/main/asciidoc/hibernate-reactive.adoc
@@ -96,18 +96,16 @@ then add the relevant configuration properties in `{config-file}`:
 [source,properties]
 .Example `{config-file}`
 ----
-# datasource configuration
-quarkus.datasource.db-kind = postgresql
-quarkus.datasource.username = quarkus_test
-quarkus.datasource.password = quarkus_test
+quarkus.datasource.db-kind = postgresql <1>
 
-quarkus.datasource.reactive.url = vertx-reactive:postgresql://localhost/quarkus_test <1>
-
-# drop and create the database at startup (use `update` to only update the schema)
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
+%prod.quarkus.datasource.username = hibernate
+%prod.quarkus.datasource.password = hibernate
+%prod.quarkus.datasource.reactive.url = vertx-reactive:postgresql://localhost/quarkus_test <2>
+%prod.quarkus.hibernate-orm.schema-management.strategy=create <3>
 ----
-
-<1> The only different property from a Hibernate ORM configuration
+<1> xref:datasource.adoc[Configure the datasource] for production, relying on xref:datasource#dev-services[Dev Services] for connection information in tests / dev mode.
+<2> The only different property from a Hibernate ORM configuration
+<3> Configure Hibernate ORM to create the schema on startup in production, which is useful for experimentation, but rely on xref:hibernate-orm.adoc#dev-mode[convenient defaults in tests / dev mode].
 
 Note that these configuration properties are not the same ones as in your typical Hibernate Reactive configuration file.
 They will often map to Hibernate Reactive configuration properties but could have different names and don't necessarily map 1:1 to each other.

--- a/docs/src/main/asciidoc/quarkus-data-hibernate.adoc
+++ b/docs/src/main/asciidoc/quarkus-data-hibernate.adoc
@@ -94,15 +94,20 @@ annotationProcessor 'org.hibernate.orm:hibernate-processor'
 
 TIP: You can use any of the xref:hibernate-orm.adoc#setting-up-and-configuring-hibernate-orm[supported JDBC drivers].
 
-Make sure you configure your datasource in your `application.properties` (although you don't have to in DEV
-mode: if you don't, a dev service will be provided for you):
+Add the relevant configuration properties in `{config-file}`.
 
 [source,properties]
+.Example `{config-file}`
 ----
+quarkus.datasource.db-kind = postgresql <1>
+
 %prod.quarkus.datasource.username = hibernate
 %prod.quarkus.datasource.password = hibernate
 %prod.quarkus.datasource.jdbc.url = jdbc:postgresql://localhost:5432/hibernate_db
+%prod.quarkus.hibernate-orm.schema-management.strategy=create <2>
 ----
+<1> xref:datasource.adoc[Configure the datasource] for production, relying on xref:datasource#dev-services[Dev Services] for connection information in tests / dev mode.
+<2> Configure Hibernate ORM to create the schema on startup in production, which is useful for experimentation, but rely on xref:hibernate-orm.adoc#dev-mode[convenient defaults in tests / dev mode].
 
 == Our first entity
 

--- a/docs/src/main/asciidoc/spring-data-jpa.adoc
+++ b/docs/src/main/asciidoc/spring-data-jpa.adoc
@@ -122,29 +122,19 @@ public class Fruit {
 
 == Configure database access properties
 
-Add the following properties to `application.properties` to configure access to a local PostgreSQL instance.
+Add the following properties to `application.properties` to configure access to a database.
 
 [source,properties]
 ----
-quarkus.datasource.db-kind=postgresql
-quarkus.datasource.username=quarkus_test
-quarkus.datasource.password=quarkus_test
-quarkus.datasource.jdbc.url=jdbc:postgresql:quarkus_test
-quarkus.datasource.jdbc.max-size=8
-quarkus.datasource.jdbc.min-size=2
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
+quarkus.datasource.db-kind=postgresql <1>
+
+%prod.quarkus.datasource.username=quarkus_test
+%prod.quarkus.datasource.password=quarkus_test
+%prod.quarkus.datasource.jdbc.url=jdbc:postgresql:quarkus_test
+%prod.quarkus.hibernate-orm.schema-management.strategy=create <2>
 ----
-
-This configuration assumes that PostgreSQL will be running locally.
-
-A very easy way to accomplish that is by using the following Docker command:
-
-[source,bash,subs=attributes+]
-----
-docker run -it --rm=true --name quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 {postgres-image}
-----
-
-If you plan on using a different setup, please change your `application.properties` accordingly.
+<1> xref:datasource.adoc[Configure the datasource] for production, relying on xref:datasource#dev-services[Dev Services] for connection information in tests / dev mode.
+<2> Configure Hibernate ORM to create the schema on startup in production, which is useful for experimentation, but rely on xref:hibernate-orm.adoc#dev-mode[convenient defaults in tests / dev mode].
 
 == Prepare the data
 

--- a/docs/src/main/asciidoc/spring-data-rest.adoc
+++ b/docs/src/main/asciidoc/spring-data-rest.adoc
@@ -142,28 +142,19 @@ public class Fruit {
 
 == Configure database access properties
 
-Add the following properties to `application.properties` to configure access to a local PostgreSQL instance.
+Add the following properties to `application.properties` to configure access to a database.
 
 [source,properties]
 ----
-quarkus.datasource.db-kind=postgresql
-quarkus.datasource.username=quarkus_test
-quarkus.datasource.password=quarkus_test
-quarkus.datasource.jdbc.url=jdbc:postgresql:quarkus_test
-quarkus.datasource.jdbc.max-size=8
-quarkus.hibernate-orm.schema-management.strategy=drop-and-create
+quarkus.datasource.db-kind=postgresql <1>
+
+%prod.quarkus.datasource.username=quarkus_test
+%prod.quarkus.datasource.password=quarkus_test
+%prod.quarkus.datasource.jdbc.url=jdbc:postgresql:quarkus_test
+%prod.quarkus.hibernate-orm.schema-management.strategy=create <2>
 ----
-
-This configuration assumes that PostgreSQL will be running locally.
-
-A very easy way to accomplish that is by using the following Docker command:
-
-[source,bash,subs=attributes+]
-----
-docker run -it --rm=true --name quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 {postgres-image}
-----
-
-If you plan on using a different setup, please change your `application.properties` accordingly.
+<1> xref:datasource.adoc[Configure the datasource] for production, relying on xref:datasource#dev-services[Dev Services] for connection information in tests / dev mode.
+<2> Configure Hibernate ORM to create the schema on startup in production, which is useful for experimentation, but rely on xref:hibernate-orm.adoc#dev-mode[convenient defaults in tests / dev mode].
 
 == Prepare the data
 


### PR DESCRIPTION
Because:

1. This was addressed in quickstarts already (https://github.com/quarkusio/quarkus-quickstarts/pull/1520), but was forgotten about in https://github.com/quarkusio/quarkus/pull/47709
2. When using dev services and it's safe, we set it automatically.
3. When in prod, it will get you fired.
4. We even have a warning about this, right there in the docs! "WARNING: Do not set `quarkus.hibernate-orm.schema-management.strategy` to `drop-and-create` or `update` in your production environment."

----

I also tried to make the configuration samples more consistent across guides, and to *slightly* improve the dev mode docs for Hibernate ORM so that we can link to it without being too ashamed of its out-of-dated-ness.

I'll send a PR to update quickstarts in the few places where this wasn't done yet. EDIT: https://github.com/quarkusio/quarkus-quickstarts/pull/1653

Note the `db-kind` part might be a bit awkward still, but I plan on removing it from docs in my PR for #51268 -- which will make the property unneecessary in many cases.