### PR TITLE
Enforce no duplicate POM dependencies via maven-enforcer-plugin

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -535,6 +535,7 @@
                             <phase>${maven-enforcer-plugin.phase}</phase>
                             <configuration>
                                 <rules>
+                                    <banDuplicatePomDependencyVersions/>
                                     <dependencyConvergence/>
                                     <externalRules>
                                         <location>classpath:enforcer-rules/quarkus-banned-dependencies.xml</location>


### PR DESCRIPTION
## Summary

- Add `banDuplicatePomDependencyVersions` rule to the existing `maven-enforcer-plugin` configuration in `build-parent/pom.xml`

This turns duplicate dependency declarations (which currently only produce a Maven warning) into a build error, preventing issues like the one fixed in #55017.

## Test plan

- [ ] CI build passes (requires #55017 to be merged first, since that removes the only current duplicate)