### PR TITLE
Sanitize multipart upload filenames to prevent path traversal

### DIFF
--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/headers/HeaderUtil.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/headers/HeaderUtil.java
@@ -425,4 +425,29 @@ public class HeaderUtil {
         }
         return null;
     }
+
+    /**
+     * Sanitizes a filename from a multipart {@code Content-Disposition} header by stripping path components and
+     * null bytes to prevent path traversal attacks.
+     *
+     * @param fileName the raw filename from the Content-Disposition header
+     * @return the base filename, or {@code null} if the input is null, empty, or resolves to a risky name ({@code .}
+     *         or {@code ..})
+     */
+    public static String sanitizeFileName(String fileName) {
+        if (fileName == null) {
+            return null;
+        }
+        fileName = fileName.replace("\0", "");
+        int lastSlash = fileName.lastIndexOf('/');
+        int lastBackslash = fileName.lastIndexOf('\\');
+        int lastSep = Math.max(lastSlash, lastBackslash);
+        if (lastSep >= 0) {
+            fileName = fileName.substring(lastSep + 1);
+        }
+        if (fileName.isEmpty() || ".".equals(fileName) || "..".equals(fileName)) {
+            return null;
+        }
+        return fileName;
+    }
 }

--- a/independent-projects/resteasy-reactive/common/runtime/src/test/java/org/jboss/resteasy/reactive/common/headers/HeaderUtilTest.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/test/java/org/jboss/resteasy/reactive/common/headers/HeaderUtilTest.java
@@ -25,4 +25,72 @@ class HeaderUtilTest {
         Locale[] multipleWeightedLocales = new Locale[] { new Locale("da"), Locale.UK, Locale.ENGLISH };
         assertArrayEquals(multipleWeightedLocales, HeaderUtil.getAcceptableLanguages(multipleWeightedLanguages).toArray());
     }
