### PR TITLE
Support management interface dynamic port in integration tests

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/HttpServerManagementTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/HttpServerManagementTest.java
@@ -1,0 +1,73 @@
+package io.quarkus.vertx.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.function.Consumer;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
+import io.quarkus.vertx.http.deployment.RouteBuildItem;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+
+public class HttpServerManagementTest {
+    private static final String APP_PROPS = "quarkus.management.enabled=true\n";
+
+    @RegisterExtension
+    static final QuarkusExtensionTest CONFIG = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset(APP_PROPS), "application.properties"))
+            .addBuildChainCustomizer(buildCustomizer());
+
+    static Consumer<BuildChainBuilder> buildCustomizer() {
+        return builder -> builder.addBuildStep(new BuildStep() {
+            @Override
+            public void execute(BuildContext context) {
+                NonApplicationRootPathBuildItem buildItem = context.consume(NonApplicationRootPathBuildItem.class);
+                context.produce(buildItem.routeBuilder()
+                        .management()
+                        .route("test")
+                        .handler(new NoOpHandler())
+                        .blockingRoute()
+                        .build());
+            }
+        }).produces(RouteBuildItem.class)
+                .consumes(NonApplicationRootPathBuildItem.class)
+                .build();
+    }
+
+    public static class NoOpHandler implements Handler<RoutingContext> {
+        @Override
+        public void handle(RoutingContext rc) {
+            rc.response().end();
+        }
+    }
+
+    @Inject
+    HttpServer webServer;
+
+    @Test
+    void ports() {
+        assertTrue(webServer.getPort() > 0);
+        assertEquals(-1, webServer.getSecurePort());
+        assertTrue(webServer.getManagementPort() > 0);
+    }
+
+    @Test
+    void uris() {
+        assertTrue(webServer.getLocalBaseUri().toString().contains(String.valueOf(webServer.getPort())));
+        assertTrue(webServer.getManagementBaseUri().isPresent());
+        assertTrue(webServer.getManagementBaseUri().get().toString()
+                .contains(String.valueOf(webServer.getManagementPort())));
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/HttpServerTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/HttpServerTest.java
@@ -23,4 +23,10 @@ public class HttpServerTest {
         assertEquals(-1, webServer.getSecurePort());
         assertEquals(-1, webServer.getManagementPort());
     }
+
+    @Test
+    void uris() {
+        assertTrue(webServer.getLocalBaseUri().toString().contains(String.valueOf(webServer.getPort())));
+        assertTrue(webServer.getManagementBaseUri().isEmpty());
+    }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/HttpServer.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/HttpServer.java
@@ -1,6 +1,7 @@
 package io.quarkus.vertx.http;
 
 import java.net.URI;
+import java.util.Optional;
 
 import io.quarkus.value.registry.ValueRegistry;
 import io.quarkus.value.registry.ValueRegistry.RuntimeInfo;
@@ -17,6 +18,7 @@ public interface HttpServer {
     RuntimeKey<Integer> MANAGEMENT_PORT = RuntimeKey.intKey("quarkus.management.port");
     RuntimeKey<Integer> MANAGEMENT_TEST_PORT = RuntimeKey.intKey("quarkus.management.test-port");
     RuntimeKey<URI> LOCAL_BASE_URI = RuntimeKey.key("quarkus.http.local-base-uri");
+    RuntimeKey<URI> LOCAL_MANAGEMENT_BASE_URI = RuntimeKey.key("quarkus.management.local-base-uri");
 
     RuntimeKey<HttpServer> HTTP_SERVER = RuntimeKey.key(HttpServer.class);
 
@@ -42,11 +44,19 @@ public interface HttpServer {
     int getManagementPort();
 
     /**
-     * Return the local base URI that Quarkus is serving on.
+     * Return the local base URI that Quarkus is serving on, including the main HTTP/HTTPS port.
      *
      * @return the local base URI that Quarkus is serving on.
      */
     URI getLocalBaseUri();
+
+    /**
+     * Return the local base URI that Quarkus management interface is serving on, including the management port.
+     *
+     * @return the local base URI that Quarkus management interface is serving on, or an empty {@link Optional} if the
+     *         management interface is not enabled.
+     */
+    Optional<URI> getManagementBaseUri();
 
     /**
      * The {@link RuntimeInfo} implementation for {@link HttpServer}. Construct instances of {@link HttpServer} with
@@ -74,6 +84,11 @@ public interface HttpServer {
                 @Override
                 public URI getLocalBaseUri() {
                     return valueRegistry.get(LOCAL_BASE_URI);
+                }
+
+                @Override
+                public Optional<URI> getManagementBaseUri() {
+                    return Optional.ofNullable(valueRegistry.getOrDefault(LOCAL_MANAGEMENT_BASE_URI, null));
                 }
             };
         }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -6,6 +6,7 @@ import static io.quarkus.vertx.http.HttpServer.HTTPS_TEST_PORT;
 import static io.quarkus.vertx.http.HttpServer.HTTP_PORT;
 import static io.quarkus.vertx.http.HttpServer.HTTP_TEST_PORT;
 import static io.quarkus.vertx.http.HttpServer.LOCAL_BASE_URI;
+import static io.quarkus.vertx.http.HttpServer.LOCAL_MANAGEMENT_BASE_URI;
 import static io.quarkus.vertx.http.HttpServer.MANAGEMENT_PORT;
 import static io.quarkus.vertx.http.HttpServer.MANAGEMENT_TEST_PORT;
 import static io.quarkus.vertx.http.runtime.options.HttpServerOptionsUtils.getInsecureRequestStrategy;
@@ -866,6 +867,20 @@ public class VertxHttpRecorder {
                                     valueRegistry.getValue().register(MANAGEMENT_TEST_PORT, actualManagementPort);
                                 }
                             }
+                            String mgmtScheme = httpManagementServerOptions.isSsl() ? "https" : "http";
+                            String mgmtHost = httpManagementServerOptions.getHost();
+                            if ("0.0.0.0".equals(mgmtHost)) {
+                                mgmtHost = "localhost";
+                            }
+                            String mgmtRootPath = managementBuildTimeConfig.rootPath();
+                            if (!mgmtRootPath.startsWith("/")) {
+                                mgmtRootPath = "/" + mgmtRootPath;
+                            }
+                            if (mgmtRootPath.length() > 1 && mgmtRootPath.endsWith("/")) {
+                                mgmtRootPath = mgmtRootPath.substring(0, mgmtRootPath.length() - 1);
+                            }
+                            valueRegistry.getValue().register(LOCAL_MANAGEMENT_BASE_URI,
+                                    URI.create(mgmtScheme + "://" + mgmtHost + ":" + actualManagementPort + mgmtRootPath));
                             managementInterfaceFuture.complete(ar.result());
                         }
                     });

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -861,14 +861,12 @@ public class VertxHttpRecorder {
                             }
 
                             actualManagementPort = ar.result().actualPort();
-                            if (actualManagementPort != httpManagementServerConfig.getTcpPort()) {
-                                valueRegistry.getValue().register(MANAGEMENT_PORT, actualManagementPort);
-                                if (launchMode.isDevOrTest()) {
-                                    valueRegistry.getValue().register(MANAGEMENT_TEST_PORT, actualManagementPort);
-                                }
+                            valueRegistry.getValue().register(MANAGEMENT_PORT, actualManagementPort);
+                            if (launchMode.isDevOrTest()) {
+                                valueRegistry.getValue().register(MANAGEMENT_TEST_PORT, actualManagementPort);
                             }
-                            String mgmtScheme = httpManagementServerOptions.isSsl() ? "https" : "http";
-                            String mgmtHost = httpManagementServerOptions.getHost();
+                            String mgmtScheme = httpManagementSslOptions != null ? "https" : "http";
+                            String mgmtHost = httpManagementServerConfig.getTcpHost();
                             if ("0.0.0.0".equals(mgmtHost)) {
                                 mgmtHost = "localhost";
                             }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/ArtifactLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/ArtifactLauncher.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import io.quarkus.bootstrap.app.CuratedApplication;
 
@@ -13,7 +12,7 @@ public interface ArtifactLauncher<T extends ArtifactLauncher.InitContext> extend
 
     void init(T t);
 
-    Optional<ListeningAddress> start() throws IOException;
+    ListeningAddresses start() throws IOException;
 
     LaunchResult runToCompletion(String[] args);
 

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
@@ -201,7 +201,7 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
     }
 
     @Override
-    public Optional<ListeningAddress> start() throws IOException {
+    public ListeningAddresses start() throws IOException {
         SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
         LogRuntimeConfig logRuntimeConfig = config.getConfigMapping(LogRuntimeConfig.class);
 
@@ -315,11 +315,11 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
 
         if (startedFunction != null) {
             waitForStartedFunction(startedFunction, containerProcess, waitTimeSeconds, logPath);
-            return Optional.empty();
+            return ListeningAddresses.EMPTY;
         } else {
             log.info("Wait for server to start by capturing listening data...");
-            Optional<ListeningAddress> result = waitForCapturedListeningData(containerProcess, logPath, waitTimeSeconds);
-            result.ifPresent(listeningAddress -> log.infof("Server started on port %s", listeningAddress.port()));
+            ListeningAddresses result = waitForCapturedListeningData(containerProcess, logPath, waitTimeSeconds);
+            result.address().ifPresent(listeningAddress -> log.infof("Server started on port %s", listeningAddress.port()));
             return result;
         }
     }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultJarLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultJarLauncher.java
@@ -80,7 +80,7 @@ public class DefaultJarLauncher implements JarArtifactLauncher {
     }
 
     @Override
-    public Optional<ListeningAddress> start() throws IOException {
+    public ListeningAddresses start() throws IOException {
         start(new String[0], true);
         Function<IntegrationTestStartedNotifier.Context, IntegrationTestStartedNotifier.Result> startedFunction = createStartedFunction();
         LogRuntimeConfig logRuntimeConfig = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class)
@@ -88,7 +88,7 @@ public class DefaultJarLauncher implements JarArtifactLauncher {
         logFile = logRuntimeConfig.file().path().toPath();
         if (startedFunction != null) {
             waitForStartedFunction(startedFunction, quarkusProcess, waitTimeSeconds, logFile);
-            return Optional.empty();
+            return ListeningAddresses.EMPTY;
         } else {
             return waitForCapturedListeningData(quarkusProcess, logRuntimeConfig.file().path().toPath(), waitTimeSeconds);
         }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultNativeImageLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultNativeImageLauncher.java
@@ -19,7 +19,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -87,7 +86,7 @@ public class DefaultNativeImageLauncher implements NativeImageLauncher {
     }
 
     @Override
-    public Optional<ListeningAddress> start() throws IOException {
+    public ListeningAddresses start() throws IOException {
         start(new String[0], true);
         LogRuntimeConfig logRuntimeConfig = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class)
                 .getConfigMapping(LogRuntimeConfig.class);
@@ -95,7 +94,7 @@ public class DefaultNativeImageLauncher implements NativeImageLauncher {
         Function<IntegrationTestStartedNotifier.Context, IntegrationTestStartedNotifier.Result> startedFunction = createStartedFunction();
         if (startedFunction != null) {
             waitForStartedFunction(startedFunction, quarkusProcess, waitTimeSeconds, logRuntimeConfig.file().path().toPath());
-            return Optional.empty();
+            return ListeningAddresses.EMPTY;
         } else {
             return waitForCapturedListeningData(quarkusProcess, logRuntimeConfig.file().path().toPath(), waitTimeSeconds);
         }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/LauncherUtil.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/LauncherUtil.java
@@ -90,19 +90,28 @@ public final class LauncherUtil {
      * listening on.
      * If the wait time is exceeded an {@code IllegalStateException} is thrown.
      */
-    static Optional<ListeningAddress> waitForCapturedListeningData(Process quarkusProcess, Path logFile, long waitTimeSeconds) {
+    static ListeningAddresses waitForCapturedListeningData(Process quarkusProcess, Path logFile, long waitTimeSeconds) {
         ensureProcessIsAlive(quarkusProcess);
 
         CountDownLatch signal = new CountDownLatch(1);
         AtomicReference<ListeningAddress> resultReference = new AtomicReference<>();
+        AtomicReference<ListeningAddress> managementResultReference = new AtomicReference<>();
         CaptureListeningDataReader captureListeningDataReader = new CaptureListeningDataReader(logFile,
-                Duration.ofSeconds(waitTimeSeconds), signal, resultReference);
+                Duration.ofSeconds(waitTimeSeconds), signal, resultReference, managementResultReference);
         new Thread(captureListeningDataReader, "capture-listening-data").start();
         try {
             signal.await(waitTimeSeconds + 2, TimeUnit.SECONDS); // wait enough for the signal to be given by the capturing thread
             ListeningAddress result = resultReference.get();
             if (result != null) {
-                return result.port() != null && result.protocol() != null ? Optional.of(result) : Optional.empty();
+                Optional<ListeningAddress> address = result.port() != null && result.protocol() != null
+                        ? Optional.of(result)
+                        : Optional.empty();
+                ListeningAddress managementResult = managementResultReference.get();
+                Optional<ListeningAddress> managementAddress = managementResult != null
+                        && managementResult.port() != null && managementResult.protocol() != null
+                                ? Optional.of(managementResult)
+                                : Optional.empty();
+                return new ListeningAddresses(address, managementAddress);
             }
             // a null result means that we could not determine the status of the process so we need to abort testing
             destroyProcess(quarkusProcess);
@@ -245,15 +254,20 @@ public final class LauncherUtil {
         private final Duration waitTime;
         private final CountDownLatch signal;
         private final AtomicReference<ListeningAddress> resultReference;
+        private final AtomicReference<ListeningAddress> managementResultReference;
         private final Pattern listeningRegex = Pattern.compile("Listening on:\\s+(https?)://[^:]*:(\\d+)");
+        private final Pattern managementListeningRegex = Pattern
+                .compile("Management interface listening on (https?)://[^:]*:(\\d+)");
         private final Pattern startedRegex = Pattern.compile(".*Quarkus .* started in \\d+.*s.*");
 
         public CaptureListeningDataReader(Path processOutput, Duration waitTime, CountDownLatch signal,
-                AtomicReference<ListeningAddress> resultReference) {
+                AtomicReference<ListeningAddress> resultReference,
+                AtomicReference<ListeningAddress> managementResultReference) {
             this.processOutput = processOutput;
             this.waitTime = waitTime;
             this.signal = signal;
             this.resultReference = resultReference;
+            this.managementResultReference = managementResultReference;
         }
 
         @Override
@@ -277,6 +291,13 @@ public final class LauncherUtil {
                         if (startedRegex.matcher(line).matches()) {
                             timeStarted = System.currentTimeMillis();
                             started = true;
+                        }
+
+                        Matcher managementMatcher = managementListeningRegex.matcher(line);
+                        if (managementMatcher.find()) {
+                            managementResultReference.set(
+                                    new ListeningAddress(Integer.valueOf(managementMatcher.group(2)),
+                                            managementMatcher.group(1)));
                         }
 
                         Matcher regexMatcher = listeningRegex.matcher(line);

--- a/test-framework/common/src/main/java/io/quarkus/test/common/LauncherUtil.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/LauncherUtil.java
@@ -94,24 +94,15 @@ public final class LauncherUtil {
         ensureProcessIsAlive(quarkusProcess);
 
         CountDownLatch signal = new CountDownLatch(1);
-        AtomicReference<ListeningAddress> resultReference = new AtomicReference<>();
-        AtomicReference<ListeningAddress> managementResultReference = new AtomicReference<>();
+        AtomicReference<ListeningAddresses> resultReference = new AtomicReference<>();
         CaptureListeningDataReader captureListeningDataReader = new CaptureListeningDataReader(logFile,
-                Duration.ofSeconds(waitTimeSeconds), signal, resultReference, managementResultReference);
+                Duration.ofSeconds(waitTimeSeconds), signal, resultReference);
         new Thread(captureListeningDataReader, "capture-listening-data").start();
         try {
             signal.await(waitTimeSeconds + 2, TimeUnit.SECONDS); // wait enough for the signal to be given by the capturing thread
-            ListeningAddress result = resultReference.get();
+            ListeningAddresses result = resultReference.get();
             if (result != null) {
-                Optional<ListeningAddress> address = result.port() != null && result.protocol() != null
-                        ? Optional.of(result)
-                        : Optional.empty();
-                ListeningAddress managementResult = managementResultReference.get();
-                Optional<ListeningAddress> managementAddress = managementResult != null
-                        && managementResult.port() != null && managementResult.protocol() != null
-                                ? Optional.of(managementResult)
-                                : Optional.empty();
-                return new ListeningAddresses(address, managementAddress);
+                return result;
             }
             // a null result means that we could not determine the status of the process so we need to abort testing
             destroyProcess(quarkusProcess);
@@ -253,21 +244,17 @@ public final class LauncherUtil {
         private final Path processOutput;
         private final Duration waitTime;
         private final CountDownLatch signal;
-        private final AtomicReference<ListeningAddress> resultReference;
-        private final AtomicReference<ListeningAddress> managementResultReference;
-        private final Pattern listeningRegex = Pattern.compile("Listening on:\\s+(https?)://[^:]*:(\\d+)");
-        private final Pattern managementListeningRegex = Pattern
-                .compile("Management interface listening on (https?)://[^:]*:(\\d+)");
+        private final AtomicReference<ListeningAddresses> resultReference;
+        private final Pattern listeningRegex = Pattern.compile(
+                "Listening on:\\s+(https?)://[^:]*:(\\d+)(?:.*Management interface listening on (https?)://[^:]*:(\\d+))?");
         private final Pattern startedRegex = Pattern.compile(".*Quarkus .* started in \\d+.*s.*");
 
         public CaptureListeningDataReader(Path processOutput, Duration waitTime, CountDownLatch signal,
-                AtomicReference<ListeningAddress> resultReference,
-                AtomicReference<ListeningAddress> managementResultReference) {
+                AtomicReference<ListeningAddresses> resultReference) {
             this.processOutput = processOutput;
             this.waitTime = waitTime;
             this.signal = signal;
             this.resultReference = resultReference;
-            this.managementResultReference = managementResultReference;
         }
 
         @Override
@@ -293,16 +280,12 @@ public final class LauncherUtil {
                             started = true;
                         }
 
-                        Matcher managementMatcher = managementListeningRegex.matcher(line);
-                        if (managementMatcher.find()) {
-                            managementResultReference.set(
-                                    new ListeningAddress(Integer.valueOf(managementMatcher.group(2)),
-                                            managementMatcher.group(1)));
-                        }
-
                         Matcher regexMatcher = listeningRegex.matcher(line);
                         if (regexMatcher.find()) {
-                            dataDetermined(regexMatcher.group(1), Integer.valueOf(regexMatcher.group(2)));
+                            dataDetermined(regexMatcher.group(1), Integer.valueOf(regexMatcher.group(2)),
+                                    regexMatcher.group(3), regexMatcher.group(3) != null
+                                            ? Integer.valueOf(regexMatcher.group(4))
+                                            : null);
                             return;
                         } else {
                             if (line.contains("Failed to start application (with profile")) {
@@ -318,7 +301,7 @@ public final class LauncherUtil {
                         // or waiting the next check interval will exceed the bailout time, it's time to finish waiting:
                         if (now + LOG_CHECK_INTERVAL > bailoutTime || now - 2 * LOG_CHECK_INTERVAL > timeStarted) {
                             if (started) {
-                                dataDetermined(null, null); // no http, all is null
+                                dataDetermined(null, null, null, null); // no http, all is null
                             } else {
                                 unableToDetermineData("Waited " + waitTime.getSeconds() + " seconds for " + processOutput
                                         + " to contain info about the listening port and protocol but no such info was found. "
@@ -360,8 +343,15 @@ public final class LauncherUtil {
             return false;
         }
 
-        private void dataDetermined(String protocolValue, Integer portValue) {
-            this.resultReference.set(new ListeningAddress(portValue, protocolValue));
+        private void dataDetermined(String protocol, Integer port,
+                String managementProtocol, Integer managementPort) {
+            Optional<ListeningAddress> address = port != null && protocol != null
+                    ? Optional.of(new ListeningAddress(port, protocol))
+                    : Optional.empty();
+            Optional<ListeningAddress> managementAddress = managementPort != null && managementProtocol != null
+                    ? Optional.of(new ListeningAddress(managementPort, managementProtocol))
+                    : Optional.empty();
+            this.resultReference.set(new ListeningAddresses(address, managementAddress));
             signal.countDown();
         }
 

--- a/test-framework/common/src/main/java/io/quarkus/test/common/ListeningAddress.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/ListeningAddress.java
@@ -24,17 +24,11 @@ public record ListeningAddress(Integer port, String protocol) {
     }
 
     public void registerManagement(ValueRegistry valueRegistry, Config config) {
-        if (!valueRegistry.containsKey(MANAGEMENT_PORT)) {
-            valueRegistry.register(MANAGEMENT_PORT, port);
-        }
-        if (!valueRegistry.containsKey(MANAGEMENT_TEST_PORT)) {
-            valueRegistry.register(MANAGEMENT_TEST_PORT, port);
-        }
-        if (!valueRegistry.containsKey(LOCAL_MANAGEMENT_BASE_URI)) {
-            valueRegistry.register(LOCAL_MANAGEMENT_BASE_URI,
-                    URI.create(isSsl() ? testManagementUrlSsl(valueRegistry, config)
-                            : testManagementUrl(valueRegistry, config)));
-        }
+        valueRegistry.register(MANAGEMENT_PORT, port);
+        valueRegistry.register(MANAGEMENT_TEST_PORT, port);
+        valueRegistry.register(LOCAL_MANAGEMENT_BASE_URI,
+                URI.create(isSsl() ? testManagementUrlSsl(valueRegistry, config)
+                        : testManagementUrl(valueRegistry, config)));
     }
 
     // Compatibility with Config and io.quarkus.vertx.http.HttpServer

--- a/test-framework/common/src/main/java/io/quarkus/test/common/ListeningAddress.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/ListeningAddress.java
@@ -23,6 +23,20 @@ public record ListeningAddress(Integer port, String protocol) {
                 URI.create(isSsl() ? testUrlSsl(valueRegistry, config) : testUrl(valueRegistry, config)));
     }
 
+    public void registerManagement(ValueRegistry valueRegistry, Config config) {
+        if (!valueRegistry.containsKey(MANAGEMENT_PORT)) {
+            valueRegistry.register(MANAGEMENT_PORT, port);
+        }
+        if (!valueRegistry.containsKey(MANAGEMENT_TEST_PORT)) {
+            valueRegistry.register(MANAGEMENT_TEST_PORT, port);
+        }
+        if (!valueRegistry.containsKey(LOCAL_MANAGEMENT_BASE_URI)) {
+            valueRegistry.register(LOCAL_MANAGEMENT_BASE_URI,
+                    URI.create(isSsl() ? testManagementUrlSsl(valueRegistry, config)
+                            : testManagementUrl(valueRegistry, config)));
+        }
+    }
+
     // Compatibility with Config and io.quarkus.vertx.http.HttpServer
     public static final RuntimeKey<Integer> HTTP_PORT = RuntimeKey.intKey("quarkus.http.port");
     public static final RuntimeKey<Integer> HTTP_TEST_PORT = RuntimeKey.intKey("quarkus.http.test-port");
@@ -31,4 +45,11 @@ public record ListeningAddress(Integer port, String protocol) {
     public static final RuntimeKey<URI> LOCAL_BASE_URI = RuntimeKey.key("quarkus.http.local-base-uri");
     public static final RuntimeKey<Optional<ListeningAddress>> LISTENING_ADDRESS = RuntimeKey
             .key("quarkus.http.listening-address");
+
+    // Compatibility with Config and io.quarkus.vertx.http.HttpServer (management interface)
+    public static final RuntimeKey<Integer> MANAGEMENT_PORT = RuntimeKey.intKey("quarkus.management.port");
+    public static final RuntimeKey<Integer> MANAGEMENT_TEST_PORT = RuntimeKey.intKey("quarkus.management.test-port");
+    public static final RuntimeKey<URI> LOCAL_MANAGEMENT_BASE_URI = RuntimeKey.key("quarkus.management.local-base-uri");
+    public static final RuntimeKey<Optional<ListeningAddress>> MANAGEMENT_LISTENING_ADDRESS = RuntimeKey
+            .key("quarkus.management.listening-address");
 }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/ListeningAddresses.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/ListeningAddresses.java
@@ -1,0 +1,11 @@
+package io.quarkus.test.common;
+
+import java.util.Optional;
+
+/**
+ * Holds the result of a listening-data capture: the main HTTP/HTTPS address and the optional management address.
+ */
+public record ListeningAddresses(Optional<ListeningAddress> address, Optional<ListeningAddress> managementAddress) {
+
+    public static final ListeningAddresses EMPTY = new ListeningAddresses(Optional.empty(), Optional.empty());
+}

--- a/test-framework/common/src/main/java/io/quarkus/test/common/RunCommandLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/RunCommandLauncher.java
@@ -15,7 +15,6 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -110,7 +109,7 @@ public class RunCommandLauncher implements ArtifactLauncher<ArtifactLauncher.Ini
     }
 
     @Override
-    public Optional<ListeningAddress> start() throws IOException {
+    public ListeningAddresses start() throws IOException {
         Path logFile = logFilePath;
 
         System.out.println("Executing \"" + String.join(" ", args) + "\"");
@@ -160,7 +159,7 @@ public class RunCommandLauncher implements ArtifactLauncher<ArtifactLauncher.Ini
             throw new RuntimeException("Unable to start target quarkus application " + this.waitTimeSeconds + "s");
         }
 
-        return Optional.empty();
+        return ListeningAddresses.EMPTY;
     }
 
     public void includeAsSysProps(Map<String, String> systemProps) {

--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestHostLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestHostLauncher.java
@@ -18,7 +18,7 @@ public class TestHostLauncher implements ArtifactLauncher {
     private String previousHost;
 
     @Override
-    public Optional<ListeningAddress> start() throws IOException {
+    public ListeningAddresses start() throws IOException {
         Config config = ConfigProvider.getConfig();
         // set 'quarkus.http.host' to ensure that RestAssured targets the proper host
         previousHost = System.setProperty("quarkus.http.host", config.getValue("quarkus.http.test-host", String.class));
@@ -34,7 +34,7 @@ public class TestHostLauncher implements ArtifactLauncher {
             port = config.getValue("quarkus.http.test-port", OptionalInt.class).orElse(8081);
             protocol = "http";
         }
-        return Optional.of(new ListeningAddress(port, protocol));
+        return new ListeningAddresses(Optional.of(new ListeningAddress(port, protocol)), Optional.empty());
     }
 
     @Override

--- a/test-framework/common/src/main/java/io/quarkus/test/common/http/TestHTTPResourceManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/http/TestHTTPResourceManager.java
@@ -15,7 +15,6 @@ import io.quarkus.bootstrap.app.RunningQuarkusApplication;
 import io.quarkus.runtime.test.TestHttpEndpointProvider;
 import io.quarkus.test.common.ListeningAddress;
 import io.quarkus.value.registry.ValueRegistry;
-import io.quarkus.value.registry.ValueRegistry.RuntimeKey;
 import io.smallrye.config.Config;
 import io.smallrye.config.SmallRyeConfig;
 
@@ -174,7 +173,7 @@ public class TestHTTPResourceManager {
 
     public static String testManagementUrl(ValueRegistry valueRegistry, Config config, String... paths) {
         String host = host(config, "quarkus.management.host");
-        int port = valueRegistry.getOrDefault(RuntimeKey.intKey("quarkus.management.test-port"), 9001);
+        int port = valueRegistry.getOrDefault(ListeningAddress.MANAGEMENT_TEST_PORT, 9001);
         String managementRootPath = managementRootPath(config, paths);
         return "http://" + host + ":" + port + managementRootPath;
     }
@@ -188,7 +187,7 @@ public class TestHTTPResourceManager {
 
     public static String testManagementUrlSsl(ValueRegistry valueRegistry, Config config, String... paths) {
         String host = host(config, "quarkus.management.host");
-        int port = valueRegistry.getOrDefault(RuntimeKey.intKey("quarkus.management.test-port"), 9001);
+        int port = valueRegistry.getOrDefault(ListeningAddress.MANAGEMENT_TEST_PORT, 9001);
         String managementRootPath = managementRootPath(config, paths);
         return "https://" + host + ":" + port + managementRootPath;
     }

--- a/test-framework/common/src/test/java/io/quarkus/test/common/TestLauncherUtil.java
+++ b/test-framework/common/src/test/java/io/quarkus/test/common/TestLauncherUtil.java
@@ -3,6 +3,7 @@ package io.quarkus.test.common;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 
 import org.assertj.core.api.SoftAssertions;
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 
 @EnabledOnOs({ OS.LINUX, OS.MAC })
 @ExtendWith(SoftAssertionsExtension.class)
@@ -114,5 +116,84 @@ public class TestLauncherUtil {
         soft.assertThatCode(proc::exitValue).doesNotThrowAnyException();
         soft.assertThat(outCapture.toString()).isEmpty();
         soft.assertThat(errCapture.toString()).isEmpty();
+    }
+
+    @Test
+    public void captureListeningDataHttpOnly(@TempDir Path tempDir) throws Exception {
+        Path logFile = tempDir.resolve("quarkus.log");
+        Process proc = new ProcessBuilder("/bin/bash", "-c",
+                "echo 'INFO  [io.quarkus] (main) Listening on: http://0.0.0.0:8080' >> " + logFile + "; " +
+                        "echo 'INFO  [io.quarkus] (main) Quarkus 999.0.0-SNAPSHOT started in 1.234s.' >> " + logFile + "; " +
+                        "sleep 10")
+                .start();
+        try {
+            ListeningAddresses result = LauncherUtil.waitForCapturedListeningData(proc, logFile, 10);
+
+            soft.assertThat(result.address()).isPresent();
+            soft.assertThat(result.address().get().port()).isEqualTo(8080);
+            soft.assertThat(result.address().get().protocol()).isEqualTo("http");
+            soft.assertThat(result.managementAddress()).isEmpty();
+        } finally {
+            proc.destroyForcibly();
+        }
+    }
+
+    @Test
+    public void captureListeningDataWithManagement(@TempDir Path tempDir) throws Exception {
+        Path logFile = tempDir.resolve("quarkus.log");
+        Process proc = new ProcessBuilder("/bin/bash", "-c",
+                "echo 'INFO  [io.quarkus] (main) Listening on: http://0.0.0.0:8080." +
+                        " Management interface listening on http://0.0.0.0:9000.' >> " + logFile + "; " +
+                        "echo 'INFO  [io.quarkus] (main) Quarkus 999.0.0-SNAPSHOT started in 1.234s.' >> " + logFile + "; " +
+                        "sleep 10")
+                .start();
+        try {
+            ListeningAddresses result = LauncherUtil.waitForCapturedListeningData(proc, logFile, 10);
+
+            soft.assertThat(result.address()).contains(new ListeningAddress(8080, "http"));
+            soft.assertThat(result.managementAddress()).contains(new ListeningAddress(9000, "http"));
+        } finally {
+            proc.destroyForcibly();
+        }
+    }
+
+    @Test
+    public void captureListeningDataWithManagementSsl(@TempDir Path tempDir) throws Exception {
+        Path logFile = tempDir.resolve("quarkus.log");
+        Process proc = new ProcessBuilder("/bin/bash", "-c",
+                "echo 'INFO  [io.quarkus] (main) Listening on: https://0.0.0.0:8443." +
+                        " Management interface listening on https://0.0.0.0:9443.' >> " + logFile + "; " +
+                        "echo 'INFO  [io.quarkus] (main) Quarkus 999.0.0-SNAPSHOT started in 1.234s.' >> " + logFile + "; " +
+                        "sleep 10")
+                .start();
+        try {
+            ListeningAddresses result = LauncherUtil.waitForCapturedListeningData(proc, logFile, 10);
+
+            soft.assertThat(result.address()).isPresent();
+            soft.assertThat(result.address().get().port()).isEqualTo(8443);
+            soft.assertThat(result.address().get().protocol()).isEqualTo("https");
+            soft.assertThat(result.managementAddress()).isPresent();
+            soft.assertThat(result.managementAddress().get().port()).isEqualTo(9443);
+            soft.assertThat(result.managementAddress().get().protocol()).isEqualTo("https");
+        } finally {
+            proc.destroyForcibly();
+        }
+    }
+
+    @Test
+    public void captureListeningDataNoHttp(@TempDir Path tempDir) throws Exception {
+        Path logFile = tempDir.resolve("quarkus.log");
+        Process proc = new ProcessBuilder("/bin/bash", "-c",
+                "echo 'INFO  [io.quarkus] (main) Quarkus 999.0.0-SNAPSHOT started in 1.234s.' >> " + logFile + "; " +
+                        "sleep 10")
+                .start();
+        try {
+            ListeningAddresses result = LauncherUtil.waitForCapturedListeningData(proc, logFile, 10);
+
+            soft.assertThat(result.address()).isEmpty();
+            soft.assertThat(result.managementAddress()).isEmpty();
+        } finally {
+            proc.destroyForcibly();
+        }
     }
 }

--- a/test-framework/junit-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
+++ b/test-framework/junit-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
@@ -314,6 +314,10 @@ public class QuarkusDevModeTest
             // Capture the listening port if available and register it in ValueRegistry
             Optional<ListeningAddress> listeningAddress = listeningAddress(startupLogHandler.getRecords());
             listeningAddress.ifPresent(address -> address.register(valueRegistry, newConfig));
+            Optional<ListeningAddress> managementListeningAddress = managementListeningAddress(
+                    startupLogHandler.getRecords());
+            managementListeningAddress.ifPresent(address -> address.registerManagement(valueRegistry, newConfig));
+            valueRegistry.register(ListeningAddress.MANAGEMENT_LISTENING_ADDRESS, managementListeningAddress);
 
             // Inject ValueRegistry and Config
             ValueRegistryInjector.inject(testInstance, valueRegistry);
@@ -335,6 +339,8 @@ public class QuarkusDevModeTest
     }
 
     private static final Pattern listeningRegex = Pattern.compile("Listening on:\\s+(https?)://[^:]*:(\\d+)");
+    private static final Pattern managementListeningRegex = Pattern
+            .compile("Management interface listening on (https?)://[^:]*:(\\d+)");
 
     private static Optional<ListeningAddress> listeningAddress(List<LogRecord> records) {
         if (records.size() == 1) {
@@ -344,6 +350,17 @@ public class QuarkusDevModeTest
                 ListeningAddress listeningAddress = new ListeningAddress(Integer.parseInt(regexMatcher.group(2)),
                         regexMatcher.group(1));
                 return Optional.of(listeningAddress);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<ListeningAddress> managementListeningAddress(List<LogRecord> records) {
+        if (records.size() == 1) {
+            LogRecord logRecord = records.get(0);
+            Matcher regexMatcher = managementListeningRegex.matcher((String) logRecord.getParameters()[4]);
+            if (regexMatcher.find()) {
+                return Optional.of(new ListeningAddress(Integer.parseInt(regexMatcher.group(2)), regexMatcher.group(1)));
             }
         }
         return Optional.empty();

--- a/test-framework/junit-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
+++ b/test-framework/junit-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
@@ -316,7 +316,6 @@ public class QuarkusDevModeTest
             ListeningAddresses listeningAddresses = listeningAddresses(startupLogHandler.getRecords());
             listeningAddresses.address().ifPresent(address -> address.register(valueRegistry, newConfig));
             listeningAddresses.managementAddress().ifPresent(address -> address.registerManagement(valueRegistry, newConfig));
-            valueRegistry.register(ListeningAddress.MANAGEMENT_LISTENING_ADDRESS, listeningAddresses.managementAddress());
 
             // Inject ValueRegistry and Config
             ValueRegistryInjector.inject(testInstance, valueRegistry);

--- a/test-framework/junit-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
+++ b/test-framework/junit-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
@@ -71,6 +71,7 @@ import io.quarkus.runtime.ValueRegistryImpl;
 import io.quarkus.runtime.configuration.ConfigUtils;
 import io.quarkus.test.common.GroovyClassValue;
 import io.quarkus.test.common.ListeningAddress;
+import io.quarkus.test.common.ListeningAddresses;
 import io.quarkus.test.common.PathTestHelper;
 import io.quarkus.test.common.PropertyTestUtil;
 import io.quarkus.test.common.RestAssuredStateManager;
@@ -312,12 +313,10 @@ public class QuarkusDevModeTest
             ConfigInjector.set(context, newConfig);
 
             // Capture the listening port if available and register it in ValueRegistry
-            Optional<ListeningAddress> listeningAddress = listeningAddress(startupLogHandler.getRecords());
-            listeningAddress.ifPresent(address -> address.register(valueRegistry, newConfig));
-            Optional<ListeningAddress> managementListeningAddress = managementListeningAddress(
-                    startupLogHandler.getRecords());
-            managementListeningAddress.ifPresent(address -> address.registerManagement(valueRegistry, newConfig));
-            valueRegistry.register(ListeningAddress.MANAGEMENT_LISTENING_ADDRESS, managementListeningAddress);
+            ListeningAddresses listeningAddresses = listeningAddresses(startupLogHandler.getRecords());
+            listeningAddresses.address().ifPresent(address -> address.register(valueRegistry, newConfig));
+            listeningAddresses.managementAddress().ifPresent(address -> address.registerManagement(valueRegistry, newConfig));
+            valueRegistry.register(ListeningAddress.MANAGEMENT_LISTENING_ADDRESS, listeningAddresses.managementAddress());
 
             // Inject ValueRegistry and Config
             ValueRegistryInjector.inject(testInstance, valueRegistry);
@@ -338,32 +337,24 @@ public class QuarkusDevModeTest
         }
     }
 
-    private static final Pattern listeningRegex = Pattern.compile("Listening on:\\s+(https?)://[^:]*:(\\d+)");
-    private static final Pattern managementListeningRegex = Pattern
-            .compile("Management interface listening on (https?)://[^:]*:(\\d+)");
+    private static final Pattern listeningRegex = Pattern.compile(
+            "Listening on:\\s+(https?)://[^:]*:(\\d+)(?:.*Management interface listening on (https?)://[^:]*:(\\d+))?");
 
-    private static Optional<ListeningAddress> listeningAddress(List<LogRecord> records) {
+    private static ListeningAddresses listeningAddresses(List<LogRecord> records) {
         if (records.size() == 1) {
             LogRecord logRecord = records.get(0);
             Matcher regexMatcher = listeningRegex.matcher((String) logRecord.getParameters()[4]);
             if (regexMatcher.find()) {
-                ListeningAddress listeningAddress = new ListeningAddress(Integer.parseInt(regexMatcher.group(2)),
-                        regexMatcher.group(1));
-                return Optional.of(listeningAddress);
+                Optional<ListeningAddress> address = Optional.of(
+                        new ListeningAddress(Integer.parseInt(regexMatcher.group(2)), regexMatcher.group(1)));
+                Optional<ListeningAddress> managementAddress = regexMatcher.group(3) != null
+                        ? Optional.of(new ListeningAddress(Integer.parseInt(regexMatcher.group(4)),
+                                regexMatcher.group(3)))
+                        : Optional.empty();
+                return new ListeningAddresses(address, managementAddress);
             }
         }
-        return Optional.empty();
-    }
-
-    private static Optional<ListeningAddress> managementListeningAddress(List<LogRecord> records) {
-        if (records.size() == 1) {
-            LogRecord logRecord = records.get(0);
-            Matcher regexMatcher = managementListeningRegex.matcher((String) logRecord.getParameters()[4]);
-            if (regexMatcher.find()) {
-                return Optional.of(new ListeningAddress(Integer.parseInt(regexMatcher.group(2)), regexMatcher.group(1)));
-            }
-        }
-        return Optional.empty();
+        return ListeningAddresses.EMPTY;
     }
 
     @Override

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
@@ -49,7 +49,7 @@ import io.quarkus.deployment.util.ContainerRuntimeUtil;
 import io.quarkus.paths.PathList;
 import io.quarkus.runtime.logging.LoggingSetupRecorder;
 import io.quarkus.test.common.ArtifactLauncher;
-import io.quarkus.test.common.ListeningAddress;
+import io.quarkus.test.common.ListeningAddresses;
 import io.quarkus.test.common.PathTestHelper;
 import io.quarkus.test.common.TestClassIndexer;
 import io.quarkus.test.common.TestResourceManager;
@@ -123,7 +123,7 @@ public final class IntegrationTestUtil {
         ((TestResourceManager) state.getTestResourceManager()).inject(valueRegistry, testInstance);
     }
 
-    static Optional<ListeningAddress> startLauncher(ArtifactLauncher<?> launcher, Map<String, String> additionalProperties)
+    static ListeningAddresses startLauncher(ArtifactLauncher<?> launcher, Map<String, String> additionalProperties)
             throws IOException {
         try {
             launcher.includeAsSysProps(additionalProperties);

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
@@ -362,9 +362,13 @@ public class QuarkusIntegrationTestExtension extends AbstractQuarkusTestWithCont
             } else {
                 valueRegistry.register(LISTENING_ADDRESS, Optional.empty());
             }
-            listeningData.managementAddress().ifPresent(
-                    managementAddress -> managementAddress.registerManagement(valueRegistry, newConfig));
-            valueRegistry.register(MANAGEMENT_LISTENING_ADDRESS, listeningData.managementAddress());
+            Optional<ListeningAddress> managementAddress = listeningData.managementAddress();
+            if (managementAddress.isPresent()) {
+                managementAddress.get().registerManagement(valueRegistry, newConfig);
+                valueRegistry.register(MANAGEMENT_LISTENING_ADDRESS, managementAddress);
+            } else {
+                valueRegistry.register(MANAGEMENT_LISTENING_ADDRESS, Optional.empty());
+            }
 
             testHttpEndpointProviders = TestHttpEndpointProvider.load();
 

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
@@ -4,6 +4,7 @@ import static io.quarkus.runtime.LaunchMode.NORMAL;
 import static io.quarkus.runtime.configuration.ConfigSourceOrdinal.INTEGRATION_TEST;
 import static io.quarkus.test.common.ListeningAddress.LISTENING_ADDRESS;
 import static io.quarkus.test.common.ListeningAddress.LOCAL_BASE_URI;
+import static io.quarkus.test.common.ListeningAddress.MANAGEMENT_LISTENING_ADDRESS;
 import static io.quarkus.test.junit.ArtifactTypeUtil.isContainer;
 import static io.quarkus.test.junit.ArtifactTypeUtil.isJar;
 import static io.quarkus.test.junit.IntegrationTestUtil.activateLogging;
@@ -61,6 +62,7 @@ import io.quarkus.runtime.logging.LogRuntimeConfig;
 import io.quarkus.runtime.test.TestHttpEndpointProvider;
 import io.quarkus.test.common.ArtifactLauncher;
 import io.quarkus.test.common.ListeningAddress;
+import io.quarkus.test.common.ListeningAddresses;
 import io.quarkus.test.common.RestAssuredStateManager;
 import io.quarkus.test.common.RunCommandLauncher;
 import io.quarkus.test.common.TestConfigUtil;
@@ -352,13 +354,17 @@ public class QuarkusIntegrationTestExtension extends AbstractQuarkusTestWithCont
             activateLogging();
 
             // Start Quarkus, capture the listening port if available and register it in ValueRegistry
-            Optional<ListeningAddress> listeningAddress = startLauncher(launcher, additionalProperties);
+            ListeningAddresses listeningData = startLauncher(launcher, additionalProperties);
+            Optional<ListeningAddress> listeningAddress = listeningData.address();
             if (listeningAddress.isPresent()) {
                 listeningAddress.get().register(valueRegistry, newConfig);
                 valueRegistry.register(LISTENING_ADDRESS, listeningAddress);
             } else {
                 valueRegistry.register(LISTENING_ADDRESS, Optional.empty());
             }
+            listeningData.managementAddress().ifPresent(
+                    managementAddress -> managementAddress.registerManagement(valueRegistry, newConfig));
+            valueRegistry.register(MANAGEMENT_LISTENING_ADDRESS, listeningData.managementAddress());
 
             testHttpEndpointProviders = TestHttpEndpointProvider.load();
 


### PR DESCRIPTION
This change extends the test framework's listening address capture logic to also detect the management interface port from process log output, and expose it via `ArtifactLauncher.start()` and `HttpServer.getManagementBaseUri()`.

See [this Zulip conversation](https://quarkusio.zulipchat.com/#narrow/channel/187030-users/topic/Management.20port.20in.20a.20.40QuarkusIntegrationTest/near/604909761) for context.