### PR TITLE
Add optional concurrency limit for virtual thread executor

### DIFF
--- a/docs/src/main/asciidoc/virtual-threads.adoc
+++ b/docs/src/main/asciidoc/virtual-threads.adoc
@@ -460,6 +460,31 @@ quarkus.virtual-threads.name-prefix=
 
 ----
 
+== Limiting virtual thread concurrency
+
+By default, a new virtual thread is created for every task with no concurrency limit.
+While virtual threads are cheap to create and park, the resources they access (such as database connection pools) are not unbounded.
+Under high load or in CPU-constrained environments (e.g., containers with strict CPU limits), unbounded virtual thread concurrency can exhaust downstream resources faster than they can be replenished, leading to connection pool starvation and transaction timeouts.
+
+To prevent this, you can set a concurrency limit that caps the number of virtual threads executing their payload simultaneously:
+
+[source, properties]
+----
+quarkus.virtual-threads.max-concurrency=16
+----
+
+The value must be a positive integer greater than or equal to 2.
+Setting it to 1 would serialize all virtual thread execution and is almost certainly a misconfiguration — a warning is logged if this happens.
+
+When set, a fair `Semaphore` is used to limit execution.
+Virtual threads are still created per-request (so the caller is never blocked), but only the configured number run their workload concurrently.
+Excess virtual threads park cheaply at the semaphore until a permit is released.
+Fair ordering ensures that threads waiting for a permit are served in FIFO order, preventing starvation under sustained load.
+
+A good starting value is the size of your most constrained resource — typically the database connection pool (`quarkus.datasource.jdbc.max-size`, which defaults to 20).
+
+NOTE: If not set, concurrency is unbounded, preserving the default behavior.
+
 == Inject the virtual thread executor
 
 In order to run tasks on virtual threads Quarkus manages an internal `ThreadPerTaskExecutor`.

--- a/extensions/virtual-threads/deployment/src/main/java/io/quarkus/virtual/threads/deployment/VirtualThreadsProcessor.java
+++ b/extensions/virtual-threads/deployment/src/main/java/io/quarkus/virtual/threads/deployment/VirtualThreadsProcessor.java
@@ -14,6 +14,7 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
+import io.quarkus.deployment.metrics.MetricsFactoryConsumerBuildItem;
 import io.quarkus.virtual.threads.VirtualThreads;
 import io.quarkus.virtual.threads.VirtualThreadsRecorder;
 
@@ -36,5 +37,12 @@ public class VirtualThreadsProcessor {
                         .setRuntimeInit()
                         .supplier(recorder.getCurrentSupplier())
                         .done());
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    public void registerMetrics(VirtualThreadsRecorder recorder,
+            BuildProducer<MetricsFactoryConsumerBuildItem> metrics) {
+        metrics.produce(new MetricsFactoryConsumerBuildItem(recorder.registerMetrics()));
     }
 }

