### PR TITLE
CycloneDX SBOM fixes

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractFastJarBuilder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/jar/AbstractFastJarBuilder.java
@@ -57,6 +57,7 @@ import io.quarkus.deployment.pkg.builditem.JarBuildItem;
 import io.quarkus.deployment.pkg.builditem.JarTreeShakeBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
 import io.quarkus.deployment.util.FileUtil;
+import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.maven.dependency.GACT;
 import io.quarkus.maven.dependency.ResolvedDependency;
@@ -248,6 +249,8 @@ abstract class AbstractFastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
             }
         }
         final Map<ArtifactKey, List<Path>> copiedArtifacts = new HashMap<>();
+        Path bootstrapRunnerPath = null;
+        List<ArtifactCoords> bootArtifacts = new ArrayList<>();
         Set<PosixFilePermission> newFilePermissions = probeNewFilePermissions(baseLib);
         for (ResolvedDependency appDep : curateOutcome.getApplicationModel().getRuntimeDependencies()) {
             if (!rebuild) {
@@ -260,6 +263,13 @@ abstract class AbstractFastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
             }
             if (parentFirstArtifactKeys.contains(appDep.getKey())) {
                 appDep.getResolvedPaths().forEach(parentFirst::add);
+                bootArtifacts.add(appDep);
+                if ("quarkus-bootstrap-runner".equals(appDep.getArtifactId())) {
+                    List<Path> paths = copiedArtifacts.get(appDep.getKey());
+                    if (paths != null && !paths.isEmpty()) {
+                        bootstrapRunnerPath = paths.get(0);
+                    }
+                }
             }
         }
         for (AdditionalApplicationArchiveBuildItem i : additionalApplicationArchives) {
@@ -292,9 +302,20 @@ abstract class AbstractFastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
 
         runnerJar.toFile().setReadable(true, false);
         Path initJar = buildDir.resolve(FastJarFormat.QUARKUS_RUN_JAR);
+        List<ArtifactCoords> mainDeps = new ArrayList<>(bootArtifacts);
         manifestConfig.setMainPurl(Purl.generic(initJar.getFileName().toString(), appArtifact.getVersion()))
-                .setMainDependencies(List.of(curateOutcome.getApplicationModel().getAppArtifact()))
+                .setMainDependencies(mainDeps)
                 .setMainPath(initJar);
+
+        if (bootstrapRunnerPath != null) {
+            manifestConfig.addFileDependency(bootstrapRunnerPath, runnerJar);
+            manifestConfig.addFileDependency(bootstrapRunnerPath, generatedZip);
+            manifestConfig.addFileDependency(bootstrapRunnerPath, appInfo);
+            if (fastJarJars.transformedJar != null) {
+                manifestConfig.addFileDependency(bootstrapRunnerPath, fastJarJars.transformedJar);
+            }
+        }
+
         boolean mutableJar = packageConfig.jar().type() == MUTABLE_JAR;
         if (mutableJar) {
             //we output the properties in a reproducible manner, so we remove the date comment
@@ -388,6 +409,7 @@ abstract class AbstractFastJarBuilder extends AbstractJarBuilder<JarBuildItem> {
                 }
                 lines.sort(Comparator.naturalOrder());
                 Files.write(deplist, lines);
+                manifestConfig.addFileDependency(initJar, deplist);
             }
         } else {
             //if it is a rebuild we might have classes

--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/SbomContributionFastJarTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/SbomContributionFastJarTest.java
@@ -4,6 +4,7 @@ import java.util.Properties;
 
 import org.junit.jupiter.api.BeforeEach;
 
+import io.quarkus.bootstrap.model.ApplicationModelBuilder;
 import io.quarkus.bootstrap.resolver.TsArtifact;
 import io.quarkus.bootstrap.resolver.TsQuarkusExt;
 import io.quarkus.maven.dependency.ArtifactCoords;
@@ -28,9 +29,14 @@ public class SbomContributionFastJarTest extends SbomContributionTestBase {
         var myLib = TsArtifact.jar("my-lib");
         myLib.addDependency(acmeCommon);
 
+        var bootstrapRunner = TsArtifact.jar("quarkus-bootstrap-runner");
+
         var myExt = new TsQuarkusExt("my-ext");
         myExt.getRuntime().addDependency(myLib);
+        myExt.getRuntime().addDependency(bootstrapRunner);
         myExt.getDeployment().addDependency(otherLib);
+        myExt.setDescriptorProp(ApplicationModelBuilder.RUNNER_PARENT_FIRST_ARTIFACTS,
+                bootstrapRunner.getKey().toString());
 
         return TsArtifact.jar("app", "2.0")
                 .addManagedDependency(platformDescriptor())
@@ -50,7 +56,10 @@ public class SbomContributionFastJarTest extends SbomContributionTestBase {
     @BeforeEach
     public void initExpectedComponents() {
 
-        expectMavenComponent(ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "app", "2.0"), comp -> {
+        final ArtifactCoords appCoords = ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "app", "2.0");
+        final ArtifactCoords bootstrapRunnerCoords = artifactCoords("quarkus-bootstrap-runner");
+
+        expectMavenComponent(appCoords, comp -> {
             assertDistributionPath(comp, "app/quarkus-application.jar");
             assertVersion(comp, "2.0");
             assertDependencies(comp,
@@ -101,13 +110,29 @@ public class SbomContributionFastJarTest extends SbomContributionTestBase {
         expectMavenComponent(artifactCoords("my-ext"), comp -> {
             assertDistributionPath(comp, "lib/main/io.quarkus.bootstrap.test.my-ext-1.jar");
             assertVersion(comp, TsArtifact.DEFAULT_VERSION);
-            assertDependencies(comp, artifactCoords("my-lib"));
+            assertDependencies(comp,
+                    artifactCoords("my-lib"),
+                    bootstrapRunnerCoords);
             assertDependencyScope(comp, ComponentDescriptor.SCOPE_RUNTIME);
         });
 
+        // quarkus-run.jar depends on boot jars and quarkus-app-dependencies.txt
         expectFileComponent("quarkus-run.jar", comp -> {
             assertVersion(comp, "2.0");
-            assertDependencies(comp, ArtifactCoords.jar(TsArtifact.DEFAULT_GROUP_ID, "app", "2.0"));
+            assertDependencyBomRefs(comp,
+                    toBomRef(bootstrapRunnerCoords),
+                    "pkg:generic/quarkus-app-dependencies.txt@2.0");
+            assertDependencyScope(comp, ComponentDescriptor.SCOPE_RUNTIME);
+        });
+
+        // bootstrap runner depends on app jar, generated-bytecode, and quarkus-application.dat
+        expectMavenComponent(bootstrapRunnerCoords, comp -> {
+            assertDistributionPath(comp, "lib/boot/io.quarkus.bootstrap.test.quarkus-bootstrap-runner-1.jar");
+            assertVersion(comp, TsArtifact.DEFAULT_VERSION);
+            assertDependencyBomRefs(comp,
+                    toBomRef(appCoords),
+                    "pkg:generic/generated-bytecode.jar@2.0",
+                    "pkg:generic/quarkus-application.dat@2.0");
             assertDependencyScope(comp, ComponentDescriptor.SCOPE_RUNTIME);
         });
 

--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/SbomContributionMutableJarTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/SbomContributionMutableJarTest.java
@@ -103,7 +103,7 @@ public class SbomContributionMutableJarTest extends SbomContributionTestBase {
 
         expectFileComponent("quarkus-run.jar", comp -> {
             assertVersion(comp, TsArtifact.DEFAULT_VERSION);
-            assertDependencies(comp, artifactCoords("app"));
+            assertDependencyBomRefs(comp, "pkg:generic/quarkus-app-dependencies.txt@" + TsArtifact.DEFAULT_VERSION);
             assertDependencyScope(comp, ComponentDescriptor.SCOPE_RUNTIME);
         });
 

--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/SbomContributionTestBase.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/SbomContributionTestBase.java
@@ -59,7 +59,7 @@ public abstract class SbomContributionTestBase extends BootstrapFromOriginalJarT
         });
     }
 
-    private static String toBomRef(ArtifactCoords coords) {
+    protected static String toBomRef(ArtifactCoords coords) {
         return Purl.maven(coords.getGroupId(), coords.getArtifactId(), coords.getVersion(),
                 coords.getType(), coords.getClassifier().isEmpty() ? null : coords.getClassifier()).toString();
     }
@@ -117,6 +117,16 @@ public abstract class SbomContributionTestBase extends BootstrapFromOriginalJarT
                     .as(() -> desc.getBomRef() + " has dependencies")
                     .isEqualTo(expectedBomRefs);
         }
+    }
+
+    protected void assertDependencyBomRefs(ComponentDescriptor desc, String... expectedBomRefs) {
+        ComponentDependencies deps = dependenciesMap.get(desc.getBomRef());
+        assertThat(deps)
+                .as(() -> desc.getBomRef() + " has dependency record")
+                .isNotNull();
+        assertThat(new HashSet<>(deps.getDependsOn()))
+                .as(() -> desc.getBomRef() + " has dependencies")
+                .isEqualTo(Set.of(expectedBomRefs));
     }
 
     @Override

--- a/extensions/cyclonedx/generator/src/main/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGenerator.java
+++ b/extensions/cyclonedx/generator/src/main/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGenerator.java
@@ -258,6 +258,11 @@ public class CycloneDxSbomGenerator {
             addTopLevelDependencies(allDescriptors, dependencyMap);
         }
 
+        // Ensure every component has a dependency entry, even leaf nodes with no dependencies
+        for (ComponentDescriptor descriptor : allDescriptors) {
+            dependencyMap.computeIfAbsent(descriptor.getBomRef(), Dependency::new);
+        }
+
         for (Dependency d : dependencyMap.values()) {
             bom.addDependency(d);
         }

--- a/extensions/cyclonedx/generator/src/main/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGenerator.java
+++ b/extensions/cyclonedx/generator/src/main/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGenerator.java
@@ -468,6 +468,11 @@ public class CycloneDxSbomGenerator {
             c.setLicenses(resolveDescriptorLicenses(descriptor.getLicenses()));
         }
 
+        // Nested (bundled) components
+        for (ComponentDescriptor nested : descriptor.getComponents()) {
+            c.addComponent(renderComponentCore(nested));
+        }
+
         c.setProperties(props);
         return c;
     }

--- a/extensions/cyclonedx/generator/src/test/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGeneratorTest.java
+++ b/extensions/cyclonedx/generator/src/test/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGeneratorTest.java
@@ -266,6 +266,40 @@ class CycloneDxSbomGeneratorTest {
                 .startsWith("urn:uuid:");
     }
 
+    @Test
+    void nestedComponentsRenderedAsBundledComponents() {
+        ComponentDescriptor nested = ComponentDescriptor.builder()
+                .setPurl(Purl.maven("org.bundled", "bundled-dep", "2.0.0", "jar", null))
+                .setBomRef("pkg:maven/org.bundled/bundled-dep@2.0.0?type=jar#bundled")
+                .build();
+
+        ComponentDescriptor parent = ComponentDescriptor.builder()
+                .setPurl(Purl.maven("com.example", "shaded-lib", "1.0.0", "jar", null))
+                .addComponent(nested)
+                .build();
+
+        SbomContribution contribution = SbomContribution.ofComponents(List.of(parent));
+
+        Bom bom = parseBom(CycloneDxSbomGenerator.newInstance()
+                .setFormat("json")
+                .setContributions(List.of(contribution))
+                .generateText().get(0));
+
+        org.cyclonedx.model.Component parentComp = bom.getComponents().stream()
+                .filter(c -> c.getName().equals("shaded-lib"))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(parentComp.getComponents())
+                .as("Parent should contain nested bundled component")
+                .hasSize(1);
+
+        org.cyclonedx.model.Component nestedComp = parentComp.getComponents().get(0);
+        assertThat(nestedComp.getName()).isEqualTo("bundled-dep");
+        assertThat(nestedComp.getGroup()).isEqualTo("org.bundled");
+        assertThat(nestedComp.getVersion()).isEqualTo("2.0.0");
+    }
+
     private static Bom parseBom(String json) {
         try {
             return new org.cyclonedx.parsers.JsonParser().parse(json.getBytes());

--- a/extensions/cyclonedx/generator/src/test/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGeneratorTest.java
+++ b/extensions/cyclonedx/generator/src/test/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGeneratorTest.java
@@ -169,6 +169,38 @@ class CycloneDxSbomGeneratorTest {
     }
 
     @Test
+    void leafComponentsHaveDependencyEntries() {
+        ComponentDescriptor react = ComponentDescriptor.builder()
+                .setPurl(Purl.npm(null, "react", "18.0.0"))
+                .build();
+        ComponentDescriptor jsTokens = ComponentDescriptor.builder()
+                .setPurl(Purl.npm(null, "js-tokens", "4.0.0"))
+                .build();
+        SbomContribution contribution = SbomContribution.of(
+                List.of(react, jsTokens),
+                List.of(ComponentDependencies.of(
+                        react.getBomRef(),
+                        List.of(jsTokens.getBomRef()))));
+
+        Bom bom = parseBom(CycloneDxSbomGenerator.newInstance()
+                .setFormat("json")
+                .setContributions(List.of(contribution))
+                .generateText().get(0));
+
+        // js-tokens is a leaf with no dependencies of its own,
+        // but it should still have an entry in the dependency graph
+        assertThat(bom.getDependencies())
+                .extracting(Dependency::getRef)
+                .contains(react.getBomRef(), jsTokens.getBomRef());
+
+        Dependency jsTokensDep = bom.getDependencies().stream()
+                .filter(d -> d.getRef().equals(jsTokens.getBomRef()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(jsTokensDep.getDependencies()).isNullOrEmpty();
+    }
+
+    @Test
     void serialNumberIsDeterministicWithOutputTimestamp() {
         Instant timestamp = Instant.parse("2025-01-15T10:00:00Z");
         ComponentDescriptor react = ComponentDescriptor.builder()

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/sbom/ComponentDescriptor.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/sbom/ComponentDescriptor.java
@@ -58,6 +58,9 @@ public class ComponentDescriptor {
             if (!this.licenses.isEmpty()) {
                 this.licenses = new ArrayList<>(this.licenses);
             }
+            if (!this.components.isEmpty()) {
+                this.components = new ArrayList<>(this.components);
+            }
         }
 
         /**
@@ -212,6 +215,21 @@ public class ComponentDescriptor {
         }
 
         /**
+         * Adds a nested (bundled) component to this component.
+         *
+         * @param component the nested component descriptor
+         * @return this builder
+         */
+        public Builder addComponent(ComponentDescriptor component) {
+            Objects.requireNonNull(component, "component is required");
+            if (this.components.isEmpty()) {
+                this.components = new ArrayList<>(2);
+            }
+            this.components.add(component);
+            return this;
+        }
+
+        /**
          * Builds an immutable ComponentDescriptor from this builder.
          *
          * @return a new immutable ComponentDescriptor instance
@@ -239,6 +257,7 @@ public class ComponentDescriptor {
     protected String pedigree;
     protected boolean topLevel;
     protected List<LicenseInfo> licenses = List.of();
+    protected List<ComponentDescriptor> components = List.of();
 
     private ComponentDescriptor() {
     }
@@ -254,6 +273,7 @@ public class ComponentDescriptor {
         this.pedigree = builder.pedigree;
         this.topLevel = builder.topLevel;
         this.licenses = List.copyOf(builder.licenses);
+        this.components = List.copyOf(builder.components);
     }
 
     /**
@@ -395,6 +415,19 @@ public class ComponentDescriptor {
      */
     public List<LicenseInfo> getLicenses() {
         return licenses;
+    }
+
+    /**
+     * Gets nested (bundled) components contained within this component.
+     * <p>
+     * These represent artifacts that have been shaded or bundled into this
+     * component's JAR, detected by the presence of additional
+     * {@code META-INF/maven/.../pom.properties} entries.
+     *
+     * @return an unmodifiable list of nested component descriptors, empty if none
+     */
+    public List<ComponentDescriptor> getComponents() {
+        return components;
     }
 
     protected ComponentDescriptor ensureImmutable() {

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/sbom/CoreSbomContributionConfig.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/sbom/CoreSbomContributionConfig.java
@@ -79,6 +79,7 @@ public class CoreSbomContributionConfig {
     private ResolvedDependency mainArtifact;
     private Collection<ArtifactCoords> mainDependencies;
     private List<ComponentHolder> additionalComponents = new ArrayList<>();
+    private Map<Path, List<Path>> extraFileDependencies = new HashMap<>();
 
     /**
      * Sets the application model whose dependencies will be converted to
@@ -216,6 +217,21 @@ public class CoreSbomContributionConfig {
     }
 
     /**
+     * Declares that the component at {@code parent} path depends on the component
+     * at {@code child} path. Both paths must correspond to files in the distribution
+     * directory so that they can be resolved to components during
+     * {@link #toSbomContribution()}.
+     *
+     * @param parent file path of the parent component
+     * @param child file path of the child component
+     * @return this config
+     */
+    public CoreSbomContributionConfig addFileDependency(Path parent, Path child) {
+        extraFileDependencies.computeIfAbsent(parent, k -> new ArrayList<>()).add(child);
+        return this;
+    }
+
+    /**
      * Converts this config into an {@link SbomContribution}, creating component
      * descriptors from the application model, deduplicating by file path and
      * Maven artifact key, resolving distribution paths, and producing the
@@ -234,7 +250,7 @@ public class CoreSbomContributionConfig {
         ComponentHolder main = resolveMainComponent(compArtifacts, compPaths, compList);
         addAdditionalComponents(compArtifacts, compPaths, compList);
         addRemainingDistributionContent(main, compArtifacts, compPaths, compList);
-        return buildContribution(main, compList);
+        return buildContribution(main, compList, compPaths);
     }
 
     private void addApplicationModelComponents(
@@ -333,10 +349,13 @@ public class CoreSbomContributionConfig {
         }
     }
 
-    private SbomContribution buildContribution(ComponentHolder main, List<ComponentHolder> compList) {
+    private SbomContribution buildContribution(ComponentHolder main, List<ComponentHolder> compList,
+            Map<Path, ComponentHolder> compPaths) {
         Set<String> directDepPurls = collectDirectDependencyPurls(main);
         SbomContribution.Builder sb = SbomContribution.builder();
         sb.setRunnerPath(runnerPath);
+
+        Map<String, List<String>> depMap = new HashMap<>();
 
         for (ComponentHolder holder : compList) {
             if (holder == main) {
@@ -351,7 +370,7 @@ public class CoreSbomContributionConfig {
                 holder.component.topLevel = true;
             }
             sb.addComponent(holder.component.ensureImmutable());
-            addDependency(holder, sb);
+            collectDependencies(holder, depMap);
         }
 
         if (distDir != null) {
@@ -361,7 +380,13 @@ public class CoreSbomContributionConfig {
         ComponentDescriptor mainComponent = main.component.ensureImmutable();
         sb.setMainComponentBomRef(mainComponent.getBomRef());
         sb.addComponent(mainComponent);
-        addDependency(main, sb);
+        collectDependencies(main, depMap);
+
+        applyExtraFileDependencies(compPaths, depMap);
+
+        for (var entry : depMap.entrySet()) {
+            sb.addDependency(ComponentDependencies.of(entry.getKey(), entry.getValue()));
+        }
 
         return sb.build();
     }
@@ -461,7 +486,7 @@ public class CoreSbomContributionConfig {
         }
     }
 
-    private static void addDependency(ComponentHolder holder, SbomContribution.Builder sb) {
+    private static void collectDependencies(ComponentHolder holder, Map<String, List<String>> depMap) {
         Collection<ArtifactCoords> deps = holder.explicitDependencies;
         if (deps == null || deps.isEmpty()) {
             deps = holder.dep != null ? holder.dep.getDependencies() : null;
@@ -469,11 +494,27 @@ public class CoreSbomContributionConfig {
         if (deps == null || deps.isEmpty()) {
             return;
         }
-        List<String> depBomRefs = new ArrayList<>(deps.size());
+        List<String> depBomRefs = depMap.computeIfAbsent(holder.component.getBomRef(), k -> new ArrayList<>());
         for (ArtifactCoords depCoords : deps) {
             depBomRefs.add(mavenPurl(depCoords).toString());
         }
-        sb.addDependency(ComponentDependencies.of(holder.component.getBomRef(), depBomRefs));
+    }
+
+    private void applyExtraFileDependencies(Map<Path, ComponentHolder> compPaths,
+            Map<String, List<String>> depMap) {
+        for (var entry : extraFileDependencies.entrySet()) {
+            ComponentHolder parent = compPaths.get(entry.getKey());
+            if (parent == null) {
+                continue;
+            }
+            List<String> depBomRefs = depMap.computeIfAbsent(parent.component.getBomRef(), k -> new ArrayList<>());
+            for (Path childPath : entry.getValue()) {
+                ComponentHolder child = compPaths.get(childPath);
+                if (child != null) {
+                    depBomRefs.add(child.component.getBomRef());
+                }
+            }
+        }
     }
 
     private static void defaultScope(ComponentHolder holder) {

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/sbom/CoreSbomContributionConfig.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/sbom/CoreSbomContributionConfig.java
@@ -1,5 +1,6 @@
 package io.quarkus.sbom;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.FileVisitResult;
@@ -13,7 +14,9 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.maven.dependency.ArtifactCoords;
@@ -245,10 +248,11 @@ public class CoreSbomContributionConfig {
         Map<ArtifactKey, ComponentHolder> compArtifacts = new HashMap<>();
         Map<Path, ComponentHolder> compPaths = new HashMap<>();
         List<ComponentHolder> compList = new ArrayList<>();
+        Map<String, AtomicInteger> bomRefCounters = new HashMap<>();
 
-        addApplicationModelComponents(compArtifacts, compPaths, compList);
+        addApplicationModelComponents(compArtifacts, compPaths, compList, bomRefCounters);
         ComponentHolder main = resolveMainComponent(compArtifacts, compPaths, compList);
-        addAdditionalComponents(compArtifacts, compPaths, compList);
+        addAdditionalComponents(compArtifacts, compPaths, compList, bomRefCounters);
         addRemainingDistributionContent(main, compArtifacts, compPaths, compList);
         return buildContribution(main, compList, compPaths);
     }
@@ -256,15 +260,82 @@ public class CoreSbomContributionConfig {
     private void addApplicationModelComponents(
             Map<ArtifactKey, ComponentHolder> compArtifacts,
             Map<Path, ComponentHolder> compPaths,
-            List<ComponentHolder> compList) {
+            List<ComponentHolder> compList,
+            Map<String, AtomicInteger> bomRefCounters) {
         if (applicationModel == null) {
             return;
         }
         ResolvedDependency appArtifact = applicationModel.getAppArtifact();
         addComponentHolder(toMavenDescriptor(appArtifact), appArtifact, compArtifacts, compPaths, compList);
+        registerBomRef(appArtifact.toCompactCoords(), bomRefCounters);
         for (ResolvedDependency dep : applicationModel.getDependencies()) {
-            addComponentHolder(toMavenDescriptor(dep), dep, compArtifacts, compPaths, compList);
+            ComponentHolder holder = addComponentHolder(toMavenDescriptor(dep), dep, compArtifacts, compPaths, compList);
+            registerBomRef(holder.component.getBomRef(), bomRefCounters);
+            detectShadedContent(dep, holder, bomRefCounters);
         }
+    }
+
+    private static void detectShadedContent(ResolvedDependency dep, ComponentHolder holder,
+            Map<String, AtomicInteger> bomRefCounters) {
+        if (!dep.isResolved() || !holder.component.getComponents().isEmpty()) {
+            return;
+        }
+        List<ComponentDescriptor> nested = new ArrayList<>();
+        dep.getContentTree().walkIfContains("META-INF/maven", visit -> {
+            if (Files.isDirectory(visit.getPath())
+                    || !visit.getPath().getFileName().toString().equals("pom.properties")) {
+                return;
+            }
+            try (BufferedReader reader = Files.newBufferedReader(visit.getPath())) {
+                Properties props = new Properties();
+                props.load(reader);
+                String groupId = props.getProperty("groupId");
+                String artifactId = props.getProperty("artifactId");
+                String version = props.getProperty("version");
+                if (groupId == null || groupId.isBlank()
+                        || artifactId == null || artifactId.isBlank()
+                        || version == null || version.isBlank()) {
+                    return;
+                }
+                if (groupId.equals(dep.getGroupId()) && artifactId.equals(dep.getArtifactId())) {
+                    return;
+                }
+                Purl purl = Purl.maven(groupId, artifactId, version, ArtifactCoords.TYPE_JAR, null);
+                String bomRef = uniqueBomRef(purl + "#bundled", bomRefCounters);
+                nested.add(ComponentDescriptor.builder()
+                        .setPurl(purl)
+                        .setBomRef(bomRef)
+                        .build());
+            } catch (IOException e) {
+                // skip unreadable pom.properties
+            }
+        });
+        if (nested.isEmpty()) {
+            return;
+        }
+        ComponentDescriptor.Builder builder;
+        if (holder.component instanceof ComponentDescriptor.Builder) {
+            builder = (ComponentDescriptor.Builder) holder.component;
+        } else {
+            builder = new ComponentDescriptor.Builder(holder.component);
+            holder.component = builder;
+        }
+        for (ComponentDescriptor child : nested) {
+            builder.addComponent(child);
+        }
+    }
+
+    private static void registerBomRef(String bomRef, Map<String, AtomicInteger> bomRefCounters) {
+        bomRefCounters.computeIfAbsent(bomRef, k -> new AtomicInteger());
+    }
+
+    private static String uniqueBomRef(String bomRef, Map<String, AtomicInteger> bomRefCounters) {
+        AtomicInteger counter = bomRefCounters.get(bomRef);
+        if (counter == null) {
+            bomRefCounters.put(bomRef, new AtomicInteger());
+            return bomRef;
+        }
+        return bomRef + "-" + counter.incrementAndGet();
     }
 
     private ComponentHolder resolveMainComponent(
@@ -308,7 +379,8 @@ public class CoreSbomContributionConfig {
     private void addAdditionalComponents(
             Map<ArtifactKey, ComponentHolder> compArtifacts,
             Map<Path, ComponentHolder> compPaths,
-            List<ComponentHolder> compList) {
+            List<ComponentHolder> compList,
+            Map<String, AtomicInteger> bomRefCounters) {
         for (ComponentHolder extra : additionalComponents) {
             ComponentDescriptor desc = extra.component;
             if (desc == null && extra.dep != null) {
@@ -321,7 +393,11 @@ public class CoreSbomContributionConfig {
                 }
                 desc = builder;
             }
-            addComponentHolder(desc, extra.dep, compArtifacts, compPaths, compList);
+            ComponentHolder holder = addComponentHolder(desc, extra.dep, compArtifacts, compPaths, compList);
+            registerBomRef(holder.component.getBomRef(), bomRefCounters);
+            if (extra.dep != null) {
+                detectShadedContent(extra.dep, holder, bomRefCounters);
+            }
         }
     }
 

--- a/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/sbom/CoreSbomContributionConfigTest.java
+++ b/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/sbom/CoreSbomContributionConfigTest.java
@@ -2,9 +2,17 @@ package io.quarkus.sbom;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
+import java.util.Properties;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.ResolvedDependency;
@@ -69,6 +77,127 @@ class CoreSbomContributionConfigTest {
         assertThat(direct.isTopLevel())
                 .as("Component matching explicit dependency should be top-level")
                 .isTrue();
+    }
+
+    @Test
+    void shadedJarBundledComponentsDetected(@TempDir Path tempDir) throws IOException {
+        Path shadedJar = createShadedJar(tempDir,
+                "com.example", "shaded-lib", "1.0.0",
+                "org.bundled", "bundled-dep", "2.0.0");
+
+        ResolvedDependency dep = ResolvedDependencyBuilder.newInstance()
+                .setGroupId("com.example")
+                .setArtifactId("shaded-lib")
+                .setVersion("1.0.0")
+                .setResolvedPaths(PathList.of(shadedJar))
+                .setDependencies(List.of())
+                .setRuntimeCp()
+                .build();
+        ResolvedDependency mainArtifact = resolvedDep("org.acme", "acme-app", "1.0.0", List.of());
+
+        SbomContribution contribution = new CoreSbomContributionConfig()
+                .setMainArtifact(mainArtifact)
+                .addComponent(dep)
+                .toSbomContribution();
+
+        ComponentDescriptor parent = findByName(contribution, "shaded-lib");
+        assertThat(parent.getComponents())
+                .as("Shaded JAR should have nested bundled components")
+                .hasSize(1);
+
+        ComponentDescriptor nested = parent.getComponents().get(0);
+        assertThat(nested.getName()).isEqualTo("bundled-dep");
+        assertThat(nested.getNamespace()).isEqualTo("org.bundled");
+        assertThat(nested.getVersion()).isEqualTo("2.0.0");
+        assertThat(nested.getBomRef())
+                .isEqualTo(Purl.maven("org.bundled", "bundled-dep", "2.0.0", "jar", null) + "#bundled");
+    }
+
+    @Test
+    void shadedJarBomRefUniqueFromStandaloneDependency(@TempDir Path tempDir) throws IOException {
+        Path shadedJar = createShadedJar(tempDir,
+                "com.example", "shaded-lib", "1.0.0",
+                "org.bundled", "bundled-dep", "2.0.0");
+
+        ResolvedDependency shadedDep = ResolvedDependencyBuilder.newInstance()
+                .setGroupId("com.example")
+                .setArtifactId("shaded-lib")
+                .setVersion("1.0.0")
+                .setResolvedPaths(PathList.of(shadedJar))
+                .setDependencies(List.of())
+                .setRuntimeCp()
+                .build();
+        ResolvedDependency standaloneDep = resolvedDep("org.bundled", "bundled-dep", "2.0.0", List.of());
+        ResolvedDependency mainArtifact = resolvedDep("org.acme", "acme-app", "1.0.0", List.of());
+
+        SbomContribution contribution = new CoreSbomContributionConfig()
+                .setMainArtifact(mainArtifact)
+                .addComponent(standaloneDep)
+                .addComponent(shadedDep)
+                .toSbomContribution();
+
+        ComponentDescriptor standalone = findByName(contribution, "bundled-dep");
+        ComponentDescriptor parent = findByName(contribution, "shaded-lib");
+        ComponentDescriptor nested = parent.getComponents().get(0);
+
+        assertThat(standalone.getBomRef())
+                .as("Standalone gets the plain PURL bomRef")
+                .doesNotContain("#");
+        assertThat(nested.getBomRef())
+                .as("Nested bomRef gets #bundled suffix")
+                .endsWith("#bundled");
+        assertThat(nested.getBomRef())
+                .as("Nested and standalone bomRefs must differ")
+                .isNotEqualTo(standalone.getBomRef());
+    }
+
+    @Test
+    void nonShadedJarHasNoNestedComponents(@TempDir Path tempDir) throws IOException {
+        Path normalJar = createShadedJar(tempDir,
+                "com.example", "normal-lib", "1.0.0");
+
+        ResolvedDependency dep = ResolvedDependencyBuilder.newInstance()
+                .setGroupId("com.example")
+                .setArtifactId("normal-lib")
+                .setVersion("1.0.0")
+                .setResolvedPaths(PathList.of(normalJar))
+                .setDependencies(List.of())
+                .setRuntimeCp()
+                .build();
+        ResolvedDependency mainArtifact = resolvedDep("org.acme", "acme-app", "1.0.0", List.of());
+
+        SbomContribution contribution = new CoreSbomContributionConfig()
+                .setMainArtifact(mainArtifact)
+                .addComponent(dep)
+                .toSbomContribution();
+
+        ComponentDescriptor parent = findByName(contribution, "normal-lib");
+        assertThat(parent.getComponents()).isEmpty();
+    }
+
+    private static Path createShadedJar(Path dir, String ownerGroupId, String ownerArtifactId, String ownerVersion,
+            String... shadedGavTriples) throws IOException {
+        Path jar = dir.resolve(ownerArtifactId + "-" + ownerVersion + ".jar");
+        try (OutputStream fos = Files.newOutputStream(jar);
+                ZipOutputStream zos = new ZipOutputStream(fos)) {
+            writePomProperties(zos, ownerGroupId, ownerArtifactId, ownerVersion);
+            for (int i = 0; i < shadedGavTriples.length; i += 3) {
+                writePomProperties(zos, shadedGavTriples[i], shadedGavTriples[i + 1], shadedGavTriples[i + 2]);
+            }
+        }
+        return jar;
+    }
+
+    private static void writePomProperties(ZipOutputStream zos, String groupId, String artifactId, String version)
+            throws IOException {
+        String path = "META-INF/maven/" + groupId + "/" + artifactId + "/pom.properties";
+        zos.putNextEntry(new ZipEntry(path));
+        Properties props = new Properties();
+        props.setProperty("groupId", groupId);
+        props.setProperty("artifactId", artifactId);
+        props.setProperty("version", version);
+        props.store(zos, null);
+        zos.closeEntry();
     }
 
     private static ComponentDescriptor findByName(SbomContribution contribution, String name) {


### PR DESCRIPTION
1. Following the spec, adds an empty `dependsOn` array to every component that has no dependencies
2. Reflect bootstrap JAR linking in `dependsOn` in `fast-jar` SBOMs
3. detect shaded JARs among dependencies and add the bundled JARs as components in the generated SBOM