### PR TITLE
[4.0] Vert.x 5.1.3 / Mutiny 3.3.0 / Mutiny Vert.x bindings 4.0.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -56,7 +56,7 @@
         <smallrye-context-propagation.version>2.3.0</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.3</smallrye-reactive-types-converter.version>
-        <smallrye-mutiny-vertx-binding.version>4.0.0-beta2</smallrye-mutiny-vertx-binding.version>
+        <smallrye-mutiny-vertx-binding.version>4.0.0</smallrye-mutiny-vertx-binding.version>
         <smallrye-reactive-messaging.version>5.0.0-beta4</smallrye-reactive-messaging.version>
         <smallrye-stork.version>3.0.0.beta2</smallrye-stork.version>
         <jakarta.activation.version>2.1.4</jakarta.activation.version>
@@ -111,7 +111,7 @@
         <wildfly-elytron.version>2.9.1.Final</wildfly-elytron.version>
         <jboss-marshalling.version>2.3.0</jboss-marshalling.version>
         <jboss-threads.version>3.9.2</jboss-threads.version>
-        <vertx.version>5.1.2</vertx.version>
+        <vertx.version>5.1.3</vertx.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
         <httpasync.version>4.1.5</httpasync.version>
@@ -136,7 +136,7 @@
         <brotli4j.version>1.23.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.6.3.Final</jboss-logging.version>
-        <mutiny.version>3.2.1</mutiny.version>
+        <mutiny.version>3.3.0</mutiny.version>
         <jctools-core.version>4.0.5</jctools-core.version>
         <kafka.version>4.2.1</kafka.version>
         <lz4.version>1.10.1</lz4.version> <!-- dependency of the kafka-clients that could be overridden by other imported BOMs in the platform -->

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/SemicolonQueryParamDefaultTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/SemicolonQueryParamDefaultTest.java
@@ -6,14 +6,12 @@ import static org.hamcrest.Matchers.is;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusExtensionTest;
 import io.vertx.ext.web.Router;
 
