### PR TITLE
Log invalid HTTP requests in the access log

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/accesslog/InvalidRequestAccessLogTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/accesslog/InvalidRequestAccessLogTest.java
@@ -1,0 +1,112 @@
+package io.quarkus.vertx.http.accesslog;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.vertx.ext.web.Router;
+
+public class InvalidRequestAccessLogTest {
+
+    private static final String APP_PROPS = """
+            quarkus.http.limits.max-header-size=512
+            quarkus.http.limits.max-initial-line-length=128
+            quarkus.http.access-log.enabled=true
+            quarkus.http.access-log.pattern=common
+            """;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Routes.class)
+                    .addAsResource(new StringAsset(APP_PROPS), "application.properties"))
+            .setLogRecordPredicate(logRecord -> logRecord.getLevel().equals(Level.INFO)
+                    && logRecord.getLoggerName().equals("io.quarkus.http.access-log"))
+            .assertLogRecords(InvalidRequestAccessLogTest::assertInvalidRequestsLogged);
+
+    @TestHTTPResource
+    URL url;
+
+    @Test
+    public void testOversizedRequestLineIsLogged() throws Exception {
+        sendOversizedRequestLine();
+    }
+
+    @Test
+    public void testOversizedHeaderIsLogged() throws Exception {
+        sendOversizedHeader();
+    }
+
+    // Common Log Format: %h %l %u %t "%r" %s %b
+    // e.g. 127.0.0.1 - - [23/Jul/2026:12:00:00 +0000] "GET /hello HTTP/1.1" 431 -
+    // %h host, then literal "- -" (%l %u), then the CLF timestamp, quoted request line, status and bytes ("-" as
+    // no body has been written when the entry is emitted).
+    private static final String CLF_HOST = "\\S+";
+    private static final String CLF_TIMESTAMP = "\\[\\d{2}/[A-Za-z]{3}/\\d{4}:\\d{2}:\\d{2}:\\d{2} [+-]\\d{4}\\]";
+
+    // The oversized request line cannot be parsed reliably, so only its status/format is asserted.
+    private static final Pattern COMMON_414 = Pattern
+            .compile("^" + CLF_HOST + " - - " + CLF_TIMESTAMP + " \"[^\"]*\" 414 -$");
+    // The oversized header leaves a valid request line, so it is asserted verbatim.
+    private static final Pattern COMMON_431 = Pattern
+            .compile("^" + CLF_HOST + " - - " + CLF_TIMESTAMP + " \"GET /hello HTTP/1\\.1\" 431 -$");
+
+    private static void assertInvalidRequestsLogged(List<LogRecord> records) {
+        List<String> messages = records.stream().map(LogRecord::getMessage).collect(Collectors.toList());
+        Assertions.assertTrue(messages.stream().anyMatch(message -> COMMON_414.matcher(message).matches()),
+                "Expected a 'common' access log entry for 414, got: " + messages);
+        Assertions.assertTrue(messages.stream().anyMatch(message -> COMMON_431.matcher(message).matches()),
+                "Expected a 'common' access log entry for 431, got: " + messages);
+    }
+
+    private void sendOversizedRequestLine() throws Exception {
+        try (Socket socket = new Socket(url.getHost(), url.getPort())) {
+            String longPath = "/" + "a".repeat(200);
+            String request = "GET " + longPath + " HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n";
+            socket.getOutputStream().write(request.getBytes(StandardCharsets.UTF_8));
+            readResponse(socket);
+        }
+    }
+
+    private void sendOversizedHeader() throws Exception {
+        try (Socket socket = new Socket(url.getHost(), url.getPort())) {
+            String largeHeaderValue = "x".repeat(600);
+            String request = "GET /hello HTTP/1.1\r\nHost: localhost\r\nX-Large: " + largeHeaderValue
+                    + "\r\nConnection: close\r\n\r\n";
+            socket.getOutputStream().write(request.getBytes(StandardCharsets.UTF_8));
+            readResponse(socket);
+        }
+    }
+
+    private static void readResponse(Socket socket) throws IOException {
+        byte[] data = new byte[4096];
+        try {
+            socket.getInputStream().read(data);
+        } catch (IOException e) {
+            // connection reset is acceptable for invalid requests
+        }
+    }
+
+    @ApplicationScoped
+    static class Routes {
+        public void register(@Observes Router router) {
+            router.route("/hello").handler(rc -> rc.response().end("hello"));
+        }
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -100,6 +100,7 @@ import io.quarkus.vertx.http.runtime.filters.QuarkusRequestWrapper;
 import io.quarkus.vertx.http.runtime.filters.accesslog.AccessLogHandler;
 import io.quarkus.vertx.http.runtime.filters.accesslog.AccessLogReceiver;
 import io.quarkus.vertx.http.runtime.filters.accesslog.DefaultAccessLogReceiver;
+import io.quarkus.vertx.http.runtime.filters.accesslog.InvalidRequestAccessLogHandler;
 import io.quarkus.vertx.http.runtime.filters.accesslog.JBossLoggingAccessLogReceiver;
 import io.quarkus.vertx.http.runtime.management.ManagementConfig;
 import io.quarkus.vertx.http.runtime.management.ManagementInterfaceBuildTimeConfig;
@@ -168,6 +169,10 @@ public class VertxHttpRecorder {
     private static volatile Runnable closeTask;
 
     static volatile Handler<HttpServerRequest> rootHandler;
+
+    // Ingredients to create one InvalidRequestAccessLogHandler per HttpServer (do not share a single handler).
+    private static volatile AccessLogReceiver invalidRequestAccessLogReceiver;
+    private static volatile String invalidRequestAccessLogPattern;
 
     private static volatile Handler<RoutingContext> nonApplicationRedirectHandler;
 
@@ -277,6 +282,8 @@ public class VertxHttpRecorder {
             closeTask = null;
         }
         rootHandler = null;
+        invalidRequestAccessLogReceiver = null;
+        invalidRequestAccessLogPattern = null;
         hotReplacementHandler = null;
         hotReplacementContext = null;
     }
@@ -528,6 +535,7 @@ public class VertxHttpRecorder {
         }
 
         AccessLogConfig accessLog = httpConfig.accessLog();
+        AccessLogReceiver accessLogReceiverForInvalidRequests = null;
         if (accessLog.enabled()) {
             AccessLogReceiver receiver;
             if (accessLog.logToFile()) {
@@ -537,6 +545,7 @@ public class VertxHttpRecorder {
             } else {
                 receiver = new JBossLoggingAccessLogReceiver(accessLog.category());
             }
+            accessLogReceiverForInvalidRequests = receiver;
             setupAccessLogHandler(mainRouterRuntimeValue, httpRouterRuntimeValue, frameworkRouter, receiver, rootPath,
                     nonRootPath, accessLog.pattern(), accessLog.consolidateReroutedRequests(), accessLog.excludePattern());
             quarkusWrapperNeeded = true;
@@ -553,11 +562,18 @@ public class VertxHttpRecorder {
                 }
             };
 
+            if (accessLogReceiverForInvalidRequests == null) {
+                accessLogReceiverForInvalidRequests = receiver;
+            }
             setupAccessLogHandler(mainRouterRuntimeValue, httpRouterRuntimeValue, frameworkRouter, receiver, rootPath,
                     nonRootPath, accessLog.pattern(), accessLog.consolidateReroutedRequests(),
                     accessLog.excludePattern().or(() -> Optional.of("^" + nonRootPath + ".*")));
             quarkusWrapperNeeded = true;
         }
+
+        // Store receiver/pattern so each HttpServer gets its own InvalidRequestAccessLogHandler.
+        invalidRequestAccessLogReceiver = accessLogReceiverForInvalidRequests;
+        invalidRequestAccessLogPattern = accessLogReceiverForInvalidRequests != null ? accessLog.pattern() : null;
 
         BiConsumer<Cookie, HttpServerRequest> cookieFunction = null;
         if (!httpConfig.sameSiteCookie().isEmpty()) {
@@ -656,6 +672,23 @@ public class VertxHttpRecorder {
                 }
             }
         }
