### PR TITLE
Reactive Pg Client: add direct SSL support

### DIFF
--- a/docs/src/main/asciidoc/reactive-sql-clients.adoc
+++ b/docs/src/main/asciidoc/reactive-sql-clients.adoc
@@ -799,6 +799,24 @@ NOTE: When a named TLS configuration is set, manual SSL properties (`trust-certi
 
 For more information about the TLS registry, see the xref:tls-registry-reference.adoc[TLS Registry Reference guide].
 
+=== Direct SSL negotiation (PostgreSQL 17+)
+
+PostgreSQL 17 introduced direct SSL: the TLS handshake starts immediately on connect, with no prior SSL request/response round-trip.
+This reduces connection latency and enables standard TLS proxies (nginx, haproxy) to terminate the connection.
+
+Configure it with the `ssl-negotiation` property:
+
+[source,properties]
+----
+quarkus.datasource.reactive.postgresql.ssl-negotiation=direct
+quarkus.datasource.reactive.postgresql.ssl-mode=require
+----
+
+The `ssl-negotiation` property accepts two values:
+
+* `postgres` (default) — traditional negotiation, compatible with all PostgreSQL versions.
+* `direct` — direct SSL, requires PostgreSQL 17 or later.
+
 == Customizing pool creation
 
 Sometimes, the database connection pool cannot be configured only by declaration.

--- a/extensions/reactive-pg-client/deployment/pom.xml
+++ b/extensions/reactive-pg-client/deployment/pom.xml
@@ -82,6 +82,34 @@
         </testResources>
         <plugins>
             <plugin>
+                <groupId>io.smallrye.certs</groupId>
+                <artifactId>smallrye-certificate-generator-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <!--
+                        Must execute early so that certs are available
+                        when the Docker Maven Plugin stops/starts the container.
+                         -->
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <certificates>
+                        <certificate>
+                            <name>postgres-server</name>
+                            <formats>
+                                <format>PEM</format>
+                            </formats>
+                            <cn>thebrain.ca</cn>
+                            <duration>2</duration>
+                        </certificate>
+                    </certificates>
+                </configuration>
+            </plugin>
+            <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <executions>
                     <execution>
@@ -153,6 +181,13 @@
                                         <ports>
                                             <port>5431:5432</port>
                                         </ports>
+                                        <volumes>
+                                            <bind>
+                                                <volume>${project.build.directory}/certificates/postgres-server.crt:/server.crt:ro</volume>
+                                                <volume>${project.build.directory}/certificates/postgres-server.key:/server.key:ro</volume>
+                                                <volume>${project.basedir}/src/test/resources/tls/ssl.sh:/docker-entrypoint-initdb.d/ssl.sh:ro</volume>
+                                            </bind>
+                                        </volumes>
                                         <wait>
                                             <!-- For some reason, Postgres will tell us it's ready *twice*,
                                             and that's the truth the second time only.

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/DirectSslNegotiationTest.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/DirectSslNegotiationTest.java
@@ -1,0 +1,51 @@
+package io.quarkus.reactive.pg.client;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vertx.sqlclient.Pool;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
+
+public class DirectSslNegotiationTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withConfigurationResource("application-default-datasource.properties")
+            .overrideConfigKey("quarkus.datasource.reactive.postgresql.ssl-negotiation", "direct")
+            .overrideConfigKey("quarkus.datasource.reactive.postgresql.ssl-mode", "require")
+            .overrideConfigKey("quarkus.datasource.reactive.trust-certificate-pem", "true")
+            .overrideConfigKey("quarkus.datasource.reactive.trust-certificate-pem.certs",
+                    "target/certificates/postgres-server-ca.crt")
+            .withApplicationRoot(jar -> jar.addClass(BeanUsingPool.class));
+
+    @Inject
+    BeanUsingPool bean;
+
+    @Test
+    public void testSslConnectionIsEstablished() throws Exception {
+        RowSet<Row> rows = bean.executeQuery();
+        Row row = rows.iterator().next();
+        assertTrue(row.getBoolean("ssl"), "Expected SSL to be active for this connection");
+    }
+
+    @ApplicationScoped
+    static class BeanUsingPool {
+
+        @Inject
+        Pool pool;
+
+        public RowSet<Row> executeQuery() throws Exception {
+            return pool.query("SELECT ssl FROM pg_stat_ssl WHERE pid = pg_backend_pid()")
+                    .execute().await(10, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/extensions/reactive-pg-client/deployment/src/test/resources/tls/ssl.sh
+++ b/extensions/reactive-pg-client/deployment/src/test/resources/tls/ssl.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Borrowed from https://github.com/muccg/docker-postgres-ssl/blob/master/9.6/docker-entrypoint-initdb.d/devssl.sh
+
+cp /server.crt "${PGDATA}"/server.crt
+cp /server.key "${PGDATA}"/server.key
+chmod og-rwx "${PGDATA}"/server.key
+chown -R postgres:postgres "${PGDATA}"
+
+# turn on ssl
+sed -ri "s/^#?(ssl\s*=\s*)\S+/\1'on'/" "$PGDATA/postgresql.conf"

--- a/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/DataSourceReactivePostgreSQLConfig.java
+++ b/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/DataSourceReactivePostgreSQLConfig.java
@@ -7,6 +7,7 @@ import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
 import io.vertx.pgclient.SslMode;
+import io.vertx.pgclient.SslNegotiation;
 
 @ConfigGroup
 public interface DataSourceReactivePostgreSQLConfig {
@@ -24,6 +25,20 @@ public interface DataSourceReactivePostgreSQLConfig {
      */
     @ConfigDocDefault("disable")
     Optional<SslMode> sslMode();
+
+    /**
+     * SSL negotiation mode.
+     * <p>
+     * Determines how SSL/TLS negotiation is performed with the PostgreSQL server:
+     * <ul>
+     * <li>{@link SslNegotiation#POSTGRES} — traditional negotiation; the client sends an SSL request message
+     * before the TLS handshake. Compatible with all PostgreSQL versions.</li>
+     * <li>{@link SslNegotiation#DIRECT} — direct SSL; the TLS handshake starts immediately on connect, with
+     * no prior SSL request message. Requires PostgreSQL 17 or later.</li>
+     * </ul>
+     * When not set, the Vert.x client default applies ({@link SslNegotiation#POSTGRES}).
+     */
+    Optional<SslNegotiation> sslNegotiation();
 
     /**
      * Level 7 proxies can load balance queries on several connections to the actual database.

--- a/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/PgPoolRecorder.java
+++ b/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/PgPoolRecorder.java
@@ -132,6 +132,10 @@ public class PgPoolRecorder {
                 pgConnectOptions.setSslMode(SslMode.REQUIRE);
             }
 
+            if (dataSourceReactivePostgreSQLConfig.sslNegotiation().isPresent()) {
+                pgConnectOptions.setSslNegotiation(dataSourceReactivePostgreSQLConfig.sslNegotiation().get());
+            }
+
             pgConnectOptions.setUseLayer7Proxy(dataSourceReactivePostgreSQLConfig.useLayer7Proxy());
 
             ReactivePoolUtil.configureSsl(pgConnectOptions, dataSourceReactiveRuntimeConfig, tlsRegistry);


### PR DESCRIPTION
PostgreSQL 17 introduced direct SSL: the TLS handshake starts immediately on connect, with no prior SSL request/response round-trip. This reduces connection latency and enables standard TLS proxies (nginx, haproxy) to terminate the connection.