### PR TITLE
[3.33] Make MultiRootPathTree.apply() consistent with accept()

### DIFF
--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/MultiRootPathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/MultiRootPathTree.java
@@ -88,54 +88,51 @@ public class MultiRootPathTree implements OpenPathTree {
 
     @Override
     public <T> T apply(String relativePath, Function<PathVisit, T> func) {
+        final AtomicBoolean applied = new AtomicBoolean();
+        var wrapper = new Function<PathVisit, T>() {
+            @Override
+            public T apply(PathVisit pathVisit) {
+                if (pathVisit != null) {
+                    applied.set(true);
+                    return func.apply(pathVisit);
+                }
+                return null;
+            }
+        };
+
         for (PathTree tree : trees) {
-            T result = tree.apply(relativePath, func);
-            if (result != null) {
+            T result = tree.apply(relativePath, wrapper);
+            if (applied.get()) {
                 return result;
             }
+        }
+        if (!applied.get()) {
+            return func.apply(null);
         }
         return null;
     }
 
     @Override
     public void accept(String relativePath, Consumer<PathVisit> func) {
-        final AtomicBoolean consumed = new AtomicBoolean();
-        final Consumer<PathVisit> wrapper = new Consumer<>() {
-            @Override
-            public void accept(PathVisit t) {
-                if (t != null) {
-                    func.accept(t);
-                    consumed.set(true);
-                }
-            }
-        };
+        final NonNullVisitConsumer wrapper = new NonNullVisitConsumer(func);
         for (PathTree tree : trees) {
             tree.accept(relativePath, wrapper);
-            if (consumed.get()) {
+            if (wrapper.accepted) {
                 break;
             }
         }
-        if (!consumed.get()) {
+        if (!wrapper.accepted) {
             func.accept(null);
         }
     }
 
     @Override
     public void acceptAll(String relativePath, Consumer<PathVisit> func) {
-        final AtomicBoolean consumed = new AtomicBoolean();
-        final Consumer<PathVisit> wrapper = new Consumer<>() {
-            @Override
-            public void accept(PathVisit t) {
-                if (t != null) {
-                    func.accept(t);
-                    consumed.set(true);
-                }
-            }
-        };
+        final NonNullVisitConsumer wrapper = new NonNullVisitConsumer(func);
         for (PathTree tree : trees) {
             tree.accept(relativePath, wrapper);
         }
-        if (!consumed.get()) {
+        if (!wrapper.accepted) {
             func.accept(null);
         }
     }
@@ -153,8 +150,8 @@ public class MultiRootPathTree implements OpenPathTree {
     @Override
     public Path getPath(String relativePath) {
         for (PathTree tree : trees) {
-            if (tree instanceof OpenPathTree) {
-                final Path p = ((OpenPathTree) tree).getPath(relativePath);
+            if (tree instanceof OpenPathTree openTree) {
+                final Path p = openTree.getPath(relativePath);
                 if (p != null) {
                     return p;
                 }
@@ -206,6 +203,24 @@ public class MultiRootPathTree implements OpenPathTree {
 
     @Override
     public String toString() {
-        return roots.stream().map(p -> p.toString()).collect(Collectors.joining(", ", "[", "]"));
+        return roots.stream().map(Path::toString).collect(Collectors.joining(", ", "[", "]"));
+    }
+
+    private static class NonNullVisitConsumer implements Consumer<PathVisit> {
+
+        final Consumer<PathVisit> delegate;
+        boolean accepted;
+
+        private NonNullVisitConsumer(Consumer<PathVisit> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void accept(PathVisit visit) {
+            if (visit != null) {
+                accepted = true;
+                delegate.accept(visit);
+            }
+        }
     }
 }

--- a/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/paths/MultiRootPathTreeTest.java
+++ b/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/paths/MultiRootPathTreeTest.java
@@ -1,0 +1,174 @@
+package io.quarkus.paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class MultiRootPathTreeTest {
+
+    @TempDir
+    static Path testDir;
+    static Path dir1;
+    static Path dir2;
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        dir1 = testDir.resolve("dir1");
+        createFile(dir1, "org/acme/Foo.class");
+        createFile(dir1, "org/acme/Bar.class");
+        createFile(dir1, "shared.txt");
+
+        dir2 = testDir.resolve("dir2");
+        createFile(dir2, "org/acme/Baz.class");
+        createFile(dir2, "shared.txt");
+    }
+
+    private static void createFile(Path root, String path) throws Exception {
+        var file = root.resolve(path);
+        Files.createDirectories(file.getParent());
+        Files.writeString(file, path);
+    }
+
+    private static MultiRootPathTree getTestMultiRootTree() {
+        return new MultiRootPathTree(
+                PathTree.ofDirectoryOrArchive(dir1),
+                PathTree.ofDirectoryOrArchive(dir2));
+    }
+
+    @Test
+    public void acceptFindsResourceInFirstTree() {
+        var tree = getTestMultiRootTree();
+        var visited = new ArrayList<String>();
+        tree.accept("org/acme/Foo.class", visit -> {
+            assertThat(visit).isNotNull();
+            visited.add(visit.getRelativePath());
+        });
+        assertThat(visited).containsExactly("org/acme/Foo.class");
+    }
+
+    @Test
+    public void acceptFindsResourceInSecondTree() {
+        var tree = getTestMultiRootTree();
+        var visited = new ArrayList<String>();
+        tree.accept("org/acme/Baz.class", visit -> {
+            assertThat(visit).isNotNull();
+            visited.add(visit.getRelativePath());
+        });
+        assertThat(visited).containsExactly("org/acme/Baz.class");
+    }
+
+    @Test
+    public void acceptStopsAtFirstMatch() {
+        var tree = getTestMultiRootTree();
+        var visited = new ArrayList<Path>();
+        tree.accept("shared.txt", visit -> {
+            assertThat(visit).isNotNull();
+            visited.add(visit.getPath());
+        });
+        assertThat(visited).hasSize(1);
+        assertThat(visited.get(0)).startsWith(dir1);
+    }
+
+    @Test
+    public void acceptCallsConsumerWithNullWhenNotFound() {
+        var tree = getTestMultiRootTree();
+        var visited = new ArrayList<PathVisit>();
+        tree.accept("does-not-exist.txt", visited::add);
+        assertThat(visited).containsExactly((PathVisit) null);
+    }
+
+    @Test
+    public void acceptOnEmptyTree() {
+        var tree = new MultiRootPathTree();
+        var visited = new ArrayList<PathVisit>();
+        tree.accept("anything.txt", visited::add);
+        assertThat(visited).containsExactly((PathVisit) null);
+    }
+
+    @Test
+    public void acceptAllVisitsAllMatches() {
+        var tree = getTestMultiRootTree();
+        var visited = new ArrayList<Path>();
+        tree.acceptAll("shared.txt", visit -> visited.add(visit.getPath()));
+        assertThat(visited).hasSize(2);
+        assertThat(visited.get(0)).startsWith(dir1);
+        assertThat(visited.get(1)).startsWith(dir2);
+    }
+
+    @Test
+    public void acceptAllCallsConsumerWithNullWhenNotFound() {
+        var tree = getTestMultiRootTree();
+        var visited = new ArrayList<PathVisit>();
+        tree.acceptAll("does-not-exist.txt", visited::add);
+        assertThat(visited).containsExactly((PathVisit) null);
+    }
+
+    @Test
+    public void acceptAllOnEmptyTree() {
+        var tree = new MultiRootPathTree();
+        var visited = new ArrayList<PathVisit>();
+        tree.acceptAll("anything.txt", visited::add);
+        assertThat(visited).containsExactly((PathVisit) null);
+    }
+
+    @Test
+    public void acceptAllWithSingleMatch() {
+        var tree = getTestMultiRootTree();
+        var visited = new ArrayList<String>();
+        tree.acceptAll("org/acme/Foo.class", visit -> visited.add(visit.getRelativePath()));
+        assertThat(visited).containsExactly("org/acme/Foo.class");
+    }
+
+    @Test
+    public void applyReturnsResultFromFirstTree() {
+        var tree = getTestMultiRootTree();
+        var result = tree.apply("org/acme/Foo.class", PathVisit::getRelativePath);
+        assertThat(result).isEqualTo("org/acme/Foo.class");
+    }
+
+    @Test
+    public void applyReturnsResultFromSecondTree() {
+        var tree = getTestMultiRootTree();
+        var result = tree.apply("org/acme/Baz.class", PathVisit::getRelativePath);
+        assertThat(result).isEqualTo("org/acme/Baz.class");
+    }
+
+    @Test
+    public void applyReturnsFirstNonNullResult() {
+        var tree = getTestMultiRootTree();
+        var result = tree.apply("shared.txt", visit -> visit.getPath().toString());
+        assertThat(result).startsWith(dir1.toString());
+    }
+
+    @Test
+    public void applyReturnsNullWhenNotFound() {
+        var tree = getTestMultiRootTree();
+        var result = tree.apply("does-not-exist.txt", visit -> visit == null ? null : "non-null");
+        assertThat(result).isNull();
+    }
+
+    @Test
+    public void applyOnEmptyTree() {
+        var tree = new MultiRootPathTree();
+        var result = tree.apply("anything.txt", visit -> visit == null ? null : "non-null");
+        assertThat(result).isNull();
+    }
+
+    @Test
+    public void applyReturnsNonNullResultWhenNotFound() {
+        var tree = getTestMultiRootTree();
+        var result = tree.apply("does-not-exist.txt", visit -> {
+            if (visit == null) {
+                return true;
+            }
+            return false;
+        });
+        assertThat(result).isTrue();
+    }
+}


### PR DESCRIPTION

This is backport of https://github.com/quarkusio/quarkus/pull/53806 to 3.33.