### PR TITLE
Upgrade sshd to 2.18.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -209,7 +209,7 @@
         <jose4j.version>0.9.6</jose4j.version>
         <java-buildpack-client.version>0.0.14</java-buildpack-client.version>
         <crac.version>1.5.0</crac.version>
-        <sshd-common.version>2.17.1</sshd-common.version>
+        <sshd-common.version>2.18.0</sshd-common.version>
         <mime4j.version>0.8.12</mime4j.version>
         <mutiny-zero.version>1.2.1</mutiny-zero.version>
         <pulsar-client.version>4.2.1</pulsar-client.version>


### PR DESCRIPTION
Proposal to upgrade sshd to 2.18.0 to align with camel-quarkus.

The update has been done on infinispan and camel:
* https://github.com/infinispan/infinispan/pull/17555 (cc @karesti please don't hesitate to indicate if we need to wait)
* https://github.com/apache/camel/pull/23589 (cc @jamesnetherton @ppalaga FYI)

