### PR TITLE
Remove duplicate opentelemetry-exporter-logging dependency

### DIFF
--- a/extensions/opentelemetry/deployment/pom.xml
+++ b/extensions/opentelemetry/deployment/pom.xml
@@ -164,11 +164,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-logging</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.slf4j</groupId>
             <artifactId>slf4j-jboss-logmanager</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
## Summary

- Remove duplicate `io.opentelemetry:opentelemetry-exporter-logging` test dependency in `quarkus-opentelemetry-deployment`

The dependency was originally added in 5e55d527274 and then accidentally re-added in ec541f389d4, causing this Maven warning:

```
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique:
io.opentelemetry:opentelemetry-exporter-logging:jar -> duplicate declaration of version (?)
```