### PR TITLE
Fix TransactionalInterceptorBase to handle reaper-cancelled transactions

### DIFF
--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/interceptor/TransactionalInterceptorBase.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/interceptor/TransactionalInterceptorBase.java
@@ -17,6 +17,7 @@ import java.util.function.Function;
 
 import jakarta.inject.Inject;
 import jakarta.interceptor.InvocationContext;
+import jakarta.transaction.RollbackException;
 import jakarta.transaction.Status;
 import jakarta.transaction.SystemException;
 import jakarta.transaction.Transaction;
@@ -396,7 +397,7 @@ public abstract class TransactionalInterceptorBase implements Serializable {
 
         for (Class<?> rollbackOnClass : transactional.rollbackOn()) {
             if (rollbackOnClass.isAssignableFrom(t.getClass())) {
-                tx.setRollbackOnly();
+                safeSetRollbackOnly(tx);
                 return;
             }
         }
@@ -404,7 +405,7 @@ public abstract class TransactionalInterceptorBase implements Serializable {
         Rollback rollbackAnnotation = t.getClass().getAnnotation(Rollback.class);
         if (rollbackAnnotation != null) {
             if (rollbackAnnotation.value()) {
-                tx.setRollbackOnly();
+                safeSetRollbackOnly(tx);
             }
             // in both cases, behaviour is specified by the annotation
             return;
@@ -412,8 +413,29 @@ public abstract class TransactionalInterceptorBase implements Serializable {
 
         // RuntimeException and Error are un-checked exceptions and rollback is expected
         if (t instanceof RuntimeException || t instanceof Error) {
-            tx.setRollbackOnly();
+            safeSetRollbackOnly(tx);
             return;
+        }
+    }
+
+    /**
+     * Sets the transaction to rollback-only, guarding against the case where
+     * the transaction has already been rolled back (e.g., by the transaction reaper).
+     * <p>
+     * Without this guard, {@code tx.setRollbackOnly()} on a dead transaction throws
+     * {@link IllegalStateException}, which would propagate through
+     * {@link #handleExceptionNoThrow} and mask the original business exception.
+     */
+    private void safeSetRollbackOnly(Transaction tx) throws SystemException {
+        try {
+            int status = tx.getStatus();
+            if (status != Status.STATUS_NO_TRANSACTION
+                    && status != Status.STATUS_ROLLEDBACK
+                    && status != Status.STATUS_COMMITTED) {
+                tx.setRollbackOnly();
+            }
+        } catch (IllegalStateException e) {
+            log.warn("Cannot set rollback-only, transaction already ended", e);
         }
     }
 
@@ -426,7 +448,11 @@ public abstract class TransactionalInterceptorBase implements Serializable {
     protected void endTransaction(TransactionManager tm, Transaction tx, RunnableWithException afterEndTransaction)
             throws Exception {
         try {
-            if (tx != tm.getTransaction()) {
+            Transaction current = tm.getTransaction();
+            if (current == null) {
+                throw new RollbackException("Transaction was already rolled back (e.g., by the transaction reaper)");
+            }
+            if (tx != current) {
                 throw new RuntimeException(jtaLogger.i18NLogger.get_wrong_tx_on_thread());
             }
 


### PR DESCRIPTION
## Summary

`TransactionalInterceptorBase` does not handle the case where the Narayana transaction reaper has already rolled back a transaction before the application thread finishes. This causes uncaught exceptions and masked business exceptions — particularly under virtual threads with CPU starvation, but also possible in any scenario where transactions exceed their timeout.

## Problem

When a transaction exceeds its configured timeout, the Narayana `TransactionReaper` rolls it back on a background thread. When the original application thread finally resumes, two things go wrong:

**1. `handleExceptionNoThrow()` masks business exceptions:**

Unguarded `tx.setRollbackOnly()` calls throw `IllegalStateException` on dead transactions, which propagates up and **masks the original business exception** the application threw.

**2. `endTransaction()` produces misleading errors:**

When `tm.getTransaction()` returns `null` (reaper disassociated the transaction), the existing `tx != tm.getTransaction()` check throws a misleading `RuntimeException` ("wrong tx on thread") instead of indicating the real cause.

**Why this matters for virtual threads:**

Under CPU-constrained environments (e.g., Docker with `--cpus=0.15`), virtual threads dispatched by `@RunOnVirtualThread` can be parked long enough for the transaction reaper to fire. When this happens, the interceptor crashes instead of handling the situation gracefully.

However, this is not exclusive to virtual threads — any scenario where a `@Transactional` method takes longer than the configured timeout will trigger the same code path.

## Changes

**`handleExceptionNoThrow()`:**
- Extracted a new `safeSetRollbackOnly()` helper that checks the transaction status before calling `tx.setRollbackOnly()`, preventing `IllegalStateException` from masking the original business exception
- Skips `setRollbackOnly()` when the transaction is already in `STATUS_NO_TRANSACTION`, `STATUS_ROLLEDBACK`, or `STATUS_COMMITTED`
- Catches `IllegalStateException` as a fallback guard and logs a warning

**`endTransaction()`:**
- Added a null check for `tm.getTransaction()` — when the reaper has already disassociated the transaction, throws `RollbackException` with a clear message instead of the misleading "wrong tx on thread" error
- The existing commit/rollback logic is preserved: `STATUS_MARKED_ROLLBACK` → `tm.rollback()`, everything else → `tm.commit()`

## Reproducer

https://github.com/eggy03/PaperTrail-API-Quarkus (branch: `zombie-txn-reproducer`)

Run with: `docker run --cpus="0.15" --memory="512m"` and load test the `/sample` POST endpoint.

Before this fix: `ARJUNA012117`, `ARJUNA012095`, `ARJUNA012108`, `ARJUNA012381` warnings cascade and business exceptions are masked.

## Test plan

- [x] Existing `TransactionConfigurationTest` (6 tests) passes
- [x] Existing narayana-jta deployment tests pass
- [x] Verified with reproducer app: zero zombie transaction warnings under load with `--cpus=0.15`