--- a/extensions/virtual-threads/runtime/src/main/java/io/quarkus/virtual/threads/BoundedExecutorService.java
+++ b/extensions/virtual-threads/runtime/src/main/java/io/quarkus/virtual/threads/BoundedExecutorService.java
@@ -1,0 +1,126 @@
+package io.quarkus.virtual.threads;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+
+import io.quarkus.runtime.util.ForwardingExecutorService;
+
+/**
+ * An {@link ExecutorService} wrapper that limits the number of concurrently executing tasks
+ * using a {@link Semaphore}. Tasks are still submitted to the delegate immediately (so the
+ * caller is never blocked), but the task payload acquires a permit before running and releases
+ * it on completion.
+ * <p>
+ * All work-dispatching methods ({@code execute}, {@code submit}, {@code invokeAll},
+ * {@code invokeAny}) are overridden to ensure the semaphore is respected.
+ * The semaphore uses fair ordering to prevent starvation under sustained load.
+ */
+class BoundedExecutorService extends ForwardingExecutorService {
+
+    private final ExecutorService delegate;
+    private final Semaphore semaphore;
+
+    BoundedExecutorService(ExecutorService delegate, int maxConcurrency) {
+        this.delegate = delegate;
+        this.semaphore = new Semaphore(maxConcurrency, true);
+    }
+
+    @Override
+    protected ExecutorService delegate() {
+        return delegate;
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        delegate.execute(wrapRunnable(command));
+    }
+
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        return delegate.submit(wrapCallable(task));
+    }
+
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        return delegate.submit(wrapRunnable(task), result);
+    }
+
+    @Override
+    public Future<?> submit(Runnable task) {
+        return delegate.submit(wrapRunnable(task));
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        return delegate.invokeAll(wrapCallables(tasks));
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+            throws InterruptedException {
+        return delegate.invokeAll(wrapCallables(tasks), timeout, unit);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+        return delegate.invokeAny(wrapCallables(tasks));
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        return delegate.invokeAny(wrapCallables(tasks), timeout, unit);
+    }
+
+    int availablePermits() {
+        return semaphore.availablePermits();
+    }
+
+    int queueLength() {
+        return semaphore.getQueueLength();
+    }
+
+    private Runnable wrapRunnable(Runnable command) {
+        return () -> {
+            try {
+                semaphore.acquire();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+            try {
+                command.run();
+            } finally {
+                semaphore.release();
+            }
+        };
+    }
+
+    private <T> Callable<T> wrapCallable(Callable<T> task) {
+        return () -> {
+            try {
+                semaphore.acquire();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw e;
+            }
+            try {
+                return task.call();
+            } finally {
+                semaphore.release();
+            }
+        };
+    }
+
+    private <T> List<Callable<T>> wrapCallables(Collection<? extends Callable<T>> tasks) {
+        return tasks.stream().map(this::wrapCallable).collect(Collectors.toList());
+    }
+}

--- a/extensions/virtual-threads/runtime/src/main/java/io/quarkus/virtual/threads/VirtualThreadsConfig.java
+++ b/extensions/virtual-threads/runtime/src/main/java/io/quarkus/virtual/threads/VirtualThreadsConfig.java
@@ -2,6 +2,7 @@ package io.quarkus.virtual.threads;
 
 import java.time.Duration;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -41,4 +42,15 @@ public interface VirtualThreadsConfig {
      */
     @WithDefault("true")
     boolean enabled();
+
+    /**
+     * The maximum number of virtual threads that are allowed to run concurrently.
+     * <p>
+     * When set, a semaphore is used to limit the number of tasks executing simultaneously.
+     * This is useful to prevent overwhelming fixed-size resources like database connection pools
+     * under high load or CPU-constrained environments.
+     * <p>
+     * If not set, concurrency is unbounded (a new virtual thread is created per task with no limit).
+     */
+    OptionalInt maxConcurrency();
 }

--- a/extensions/virtual-threads/runtime/src/main/java/io/quarkus/virtual/threads/VirtualThreadsRecorder.java
+++ b/extensions/virtual-threads/runtime/src/main/java/io/quarkus/virtual/threads/VirtualThreadsRecorder.java
@@ -144,7 +144,22 @@ public class VirtualThreadsRecorder {
         if (config.enabled()) {
             try {
                 String prefix = config.namePrefix().orElse(null);
-                return new ContextPreservingExecutorService(newVirtualThreadPerTaskExecutorWithName(prefix));
+                ExecutorService executor = new ContextPreservingExecutorService(
+                        newVirtualThreadPerTaskExecutorWithName(prefix));
+                if (config.maxConcurrency().isPresent()) {
+                    int max = config.maxConcurrency().getAsInt();
+                    if (max <= 0) {
+                        throw new IllegalArgumentException(
+                                "quarkus.virtual-threads.max-concurrency must be a positive integer, got: " + max);
+                    }
+                    if (max < 2) {
+                        logger.warnf("quarkus.virtual-threads.max-concurrency is set to %d, which will serialize" +
+                                " all virtual thread execution. Consider a higher value.", max);
+                    }
+                    logger.infof("Virtual thread concurrency limited to %d", max);
+                    executor = new BoundedExecutorService(executor, max);
+                }
+                return executor;
             } catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException | ClassNotFoundException e) {
                 logger.debug("Unable to invoke java.util.concurrent.Executors#newVirtualThreadPerTaskExecutor", e);
                 //quite ugly but works

--- a/extensions/virtual-threads/runtime/src/main/java/io/quarkus/virtual/threads/VirtualThreadsRecorder.java
+++ b/extensions/virtual-threads/runtime/src/main/java/io/quarkus/virtual/threads/VirtualThreadsRecorder.java
@@ -7,6 +7,7 @@ import java.lang.reflect.Method;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import org.jboss.logging.Logger;
@@ -14,6 +15,7 @@ import org.jboss.logging.Logger;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
+import io.quarkus.runtime.metrics.MetricsFactory;
 
 @Recorder
 public class VirtualThreadsRecorder {
@@ -25,6 +27,7 @@ public class VirtualThreadsRecorder {
     @Deprecated(since = "3.25", forRemoval = true)
     static volatile VirtualThreadsConfig config;
     private static volatile ExecutorService current;
+    private static volatile BoundedExecutorService boundedExecutor;
     private static final Object lock = new Object();
 
     private final VirtualThreadsConfig runtimeConfig;
@@ -52,6 +55,7 @@ public class VirtualThreadsRecorder {
                             service.shutdownNow();
                         }
                         current = null;
+                        boundedExecutor = null;
                     }
                 });
             } else {
@@ -60,6 +64,7 @@ public class VirtualThreadsRecorder {
                     public void run() {
                         ExecutorService service = current;
                         current = null;
+                        boundedExecutor = null;
                         if (service != null) {
                             service.shutdown();
 
@@ -95,6 +100,28 @@ public class VirtualThreadsRecorder {
 
     public Supplier<ExecutorService> getCurrentSupplier() {
         return VIRTUAL_THREADS_EXECUTOR_SUPPLIER;
+    }
+
+    /* RUNTIME_INIT */
+    public Consumer<MetricsFactory> registerMetrics() {
+        return new Consumer<MetricsFactory>() {
+            @Override
+            public void accept(MetricsFactory metricsFactory) {
+                // Ensure the executor is created so boundedExecutor is populated
+                getCurrent();
+                BoundedExecutorService bounded = boundedExecutor;
+                if (bounded == null) {
+                    return;
+                }
+                metricsFactory.builder("virtual_threads.permits.available")
+                        .description("Number of permits currently available in the virtual thread concurrency limiter.")
+                        .buildGauge(bounded::availablePermits);
+                metricsFactory.builder("virtual_threads.permits.queue_length")
+                        .description(
+                                "Number of virtual threads currently waiting to acquire a permit from the concurrency limiter.")
+                        .buildGauge(bounded::queueLength);
+            }
+        };
     }
 
     public static ExecutorService getCurrent() {
@@ -157,7 +184,9 @@ public class VirtualThreadsRecorder {
                                 " all virtual thread execution. Consider a higher value.", max);
                     }
                     logger.infof("Virtual thread concurrency limited to %d", max);
-                    executor = new BoundedExecutorService(executor, max);
+                    BoundedExecutorService bounded = new BoundedExecutorService(executor, max);
+                    boundedExecutor = bounded;
+                    executor = bounded;
                 }
                 return executor;
             } catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException | ClassNotFoundException e) {

--- a/extensions/virtual-threads/runtime/src/test/java/io/quarkus/virtual/threads/VirtualThreadExecutorSupplierTest.java
+++ b/extensions/virtual-threads/runtime/src/test/java/io/quarkus/virtual/threads/VirtualThreadExecutorSupplierTest.java
@@ -8,10 +8,13 @@ import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -128,6 +131,196 @@ class VirtualThreadExecutorSupplierTest {
             }));
         }, false).toCompletionStage().toCompletableFuture().get();
         assertThat(futures).allSatisfy(contextFuture -> assertThat(contextFuture.get()).isNotNull());
