### PR TITLE
[4.0] Improve Vert.x SQL client options coverage in reactive datasource config

### DIFF
--- a/docs/src/main/asciidoc/reactive-sql-clients.adoc
+++ b/docs/src/main/asciidoc/reactive-sql-clients.adoc
@@ -780,6 +780,43 @@ For example, you could ensure connections are recycled after 60 minutes:
 quarkus.datasource.reactive.max-lifetime=PT60M
 ----
 
+== Pool `connection-timeout`
+
+The `connection-timeout` controls how long a request waits for a connection from the pool before failing.
+
+NOTE: The default connection timeout is 30 seconds (`30S`).
+
+For example, you could set a 5-second timeout:
+
+[source,properties]
+----
+quarkus.datasource.reactive.connection-timeout=5S
+----
+
+== Pool `max-wait-queue-size`
+
+You can limit how many requests wait in the queue when all pool connections are in use.
+Further requests are rejected immediately when the queue is full.
+
+NOTE: By default, the wait queue is unbounded.
+
+[source,properties]
+----
+quarkus.datasource.reactive.max-wait-queue-size=100
+----
+
+== Pool `pool-cleaner-period`
+
+The `pool-cleaner-period` controls how often the pool checks for idle connections eligible for removal.
+This works in conjunction with `idle-timeout`.
+
+NOTE: The default pool cleaner period is 1 second.
+
+[source,properties]
+----
+quarkus.datasource.reactive.pool-cleaner-period=5S
+----
+
 == TLS configuration
 
 All reactive SQL clients support TLS configuration through the Quarkus TLS registry.