+    }
+
+    private static void configureHttpServer(HttpServer httpServer, Handler<HttpServerRequest> requestHandler) {
+        httpServer.requestHandler(requestHandler);
+        Handler<HttpServerRequest> invalid = createInvalidRequestHandler();
+        if (invalid != null) {
+            httpServer.invalidRequestHandler(invalid);
+        }
+    }
+
+    private static Handler<HttpServerRequest> createInvalidRequestHandler() {
+        AccessLogReceiver receiver = invalidRequestAccessLogReceiver;
+        if (receiver == null) {
+            return null;
+        }
+        return new InvalidRequestAccessLogHandler(receiver, invalidRequestAccessLogPattern,
+                VertxHttpRecorder.class.getClassLoader());
     }
 
     private void setupAccessLogHandler(Optional<RuntimeValue<Router>> mainRouterRuntimeValue,
@@ -758,19 +791,19 @@ public class VertxHttpRecorder {
                         "Unable to write in the domain socket directory (`%s`). Binding to the socket is likely going to fail.",
                         managementConfig.domainSocket());
             }
-            vertx.createHttpServer(domainSocketConfigForManagement, null)
-                    .requestHandler(managementRouter)
-                    .listen().onComplete(ar -> {
-                        if (ar.failed()) {
-                            managementInterfaceDomainSocketFuture.completeExceptionally(
-                                    new IllegalStateException(
-                                            "Unable to start the management interface on the "
-                                                    + domainSocketConfigForManagement.getTcpHost() + " domain socket",
-                                            ar.cause()));
-                        } else {
-                            managementInterfaceDomainSocketFuture.complete(ar.result());
-                        }
-                    });
+            HttpServer managementDomainSocketServer = vertx.createHttpServer(domainSocketConfigForManagement, null);
+            configureHttpServer(managementDomainSocketServer, managementRouter);
+            managementDomainSocketServer.listen().onComplete(ar -> {
+                if (ar.failed()) {
+                    managementInterfaceDomainSocketFuture.completeExceptionally(
+                            new IllegalStateException(
+                                    "Unable to start the management interface on the "
+                                            + domainSocketConfigForManagement.getTcpHost() + " domain socket",
+                                    ar.cause()));
+                } else {
+                    managementInterfaceDomainSocketFuture.complete(ar.result());
+                }
+            });
         } else {
             managementInterfaceDomainSocketFuture.complete(null);
         }
