### PR TITLE
Quarkus REST: fix response status for sub-resource requests with a malformed content type

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/SubResourceMediaTypeTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/SubResourceMediaTypeTest.java
@@ -1,5 +1,8 @@
 package io.quarkus.resteasy.reactive.server.test.resource.basic;
 
+import static io.restassured.RestAssured.config;
+import static io.restassured.RestAssured.given;
+import static io.restassured.config.EncoderConfig.encoderConfig;
 import static org.hamcrest.Matchers.equalTo;
 
 import java.io.IOException;
@@ -30,6 +33,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusExtensionTest;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
 
 public class SubResourceMediaTypeTest {
     @RegisterExtension
@@ -92,6 +96,16 @@ public class SubResourceMediaTypeTest {
             RestAssured.given().accept("text/plain").multiPart("file", "name1,street1,city1,state1,zip")
                     .post("/store/addresses").then().statusCode(200).body(equalTo("name1,street1,city1,state1,zip"));
         }
+    }
+
+    @Test
+    public void malformedContentType() {
+        given().config(config().encoderConfig(encoderConfig().encodeContentTypeAs("invalid/@@##", ContentType.TEXT)))
+                .body("dummy")
+                .contentType("invalid/@@##")
+                .post("/store/addresses")
+                .then()
+                .statusCode(415);
     }
 
     @Path("store")

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/MediaTypeMapper.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/MediaTypeMapper.java
@@ -106,7 +106,11 @@ public class MediaTypeMapper implements ServerRestHandler {
         }
         List<MediaType> result = new ArrayList<>(contentTypeList.size());
         for (String s : contentTypeList) {
-            result.add(MediaTypeHelper.valueOf(s));
+            try {
+                result.add(MediaTypeHelper.valueOf(s));
+            } catch (IllegalArgumentException e) {
+                throw new NotSupportedException("The content-type header value did not correspond to a valid media type");
+            }
         }
         return result;
     }


### PR DESCRIPTION
Do what https://github.com/quarkusio/quarkus/blob/main/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/ClassRoutingHandler.java#L127-L129 does

* Closes: https://github.com/quarkusio/quarkus/issues/55008