### PR TITLE
Add QE Test Suite to Quarkus CI pipeline

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -1293,6 +1293,120 @@ jobs:
             build-reports.zip
           retention-days: 7
 
+  qe-test-suite-tests:
+    name: QE Test Suite - JDK ${{matrix.java.name}}
+    runs-on: ${{ matrix.java.runs-on && fromJson(needs.configure.outputs.config).runners[format('{0}-{1}', matrix.java.os-name, 'large')].runsOn && format('{0}/tag={1}', fromJson(needs.configure.outputs.config).runners[format('{0}-{1}', matrix.java.os-name, 'large')].runsOn, matrix.java.tag) || matrix.java.os-name }}
+    needs: [configure, build-jdk17, calculate-test-jobs]
+    # Skip main in forks
+    if: needs.calculate-test-jobs.outputs.run_quickstarts == 'true'
+    continue-on-error: true
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      COMMON_MAVEN_ARGS: ${{ needs.configure.outputs.common-maven-args }}
+      RUNS_ON_ENABLED: ${{ fromJson(needs.configure.outputs.config).runners[matrix.java.os-name].runsOn && 'true' || 'false' }}
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        java:
+          - {
+            name: "25",
+            java-version: 25,
+            os-name: "ubuntu-latest",
+            tag: "qe-test-suite-jdk-25",
+            runs-on: true
+          }
+    steps:
+      - uses: runs-on/action@d141ef83eb66d096ce8afc767e09115a65c63b60 # v2.1.2
+      - name: Gradle Enterprise environment
+        run: |
+          echo "GE_TAGS=jdk-${{matrix.java.name}}" >> "$GITHUB_ENV"
+          echo "GE_CUSTOM_VALUES=gh-job-name=QE Test Suite - JDK ${{matrix.java.name}}" >> "$GITHUB_ENV"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Restore Maven Repository
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.m2/repository
+          key: ${{ needs.configure.outputs.m2-cache-key }}
+          restore-keys: |
+            ${{ needs.configure.outputs.m2-monthly-branch-cache-key }}-
+            ${{ needs.configure.outputs.m2-monthly-cache-key }}-
+      - name: Download previously uploaded .m2 content
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: m2-content
+          path: .
+      - name: Extract previously uploaded .m2 content
+        run: tar -xzf m2-content.tgz -C ~
+      - name: Set up JDK ${{ matrix.java.java-version }}
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java.java-version }}
+      - name: Setup Develocity Build Scan capture
+        uses: gradle/develocity-actions/setup-maven@974e8dbcbda40db6828fc35f349c80a7c0e71529 # v2.1
+        with:
+          capture-strategy: ON_DEMAND
+          job-name: "QE Test Suite - JDK ${{matrix.java.name}}"
+          add-pr-comment: false
+          add-job-summary: false
+          develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          develocity-token-expiry: 6
+      - name: Get Quarkus version
+        id: get-quarkus-version
+        run: |
+          echo "quarkus-version=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_OUTPUT
+      - name: Clone QE Test Suite
+        run: |
+          echo "Cloning quarkus-qe/quarkus-test-suite (branch: main)"
+          git clone --depth=1 -b main https://github.com/quarkus-qe/quarkus-test-suite.git
+      - name: Test Impacted QE Test Suite Modules
+        working-directory: quarkus-test-suite
+        env:
+          CAPTURE_BUILD_SCAN: true
+          SCALPEL_IMPACTED_GAV: ${{ needs.build-jdk17.outputs.scalpel_impacted_gav }}
+        run: |
+          echo "=== SCALPEL_IMPACTED_GAV ==="
+          echo "$SCALPEL_IMPACTED_GAV"
+          echo "============================"
+          QUARKUS_VERSION_ARGS="-Dquarkus.platform.version=${{ steps.get-quarkus-version.outputs.quarkus-version }}"
+          if [ "$SCALPEL_IMPACTED_GAV" == '_all_' ]; then
+            export LANG=en_US && ./mvnw -e -B -fae --global-settings ../.github/mvn-settings.xml --settings .github/mvn-settings.xml clean verify -Dquarkus.platform.group-id=io.quarkus $QUARKUS_VERSION_ARGS
+          else
+            echo "$SCALPEL_IMPACTED_GAV" > gib-dependencies.log
+            export LANG=en_US && ./mvnw -e -B -fae --global-settings ../.github/mvn-settings.xml --settings .github/mvn-settings.xml clean verify -Dquarkus.platform.group-id=io.quarkus $QUARKUS_VERSION_ARGS \
+              -Dincremental -Dgib.loadImpactedDependenciesFrom=gib-dependencies.log
+          fi
+      - name: Prepare build reports archive
+        if: always()
+        run: |
+          7z a -tzip build-reports.zip -r \
+              'quarkus-test-suite/**/target/*-reports/TEST-*.xml' \
+              'quarkus-test-suite/target/build-report.json' \
+              'quarkus-test-suite/LICENSE' \
+      - name: Upload build reports
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: "build-reports-${{ github.run_attempt }}-QE Test Suite - JDK ${{matrix.java.name}}"
+          path: |
+            build-reports.zip
+          retention-days: 7
+      - name: Report QE Test Suite failure
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '⚠️ **QE Test Suite failed.** This does not block merging — these tests are maintained by the QE team (@quarkus-qe). [View logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})'
+            });
+
   platform-tests:
     name: Platform Tests - JDK ${{matrix.java.name}}
     runs-on: ${{ matrix.java.runs-on && fromJson(needs.configure.outputs.config).runners[format('{0}-{1}', matrix.java.os-name, 'large')].runsOn && format('{0}/tag={1}', fromJson(needs.configure.outputs.config).runners[format('{0}-{1}', matrix.java.os-name, 'large')].runsOn, matrix.java.tag) || matrix.java.os-name }}
