### PR TITLE
Bump dekorate to 4.1.8 fixing CVE-2026-8484

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -156,7 +156,7 @@
         <kotlin-serialization.version>1.11.0</kotlin-serialization.version>
         <kotlin-metadata.version>0.9.0</kotlin-metadata.version>
         <azure.toolkit-lib.version>0.53.0</azure.toolkit-lib.version>
-        <dekorate.version>4.1.5</dekorate.version> <!-- Please check with Java Operator SDK team before updating -->
+        <dekorate.version>4.1.8</dekorate.version> <!-- Please check with Java Operator SDK team before updating -->
         <maven-invoker.version>3.2.0</maven-invoker.version>
         <awaitility.version>4.3.0</awaitility.version>
         <jboss-logmanager.version>3.2.2.Final</jboss-logmanager.version>


### PR DESCRIPTION
- Bump dekorate to 4.1.8 fixing - [CVE-2026-8484](https://cert.pl/en/posts/2026/06/CVE-2026-8484/). 
- See dekorate issue where the CVE has been reported: https://github.com/dekorateio/dekorate/issues/1319