@@ -832,62 +865,63 @@ public class VertxHttpRecorder {
         }
 
         if (httpManagementServerConfig != null) {
-            createHttpServer(vertx, httpManagementServerConfig, httpManagementSslOptions, httpManagementSslEngineOptions)
-                    .requestHandler(managementRouter)
-                    .listen(address).onComplete(ar -> {
-                        if (ar.failed()) {
-                            managementInterfaceFuture.completeExceptionally(
-                                    new IllegalStateException("Unable to start the management interface on "
-                                            + httpManagementServerConfig.getTcpHost() + ":"
-                                            + httpManagementServerConfig.getTcpPort(), ar.cause()));
-                        } else {
-                            if (httpManagementSslOptions != null
-                                    && (managementConfig.ssl().certificate().reloadPeriod().isPresent())) {
-                                try {
-                                    ClientAuth clientAuth = managementBuildTimeConfig.tlsClientAuth();
-                                    long l = TlsCertificateReloader.initCertReloadingAction(
-                                            vertx, ar.result(), httpManagementServerConfig, httpManagementSslOptions,
-                                            managementConfig.ssl(), registry,
-                                            managementConfig.tlsConfigurationName(), clientAuth);
-                                    if (l != -1) {
-                                        refresTaskIds.add(l);
-                                    }
-                                } catch (IllegalArgumentException e) {
-                                    managementInterfaceFuture.completeExceptionally(e);
-                                    return;
-                                }
+            HttpServer managementServer = createHttpServer(vertx, httpManagementServerConfig, httpManagementSslOptions,
+                    httpManagementSslEngineOptions);
+            configureHttpServer(managementServer, managementRouter);
+            managementServer.listen(address).onComplete(ar -> {
+                if (ar.failed()) {
+                    managementInterfaceFuture.completeExceptionally(
+                            new IllegalStateException("Unable to start the management interface on "
+                                    + httpManagementServerConfig.getTcpHost() + ":"
+                                    + httpManagementServerConfig.getTcpPort(), ar.cause()));
+                } else {
+                    if (httpManagementSslOptions != null
+                            && (managementConfig.ssl().certificate().reloadPeriod().isPresent())) {
+                        try {
+                            ClientAuth clientAuth = managementBuildTimeConfig.tlsClientAuth();
+                            long l = TlsCertificateReloader.initCertReloadingAction(
+                                    vertx, ar.result(), httpManagementServerConfig, httpManagementSslOptions,
+                                    managementConfig.ssl(), registry,
+                                    managementConfig.tlsConfigurationName(), clientAuth);
+                            if (l != -1) {
+                                refresTaskIds.add(l);
                             }
-
-                            if (httpManagementSslOptions != null) {
-                                ClientAuth clientAuth = managementBuildTimeConfig.tlsClientAuth();
-                                CDI.current().select(HttpCertificateUpdateEventListener.class).get()
-                                        .register(ar.result(),
-                                                managementConfig.tlsConfigurationName().orElse(TlsConfig.DEFAULT_NAME),
-                                                "management interface", clientAuth);
-                            }
-
-                            actualManagementPort = ar.result().actualPort();
-                            valueRegistry.getValue().register(MANAGEMENT_PORT, actualManagementPort);
-                            if (launchMode.isDevOrTest()) {
-                                valueRegistry.getValue().register(MANAGEMENT_TEST_PORT, actualManagementPort);
-                            }
-                            String mgmtScheme = httpManagementSslOptions != null ? "https" : "http";
-                            String mgmtHost = httpManagementServerConfig.getTcpHost();
-                            if ("0.0.0.0".equals(mgmtHost)) {
-                                mgmtHost = "localhost";
-                            }
-                            String mgmtRootPath = managementBuildTimeConfig.rootPath();
-                            if (!mgmtRootPath.startsWith("/")) {
-                                mgmtRootPath = "/" + mgmtRootPath;
-                            }
-                            if (mgmtRootPath.length() > 1 && mgmtRootPath.endsWith("/")) {
-                                mgmtRootPath = mgmtRootPath.substring(0, mgmtRootPath.length() - 1);
-                            }
-                            valueRegistry.getValue().register(LOCAL_MANAGEMENT_BASE_URI,
-                                    URI.create(mgmtScheme + "://" + mgmtHost + ":" + actualManagementPort + mgmtRootPath));
-                            managementInterfaceFuture.complete(ar.result());
+                        } catch (IllegalArgumentException e) {
+                            managementInterfaceFuture.completeExceptionally(e);
+                            return;
                         }
-                    });
+                    }
+
+                    if (httpManagementSslOptions != null) {
+                        ClientAuth clientAuth = managementBuildTimeConfig.tlsClientAuth();
+                        CDI.current().select(HttpCertificateUpdateEventListener.class).get()
+                                .register(ar.result(),
+                                        managementConfig.tlsConfigurationName().orElse(TlsConfig.DEFAULT_NAME),
+                                        "management interface", clientAuth);
+                    }
+
+                    actualManagementPort = ar.result().actualPort();
+                    valueRegistry.getValue().register(MANAGEMENT_PORT, actualManagementPort);
+                    if (launchMode.isDevOrTest()) {
+                        valueRegistry.getValue().register(MANAGEMENT_TEST_PORT, actualManagementPort);
+                    }
+                    String mgmtScheme = httpManagementSslOptions != null ? "https" : "http";
+                    String mgmtHost = httpManagementServerConfig.getTcpHost();
+                    if ("0.0.0.0".equals(mgmtHost)) {
+                        mgmtHost = "localhost";
+                    }
+                    String mgmtRootPath = managementBuildTimeConfig.rootPath();
+                    if (!mgmtRootPath.startsWith("/")) {
+                        mgmtRootPath = "/" + mgmtRootPath;
+                    }
+                    if (mgmtRootPath.length() > 1 && mgmtRootPath.endsWith("/")) {
+                        mgmtRootPath = mgmtRootPath.substring(0, mgmtRootPath.length() - 1);
+                    }
+                    valueRegistry.getValue().register(LOCAL_MANAGEMENT_BASE_URI,
+                            URI.create(mgmtScheme + "://" + mgmtHost + ":" + actualManagementPort + mgmtRootPath));
+                    managementInterfaceFuture.complete(ar.result());
+                }
+            });
 
         } else {
             managementInterfaceFuture.complete(null);
@@ -1322,9 +1356,9 @@ public class VertxHttpRecorder {
             if (httpServerEnabled) {
                 httpServer = vertx.createHttpServer(httpConfig_server, null);
                 if (insecureRequests == InsecureRequests.ENABLED) {
-                    httpServer.requestHandler(ACTUAL_ROOT);
+                    configureHttpServer(httpServer, ACTUAL_ROOT);
                 } else {
-                    httpServer.requestHandler(new Handler<HttpServerRequest>() {
+                    configureHttpServer(httpServer, new Handler<HttpServerRequest>() {
                         @Override
                         public void handle(HttpServerRequest req) {
                             try {
@@ -1355,14 +1389,14 @@ public class VertxHttpRecorder {
 
             if (domainSocketConfig_server != null) {
                 domainSocketServer = vertx.createHttpServer(domainSocketConfig_server, null);
-                domainSocketServer.requestHandler(ACTUAL_ROOT);
+                configureHttpServer(domainSocketServer, ACTUAL_ROOT);
                 setupUnixDomainSocketHttpServer(domainSocketServer, domainSocketConfig_server, startFuture, remainingCount,
                         container, notifyStartObservers);
             }
 
             if (httpsConfig_server != null) {
                 httpsServer = createHttpServer(vertx, httpsConfig_server, sslOptions, sslEngineOptions);
-                httpsServer.requestHandler(ACTUAL_ROOT);
+                configureHttpServer(httpsServer, ACTUAL_ROOT);
                 setupTcpHttpServer(httpsServer, httpsConfig_server, true, sslOptions, startFuture, remainingCount,
                         connectionCount, container, notifyStartObservers);
             }
@@ -1679,6 +1713,10 @@ public class VertxHttpRecorder {
                                     null,
                                     null);
                             conn.handler(ACTUAL_ROOT);
+                            Handler<HttpServerRequest> invalid = createInvalidRequestHandler();
+                            if (invalid != null) {
+                                conn.invalidRequestHandler(invalid);
+                            }
                             return conn;
                         });
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/accesslog/AccessLogHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/accesslog/AccessLogHandler.java
@@ -123,7 +123,7 @@ public class AccessLogHandler implements Handler<RoutingContext> {
         this.excludePattern = null;
     }
 
-    private static String handleCommonNames(String formatString) {
+    static String handleCommonNames(String formatString) {
         switch (formatString) {
             case "common":
                 return "%h %l %u %t \"%r\" %s %b";

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/accesslog/InvalidRequestAccessLogHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/accesslog/InvalidRequestAccessLogHandler.java
@@ -1,0 +1,59 @@
+package io.quarkus.vertx.http.runtime.filters.accesslog;
+
+import java.util.Collections;
+
+import io.netty.handler.codec.DecoderResult;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.TooLongHttpHeaderException;
+import io.netty.handler.codec.http.TooLongHttpLineException;
+import io.quarkus.vertx.http.runtime.attribute.ExchangeAttribute;
+import io.quarkus.vertx.http.runtime.attribute.ExchangeAttributeParser;
+import io.quarkus.vertx.http.runtime.attribute.SubstituteEmptyWrapper;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpServerRequest;
+
+/**
+ * Logs invalid HTTP requests rejected by the Vert.x HTTP decoder (e.g. 414, 431) to the access log.
+ * <p>
+ * These requests never reach the Vert.x Web router, so the regular {@link AccessLogHandler} cannot log them.
+ * Formatting uses the same {@link ExchangeAttribute} pipeline as the main access log.
+ */
+public class InvalidRequestAccessLogHandler implements Handler<HttpServerRequest> {
+
+    private final AccessLogReceiver accessLogReceiver;
+    private final ExchangeAttribute tokens;
+
+    public InvalidRequestAccessLogHandler(AccessLogReceiver accessLogReceiver, String pattern, ClassLoader classLoader) {
+        this.accessLogReceiver = accessLogReceiver;
+        this.tokens = new ExchangeAttributeParser(classLoader, Collections.singletonList(new SubstituteEmptyWrapper("-")))
+                .parse(AccessLogHandler.handleCommonNames(pattern));
+    }
+
+    @Override
+    public void handle(HttpServerRequest request) {
+        int statusCode = resolveStatusCode(request);
+        request.response().setStatusCode(statusCode);
+        accessLogReceiver.logMessage(tokens.readAttribute(new InvalidRequestRoutingContext(request)));
+        HttpServerRequest.DEFAULT_INVALID_REQUEST_HANDLER.handle(request);
+    }
+
+    static int resolveStatusCode(HttpServerRequest request) {
+        DecoderResult decoderResult = request.decoderResult();
+        return statusCodeForCause(decoderResult != null ? decoderResult.cause() : null);
+    }
+
+    /**
+     * Maps the decoder failure cause to an HTTP status code, mirroring
+     * {@link HttpServerRequest#DEFAULT_INVALID_REQUEST_HANDLER} by matching Netty's typed exceptions
+     * rather than their (unstable) messages. A test asserts this mapping so we notice if Netty changes it.
+     */
+    static int statusCodeForCause(Throwable cause) {
+        if (cause instanceof TooLongHttpLineException) {
+            return HttpResponseStatus.REQUEST_URI_TOO_LONG.code();
+        }
+        if (cause instanceof TooLongHttpHeaderException) {
+            return HttpResponseStatus.REQUEST_HEADER_FIELDS_TOO_LARGE.code();
+        }
+        return HttpResponseStatus.BAD_REQUEST.code();
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/accesslog/InvalidRequestRoutingContext.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/accesslog/InvalidRequestRoutingContext.java
@@ -1,0 +1,257 @@
+package io.quarkus.vertx.http.runtime.filters.accesslog;
+
+import java.nio.charset.Charset;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.auth.User;
+import io.vertx.ext.web.FileUpload;
+import io.vertx.ext.web.ParsedHeaderValues;
+import io.vertx.ext.web.RequestBody;
+import io.vertx.ext.web.Route;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.Session;
+import io.vertx.ext.web.UserContext;
+
+/**
+ * Minimal {@link RoutingContext} for invalid requests that never reach the Vert.x Web router.
+ * <p>
+ * Enough for {@link io.quarkus.vertx.http.runtime.attribute.ExchangeAttribute} formatting:
+ * delegates {@link #request()} / {@link #response()}, and returns empty/null for router-only state.
+ * Missing values are turned into {@code -} by {@link io.quarkus.vertx.http.runtime.attribute.SubstituteEmptyWrapper}.
+ */
+final class InvalidRequestRoutingContext implements RoutingContext {
+
+    private final HttpServerRequest request;
+    private Map<String, Object> data;
+
+    InvalidRequestRoutingContext(HttpServerRequest request) {
+        this.request = request;
+    }
+
+    @Override
+    public HttpServerRequest request() {
+        return request;
+    }
+
+    @Override
+    public HttpServerResponse response() {
+        return request.response();
+    }
+
+    @Override
+    public void next() {
+    }
+
+    @Override
+    public void fail(int statusCode) {
+    }
+
+    @Override
+    public void fail(Throwable throwable) {
+    }
+
+    @Override
+    public void fail(int statusCode, Throwable throwable) {
+    }
+
+    @Override
+    public RoutingContext put(String key, Object obj) {
+        getData().put(key, obj);
+        return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T get(String key) {
+        if (data == null) {
+            return null;
+        }
+        return (T) data.get(key);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T get(String key, T defaultValue) {
+        if (data == null) {
+            return defaultValue;
+        }
+        T value = (T) data.get(key);
+        return value != null ? value : defaultValue;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T remove(String key) {
+        if (data == null) {
+            return null;
+        }
+        return (T) data.remove(key);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> Map<String, T> data() {
+        return (Map<String, T>) getData();
+    }
+
+    private Map<String, Object> getData() {
+        if (data == null) {
+            data = new HashMap<>();
+        }
+        return data;
+    }
+
+    @Override
+    public Vertx vertx() {
+        return null;
+    }
+
+    @Override
+    public String mountPoint() {
+        return null;
+    }
+
+    @Override
+    public Route currentRoute() {
+        return null;
+    }
+
+    @Override
+    public String normalizedPath() {
+        String path = request.path();
+        return path != null ? path : "/";
+    }
+
+    @Override
+    public RequestBody body() {
+        return null;
+    }
+
+    @Override
+    public List<FileUpload> fileUploads() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void cancelAndCleanupFileUploads() {
+    }
+
+    @Override
+    public Session session() {
+        return null;
+    }
+
+    @Override
+    public boolean isSessionAccessed() {
+        return false;
+    }
+
+    @Override
+    public UserContext userContext() {
+        return null;
+    }
+
+    @Override
+    public User user() {
+        // Override default RoutingContext.user() which would NPE on a null userContext().
+        return null;
+    }
+
+    @Override
+    public Throwable failure() {
+        return null;
+    }
+
+    @Override
+    public int statusCode() {
+        return request.response().getStatusCode();
+    }
+
+    @Override
+    public String getAcceptableContentType() {
+        return null;
+    }
+
+    @Override
+    public ParsedHeaderValues parsedHeaders() {
+        return null;
+    }
+
+    @Override
+    public int addHeadersEndHandler(Handler<Void> handler) {
+        return -1;
+    }
+
+    @Override
+    public boolean removeHeadersEndHandler(int handlerID) {
+        return false;
+    }
+
+    @Override
+    public int addBodyEndHandler(Handler<Void> handler) {
+        return -1;
+    }
+
+    @Override
+    public boolean removeBodyEndHandler(int handlerID) {
+        return false;
+    }
+
+    @Override
+    public int addEndHandler(Handler<AsyncResult<Void>> handler) {
+        return -1;
+    }
+
+    @Override
+    public boolean removeEndHandler(int handlerID) {
+        return false;
+    }
+
+    @Override
+    public boolean failed() {
+        return false;
+    }
+
+    @Override
+    public void setAcceptableContentType(String contentType) {
+    }
+
+    @Override
+    public void reroute(HttpMethod method, String path) {
+    }
+
+    @Override
+    public Map<String, String> pathParams() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public String pathParam(String name) {
+        return null;
+    }
+
+    @Override
+    public MultiMap queryParams() {
+        return request.params();
+    }
+
+    @Override
+    public MultiMap queryParams(Charset charset) {
+        return request.params();
+    }
+
+    @Override
+    public List<String> queryParam(String name) {
+        return request.params().getAll(name);
+    }
+}

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/filters/accesslog/InvalidRequestAccessLogHandlerTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/filters/accesslog/InvalidRequestAccessLogHandlerTest.java
@@ -1,0 +1,36 @@
+package io.quarkus.vertx.http.runtime.filters.accesslog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.TooLongHttpHeaderException;
+import io.netty.handler.codec.http.TooLongHttpLineException;
+
+/**
+ * Guards the mapping from Netty decoder failures to HTTP status codes. If Netty renames or removes these
+ * typed exceptions, this test fails so we notice and adapt (see review on the invalid-request access log).
+ */
+class InvalidRequestAccessLogHandlerTest {
+
+    @Test
+    void tooLongLineMapsToUriTooLong() {
+        assertThat(InvalidRequestAccessLogHandler.statusCodeForCause(new TooLongHttpLineException("boom")))
+                .isEqualTo(HttpResponseStatus.REQUEST_URI_TOO_LONG.code());
+    }
+
+    @Test
+    void tooLongHeaderMapsToHeaderFieldsTooLarge() {
+        assertThat(InvalidRequestAccessLogHandler.statusCodeForCause(new TooLongHttpHeaderException("boom")))
+                .isEqualTo(HttpResponseStatus.REQUEST_HEADER_FIELDS_TOO_LARGE.code());
+    }
+
+    @Test
+    void otherCausesMapToBadRequest() {
+        assertThat(InvalidRequestAccessLogHandler.statusCodeForCause(new RuntimeException("boom")))
+                .isEqualTo(HttpResponseStatus.BAD_REQUEST.code());
+        assertThat(InvalidRequestAccessLogHandler.statusCodeForCause(null))
+                .isEqualTo(HttpResponseStatus.BAD_REQUEST.code());
+    }
+}


### PR DESCRIPTION
Invalid HTTP requests rejected by the Vert.x HTTP decoder (414 URI too long, 431 header fields too large) never reached the Quarkus access log handler, so operators had no application-side record of these requests.

This change registers a Vert.x `invalidRequestHandler` that writes an access log entry using the configured pattern, then delegates to the default Vert.x handler to send the proper error response.

Fixes #55082

Release note: HTTP access logging now includes invalid requests rejected with 414 and 431 status codes.

