### PR TITLE
ArC: bean deployment - introduce beansView and optimize bean-by-type map updates

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
@@ -463,11 +463,7 @@ public class ArcProcessor {
         BeanProcessor beanProcessor = beanRegistrationPhase.getBeanProcessor();
         beanProcessor.registerSyntheticInjectionPoints(beanRegistrationPhase.getContext());
 
-        // Initialize the type -> bean map
-        beanProcessor.getBeanDeployment().initBeanByTypeMap();
-
         ObserverRegistrar.RegistrationContext registrationContext = beanProcessor.registerSyntheticObservers();
-
         return new ObserverRegistrationPhaseBuildItem(registrationContext, beanProcessor);
     }
 
@@ -485,6 +481,7 @@ public class ArcProcessor {
         }
 
         BeanProcessor beanProcessor = observerRegistrationPhase.getBeanProcessor();
+        beanProcessor.synthesisFinished();
         synthesisFinished.produce(new SynthesisFinishedBuildItem(beanProcessor.getBeanDeployment()));
 
         Consumer<BytecodeTransformer> bytecodeTransformerConsumer = new BytecodeTransformerConsumer(bytecodeTransformer);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -85,6 +85,9 @@ public class BeanDeployment {
     private final Map<DotName, StereotypeInfo> stereotypes;
 
     private final List<BeanInfo> beans;
+    private final List<BeanInfo> syntheticBeans;
+    // Unmodifiable live view that concatenates beans and syntheticBeans
+    private final Collection<BeanInfo> beansView;
     private volatile Map<DotName, List<BeanInfo>> beansByType;
     private final List<SkippedClass> skippedClasses;
 
@@ -237,6 +240,8 @@ public class BeanDeployment {
         this.interceptors = new CopyOnWriteArrayList<>();
         this.decorators = new CopyOnWriteArrayList<>();
         this.beans = new CopyOnWriteArrayList<>();
+        this.syntheticBeans = new CopyOnWriteArrayList<>();
+        this.beansView = new ConcatCollectionView<>(beans, syntheticBeans);
         this.skippedClasses = new CopyOnWriteArrayList<>();
         this.observers = new CopyOnWriteArrayList<>();
         this.invokers = ConcurrentHashMap.newKeySet();
@@ -300,7 +305,7 @@ public class BeanDeployment {
         this.skippedClasses.addAll(beanDiscoveryResult.skippedClasses);
         // Note that we use unmodifiable views because the underlying collections may change in the next phase
         // E.g. synthetic beans are added and unused interceptors removed
-        buildContext.putInternal(Key.BEANS, Collections.unmodifiableList(beans));
+        buildContext.putInternal(Key.BEANS, beansView);
         buildContext.putInternal(Key.OBSERVERS, Collections.unmodifiableList(observers));
         this.interceptors.addAll(findInterceptors(injectionPoints));
         buildContext.putInternal(Key.INTERCEPTORS, Collections.unmodifiableList(interceptors));
@@ -315,18 +320,20 @@ public class BeanDeployment {
                     invokerFactory);
         }
 
-        return registerSyntheticBeans(beanRegistrars, buildContext);
+        RegistrationContext ret = registerSyntheticBeans(beanRegistrars, buildContext);
+        updateBeanByTypeMap(beans, false);
+        return ret;
     }
 
     void init(Consumer<BytecodeTransformer> bytecodeTransformerConsumer,
             List<Predicate<BeanInfo>> additionalUnusedBeanExclusions) {
         long start = System.nanoTime();
 
-        initObserverAndProducerMethods(observers, beans);
+        initObserverAndProducerMethods(observers, beansView);
 
         // Collect dependency resolution errors
         List<Throwable> errors = new ArrayList<>();
-        for (BeanInfo bean : beans) {
+        for (BeanInfo bean : beansView) {
             bean.init(errors, bytecodeTransformerConsumer, transformUnproxyableClasses);
         }
         for (ObserverInfo observer : observers) {
@@ -362,7 +369,7 @@ public class BeanDeployment {
                     removedInterceptors.size(), removedDecorators.size(),
                     TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - removalStart));
             //we need to re-initialize it, so it does not contain removed beans
-            initBeanByTypeMap();
+            updateBeanByTypeMap(beansView, false);
             buildContext.putInternal(Key.REMOVED_INTERCEPTORS, Collections.unmodifiableSet(removedInterceptors));
             buildContext.putInternal(Key.REMOVED_DECORATORS, Collections.unmodifiableSet(removedDecorators));
         }
@@ -371,35 +378,47 @@ public class BeanDeployment {
     }
 
     /**
-     * Re-initialize the map that is used to speed-up lookup requests.
+     * Update the map that is used to speed-up lookup requests.
+     *
+     * @param beans
+     * @param append {@code true} to add to the existing map, {@code false} to rebuild from scratch
      */
-    public void initBeanByTypeMap() {
-        Map<DotName, List<BeanInfo>> map = new HashMap<>();
+    void updateBeanByTypeMap(Collection<BeanInfo> beans, boolean append) {
+        Map<DotName, List<BeanInfo>> map = append ? this.beansByType : new HashMap<>();
         for (BeanInfo bean : beans) {
-            bean.types.stream().map(Type::name).distinct().forEach(rawTypeName -> {
-                if (DotNames.OBJECT.equals(rawTypeName)) {
-                    // Every bean has java.lang.Object - no need to cache results here
-                    return;
-                }
-                List<BeanInfo> beans = map.get(rawTypeName);
-                if (beans == null) {
-                    // Very often, there will be exactly one bean for a given type
-                    map.put(rawTypeName, List.of(bean));
-                } else {
-                    if (beans.size() == 1) {
-                        map.put(rawTypeName, List.of(beans.get(0), bean));
-                    } else {
-                        BeanInfo[] array = new BeanInfo[beans.size() + 1];
-                        for (int i = 0; i < beans.size(); i++) {
-                            array[i] = beans.get(i);
-                        }
-                        array[beans.size()] = bean;
-                        map.put(rawTypeName, List.of(array));
-                    }
-                }
-            });
+            processBeanTypes(bean, map);
         }
+        // Always volatile-write to ensure visibility across threads
         this.beansByType = map;
+    }
+
+    void synthesisFinished() {
+        updateBeanByTypeMap(syntheticBeans, true);
+    }
+
+    private void processBeanTypes(BeanInfo bean, Map<DotName, List<BeanInfo>> map) {
+        bean.types.stream().map(Type::name).distinct().forEach(rawTypeName -> {
+            if (DotNames.OBJECT.equals(rawTypeName)) {
+                // Every bean has java.lang.Object - no need to cache results here
+                return;
+            }
+            List<BeanInfo> beans = map.get(rawTypeName);
+            if (beans == null) {
+                // Very often, there will be exactly one bean for a given type
+                map.put(rawTypeName, List.of(bean));
+            } else {
+                if (beans.size() == 1) {
+                    map.put(rawTypeName, List.of(beans.get(0), bean));
+                } else {
+                    BeanInfo[] array = new BeanInfo[beans.size() + 1];
+                    for (int i = 0; i < beans.size(); i++) {
+                        array[i] = beans.get(i);
+                    }
+                    array[beans.size()] = bean;
+                    map.put(rawTypeName, List.of(array));
+                }
+            }
+        });
     }
 
     private void removeUnusedComponents(Set<BeanInfo> declaresObserver, Set<BeanInfo> invokerLookups,
@@ -426,7 +445,7 @@ public class BeanDeployment {
                 }
             }
             if (removable) {
-                for (BeanInfo bean : this.beans) {
+                for (BeanInfo bean : this.beansView) {
                     if (bean.getBoundInterceptors().contains(interceptor)) {
                         removable = false;
                         break;
@@ -470,7 +489,7 @@ public class BeanDeployment {
                 }
             }
             if (removable) {
-                for (BeanInfo bean : this.beans) {
+                for (BeanInfo bean : this.beansView) {
                     if (bean.getBoundDecorators().contains(decorator)) {
                         removable = false;
                         break;
@@ -499,10 +518,11 @@ public class BeanDeployment {
 
     private Set<BeanInfo> removeUnusedBeans(Set<BeanInfo> declaresObserver, Set<BeanInfo> invokerLookups,
             List<Predicate<BeanInfo>> allUnusedExclusions) {
-        Set<BeanInfo> removableBeans = UnusedBeans.findRemovableBeans(beanResolver, this.beans, this.injectionPoints,
+        Set<BeanInfo> removableBeans = UnusedBeans.findRemovableBeans(beanResolver, this.beansView, this.injectionPoints,
                 declaresObserver, invokerLookups, allUnusedExclusions);
         if (!removableBeans.isEmpty()) {
             this.beans.removeAll(removableBeans);
+            this.syntheticBeans.removeAll(removableBeans);
             this.removedBeans.addAll(removableBeans);
             List<InjectionPointInfo> removableInjectionPoints = new ArrayList<>();
             for (BeanInfo bean : removableBeans) {
@@ -540,7 +560,7 @@ public class BeanDeployment {
     }
 
     public Collection<BeanInfo> getBeans() {
-        return Collections.unmodifiableList(beans);
+        return beansView;
     }
 
     Collection<BeanInfo> getBeansByRawType(DotName typeName) {
@@ -805,7 +825,7 @@ public class BeanDeployment {
         return observerAndProducerMethods;
     }
 
-    private void initObserverAndProducerMethods(List<ObserverInfo> observers, List<BeanInfo> beans) {
+    private void initObserverAndProducerMethods(List<ObserverInfo> observers, Collection<BeanInfo> beans) {
         Set<MethodInfo> ret = new HashSet<>();
         for (ObserverInfo observer : observers) {
             if (!observer.isSynthetic()) {
@@ -1592,14 +1612,14 @@ public class BeanDeployment {
     }
 
     private void addSyntheticBean(BeanInfo bean) {
-        for (BeanInfo b : beans) {
+        for (BeanInfo b : beansView) {
             if (b.getIdentifier().equals(bean.getIdentifier())) {
                 throw new IllegalStateException(
                         "A synthetic bean with identifier " + bean.getIdentifier() + " is already registered: "
                                 + b);
             }
         }
-        beans.add(bean);
+        syntheticBeans.add(bean);
     }
 
     void addSyntheticInterceptor(InterceptorInfo interceptor) {
@@ -1737,7 +1757,7 @@ public class BeanDeployment {
             }
         }
 
-        for (BeanInfo bean : beans) {
+        for (BeanInfo bean : beansView) {
             if (bean.getName() != null) {
                 List<BeanInfo> named = namedBeans.get(bean.getName());
                 if (named == null) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanProcessor.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanProcessor.java
@@ -51,8 +51,8 @@ import io.quarkus.gizmo2.Expr;
  * <li>{@link #registerScopes()}</li>
  * <li>{@link #registerBeans()}</li>
  * <li>{@link #registerSyntheticInjectionPoints(io.quarkus.arc.processor.BeanRegistrar.RegistrationContext)}</li>
- * <li>{@link BeanDeployment#initBeanByTypeMap()}</li>
  * <li>{@link #registerSyntheticObservers()}</li>
+ * <li>{@link #synthesisFinished()}
  * <li>{@link #initialize(Consumer, List)}</li>
  * <li>{@link #validate(Consumer)}</li>
  * <li>{@link #processValidationErrors(io.quarkus.arc.processor.BeanDeploymentValidator.ValidationContext)}</li>
@@ -146,6 +146,9 @@ public class BeanProcessor {
     /**
      * Analyze the deployment and register all beans and observers declared on the classes. Furthermore, register all synthetic
      * beans provided by bean registrars.
+     * <p>
+     * Note that synthetic bean configurators may be finished after this method completes, but not later
+     * than the {@link #initialize(Consumer, List)} is called.
      *
      * @return the context applied to {@link BeanRegistrar}
      */
@@ -164,6 +167,16 @@ public class BeanProcessor {
 
     public ObserverRegistrar.RegistrationContext registerSyntheticObservers() {
         return beanDeployment.registerSyntheticObservers(observerRegistrars);
+    }
+
+    /**
+     * Notify the bean deployment that all synthetic beans and observers have been registered.
+     * <p>
+     * Must be called after all synthetic bean configurators are finished and before
+     * {@link #initialize(Consumer, List)}.
+     */
+    public void synthesisFinished() {
+        beanDeployment.synthesisFinished();
     }
 
     /**
@@ -573,8 +586,8 @@ public class BeanProcessor {
         registerScopes();
         RegistrationContext registrationContext = registerBeans();
         registerSyntheticInjectionPoints(registrationContext);
-        beanDeployment.initBeanByTypeMap();
         registerSyntheticObservers();
+        synthesisFinished();
         initialize(unsupportedBytecodeTransformer, Collections.emptyList());
         ValidationContext validationContext = validate(unsupportedBytecodeTransformer);
         processValidationErrors(validationContext);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ConcatCollectionView.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ConcatCollectionView.java
@@ -1,0 +1,65 @@
+package io.quarkus.arc.processor;
+
+import java.util.AbstractCollection;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+
+/**
+ * An unmodifiable live view that concatenates two collections without copying elements.
+ * <p>
+ * Changes to the underlying collections are immediately reflected in this view.
+ *
+ * @param <E> the element type
+ */
+class ConcatCollectionView<E> extends AbstractCollection<E> {
+
+    private final Collection<E> first;
+    private final Collection<E> second;
+
+    ConcatCollectionView(Collection<E> first, Collection<E> second) {
+        this.first = Objects.requireNonNull(first);
+        this.second = Objects.requireNonNull(second);
+    }
+
+    @Override
+    public int size() {
+        return first.size() + second.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return first.isEmpty() && second.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return first.contains(o) || second.contains(o);
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+        return new Iterator<>() {
+            final Iterator<E> firstIt = first.iterator();
+            final Iterator<E> secondIt = second.iterator();
+
+            @Override
+            public boolean hasNext() {
+                return firstIt.hasNext() || secondIt.hasNext();
+            }
+
+            @Override
+            public E next() {
+                if (firstIt.hasNext()) {
+                    return firstIt.next();
+                }
+                if (secondIt.hasNext()) {
+                    return secondIt.next();
+                }
+                throw new NoSuchElementException();
+            }
+        };
+    }
+
+}

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/ConcatCollectionViewTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/ConcatCollectionViewTest.java
@@ -1,0 +1,72 @@
+package io.quarkus.arc.processor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import org.junit.jupiter.api.Test;
+
+public class ConcatCollectionViewTest {
+
+    @Test
+    public void testSizeAndContents() {
+        List<String> first = List.of("a", "b");
+        List<String> second = List.of("c", "d", "e");
+        ConcatCollectionView<String> view = new ConcatCollectionView<>(first, second);
+
+        assertThat(view).hasSize(5).containsExactly("a", "b", "c", "d", "e");
+    }
+
+    @Test
+    public void testEmptyCollections() {
+        ConcatCollectionView<String> bothEmpty = new ConcatCollectionView<>(List.of(), List.of());
+        assertThat(bothEmpty).isEmpty();
+
+        ConcatCollectionView<String> firstEmpty = new ConcatCollectionView<>(List.of(), List.of("x"));
+        assertThat(firstEmpty).hasSize(1).containsExactly("x");
+
+        ConcatCollectionView<String> secondEmpty = new ConcatCollectionView<>(List.of("x"), List.of());
+        assertThat(secondEmpty).hasSize(1).containsExactly("x");
+    }
+
+    @Test
+    public void testContains() {
+        ConcatCollectionView<String> view = new ConcatCollectionView<>(List.of("a"), List.of("b"));
+
+        assertThat(view.contains("a")).isTrue();
+        assertThat(view.contains("b")).isTrue();
+        assertThat(view.contains("c")).isFalse();
+    }
+
+    @Test
+    public void testLiveView() {
+        List<String> first = new ArrayList<>(List.of("a"));
+        List<String> second = new ArrayList<>();
+        ConcatCollectionView<String> view = new ConcatCollectionView<>(first, second);
+
+        assertThat(view).hasSize(1).containsExactly("a");
+
+        second.add("b");
+        assertThat(view).hasSize(2).containsExactly("a", "b");
+
+        first.add("a2");
+        assertThat(view).hasSize(3).containsExactly("a", "a2", "b");
+
+        first.clear();
+        assertThat(view).hasSize(1).containsExactly("b");
+    }
+
+    @Test
+    public void testIteratorExhausted() {
+        ConcatCollectionView<String> view = new ConcatCollectionView<>(List.of("a"), List.of());
+        Iterator<String> it = view.iterator();
+        assertThat(it.next()).isEqualTo("a");
+        assertThat(it.hasNext()).isFalse();
+        assertThatThrownBy(it::next).isInstanceOf(NoSuchElementException.class);
+    }
+
+}

--- a/test-framework/junit-component/src/main/java/io/quarkus/test/component/ComponentContainer.java
+++ b/test-framework/junit-component/src/main/java/io/quarkus/test/component/ComponentContainer.java
@@ -464,9 +464,10 @@ class ComponentContainer {
                 }
                 beanResolver.set(registrationContext.get(Key.DEPLOYMENT).getBeanResolver());
                 beanProcessor.registerScopes();
-                beanProcessor.registerBeans();
-                beanProcessor.getBeanDeployment().initBeanByTypeMap();
+                var context = beanProcessor.registerBeans();
+                beanProcessor.registerSyntheticInjectionPoints(context);
                 beanProcessor.registerSyntheticObservers();
+                beanProcessor.synthesisFinished();
                 beanProcessor.initialize(bytecodeTransformerConsumer, Collections.emptyList());
                 ValidationContext validationContext = beanProcessor.validate(bytecodeTransformerConsumer);
                 beanProcessor.processValidationErrors(validationContext);


### PR DESCRIPTION
- add `beansView` - unmodifiable live view that concatenates two collections without copying elements
- use `beansView` (beans + syntheticBeans) consistently in `BeanDeployment` so that the `BeanResolver` can be used in build steps that consume `BeanDiscoveryFinishedBuildItem`
- replace `initBeanByTypeMap()` with `updateBeanByTypeMap()` that supports appending to the existing map, avoiding a full rebuild when synthetic beans are registered
- simplify `addSyntheticBean()` - iterate the live view and avoid copying the whole list of beans