### PR TITLE
Fix gRPC @RunOnVirtualThread half-close race under load

### DIFF
--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcServerRecorder.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcServerRecorder.java
@@ -709,15 +709,12 @@ public class GrpcServerRecorder {
         interceptors.addAll(globalInterceptors);
         interceptors.addAll(grpcContainer.getSortedPerServiceInterceptors(service.getImplementationClassName()));
 
-        // We only register the blocking interceptor if needed by at least one method of the service (either blocking or runOnVirtualThread)
-        if (!blockingMethodsPerService.isEmpty()) {
-            List<String> list = blockingMethodsPerService.get(service.getImplementationClassName());
-            List<String> virtuals = virtualMethodsPerService.get(service.getImplementationClassName());
-            if (list != null || virtuals != null) {
-                interceptors
-                        .add(new BlockingServerInterceptor(vertx, list, virtuals,
-                                VirtualThreadsRecorder.getCurrent(), devMode));
-            }
+        List<String> list = blockingMethodsPerService.get(service.getImplementationClassName());
+        List<String> virtuals = virtualMethodsPerService.get(service.getImplementationClassName());
+        if (list != null || virtuals != null) {
+            interceptors
+                    .add(new BlockingServerInterceptor(vertx, list, virtuals,
+                            VirtualThreadsRecorder.getCurrent(), devMode));
         }
         interceptors.sort(Interceptors.INTERCEPTOR_COMPARATOR);
         return ServerInterceptors.intercept(service.definition, interceptors);

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/blocking/BlockingServerInterceptor.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/blocking/BlockingServerInterceptor.java
@@ -19,6 +19,7 @@ import org.jboss.logging.Logger;
 
 import io.grpc.Context;
 import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
@@ -166,7 +167,8 @@ public class BlockingServerInterceptor implements ServerInterceptor, Function<St
             // it is initialized by io.quarkus.grpc.runtime.supports.context.GrpcRequestContextGrpcInterceptor
             // that should always be called before this interceptor
             ContextState state = requestContext.getState();
-            VirtualReplayListener<ReqT> replay = new VirtualReplayListener<>(state);
+            boolean deferHalfCloseUntilMessage = deferHalfCloseUntilMessage(call.getMethodDescriptor().getType());
+            VirtualReplayListener<ReqT> replay = new VirtualReplayListener<>(state, deferHalfCloseUntilMessage);
             virtualThreadExecutor.execute(() -> {
                 ServerCall.Listener<ReqT> listener;
                 try {
@@ -184,7 +186,8 @@ public class BlockingServerInterceptor implements ServerInterceptor, Function<St
             // it is initialized by io.quarkus.grpc.runtime.supports.context.GrpcRequestContextGrpcInterceptor
             // that should always be called before this interceptor
             ContextState state = requestContext.getState();
-            ReplayListener<ReqT> replay = new ReplayListener<>(state);
+            boolean deferHalfCloseUntilMessage = deferHalfCloseUntilMessage(call.getMethodDescriptor().getType());
+            ReplayListener<ReqT> replay = new ReplayListener<>(state, deferHalfCloseUntilMessage);
             vertx.executeBlocking(() -> {
                 ServerCall.Listener<ReqT> listener;
                 try {
@@ -218,6 +221,7 @@ public class BlockingServerInterceptor implements ServerInterceptor, Function<St
     private class ReplayListener<ReqT> extends ServerCall.Listener<ReqT> {
         private final InjectableContext.ContextState requestContextState;
         private final Context grpcContext;
+        private final boolean deferHalfCloseUntilMessage;
 
         // exclusive to event loop context
         private volatile ServerCall.Listener<ReqT> delegate;
@@ -228,10 +232,12 @@ public class BlockingServerInterceptor implements ServerInterceptor, Function<St
         // preserve the request-before-half-close invariant before draining.
         private final Deque<ReplayEvent<ReqT>> incomingEvents = new ArrayDeque<>();
         private volatile boolean isConsumingFromIncomingEvents;
+        private boolean messageReceived;
 
-        private ReplayListener(InjectableContext.ContextState requestContextState) {
+        private ReplayListener(InjectableContext.ContextState requestContextState, boolean deferHalfCloseUntilMessage) {
             this.requestContextState = requestContextState;
             this.grpcContext = Context.current();
+            this.deferHalfCloseUntilMessage = deferHalfCloseUntilMessage;
         }
 
         /**
@@ -241,15 +247,24 @@ public class BlockingServerInterceptor implements ServerInterceptor, Function<St
          * @param delegate the original
          */
         void setDelegate(ServerCall.Listener<ReqT> delegate) {
-            ReplayEvent<ReqT> first = null;
             synchronized (incomingEvents) {
                 this.delegate = delegate;
-                if (!this.isConsumingFromIncomingEvents) {
-                    reorderForRequestBeforeHalfClose(incomingEvents);
-                    first = incomingEvents.poll();
-                    if (first != null) {
-                        this.isConsumingFromIncomingEvents = true;
-                    }
+            }
+            tryStartDraining();
+        }
+
+        private void tryStartDraining() {
+            ReplayEvent<ReqT> first = null;
+            synchronized (incomingEvents) {
+                if (this.delegate == null || this.isConsumingFromIncomingEvents) {
+                    return;
+                }
+                if (!prepareDrainQueue(deferHalfCloseUntilMessage, messageReceived, incomingEvents)) {
+                    return;
+                }
+                first = incomingEvents.poll();
+                if (first != null) {
+                    this.isConsumingFromIncomingEvents = true;
                 }
             }
             if (first != null) {
@@ -260,7 +275,14 @@ public class BlockingServerInterceptor implements ServerInterceptor, Function<St
         private void scheduleOrEnqueue(ReplayEvent<ReqT> event) {
             Consumer<ServerCall.Listener<ReqT>> toRunDirectly = null;
             synchronized (incomingEvents) {
-                if (this.delegate != null && !this.isConsumingFromIncomingEvents && incomingEvents.isEmpty()) {
+                if (event.kind == EventKind.MESSAGE) {
+                    messageReceived = true;
+                }
+                boolean canRunDirectly = this.delegate != null
+                        && !this.isConsumingFromIncomingEvents
+                        && incomingEvents.isEmpty()
+                        && !(deferHalfCloseUntilMessage && event.kind == EventKind.HALF_CLOSE && !messageReceived);
+                if (canRunDirectly) {
                     toRunDirectly = event.action;
                     this.isConsumingFromIncomingEvents = true;
                 } else {
@@ -269,6 +291,8 @@ public class BlockingServerInterceptor implements ServerInterceptor, Function<St
             }
             if (toRunDirectly != null) {
                 executeBlockingWithRequestContext(toRunDirectly);
+            } else {
+                tryStartDraining();
             }
         }
 
@@ -300,7 +324,11 @@ public class BlockingServerInterceptor implements ServerInterceptor, Function<St
             vertx.executeBlocking(blockingHandler, false).onComplete(p -> {
                 ReplayEvent<ReqT> next;
                 synchronized (incomingEvents) {
-                    next = incomingEvents.poll();
+                    ReplayEvent<ReqT> polled = null;
+                    if (prepareDrainQueue(deferHalfCloseUntilMessage, messageReceived, incomingEvents)) {
+                        polled = incomingEvents.poll();
+                    }
+                    next = polled;
                     if (next == null) {
                         this.isConsumingFromIncomingEvents = false;
                     }
@@ -342,12 +370,13 @@ public class BlockingServerInterceptor implements ServerInterceptor, Function<St
      * When injected, replay the events.
      * <p>
      * Note that event must be executed in order, explaining why incomingEvents
-     * are executed sequentially
+     * are executed sequentially.
      * <p>
      * This replay listener is only used for virtual threads.
      */
     private class VirtualReplayListener<ReqT> extends ServerCall.Listener<ReqT> {
         private final InjectableContext.ContextState requestContextState;
+        private final boolean deferHalfCloseUntilMessage;
 
         // exclusive to event loop context
         private ServerCall.Listener<ReqT> delegate;
@@ -355,9 +384,12 @@ public class BlockingServerInterceptor implements ServerInterceptor, Function<St
         // rationale on why this is reordered before draining.
         private final Deque<ReplayEvent<ReqT>> incomingEvents = new ArrayDeque<>();
         private volatile boolean isConsumingFromIncomingEvents = false;
+        private boolean messageReceived;
 
-        private VirtualReplayListener(InjectableContext.ContextState requestContextState) {
+        private VirtualReplayListener(InjectableContext.ContextState requestContextState,
+                boolean deferHalfCloseUntilMessage) {
             this.requestContextState = requestContextState;
+            this.deferHalfCloseUntilMessage = deferHalfCloseUntilMessage;
         }
 
         /**
@@ -367,15 +399,24 @@ public class BlockingServerInterceptor implements ServerInterceptor, Function<St
          * @param delegate the original
          */
         void setDelegate(ServerCall.Listener<ReqT> delegate) {
-            ReplayEvent<ReqT> first = null;
             synchronized (incomingEvents) {
                 this.delegate = delegate;
-                if (!this.isConsumingFromIncomingEvents) {
-                    reorderForRequestBeforeHalfClose(incomingEvents);
-                    first = incomingEvents.poll();
-                    if (first != null) {
-                        this.isConsumingFromIncomingEvents = true;
-                    }
+            }
+            tryStartDraining();
+        }
+
+        private void tryStartDraining() {
+            ReplayEvent<ReqT> first = null;
+            synchronized (incomingEvents) {
+                if (this.delegate == null || this.isConsumingFromIncomingEvents) {
+                    return;
+                }
+                if (!prepareDrainQueue(deferHalfCloseUntilMessage, messageReceived, incomingEvents)) {
+                    return;
+                }
+                first = incomingEvents.poll();
+                if (first != null) {
+                    this.isConsumingFromIncomingEvents = true;
                 }
             }
             if (first != null) {
@@ -386,7 +427,14 @@ public class BlockingServerInterceptor implements ServerInterceptor, Function<St
         private void scheduleOrEnqueue(ReplayEvent<ReqT> event) {
             Consumer<ServerCall.Listener<ReqT>> toRunDirectly = null;
             synchronized (incomingEvents) {
-                if (this.delegate != null && !this.isConsumingFromIncomingEvents && incomingEvents.isEmpty()) {
+                if (event.kind == EventKind.MESSAGE) {
+                    messageReceived = true;
+                }
+                boolean canRunDirectly = this.delegate != null
+                        && !this.isConsumingFromIncomingEvents
+                        && incomingEvents.isEmpty()
+                        && !(deferHalfCloseUntilMessage && event.kind == EventKind.HALF_CLOSE && !messageReceived);
+                if (canRunDirectly) {
                     toRunDirectly = event.action;
                     this.isConsumingFromIncomingEvents = true;
                 } else {
@@ -395,6 +443,8 @@ public class BlockingServerInterceptor implements ServerInterceptor, Function<St
             }
             if (toRunDirectly != null) {
                 executeVirtualWithRequestContext(toRunDirectly);
+            } else {
+                tryStartDraining();
             }
         }
 
@@ -416,7 +466,11 @@ public class BlockingServerInterceptor implements ServerInterceptor, Function<St
                     finalBlockingHandler.call();
                     ReplayEvent<ReqT> next;
                     synchronized (incomingEvents) {
-                        next = incomingEvents.poll();
+                        ReplayEvent<ReqT> polled = null;
+                        if (prepareDrainQueue(deferHalfCloseUntilMessage, messageReceived, incomingEvents)) {
+                            polled = incomingEvents.poll();
+                        }
+                        next = polled;
                         if (next == null) {
                             this.isConsumingFromIncomingEvents = false;
                         }
@@ -454,6 +508,29 @@ public class BlockingServerInterceptor implements ServerInterceptor, Function<St
         public void onReady() {
             scheduleOrEnqueue(new ReplayEvent<>(EventKind.OTHER, ServerCall.Listener::onReady));
         }
+    }
+
+    /**
+     * Unary and server-streaming RPCs require an inbound request message before the client's
+     * half-close can be delivered to the grpc-stub listener. Client-streaming and bidi may
+     * legitimately half-close with zero messages (empty client stream).
+     */
+    private static boolean deferHalfCloseUntilMessage(MethodDescriptor.MethodType type) {
+        return type == MethodDescriptor.MethodType.UNARY
+                || type == MethodDescriptor.MethodType.SERVER_STREAMING;
+    }
+
+    /**
+     * Prepares the event queue for draining. Always reorders messages ahead of half-close for
+     * every method type; optionally blocks draining when a unary / server-streaming call has
+     * not yet received its request message.
+     *
+     * @return {@code true} if the caller may poll the queue; {@code false} if draining must wait
+     */
+    private static <ReqT> boolean prepareDrainQueue(boolean deferHalfCloseUntilMessage, boolean messageReceived,
+            Deque<ReplayEvent<ReqT>> queue) {
+        reorderForRequestBeforeHalfClose(queue);
+        return !deferHalfCloseUntilMessage || messageReceived;
     }
 
     /**

--- a/extensions/grpc/runtime/src/test/java/io/quarkus/grpc/runtime/supports/blocking/BlockingServerInterceptorEventOrderingTest.java
+++ b/extensions/grpc/runtime/src/test/java/io/quarkus/grpc/runtime/supports/blocking/BlockingServerInterceptorEventOrderingTest.java
@@ -289,6 +289,182 @@ class BlockingServerInterceptorEventOrderingTest {
                 .containsExactly("onMessage:first", "onMessage:second", "onHalfClose");
     }
 
+    /**
+     * {@code onHalfClose} alone is queued before the deferred executor runs; {@code onMessage} arrives only
+     * after {@code setDelegate}.
+     */
+    @Test
+    @Timeout(10)
+    void virtualThreadPath_deliversOnMessageBeforeOnHalfClose_whenMessageArrivesAfterSetDelegate() throws Exception {
+        BlockingServerInterceptor interceptor = newInterceptor(Collections.emptyList(),
+                Collections.singletonList("unary"));
+
+        ServerCall serverCall = mock(ServerCall.class);
+        MethodDescriptor methodDescriptor = mock(MethodDescriptor.class);
+        when(methodDescriptor.getFullMethodName()).thenReturn("my-service/unary");
+        when(methodDescriptor.getType()).thenReturn(MethodDescriptor.MethodType.UNARY);
+        when(serverCall.getMethodDescriptor()).thenReturn(methodDescriptor);
+
+        RecordingServerCallHandler next = new RecordingServerCallHandler();
+        ServerCall.Listener replayListener = interceptor.interceptCall(serverCall, new Metadata(), next);
+
+        replayListener.onHalfClose();
+        runAllDeferredTasks();
+        replayListener.onMessage("hi");
+        runAllDeferredTasks();
+
+        next.awaitEvents(2);
+        assertThat(next.events)
+                .as("onMessage must be delivered after setDelegate even if onHalfClose was queued first")
+                .containsExactly("onMessage:hi", "onHalfClose");
+    }
+
+    /**
+     * Same deferred-message race on the {@code @Blocking} path.
+     */
+    @Test
+    @Timeout(10)
+    void blockingPath_deliversOnMessageBeforeOnHalfClose_whenMessageArrivesAfterSetDelegate() throws Exception {
+        BlockingServerInterceptor interceptor = newInterceptor(Collections.singletonList("unary"),
+                Collections.emptyList());
+
+        ServerCall serverCall = mock(ServerCall.class);
+        MethodDescriptor methodDescriptor = mock(MethodDescriptor.class);
+        when(methodDescriptor.getFullMethodName()).thenReturn("my-service/unary");
+        when(methodDescriptor.getType()).thenReturn(MethodDescriptor.MethodType.UNARY);
+        when(serverCall.getMethodDescriptor()).thenReturn(methodDescriptor);
+
+        RecordingServerCallHandler next = new RecordingServerCallHandler();
+        next.startCallGate.set(true);
+
+        ServerCall.Listener replayListener = interceptor.interceptCall(serverCall, new Metadata(), next);
+
+        replayListener.onHalfClose();
+        next.startCallGate.set(false);
+        synchronized (next.startCallGate) {
+            next.startCallGate.notifyAll();
+        }
+        replayListener.onMessage("hi");
+
+        next.awaitEvents(2);
+        assertThat(next.events)
+                .as("onMessage must be delivered after setDelegate even if onHalfClose was queued first")
+                .containsExactly("onMessage:hi", "onHalfClose");
+    }
+
+    @Test
+    @Timeout(10)
+    void serverStreaming_virtualThreadPath_defersHalfCloseUntilRequestMessage() throws Exception {
+        BlockingServerInterceptor interceptor = newInterceptor(Collections.emptyList(),
+                Collections.singletonList("serverStreaming"));
+
+        ServerCall serverCall = mock(ServerCall.class);
+        MethodDescriptor methodDescriptor = mock(MethodDescriptor.class);
+        when(methodDescriptor.getFullMethodName()).thenReturn("my-service/serverStreaming");
+        when(methodDescriptor.getType()).thenReturn(MethodDescriptor.MethodType.SERVER_STREAMING);
+        when(serverCall.getMethodDescriptor()).thenReturn(methodDescriptor);
+
+        RecordingServerCallHandler next = new RecordingServerCallHandler();
+        ServerCall.Listener replayListener = interceptor.interceptCall(serverCall, new Metadata(), next);
+
+        replayListener.onHalfClose();
+        runAllDeferredTasks();
+        assertThat(next.events).isEmpty();
+
+        replayListener.onMessage("hi");
+        runAllDeferredTasks();
+
+        next.awaitEvents(2);
+        assertThat(next.events).containsExactly("onMessage:hi", "onHalfClose");
+    }
+
+    @Test
+    @Timeout(10)
+    void clientStreaming_virtualThreadPath_promotesMultipleMessagesBeforeHalfClose() throws Exception {
+        BlockingServerInterceptor interceptor = newInterceptor(Collections.emptyList(),
+                Collections.singletonList("clientStreaming"));
+
+        ServerCall serverCall = mock(ServerCall.class);
+        MethodDescriptor methodDescriptor = mock(MethodDescriptor.class);
+        when(methodDescriptor.getFullMethodName()).thenReturn("my-service/clientStreaming");
+        when(methodDescriptor.getType()).thenReturn(MethodDescriptor.MethodType.CLIENT_STREAMING);
+        when(serverCall.getMethodDescriptor()).thenReturn(methodDescriptor);
+
+        RecordingServerCallHandler next = new RecordingServerCallHandler();
+        ServerCall.Listener replayListener = interceptor.interceptCall(serverCall, new Metadata(), next);
+
+        replayListener.onHalfClose();
+        replayListener.onMessage("first");
+        replayListener.onMessage("second");
+        runAllDeferredTasks();
+
+        next.awaitEvents(3);
+        assertThat(next.events).containsExactly("onMessage:first", "onMessage:second", "onHalfClose");
+    }
+
+    @Test
+    @Timeout(10)
+    void clientStreaming_virtualThreadPath_allowsHalfCloseWithoutRequestMessage() throws Exception {
+        BlockingServerInterceptor interceptor = newInterceptor(Collections.emptyList(),
+                Collections.singletonList("clientStreaming"));
+
+        ServerCall serverCall = mock(ServerCall.class);
+        MethodDescriptor methodDescriptor = mock(MethodDescriptor.class);
+        when(methodDescriptor.getFullMethodName()).thenReturn("my-service/clientStreaming");
+        when(methodDescriptor.getType()).thenReturn(MethodDescriptor.MethodType.CLIENT_STREAMING);
+        when(serverCall.getMethodDescriptor()).thenReturn(methodDescriptor);
+
+        RecordingServerCallHandler next = new RecordingServerCallHandler();
+        ServerCall.Listener replayListener = interceptor.interceptCall(serverCall, new Metadata(), next);
+
+        replayListener.onHalfClose();
+        runAllDeferredTasks();
+
+        next.awaitEvents(1);
+        assertThat(next.events).containsExactly("onHalfClose");
+    }
+
+    @Test
+    @Timeout(10)
+    void virtualThreadPath_messageReceivedSetUnderLockBeforeSetDelegateDrains() throws Exception {
+        BlockingServerInterceptor interceptor = newInterceptor(Collections.emptyList(),
+                Collections.singletonList("unary"));
+
+        ServerCall serverCall = mock(ServerCall.class);
+        MethodDescriptor methodDescriptor = mock(MethodDescriptor.class);
+        when(methodDescriptor.getFullMethodName()).thenReturn("my-service/unary");
+        when(methodDescriptor.getType()).thenReturn(MethodDescriptor.MethodType.UNARY);
+        when(serverCall.getMethodDescriptor()).thenReturn(methodDescriptor);
+
+        RecordingServerCallHandler next = new RecordingServerCallHandler();
+        next.blockStartCallUntilMessageReceived.set(true);
+
+        ServerCall.Listener replayListener = interceptor.interceptCall(serverCall, new Metadata(), next);
+        replayListener.onHalfClose();
+
+        Thread executorThread = new Thread(() -> {
+            Runnable task = deferred.poll();
+            if (task != null) {
+                task.run();
+            }
+        });
+        executorThread.start();
+        executorThread.join(2000);
+
+        assertThat(next.events).isEmpty();
+
+        replayListener.onMessage("hi");
+        next.blockStartCallUntilMessageReceived.set(false);
+        synchronized (next.blockStartCallUntilMessageReceived) {
+            next.blockStartCallUntilMessageReceived.notifyAll();
+        }
+        executorThread.join(2000);
+        runAllDeferredTasks();
+
+        next.awaitEvents(2);
+        assertThat(next.events).containsExactly("onMessage:hi", "onHalfClose");
+    }
+
     private BlockingServerInterceptor newInterceptor(List<String> blocking, List<String> virtual) {
         return new BlockingServerInterceptor(vertx, blocking, virtual, controllableVirtualExecutor, false) {
             @Override
@@ -318,6 +494,8 @@ class BlockingServerInterceptorEventOrderingTest {
 
         final List<String> events = new CopyOnWriteArrayList<>();
         final java.util.concurrent.atomic.AtomicBoolean startCallGate = new java.util.concurrent.atomic.AtomicBoolean(false);
+        final java.util.concurrent.atomic.AtomicBoolean blockStartCallUntilMessageReceived = new java.util.concurrent.atomic.AtomicBoolean(
+                false);
 
         @Override
         public ServerCall.Listener startCall(ServerCall serverCall, Metadata metadata) {
@@ -327,6 +505,16 @@ class BlockingServerInterceptorEventOrderingTest {
                 while (startCallGate.get()) {
                     try {
                         startCallGate.wait();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+            synchronized (blockStartCallUntilMessageReceived) {
+                while (blockStartCallUntilMessageReceived.get()) {
+                    try {
+                        blockStartCallUntilMessageReceived.wait(50);
                     } catch (InterruptedException e) {
                         Thread.currentThread().interrupt();
                         throw new RuntimeException(e);
@@ -371,4 +559,5 @@ class BlockingServerInterceptorEventOrderingTest {
             }
         }
     }
+
 }


### PR DESCRIPTION
When a gRPC service method is annotated with `@RunOnVirtualThread` and the server uses the unified HTTP transport (`quarkus.grpc.server.use-separate-server=false`), `BlockingServerInterceptor` defers `startCall` onto a virtual thread. That delays `call.request(N)`, which gates delivery of `onMessage`, while `onHalfClose` is not gated. Under load the replay listener could therefore deliver `onHalfClose` before `onMessage`, causing grpc-java to close the call with `INTERNAL: Half-closed without a request` (#48940).

This change defers draining `onHalfClose` for unary calls until the request message has been received, prevents the fast-path from running `onHalfClose` too early, and reorders queued events before every drain. It also fixes interceptor registration for services that only use `@RunOnVirtualThread` (no `@Blocking` methods), where `BlockingServerInterceptor` was previously skipped.

Fixes #48940