@@ -830,6 +867,8 @@ public class CustomPoolCreator implements PoolCreator {
 ----
 
 For a named datasource, annotate the bean with `@ReactiveDataSource("datasource-name")`.
+
+TIP: `PoolCreator` is also the way to set Vert.x options that cannot be expressed as configuration properties, such as `SqlConnectOptions.setPreparedStatementCacheSqlFilter(Predicate<String>)`.
 
 == Pipelining
 

--- a/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/DataSourceReactiveRuntimeConfig.java
+++ b/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/DataSourceReactiveRuntimeConfig.java
@@ -27,6 +27,23 @@ public interface DataSourceReactiveRuntimeConfig {
     Optional<Boolean> cachePreparedStatements();
 
     /**
+     * The maximum number of prepared statements that the client will cache.
+     * <p>
+     * Only effective when {@code cache-prepared-statements} is enabled (PostgreSQL, MySQL/MariaDB, Db2).
+     */
+    @ConfigDocDefault("256")
+    OptionalInt preparedStatementCacheMaxSize();
+
+    /**
+     * The maximum length of SQL text that the client will cache in a prepared statement.
+     * Queries exceeding this limit are not cached.
+     * <p>
+     * Only effective when {@code cache-prepared-statements} is enabled (PostgreSQL, MySQL/MariaDB, Db2).
+     */
+    @ConfigDocDefault("2048")
+    OptionalInt preparedStatementCacheSqlLimit();
+
+    /**
      * The datasource URLs.
      * <p>
      * If multiple values are set, this datasource will create a pool with a list of servers instead of a single server.
@@ -127,6 +144,27 @@ public interface DataSourceReactiveRuntimeConfig {
      * When set, manual trust/key certificate properties are ignored.
      */
     Optional<String> tlsConfigurationName();
+
+    /**
+     * The maximum time to wait for a connection from the pool.
+     */
+    @ConfigDocDefault("30S")
+    Optional<Duration> connectionTimeout();
+
+    /**
+     * The maximum number of requests allowed in the wait queue of the pool.
+     * If the queue is full, further requests are rejected.
+     * <p>
+     * A value of -1 means there is no limit.
+     */
+    @ConfigDocDefault("-1")
+    OptionalInt maxWaitQueueSize();
+
+    /**
+     * How often the pool is checked for idle connections eligible for removal.
+     */
+    @ConfigDocDefault("1S")
+    Optional<Duration> poolCleanerPeriod();
 
     /**
      * The maximum time a connection remains unused in the pool before it is closed.

--- a/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/ReactivePoolUtil.java
+++ b/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/ReactivePoolUtil.java
@@ -3,6 +3,7 @@ package io.quarkus.reactive.datasource.runtime;
 import static io.quarkus.credentials.CredentialsProvider.PASSWORD_PROPERTY_NAME;
 import static io.quarkus.credentials.CredentialsProvider.USER_PROPERTY_NAME;
 import static io.quarkus.reactive.datasource.runtime.UnitisedTime.unitised;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import java.util.List;
 import java.util.Map;
@@ -51,6 +52,20 @@ public final class ReactivePoolUtil {
         PoolOptions poolOptions = new PoolOptions();
 
         poolOptions.setMaxSize(config.maxSize());
+
+        if (config.connectionTimeout().isPresent()) {
+            var connectionTimeout = unitised(config.connectionTimeout().get());
+            poolOptions.setConnectionTimeout(connectionTimeout.value).setConnectionTimeoutUnit(connectionTimeout.unit);
+        }
+
+        if (config.maxWaitQueueSize().isPresent()) {
+            poolOptions.setMaxWaitQueueSize(config.maxWaitQueueSize().getAsInt());
+        }
+
+        if (config.poolCleanerPeriod().isPresent()) {
+            var cleanerPeriod = unitised(config.poolCleanerPeriod().get());
+            poolOptions.setPoolCleanerPeriod((int) MILLISECONDS.convert(cleanerPeriod.value, cleanerPeriod.unit));
+        }
 
         if (config.idleTimeout().isPresent()) {
             var idleTimeout = unitised(config.idleTimeout().get());
@@ -122,6 +137,22 @@ public final class ReactivePoolUtil {
             if (password != null) {
                 connectOptions.setPassword(password);
             }
+        }
+    }
+
+    /**
+     * Apply all prepared statement cache settings from the generic reactive datasource config to connect options.
+     * <p>
+     * Only call this for SQL clients that support prepared statement caching.
+     */
+    public static void configurePreparedStatementCache(SqlConnectOptions connectOptions,
+            DataSourceReactiveRuntimeConfig config) {
+        connectOptions.setCachePreparedStatements(config.cachePreparedStatements().orElse(true));
+        if (config.preparedStatementCacheMaxSize().isPresent()) {
+            connectOptions.setPreparedStatementCacheMaxSize(config.preparedStatementCacheMaxSize().getAsInt());
+        }
+        if (config.preparedStatementCacheSqlLimit().isPresent()) {
+            connectOptions.setPreparedStatementCacheSqlLimit(config.preparedStatementCacheSqlLimit().getAsInt());
         }
     }
 

--- a/extensions/reactive-db2-client/runtime/src/main/java/io/quarkus/reactive/db2/client/runtime/DB2PoolRecorder.java
+++ b/extensions/reactive-db2-client/runtime/src/main/java/io/quarkus/reactive/db2/client/runtime/DB2PoolRecorder.java
@@ -35,8 +35,6 @@ import io.vertx.sqlclient.SqlConnectOptions;
 @Recorder
 public class DB2PoolRecorder {
 
-    private static final boolean SUPPORTS_CACHE_PREPARED_STATEMENTS = true;
-
     private static final Logger log = Logger.getLogger(DB2PoolRecorder.class);
     private static final TypeLiteral<Instance<PoolCreator>> POOL_CREATOR_TYPE_LITERAL = new TypeLiteral<>() {
     };
@@ -115,8 +113,7 @@ public class DB2PoolRecorder {
 
         ReactivePoolUtil.configureCredentials(connectOptions, dataSourceRuntimeConfig);
 
-        connectOptions.setCachePreparedStatements(
-                dataSourceReactiveRuntimeConfig.cachePreparedStatements().orElse(SUPPORTS_CACHE_PREPARED_STATEMENTS));
+        ReactivePoolUtil.configurePreparedStatementCache(connectOptions, dataSourceReactiveRuntimeConfig);
 
         if (dataSourceReactiveDB2Config.ssl()) {
             connectOptions.setSsl(true);

--- a/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/DataSourceReactiveMySQLConfig.java
+++ b/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/DataSourceReactiveMySQLConfig.java
@@ -32,7 +32,10 @@ public interface DataSourceReactiveMySQLConfig {
 
     /**
      * Connection timeout in seconds
+     *
+     * @deprecated Use {@code quarkus.datasource.reactive.connection-timeout} instead.
      */
+    @Deprecated
     OptionalInt connectionTimeout();
 
     /**
@@ -54,4 +57,33 @@ public interface DataSourceReactiveMySQLConfig {
      */
     @ConfigDocDefault("false")
     Optional<Boolean> useAffectedRows();
+
+    /**
+     * Set the Java charset to use to encode query string and parameter values.
+     * The charset is UTF-8 by default.
+     */
+    @ConfigDocDefault("UTF-8")
+    Optional<String> characterEncoding();
+
+    /**
+     * Path to the server RSA public key file.
+     * <p>
+     * Used to securely encrypt the password during login when using SHA-256
+     * authentication plugins (e.g., {@code caching_sha2_password}) over unencrypted
+     * (non-TLS) connections. Specifying this locally prevents Man-in-the-Middle
+     * attacks by avoiding automatic public key retrieval from the server.
+     */
+    Optional<String> serverRsaPublicKeyPath();
+
+    /**
+     * The server RSA public key content.
+     * <p>
+     * Used to securely encrypt the password during login when using SHA-256
+     * authentication plugins (e.g., {@code caching_sha2_password}) over unencrypted
+     * (non-TLS) connections. Specifying this locally prevents Man-in-the-Middle
+     * attacks by avoiding automatic public key retrieval from the server.
+     * <p>
+     * If set, takes precedence over {@code server-rsa-public-key-path}.
+     */
+    Optional<String> serverRsaPublicKeyValue();
 }

--- a/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/MySQLPoolRecorder.java
+++ b/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/MySQLPoolRecorder.java
@@ -11,7 +11,10 @@ import java.util.function.Supplier;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.util.TypeLiteral;
 
+import org.jboss.logging.Logger;
+
 import io.quarkus.arc.SyntheticCreationalContext;
+import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.quarkus.datasource.runtime.DataSourceRuntimeConfig;
 import io.quarkus.datasource.runtime.DataSourcesRuntimeConfig;
 import io.quarkus.reactive.datasource.PoolCreator;
@@ -25,6 +28,7 @@ import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.tls.TlsConfigurationRegistry;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.mysqlclient.MySQLBuilder;
 import io.vertx.mysqlclient.MySQLConnectOptions;
@@ -36,7 +40,7 @@ import io.vertx.sqlclient.SqlConnectOptions;
 @Recorder
 public class MySQLPoolRecorder {
 
-    private static final boolean SUPPORTS_CACHE_PREPARED_STATEMENTS = true;
+    private static final Logger log = Logger.getLogger(MySQLPoolRecorder.class);
 
     private static final TypeLiteral<Instance<PoolCreator>> POOL_CREATOR_TYPE_LITERAL = new TypeLiteral<>() {
     };
@@ -84,8 +88,9 @@ public class MySQLPoolRecorder {
             TlsConfigurationRegistry tlsRegistry,
             SyntheticCreationalContext<Pool> context) {
         PoolOptions poolOptions = ReactivePoolUtil.toPoolOptions(eventLoopCount, dataSourceReactiveRuntimeConfig);
-        // MySQL-specific: connection timeout
-        if (dataSourceReactiveMySQLConfig.connectionTimeout().isPresent()) {
+        if (dataSourceReactiveRuntimeConfig.connectionTimeout().isEmpty()
+                && dataSourceReactiveMySQLConfig.connectionTimeout().isPresent()) {
+            logWarningForDeprecatedConnectionTimeout(dataSourceName);
             poolOptions.setConnectionTimeout(dataSourceReactiveMySQLConfig.connectionTimeout().getAsInt());
             poolOptions.setConnectionTimeoutUnit(TimeUnit.SECONDS);
         }
@@ -95,6 +100,17 @@ public class MySQLPoolRecorder {
         Supplier<Future<SqlConnectOptions>> databasesSupplier = ReactivePoolUtil.toDatabasesSupplier(mysqlConnectOptionsList,
                 dataSourceRuntimeConfig, MySQLConnectOptions::new);
         return createPool(vertx, poolOptions, mysqlConnectOptionsList, dataSourceName, databasesSupplier, context);
+    }
+
+    private void logWarningForDeprecatedConnectionTimeout(String dataSourceName) {
+        if (DataSourceUtil.isDefault(dataSourceName)) {
+            log.warn("'quarkus.datasource.reactive.mysql.connection-timeout' is deprecated,"
+                    + " use 'quarkus.datasource.reactive.connection-timeout' instead");
+        } else {
+            log.warnf("'quarkus.datasource.\"%s\".reactive.mysql.connection-timeout' is deprecated,"
+                    + " use 'quarkus.datasource.\"%s\".reactive.connection-timeout' instead",
+                    dataSourceName, dataSourceName);
+        }
     }
 
     private List<MySQLConnectOptions> toMySQLConnectOptions(String dataSourceName,
@@ -119,12 +135,21 @@ public class MySQLPoolRecorder {
         mysqlConnectOptionsList.forEach(mysqlConnectOptions -> {
             ReactivePoolUtil.configureCredentials(mysqlConnectOptions, dataSourceRuntimeConfig);
 
-            mysqlConnectOptions
-                    .setCachePreparedStatements(dataSourceReactiveRuntimeConfig.cachePreparedStatements()
-                            .orElse(SUPPORTS_CACHE_PREPARED_STATEMENTS));
+            ReactivePoolUtil.configurePreparedStatementCache(mysqlConnectOptions, dataSourceReactiveRuntimeConfig);
 
             dataSourceReactiveMySQLConfig.charset().ifPresent(mysqlConnectOptions::setCharset);
             dataSourceReactiveMySQLConfig.collation().ifPresent(mysqlConnectOptions::setCollation);
+            if (dataSourceReactiveMySQLConfig.characterEncoding().isPresent()) {
+                mysqlConnectOptions.setCharacterEncoding(dataSourceReactiveMySQLConfig.characterEncoding().get());
+            }
+            if (dataSourceReactiveMySQLConfig.serverRsaPublicKeyPath().isPresent()) {
+                mysqlConnectOptions.setServerRsaPublicKeyPath(dataSourceReactiveMySQLConfig.serverRsaPublicKeyPath().get());
+            }
+            if (dataSourceReactiveMySQLConfig.serverRsaPublicKeyValue().isPresent()) {
+                mysqlConnectOptions
+                        .setServerRsaPublicKeyValue(
+                                Buffer.buffer(dataSourceReactiveMySQLConfig.serverRsaPublicKeyValue().get()));
+            }
 
             if (dataSourceReactiveMySQLConfig.pipeliningLimit().isPresent()) {
                 mysqlConnectOptions.setPipeliningLimit(dataSourceReactiveMySQLConfig.pipeliningLimit().getAsInt());

--- a/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/PgPoolRecorder.java
+++ b/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/PgPoolRecorder.java
@@ -34,8 +34,6 @@ import io.vertx.sqlclient.SqlConnectOptions;
 @Recorder
 public class PgPoolRecorder {
 
-    private static final boolean SUPPORTS_CACHE_PREPARED_STATEMENTS = true;
-
     private static final TypeLiteral<Instance<PoolCreator>> POOL_CREATOR_TYPE_LITERAL = new TypeLiteral<>() {
     };
 
@@ -111,8 +109,7 @@ public class PgPoolRecorder {
         pgConnectOptionsList.forEach(pgConnectOptions -> {
             ReactivePoolUtil.configureCredentials(pgConnectOptions, dataSourceRuntimeConfig);
 
-            pgConnectOptions.setCachePreparedStatements(
-                    dataSourceReactiveRuntimeConfig.cachePreparedStatements().orElse(SUPPORTS_CACHE_PREPARED_STATEMENTS));
+            ReactivePoolUtil.configurePreparedStatementCache(pgConnectOptions, dataSourceReactiveRuntimeConfig);
 
             if (dataSourceReactivePostgreSQLConfig.pipeliningLimit().isPresent()) {
                 pgConnectOptions.setPipeliningLimit(dataSourceReactivePostgreSQLConfig.pipeliningLimit().getAsInt());


### PR DESCRIPTION
Add missing pool and connection options to the shared reactive datasource configuration:

- `connection-timeout`, `max-wait-queue-size`, `pool-cleaner-period` as shared pool options (all reactive clients)
- `prepared-statement-cache-max-size` and `prepared-statement-cache-sql-limit` as shared connect options for clients that support prepared statement caching (PostgreSQL, MySQL, DB2); cache configuration is now centralized in `ReactivePoolUtil#configurePreparedStatementCache`
- MySQL-specific: `character-encoding`, `server-rsa-public-key-path`, `server-rsa-public-key-value`

Deprecate `quarkus.datasource.reactive.mysql.connection-timeout` in favour of the new shared `quarkus.datasource.reactive.connection-timeout`. The deprecated property is still honoured as a fallback with a warning.

Update `reactive-sql-clients.adoc` to document the new pool options and the use of `PoolCreator` for non-serializable connect options such as `preparedStatementCacheSqlFilter`.