### PR TITLE
Initialize bean-by-type map in BeanProcessor.registerBeans()

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
@@ -463,7 +463,7 @@ public class ArcProcessor {
         BeanProcessor beanProcessor = beanRegistrationPhase.getBeanProcessor();
         beanProcessor.registerSyntheticInjectionPoints(beanRegistrationPhase.getContext());
 
-        // Initialize the type -> bean map
+        // Re-initialize the type -> bean map after synthetic injection points are registered
         beanProcessor.getBeanDeployment().initBeanByTypeMap();
 
         ObserverRegistrar.RegistrationContext registrationContext = beanProcessor.registerSyntheticObservers();

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanProcessor.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanProcessor.java
@@ -51,7 +51,6 @@ import io.quarkus.gizmo2.Expr;
  * <li>{@link #registerScopes()}</li>
  * <li>{@link #registerBeans()}</li>
  * <li>{@link #registerSyntheticInjectionPoints(io.quarkus.arc.processor.BeanRegistrar.RegistrationContext)}</li>
- * <li>{@link BeanDeployment#initBeanByTypeMap()}</li>
  * <li>{@link #registerSyntheticObservers()}</li>
  * <li>{@link #initialize(Consumer, List)}</li>
  * <li>{@link #validate(Consumer)}</li>
@@ -150,7 +149,11 @@ public class BeanProcessor {
      * @return the context applied to {@link BeanRegistrar}
      */
     public BeanRegistrar.RegistrationContext registerBeans() {
-        return beanDeployment.registerBeans(beanRegistrars);
+        BeanRegistrar.RegistrationContext context = beanDeployment.registerBeans(beanRegistrars);
+        // Initialize the type -> bean map so that BeanResolver is functional
+        // for consumers of BeanDiscoveryFinishedBuildItem
+        beanDeployment.initBeanByTypeMap();
+        return context;
     }
 
     /**
@@ -573,7 +576,6 @@ public class BeanProcessor {
         registerScopes();
         RegistrationContext registrationContext = registerBeans();
         registerSyntheticInjectionPoints(registrationContext);
-        beanDeployment.initBeanByTypeMap();
         registerSyntheticObservers();
         initialize(unsupportedBytecodeTransformer, Collections.emptyList());
         ValidationContext validationContext = validate(unsupportedBytecodeTransformer);


### PR DESCRIPTION
Call `initBeanByTypeMap()` at the end of `BeanProcessor.registerBeans()` so that `BeanResolver` is functional as soon as bean registration completes. This is needed for consumers of BeanDiscoveryFinishedBuildItem that use the resolver (e.g. `InjectionPointScanningUtil` in https://github.com/quarkusio/quarkus/pull/55032).

---

Extracted from #55032 , since that PR will likely take some time to merge.