### PR TITLE
ci: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -210,7 +210,7 @@ jobs:
           echo "quarkus-metadata-cache-key-default=quarkus-metadata-cache-${CURRENT_WEEK}-${{ github.event.repository.default_branch }}" >> $GITHUB_OUTPUT
       - name: Configure Runs-On
         id: configure
-        uses: quarkusio/runs-on-action@main
+        uses: quarkusio/runs-on-action@50f65c7bc42fe2983c36729989fe5c79634ac5e0 # main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           main-repository: quarkusio/quarkus
@@ -2013,7 +2013,7 @@ jobs:
           distribution: temurin
           java-version: 25
       - name: Produce report and add it as job summary
-        uses: quarkusio/action-build-reporter@main
+        uses: quarkusio/action-build-reporter@1e64a0f4bf7d7868af1867472c91ed039db7fa1d # main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           build-reports-artifacts-path: build-reports-artifacts

--- a/.github/workflows/develocity-publish-build-scans.yml
+++ b/.github/workflows/develocity-publish-build-scans.yml
@@ -46,7 +46,7 @@ jobs:
             echo -e "\n\`\`\`" >> $GITHUB_STEP_SUMMARY;
           fi
       - name: Inject build scans in reports
-        uses: quarkusio/action-helpers@main
+        uses: quarkusio/action-helpers@4f05abc46fce576bd83fe6d61df45506783f60d1 # main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           action: inject-build-scans

--- a/.github/workflows/jdk-early-access-build.yml
+++ b/.github/workflows/jdk-early-access-build.yml
@@ -107,14 +107,14 @@ jobs:
       # Test reports disabled due to: https://github.com/ScaCap/action-surefire-report/issues/39
       #- name: Publish Test Report
       #  if: always()
-      #  uses: scacap/action-surefire-report@v1
+      #  uses: scacap/action-surefire-report@3dacff26879cd2a7f2160d101254032a3707fe6f # v1
       #  with:
       #    github_token: ${{ secrets.GITHUB_TOKEN }}
       #    # fail required to upload failure archive in subsequent actions
       #    fail_on_test_failures: true
       #- name: Publish Gradle Test Report
       #  if: always()
-      #  uses: scacap/action-surefire-report@v1
+      #  uses: scacap/action-surefire-report@3dacff26879cd2a7f2160d101254032a3707fe6f # v1
       #  with:
       #    github_token: ${{ secrets.GITHUB_TOKEN }}
       #    # fail required to upload failure archive in subsequent actions
@@ -137,7 +137,7 @@ jobs:
         run: rm -r ~/.m2/repository/io/quarkus
       - name: Report status
         if: always() && github.repository == 'quarkusio/quarkus' && github.event_name != 'workflow_dispatch'
-        uses: quarkusio/report-status-in-issue@main
+        uses: quarkusio/report-status-in-issue@ee5fc1fa67e60f86018bef7d352e31eadf2dc588 # main
         with:
           github-token: ${{ secrets.GITHUB_API_TOKEN }}
           status: ${{ job.status }}

--- a/.github/workflows/native-it-selected-graalvm.yml
+++ b/.github/workflows/native-it-selected-graalvm.yml
@@ -420,7 +420,7 @@ jobs:
           distribution: temurin
           java-version: 17
       - name: Produce report and add it as job summary
-        uses: quarkusio/action-build-reporter@main
+        uses: quarkusio/action-build-reporter@1e64a0f4bf7d7868af1867472c91ed039db7fa1d # main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           build-reports-artifacts-path: build-reports-artifacts

--- a/.github/workflows/preview-teardown.yml
+++ b/.github/workflows/preview-teardown.yml
@@ -21,7 +21,7 @@ jobs:
         id: deploy
         run: npx surge teardown https://quarkus-pr-main-${{ github.event.number }}-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }} || true
       - name: Update PR status comment
-        uses: quarkusio/action-helpers@main
+        uses: quarkusio/action-helpers@4f05abc46fce576bd83fe6d61df45506783f60d1 # main
         with:
           action: maintain-one-comment
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -105,7 +105,7 @@ jobs:
           PR_ID: ${{ steps.pr.outputs.id }}
 
       - name: Update PR status comment on success
-        uses: quarkusio/action-helpers@main
+        uses: quarkusio/action-helpers@4f05abc46fce576bd83fe6d61df45506783f60d1 # main
         with:
           action: maintain-one-comment
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -119,7 +119,7 @@ jobs:
             <img width="300" src="https://user-images.githubusercontent.com/507615/90250366-88233900-de6e-11ea-95a5-84f0762ffd39.png">
           body-marker: <!-- Preview status comment marker -->
       - name: Update PR status comment on failure
-        uses: quarkusio/action-helpers@main
+        uses: quarkusio/action-helpers@4f05abc46fce576bd83fe6d61df45506783f60d1 # main
         if: ${{ failure() }}
         with:
           action: maintain-one-comment

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -54,7 +54,7 @@ jobs:
             clean install
       - name: Report status
         if: always()
-        uses: quarkusio/report-status-in-issue@main
+        uses: quarkusio/report-status-in-issue@ee5fc1fa67e60f86018bef7d352e31eadf2dc588 # main
         with:
           github-token: ${{ secrets.GITHUB_API_TOKEN }}
           status: ${{ job.status }}


### PR DESCRIPTION
Pin unpinned GitHub Actions to immutable commit SHAs. Defense against supply-chain attacks via mutable tags. Version tags retained as inline comments. See: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions