### PR TITLE
OIDC: make ClientAssertionProvider async to support retriving JWT-SVID using a SPIFFE client

### DIFF
--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
@@ -32,7 +32,6 @@ import io.quarkus.oidc.common.runtime.OidcWebClient;
 import io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials.Jwt.Source;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.groups.UniOnItem;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.DecodeException;
@@ -134,9 +133,10 @@ public class OidcClientImpl implements OidcClient {
         if (tokenRevokeUri != null) {
             MultiMap tokenRevokeParams = new MultiMap(io.vertx.core.MultiMap.caseInsensitiveMultiMap());
             tokenRevokeParams.set(OidcConstants.REVOCATION_TOKEN, accessToken);
-            return postRequest(requestProps, OidcEndpoint.Type.TOKEN_REVOCATION, client.postAbs(tokenRevokeUri),
-                    tokenRevokeParams, additionalParameters, Operation.REVOKE)
-                    .transformToUni(resp -> toRevokeResponse(requestProps, resp));
+            return withAsyncCredentials().flatMap(asyncCredentials -> postRequest(requestProps,
+                    OidcEndpoint.Type.TOKEN_REVOCATION,
+                    client.postAbs(tokenRevokeUri), tokenRevokeParams, additionalParameters, Operation.REVOKE, asyncCredentials)
+                    .flatMap(resp -> toRevokeResponse(requestProps, resp)));
         } else {
             LOG.debugf("%s OidcClient can not revoke the access token because the revocation endpoint URL is not set");
             return Uni.createFrom().item(false);
@@ -177,9 +177,10 @@ public class OidcClientImpl implements OidcClient {
         return Uni.createFrom().deferred(new Supplier<Uni<? extends Tokens>>() {
             @Override
             public Uni<Tokens> get() {
-                return postRequest(requestProps, endpointType, client.postAbs(tokenRequestUri), formBody,
-                        additionalGrantParameters, op)
-                        .transformToUni(resp -> emitGrantTokens(requestProps, resp, op));
+                return withAsyncCredentials()
+                        .flatMap(asyncCredentials -> postRequest(requestProps, endpointType,
+                                client.postAbs(tokenRequestUri), formBody, additionalGrantParameters, op, asyncCredentials))
+                        .flatMap(resp -> emitGrantTokens(requestProps, resp, op));
             }
         });
     }
@@ -196,7 +197,7 @@ public class OidcClientImpl implements OidcClient {
             OidcEndpoint.Type endpointType, HttpRequest<Buffer> request,
             MultiMap formBody,
             Map<String, String> additionalGrantParameters,
-            Operation op) {
+            Operation op, AsyncCredentials asyncCredentials) {
         PreparedPostRequest.CredentialsToRetry credentialsToRetry = null;
         MultiMap body = formBody;
         request.putHeader(HttpHeaders.CONTENT_TYPE.toString(),
@@ -214,8 +215,8 @@ public class OidcClientImpl implements OidcClient {
             }
         } else if (jwtAssertionProvided) {
             String clientAssertion = additionalGrantParameters.get(OidcConstants.CLIENT_ASSERTION);
-            if (clientAssertion == null && clientAssertionProvider != null) {
-                clientAssertion = clientAssertionProvider.getClientAssertion();
+            if (clientAssertion == null) {
+                clientAssertion = asyncCredentials.clientAssertion;
                 if (clientAssertion != null) {
                     body.set(OidcConstants.CLIENT_ASSERTION, clientAssertion);
                 }
@@ -297,12 +298,12 @@ public class OidcClientImpl implements OidcClient {
         return oidcConfig.credentials().clientSecret().provider().key().isPresent();
     }
 
-    private UniOnItem<HttpResponse<Buffer>> postRequest(
+    private Uni<HttpResponse<Buffer>> postRequest(
             OidcRequestContextProperties requestProps,
             OidcEndpoint.Type endpointType, HttpRequest<Buffer> request,
             MultiMap formBody,
             Map<String, String> additionalGrantParameters,
-            Operation op) {
+            Operation op, AsyncCredentials asyncCredentials) {
 
         final MultiMap newFormBody;
         boolean hasClientSecretProvider = hasClientSecretProvider();
@@ -313,7 +314,7 @@ public class OidcClientImpl implements OidcClient {
         }
 
         var preparedRequest = preparePostRequest(requestProps, endpointType, request, newFormBody, additionalGrantParameters,
-                op);
+                op, asyncCredentials);
         if (hasClientSecretProvider && preparedRequest.credentialsToRetry != null) {
             return preparedRequest.postRequest.flatMap(httpResponse -> {
                 if (httpResponse.statusCode() == 401) {
@@ -347,15 +348,15 @@ public class OidcClientImpl implements OidcClient {
                             LOG.debug("HTTP request failed with response status code 401 and the CredentialsProvider"
                                     + " provided new credentials, retrying the request with new credentials");
                             return preparePostRequest(requestProps, endpointType, request, formBody,
-                                    additionalGrantParameters, op).postRequest;
+                                    additionalGrantParameters, op, asyncCredentials).postRequest;
                         }
                         return Uni.createFrom().item(httpResponse);
                     });
                 }
                 return Uni.createFrom().item(httpResponse);
-            }).onItem();
+            });
         }
-        return preparedRequest.postRequest.onItem();
+        return preparedRequest.postRequest;
     }
 
     private Uni<Tokens> emitGrantTokens(OidcRequestContextProperties requestProps, HttpResponse<Buffer> resp, Operation op) {
@@ -469,6 +470,13 @@ public class OidcClientImpl implements OidcClient {
         return OidcCommonUtils.filterHttpRequest(requestProps, request, body, requestFilters, endpointType);
     }
 
+    private Uni<AsyncCredentials> withAsyncCredentials() {
+        if (clientAssertionProvider != null) {
+            return clientAssertionProvider.getClientAssertion().map(AsyncCredentials::new);
+        }
+        return AsyncCredentials.UNI_WITH_EMPTY_CREDENTIALS;
+    }
+
     OidcClientConfig getConfig() {
         return oidcConfig;
     }
@@ -518,5 +526,10 @@ public class OidcClientImpl implements OidcClient {
 
     record ClientCredentials(Key clientJwtKey, String clientSecret, String clientSecretBasicAuthScheme,
             boolean jwtAssertionProvided, ClientAssertionProvider clientAssertionProvider) {
+    }
+
+    record AsyncCredentials(String clientAssertion) {
+        private static final Uni<AsyncCredentials> UNI_WITH_EMPTY_CREDENTIALS = Uni.createFrom()
+                .item(new AsyncCredentials(null));
     }
 }

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
@@ -247,13 +247,12 @@ public class OidcClientRecorder {
                     } else if (clientCredentials.jwtAssertionProvided()
                             && clientCredentials.clientAssertionProvider() != null
                             && oidcConfig.credentials().jwt().source() == Credentials.Jwt.Source.BEARER) {
-                        String assertion = clientCredentials.clientAssertionProvider().getClientAssertion();
-                        if (assertion == null) {
-                            throw new OidcClientException(
-                                    "Cannot access discovery endpoint because a JWT bearer client_assertion is not available");
-                        }
-                        context.request().putHeader(String.valueOf(HttpHeaders.AUTHORIZATION),
-                                OidcConstants.BEARER_SCHEME + " " + assertion);
+                        return clientCredentials.clientAssertionProvider().getClientAssertion()
+                                .onItem().ifNull().failWith(() -> new OidcClientException(
+                                        "Cannot access discovery endpoint because a JWT bearer client_assertion is not available"))
+                                .invoke(assertion -> context.request().putHeader(String.valueOf(HttpHeaders.AUTHORIZATION),
+                                        OidcConstants.BEARER_SCHEME + " " + assertion))
+                                .replaceWithVoid();
                     }
                     return Uni.createFrom().voidItem();
                 }

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/ClientAssertionProvider.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/ClientAssertionProvider.java
@@ -1,17 +1,18 @@
 package io.quarkus.oidc.common.runtime;
 
+import io.smallrye.mutiny.Uni;
+
 /**
  * Client assertion provider.
  */
 public sealed interface ClientAssertionProvider permits KubernetesServiceClientAssertionProvider {
 
     /**
-     * Gets current client assertion. This method should not block. If the client assertion is retrieved with blocking
-     * IO operation, we recommend to keep the assertion up to date using a periodic scheduled task.
+     * Gets current client assertion.
      *
-     * @return client assertion
+     * @return {@link Uni} which resolves to a client assertion
      */
-    String getClientAssertion();
+    Uni<String> getClientAssertion();
 
     /**
      * Gets the client assertion type.

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/KubernetesServiceClientAssertionProvider.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/KubernetesServiceClientAssertionProvider.java
@@ -9,6 +9,7 @@ import org.eclipse.microprofile.jwt.Claims;
 import org.jboss.logging.Logger;
 
 import io.quarkus.oidc.common.runtime.config.OidcClientCommonConfig.Credentials.Jwt.Source;
+import io.smallrye.mutiny.Uni;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
@@ -46,7 +47,11 @@ final class KubernetesServiceClientAssertionProvider implements ClientAssertionP
     }
 
     @Override
-    public String getClientAssertion() {
+    public Uni<String> getClientAssertion() {
+        return Uni.createFrom().item(this::getAvailableClientAssertion);
+    }
+
+    String getAvailableClientAssertion() {
         ClientAssertion clientAssertion = this.clientAssertion;
         if (isInvalid(clientAssertion)) {
             clientAssertion = loadClientAssertion();

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -999,7 +999,7 @@ public class OidcCommonUtils {
         if (jwtConfig.source() != Source.CLIENT && jwtConfig.tokenPath().isPresent()) {
             var clientAssertionProvider = new KubernetesServiceClientAssertionProvider(vertx, jwtConfig.tokenPath().get(),
                     jwtConfig.source());
-            if (clientAssertionProvider.getClientAssertion() == null) {
+            if (clientAssertionProvider.getAvailableClientAssertion() == null) {
                 throw exceptionCreator
                         .apply("Cannot find a valid "
                                 + (jwtConfig.source() == Source.SPIFFE_JWT ? "SPIFFE JWT-SVID" : "JWT bearer")

--- a/extensions/oidc-common/runtime/src/test/java/io/quarkus/oidc/common/runtime/KubernetesServiceClientAssertionProviderTest.java
+++ b/extensions/oidc-common/runtime/src/test/java/io/quarkus/oidc/common/runtime/KubernetesServiceClientAssertionProviderTest.java
@@ -30,7 +30,7 @@ public class KubernetesServiceClientAssertionProviderTest {
         try (var clientAssertionProvider = new KubernetesServiceClientAssertionProvider(vertx, jwtBearerTokenPath,
                 Source.BEARER)) {
             // assert first token is loaded
-            assertEquals(jwtBearerToken, clientAssertionProvider.getClientAssertion());
+            assertEquals(jwtBearerToken, clientAssertionProvider.getAvailableClientAssertion());
             assertEquals(OidcConstants.JWT_BEARER_CLIENT_ASSERTION_TYPE, clientAssertionProvider.getClientAssertionType());
 
             // create a new token
@@ -38,7 +38,8 @@ public class KubernetesServiceClientAssertionProviderTest {
             storeNewJwtBearerToken(jwtBearerTokenPath, secondJwtBearerToken);
 
             Awaitility.await().atMost(Duration.ofSeconds(10))
-                    .untilAsserted(() -> assertEquals(secondJwtBearerToken, clientAssertionProvider.getClientAssertion()));
+                    .untilAsserted(
+                            () -> assertEquals(secondJwtBearerToken, clientAssertionProvider.getAvailableClientAssertion()));
         } finally {
             vertx.close().toCompletionStage().toCompletableFuture().join();
         }
@@ -51,13 +52,13 @@ public class KubernetesServiceClientAssertionProviderTest {
 
         storeNewJwtBearerToken(emptyTokenPath, "");
         try (var clientAssertionProvider = new KubernetesServiceClientAssertionProvider(vertx, emptyTokenPath, Source.BEARER)) {
-            assertNull(clientAssertionProvider.getClientAssertion());
+            assertNull(clientAssertionProvider.getAvailableClientAssertion());
 
             String validToken = createJwtBearerToken();
             storeNewJwtBearerToken(emptyTokenPath, validToken);
 
             Awaitility.await().atMost(Duration.ofSeconds(10))
-                    .untilAsserted(() -> assertEquals(validToken, clientAssertionProvider.getClientAssertion()));
+                    .untilAsserted(() -> assertEquals(validToken, clientAssertionProvider.getAvailableClientAssertion()));
         } finally {
             vertx.close().toCompletionStage().toCompletableFuture().join();
         }
@@ -71,14 +72,14 @@ public class KubernetesServiceClientAssertionProviderTest {
         storeNewJwtBearerToken(svidTokenPath, svidToken);
         try (var clientAssertionProvider = new KubernetesServiceClientAssertionProvider(vertx, svidTokenPath,
                 Source.SPIFFE_JWT)) {
-            assertEquals(svidToken, clientAssertionProvider.getClientAssertion());
+            assertEquals(svidToken, clientAssertionProvider.getAvailableClientAssertion());
             assertEquals(OidcConstants.SPIFFE_SVID_CLIENT_ASSERTION_TYPE, clientAssertionProvider.getClientAssertionType());
 
             String secondSvidToken = createSpiffeSvidToken();
             storeNewJwtBearerToken(svidTokenPath, secondSvidToken);
 
             Awaitility.await().atMost(Duration.ofSeconds(10))
-                    .untilAsserted(() -> assertEquals(secondSvidToken, clientAssertionProvider.getClientAssertion()));
+                    .untilAsserted(() -> assertEquals(secondSvidToken, clientAssertionProvider.getAvailableClientAssertion()));
         } finally {
             vertx.close().toCompletionStage().toCompletableFuture().join();
         }
@@ -92,7 +93,7 @@ public class KubernetesServiceClientAssertionProviderTest {
         storeNewJwtBearerToken(svidTokenPath, token);
         try (var clientAssertionProvider = new KubernetesServiceClientAssertionProvider(vertx, svidTokenPath,
                 Source.SPIFFE_JWT)) {
-            assertNull(clientAssertionProvider.getClientAssertion());
+            assertNull(clientAssertionProvider.getAvailableClientAssertion());
         } finally {
             vertx.close().toCompletionStage().toCompletableFuture().join();
         }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClientImpl.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClientImpl.java
@@ -147,19 +147,20 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
 
     Uni<JsonWebKeySet> getJsonWebKeySet(OidcRequestContextProperties contextProperties) {
         final OidcRequestContextProperties requestProps = getRequestProps(contextProperties);
-        return doGetJsonWebKeySet(requestProps, List.of())
+        return withAsyncCredentials().flatMap(asyncCredentials -> doGetJsonWebKeySet(requestProps, List.of(), asyncCredentials)
                 .onFailure(OidcCommonUtils.validOidcClientRedirect(metadata.getJsonWebKeySetUri()))
                 .recoverWithUni(
                         new Function<Throwable, Uni<? extends JsonWebKeySet>>() {
                             @Override
                             public Uni<JsonWebKeySet> apply(Throwable t) {
                                 OidcClientRedirectException ex = (OidcClientRedirectException) t;
-                                return doGetJsonWebKeySet(requestProps, ex.getCookies());
+                                return doGetJsonWebKeySet(requestProps, ex.getCookies(), asyncCredentials);
                             }
-                        });
+                        }));
     }
 
-    private Uni<JsonWebKeySet> doGetJsonWebKeySet(OidcRequestContextProperties requestProps, List<String> cookies) {
+    private Uni<JsonWebKeySet> doGetJsonWebKeySet(OidcRequestContextProperties requestProps, List<String> cookies,
+            AsyncCredentials asyncCredentials) {
         LOG.debugf("Get verification JWT Key Set at %s", metadata.getJsonWebKeySetUri());
         HttpRequest<Buffer> request = client.getAbs(metadata.getJsonWebKeySetUri());
         if (!cookies.isEmpty()) {
@@ -168,17 +169,19 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
         final UniOnItem<HttpResponse<Buffer>> httpResponse;
         if (oidcConfig.credentials().forAllEndpoints()) {
             var requestPropsCopy = requestProps != null ? new OidcRequestContextProperties(requestProps.getAll()) : null;
-            var preparedRequest = prepareGetJsonWebKeySetRequest(requestProps, cookies, true);
+            var preparedRequest = prepareGetJsonWebKeySetRequest(requestProps, cookies, true, asyncCredentials);
             httpResponse = withCredentialsRetry(preparedRequest,
-                    () -> prepareGetJsonWebKeySetRequest(requestPropsCopy, cookies, true));
+                    () -> prepareGetJsonWebKeySetRequest(requestPropsCopy, cookies, true, asyncCredentials))
+                    .onItem();
         } else {
-            httpResponse = prepareGetJsonWebKeySetRequest(requestProps, cookies, false).httpRequestUni.onItem();
+            httpResponse = prepareGetJsonWebKeySetRequest(requestProps, cookies, false, asyncCredentials).httpRequestUni
+                    .onItem();
         }
         return httpResponse.transformToUni(resp -> getJsonWebKeySet(requestProps, resp));
     }
 
     private PreparedHttpRequest prepareGetJsonWebKeySetRequest(OidcRequestContextProperties requestProps, List<String> cookies,
-            boolean addCredentials) {
+            boolean addCredentials, AsyncCredentials asyncCredentials) {
         LOG.debugf("Get verification JWT Key Set at %s", metadata.getJsonWebKeySetUri());
         HttpRequest<Buffer> request = client.getAbs(metadata.getJsonWebKeySetUri());
         if (!cookies.isEmpty()) {
@@ -189,7 +192,7 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
             credentialsToRetry = setHttpAuthorizationForJwks(request,
                     new ClientCredentials(null, clientSecret, null, clientSecretBasicAuthScheme,
                             jwtAssertionProvided, clientAssertionProvider, clientSecretQueryAuthentication),
-                    oidcConfig);
+                    oidcConfig, asyncCredentials);
         }
         var filteredRequest = filterHttpRequest(requestProps, OidcEndpoint.Type.JWKS, request, null)
                 .flatMap(httpRequest -> OidcCommonUtils.sendRequest(vertx, httpRequest, oidcConfig.useBlockingDnsLookup()));
@@ -393,7 +396,8 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
     }
 
     private PreparedHttpRequest prepareHttpRequest(OidcRequestContextProperties requestProps, String uri,
-            MultiMap formBody, TokenOperation op, OidcEndpoint.Type endpointType, Buffer bodyBuffer) {
+            MultiMap formBody, TokenOperation op, OidcEndpoint.Type endpointType, Buffer bodyBuffer,
+            AsyncCredentials asyncCredentials) {
         HttpRequest<Buffer> request = client.postAbs(uri);
 
         final Buffer buffer;
@@ -414,7 +418,7 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
                     credentialsToRetry = PreparedHttpRequest.CredentialsToRetry.CLIENT_SECRET_BASIC_AUTH_SCHEME;
                 }
             } else if (jwtAssertionProvided) {
-                final String clientAssertion = clientAssertionProvider.getClientAssertion();
+                final String clientAssertion = asyncCredentials.clientAssertion;
                 if (clientAssertion == null) {
                     throw new OIDCException(String.format(
                             "Cannot get token for tenant '%s' because a %s client_assertion is not available",
@@ -504,12 +508,17 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
             newFormBody = formBody;
         }
 
-        var preparedRequest = prepareHttpRequest(requestProps, uri, newFormBody, op, endpointType, bodyBuffer);
-        if (hasClientSecretProvider && preparedRequest.credentialsToRetry != null) {
-            return withCredentialsRetry(preparedRequest,
-                    () -> prepareHttpRequest(requestProps, uri, formBody, op, endpointType, bodyBuffer));
-        }
-        return preparedRequest.httpRequestUni.onItem();
+        return withAsyncCredentials()
+                .flatMap(asyncCredentials -> {
+                    var preparedRequest = prepareHttpRequest(requestProps, uri, newFormBody, op, endpointType, bodyBuffer,
+                            asyncCredentials);
+                    if (hasClientSecretProvider && preparedRequest.credentialsToRetry != null) {
+                        return withCredentialsRetry(preparedRequest,
+                                () -> prepareHttpRequest(requestProps, uri, formBody, op, endpointType, bodyBuffer,
+                                        asyncCredentials));
+                    }
+                    return preparedRequest.httpRequestUni;
+                }).onItem();
     }
 
     private boolean hasClientSecretProvider() {
@@ -659,23 +668,24 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
     }
 
     static void setHttpAuthorizationForDiscovery(HttpRequest<Buffer> request,
-            ClientCredentials clientCredentials, OidcClientCommonConfig oidcConfig) {
-        setHttpAuthorization(request, clientCredentials, oidcConfig, MetadataOperation.DISCOVERY);
+            ClientCredentials clientCredentials, OidcClientCommonConfig oidcConfig, AsyncCredentials asyncCredentials) {
+        setHttpAuthorization(request, clientCredentials, oidcConfig, MetadataOperation.DISCOVERY, asyncCredentials);
     }
 
     static PreparedHttpRequest.CredentialsToRetry setHttpAuthorizationForJwks(HttpRequest<Buffer> request,
-            ClientCredentials clientCredentials, OidcClientCommonConfig oidcConfig) {
-        return setHttpAuthorization(request, clientCredentials, oidcConfig, MetadataOperation.JWKS);
+            ClientCredentials clientCredentials, OidcClientCommonConfig oidcConfig, AsyncCredentials asyncCredentials) {
+        return setHttpAuthorization(request, clientCredentials, oidcConfig, MetadataOperation.JWKS, asyncCredentials);
     }
 
     private static PreparedHttpRequest.CredentialsToRetry setHttpAuthorization(HttpRequest<Buffer> request,
-            ClientCredentials clientCredentials, OidcClientCommonConfig oidcConfig, MetadataOperation op) {
+            ClientCredentials clientCredentials, OidcClientCommonConfig oidcConfig, MetadataOperation op,
+            AsyncCredentials asyncCredentials) {
         if (clientCredentials.clientSecretBasicAuthScheme != null) {
             request.putHeader(AUTHORIZATION_HEADER, clientCredentials.clientSecretBasicAuthScheme);
             return PreparedHttpRequest.CredentialsToRetry.CLIENT_SECRET_BASIC_AUTH_SCHEME;
         } else if (clientCredentials.jwtAssertionProvided && clientCredentials.clientAssertionProvider != null
                 && oidcConfig.credentials().jwt().source() == OidcClientCommonConfig.Credentials.Jwt.Source.BEARER) {
-            final String clientAssertion = clientCredentials.clientAssertionProvider.getClientAssertion();
+            final String clientAssertion = asyncCredentials.clientAssertion;
             if (clientAssertion == null) {
                 throw new OIDCException(String.format(
                         "Cannot access the %s endpoint for client '%s' because a JWT bearer client_assertion is not available",
@@ -686,7 +696,7 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
         return null;
     }
 
-    private UniOnItem<HttpResponse<Buffer>> withCredentialsRetry(PreparedHttpRequest preparedRequest,
+    private Uni<HttpResponse<Buffer>> withCredentialsRetry(PreparedHttpRequest preparedRequest,
             Supplier<PreparedHttpRequest> refreshRequestSupplier) {
         return preparedRequest.httpRequestUni.flatMap(httpResponse -> {
             if (httpResponse.statusCode() == 401) {
@@ -725,7 +735,7 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
                 });
             }
             return Uni.createFrom().item(httpResponse);
-        }).onItem();
+        });
     }
 
     static boolean isIntrospection(TokenOperation op) {
@@ -775,9 +785,25 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
         return null;
     }
 
+    private Uni<AsyncCredentials> withAsyncCredentials() {
+        return withAsyncCredentials(clientAssertionProvider);
+    }
+
+    static Uni<AsyncCredentials> withAsyncCredentials(ClientAssertionProvider clientAssertionProvider) {
+        if (clientAssertionProvider != null) {
+            return clientAssertionProvider.getClientAssertion().map(AsyncCredentials::new);
+        }
+        return AsyncCredentials.UNI_WITH_EMPTY_CREDENTIALS;
+    }
+
     record ClientCredentials(Key clientJwtKey, String clientSecret, String jwtSecret,
             String clientSecretBasicAuthScheme,
             boolean jwtAssertionProvided, ClientAssertionProvider clientAssertionProvider,
             boolean clientSecretQueryAuthentication) {
+    }
+
+    record AsyncCredentials(String clientAssertion) {
+        private static final Uni<AsyncCredentials> UNI_WITH_EMPTY_CREDENTIALS = Uni.createFrom()
+                .item(new AsyncCredentials(null));
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantContextFactory.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantContextFactory.java
@@ -492,9 +492,11 @@ final class TenantContextFactory {
                 OidcRequestFilter authFilter = new OidcRequestFilter() {
                     @Override
                     public Uni<Void> filter(OidcRequestFilterContext context) {
-                        OidcProviderClientImpl.setHttpAuthorizationForDiscovery(context.request(),
-                                clientCredentials, oidcConfig);
-                        return Uni.createFrom().voidItem();
+                        return OidcProviderClientImpl.withAsyncCredentials(clientCredentials.clientAssertionProvider())
+                                .invoke(asyncCredentials -> OidcProviderClientImpl.setHttpAuthorizationForDiscovery(
+                                        context.request(),
+                                        clientCredentials, oidcConfig, asyncCredentials))
+                                .replaceWithVoid();
                     }
                 };
                 discoveryFilters.computeIfAbsent(OidcEndpoint.Type.DISCOVERY, k -> new ArrayList<>()).add(authFilter);


### PR DESCRIPTION
SPIFFE client will provide JWT-SVID asynchronously and we agreed that we should prepare the client assertion provider first. We might end up caching the SVIDs, but we still need to be able to provide it on fly if necessary.
