### PR TITLE
Add `@Timed` service level objective support

### DIFF
--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/runtime/MicrometerTimedInterceptorTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/runtime/MicrometerTimedInterceptorTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.micrometer.runtime;
 
+import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 
 import jakarta.inject.Inject;
@@ -13,6 +14,8 @@ import io.micrometer.core.instrument.LongTaskTimer;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.distribution.CountAtBucket;
+import io.micrometer.core.instrument.distribution.HistogramSnapshot;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.quarkus.micrometer.test.CountedResource;
 import io.quarkus.micrometer.test.GuardedResult;
@@ -234,6 +237,39 @@ public class MicrometerTimedInterceptorTest {
                 .tag("extra", "tag").timer();
         Assertions.assertNotNull(bravoTimer);
         Assertions.assertEquals(1, bravoTimer.count());
+    }
+
+    @Test
+    void testTimeMethod_emptyServiceLevelObjectives() {
+        timed.emptyServiceLevelObjectives();
+
+        Timer timer = registry.get("emptyServiceLevelObjectives")
+                .tag("method", "emptyServiceLevelObjectives")
+                .tag("class", "io.quarkus.micrometer.test.TimedResource")
+                .tag("exception", "none").timer();
+
+        Assertions.assertNotNull(timer);
+        Assertions.assertEquals(1, timer.count());
+
+        HistogramSnapshot snapshot = timer.takeSnapshot();
+        Assertions.assertEquals(0, snapshot.histogramCounts().length);
+    }
+
+    @Test
+    void testTimeMethod_customServiceLevelObjectives() {
+        timed.customServiceLevelObjectives();
+
+        Timer timer = registry.get("customServiceLevelObjectives")
+                .tag("method", "customServiceLevelObjectives")
+                .tag("class", "io.quarkus.micrometer.test.TimedResource")
+                .tag("exception", "none").timer();
+
+        Assertions.assertNotNull(timer);
+        Assertions.assertEquals(1, timer.count());
+
+        HistogramSnapshot snapshot = timer.takeSnapshot();
+        Assertions.assertArrayEquals(new double[] { 1e7, 2.5e7, 5e7, 1e8, 5e8, 1e9 },
+                Arrays.stream(snapshot.histogramCounts()).mapToDouble(CountAtBucket::bucket).toArray());
     }
 
 }

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/runtime/MicrometerTimedInterceptorTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/runtime/MicrometerTimedInterceptorTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.micrometer.runtime;
 
+import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 
 import jakarta.inject.Inject;
@@ -13,6 +14,8 @@ import io.micrometer.core.instrument.LongTaskTimer;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.distribution.CountAtBucket;
+import io.micrometer.core.instrument.distribution.HistogramSnapshot;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.quarkus.micrometer.test.CountedResource;
 import io.quarkus.micrometer.test.GuardedResult;
@@ -235,6 +238,39 @@ public class MicrometerTimedInterceptorTest {
                 .tag("extra", "tag").timer();
         Assertions.assertNotNull(bravoTimer);
         Assertions.assertEquals(1, bravoTimer.count());
+    }
+
+    @Test
+    void testTimeMethod_emptyServiceLevelObjectives() {
+        timed.emptyServiceLevelObjectives();
+
+        Timer timer = registry.get("emptyServiceLevelObjectives")
+                .tag("method", "emptyServiceLevelObjectives")
+                .tag("class", "io.quarkus.micrometer.test.TimedResource")
+                .tag("exception", "none").timer();
+
+        Assertions.assertNotNull(timer);
+        Assertions.assertEquals(1, timer.count());
+
+        HistogramSnapshot snapshot = timer.takeSnapshot();
+        Assertions.assertEquals(0, snapshot.histogramCounts().length);
+    }
+
+    @Test
+    void testTimeMethod_customServiceLevelObjectives() {
+        timed.customServiceLevelObjectives();
+
+        Timer timer = registry.get("customServiceLevelObjectives")
+                .tag("method", "customServiceLevelObjectives")
+                .tag("class", "io.quarkus.micrometer.test.TimedResource")
+                .tag("exception", "none").timer();
+
+        Assertions.assertNotNull(timer);
+        Assertions.assertEquals(1, timer.count());
+
+        HistogramSnapshot snapshot = timer.takeSnapshot();
+        Assertions.assertArrayEquals(new double[] { 1e7, 2.5e7, 5e7, 1e8, 5e8, 1e9 },
+                Arrays.stream(snapshot.histogramCounts()).mapToDouble(CountAtBucket::bucket).toArray());
     }
 
 }

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/test/TimedResource.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/test/TimedResource.java
@@ -63,4 +63,15 @@ public class TimedResource {
             throw new NullPointerException("Failed on purpose");
         }
     }