@@ -1999,7 +2113,7 @@ jobs:
   build-report:
     runs-on: ubuntu-latest
     name: Build report
-    needs: [configure,build-jdk17,jvm-tests,maven-tests,gradle-tests,devtools-tests,kubernetes-tests,quickstarts-tests,platform-tests,tcks-test,native-tests,virtual-thread-native-tests,oracle-test-pilot-jvm-tests,oracle-test-pilot-native-tests]
+    needs: [configure,build-jdk17,jvm-tests,maven-tests,gradle-tests,devtools-tests,kubernetes-tests,quickstarts-tests,qe-test-suite-tests,platform-tests,tcks-test,native-tests,virtual-thread-native-tests,oracle-test-pilot-jvm-tests,oracle-test-pilot-native-tests]
     if: always() && needs.configure.outputs.run-ci-build == 'true'
     steps:
       - uses: runs-on/action@d141ef83eb66d096ce8afc767e09115a65c63b60 # v2.1.2


### PR DESCRIPTION
## Summary

- Add a new `qe-test-suite-tests` job to the CI workflow that clones `quarkus-qe/quarkus-test-suite` and runs its tests against the current Quarkus build
- Uses the same Scalpel GAV + GiB incremental pattern as `quickstarts-tests` to only test impacted modules
- `continue-on-error: true` — failures never block the CI pipeline
- On PR failures, posts a comment mentioning `@quarkus-qe` so the QE team is notified (community contributors are not gated by QE test failures)
- Added to the `build-report` aggregation for visibility in the CI summary

## Dependencies

- quarkus-qe/quarkus-test-suite#3056 — adds the GiB `incremental` profile to the test suite's pom.xml (required for the `-Dincremental -Dgib.loadImpactedDependenciesFrom` pattern)

## Test plan

- [x] YAML validates successfully
- [ ] Verify on a test PR that the job clones and runs correctly
- [ ] Verify `continue-on-error` prevents CI from being blocked on QE test failures
- [ ] Verify PR comment is posted when QE tests fail