### PR TITLE
Reduce allocation in HTTP instrumentation

### DIFF
--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/MicrometerRecorder.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/MicrometerRecorder.java
@@ -33,6 +33,7 @@ import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.quarkus.arc.Arc;
 import io.quarkus.micrometer.runtime.binder.HttpBinderConfiguration;
+import io.quarkus.micrometer.runtime.binder.HttpCommonTags;
 import io.quarkus.micrometer.runtime.binder.JVMInfoBinder;
 import io.quarkus.micrometer.runtime.config.MicrometerConfig;
 import io.quarkus.micrometer.runtime.config.runtime.HttpClientConfig;
@@ -284,6 +285,8 @@ public class MicrometerRecorder {
     @RuntimeInit
     public RuntimeValue<HttpBinderConfiguration> configureHttpMetrics(boolean httpServerMetricsEnabled,
             boolean httpClientMetricsEnabled) {
+        config.binder().http().additionalMethods()
+                .ifPresent(HttpCommonTags::setAdditionalHttpMethods);
         return new RuntimeValue<HttpBinderConfiguration>(
                 new HttpBinderConfiguration(httpServerMetricsEnabled, httpClientMetricsEnabled, httpServerConfig.getValue(),
                         httpClientConfig.getValue(), vertxConfig.getValue()));

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/HttpCommonTags.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/HttpCommonTags.java
@@ -1,11 +1,48 @@
 package io.quarkus.micrometer.runtime.binder;
 
+import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
+import java.util.Set;
+
+import org.jboss.logging.Logger;
 
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.binder.http.Outcome;
 
 public class HttpCommonTags {
+    private static final Logger log = Logger.getLogger(HttpCommonTags.class);
+    private static final int MAX_HTTP_METHODS = 32;
+
+    // Standard RFC 9110/5789/9512 methods
+    private static final Set<String> allowedHttpMethods = new HashSet<>(10);
+
+    static {
+        allowedHttpMethods.add("GET");
+        allowedHttpMethods.add("HEAD");
+        allowedHttpMethods.add("POST");
+        allowedHttpMethods.add("PUT");
+        allowedHttpMethods.add("DELETE");
+        allowedHttpMethods.add("CONNECT");
+        allowedHttpMethods.add("OPTIONS");
+        allowedHttpMethods.add("TRACE");
+        allowedHttpMethods.add("PATCH");
+        allowedHttpMethods.add("QUERY");
+    }
+
+    public static void setAdditionalHttpMethods(List<String> additionalMethods) {
+        if (additionalMethods != null) {
+            for (String method : additionalMethods) {
+                if (allowedHttpMethods.size() >= MAX_HTTP_METHODS) {
+                    log.warnf("Maximum number of allowed HTTP methods (%d) reached. Ignoring remaining entries.",
+                            MAX_HTTP_METHODS);
+                    break;
+                }
+                allowedHttpMethods.add(method.toUpperCase());
+            }
+        }
+    }
+
     public static final Tag URI_NOT_FOUND = Tag.of("uri", "NOT_FOUND");
     public static final Tag URI_REDIRECTION = Tag.of("uri", "REDIRECTION");
     public static final Tag URI_ROOT = Tag.of("uri", "root");
@@ -23,7 +60,10 @@ public class HttpCommonTags {
      * @return the method tag
      */
     public static Tag method(String method) {
-        return method == null ? METHOD_UNKNOWN : Tag.of("method", method);
+        if (method == null || !allowedHttpMethods.contains(method)) {
+            return METHOD_UNKNOWN;
+        }
+        return Tag.of("method", method);
     }
 
     /**

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxMetricsTags.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxMetricsTags.java
@@ -20,7 +20,10 @@ public class VertxMetricsTags {
      * @return the method tag whose value is a capitalized method (e.g. GET).
      */
     public static Tag method(HttpMethod method) {
-        return (method != null) ? Tag.of("method", method.toString()) : HttpCommonTags.METHOD_UNKNOWN;
+        if (method == null) {
+            return HttpCommonTags.METHOD_UNKNOWN;
+        }
+        return HttpCommonTags.method(method.toString());
     }
 
     /**

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/HttpConfigGroup.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/HttpConfigGroup.java
@@ -1,0 +1,28 @@
+package io.quarkus.micrometer.runtime.config;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+
+/**
+ * Build / static runtime config for HTTP metrics shared between server and client.
+ */
+@ConfigGroup
+public interface HttpConfigGroup {
+
+    /**
+     * Comma-separated list of additional HTTP methods to allow in the
+     * {@code method} metric tag, beyond the standard RFC 9110/5789/9512 methods
+     * (GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH, QUERY).
+     *
+     * Non-standard HTTP methods are replaced with {@code UNKNOWN} by default
+     * to prevent metrics cardinality explosion. Use this property to allow
+     * specific custom methods (e.g. WebDAV methods like {@code PROPFIND}).
+     *
+     * The total number of methods to track cannot exceed 32.
+     *
+     * @asciidoclet
+     */
+    Optional<List<String>> additionalMethods();
+}

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/MicrometerConfig.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/MicrometerConfig.java
@@ -154,6 +154,8 @@ public interface MicrometerConfig {
     /** Build / static runtime config for binders */
     @ConfigGroup
     interface BinderConfig {
+        HttpConfigGroup http();
+
         HttpClientConfigGroup httpClient();
 
         HttpServerConfigGroup httpServer();

--- a/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/binder/HttpCommonTagsTest.java
+++ b/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/binder/HttpCommonTagsTest.java
@@ -1,5 +1,8 @@
 package io.quarkus.micrometer.runtime.binder;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -9,6 +12,55 @@ import io.micrometer.core.instrument.Tag;
  * Test tag creation
  */
 public class HttpCommonTagsTest {
+
+    @Test
+    public void testStandardMethodsAreAllowed() {
+        Assertions.assertEquals(Tag.of("method", "GET"), HttpCommonTags.method("GET"));
+        Assertions.assertEquals(Tag.of("method", "HEAD"), HttpCommonTags.method("HEAD"));
+        Assertions.assertEquals(Tag.of("method", "POST"), HttpCommonTags.method("POST"));
+        Assertions.assertEquals(Tag.of("method", "PUT"), HttpCommonTags.method("PUT"));
+        Assertions.assertEquals(Tag.of("method", "DELETE"), HttpCommonTags.method("DELETE"));
+        Assertions.assertEquals(Tag.of("method", "CONNECT"), HttpCommonTags.method("CONNECT"));
+        Assertions.assertEquals(Tag.of("method", "OPTIONS"), HttpCommonTags.method("OPTIONS"));
+        Assertions.assertEquals(Tag.of("method", "TRACE"), HttpCommonTags.method("TRACE"));
+        Assertions.assertEquals(Tag.of("method", "PATCH"), HttpCommonTags.method("PATCH"));
+        Assertions.assertEquals(Tag.of("method", "QUERY"), HttpCommonTags.method("QUERY"));
+    }
+
+    @Test
+    public void testNonStandardMethodsAreRejected() {
+        Assertions.assertEquals(HttpCommonTags.METHOD_UNKNOWN, HttpCommonTags.method(null));
+        Assertions.assertEquals(HttpCommonTags.METHOD_UNKNOWN, HttpCommonTags.method("WELL"));
+        Assertions.assertEquals(HttpCommonTags.METHOD_UNKNOWN, HttpCommonTags.method("FOOBAR"));
+        Assertions.assertEquals(HttpCommonTags.METHOD_UNKNOWN, HttpCommonTags.method("get"));
+    }
+
+    @Test
+    public void testAdditionalMethodsAreAllowed() {
+        Assertions.assertEquals(HttpCommonTags.METHOD_UNKNOWN, HttpCommonTags.method("PROPFIND"));
+
+        HttpCommonTags.setAdditionalHttpMethods(List.of("PROPFIND", "MKCOL"));
+
+        Assertions.assertEquals(Tag.of("method", "PROPFIND"), HttpCommonTags.method("PROPFIND"));
+        Assertions.assertEquals(Tag.of("method", "MKCOL"), HttpCommonTags.method("MKCOL"));
+        Assertions.assertEquals(Tag.of("method", "GET"), HttpCommonTags.method("GET"));
+        Assertions.assertEquals(HttpCommonTags.METHOD_UNKNOWN, HttpCommonTags.method("FOOBAR"));
+    }
+
+    @Test
+    public void testAdditionalMethodsCappedAt32() {
+        // 10 standard methods + 23 additional = 33, exceeding the cap of 32
+        List<String> methods = new ArrayList<>(23);
+        for (int i = 1; i <= 23; i++) {
+            methods.add("CUSTOM" + i);
+        }
+        HttpCommonTags.setAdditionalHttpMethods(methods);
+
+        // CUSTOM1 fits within the 32 cap
+        Assertions.assertEquals(Tag.of("method", "CUSTOM1"), HttpCommonTags.method("CUSTOM1"));
+        // CUSTOM23 is the 33rd method and should be rejected
+        Assertions.assertEquals(HttpCommonTags.METHOD_UNKNOWN, HttpCommonTags.method("CUSTOM23"));
+    }
 
     @Test
     public void testStatus() {

--- a/integration-tests/micrometer-prometheus/src/test/java/io/quarkus/it/micrometer/prometheus/AdditionalHttpMethodsProfile.java
+++ b/integration-tests/micrometer-prometheus/src/test/java/io/quarkus/it/micrometer/prometheus/AdditionalHttpMethodsProfile.java
@@ -1,0 +1,13 @@
+package io.quarkus.it.micrometer.prometheus;
+
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class AdditionalHttpMethodsProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of("quarkus.micrometer.binder.http.additional-methods", "PROPFIND");
+    }
+}

--- a/integration-tests/micrometer-prometheus/src/test/java/io/quarkus/it/micrometer/prometheus/AdditionalHttpMethodsTest.java
+++ b/integration-tests/micrometer-prometheus/src/test/java/io/quarkus/it/micrometer/prometheus/AdditionalHttpMethodsTest.java
@@ -1,0 +1,68 @@
+package io.quarkus.it.micrometer.prometheus;
+
+import static io.restassured.RestAssured.get;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URL;
+import java.util.concurrent.CountDownLatch;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.client.WebClient;
+
+@QuarkusTest
+@TestProfile(AdditionalHttpMethodsProfile.class)
+public class AdditionalHttpMethodsTest {
+
+    @Inject
+    Vertx vertx;
+
+    @TestHTTPResource
+    URL url;
+
+    @Test
+    void testConfiguredAdditionalMethodIsPreserved() throws Exception {
+        WebClient client = WebClient.create(vertx);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        client.request(HttpMethod.valueOf("PROPFIND"), url.getPort(), url.getHost(), "/message")
+                .send()
+                .onComplete(ar -> latch.countDown());
+        latch.await(5, SECONDS);
+        client.close();
+
+        await().atMost(5, SECONDS).untilAsserted(() -> {
+            String body = get("/q/metrics").then().extract().asString();
+            assertTrue(body.contains("method=\"PROPFIND\""),
+                    "Configured additional HTTP method PROPFIND should be preserved in metrics");
+        });
+    }
+
+    @Test
+    void testUnconfiguredMethodStillBecomesUnknown() throws Exception {
+        WebClient client = WebClient.create(vertx);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        client.request(HttpMethod.valueOf("FOOBAR"), url.getPort(), url.getHost(), "/message")
+                .send()
+                .onComplete(ar -> latch.countDown());
+        latch.await(5, SECONDS);
+        client.close();
+
+        await().atMost(5, SECONDS).untilAsserted(() -> {
+            String body = get("/q/metrics").then().extract().asString();
+            assertFalse(body.contains("method=\"FOOBAR\""),
+                    "Non-configured HTTP method FOOBAR should not appear in metrics");
+        });
+    }
+}

--- a/integration-tests/micrometer-prometheus/src/test/java/io/quarkus/it/micrometer/prometheus/HttpMethodTagsTest.java
+++ b/integration-tests/micrometer-prometheus/src/test/java/io/quarkus/it/micrometer/prometheus/HttpMethodTagsTest.java
@@ -1,0 +1,61 @@
+package io.quarkus.it.micrometer.prometheus;
+
+import static io.restassured.RestAssured.get;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URL;
+import java.util.concurrent.CountDownLatch;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.client.WebClient;
+
+@QuarkusTest
+public class HttpMethodTagsTest {
+
+    @Inject
+    Vertx vertx;
+
+    @TestHTTPResource
+    URL url;
+
+    @Test
+    void testNonStandardMethodBecomesUnknown() throws Exception {
+        WebClient client = WebClient.create(vertx);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        client.request(HttpMethod.valueOf("PROPFIND"), url.getPort(), url.getHost(), "/message")
+                .send()
+                .onComplete(ar -> latch.countDown());
+        latch.await(5, SECONDS);
+        client.close();
+
+        await().atMost(5, SECONDS).untilAsserted(() -> {
+            String body = get("/q/metrics").then().extract().asString();
+            assertTrue(body.contains("method=\"UNKNOWN\""),
+                    "Non-standard HTTP method should be recorded as UNKNOWN");
+            assertFalse(body.contains("method=\"PROPFIND\""),
+                    "Non-standard HTTP method PROPFIND should not appear in metrics");
+        });
+    }
+
+    @Test
+    void testStandardMethodIsPreserved() throws Exception {
+        get("/message").then().statusCode(200);
+
+        await().atMost(5, SECONDS).untilAsserted(() -> {
+            String body = get("/q/metrics").then().extract().asString();
+            assertTrue(body.contains("method=\"GET\""),
+                    "Standard HTTP method GET should be preserved in metrics");
+        });
+    }
+}


### PR DESCRIPTION
Fix the way http methods are handled in the Micrometer instrumentation.
This prevents potential OOM from happening and needs to be backported.