-@Disabled("Settings not present in Vert.x 5, need to be investigated")
 public class SemicolonQueryParamDefaultTest {
 
     @RegisterExtension

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/SemicolonQueryParamDisabledTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/SemicolonQueryParamDisabledTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.Matchers.is;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -17,7 +16,6 @@ import io.vertx.ext.web.Router;
  * Tests that semicolons are treated as literal characters when
  * {@code quarkus.http.use-semicolon-as-query-param-delimiter} is set to {@code false}.
  */
-@Disabled("Settings not present in Vert.x 5. It needs to be investigated.")
 public class SemicolonQueryParamDisabledTest {
 
     @RegisterExtension

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtils.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtils.java
@@ -286,9 +286,7 @@ public class HttpServerOptionsUtils {
         httpServerOptions.setTcpCork(httpConfig.tcpCork());
         httpServerOptions.setAcceptBacklog(httpConfig.acceptBacklog());
         httpServerOptions.setTcpFastOpen(httpConfig.tcpFastOpen());
-        // TODO This settings has been removed from Vert.x 5. It needs to be investigated.
-        // httpServerOptions
-        //        .setUseSemicolonAsQueryParamDelimiter(httpConfig.useSemicolonAsQueryParamDelimiter());
+        httpServerOptions.setUseSemicolonAsQueryParamDelimiter(httpConfig.useSemicolonAsQueryParamDelimiter());
         httpServerOptions.setTcpUserTimeout((int) httpConfig.tcpUserTimeout().toMillis());
         httpServerOptions.setSoLinger(httpConfig.soLinger());
         if (httpConfig.sendBufferSize().isPresent()) {
@@ -454,8 +452,7 @@ public class HttpServerOptionsUtils {
         }
         options.setDecompressionSupported(managementBuildTimeConfig.enableDecompression());
         options.setHandle100ContinueAutomatically(managementConfig.handle100ContinueAutomatically());
-        // TODO This setting disappeared in Vert.x 5. It needs to be investigated.
-        // options.setUseSemicolonAsQueryParamDelimiter(managementConfig.useSemicolonAsQueryParamDelimiter());
+        options.setUseSemicolonAsQueryParamDelimiter(managementConfig.useSemicolonAsQueryParamDelimiter());
 
         options.setUseProxyProtocol(managementConfig.proxy().useProxyProtocol());
         options.setProxyProtocolTimeout(managementConfig.proxyProtocolTimeout().toMillis());

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -48,7 +48,7 @@
         <version.jandex>3.6.0</version.jandex>
         <version.gizmo2>2.1.1</version.gizmo2>
         <version.jboss-logging>3.6.3.Final</version.jboss-logging>
-        <version.mutiny>3.2.1</version.mutiny>
+        <version.mutiny>3.3.0</version.mutiny>
         <version.bridger>1.6.Final</version.bridger>
         <version.smallrye-common>2.19.0</version.smallrye-common>
         <!-- test versions -->

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -44,7 +44,7 @@
         <version.gizmo2>2.1.1</version.gizmo2>
         <version.jboss-logging>3.6.3.Final</version.jboss-logging>
         <version.smallrye-common>2.19.0</version.smallrye-common>
-        <version.smallrye-mutiny>3.2.1</version.smallrye-mutiny>
+        <version.smallrye-mutiny>3.3.0</version.smallrye-mutiny>
         <version.lsp4j>0.24.0</version.lsp4j>
     </properties>
 

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -55,10 +55,10 @@
         <gizmo.version>1.10.1</gizmo.version>
         <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>
 
-        <mutiny.version>3.2.1</mutiny.version>
-        <smallrye-mutiny-vertx-core.version>4.0.0-beta2</smallrye-mutiny-vertx-core.version>
+        <mutiny.version>3.3.0</mutiny.version>
+        <smallrye-mutiny-vertx-core.version>4.0.0</smallrye-mutiny-vertx-core.version>
         <smallrye-common.version>2.19.0</smallrye-common.version>
-        <vertx.version>5.1.2</vertx.version>
+        <vertx.version>5.1.3</vertx.version>
         <rest-assured.version>6.0.0</rest-assured.version>
         <commons-logging-jboss-logging.version>2.0.0.Final</commons-logging-jboss-logging.version>
         <jackson-bom.version>2.22.0</jackson-bom.version>

--- a/independent-projects/vertx-utils/pom.xml
+++ b/independent-projects/vertx-utils/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <jboss-logging.version>3.6.3.Final</jboss-logging.version>
-        <vertx.version>5.1.2</vertx.version>
+        <vertx.version>5.1.3</vertx.version>
     </properties>
 
     <dependencies>

--- a/integration-tests/oidc-dev-services/src/test/java/io/quarkus/it/oidc/dev/services/WebSocketOidcTest.java
+++ b/integration-tests/oidc-dev-services/src/test/java/io/quarkus/it/oidc/dev/services/WebSocketOidcTest.java
@@ -178,8 +178,7 @@ public class WebSocketOidcTest {
             // permission checker only allows 'hello', so expect connection will be closed
             // this checks that permission checker is actually invoked, which is important because it checks for us
             // that updated identity is passed to the checker on the next invocation
-            // TODO Re-enable the following assertion once https://github.com/eclipse-vertx/vert.x/issues/6144 is fixed.
-            //Assertions.assertNull(ws1.get().closeStatusCode());
+            Assertions.assertNull(ws1.get().closeStatusCode());
             ws1.get().writeTextMessage(createRequest("bye", oidcTestClient.getAccessToken("alice", "alice")));
             Awaitility.await().atMost(TIMEOUT).untilAsserted(
                     () -> {
@@ -230,18 +229,15 @@ public class WebSocketOidcTest {
             assertEquals(1, messages.size(), "Messages: " + messages);
             assertEquals("bye", messages.get(0));
 
-            // TODO Re-enable the following assertion once https://github.com/eclipse-vertx/vert.x/issues/6144 is fixed.
             // after about 2 seconds, updated SecurityIdentity will expire, so expect connection closed
-            //Assertions.assertNull(ws1.get().closeStatusCode());
+            Assertions.assertNull(ws1.get().closeStatusCode());
             Awaitility.await().atMost(TIMEOUT).untilAsserted(
                     () -> {
-                        // TODO Re-enable the following assertions once https://github.com/eclipse-vertx/vert.x/issues/6144 is fixed.
-                        //Assertions.assertNotNull(ws1.get().closeStatusCode());
-                        //assertEquals(WebSocketCloseStatus.POLICY_VIOLATION.code(), (int) ws1.get().closeStatusCode());
+                        Assertions.assertNotNull(ws1.get().closeStatusCode());
+                        assertEquals(WebSocketCloseStatus.POLICY_VIOLATION.code(), (int) ws1.get().closeStatusCode());
                     });
-            // TODO Re-enable the following assertion once https://github.com/eclipse-vertx/vert.x/issues/6144 is fixed.
-            //  var closeReason = ws1.get().closeReason();
-            //  Assertions.assertTrue(closeReason.contains("Authentication expired"), closeReason);
+            var closeReason = ws1.get().closeReason();
+            Assertions.assertTrue(closeReason.contains("Authentication expired"), closeReason);
         } finally {
             client.close().toCompletionStage().toCompletableFuture().get(5, TimeUnit.SECONDS);
         }
@@ -293,8 +289,7 @@ public class WebSocketOidcTest {
             ws1.get().writeTextMessage(nextToken);
 
             // by default the authorization failure should result in closing of the connection
-            // TODO Re-enable the following assertion once https://github.com/eclipse-vertx/vert.x/issues/6144 is fixed.
-            //Assertions.assertNull(ws1.get().closeStatusCode());
+            Assertions.assertNull(ws1.get().closeStatusCode());
             Awaitility.await().atMost(TIMEOUT).untilAsserted(
                     () -> {
                         Assertions.assertNotNull(ws1.get().closeStatusCode());


### PR DESCRIPTION
Bump Vert.x / Mutiny / Mutiny Vert.x bindings

- Vert.x 5.1.3
- Mutiny 3.3.0
- Mutiny Vert.x bindings 4.0.0

Fix missing semicolon query parameter supports

Fixes #54862
Fixes #54796

Re-enable assertions in WebSocketOidcTest now a NPE has been fixed upstream