### PR TITLE
Use branch instead of version to avoid dead link on main guides

### DIFF
--- a/docs/src/main/asciidoc/_attributes.adoc
+++ b/docs/src/main/asciidoc/_attributes.adoc
@@ -3,7 +3,14 @@
 :project-name: Quarkus
 :quarkus-version: ${project.version}
 :quarkus-platform-groupid: io.quarkus.platform
-// .
+//
+  ifeval::["{quarkus-version}" == "999-SNAPSHOT"]
+  :quarkus-branch: main
+  endif::[]
+  ifeval::["{quarkus-version}" != "999-SNAPSHOT"]
+  :quarkus-branch: {quarkus-version}
+  endif::[]
+//
 :maven-version: ${proposed-maven-version}
 :graalvm-version: ${graal-community.version-for-documentation}
 :graalvm-docs-version: ${graal-community.tag-for-documentation}

--- a/docs/src/main/asciidoc/_attributes.adoc
+++ b/docs/src/main/asciidoc/_attributes.adoc
@@ -4,6 +4,12 @@
 :quarkus-version: ${project.version}
 :quarkus-platform-groupid: io.quarkus.platform
 // .
+ifeval::["{quarkus-version}" == "999-SNAPSHOT"]
+:quarkus-branch: main
+endif::[]
+ifeval::["{quarkus-version}" != "999-SNAPSHOT"]
+:quarkus-branch: {quarkus-version}
+endif::[]
 :maven-version: ${proposed-maven-version}
 :graalvm-version: ${graal-community.version-for-documentation}
 :graalvm-docs-version: ${graal-community.tag-for-documentation}

--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -557,7 +557,7 @@ If you do not specify it on the command line, the plugin will derive it from `ex
 So you may consider omitting explicit `name` in some cases.
 
 // The following link should point to the mojo page once https://github.com/quarkusio/quarkusio.github.io/issues/265 is fixed
-Please refer to https://github.com/quarkusio/quarkus/blob/{quarkus-version}/devtools/maven/src/main/java/io/quarkus/maven/CreateExtensionMojo.java[CreateExtensionMojo JavaDoc] for all the available options of the mojo.
+Please refer to https://github.com/quarkusio/quarkus/blob/{quarkus-branch}/devtools/maven/src/main/java/io/quarkus/maven/CreateExtensionMojo.java[CreateExtensionMojo JavaDoc] for all the available options of the mojo.
 
 ==== Using Gradle
 

--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -555,7 +555,7 @@ If you do not specify it on the command line, the plugin will derive it from `ex
 So you may consider omitting explicit `name` in some cases.
 
 // The following link should point to the mojo page once https://github.com/quarkusio/quarkusio.github.io/issues/265 is fixed
-Please refer to https://github.com/quarkusio/quarkus/blob/{quarkus-version}/devtools/maven/src/main/java/io/quarkus/maven/CreateExtensionMojo.java[CreateExtensionMojo JavaDoc] for all the available options of the mojo.
+Please refer to https://github.com/quarkusio/quarkus/blob/{quarkus-branch}/devtools/maven/src/main/java/io/quarkus/maven/CreateExtensionMojo.java[CreateExtensionMojo JavaDoc] for all the available options of the mojo.
 
 ==== Using Gradle
 


### PR DESCRIPTION
We have one guide that references git paths directly. In most cases, the git path and quarkus version match, but for 999-SNAPSHOT, they do not. We should use `main` instead.