### PR TITLE
Qute: handle not-found params in JsonObject and Plus value resolvers

### DIFF
--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/jsonobject/JsonObjectValueResolverTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/jsonobject/JsonObjectValueResolverTest.java
@@ -2,11 +2,14 @@ package io.quarkus.qute.deployment.jsonobject;
 
 import java.util.HashMap;
 
+import jakarta.inject.Inject;
+
 import org.assertj.core.api.Assertions;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkus.qute.Template;
 import io.quarkus.qute.TemplateInstance;
 import io.quarkus.test.QuarkusExtensionTest;
 import io.vertx.core.json.JsonObject;
@@ -19,10 +22,19 @@ public class JsonObjectValueResolverTest {
                     app -> app.addClass(foo.class)
                             .addAsResource(new StringAsset(
                                     "{tool.name} {tool.fieldNames} {tool.fields} {tool.size} {tool.empty} {tool.isEmpty} {tool.get('name')} {tool.containsKey('name')}"),
-                                    "templates/JsonObjectValueResolverTest/foo.txt"));
+                                    "templates/JsonObjectValueResolverTest/foo.txt")
+                            .addAsResource(new StringAsset(
+                                    "{tool.get(nonExistent)} {tool.containsKey(nonExistent)}"),
+                                    "templates/notFound.txt")
+                            .addAsResource(new StringAsset(
+                                    "quarkus.qute.strict-rendering=false"),
+                                    "application.properties"));
 
     record foo(JsonObject tool) implements TemplateInstance {
     }
+
+    @Inject
+    Template notFound;
 
     @Test
     void testJsonObjectValueResolver() {
@@ -31,5 +43,12 @@ public class JsonObjectValueResolverTest {
         JsonObject jsonObject = new JsonObject(toolMap);
         String result = new foo(jsonObject).render();
         Assertions.assertThat(result).isEqualTo("Roq [name] [name] 1 false false Roq true");
+    }
+
+    @Test
+    void testJsonObjectNotFoundParam() {
+        JsonObject jsonObject = new JsonObject(new HashMap<>());
+        String result = notFound.render(jsonObject);
+        Assertions.assertThat(result).isEqualTo("NOT_FOUND NOT_FOUND");
     }
 }

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/jsonobject/JsonObjectValueResolver.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/jsonobject/JsonObjectValueResolver.java
@@ -1,8 +1,8 @@
 package io.quarkus.qute.runtime.jsonobject;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
+import io.quarkus.qute.CompletedStage;
 import io.quarkus.qute.EngineConfiguration;
 import io.quarkus.qute.EvalContext;
 import io.quarkus.qute.Results;
@@ -28,27 +28,33 @@ public class JsonObjectValueResolver implements ValueResolver {
         switch (context.getName()) {
             case "fieldNames":
             case "fields":
-                return CompletableFuture.completedFuture(jsonObject.fieldNames());
+                return CompletedStage.of(jsonObject.fieldNames());
             case "size":
-                return CompletableFuture.completedFuture(jsonObject.size());
+                return CompletedStage.of(jsonObject.size());
             case "empty":
             case "isEmpty":
-                return CompletableFuture.completedFuture(jsonObject.isEmpty());
+                return CompletedStage.of(jsonObject.isEmpty());
             case "get":
                 if (context.getParams().size() == 1) {
                     return context.evaluate(context.getParams().get(0)).thenCompose(k -> {
-                        return CompletableFuture.completedFuture(jsonObject.getValue((String) k));
+                        if (k == null || Results.isNotFound(k)) {
+                            return Results.notFound(context);
+                        }
+                        return CompletedStage.of(jsonObject.getValue(k.toString()));
                     });
                 }
             case "containsKey":
                 if (context.getParams().size() == 1) {
                     return context.evaluate(context.getParams().get(0)).thenCompose(k -> {
-                        return CompletableFuture.completedFuture(jsonObject.containsKey((String) k));
+                        if (k == null || Results.isNotFound(k)) {
+                            return Results.notFound(context);
+                        }
+                        return CompletedStage.of(jsonObject.containsKey(k.toString()));
                     });
                 }
             default:
                 return jsonObject.containsKey(context.getName())
-                        ? CompletableFuture.completedFuture(jsonObject.getValue(context.getName()))
+                        ? CompletedStage.of(jsonObject.getValue(context.getName()))
                         : Results.notFound(context);
         }
     }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ValueResolvers.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ValueResolvers.java
@@ -528,7 +528,12 @@ public final class ValueResolvers {
         public CompletionStage<Object> resolve(EvalContext context) {
             if (context.getBase() instanceof CharSequence) {
                 return context.evaluate(context.getParams().get(0))
-                        .thenApply(param -> context.getBase().toString() + (param != null ? param.toString() : ""));
+                        .thenCompose(param -> {
+                            if (param == null || Results.isNotFound(param)) {
+                                return Results.notFound(context);
+                            }
+                            return CompletedStage.of(context.getBase().toString() + param.toString());
+                        });
             }
             return super.resolve(context);
         }

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/NumberResolversTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/NumberResolversTest.java
@@ -31,6 +31,12 @@ public class NumberResolversTest {
     }
 
     @Test
+    public void testPlusNotFoundParam() {
+        Engine engine = Engine.builder().addDefaults().strictRendering(false).build();
+        assertEquals("NOT_FOUND", engine.parse("{name + nonExistent}").data("name", "foo").render());
+    }
+
+    @Test
     public void testMinus() {
         Engine engine = Engine.builder().addDefaults().build();
         int one = 1;


### PR DESCRIPTION
- check for null/NotFound before using evaluated params in JsonObjectValueResolver.get() and containsKey()
- also replace CompletableFuture with CompletedStage in JsonObjectValueResolver
- use toString() instead of String cast for param keys
- also fix PlusResolver string concat silently appending "NOT_FOUND"
- resolves #55057