### PR TITLE
Fix regression in QuarkusDevModeTest

### DIFF
--- a/test-framework/junit-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
+++ b/test-framework/junit-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
@@ -146,6 +146,7 @@ public class QuarkusDevModeTest
     private String[] commandLineArgs = new String[0];
     private final Map<String, String> buildSystemProperties = new HashMap<>();
     private boolean allowFailedStart = false;
+    private boolean restAssuredStateSet = false;
 
     private static final List<CompilationProvider> compilationProviders;
 
@@ -323,6 +324,7 @@ public class QuarkusDevModeTest
 
             if (valueRegistry.containsKey(LOCAL_BASE_URI)) {
                 RestAssuredStateManager.setTestUri(valueRegistry.get(LOCAL_BASE_URI));
+                restAssuredStateSet = true;
             }
 
         } catch (Exception e) {
@@ -394,7 +396,10 @@ public class QuarkusDevModeTest
                 FileUtil.deleteDirectory(deploymentDir);
             }
         }
-        RestAssuredStateManager.clearState();
+        if (restAssuredStateSet) {
+            RestAssuredStateManager.clearState();
+            restAssuredStateSet = false;
+        }
         ThreadLocalConfigSourceProvider.reset();
         ConfigInjector.clear(context);
         ValueRegistryInjector.clear(context);


### PR DESCRIPTION
Since #55016 was merged, we had failures in
`DevServicesKafkaContinuousTestingTest.testContinuousTestingDisablesDevServicesWhenPropertiesChange` :

```
java.lang.IllegalArgumentException: baseURI cannot be null
	at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache(IndyInterface.java:344)
	at io.restassured.internal.common.assertion.AssertParameter.notNull(AssertParameter.groovy:26)
	at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache(IndyInterface.java:344)
	at io.restassured.internal.RequestSpecificationImpl.<init>(RequestSpecificationImpl.groovy:135)
	at io.restassured.RestAssured.createTestSpecification(RestAssured.java:1453)
	at io.restassured.RestAssured.when(RestAssured.java:674)
	at io.quarkus.it.kafka.continuoustesting.DevServicesKafkaContinuousTestingTest.ping500(DevServicesKafkaContinuousTestingTest.java:144)
```

We need to be more careful when resetting the state.

This can be triggered by dev mode tests that disable the banner altogether.