+
+    @Test
+    void sanitizeFileNamePassesNormalFilenames() {
+        assertEquals("report.pdf", HeaderUtil.sanitizeFileName("report.pdf"));
+        assertEquals("my file (1).txt", HeaderUtil.sanitizeFileName("my file (1).txt"));
+        assertEquals(".hidden", HeaderUtil.sanitizeFileName(".hidden"));
+    }
+
+    @Test
+    void sanitizeFileNameStripsForwardSlashTraversal() {
+        assertEquals("pwned.txt", HeaderUtil.sanitizeFileName("../../../tmp/pwned.txt"));
+        assertEquals("pwned.txt", HeaderUtil.sanitizeFileName("/tmp/pwned.txt"));
+        assertEquals("pwned.txt", HeaderUtil.sanitizeFileName("a/b/c/pwned.txt"));
+    }
+
+    @Test
+    void sanitizeFileNameStripsBackslashTraversal() {
+        assertEquals("pwned.txt", HeaderUtil.sanitizeFileName("..\\..\\..\\tmp\\pwned.txt"));
+        assertEquals("pwned.txt", HeaderUtil.sanitizeFileName("C:\\Users\\bad\\pwned.txt"));
+    }
+
+    @Test
+    void sanitizeFileNameStripsMixedSeparators() {
+        assertEquals("pwned.txt", HeaderUtil.sanitizeFileName("../..\\../tmp/pwned.txt"));
+    }
+
+    @Test
+    void sanitizeFileNameStripsNullBytes() {
+        assertEquals("shell.jsp.txt", HeaderUtil.sanitizeFileName("shell.jsp\0.txt"));
+        assertEquals("file.txt", HeaderUtil.sanitizeFileName("file\0.txt"));
+    }
+
+    @Test
+    void sanitizeFileNameRejectsDotAndDotDot() {
+        assertNull(HeaderUtil.sanitizeFileName("."));
+        assertNull(HeaderUtil.sanitizeFileName(".."));
+        assertNull(HeaderUtil.sanitizeFileName("foo/.."));
+        assertNull(HeaderUtil.sanitizeFileName("foo/."));
+    }
+
+    @Test
+    void sanitizeFileNameRejectsEmptyAndNull() {
+        assertNull(HeaderUtil.sanitizeFileName(null));
+        assertNull(HeaderUtil.sanitizeFileName(""));
+        assertNull(HeaderUtil.sanitizeFileName("/"));
+        assertNull(HeaderUtil.sanitizeFileName("\\"));
+        assertNull(HeaderUtil.sanitizeFileName("///"));
+    }
+
+    @Test
+    void sanitizeFileNameHandlesNullByteInPath() {
+        assertEquals("pwned.txt", HeaderUtil.sanitizeFileName("../\0../pwned.txt"));
+    }
+
+    @Test
+    void sanitizeFileNamePreservesUnicodeFilenames() {
+        assertEquals("文件.txt", HeaderUtil.sanitizeFileName("文件.txt"));
+        assertEquals("café.pdf", HeaderUtil.sanitizeFileName("café.pdf"));
+        assertEquals("文件.txt", HeaderUtil.sanitizeFileName("path/to/文件.txt"));
+    }
+
+    @Test
+    void sanitizeFileNameWithExtractQuotedValueFromHeaderWithEncoding() {
+        String header = "form-data; name=\"file\"; filename*=UTF-8''..%2F..%2Fpwned.txt";
+        String extracted = HeaderUtil.extractQuotedValueFromHeaderWithEncoding(header, "filename");
+        String sanitized = HeaderUtil.sanitizeFileName(extracted);
+        assertEquals("pwned.txt", sanitized);
+    }
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/multipart/MultiPartParserDefinition.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/multipart/MultiPartParserDefinition.java
@@ -262,7 +262,8 @@ public class MultiPartParserDefinition implements FormParserFactory.ParserDefini
             if (disposition != null) {
                 if (disposition.startsWith("form-data")) {
                     currentName = HeaderUtil.extractQuotedValueFromHeader(disposition, "name");
-                    fileName = HeaderUtil.extractQuotedValueFromHeaderWithEncoding(disposition, "filename");
+                    fileName = HeaderUtil.sanitizeFileName(
+                            HeaderUtil.extractQuotedValueFromHeaderWithEncoding(disposition, "filename"));
                     String contentType = headers.getFirst(HttpHeaders.CONTENT_TYPE);
                     if (((fileName != null) || isFileContentType(contentType) || fileFormNames.contains(currentName))
                             && fileSizeThreshold == 0) {

--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.java
@@ -22,6 +22,7 @@ import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 
 import org.jboss.resteasy.reactive.common.ResteasyReactiveConfig;
+import org.jboss.resteasy.reactive.common.headers.HeaderUtil;
 import org.jboss.resteasy.reactive.common.util.CaseInsensitiveMap;
 import org.jboss.resteasy.reactive.server.core.Deployment;
 import org.jboss.resteasy.reactive.server.core.LazyResponse;
@@ -364,7 +365,7 @@ public class VertxResteasyReactiveRequestContext extends ResteasyReactiveRequest
             if (i.contentType() != null) {
                 headers.add(HttpHeaders.CONTENT_TYPE, i.contentType());
             }
-            ret.add(i.name(), Paths.get(i.uploadedFileName()), i.fileName(), headers);
+            ret.add(i.name(), Paths.get(i.uploadedFileName()), HeaderUtil.sanitizeFileName(i.fileName()), headers);
         }
         for (var i : request.formAttributes()) {
             ret.add(i.getKey(), i.getValue());


### PR DESCRIPTION
Add HeaderUtil.sanitizeFileName() that strips path separators, null bytes, and rejects '.' / '..' filenames.

This is a hardening measure, as Quarkus already writes uploads to randomly named temp files, but FileUpload.fileName() returns the raw client-provided name, including traversal sequences. Which means that if the app does not sanitize its output, it can compromise the application's security. This PR strips all the bad characters from the file name, so the app does not have to validate the value.

This issue has been discovered by @BarDweller. 