+
+    @Timed(value = "emptyServiceLevelObjectives")
+    public void emptyServiceLevelObjectives() {
+        // empty by intention
+    }
+
+    @Timed(value = "customServiceLevelObjectives", serviceLevelObjectives = { 0.01, 0.025, 0.05, 0.1, 0.5, 1.0 })
+    public void customServiceLevelObjectives() {
+        // empty by intention
+    }
+
 }

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/MicrometerTimedInterceptor.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/MicrometerTimedInterceptor.java
@@ -1,9 +1,12 @@
 package io.quarkus.micrometer.runtime;
 
+import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 
 import jakarta.annotation.Priority;
 import jakarta.interceptor.AroundInvoke;
@@ -16,6 +19,7 @@ import io.micrometer.core.instrument.LongTaskTimer;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.util.TimeUtils;
 import io.quarkus.arc.ArcInvocationContext;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.tuples.Functions;
@@ -116,7 +120,11 @@ public class MicrometerTimedInterceptor {
                     .tags(timerTags)
                     .tag("exception", exceptionClass)
                     .publishPercentileHistogram(timed.histogram())
-                    .publishPercentiles(timed.percentiles().length == 0 ? null : timed.percentiles());
+                    .publishPercentiles(timed.percentiles().length == 0 ? null : timed.percentiles())
+                    .serviceLevelObjectives(
+                            timed.serviceLevelObjectives().length > 0 ? Arrays.stream(timed.serviceLevelObjectives())
+                                    .mapToObj(s -> Duration.ofNanos((long) TimeUtils.secondsToUnit(s, TimeUnit.NANOSECONDS)))
+                                    .toArray(Duration[]::new) : null);
 
             sample.stop(builder.register(meterRegistry));
         } catch (Exception e) {

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/MicrometerTimedInterceptor.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/MicrometerTimedInterceptor.java
@@ -1,9 +1,13 @@
 package io.quarkus.micrometer.runtime;
 
+import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.function.DoubleFunction;
 
 import jakarta.annotation.Priority;
 import jakarta.interceptor.AroundInvoke;
@@ -16,6 +20,7 @@ import io.micrometer.core.instrument.LongTaskTimer;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.util.TimeUtils;
 import io.quarkus.arc.ArcInvocationContext;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.tuples.Functions;
@@ -116,7 +121,17 @@ public class MicrometerTimedInterceptor {
                     .tags(timerTags)
                     .tag("exception", exceptionClass)
                     .publishPercentileHistogram(timed.histogram())
-                    .publishPercentiles(timed.percentiles().length == 0 ? null : timed.percentiles());
+                    .publishPercentiles(timed.percentiles().length == 0 ? null : timed.percentiles())
+                    .serviceLevelObjectives(
+                            timed.serviceLevelObjectives().length > 0 ? Arrays.stream(timed.serviceLevelObjectives())
+                                    .mapToObj(new DoubleFunction<Duration>() {
+                                        @Override
+                                        public Duration apply(double value) {
+                                            return Duration
+                                                    .ofNanos((long) TimeUtils.secondsToUnit(value, TimeUnit.NANOSECONDS));
+                                        }
+                                    })
+                                    .toArray(Duration[]::new) : null);
 
             sample.stop(builder.register(meterRegistry));
         } catch (Exception e) {


### PR DESCRIPTION
Support custom service level objectives `@Timed(serviceLevelObjectives = { ... })`.

Enable custom service level objectives to be used instead of predefined ones when enable histogram via  `@Timed(histogram = true)`.

