### PR TITLE
Generalize handing of any single-type-parameter parameterized type

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
@@ -239,7 +239,7 @@ public abstract class JacksonCodeGenerator {
         LIST(true),
         SET(true),
         MAP(true),
-        OPTIONAL(true),
+        WRAPPER(true),
         TYPE_VARIABLE(true);
 
         private final boolean generic;
@@ -275,10 +275,8 @@ public abstract class JacksonCodeGenerator {
                     registerTypeToBeGenerated(pType.arguments().get(0));
                     return FieldKind.LIST;
                 }
-                if (Optional.class.getName().equals(typeName)) {
-                    registerTypeToBeGenerated(pType.arguments().get(0));
-                    return FieldKind.OPTIONAL;
-                }
+                registerTypeToBeGenerated(pType.arguments().get(0));
+                return FieldKind.WRAPPER;
             }
             if (pType.arguments().size() == 2 && isAssignableTo(typeName, MAP_NAME)) {
                 registerTypeToBeGenerated(pType.arguments().get(0));

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonDeserializerFactory.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonDeserializerFactory.java
@@ -709,7 +709,7 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
                 ResultHandle valueTypes = bytecode.readInstanceField(valueTypesField, bytecode.getThis());
                 yield bytecode.readArrayValue(valueTypes, parameterIndex);
             }
-            case LIST, SET, OPTIONAL -> {
+            case LIST, SET, WRAPPER -> {
                 Type contentType = ((ParameterizedType) fieldType).arguments().get(0);
                 MethodDescriptor getTypeFactory = ofMethod(DeserializationContext.class, "getTypeFactory",
                         TypeFactory.class);

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/ParameterizedTypeReflectionFreeSerializerTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/ParameterizedTypeReflectionFreeSerializerTest.java
@@ -1,0 +1,76 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import static org.hamcrest.Matchers.is;
+
+import java.util.function.Supplier;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+
+public class ParameterizedTypeReflectionFreeSerializerTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(ParameterizedTypeResource.class,
+                                    ParameterizedTypeResource.Difficulty.class,
+                                    ParameterizedTypeResource.ChildDto.class,
+                                    ParameterizedTypeResource.Holder.class,
+                                    ParameterizedTypeResource.ThingRequest.class)
+                            .addAsResource(
+                                    new StringAsset(
+                                            "quarkus.rest.jackson.optimization.enable-reflection-free-serializers=true\n"),
+                                    "application.properties");
+                }
+            });
+
+    @Test
+    public void testGenericWrapperEnumDeserialization() {
+        // Holder<Difficulty> must preserve the type parameter so the enum
+        // deserializes correctly, not as a raw String (ClassCastException)
+        RestAssured
+                .with()
+                .body("{\"difficulty\":{\"value\":\"HARD\"},\"child\":{\"value\":{\"label\":\"x\"}}}")
+                .contentType("application/json; charset=utf-8")
+                .post("/parameterized-type")
+                .then()
+                .statusCode(200)
+                .body("difficulty", is("HARD"));
+    }
+
+    @Test
+    public void testGenericWrapperDtoDeserialization() {
+        // Holder<ChildDto> must preserve the type parameter so the nested DTO
+        // deserializes correctly, not as a LinkedHashMap (ClassCastException)
+        RestAssured
+                .with()
+                .body("{\"difficulty\":{\"value\":\"EASY\"},\"child\":{\"value\":{\"label\":\"hello\"}}}")
+                .contentType("application/json; charset=utf-8")
+                .post("/parameterized-type")
+                .then()
+                .statusCode(200)
+                .body("child", is("hello"));
+    }
+
+    @Test
+    public void testGenericWrapperAbsentField() {
+        RestAssured
+                .with()
+                .body("{}")
+                .contentType("application/json; charset=utf-8")
+                .post("/parameterized-type")
+                .then()
+                .statusCode(200)
+                .body("difficulty", is("absent"),
+                        "child", is("absent"));
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/ParameterizedTypeResource.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/ParameterizedTypeResource.java
@@ -1,0 +1,49 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/parameterized-type")
+public class ParameterizedTypeResource {
+
+    public enum Difficulty {
+        EASY,
+        HARD
+    }
+
+    public record ChildDto(String label) {
+    }
+
+    public static class Holder<T> {
+        private T value;
+
+        public T getValue() {
+            return value;
+        }
+
+        public void setValue(T value) {
+            this.value = value;
+        }
+    }
+
+    public record ThingRequest(
+            Holder<Difficulty> difficulty,
+            Holder<ChildDto> child) {
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public String create(ThingRequest request) {
+        String diff = request.difficulty() != null && request.difficulty().getValue() != null
+                ? request.difficulty().getValue().name()
+                : "absent";
+        String kid = request.child() != null && request.child().getValue() != null
+                ? request.child().getValue().label()
+                : "absent";
+        return "{\"difficulty\":\"" + diff + "\",\"child\":\"" + kid + "\"}";
+    }
+}


### PR DESCRIPTION
The generated reflection-free deserializer only recognizes `Optional` as a single-type-parameter wrapper type. Any other wrapper, like `JsonNullable<T>` from `jackson-databind-nullable` in the case of the reported issue, falls through to `FieldKind.OBJECT`, which discards the type parameter. This causes `ClassCastException` at runtime, as enums are deserializes as `String` and nested DTOs as `LinkedHashMap`.

This fix generalizes the `Optional` handling to cover any single-type-parameter parameterized type that isn't already recognized as a `Collection`, `Set`, or `Iterable`. In fact, the deserialization logic for the `OPTIONAL` case already does the right thing, since it calls `TypeFactory.constructParametricType(outerClass, innerTypeClass)` which preserves the type parameter. The serialization logic is unaffected as the `OPTIONAL` case already falls through to `serializePojo()`, delegating to Jackson's standard serialization.

- Fixes: #55143
