### PR TITLE
Add Literal helper to NamedOidcClient qualifier

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
@@ -532,6 +532,54 @@ public class OidcClientRequestCustomFilter implements ClientRequestFilter {
 }
 ----
 
+Additionally, if you want to do a programmatic lookup of an `OidcClient`,
+use the `NamedOidcClient.Literal` qualifier to select it instead of relying on a static `@NamedOidcClient` injection point:
+
+[source,java]
+----
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.oidc.client.NamedOidcClient;
+import io.quarkus.oidc.client.OidcClient;
+import io.smallrye.mutiny.Uni;
+
+@Path("/clients")
+public class OidcClientResource {
+
+    @Inject
+    @Any
+    Instance<OidcClient> clients; // <1>
+
+    @GET
+    @Path("{name}/user-name")
+    public Uni<String> getUserName(@PathParam("name") String name) {
+        OidcClient client = clients.select(NamedOidcClient.Literal.of(name)).get();
+        return client.getTokens().onItem().transform(tokens -> tokens.getAccessToken());
+    }
+
+    @GET
+    @Path("{name}/access-token")
+    public Uni<String> getAccessToken(@PathParam("name") String name) {
+        // Alternatively, look the OidcClient up directly from the CDI container
+        OidcClient client = Arc.container().instance(OidcClient.class, NamedOidcClient.Literal.of(name)).get(); // <2>
+        return client.getTokens().onItem().transform(tokens -> tokens.getAccessToken());
+    }
+}
+----
+<1> Inject with `@Any` so that all the named `OidcClient` beans are available for selection by the `NamedOidcClient.Literal` qualifier.
+<2> `Arc.container()` resolves the bean directly without an injected `Instance`, passing the `NamedOidcClient.Literal` qualifier to select the wanted `OidcClient`.
+
+[NOTE]
+====
+Prefer the static `@NamedOidcClient` injection point whenever the client name is known in advance.
+====
+
 [[rest-client-oidc-filter]]
 === Use OidcClient in RestClient Reactive ClientFilter
 

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/NamedOidcClientInjectionTestCase.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/NamedOidcClientInjectionTestCase.java
@@ -41,6 +41,20 @@ public class NamedOidcClientInjectionTestCase {
         validateTokens(token1, token2);
     }
 
+    @Test
+    public void testProgrammaticNamedClientLookup() {
+        String token1 = doTestGetTokenByProgrammaticLookup("client1");
+        String token2 = doTestGetTokenByProgrammaticLookup("client2");
+        validateTokens(token1, token2);
+    }
+
+    @Test
+    public void testProgrammaticNamedClientLookupUsingArc() {
+        String token1 = doTestGetTokenByProgrammaticLookupArc("client1");
+        String token2 = doTestGetTokenByProgrammaticLookupArc("client2");
+        validateTokens(token1, token2);
+    }
+
     private void validateTokens(String token1, String token2) {
         assertThat(token1, is(not(equalTo(token2))));
         assertThat(preferredUserOf(token1), is("alice"));
@@ -59,6 +73,18 @@ public class NamedOidcClientInjectionTestCase {
 
     private String doTestGetTokenByNamedTokensProvider(String clientId) {
         String token = RestAssured.when().get("/" + clientId + "/token/singleton").body().asString();
+        assertThat(token, is(notNullValue()));
+        return token;
+    }
+
+    private String doTestGetTokenByProgrammaticLookup(String clientId) {
+        String token = RestAssured.when().get("/" + clientId + "/token/programmatic").body().asString();
+        assertThat(token, is(notNullValue()));
+        return token;
+    }
+
+    private String doTestGetTokenByProgrammaticLookupArc(String clientId) {
+        String token = RestAssured.when().get("/" + clientId + "/token/programmatic-arc").body().asString();
         assertThat(token, is(notNullValue()));
         return token;
     }

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/NamedOidcClientResource.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/NamedOidcClientResource.java
@@ -1,9 +1,13 @@
 package io.quarkus.oidc.client;
 
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 
+import io.quarkus.arc.Arc;
 import io.smallrye.mutiny.Uni;
 
 @Path("/")
@@ -24,6 +28,10 @@ public class NamedOidcClientResource {
     @Inject
     @NamedOidcClient("client2")
     Tokens tokens2;
+
+    @Inject
+    @Any
+    Instance<OidcClient> clients;
 
     @GET
     @Path("/client1/token")
@@ -47,5 +55,19 @@ public class NamedOidcClientResource {
     @Path("/client2/token/singleton")
     public String accessToken2() {
         return tokens2.getAccessToken();
+    }
+
+    @GET
+    @Path("/{client}/token/programmatic")
+    public Uni<String> programmaticTokenUni(@PathParam("client") String client) {
+        OidcClient oidcClient = clients.select(NamedOidcClient.Literal.of(client)).get();
+        return oidcClient.getTokens().flatMap(tokens -> Uni.createFrom().item(tokens.getAccessToken()));
+    }
+
+    @GET
+    @Path("/{client}/token/programmatic-arc")
+    public Uni<String> programmaticTokenUniArc(@PathParam("client") String client) {
+        OidcClient oidcClient = Arc.container().instance(OidcClient.class, NamedOidcClient.Literal.of(client)).get();
+        return oidcClient.getTokens().flatMap(tokens -> Uni.createFrom().item(tokens.getAccessToken()));
     }
 }

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/NamedOidcClient.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/NamedOidcClient.java
@@ -10,6 +10,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 /**
@@ -24,4 +25,23 @@ public @interface NamedOidcClient {
      * @return name of OIDC client to be injected
      */
     String value();
+
+    public static final class Literal extends AnnotationLiteral<NamedOidcClient> implements NamedOidcClient {
+
+        private static final long serialVersionUID = 1L;
+        private final String value;
+
+        public static Literal of(String value) {
+            return new Literal(value);
+        }
+
+        private Literal(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String value() {
+            return this.value;
+        }
+    }
 }


### PR DESCRIPTION
This pull request provides an AnnotationLiteral implementation so NamedOidcClient can be used as a qualifier for programmatic CDI lookup and instance selection. 