### PR TITLE
Quarkus Mailer: support for rotating credentials

### DIFF
--- a/docs/src/main/asciidoc/credentials-provider.adoc
+++ b/docs/src/main/asciidoc/credentials-provider.adoc
@@ -38,6 +38,7 @@ by the following credentials consumer extensions:
 * `oidc`
 * `oidc-client`
 * `messaging-rabbitmq`
+* `mailer`
 
 All extensions that rely on username/password authentication also allow setting configuration
 properties in the `application.properties` as an alternative. But the `Credentials Provider` is the only option

--- a/docs/src/main/asciidoc/mailer-reference.adoc
+++ b/docs/src/main/asciidoc/mailer-reference.adoc
@@ -380,6 +380,55 @@ More details about this extension and its configuration can be found in the http
 For more information about the Mailer configuration please refer to the <<configuration-reference,Configuration Reference>>.
 ====
 
+[#rotating-credentials]
+=== Rotating credentials
+
+The mailer supports dynamic credential rotation through the xref:credentials-provider.adoc[Credentials Provider] interface.
+This is useful for:
+
+* `XOAUTH2` tokens that expire and need refreshing
+* Credential rotation for security compliance
+* Integration with secret management systems (HashiCorp Vault, AWS Secrets Manager, etc.)
+
+[NOTE]
+====
+When a credentials provider is configured, the `quarkus.mailer.username` and `quarkus.mailer.password` properties are ignored.
+All credentials are fetched from the provider.
+====
+
+To ensure new credentials are picked up promptly, tune the connection pool settings:
+
+[source, properties]
+----
+# Recycle idle connections after 5 minutes
+quarkus.mailer.keep-alive-timeout=5M
+# Check for expired connections every second
+quarkus.mailer.pool-cleaner-period=1S
+----
+
+IMPORTANT: Set `keep-alive-timeout` to less than your credential TTL so that connections are recycled before credentials expire.
+
+=== Configuring XOAUTH2
+
+`XOAUTH2` is an authentication mechanism that uses OAuth 2.0 access tokens instead of passwords.
+It is commonly used with Gmail and other providers that support OAuth 2.0 for SMTP authentication.
+
+[source, properties]
+----
+quarkus.mailer.host=smtp.gmail.com
+quarkus.mailer.port=587
+quarkus.mailer.start-tls=REQUIRED
+quarkus.mailer.login=XOAUTH2
+quarkus.mailer.username=YOUREMAIL@gmail.com
+quarkus.mailer.password=YOUR_ACCESS_TOKEN
+----
+
+OAuth 2.0 access tokens are typically short-lived.
+To handle token refresh automatically, use a xref:credentials-provider.adoc[Credentials Provider] that fetches fresh tokens.
+
+The credentials provider must return the username as the `user` property and the OAuth 2.0 access token as the `password` property.
+See <<rotating-credentials,Rotating Credentials>> for more details on connection pool tuning.
+
 == Configuring TLS
 
 SMTP provides various way to use TLS:

--- a/extensions/mailer/deployment/pom.xml
+++ b/extensions/mailer/deployment/pom.xml
@@ -35,6 +35,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-mutiny-deployment</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-credentials-deployment</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/mailer/runtime/pom.xml
+++ b/extensions/mailer/runtime/pom.xml
@@ -32,6 +32,10 @@
             <artifactId>quarkus-mutiny</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-credentials</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-mutiny-vertx-mail-client</artifactId>
         </dependency>

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailCredentialsSupplier.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailCredentialsSupplier.java
@@ -1,0 +1,32 @@
+package io.quarkus.mailer.runtime;
+
+import static io.quarkus.credentials.CredentialsProvider.PASSWORD_PROPERTY_NAME;
+import static io.quarkus.credentials.CredentialsProvider.USER_PROPERTY_NAME;
+
+import java.util.function.Supplier;
+
+import io.quarkus.credentials.CredentialsProvider;
+import io.smallrye.mutiny.vertx.UniHelper;
+import io.vertx.core.Future;
+import io.vertx.ext.auth.authentication.UsernamePasswordCredentials;
+
+class MailCredentialsSupplier implements Supplier<Future<UsernamePasswordCredentials>> {
+
+    private final CredentialsProvider credentialsProvider;
+    private final String credentialsProviderName;
+
+    MailCredentialsSupplier(CredentialsProvider credentialsProvider, String credentialsProviderName) {
+        this.credentialsProvider = credentialsProvider;
+        this.credentialsProviderName = credentialsProviderName;
+    }
+
+    @Override
+    public Future<UsernamePasswordCredentials> get() {
+        return credentialsProvider.getCredentialsAsync(credentialsProviderName)
+                .map(credentials -> new UsernamePasswordCredentials(
+                        credentials.get(USER_PROPERTY_NAME),
+                        credentials.get(PASSWORD_PROPERTY_NAME)))
+                .convert()
+                .with(UniHelper::toFuture);
+    }
+}

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailerRuntimeConfig.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailerRuntimeConfig.java
@@ -8,6 +8,7 @@ import java.util.OptionalLong;
 import java.util.regex.Pattern;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.configuration.TrimmedStringConverter;
 import io.smallrye.config.WithConverter;
 import io.smallrye.config.WithDefault;
 
@@ -282,4 +283,20 @@ public interface MailerRuntimeConfig {
      * Some SMTP servers have the requirement to allow only a number of emails sent per connection.
      */
     OptionalLong maxMailsPerConnection();
+
+    /**
+     * The credentials provider name.
+     */
+    Optional<@WithConverter(TrimmedStringConverter.class) String> credentialsProvider();
+
+    /**
+     * The credentials provider bean name.
+     * <p>
+     * This is a bean name (as in {@code @Named}) of a bean that implements {@code CredentialsProvider}.
+     * It is used to select the credentials provider bean when multiple exist.
+     * This is unnecessary when there is only one credentials provider available.
+     * <p>
+     * For Vault, the credentials provider bean name is {@code vault-credentials-provider}.
+     */
+    Optional<@WithConverter(TrimmedStringConverter.class) String> credentialsProviderName();
 }

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/Mailers.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/Mailers.java
@@ -15,6 +15,8 @@ import jakarta.inject.Singleton;
 
 import org.jboss.logging.Logger;
 
+import io.quarkus.credentials.CredentialsProvider;
+import io.quarkus.credentials.runtime.CredentialsProviderFinder;
 import io.quarkus.mailer.Mailer;
 import io.quarkus.mailer.MockMailbox;
 import io.quarkus.mailer.SentMail;
@@ -34,6 +36,7 @@ import io.vertx.ext.mail.CanonicalizationAlgorithm;
 import io.vertx.ext.mail.DKIMSignOptions;
 import io.vertx.ext.mail.LoginOption;
 import io.vertx.ext.mail.MailClient;
+import io.vertx.ext.mail.MailClientBuilder;
 import io.vertx.ext.mail.MailConfig;
 import io.vertx.ext.mail.StartTLSOptions;
 
@@ -146,8 +149,24 @@ public class Mailers {
     private MailClient createMailClient(Vertx vertx, String name, MailerRuntimeConfig config,
             TlsConfigurationRegistry tlsRegistry) {
         io.vertx.ext.mail.MailConfig cfg = toVertxMailConfig(name, config, tlsRegistry);
+        MailClientBuilder clientBuilder = MailClient.builder(vertx).with(cfg);
+        if (config.credentialsProvider().isPresent()) {
+            String beanName = config.credentialsProviderName().orElse(null);
+            CredentialsProvider credentialsProvider = findCredentialsProvider(name, beanName);
+            String providerName = config.credentialsProvider().get();
+            MailCredentialsSupplier credentialsSupplier = new MailCredentialsSupplier(credentialsProvider, providerName);
+            clientBuilder.withCredentialsSupplier(credentialsSupplier);
+        }
         // Do not create a shared instance, as we want separated connection pool for each SMTP servers.
-        return MailClient.create(vertx, cfg);
+        return clientBuilder.build();
+    }
+
+    private CredentialsProvider findCredentialsProvider(String mailerName, String beanName) {
+        try {
+            return CredentialsProviderFinder.find(beanName);
+        } catch (Exception e) {
+            throw new ConfigurationException("Unable to find credentials provider for the mailer " + mailerName + ".", e);
+        }
     }
 
     private io.vertx.ext.mail.DKIMSignOptions toVertxDkimSignOptions(DkimSignOptionsConfig optionsConfig) {
@@ -229,11 +248,13 @@ public class Mailers {
             cfg.setOwnHostname(config.ownHostName().get());
         }
 
-        if (config.username().isPresent()) {
-            cfg.setUsername(config.username().get());
-        }
-        if (config.password().isPresent()) {
-            cfg.setPassword(config.password().get());
+        if (config.credentialsProvider().isEmpty()) {
+            if (config.username().isPresent()) {
+                cfg.setUsername(config.username().get());
+            }
+            if (config.password().isPresent()) {
+                cfg.setPassword(config.password().get());
+            }
         }
 
         if (config.port().isPresent()) {

--- a/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/runtime/FakeSmtpTestBase.java
+++ b/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/runtime/FakeSmtpTestBase.java
@@ -323,6 +323,16 @@ public class FakeSmtpTestBase {
         public OptionalLong maxMailsPerConnection() {
             return OptionalLong.empty();
         }
+
+        @Override
+        public Optional<String> credentialsProvider() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> credentialsProviderName() {
+            return Optional.empty();
+        }
     }
 
 }

--- a/integration-tests/mailer/src/main/java/io/quarkus/it/mailer/ChangingCredentialsProvider.java
+++ b/integration-tests/mailer/src/main/java/io/quarkus/it/mailer/ChangingCredentialsProvider.java
@@ -1,0 +1,26 @@
+package io.quarkus.it.mailer;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.credentials.CredentialsProvider;
+
+@ApplicationScoped
+@Unremovable
+public class ChangingCredentialsProvider implements CredentialsProvider {
+
+    private final AtomicInteger counter = new AtomicInteger();
+
+    @Override
+    public Map<String, String> getCredentials(String credentialsProviderName) {
+        int count = counter.getAndIncrement();
+        return Map.of(USER_PROPERTY_NAME, "user" + count, PASSWORD_PROPERTY_NAME, "pass" + count);
+    }
+
+    public int count() {
+        return counter.get();
+    }
+}

--- a/integration-tests/mailer/src/main/java/io/quarkus/it/mailer/MailResource.java
+++ b/integration-tests/mailer/src/main/java/io/quarkus/it/mailer/MailResource.java
@@ -49,6 +49,9 @@ public class MailResource {
     @MailerName("tls-registry-trust-all")
     Mailer tlsRegistryMailerWithTrustAll;
 
+    @MailerName("custom-credentials-provider")
+    Mailer mailerWithCustomCredentialsProvider;
+
     private Mailer select(String name) {
         if (name == null) {
             return defaultMailer;
@@ -232,4 +235,21 @@ public class MailResource {
         return "ok";
     }
 
+    @Inject
+    ChangingCredentialsProvider credentialsProvider;
+
+    /**
+     * Send a simple text email with a mailer that uses a credentials provider.
+     */
+    @GET
+    @Path("/custom-credentials-provider")
+    public String sendSimpleTextWithChangingCredentials() {
+        mailerWithCustomCredentialsProvider.send(Mail.withText("nobody@quarkus.io",
+                "simple test email",
+                "This is a simple test email.\nRegards,\nRoger the robot"));
+        mailerWithCustomCredentialsProvider.send(Mail.withText("nobody@quarkus.io",
+                "simple test email",
+                "This is a simple test email.\nRegards,\nRoger the robot"));
+        return String.valueOf(credentialsProvider.count());
+    }
 }

--- a/integration-tests/mailer/src/main/resources/application.properties
+++ b/integration-tests/mailer/src/main/resources/application.properties
@@ -83,3 +83,11 @@ quarkus.mailer.tls-registry-trust-all.host=${mailpit-tls.host}
 quarkus.mailer.tls-registry-trust-all.port=${mailpit-tls.port}
 quarkus.mailer.tls-registry-trust-all.from=roger-the-robot@quarkus.io
 
+# TLS mailer using credentials provider
+quarkus.mailer.custom-credentials-provider.tls-configuration-name=tls-registry-trust-all
+quarkus.mailer.custom-credentials-provider.host=${mailpit-tls.host}
+quarkus.mailer.custom-credentials-provider.port=${mailpit-tls.port}
+quarkus.mailer.custom-credentials-provider.from=roger-the-robot@quarkus.io
+quarkus.mailer.custom-credentials-provider.credentials-provider=custom
+quarkus.mailer.custom-credentials-provider.keep-alive=false
+quarkus.mailer.custom-credentials-provider.max-pool-size=1

--- a/integration-tests/mailer/src/test/java/io/quarkus/it/mailer/MailerTest.java
+++ b/integration-tests/mailer/src/test/java/io/quarkus/it/mailer/MailerTest.java
@@ -1,11 +1,13 @@
 package io.quarkus.it.mailer;
 
+import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import java.util.stream.Collectors;
 
 import org.eclipse.microprofile.config.ConfigProvider;
+import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -231,6 +233,21 @@ public class MailerTest {
 
         String content = clientTls.getMessageTextContent(email);
         assertThat(content).contains("This is a simple test email.");
+    }
+
+    @Test
+    public void sendEmailWithCustomCredentialsProvider() {
+        given()
+                .when().get("/mail/custom-credentials-provider")
+                .then()
+                .statusCode(200)
+                .body(CoreMatchers.equalTo("2"));
+
+        Message email = getLastEmail(clientTls);
+        assertThat(email).isNotNull();
+
+        assertThat(email.to().address()).isEqualTo("nobody@quarkus.io");
+        assertThat(email.subject).isEqualTo("simple test email");
     }
 
     private Message getLastEmail() {


### PR DESCRIPTION
The mailer supports dynamic credential rotation through the Credentials Provider interface. This is useful for:

* `XOAUTH2` tokens that expire and need refreshing
* Credential rotation for security compliance
* Integration with secret management systems (HashiCorp Vault, AWS Secrets Manager, etc.)

This is a copy of #54939 that I merged to the wrong branch (4.0 instead of _main_). The original PR was approved and passed the CI. 

