### PR TITLE
Sanitize json property names while generating reflection-free Jackson serializers

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
@@ -175,7 +175,7 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
     private static final String SUPER_CLASS_NAME = GeneratedSerializer.class.getName();
     private static final String SER_STRINGS_CLASS_NAME = "SerializedStrings$quarkusjacksonserializer";
 
-    private final Map<String, Set<String>> generatedFields = new HashMap<>();
+    private final Map<String, Map<String, String>> generatedFields = new HashMap<>();
 
     public JacksonSerializerFactory(BuildProducer<GeneratedClassBuildItem> generatedClassBuildItemBuildProducer,
             IndexView jandexIndex) {
@@ -196,7 +196,7 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
 
         MethodDescriptor serStringCtor = MethodDescriptor.ofConstructor(SerializedString.class, String.class);
 
-        for (Map.Entry<String, Set<String>> fieldsInPkg : generatedFields.entrySet()) {
+        for (Map.Entry<String, Map<String, String>> fieldsInPkg : generatedFields.entrySet()) {
             try (ClassCreator classCreator = new ClassCreator(
                     new GeneratedClassGizmoAdaptor(generatedClassBuildItemBuildProducer, true),
                     fieldsInPkg.getKey() + "." + SER_STRINGS_CLASS_NAME, null,
@@ -204,11 +204,12 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
 
                 MethodCreator clinit = classCreator.getMethodCreator("<clinit>", void.class).setModifiers(ACC_STATIC);
 
-                for (String field : fieldsInPkg.getValue()) {
-                    FieldCreator fieldCreator = classCreator.getFieldCreator(field, SerializedString.class.getName())
+                for (Map.Entry<String, String> field : fieldsInPkg.getValue().entrySet()) {
+                    FieldCreator fieldCreator = classCreator
+                            .getFieldCreator(field.getKey(), SerializedString.class.getName())
                             .setModifiers(ACC_STATIC | ACC_FINAL);
                     clinit.writeStaticField(fieldCreator.getFieldDescriptor(),
-                            clinit.newInstance(serStringCtor, clinit.load(field)));
+                            clinit.newInstance(serStringCtor, clinit.load(field.getValue())));
                 }
 
                 clinit.returnVoid();
@@ -429,7 +430,8 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
             bytecode.invokeStaticMethod(serializeUnwrapped, arg, ctx.jsonGenerator, ctx.serializerProvider);
         } else {
             String pkgName = classInfo.name().packagePrefixName().toString();
-            generatedFields.computeIfAbsent(pkgName, pkg -> new HashSet<>()).add(fieldSpecs.jsonName);
+            generatedFields.computeIfAbsent(pkgName, pkg -> new HashMap<>())
+                    .put(sanitizeFieldName(fieldSpecs.jsonName), fieldSpecs.jsonName);
             String typeName = fieldSpecs.fieldType.name().toString();
 
             if (fieldSpecs.isRawValue()) {
@@ -533,7 +535,7 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
     private static void writeFieldName(FieldSpecs fieldSpecs, BytecodeCreator bytecode, SerializationContext ctx,
             String pkgName) {
         ResultHandle serStringHandle = bytecode.readStaticField(
-                FieldDescriptor.of(pkgName + "." + SER_STRINGS_CLASS_NAME, fieldSpecs.jsonName,
+                FieldDescriptor.of(pkgName + "." + SER_STRINGS_CLASS_NAME, sanitizeFieldName(fieldSpecs.jsonName),
                         SerializedString.class.getName()));
 
         if (fieldSpecs.hasExplicitJsonName) {
@@ -646,6 +648,22 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
         ResultHandle invalidException = isFailEnabledBranch.invokeStaticMethod(exceptionConstructor, jsonGenerator,
                 isFailEnabledBranch.load(errorMsg), javaType);
         isFailEnabledBranch.throwException(invalidException);
+    }
+
+    static String sanitizeFieldName(String jsonName) {
+        StringBuilder sb = null;
+        for (int i = 0; i < jsonName.length(); i++) {
+            char c = jsonName.charAt(i);
+            boolean valid = i == 0 ? Character.isJavaIdentifierStart(c) : Character.isJavaIdentifierPart(c);
+            if (!valid && sb == null) {
+                sb = new StringBuilder(jsonName.length());
+                sb.append(jsonName, 0, i);
+            }
+            if (sb != null) {
+                sb.append(valid ? c : '_');
+            }
+        }
+        return sb != null ? sb.toString() : jsonName;
     }
 
     private record SerializationContext(ResultHandle valueHandle, ResultHandle jsonGenerator, ResultHandle serializerProvider,

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/AbstractGeneratedAnnotationTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/AbstractGeneratedAnnotationTest.java
@@ -712,6 +712,32 @@ public abstract class AbstractGeneratedAnnotationTest {
                 .body("label", Matchers.is("from-json"));
     }
 
+    // --- @JsonProperty with special characters (hyphens, dots) ---
+
+    @Test
+    public void testSpecialCharPropertySerialization() {
+        RestAssured.get("/generated/special-char-property")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("'ROUND-0.2'", Matchers.is(1))
+                .body("normal_name", Matchers.is("test"));
+    }
+
+    @Test
+    public void testSpecialCharPropertyRoundTrip() {
+        given()
+                .contentType("application/json")
+                .body("{\"ROUND-0.2\":5,\"normal_name\":\"hello\"}")
+                .when()
+                .post("/generated/special-char-property")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("'ROUND-0.2'", Matchers.is(5))
+                .body("normal_name", Matchers.is("hello"));
+    }
+
     // --- @JsonRawValue ---
 
     @Test

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationResource.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationResource.java
@@ -420,4 +420,22 @@ public class GeneratedAnnotationResource {
     public PackageProtectedBean echoPackageProtected(PackageProtectedBean bean) {
         return bean;
     }
+
+    // --- SpecialCharPropertyBean: @JsonProperty with special characters (hyphens, dots) ---
+
+    @GET
+    @Path("/special-char-property")
+    public SpecialCharPropertyBean getSpecialCharProperty() {
+        SpecialCharPropertyBean bean = new SpecialCharPropertyBean();
+        bean.setRoundValue(1);
+        bean.setNormalName("test");
+        return bean;
+    }
+
+    @POST
+    @Path("/special-char-property")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public SpecialCharPropertyBean echoSpecialCharProperty(SpecialCharPropertyBean bean) {
+        return bean;
+    }
 }

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationTest.java
@@ -48,7 +48,8 @@ public class GeneratedAnnotationTest extends AbstractGeneratedAnnotationTest {
                                     IncludeBean.class,
                                     PropertyOrderBean.class,
                                     RawValueBean.class,
-                                    PackageProtectedBean.class)
+                                    PackageProtectedBean.class,
+                                    SpecialCharPropertyBean.class)
                             .addAsResource(new StringAsset(
                                     "quarkus.jackson.fail-on-unknown-properties=true\n" +
                                             "quarkus.rest.jackson.optimization.enable-reflection-free-serializers=false\n"),

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationWithReflectionFreeSerializersTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationWithReflectionFreeSerializersTest.java
@@ -51,7 +51,8 @@ public class GeneratedAnnotationWithReflectionFreeSerializersTest extends Abstra
                                     IncludeBean.class,
                                     PropertyOrderBean.class,
                                     RawValueBean.class,
-                                    PackageProtectedBean.class)
+                                    PackageProtectedBean.class,
+                                    SpecialCharPropertyBean.class)
                             .addAsResource(new StringAsset(
                                     "quarkus.jackson.fail-on-unknown-properties=true\n" +
                                             "quarkus.rest.jackson.optimization.enable-reflection-free-serializers=true\n"),

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/SpecialCharPropertyBean.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/SpecialCharPropertyBean.java
@@ -1,0 +1,28 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class SpecialCharPropertyBean {
+
+    @JsonProperty("ROUND-0.2")
+    private int roundValue;
+
+    @JsonProperty("normal_name")
+    private String normalName;
+
+    public int getRoundValue() {
+        return roundValue;
+    }
+
+    public void setRoundValue(int roundValue) {
+        this.roundValue = roundValue;
+    }
+
+    public String getNormalName() {
+        return normalName;
+    }
+
+    public void setNormalName(String normalName) {
+        this.normalName = normalName;
+    }
+}


### PR DESCRIPTION
- Fixes: #55080
 
Implementation details:

  1. Changed `generatedFields` from `Map<String, Set<String>>` to `Map<String, Map<String, String>>` to map sanitized field name to original JSON name
  2. `createFieldNamesClass()` uses the sanitized name for the bytecode field, but passes the original JSON name to `new SerializedString()`
  3. `writeFieldName()` uses the sanitized name when reading the static field
  4. Added `sanitizeFieldName()` that replaces characters invalid in Java identifiers with `_`