### PR TITLE
Register for reflection all constructors of service providers

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageReflectConfigStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageReflectConfigStep.java
@@ -3,6 +3,7 @@ package io.quarkus.deployment.steps;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -53,9 +54,11 @@ public class NativeImageReflectConfigStep {
 
         for (ServiceProviderBuildItem i : serviceProviderBuildItems) {
             for (String provider : i.providers()) {
-                // Register the nullary constructor
-                addReflectiveMethod(reflectiveClasses,
-                        new ReflectiveMethodBuildItem("Class registered as provider", provider, "<init>", new String[0]));
+                // Register all constructors as security providers may use
+                // java.security.Provider.Service.newInstance(Object constructorParameter) to instantiate the service
+                // through a different, than the nullary, constructor.
+                addReflectiveClass(reflectiveClasses, Collections.emptySet(),
+                        ReflectiveClassBuildItem.builder(provider).reason("Class registered as provider").build());
                 // Register public provider() method for lookkup to avoid throwing a MissingReflectionRegistrationError at run time.
                 // See ServiceLoader#loadProvider and ServiceLoader#findStaticProviderMethod.
                 addReflectiveMethod(reflectiveClasses,


### PR DESCRIPTION
Security providers may use
java.security.Provider.Service.newInstance(Object constructorParameter)
to instantiate the service through a different, than the nullary,
constructor.

This results in runtime failures with GraalVM >= 25.1

Closes https://github.com/quarkusio/quarkus/issues/55022
