### PR TITLE
Prepare for UBI 10

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/images/ContainerImages.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/images/ContainerImages.java
@@ -32,6 +32,11 @@ public class ContainerImages {
     public static final String UBI9_VERSION = "9.7";
 
     /**
+     * UBI 10 version
+     */
+    public static final String UBI10_VERSION = "10.2";
+
+    /**
      * Version used for more UBI8 Java images.
      */
     public static final String UBI8_JAVA_VERSION = "1.23";
@@ -42,9 +47,19 @@ public class ContainerImages {
     public static final String UBI9_JAVA_VERSION = "1.24";
 
     /**
+     * Version used for more UBI10 Java images.
+     */
+    public static final String UBI10_JAVA_VERSION = "1.24";
+
+    /**
      * Version uses for the native builder image.
      */
     public static final String NATIVE_BUILDER_VERSION = "jdk-25";
+
+    /**
+     * Version uses for the native builder image.
+     */
+    public static final String UBI10_NATIVE_BUILDER_VERSION = "jdk-25";
 
     // === Runtime images for containers (native)
 
@@ -58,6 +73,11 @@ public class ContainerImages {
     public static final String UBI9_MINIMAL_VERSION = UBI9_VERSION;
     public static final String UBI9_MINIMAL = UBI9_MINIMAL_IMAGE_NAME + ":" + UBI9_MINIMAL_VERSION;
 
+    // UBI 10 Minimal - https://catalog.redhat.com/en/software/containers/ubi10-minimal/66f16af45db83414cddcfc99
+    public static final String UBI10_MINIMAL_IMAGE_NAME = "registry.access.redhat.com/ubi10/ubi-minimal";
+    public static final String UBI10_MINIMAL_VERSION = UBI10_VERSION;
+    public static final String UBI10_MINIMAL = UBI10_MINIMAL_IMAGE_NAME + ":" + UBI10_MINIMAL_VERSION;
+
     // UBI 8 Quarkus Micro image - https://quay.io/repository/quarkus/quarkus-micro-image?tab=tags
     public static final String UBI8_QUARKUS_MICRO_IMAGE_NAME = "quay.io/quarkus/quarkus-micro-image";
     public static final String UBI8_QUARKUS_MICRO_VERSION = "2.0";
@@ -68,10 +88,15 @@ public class ContainerImages {
     public static final String UBI9_QUARKUS_MICRO_VERSION = "2.0";
     public static final String UBI9_QUARKUS_MICRO_IMAGE = UBI9_QUARKUS_MICRO_IMAGE_NAME + ":" + UBI9_QUARKUS_MICRO_VERSION;
 
+    // UBI 10 Quarkus Micro image - https://quay.io/repository/quarkus/ubi10-quarkus-micro-image?tab=tags
+    public static final String UBI10_QUARKUS_MICRO_IMAGE_NAME = "quay.io/quarkus/ubi10-quarkus-micro-image";
+    public static final String UBI10_QUARKUS_MICRO_VERSION = "2.0";
+    public static final String UBI10_QUARKUS_MICRO_IMAGE = UBI10_QUARKUS_MICRO_IMAGE_NAME + ":" + UBI10_QUARKUS_MICRO_VERSION;
+
     // default Quarkus Micro image - https://quay.io/repository/quarkus/quarkus-micro-image?tab=tags
-    public static final String QUARKUS_MICRO_IMAGE_NAME = UBI9_QUARKUS_MICRO_IMAGE_NAME;
-    public static final String QUARKUS_MICRO_VERSION = UBI9_QUARKUS_MICRO_VERSION;
-    public static final String QUARKUS_MICRO_IMAGE = UBI9_QUARKUS_MICRO_IMAGE;
+    public static final String QUARKUS_MICRO_IMAGE_NAME = UBI10_QUARKUS_MICRO_IMAGE_NAME;
+    public static final String QUARKUS_MICRO_VERSION = UBI10_QUARKUS_MICRO_VERSION;
+    public static final String QUARKUS_MICRO_IMAGE = UBI10_QUARKUS_MICRO_IMAGE;
 
     // === Runtime images for containers (JVM)
     private static final Pattern RUN_JAVA_IMAGE_MATCHER = Pattern
@@ -97,10 +122,20 @@ public class ContainerImages {
     public static final String UBI9_JAVA_21_VERSION = UBI9_JAVA_VERSION;
     public static final String UBI9_JAVA_21 = UBI9_JAVA_21_IMAGE_NAME + ":" + UBI9_JAVA_21_VERSION;
 
+    // UBI 10 OpenJDK 21 Runtime - https://catalog.redhat.com/en/software/containers/ubi10/openjdk-21-runtime/690ca3b700d71ac7397b98c6
+    public static final String UBI10_JAVA_21_IMAGE_NAME = "registry.access.redhat.com/ubi10/openjdk-21-runtime";
+    public static final String UBI10_JAVA_21_VERSION = UBI10_JAVA_VERSION;
+    public static final String UBI10_JAVA_21 = UBI10_JAVA_21_IMAGE_NAME + ":" + UBI10_JAVA_21_VERSION;
+
     // UBI 9 OpenJDK 25 Runtime - https://catalog.redhat.com/en/software/containers/ubi9/openjdk-25-runtime/69204990c46419100ce30a5b
     public static final String UBI9_JAVA_25_IMAGE_NAME = "registry.access.redhat.com/ubi9/openjdk-25-runtime";
     public static final String UBI9_JAVA_25_VERSION = UBI9_JAVA_VERSION;
     public static final String UBI9_JAVA_25 = UBI9_JAVA_25_IMAGE_NAME + ":" + UBI9_JAVA_25_VERSION;
+
+    // UBI 10 OpenJDK 25 Runtime - https://catalog.redhat.com/en/software/containers/ubi10/openjdk-25-runtime/690ca3e4c827022925ed2db5
+    public static final String UBI10_JAVA_25_IMAGE_NAME = "registry.access.redhat.com/ubi10/openjdk-25-runtime";
+    public static final String UBI10_JAVA_25_VERSION = UBI10_JAVA_VERSION;
+    public static final String UBI10_JAVA_25 = UBI10_JAVA_25_IMAGE_NAME + ":" + UBI10_JAVA_25_VERSION;
 
     // === Source To Image images
 
@@ -116,24 +151,30 @@ public class ContainerImages {
     public static final String UBI9_QUARKUS_BINARY_S2I = UBI9_QUARKUS_BINARY_S2I_IMAGE_NAME + ":"
             + UBI9_QUARKUS_BINARY_S2I_VERSION;
 
+    // UBI 10 Quarkus Binary Source To Image - https://quay.io/repository/quarkus/ubi10-quarkus-native-binary-s2i?tab=tags
+    public static final String UBI10_QUARKUS_BINARY_S2I_IMAGE_NAME = "quay.io/quarkus/ubi10-quarkus-native-binary-s2i";
+    public static final String UBI10_QUARKUS_BINARY_S2I_VERSION = "2.0";
+    public static final String UBI10_QUARKUS_BINARY_S2I = UBI10_QUARKUS_BINARY_S2I_IMAGE_NAME + ":"
+            + UBI10_QUARKUS_BINARY_S2I_VERSION;
+
     // default Quarkus Binary Source To Image - https://quay.io/repository/quarkus/ubi9-quarkus-native-binary-s2i?tab=tags
-    public static final String QUARKUS_BINARY_S2I_IMAGE_NAME = UBI9_QUARKUS_BINARY_S2I_IMAGE_NAME;
-    public static final String QUARKUS_BINARY_S2I_VERSION = UBI9_QUARKUS_BINARY_S2I_VERSION;
-    public static final String QUARKUS_BINARY_S2I = UBI9_QUARKUS_BINARY_S2I;
+    public static final String QUARKUS_BINARY_S2I_IMAGE_NAME = UBI10_QUARKUS_BINARY_S2I_IMAGE_NAME;
+    public static final String QUARKUS_BINARY_S2I_VERSION = UBI10_QUARKUS_BINARY_S2I_VERSION;
+    public static final String QUARKUS_BINARY_S2I = UBI10_QUARKUS_BINARY_S2I;
 
     // Java 17 Source To Image - https://catalog.redhat.com/software/containers/ubi9/openjdk-17/61ee7c26ed74b2ffb22b07f6
     public static final String S2I_JAVA_17_IMAGE_NAME = "registry.access.redhat.com/ubi9/openjdk-17";
     public static final String S2I_JAVA_17_VERSION = UBI9_JAVA_VERSION;
     public static final String S2I_JAVA_17 = S2I_JAVA_17_IMAGE_NAME + ":" + S2I_JAVA_17_VERSION;
 
-    // Java Source To Image - https://catalog.redhat.com/software/containers/ubi9/openjdk-21/6501cdb5c34ae048c44f7814
-    public static final String S2I_JAVA_21_IMAGE_NAME = "registry.access.redhat.com/ubi9/openjdk-21";
-    public static final String S2I_JAVA_21_VERSION = UBI9_JAVA_VERSION;
+    // Java Source To Image - https://catalog.redhat.com/en/software/containers/ubi10/openjdk-21/690ca3318f730aed0b1497fd
+    public static final String S2I_JAVA_21_IMAGE_NAME = "registry.access.redhat.com/ubi10/openjdk-21";
+    public static final String S2I_JAVA_21_VERSION = UBI10_JAVA_VERSION;
     public static final String S2I_JAVA_21 = S2I_JAVA_21_IMAGE_NAME + ":" + S2I_JAVA_21_VERSION;
 
-    // Java Source To Image - https://catalog.redhat.com/en/software/containers/ubi9/openjdk-25/69204893fc0d23c633bf5c29
-    public static final String S2I_JAVA_25_IMAGE_NAME = "registry.access.redhat.com/ubi9/openjdk-25";
-    public static final String S2I_JAVA_25_VERSION = UBI9_JAVA_VERSION;
+    // Java Source To Image - https://catalog.redhat.com/en/software/containers/ubi10/openjdk-25/690ca440f43a9c6b120b2970
+    public static final String S2I_JAVA_25_IMAGE_NAME = "registry.access.redhat.com/ubi10/openjdk-25";
+    public static final String S2I_JAVA_25_VERSION = UBI10_JAVA_VERSION;
     public static final String S2I_JAVA_25 = S2I_JAVA_25_IMAGE_NAME + ":" + S2I_JAVA_25_VERSION;
 
     // === Native Builder images
@@ -148,6 +189,11 @@ public class ContainerImages {
     public static final String UBI9_MANDREL_BUILDER_VERSION = NATIVE_BUILDER_VERSION;
     public static final String UBI9_MANDREL_BUILDER = UBI9_MANDREL_BUILDER_IMAGE_NAME + ":" + UBI9_MANDREL_BUILDER_VERSION;
 
+    // Mandrel Builder Image - https://quay.io/repository/quarkus/ubi10-quarkus-mandrel-builder-image?tab=tags
+    public static final String UBI10_MANDREL_BUILDER_IMAGE_NAME = "quay.io/quarkus/ubi10-quarkus-mandrel-builder-image";
+    public static final String UBI10_MANDREL_BUILDER_VERSION = UBI10_NATIVE_BUILDER_VERSION;
+    public static final String UBI10_MANDREL_BUILDER = UBI10_MANDREL_BUILDER_IMAGE_NAME + ":" + UBI10_MANDREL_BUILDER_VERSION;
+
     // GraalVM CE Builder Image - https://quay.io/repository/quarkus/ubi-quarkus-graalvmce-builder-image?tab=tags
     public static final String UBI8_GRAALVM_BUILDER_IMAGE_NAME = "quay.io/quarkus/ubi-quarkus-graalvmce-builder-image";
     public static final String UBI8_GRAALVM_BUILDER_VERSION = NATIVE_BUILDER_VERSION;
@@ -158,13 +204,18 @@ public class ContainerImages {
     public static final String UBI9_GRAALVM_BUILDER_VERSION = NATIVE_BUILDER_VERSION;
     public static final String UBI9_GRAALVM_BUILDER = UBI9_GRAALVM_BUILDER_IMAGE_NAME + ":" + UBI9_GRAALVM_BUILDER_VERSION;
 
+    // GraalVM CE Builder Image - https://quay.io/repository/quarkus/ubi10-quarkus-graalvmce-builder-image?tab=tags
+    public static final String UBI10_GRAALVM_BUILDER_IMAGE_NAME = "quay.io/quarkus/ubi10-quarkus-graalvmce-builder-image";
+    public static final String UBI10_GRAALVM_BUILDER_VERSION = UBI10_NATIVE_BUILDER_VERSION;
+    public static final String UBI10_GRAALVM_BUILDER = UBI10_GRAALVM_BUILDER_IMAGE_NAME + ":" + UBI10_GRAALVM_BUILDER_VERSION;
+
     public static String getDefaultJvmImage(CompiledJavaVersionBuildItem.JavaVersion version) {
         if (version.isJava25OrHigher() == Status.TRUE) {
-            return UBI9_JAVA_25;
+            return UBI10_JAVA_25;
         }
 
         if (version.isJava21OrHigher() == Status.TRUE) {
-            return UBI9_JAVA_21;
+            return UBI10_JAVA_21;
         }
 
         return UBI9_JAVA_17;

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -220,16 +220,17 @@ public interface NativeConfig {
     interface BuilderImageConfig {
         /**
          * The docker image to use to do the image build. It can be one of `graalvm`, `mandrel`, or the full image path, e.g.
-         * {@code quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:jdk-21}.
+         * {@code quay.io/quarkus/ubi10-quarkus-mandrel-builder-image:jdk-21}.
          * <p>
-         * <strong>Note:</strong> Builder images are available using UBI 8 and UBI 9 base images, for example:
+         * <strong>Note:</strong> Builder images are available using UBI 8, UBI 9, and UBI 10 base images, for example:
          * <ul>
-         * <li>UBI 8: {@code quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21} (UBI 8)</li>
-         * <li>UBI 9: {@code quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:jdk-21} (UBI 9)</li>
+         * <li>UBI 10: {@code quay.io/quarkus/ubi10-quarkus-mandrel-builder-image:jdk-21} (default)</li>
+         * <li>UBI 9: {@code quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:jdk-21}</li>
+         * <li>UBI 8: {@code quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21}</li>
          * </ul>
          * <p>
-         * You need to be aware that if you use a builder image using UBI9 and you plan to build a container, you must
-         * ensure that the base image used in the container is also UBI9.
+         * You need to be aware that if you use a builder image using UBI 10 and you plan to build a container, you must
+         * ensure that the base image used in the container is also UBI 10.
          */
         @WithParentName
         @WithDefault("${platform.quarkus.native.builder-image}")
@@ -254,9 +255,9 @@ public interface NativeConfig {
         default String getEffectiveImage() {
             final String builderImageName = this.image().toUpperCase();
             if (builderImageName.equals(BuilderImageProvider.GRAALVM.name())) {
-                return ContainerImages.UBI9_GRAALVM_BUILDER;
+                return ContainerImages.UBI10_GRAALVM_BUILDER;
             } else if (builderImageName.equals(BuilderImageProvider.MANDREL.name())) {
-                return ContainerImages.UBI9_MANDREL_BUILDER;
+                return ContainerImages.UBI10_MANDREL_BUILDER;
             } else {
                 return this.image();
             }

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/NativeConfigTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/NativeConfigTest.java
@@ -8,20 +8,20 @@ class NativeConfigTest {
 
     @Test
     public void testBuilderImageProperlyDetected() {
-        assertThat(createConfig("graalvm").builderImage().getEffectiveImage()).contains("ubi9-quarkus-graalvmce-builder-image")
+        assertThat(createConfig("graalvm").builderImage().getEffectiveImage()).contains("ubi10-quarkus-graalvmce-builder-image")
                 .contains("jdk-25");
-        assertThat(createConfig("GraalVM").builderImage().getEffectiveImage()).contains("ubi9-quarkus-graalvmce-builder-image")
+        assertThat(createConfig("GraalVM").builderImage().getEffectiveImage()).contains("ubi10-quarkus-graalvmce-builder-image")
                 .contains("jdk-25");
-        assertThat(createConfig("GraalVM").builderImage().getEffectiveImage()).contains("ubi9-quarkus-graalvmce-builder-image")
+        assertThat(createConfig("GraalVM").builderImage().getEffectiveImage()).contains("ubi10-quarkus-graalvmce-builder-image")
                 .contains("jdk-25");
-        assertThat(createConfig("GRAALVM").builderImage().getEffectiveImage()).contains("ubi9-quarkus-graalvmce-builder-image")
+        assertThat(createConfig("GRAALVM").builderImage().getEffectiveImage()).contains("ubi10-quarkus-graalvmce-builder-image")
                 .contains("jdk-25");
 
-        assertThat(createConfig("mandrel").builderImage().getEffectiveImage()).contains("ubi9-quarkus-mandrel-builder-image")
+        assertThat(createConfig("mandrel").builderImage().getEffectiveImage()).contains("ubi10-quarkus-mandrel-builder-image")
                 .contains("jdk-25");
-        assertThat(createConfig("Mandrel").builderImage().getEffectiveImage()).contains("ubi9-quarkus-mandrel-builder-image")
+        assertThat(createConfig("Mandrel").builderImage().getEffectiveImage()).contains("ubi10-quarkus-mandrel-builder-image")
                 .contains("jdk-25");
-        assertThat(createConfig("MANDREL").builderImage().getEffectiveImage()).contains("ubi9-quarkus-mandrel-builder-image")
+        assertThat(createConfig("MANDREL").builderImage().getEffectiveImage()).contains("ubi10-quarkus-mandrel-builder-image")
                 .contains("jdk-25");
 
         assertThat(createConfig("aRandomString").builderImage().getEffectiveImage()).isEqualTo("aRandomString");

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunnerTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunnerTest.java
@@ -29,7 +29,7 @@ class NativeImageBuildContainerRunnerTest {
                 Collections.emptyList());
         found = false;
         for (String part : command) {
-            if (part.contains("ubi9-quarkus-graalvmce-builder-image")) {
+            if (part.contains("ubi10-quarkus-graalvmce-builder-image")) {
                 found = true;
                 break;
             }
@@ -42,7 +42,7 @@ class NativeImageBuildContainerRunnerTest {
                 Collections.emptyList());
         found = false;
         for (String part : command) {
-            if (part.contains("ubi9-quarkus-mandrel-builder-image")) {
+            if (part.contains("ubi10-quarkus-mandrel-builder-image")) {
                 found = true;
                 break;
             }

--- a/devtools/bom-descriptor-json/src/main/resources/catalog-overrides.json
+++ b/devtools/bom-descriptor-json/src/main/resources/catalog-overrides.json
@@ -150,10 +150,10 @@
     "project": {
       "default-codestart": "rest",
       "codestart-data": {
-        "tooling-dockerfiles.dockerfile.jvm.from-template": "registry.access.redhat.com/ubi9/openjdk-{java.version}-runtime:1.24",
-        "tooling-dockerfiles.dockerfile.jvm.from": "registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24",
-        "tooling-dockerfiles.dockerfile.native.from": "registry.access.redhat.com/ubi9/ubi-minimal:9.7",
-        "tooling-dockerfiles.dockerfile.native-micro.from": "quay.io/quarkus/ubi9-quarkus-micro-image:2.0"
+        "tooling-dockerfiles.dockerfile.jvm.from-template": "registry.access.redhat.com/ubi10/openjdk-{java.version}-runtime:1.24",
+        "tooling-dockerfiles.dockerfile.jvm.from": "registry.access.redhat.com/ubi10/openjdk-21-runtime:1.24",
+        "tooling-dockerfiles.dockerfile.native.from": "registry.access.redhat.com/ubi10/ubi-minimal:10.2",
+        "tooling-dockerfiles.dockerfile.native-micro.from": "quay.io/quarkus/ubi10-quarkus-micro-image:2.0"
       },
       "properties": {
         "doc-root": "https://quarkus.io",

--- a/docs/src/main/asciidoc/_attributes.adoc
+++ b/docs/src/main/asciidoc/_attributes.adoc
@@ -99,9 +99,9 @@
 :openshift: OpenShift
 :name-image-ubi9-open-jdk-17: registry.access.redhat.com/ubi9/openjdk-17
 :name-image-ubi9-open-jdk-17-short: ubi9/openjdk-17
-:name-image-ubi9-open-jdk-21: registry.access.redhat.com/ubi9/openjdk-21
-:name-image-ubi9-open-jdk-21-short: ubi9/openjdk-21
-:name-image-ubi9-open-jdk-25: registry.access.redhat.com/ubi9/openjdk-25
-:name-image-ubi9-open-jdk-25-short: ubi9/openjdk-25
+:name-image-ubi10-open-jdk-21: registry.access.redhat.com/ubi10/openjdk-21
+:name-image-ubi10-open-jdk-21-short: ubi10/openjdk-21
+:name-image-ubi10-open-jdk-25: registry.access.redhat.com/ubi10/openjdk-25
+:name-image-ubi10-open-jdk-25-short: ubi10/openjdk-25
 // .
 include::_attributes-local.adoc[]

--- a/docs/src/main/asciidoc/aws-lambda.adoc
+++ b/docs/src/main/asciidoc/aws-lambda.adoc
@@ -580,7 +580,7 @@ To extract the required SSL files, you must start up a Docker container in the b
 First, let's start the Mandrel builder container, noting the container id output.
 [source,bash,subs=attributes+]
 ----
-docker run -it -d --entrypoint bash quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor}
+docker run -it -d --entrypoint bash quay.io/quarkus/ubi10-quarkus-mandrel-builder-image:{mandrel-flavor}
 
 # This will output a container id, like 6304eea6179522aff69acb38eca90bedfd4b970a5475aa37ccda3585bc2abdde
 # Note this value as we will need it for the commands below

--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -257,7 +257,7 @@ To see the `GreetingResourceIT` run against the native executable, use `./mvnw v
 $ ./mvnw verify -Dnative
 ...
 Finished generating 'getting-started-1.0.0-SNAPSHOT-runner' in 22.0s.
-[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildRunner] docker run --env LANG=C --rm --user 1000:1000 -v /home/zakkak/code/quarkus-quickstarts/getting-started/target/getting-started-1.0.0-SNAPSHOT-native-image-source-jar:/project:z --entrypoint /bin/bash quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor} -c objcopy --strip-debug getting-started-1.0.0-SNAPSHOT-runner
+[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildRunner] docker run --env LANG=C --rm --user 1000:1000 -v /home/zakkak/code/quarkus-quickstarts/getting-started/target/getting-started-1.0.0-SNAPSHOT-native-image-source-jar:/project:z --entrypoint /bin/bash quay.io/quarkus/ubi10-quarkus-mandrel-builder-image:{mandrel-flavor} -c objcopy --strip-debug getting-started-1.0.0-SNAPSHOT-runner
 [INFO] [io.quarkus.deployment.QuarkusAugmentor] Quarkus augmentation completed in 70686ms
 [INFO]
 [INFO] --- maven-failsafe-plugin:3.0.0-M7:integration-test (default) @ getting-started ---
@@ -427,18 +427,19 @@ Executable built that way with the container runtime will be a 64-bit Linux exec
 
 [IMPORTANT]
 ====
-Starting with Quarkus 3.19+, the _builder_ image used to build the native executable is based on UBI 9.
-It means that the native executable produced by the container build will be based on UBI 9 as well.
-So, if you plan to build a container, make sure that the base image in your `Dockerfile` is compatible with UBI 9.
-The native executable will not run on UBI 8 base images.
+The _builder_ image used to build the native executable is based on UBI 10.
+It means that the native executable produced by the container build will be based on UBI 10 as well.
+So, if you plan to build a container, make sure that the base image in your `Dockerfile` is compatible with UBI 10.
+The native executable will not run on UBI 8 or UBI 9 base images.
 
 You can configure the builder image used for the container build by setting the `quarkus.native.builder-image` property.
-For example, to switch back to an UBI8 _builder image_ you can use:
+For example, to switch back to an UBI 9 _builder image_ you can use:
 
-`quarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:{mandrel-flavor}`
+`quarkus.native.builder-image=quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor}`
 
-You can see the available tags for UBI8 https://quay.io/repository/quarkus/ubi-quarkus-mandrel-builder-image?tab=tags[here]
-and for UBI9 https://quay.io/repository/quarkus/ubi9-quarkus-mandrel-builder-image?tab=tags[here (UBI 9)])
+You can see the available tags for UBI 8 https://quay.io/repository/quarkus/ubi-quarkus-mandrel-builder-image?tab=tags[here (UBI 8)],
+for UBI 9 https://quay.io/repository/quarkus/ubi9-quarkus-mandrel-builder-image?tab=tags[here (UBI 9)],
+and for UBI 10 https://quay.io/repository/quarkus/ubi10-quarkus-mandrel-builder-image?tab=tags[here (UBI 10)])
 
 ====
 
@@ -468,8 +469,9 @@ Please note that the above command points to a floating tag.
 It is highly recommended to use the floating tag,
 so that your builder image remains up-to-date and secure.
 If you absolutely must, you may hard-code to a specific tag
-(see https://quay.io/repository/quarkus/ubi-quarkus-mandrel-builder-image?tab=tags[here (UBI 8)]
-and  https://quay.io/repository/quarkus/ubi9-quarkus-mandrel-builder-image?tab=tags[here (UBI 9)] for available tags),
+(see https://quay.io/repository/quarkus/ubi-quarkus-mandrel-builder-image?tab=tags[here (UBI 8)],
+https://quay.io/repository/quarkus/ubi9-quarkus-mandrel-builder-image?tab=tags[here (UBI 9)],
+and https://quay.io/repository/quarkus/ubi10-quarkus-mandrel-builder-image?tab=tags[here (UBI 10)] for available tags),
 but be aware that you won't get security updates that way and it's unsupported.
 ====
 
@@ -516,7 +518,7 @@ The project generation has provided a `Dockerfile.native-micro` in the `src/main
 
 [source,dockerfile]
 ----
-FROM quay.io/quarkus/ubi9-quarkus-micro-image:2.0
+FROM quay.io/quarkus/ubi10-quarkus-micro-image:2.0
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \
@@ -533,13 +535,13 @@ ENTRYPOINT ["./application", "-Dquarkus.http.host=0.0.0.0"]
 .Quarkus Micro Image?
 ====
 The Quarkus Micro Image is a small container image providing the right set of dependencies to run your native application.
-It is based on https://catalog.redhat.com/software/containers/ubi9-micro/61832b36dd607bfc82e66399?container-tabs=overview[UBI Micro].
+It is based on https://catalog.redhat.com/en/software/containers/ubi10-micro/66f16b145db83414cddcfcb3?container-tabs=overview[UBI Micro].
 This base image has been tailored to work perfectly in containers.
 
 You can read more about UBI images on:
 
 * https://www.redhat.com/en/blog/introducing-red-hat-universal-base-image[Introduction to Universal Base Image]
-* https://catalog.redhat.com/software/containers/ubi9/ubi/615bcf606feffc5384e8452e[Red Hat Universal Base Image 9]
+* https://catalog.redhat.com/en/software/containers/ubi10/ubi/66f16b555db83414cddcfcbe[Red Hat Universal Base Image 10]
 
 UBI images can be used without any limitations.
 
@@ -566,7 +568,7 @@ The project generation has also provided a `Dockerfile.native` in the `src/main/
 
 [source,dockerfile]
 ----
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.2
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \
@@ -606,7 +608,7 @@ Sample Dockerfile for building with Maven:
 [source,dockerfile,subs=attributes+]
 ----
 ## Stage 1 : build with maven builder image with native capabilities
-FROM quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor} AS build
+FROM quay.io/quarkus/ubi10-quarkus-mandrel-builder-image:{mandrel-flavor} AS build
 COPY --chown=quarkus:quarkus --chmod=0755 mvnw /code/mvnw
 COPY --chown=quarkus:quarkus .mvn /code/.mvn
 COPY --chown=quarkus:quarkus pom.xml /code/
@@ -617,7 +619,7 @@ COPY src /code/src
 RUN ./mvnw package -Dnative
 
 ## Stage 2 : create the docker final image
-FROM quay.io/quarkus/ubi9-quarkus-micro-image:2.0
+FROM quay.io/quarkus/ubi10-quarkus-micro-image:2.0
 WORKDIR /work/
 COPY --from=build /code/target/*-runner /work/application
 
@@ -644,7 +646,7 @@ Sample Dockerfile for building with Gradle:
 [source,dockerfile,subs=attributes+]
 ----
 ## Stage 1 : build with maven builder image with native capabilities
-FROM quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor} AS build
+FROM quay.io/quarkus/ubi10-quarkus-mandrel-builder-image:{mandrel-flavor} AS build
 USER root
 RUN microdnf install findutils -y
 COPY --chown=quarkus:quarkus gradlew /code/gradlew
@@ -658,7 +660,7 @@ COPY src /code/src
 RUN ./gradlew build -Dquarkus.native.enabled=true
 
 ## Stage 2 : create the docker final image
-FROM quay.io/quarkus/ubi9-quarkus-micro-image:2.0
+FROM quay.io/quarkus/ubi10-quarkus-micro-image:2.0
 WORKDIR /work/
 COPY --from=build /code/build/*-runner /work/application
 RUN chmod 775 /work
@@ -689,7 +691,7 @@ Please see xref:native-and-ssl.adoc#working-with-containers[our Using SSL With N
 
 [NOTE,subs=attributes+]
 ====
-To use GraalVM CE instead of Mandrel, update the `FROM` clause to: `FROM quay.io/quarkus/ubi9-quarkus-graalvmce-builder-image:{graalvm-flavor} AS build`.
+To use GraalVM CE instead of Mandrel, update the `FROM` clause to: `FROM quay.io/quarkus/ubi10-quarkus-graalvmce-builder-image:{graalvm-flavor} AS build`.
 ====
 
 === Using a Distroless base image
@@ -730,7 +732,7 @@ Sample multistage Dockerfile for building an image from `scratch`:
 [source,dockerfile,subs=attributes+]
 ----
 ## Stage 1 : build with maven builder image with native capabilities
-FROM quay.io/quarkus/ubi9-quarkus-graalvmce-builder-image:{graalvm-flavor} AS build
+FROM quay.io/quarkus/ubi10-quarkus-graalvmce-builder-image:{graalvm-flavor} AS build
 USER root
 RUN microdnf install make gcc -y
 COPY --chown=quarkus:quarkus mvnw /code/mvnw

--- a/docs/src/main/asciidoc/container-image.adoc
+++ b/docs/src/main/asciidoc/container-image.adoc
@@ -48,7 +48,7 @@ For example, the presence of `src/main/jib/foo/bar` would result in  `/foo/bar` 
 
 There are cases where the built container image may need to have Java debugging conditionally enabled at runtime.
 
-When the base image has not been changed (and therefore `ubi9/openjdk-17-runtime`, or `ubi9/openjdk-21-runtime` is used), then the `quarkus.jib.jvm-additional-arguments` configuration property can be used in order to
+When the base image has not been changed (and therefore `ubi9/openjdk-17-runtime`, or `ubi10/openjdk-21-runtime` is used), then the `quarkus.jib.jvm-additional-arguments` configuration property can be used in order to
 make the JVM listen on the debug port at startup.
 
 The exact configuration is:
@@ -64,7 +64,7 @@ Other base images might provide launch scripts that enable debugging when an env
 
 The `quarkus.jib.jvm-entrypoint` configuration property can be used to completely override the container entry point and can thus be used to either hard code the JVM debug configuration or point to a script that handles the details.
 
-For example, if the base images `ubi9/openjdk-17-runtime` or  `ubi9/openjdk-21-runtime` are used to build the container, the entry point can be hard-coded on the application properties file.
+For example, if the base images `ubi9/openjdk-17-runtime` or  `ubi10/openjdk-21-runtime` are used to build the container, the entry point can be hard-coded on the application properties file.
 
 .Example application.properties
 [source,properties]
@@ -89,7 +89,7 @@ java \
   -jar quarkus-run.jar
 ----
 
-NOTE: `/home/jboss` is the WORKDIR for all quarkus binaries in the base images `ubi9/openjdk-17-runtime` and `ubi9/openjdk-21-runtime` (https://catalog.redhat.com/software/containers/ubi9/openjdk-21-runtime/6501ce769a0d86945c422d5f?container-tabs=dockerfile[Dockerfile for ubi9/openjdk-17-runtime, window="_blank"])
+NOTE: `/home/jboss` is the WORKDIR for all quarkus binaries in the base images `ubi9/openjdk-17-runtime` and `ubi10/openjdk-21-runtime` (https://catalog.redhat.com/en/software/containers/ubi10/openjdk-21-runtime/690ca3b700d71ac7397b98c6?container-tabs=dockerfile[Dockerfile for ubi10/openjdk-21-runtime, window="_blank"])
 
 ==== Multi-module projects and layering
 
@@ -150,7 +150,7 @@ For example, building multi-platform images is implemented differently for Docke
 === OpenShift
 
 The extension `quarkus-container-image-openshift` is using OpenShift binary builds in order to perform container builds inside the OpenShift cluster.
-The idea behind the binary build is that you just upload the artifact and its dependencies to the cluster and during the build they will be merged to a builder image (defaults to `ubi9/openjdk-17` or `ubi9/openjdk-21`).
+The idea behind the binary build is that you just upload the artifact and its dependencies to the cluster and during the build they will be merged to a builder image (defaults to `ubi9/openjdk-17` or `ubi10/openjdk-21`).
 
 The benefit of this approach, is that it can be combined with OpenShift's `DeploymentConfig` that makes it easy to roll out changes to the cluster.
 

--- a/docs/src/main/asciidoc/deploying-to-openshift-s2i-howto.adoc
+++ b/docs/src/main/asciidoc/deploying-to-openshift-s2i-howto.adoc
@@ -74,14 +74,14 @@ oc import-image {name-image-ubi9-open-jdk-17-short} --from={name-image-ubi9-open
 +
 [source,shell,subs="attributes+",options="nowrap"]
 ----
-oc import-image {name-image-ubi9-open-jdk-21-short} --from={name-image-ubi9-open-jdk-21} --confirm
+oc import-image {name-image-ubi10-open-jdk-21-short} --from={name-image-ubi10-open-jdk-21} --confirm
 ----
 +
 * Java {jdk-version-latest}:
 +
 [source,shell,subs="attributes+",options="nowrap"]
 ----
-oc import-image {name-image-ubi9-open-jdk-25-short} --from={name-image-ubi9-open-jdk-25} --confirm
+oc import-image {name-image-ubi10-open-jdk-25-short} --from={name-image-ubi10-open-jdk-25} --confirm
 ----
 +
 [NOTE]
@@ -92,8 +92,8 @@ oc import-image {name-image-ubi9-open-jdk-25-short} --from={name-image-ubi9-open
 +
 For more information, see the link:https://docs.openshift.com/container-platform/[Red Hat Openshift Container Platform] documentation.
 
-* If you are deploying on IBM Z infrastructure, enter `oc import-image {name-image-ubi9-open-jdk-21-short} --from=registry.redhat.io/{name-image-ubi9-open-jdk-21-short} --confirm` instead.
-For information about this image, see link:https://catalog.redhat.com/en/software/containers/ubi9/openjdk-21-runtime/6501ce769a0d86945c422d5f[OpenJDK 21 runtime image on UBI9].
+* If you are deploying on IBM Z infrastructure, enter `oc import-image {name-image-ubi10-open-jdk-21-short} --from=registry.redhat.io/{name-image-ubi10-open-jdk-21-short} --confirm` instead.
+For information about this image, see link:https://catalog.redhat.com/en/software/containers/ubi10/openjdk-21-runtime/690ca3b700d71ac7397b98c6[OpenJDK 21 runtime image on UBI 10].
 ====
 
 . Build the project, create the application, and deploy the {openshift} service.
@@ -108,14 +108,14 @@ oc new-app {name-image-ubi9-open-jdk-17}~<git_path> --name=<project_name>
 +
 [source,shell,subs="attributes+",options="nowrap"]
 ----
-oc new-app {name-image-ubi9-open-jdk-21}~<git_path> --name=<project_name>
+oc new-app {name-image-ubi10-open-jdk-21}~<git_path> --name=<project_name>
 ----
 +
 * Java {jdk-version-latest}:
 +
 [source,shell,subs="attributes+",options="nowrap"]
 ----
-oc new-app {name-image-ubi9-open-jdk-25}~<git_path> --name=<project_name>
+oc new-app {name-image-ubi10-open-jdk-25}~<git_path> --name=<project_name>
 ----
 +
 .. Replace `<git_path>` with the path of the Git repository that hosts your Quarkus project.
@@ -124,7 +124,7 @@ For example, for Java {jdk-version-other}:
 +
 [source,shell,subs="attributes+",options="nowrap"]
 ----
-oc new-app {name-image-ubi9-open-jdk-21}~https://github.com/johndoe/code-with-quarkus.git --name=code-with-quarkus
+oc new-app {name-image-ubi10-open-jdk-21}~https://github.com/johndoe/code-with-quarkus.git --name=code-with-quarkus
 ----
 {nbsp}
 +
@@ -134,7 +134,7 @@ If you do not have SSH keys configured for the Git repository, when specifying t
 +
 [NOTE]
 ====
-If you are deploying on IBM Z infrastructure, enter `oc new-app ubi9/openjdk-21~<git_path> --name=<project_name>` instead.
+If you are deploying on IBM Z infrastructure, enter `oc new-app ubi10/openjdk-21~<git_path> --name=<project_name>` instead.
 ====
 
 . To deploy an updated version of the project, push changes to the Git repository, and then run:

--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -518,13 +518,13 @@ Configuring the `quarkusBuild` task can be done as following:
 quarkusBuild {
     nativeArgs {
         containerBuild = true <1>
-        builderImage = "quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor}" <2>
+        builderImage = "quay.io/quarkus/ubi10-quarkus-mandrel-builder-image:{mandrel-flavor}" <2>
     }
 }
 ----
 
 <1> Set `quarkus.native.container-build` property to `true`
-<2> Set `quarkus.native.builder-image` property to `quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor}`
+<2> Set `quarkus.native.builder-image` property to `quay.io/quarkus/ubi10-quarkus-mandrel-builder-image:{mandrel-flavor}`
 ****
 
 [role="secondary asciidoc-tabs-sync-kotlin"]
@@ -535,13 +535,13 @@ quarkusBuild {
 tasks.quarkusBuild {
     nativeArgs {
         "container-build" to true <1>
-        "builder-image" to "quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor}" <2>
+        "builder-image" to "quay.io/quarkus/ubi10-quarkus-mandrel-builder-image:{mandrel-flavor}" <2>
     }
 }
 ----
 
 <1> Set `quarkus.native.container-build` property to `true`
-<2> Set `quarkus.native.builder-image` property to `quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor}`
+<2> Set `quarkus.native.builder-image` property to `quay.io/quarkus/ubi10-quarkus-mandrel-builder-image:{mandrel-flavor}`
 ****
 
 [WARNING]
@@ -564,15 +564,15 @@ Note that in this case the build itself runs in a Docker container too, so you d
 
 [TIP]
 ====
-By default, the native executable will be generated using the `quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor}` Docker image.
+By default, the native executable will be generated using the `quay.io/quarkus/ubi10-quarkus-mandrel-builder-image:{mandrel-flavor}` Docker image.
 
 If you want to build a native executable with a different Docker image (for instance to use a different GraalVM version),
 use the `-Dquarkus.native.builder-image=<image name>` build argument.
 
-The list of the available Docker images can be found on https://quay.io/repository/quarkus/ubi9-quarkus-mandrel-builder-image?tab=tags[quay.io].
+The list of the available Docker images can be found on https://quay.io/repository/quarkus/ubi10-quarkus-mandrel-builder-image?tab=tags[quay.io].
 Be aware that a given Quarkus version might not be compatible with all the images available.
 
-Note also that starting Quarkus 3.19, the default _builder_ images are based on UBI 9. To use the previous UBI 8 based images, you can use the pick an image from the https://quay.io/repository/quarkus/ubi-quarkus-mandrel-builder-image?tab=tags[quay.io repository].
+The default _builder_ images are based on UBI 10. To use older UBI based images, you can pick an image from the https://quay.io/repository/quarkus/ubi9-quarkus-mandrel-builder-image?tab=tags[quay.io repository (UBI 9)] or the https://quay.io/repository/quarkus/ubi-quarkus-mandrel-builder-image?tab=tags[quay.io repository (UBI 8)].
 ====
 
 == Running native tests

--- a/docs/src/main/asciidoc/maven-tooling.adoc
+++ b/docs/src/main/asciidoc/maven-tooling.adoc
@@ -519,17 +519,17 @@ Note that in this case the build itself runs in a Docker container too, so you d
 
 [TIP]
 ====
-By default, the native executable will be generated using the `quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor}` Docker image.
+By default, the native executable will be generated using the `quay.io/quarkus/ubi10-quarkus-mandrel-builder-image:{mandrel-flavor}` Docker image.
 
 If you want to build a native executable with a different Docker image (for instance to use a different GraalVM version),
 use the `-Dquarkus.native.builder-image=<image name>` build argument.
 
-The list of the available Docker images can be found on https://quay.io/repository/quarkus/ubi9-quarkus-mandrel-builder-image?tab=tags[quay.io].
+The list of the available Docker images can be found on https://quay.io/repository/quarkus/ubi10-quarkus-mandrel-builder-image?tab=tags[quay.io].
 Be aware that a given Quarkus version might not be compatible with all the images available.
 
-Starting from Quarkus 3.19, the _builder_ image is based on UBI 9, and thus requires an UBI 9 base image if you want to run the native executable in a container.
-You can switch back to UBI 8, by setting the `quarkus.native.builder-image` property to one of the available image from the https://quay.io/repository/quarkus/ubi-quarkus-mandrel-builder-image?tab=tags[quay.io repository].
-For example ``quay.io/quarkus/ubi-quarkus-mandrel-builder-image:{mandrel-flavor}` is using UBI 8, and so the resulting native executable will be compatible with UBI 8 base images.
+The _builder_ image is based on UBI 10, and thus requires an UBI 10 base image if you want to run the native executable in a container.
+You can switch to an older UBI version by setting the `quarkus.native.builder-image` property to one of the available images from the https://quay.io/repository/quarkus/ubi9-quarkus-mandrel-builder-image?tab=tags[quay.io repository (UBI 9)] or the https://quay.io/repository/quarkus/ubi-quarkus-mandrel-builder-image?tab=tags[quay.io repository (UBI 8)].
+For example `quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor}` is using UBI 9, and so the resulting native executable will be compatible with UBI 9 base images.
 
 ====
 

--- a/docs/src/main/asciidoc/native-reference.adoc
+++ b/docs/src/main/asciidoc/native-reference.adoc
@@ -592,7 +592,7 @@ $ ./mvnw verify -DskipITs=false -Dquarkus.test.integration-test-profile=test-wit
 [INFO]  T E S T S
 [INFO] -------------------------------------------------------
 [INFO] Running org.acme.GreetingResourceIT
-2024-05-14 16:29:53,941 INFO  [io.qua.tes.com.DefaultDockerContainerLauncher] (main) Executing "podman run --name quarkus-integration-test-PodgW -i --rm --user 501:20 -p 8081:8081 -p 8444:8444 --entrypoint java -v /tmp/new-project/target:/project --env QUARKUS_LOG_CATEGORY__IO_QUARKUS__LEVEL=INFO --env QUARKUS_HTTP_PORT=8081 --env QUARKUS_HTTP_SSL_PORT=8444 --env TEST_URL=http://localhost:8081 --env QUARKUS_PROFILE=test-with-native-agent --env QUARKUS_TEST_INTEGRATION_TEST_PROFILE=test-with-native-agent quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:jdk-21 -agentlib:native-image-agent=access-filter-file=quarkus-access-filter.json,caller-filter-file=quarkus-caller-filter.json,config-output-dir=native-image-agent-base-config, -jar quarkus-app/quarkus-run.jar"
+2024-05-14 16:29:53,941 INFO  [io.qua.tes.com.DefaultDockerContainerLauncher] (main) Executing "podman run --name quarkus-integration-test-PodgW -i --rm --user 501:20 -p 8081:8081 -p 8444:8444 --entrypoint java -v /tmp/new-project/target:/project --env QUARKUS_LOG_CATEGORY__IO_QUARKUS__LEVEL=INFO --env QUARKUS_HTTP_PORT=8081 --env QUARKUS_HTTP_SSL_PORT=8444 --env TEST_URL=http://localhost:8081 --env QUARKUS_PROFILE=test-with-native-agent --env QUARKUS_TEST_INTEGRATION_TEST_PROFILE=test-with-native-agent quay.io/quarkus/ubi10-quarkus-mandrel-builder-image:jdk-21 -agentlib:native-image-agent=access-filter-file=quarkus-access-filter.json,caller-filter-file=quarkus-caller-filter.json,config-output-dir=native-image-agent-base-config, -jar quarkus-app/quarkus-run.jar"
 ...
 [INFO]
 [INFO] --- quarkus:{quarkus-version}:native-image-agent (default) @ new-project ---
@@ -846,7 +846,7 @@ So, go ahead and add the following options to that file:
 [source,properties,subs=attributes+]
 ----
 quarkus.native.container-build=true
-quarkus.native.builder-image=quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor}
+quarkus.native.builder-image=quay.io/quarkus/ubi10-quarkus-mandrel-builder-image:{mandrel-flavor}
 quarkus.container-image.build=true
 quarkus.container-image.group=test
 ----
@@ -1266,7 +1266,7 @@ These are called expert options and you can learn more about them by running:
 
 [source,bash,subs=attributes+]
 ----
-docker run quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor} --expert-options-all
+docker run quay.io/quarkus/ubi10-quarkus-mandrel-builder-image:{mandrel-flavor} --expert-options-all
 ----
 
 [WARNING]
@@ -2462,7 +2462,7 @@ E.g.
 [source,bash,subs=attributes+]
 ----
 ./mvnw package -DskipTests -Dnative -Dquarkus.native.container-build=true \
-    -Dquarkus.native.builder-image=quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor} \
+    -Dquarkus.native.builder-image=quay.io/quarkus/ubi10-quarkus-mandrel-builder-image:{mandrel-flavor} \
     -Dquarkus.native.monitoring=jfr
 ----
 

--- a/docs/src/main/asciidoc/platform.adoc
+++ b/docs/src/main/asciidoc/platform.adoc
@@ -138,22 +138,23 @@ A platform properties file for the example above would contain:
 
 [source,text,subs=attributes+]
 ----
-platform.quarkus.native.builder-image=quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor}
+platform.quarkus.native.builder-image=quay.io/quarkus/ubi10-quarkus-mandrel-builder-image:{mandrel-flavor}
 ----
 
 [IMPORTANT]
 ====
-Starting with Quarkus 3.19+, the _builder_ image used to build the native executable is based on UBI 9.
-It means that the native executable produced by the container build will be based on UBI 9 as well.
-So, if you plan to build a container, make sure that the base image in your `Dockerfile` is compatible with UBI 9.
-The native executable will not run on UBI 8 base images.
+The _builder_ image used to build the native executable is based on UBI 10.
+It means that the native executable produced by the container build will be based on UBI 10 as well.
+So, if you plan to build a container, make sure that the base image in your `Dockerfile` is compatible with UBI 10.
+The native executable will not run on UBI 8 or UBI 9 base images.
 
-For example to switch back to an UBI8 _builder image_ you can use:
+For example to switch back to an UBI 9 _builder image_ you can use:
 
-`platform.quarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:{mandrel-flavor}`
+`platform.quarkus.native.builder-image=quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor}`
 
-You can see the available tags for UBI8 https://quay.io/repository/quarkus/ubi-quarkus-mandrel-builder-image?tab=tags[here]
-and for UBI9 https://quay.io/repository/quarkus/ubi9-quarkus-mandrel-builder-image?tab=tags[here (UBI 9)])
+You can see the available tags for UBI 8 https://quay.io/repository/quarkus/ubi-quarkus-mandrel-builder-image?tab=tags[here (UBI 8)],
+for UBI 9 https://quay.io/repository/quarkus/ubi9-quarkus-mandrel-builder-image?tab=tags[here (UBI 9)],
+and for UBI 10 https://quay.io/repository/quarkus/ubi10-quarkus-mandrel-builder-image?tab=tags[here (UBI 10)])
 ====
 
 

--- a/docs/src/main/asciidoc/quarkus-runtime-base-image.adoc
+++ b/docs/src/main/asciidoc/quarkus-runtime-base-image.adoc
@@ -9,9 +9,9 @@ include::_attributes.adoc[]
 :topics: docker,podman,images
 
 To ease the containerization of native executables, Quarkus provides a base image providing the requirements to run these executables.
-The `ubi9-quarkus-micro-image:2.0` image is:
+The `ubi10-quarkus-micro-image:2.0` image is:
 
-* small (based on `ubi9-micro`)
+* small (based on `ubi10-micro`)
 * designed for containers
 * contains the right set of dependencies (glibc, libstdc++, zlib)
 * support upx-compressed executables (more details on the xref:upx.adoc[enabling compression documentation])
@@ -22,7 +22,7 @@ In your `Dockerfile`, just use:
 
 [source, dockerfile]
 ----
-FROM quay.io/quarkus/ubi9-quarkus-micro-image:2.0
+FROM quay.io/quarkus/ubi10-quarkus-micro-image:2.0
 WORKDIR /work/
 COPY --chmod=0755 target/*-runner /work/application
 EXPOSE 8080
@@ -48,11 +48,11 @@ Headless graphics, PDF documents, QR code images etc. manipulation is natively s
 [source, dockerfile]
 ----
 # First stage - install the dependencies in an intermediate container
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6 as nativelibs
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.2 as nativelibs
 RUN microdnf install -y freetype fontconfig expat
 
 # Second stage - copy the dependencies
-FROM quay.io/quarkus/ubi9-quarkus-micro-image:2.0
+FROM quay.io/quarkus/ubi10-quarkus-micro-image:2.0
 WORKDIR /work/
 COPY --from=nativelibs \
    /lib64/libz.so.1 \
@@ -100,7 +100,7 @@ ENTRYPOINT ["./application", "-Dquarkus.http.host=0.0.0.0"]
 
 == Alternative - Using ubi-minimal
 
-If the micro image does not suit your requirements, you can use https://catalog.redhat.com/software/containers/ubi9-minimal/61832888c0d15aff4912fe0d[ubi9-minimal].
+If the micro image does not suit your requirements, you can use https://catalog.redhat.com/en/software/containers/ubi10-minimal/66f16af45db83414cddcfc99[ubi10-minimal].
 It's a bigger image, but contains more utilities and is closer to a full Linux distribution.
 Typically, it contains a package manager (`microdnf`), so you can install packages more easily.
 
@@ -108,7 +108,7 @@ To use this base image, use the following `Dockerfile`:
 
 [source, dockerfile]
 ----
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.2
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \
@@ -125,7 +125,7 @@ To make documents processing, graphics, PDFs, etc. available for the application
 
 [source, dockerfile]
 ----
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.2
 RUN microdnf install -y freetype fontconfig \
     && microdnf clean all
 

--- a/docs/src/main/asciidoc/virtual-threads.adoc
+++ b/docs/src/main/asciidoc/virtual-threads.adoc
@@ -366,7 +366,7 @@ To containerize your Quarkus application that use `@RunOnVirtualThread`, add the
 quarkus.container-image.build=true
 quarkus.container-image.group=<your-group-name>
 quarkus.container-image.name=<you-container-name>
-quarkus.jib.base-jvm-image=registry.access.redhat.com/ubi9/openjdk-21-runtime <1>
+quarkus.jib.base-jvm-image=registry.access.redhat.com/ubi10/openjdk-21-runtime <1>
 quarkus.jib.platforms=linux/amd64,linux/arm64 <2>
 ----
 <1> Make sure you use a base image supporting virtual threads. Here we use an image providing Java 21. Quarkus picks an image providing Java 21+ automatically if you do not set one.

--- a/extensions/container-image/container-image-docker-common/deployment/src/test/java/io/quarkus/container/image/docker/common/deployment/UbiMinimalBaseProviderTest.java
+++ b/extensions/container-image/container-image-docker-common/deployment/src/test/java/io/quarkus/container/image/docker/common/deployment/UbiMinimalBaseProviderTest.java
@@ -43,7 +43,9 @@ class UbiMinimalBaseProviderTest {
                 Arguments.of(8, 17, ContainerImages.UBI8_MINIMAL_VERSION),
                 Arguments.of(8, 21, ContainerImages.UBI8_MINIMAL_VERSION),
                 Arguments.of(9, 17, ContainerImages.UBI9_MINIMAL_VERSION),
-                Arguments.of(9, 21, ContainerImages.UBI9_MINIMAL_VERSION));
+                Arguments.of(9, 21, ContainerImages.UBI9_MINIMAL_VERSION),
+                Arguments.of(10, 21, ContainerImages.UBI10_MINIMAL_VERSION),
+                Arguments.of(10, 25, ContainerImages.UBI10_MINIMAL_VERSION));
     }
 
     @Test

--- a/extensions/container-image/container-image-docker-common/deployment/src/test/resources/ubi10-java21
+++ b/extensions/container-image/container-image-docker-common/deployment/src/test/resources/ubi10-java21
@@ -1,0 +1,31 @@
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.2
+
+ARG JAVA_PACKAGE=java-21-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.8
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf -y install ca-certificates ${JAVA_PACKAGE} \
+    && microdnf -y update \
+    && microdnf -y clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+# We make four distinct layers so if there are application changes the library layers can be re-used
+COPY --chown=1001 target/quarkus-app/lib/ /deployments/lib/
+COPY --chown=1001 target/quarkus-app/*.jar /deployments/
+COPY --chown=1001 target/quarkus-app/app/ /deployments/app/
+COPY --chown=1001 target/quarkus-app/quarkus/ /deployments/quarkus/
+
+EXPOSE 8080
+USER 1001
+
+ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/extensions/container-image/container-image-docker-common/deployment/src/test/resources/ubi10-java25
+++ b/extensions/container-image/container-image-docker-common/deployment/src/test/resources/ubi10-java25
@@ -1,0 +1,31 @@
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.2
+
+ARG JAVA_PACKAGE=java-25-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.8
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf -y install ca-certificates ${JAVA_PACKAGE} \
+    && microdnf -y update \
+    && microdnf -y clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+# We make four distinct layers so if there are application changes the library layers can be re-used
+COPY --chown=1001 target/quarkus-app/lib/ /deployments/lib/
+COPY --chown=1001 target/quarkus-app/*.jar /deployments/
+COPY --chown=1001 target/quarkus-app/app/ /deployments/app/
+COPY --chown=1001 target/quarkus-app/quarkus/ /deployments/quarkus/
+
+EXPOSE 8080
+USER 1001
+
+ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/ContainerImageJibConfig.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/ContainerImageJibConfig.java
@@ -21,10 +21,10 @@ public interface ContainerImageJibConfig {
     /**
      * The base image to be used when a container image is being produced for the jar build.
      *
-     * When the application is built against Java 25 or higher, {@code registry.access.redhat.com/ubi9/openjdk-25-runtime:1.24}
+     * When the application is built against Java 25 or higher, {@code registry.access.redhat.com/ubi10/openjdk-25-runtime:1.24}
      * is used as the default.
      * Otherwise, when the application is built against Java 21 to Java 24,
-     * {@code registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24}
+     * {@code registry.access.redhat.com/ubi10/openjdk-21-runtime:1.24}
      * is used as the default.
      * Otherwise {@code registry.access.redhat.com/ubi9/openjdk-17-runtime:1.24} is used as the default.
      */
@@ -32,8 +32,8 @@ public interface ContainerImageJibConfig {
 
     /**
      * The base image to be used when a container image is being produced for the native binary build.
-     * The default is "quay.io/quarkus/ubi9-quarkus-micro-image:2.0". You can also use
-     * "registry.access.redhat.com/ubi9/ubi-minimal" which is a bigger base image, but provide more built-in utilities
+     * The default is "quay.io/quarkus/ubi10-quarkus-micro-image:2.0". You can also use
+     * "registry.access.redhat.com/ubi10/ubi-minimal" which is a bigger base image, but provide more built-in utilities
      * such as the microdnf package manager.
      */
     @WithDefault(ContainerImages.QUARKUS_MICRO_IMAGE)

--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/ContainerImageOpenshiftConfig.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/ContainerImageOpenshiftConfig.java
@@ -49,10 +49,10 @@ public interface ContainerImageOpenshiftConfig {
      * The value of this property is used to create an ImageStream for the builder image used in the OpenShift build.
      * When it references images already available in the internal OpenShift registry, the corresponding streams are used
      * instead.
-     * When the application is built against Java 25 or higher, {@code registry.access.redhat.com/ubi9/openjdk-25:1.24}
+     * When the application is built against Java 25 or higher, {@code registry.access.redhat.com/ubi10/openjdk-25:1.24}
      * is used as the default.
      * Otherwise, when the application is built against Java 21 to Java 24,
-     * {@code registry.access.redhat.com/ubi9/openjdk-21:1.24}
+     * {@code registry.access.redhat.com/ubi10/openjdk-21:1.24}
      * is used as the default.
      * Otherwise {@code registry.access.redhat.com/ubi9/openjdk-17:1.24} is used as the default.
      */

--- a/independent-projects/tools/devtools-testing/src/main/resources/fake-catalog.json
+++ b/independent-projects/tools/devtools-testing/src/main/resources/fake-catalog.json
@@ -429,10 +429,10 @@
     "project": {
       "default-codestart": "resteasy-reactive",
       "codestart-data": {
-        "dockerfile.jvm.from-template": "registry.access.redhat.com/ubi9/openjdk-{java.version}:1.23",
-        "dockerfile.jvm.from": "registry.access.redhat.com/ubi9/openjdk-${recommended-java-version}:1.23",
-        "dockerfile.native.from": "registry.access.redhat.com/ubi9/ubi-minimal:9.7",
-        "dockerfile.native-micro": "quay.io/quarkus/ubi9-quarkus-micro-image:2.0"
+        "dockerfile.jvm.from-template": "registry.access.redhat.com/ubi10/openjdk-{java.version}-runtime:1.24",
+        "dockerfile.jvm.from": "registry.access.redhat.com/ubi10/openjdk-${recommended-java-version}-runtime:1.24",
+        "dockerfile.native.from": "registry.access.redhat.com/ubi10/ubi-minimal:10.2",
+        "dockerfile.native-micro": "quay.io/quarkus/ubi10-quarkus-micro-image:2.0"
       },
       "properties": {
         "doc-root": "https://quarkus.io",

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/launcher/DockerContainerLauncherProvider.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/launcher/DockerContainerLauncherProvider.java
@@ -67,7 +67,7 @@ public class DockerContainerLauncherProvider implements ArtifactLauncherProvider
                 Optional<String> entryPoint = Optional.of("java");
                 Map<String, String> volumeMounts = new HashMap<>(volumeMounts(config));
                 volumeMounts.put(context.buildOutputDirectory().toString(), "/project");
-                containerImage = ContainerImages.UBI9_MANDREL_BUILDER;
+                containerImage = ContainerImages.UBI10_MANDREL_BUILDER;
 
                 List<String> programArgs = new ArrayList<>();
                 addNativeAgentProgramArgs(programArgs, context);


### PR DESCRIPTION
This is a simplification of https://github.com/quarkusio/quarkus/pull/50871 as we already included the Java 25 work into the tree.

UBI 10 only supports Java 21 and 25 but it's now a consistent viable target for Quarkus 4 given we are dropping Java 17.

Created as draft as I expect some conflicts when we will merge 4 in main.