+    }
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_20, disabledReason = "Virtual Threads are a preview feature starting from Java 20")
+    void boundedExecutorLimitsConcurrencyViaExecute() throws Exception {
+        int maxConcurrency = 3;
+        int totalTasks = 10;
+        ExecutorService rawExecutor = VirtualThreadsRecorder.getCurrent();
+        BoundedExecutorService bounded = new BoundedExecutorService(rawExecutor, maxConcurrency);
+
+        AtomicInteger running = new AtomicInteger(0);
+        AtomicInteger peak = new AtomicInteger(0);
+        CountDownLatch allDone = new CountDownLatch(totalTasks);
+
+        for (int i = 0; i < totalTasks; i++) {
+            bounded.execute(() -> {
+                int current = running.incrementAndGet();
+                peak.accumulateAndGet(current, Math::max);
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    running.decrementAndGet();
+                    allDone.countDown();
+                }
+            });
+        }
+
+        assertThat(allDone.await(10, TimeUnit.SECONDS)).isTrue();
+        assertThat(peak.get()).isLessThanOrEqualTo(maxConcurrency);
+    }
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_20, disabledReason = "Virtual Threads are a preview feature starting from Java 20")
+    void boundedExecutorLimitsConcurrencyViaSubmitRunnable() throws Exception {
+        int maxConcurrency = 3;
+        int totalTasks = 10;
+        ExecutorService rawExecutor = VirtualThreadsRecorder.getCurrent();
+        BoundedExecutorService bounded = new BoundedExecutorService(rawExecutor, maxConcurrency);
+
+        AtomicInteger running = new AtomicInteger(0);
+        AtomicInteger peak = new AtomicInteger(0);
+        CountDownLatch allDone = new CountDownLatch(totalTasks);
+
+        List<Future<?>> futures = new java.util.ArrayList<>();
+        for (int i = 0; i < totalTasks; i++) {
+            futures.add(bounded.submit(() -> {
+                int current = running.incrementAndGet();
+                peak.accumulateAndGet(current, Math::max);
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    running.decrementAndGet();
+                    allDone.countDown();
+                }
+            }));
+        }
+
+        assertThat(allDone.await(10, TimeUnit.SECONDS)).isTrue();
+        assertThat(peak.get()).isLessThanOrEqualTo(maxConcurrency);
+        for (Future<?> f : futures) {
+            f.get(1, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_20, disabledReason = "Virtual Threads are a preview feature starting from Java 20")
+    void boundedExecutorLimitsConcurrencyViaSubmitCallable() throws Exception {
+        int maxConcurrency = 3;
+        int totalTasks = 10;
+        ExecutorService rawExecutor = VirtualThreadsRecorder.getCurrent();
+        BoundedExecutorService bounded = new BoundedExecutorService(rawExecutor, maxConcurrency);
+
+        AtomicInteger running = new AtomicInteger(0);
+        AtomicInteger peak = new AtomicInteger(0);
+        CountDownLatch allDone = new CountDownLatch(totalTasks);
+
+        List<Future<Integer>> futures = new java.util.ArrayList<>();
+        for (int i = 0; i < totalTasks; i++) {
+            final int taskId = i;
+            futures.add(bounded.submit(() -> {
+                int current = running.incrementAndGet();
+                peak.accumulateAndGet(current, Math::max);
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw e;
+                } finally {
+                    running.decrementAndGet();
+                    allDone.countDown();
+                }
+                return taskId;
+            }));
+        }
+
+        assertThat(allDone.await(10, TimeUnit.SECONDS)).isTrue();
+        assertThat(peak.get()).isLessThanOrEqualTo(maxConcurrency);
+        for (int i = 0; i < totalTasks; i++) {
+            assertThat(futures.get(i).get(1, TimeUnit.SECONDS)).isEqualTo(i);
+        }
+    }
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_20, disabledReason = "Virtual Threads are a preview feature starting from Java 20")
+    void boundedExecutorLimitsConcurrencyViaInvokeAll() throws Exception {
+        int maxConcurrency = 3;
+        int totalTasks = 10;
+        ExecutorService rawExecutor = VirtualThreadsRecorder.getCurrent();
+        BoundedExecutorService bounded = new BoundedExecutorService(rawExecutor, maxConcurrency);
+
+        AtomicInteger running = new AtomicInteger(0);
+        AtomicInteger peak = new AtomicInteger(0);
+
+        List<Callable<Integer>> tasks = new java.util.ArrayList<>();
+        for (int i = 0; i < totalTasks; i++) {
+            final int taskId = i;
+            tasks.add(() -> {
+                int current = running.incrementAndGet();
+                peak.accumulateAndGet(current, Math::max);
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw e;
+                } finally {
+                    running.decrementAndGet();
+                }
+                return taskId;
+            });
+        }
+
+        List<Future<Integer>> results = bounded.invokeAll(tasks);
+
+        assertThat(peak.get()).isLessThanOrEqualTo(maxConcurrency);
+        assertThat(results).hasSize(totalTasks);
+        for (int i = 0; i < totalTasks; i++) {
+            assertThat(results.get(i).get()).isEqualTo(i);
+        }
+    }
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_20, disabledReason = "Virtual Threads are a preview feature starting from Java 20")
+    void boundedExecutorLimitsConcurrencyViaInvokeAny() throws Exception {
+        int maxConcurrency = 2;
+        ExecutorService rawExecutor = VirtualThreadsRecorder.getCurrent();
+        BoundedExecutorService bounded = new BoundedExecutorService(rawExecutor, maxConcurrency);
+
+        AtomicInteger running = new AtomicInteger(0);
+        AtomicInteger peak = new AtomicInteger(0);
+
+        List<Callable<String>> tasks = List.of(
+                () -> {
+                    int current = running.incrementAndGet();
+                    peak.accumulateAndGet(current, Math::max);
+                    try {
+                        Thread.sleep(50);
+                        return "first";
+                    } finally {
+                        running.decrementAndGet();
+                    }
+                },
+                () -> {
+                    int current = running.incrementAndGet();
+                    peak.accumulateAndGet(current, Math::max);
+                    try {
+                        Thread.sleep(50);
+                        return "second";
+                    } finally {
+                        running.decrementAndGet();
+                    }
+                },
+                () -> {
+                    int current = running.incrementAndGet();
+                    peak.accumulateAndGet(current, Math::max);
+                    try {
+                        Thread.sleep(50);
+                        return "third";
+                    } finally {
+                        running.decrementAndGet();
+                    }
+                });
+
+        String result = bounded.invokeAny(tasks);
+
+        assertThat(result).isIn("first", "second", "third");
+        assertThat(peak.get()).isLessThanOrEqualTo(maxConcurrency);
     }
 
     public static void assertThatItRunsOnVirtualThread() {


### PR DESCRIPTION
## Summary

The virtual thread executor created by `VirtualThreadsRecorder` uses `Executors.newThreadPerTaskExecutor()` which is completely unbounded — every incoming request immediately spawns a new virtual thread with no backpressure. This leads to resource exhaustion under load, particularly when downstream resources like database connection pools are fixed-size.

This PR adds a new `quarkus.virtual-threads.max-concurrency` configuration property that, when set, limits the number of virtual threads executing concurrently using a fair semaphore.

## Problem

With `@RunOnVirtualThread`, every request gets its own virtual thread immediately. Unlike platform thread pools (which have a fixed size providing natural backpressure), virtual threads have no built-in concurrency control. Under load, this means:

1. Hundreds of virtual threads start concurrently
2. They all compete for a fixed-size connection pool (e.g., 16 connections)
3. Most park at `ConnectionPool.handlerTransferQueue.poll()` waiting for a connection
4. The Narayana transaction reaper times out the waiting transactions (default 60s)
5. This creates zombie transactions — transactions rolled back by the reaper while virtual threads are still parked

**This is not a theoretical problem.** It was reproduced with a minimal Quarkus application running in Docker with `--cpus=0.15`:

- Without concurrency limit: **120 WARN lines** (zombie transactions, reaper cancellations, Hibernate afterCompletion on wrong thread)
- With `quarkus.virtual-threads.max-concurrency=16`: **0 WARN lines**

The issue is JVM-independent — it was tested on both IBM Semeru (OpenJ9) and Eclipse Temurin (HotSpot with JEP 491). In fact, Temurin produced *more* warnings because JEP 491 eliminates virtual thread pinning on `synchronized`, allowing more threads to progress past locks and exhaust the connection pool faster.

## Changes

**`VirtualThreadsConfig.java`:**
- Added `maxConcurrency()` property (`OptionalInt`, no default = unbounded for backward compatibility)

**New `BoundedExecutorService.java`:**
- Extends `ForwardingExecutorService`
- Wraps the delegate with a fair `java.util.concurrent.Semaphore` (FIFO ordering prevents starvation under sustained load)
- All work-dispatching methods are overridden (`execute`, `submit(Callable)`, `submit(Runnable)`, `submit(Runnable, T)`, `invokeAll`, `invokeAny`) to ensure the semaphore is respected regardless of how work is submitted
- The semaphore acquire happens *inside* the virtual thread (inside the wrapped `Runnable`/`Callable`), not before `delegate.execute()` — this ensures the caller (event-loop thread) is never blocked
- Virtual threads are still created per-request, but only N execute their payload concurrently; excess threads park cheaply at the semaphore
- Exposes `availablePermits()` and `queueLength()` for observability

**`VirtualThreadsRecorder.java`:**
- In `createExecutor()`: wraps the `ContextPreservingExecutorService` in `BoundedExecutorService` when `maxConcurrency` is set
- Validates that `maxConcurrency` is positive; logs a warning when set to less than 2 (which would serialize all execution)
- Adds `registerMetrics()` method that registers `virtual_threads.permits.available` and `virtual_threads.permits.queue_length` gauges via `MetricsFactory`
- Clears `boundedExecutor` reference on shutdown

**`VirtualThreadsProcessor.java`:**
- New `registerMetrics` build step that produces a `MetricsFactoryConsumerBuildItem` — follows the same pattern as Agroal's metrics integration, no direct Micrometer dependency required

**`virtual-threads.adoc`:**
- Documents the `max-concurrency` property with guidance on acceptable values and fair ordering behavior

**`VirtualThreadExecutorSupplierTest.java`:**
- Added 5 tests verifying that peak concurrency never exceeds the configured limit across all dispatching methods: `execute`, `submit(Runnable)`, `submit(Callable)`, `invokeAll`, and `invokeAny`

## Design decisions

- **Opt-in with no default**: Setting a default would change existing behavior. Users who need it (CPU-constrained environments, small connection pools) can set it to match their bottleneck resource.
- **Semaphore inside the virtual thread**: If we acquired the semaphore before `delegate.execute()`, the calling event-loop thread would block — defeating the purpose of virtual threads. By acquiring inside, the caller returns immediately and the virtual thread parks cheaply at the semaphore.
- **Fair semaphore**: Prevents starvation under sustained load by serving waiting threads in FIFO order.
- **All dispatching methods overridden**: `submit`, `invokeAll`, and `invokeAny` all go through `wrapRunnable`/`wrapCallable` helpers to guarantee the semaphore is respected no matter how work is submitted.
- **Applied globally**: The semaphore is applied inside `VirtualThreadsRecorder.createExecutor()`, which all extensions call via `getCurrent()`. This ensures the limit applies to REST, gRPC, WebSockets, messaging, and all other extensions that dispatch to virtual threads.
- **Metrics via MetricsFactory**: Uses the standard `MetricsFactoryConsumerBuildItem` pattern so metrics are provider-agnostic — works with Micrometer or any other metrics backend without adding a direct dependency.

## Reproducer

https://github.com/eggy03/PaperTrail-API-Quarkus (branch: `zombie-txn-reproducer`)

Results across all test configurations:

| Configuration | Zombie TXN warnings | Total WARN |
|---|---|---|
| Quarkus 3.36.3 (Semeru, no fix) | 12 | 52 |
| Quarkus 3.36.3 (Temurin + JEP 491, no fix) | 30 | 120 |
| **Quarkus 999-SNAPSHOT + maxConcurrency=16** | **0** | **0** |

## Test plan

- [x] 5 new `boundedExecutor*` tests pass (verify peak concurrency ≤ limit via `execute`, `submit(Runnable)`, `submit(Callable)`, `invokeAll`, `invokeAny`)
- [x] All 11 virtual-threads runtime tests pass
- [x] Full `just build-fast` succeeds
- [x] Verified with reproducer app: zero zombie transaction warnings under `--cpus=0.15` load test