### PR TITLE
Add regression tests for QuteProcessor

### DIFF
--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/QuteProcessorTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/QuteProcessorTest.java
@@ -1,11 +1,15 @@
 package io.quarkus.qute.deployment;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
+import java.lang.reflect.Proxy;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -15,11 +19,12 @@ import io.quarkus.qute.Engine;
 import io.quarkus.qute.Expression;
 import io.quarkus.qute.Template;
 import io.quarkus.qute.deployment.TemplatesAnalysisBuildItem.TemplateAnalysis;
+import io.quarkus.qute.runtime.QuteConfig;
 
 public class QuteProcessorTest {
 
     @Test
-    public void testTemplateDataIgnorePattern() {
+    public void testTemplateDataIgnorePattern() throws Exception {
         List<String> names = List.of("foo", "bar");
         Pattern p = Pattern.compile(QuteProcessor.buildIgnorePattern(names));
         // Ignore "baz" and "getFoo"
@@ -34,7 +39,7 @@ public class QuteProcessorTest {
     }
 
     @Test
-    public void testCollectNamespaceExpressions() {
+    public void testCollectNamespaceExpressions() throws Exception {
         Template template = Engine.builder().build().parse("{msg:hello} {msg2:hello_alpha} {foo:baz.get(foo:bar)}");
         TemplateAnalysis analysis = new TemplateAnalysis("foo", template, null);
         Set<Expression> msg = QuteProcessor.collectNamespaceExpressions(analysis, "msg");
@@ -51,6 +56,39 @@ public class QuteProcessorTest {
             assertTrue(
                     fooExpr.toOriginalString().equals("foo:bar") || fooExpr.toOriginalString().equals("foo:baz.get(foo:bar)"));
         }
+    }
+
+    @Test
+    public void testCollectTemplateRoots() {
+        TemplateRootsBuildItem roots = new QuteProcessor().collectTemplateRoots(List.of(
+                new TemplateRootBuildItem("templates"),
+                new TemplateRootBuildItem("/emails/"),
+                new TemplateRootBuildItem("templates")));
+
+        assertEquals(Set.of("templates", "emails"), roots.getPaths());
+    }
+
+    @Test
+    public void testCollectTemplateVariants() throws IOException {
+        EffectiveTemplatePathsBuildItem paths = new EffectiveTemplatePathsBuildItem(List.of(
+                templatePath("item.html"), templatePath("item.txt"), templatePath("detail.html"),
+                templatePath("ignored.json")));
+
+        Map<String, List<String>> variants = new QuteProcessor()
+                .collectTemplateVariants(paths, configWithSuffixes("html", "txt")).getVariants();
+
+        assertThat(variants).containsOnlyKeys("item", "detail");
+        assertThat(variants.get("item")).containsExactlyInAnyOrder("item.html", "item.txt");
+        assertThat(variants.get("detail")).containsExactly("detail.html");
+    }
+
+    private static TemplatePathBuildItem templatePath(String path) {
+        return TemplatePathBuildItem.builder().path(path).extensionInfo("test").build();
+    }
+
+    private static QuteConfig configWithSuffixes(String... suffixes) {
+        return (QuteConfig) Proxy.newProxyInstance(QuteConfig.class.getClassLoader(), new Class<?>[] { QuteConfig.class },
+                (proxy, method, args) -> method.getName().equals("suffixes") ? List.of(suffixes) : null);
     }
 
 }


### PR DESCRIPTION
# Add regression tests for QuteProcessor

I added two regression tests for Qute template discovery.

Impact on coverage:

- Covers `collectTemplateRoots` and `collectTemplateVariants`, including the covered lines that collect configured [template roots](https://github.com/quarkusio/quarkus/blob/5b8508beac194241cbe9a4cbf2520c6ca8340e58/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java#L213-L218) and group [template paths by base name](https://github.com/quarkusio/quarkus/blob/5b8508beac194241cbe9a4cbf2520c6ca8340e58/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java#L2527-L2547).
- Adds coverage for 22 `QuteProcessor` lines and 10 branches.

Why:

These paths were not directly covered before. The new tests check that template roots are normalized/deduplicated and that variants respect the configured suffixes.

This is only a test change; it does not change public APIs or runtime behavior.

I hope you find these tests useful. 😄 Please let me know if you have any questions or concerns.

Thanks,
Amir