### PR TITLE
Expose Narayana transaction reaper configuration

### DIFF
--- a/docs/src/main/asciidoc/transaction.adoc
+++ b/docs/src/main/asciidoc/transaction.adoc
@@ -292,6 +292,54 @@ include::{includes}/duration-format-note.adoc[]
 
 The default value is 60 seconds.
 
+== Configuring the transaction reaper
+
+The transaction reaper is a background thread that monitors running transactions and cancels those that exceed
+their timeout. It periodically scans for timed-out transactions (every `check-period`, default 120 seconds).
+When a transaction times out, the reaper follows this sequence:
+
+1. Schedules the transaction for cancellation
+2. A cancel worker attempts to roll back the transaction
+3. After `cancel-wait-period` (default 500ms), the reaper interrupts the cancel worker if it has not finished
+4. After `cancel-fail-wait-period` (default 500ms), the reaper declares the transaction a zombie if the worker still has not finished
+5. Once the number of zombies exceeds `zombie-max` (default 8), the reaper escalates to ERROR-level logging
+
+In CPU-constrained environments (e.g., containers with strict CPU limits), the default cancel wait periods
+may be too aggressive — the reaper can declare a zombie before the application thread gets a chance to respond
+to the cancellation. When this happens, you will see warnings like:
+
+[source]
+----
+ARJUNA012117: TransactionReaper::check timeout for TX ... in state CANCEL
+ARJUNA012120: cancel for ... returned, but worker is not done
+ARJUNA012378: ReaperElement appears to be wedged
+ARJUNA012108: CheckedAction::check - atomic action ... aborting with N threads active
+----
+
+If you see these messages, increase the cancel wait periods to give the reaper more time.
+
+For CPU-constrained environments, increase the cancel wait periods:
+
+[source, properties]
+----
+# Time before interrupting a cancel worker (default: 500ms)
+quarkus.transaction-manager.reaper.cancel-wait-period=30s
+# Time after interrupting before declaring a zombie (default: 500ms)
+quarkus.transaction-manager.reaper.cancel-fail-wait-period=30s
+----
+
+Other reaper settings can also be tuned if needed:
+
+[source, properties]
+----
+# How often the reaper scans for timed-out transactions (default: 120s)
+quarkus.transaction-manager.reaper.check-period=120s
+# Zombie count threshold before ERROR-level logging (default: 8)
+quarkus.transaction-manager.reaper.zombie-max=8
+----
+
+include::{includes}/duration-format-note.adoc[]
+
 == Configuring transaction node name identifier
 
 Narayana, as the underlying transaction manager, has a concept of a unique node identifier.

--- a/extensions/narayana-jta/deployment/src/main/java/io/quarkus/narayana/jta/deployment/NarayanaJtaProcessor.java
+++ b/extensions/narayana-jta/deployment/src/main/java/io/quarkus/narayana/jta/deployment/NarayanaJtaProcessor.java
@@ -171,6 +171,7 @@ class NarayanaJtaProcessor {
                 nativeImageFeatures);
         recorder.setNodeName();
         recorder.setDefaultTimeout();
+        recorder.setReaperConfig();
         recorder.setConfig();
     }
 

--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/NarayanaJtaRecorder.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/NarayanaJtaRecorder.java
@@ -102,6 +102,15 @@ public class NarayanaJtaRecorder {
         TxControl.setDefaultTimeout((int) transactions.getValue().defaultTransactionTimeout().getSeconds());
     }
 
+    public void setReaperConfig() {
+        var coordinatorBean = arjPropertyManager.getCoordinatorEnvironmentBean();
+        var reaper = transactions.getValue().reaper();
+        coordinatorBean.setTxReaperTimeout(reaper.checkPeriod().toMillis());
+        coordinatorBean.setTxReaperCancelWaitPeriod(reaper.cancelWaitPeriod().toMillis());
+        coordinatorBean.setTxReaperCancelFailWaitPeriod(reaper.cancelFailWaitPeriod().toMillis());
+        coordinatorBean.setTxReaperZombieMax(reaper.zombieMax());
+    }
+
     public static Properties getDefaultProperties() {
         return defaultProperties;
     }

--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/TransactionManagerConfiguration.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/TransactionManagerConfiguration.java
@@ -71,9 +71,58 @@ public interface TransactionManagerConfiguration {
     List<String> xaResourceOrphanFilters();
 
     /**
+     * The transaction reaper configuration.
+     * <p>
+     * The transaction reaper is a background thread that monitors running transactions and cancels
+     * those that exceed their timeout. These settings control how aggressively it acts.
+     */
+    ReaperConfig reaper();
+
+    /**
      * The object store configuration.
      */
     ObjectStoreConfig objectStore();
+
+    @ConfigGroup
+    interface ReaperConfig {
+        /**
+         * The interval at which the reaper checks for timed-out transactions.
+         */
+        @WithDefault("120s")
+        Duration checkPeriod();
+
+        /**
+         * The time the reaper waits before interrupting a cancel worker that is rolling back
+         * a timed-out transaction.
+         * <p>
+         * When a transaction exceeds its timeout, the reaper schedules a cancel and waits this period before
+         * interrupting the cancel worker. In CPU-constrained environments (e.g., containers with strict CPU limits),
+         * the default of 500ms may be too aggressive, causing premature zombie transaction declarations.
+         */
+        @WithDefault("500ms")
+        Duration cancelWaitPeriod();
+
+        /**
+         * The time the reaper waits after interrupting a cancel worker before declaring the
+         * transaction a zombie.
+         * <p>
+         * After interrupting a cancel worker, the reaper waits this period. If the worker has not completed
+         * by then, the transaction is marked as a zombie. In CPU-constrained environments, increasing this
+         * value gives the application thread more time to respond to the cancellation.
+         */
+        @WithDefault("500ms")
+        Duration cancelFailWaitPeriod();
+
+        /**
+         * The maximum number of zombie transactions before the reaper escalates to ERROR-level logging.
+         * <p>
+         * A zombie transaction is one where the cancel worker was unable to roll it back within the
+         * configured wait periods. Once this threshold is reached, subsequent zombies are logged at
+         * ERROR level instead of WARN.
+         */
+        @WithDefault("8")
+        int zombieMax();
+    }
 
     @ConfigGroup
     public interface ObjectStoreConfig {


### PR DESCRIPTION
## Summary

Expose the Narayana transaction reaper's configuration as Quarkus properties under `quarkus.transaction-manager.reaper`. These control how the reaper monitors and cancels timed-out transactions.

## Problem

When a transaction exceeds its timeout (default 60s), the Narayana `TransactionReaper` follows this state machine:

```
RUN → SCHEDULE_CANCEL → CANCEL (worker tries rollback)
    → interrupt worker after cancelWaitPeriod (500ms)
    → ZOMBIE after cancelFailWaitPeriod (500ms)
```

None of these reaper settings were exposed through Quarkus configuration properties. The only way to change them was via JVM system properties:

```
-Dcom.arjuna.ats.arjuna.coordinator.txReaperTimeout=120000
-Dcom.arjuna.ats.arjuna.coordinator.txReaperCancelWaitPeriod=500
-Dcom.arjuna.ats.arjuna.coordinator.txReaperCancelFailWaitPeriod=500
-Dcom.arjuna.ats.arjuna.coordinator.txReaperZombieMax=8
```

In CPU-constrained environments (e.g., containers with `--cpus=0.15`), the 500ms cancel wait periods are too aggressive — the reaper declares a transaction as a zombie before the application thread even gets a chance to respond to the cancellation. This produces cascading warnings:

- `ARJUNA012378: ReaperElement appears to be wedged`
- `ARJUNA012120: worker marked as zombie and TX scheduled for mark-as-rollback`
- `ARJUNA012108: CheckedAction::check - atomic action aborting with N threads active`

## Changes

**`TransactionManagerConfiguration.java`:**
- Added a new `ReaperConfig` config group under `quarkus.transaction-manager.reaper` with four properties:
  - `check-period` (default `120s`) — interval at which the reaper scans for timed-out transactions
  - `cancel-wait-period` (default `500ms`) — time the reaper waits before interrupting a cancel worker
  - `cancel-fail-wait-period` (default `500ms`) — time the reaper waits after interrupting before declaring a zombie
  - `zombie-max` (default `8`) — zombie count threshold before escalating to ERROR-level logging

**`NarayanaJtaRecorder.java`:**
- Added `setReaperConfig()` method that applies all four reaper settings to the `CoordinatorEnvironmentBean`

**`NarayanaJtaProcessor.java`:**
- Added `recorder.setReaperConfig()` call alongside the existing `setDefaultTimeout()` call

**`transaction.adoc`:**
- Added "Configuring the transaction reaper" documentation section

## Usage

```properties
# Increase cancel wait periods for CPU-constrained environments
quarkus.transaction-manager.reaper.cancel-wait-period=30s
quarkus.transaction-manager.reaper.cancel-fail-wait-period=30s

# Adjust the reaper check interval
quarkus.transaction-manager.reaper.check-period=120s

# Set the zombie threshold before ERROR-level logging
quarkus.transaction-manager.reaper.zombie-max=8
```

All defaults match the Narayana hardcoded values — no change for users who don't set these properties.

## Related PRs

- #55010 — Fix `TransactionalInterceptorBase` to handle reaper-cancelled transactions gracefully
- #55011 — Add optional concurrency limit for virtual thread executor (`quarkus.virtual-threads.max-concurrency`)

Together, these three PRs address zombie transactions under `@RunOnVirtualThread` with CPU starvation. This PR specifically helps users who cannot avoid transaction timeouts and need to tune the reaper's behavior.

## Reproducer

https://github.com/eggy03/PaperTrail-API-Quarkus (branch: `zombie-txn-reproducer`)

## Test plan

- [x] All 50 narayana-jta deployment tests pass
- [x] Compilation verified