### PR TITLE
Signals: clarify SignalMetadataEnricher threading

### DIFF
--- a/docs/src/main/asciidoc/signals.adoc
+++ b/docs/src/main/asciidoc/signals.adoc
@@ -474,7 +474,7 @@ Both `SignalMetadataEnricher` and `ReceiverInterceptor` implementations must be 
 === Signal Metadata Enricher
 
 A `SignalMetadataEnricher` enriches the metadata of a signal emission _before_ any receiver is invoked.
-It is called once per emission (i.e., per call to `publish()`, `send()`, or `request()`), not per receiver.
+It is called once per emission (i.e., per call to `publish()`, `send()`, or `request()`), not per receiver, and is executed synchronously on the thread that emits the signal.
 
 [source,java]
 ----

--- a/extensions/signals/runtime-api/src/main/java/io/quarkus/signals/spi/SignalMetadataEnricher.java
+++ b/extensions/signals/runtime-api/src/main/java/io/quarkus/signals/spi/SignalMetadataEnricher.java
@@ -11,7 +11,8 @@ import io.smallrye.common.annotation.Experimental;
  * identifier. The ordering of enrichers can be defined with {@link RelativeOrder}.
  * <p>
  * This SPI is called once per emission (i.e., per call to {@link Signal#publish(Object)}, {@link Signal#send(Object)}, or
- * {@link Signal#request(Object, Class)}), not per receiver.
+ * {@link Signal#request(Object, Class)}), not per receiver. The enricher is executed synchronously on the thread that
+ * emits the signal, before any receiver is invoked.
  *
  * @see RelativeOrder
  */


### PR DESCRIPTION
- enrichers are executed synchronously on the emitting thread