### PR TITLE
Reactive MSSQL Client: add TDS 8.0 protocol support

### DIFF
--- a/docs/src/main/asciidoc/reactive-sql-clients.adoc
+++ b/docs/src/main/asciidoc/reactive-sql-clients.adoc
@@ -854,6 +854,19 @@ The `ssl-negotiation` property accepts two values:
 * `postgres` (default) — traditional negotiation, compatible with all PostgreSQL versions.
 * `direct` — direct SSL, requires PostgreSQL 17 or later.
 
+=== TDS 8.0 (Microsoft SQL Server 2022+)
+
+Microsoft SQL Server 2022 and later support TDS 8.0, which performs the TLS handshake before any TDS protocol exchange.
+The reactive MSSQL client exposes this via the `encryption-mode` configuration property:
+
+[source,properties]
+----
+quarkus.datasource.reactive.mssql.encryption-mode=strict
+----
+
+`strict` enables TDS 8.0.
+The other values are `on` (optional encryption, equivalent to `ssl=true`) and `off` (no encryption, the default).
+
 == Customizing pool creation
 
 Sometimes, the database connection pool cannot be configured only by declaration.

--- a/extensions/reactive-mssql-client/deployment/pom.xml
+++ b/extensions/reactive-mssql-client/deployment/pom.xml
@@ -90,6 +90,34 @@
         </testResources>
         <plugins>
             <plugin>
+                <groupId>io.smallrye.certs</groupId>
+                <artifactId>smallrye-certificate-generator-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <!--
+                        Must execute early so that certs are available
+                        when the Docker Maven Plugin stops/starts the container.
+                         -->
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <certificates>
+                        <certificate>
+                            <name>mssql-server</name>
+                            <formats>
+                                <format>PEM</format>
+                            </formats>
+                            <cn>sql1</cn>
+                            <duration>2</duration>
+                        </certificate>
+                    </certificates>
+                </configuration>
+            </plugin>
+            <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <executions>
                     <execution>
@@ -162,6 +190,13 @@
                                             <ACCEPT_EULA>Y</ACCEPT_EULA>
                                             <MSSQL_SA_PASSWORD>yourStrong(!)Password</MSSQL_SA_PASSWORD>
                                         </env>
+                                        <volumes>
+                                            <bind>
+                                                <volume>${project.build.directory}/certificates/mssql-server.crt:/etc/ssl/certs/mssql.pem:ro</volume>
+                                                <volume>${project.build.directory}/certificates/mssql-server.key:/etc/ssl/certs/mssql.key:ro</volume>
+                                                <volume>${project.basedir}/src/test/resources/tls/mssql-tls.conf:/var/opt/mssql/mssql.conf:ro</volume>
+                                            </bind>
+                                        </volumes>
                                         <log>
                                             <prefix>MSSQL:</prefix>
                                             <date>default</date>

--- a/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/EncryptionModeOnTest.java
+++ b/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/EncryptionModeOnTest.java
@@ -1,0 +1,54 @@
+package io.quarkus.reactive.mssql.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vertx.sqlclient.Pool;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
+
+public class EncryptionModeOnTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withConfigurationResource("application-default-datasource.properties")
+            .overrideConfigKey("quarkus.datasource.reactive.mssql.encryption-mode", "on")
+            .overrideConfigKey("quarkus.datasource.reactive.trust-certificate-pem", "true")
+            .overrideConfigKey("quarkus.datasource.reactive.trust-certificate-pem.certs",
+                    "target/certificates/mssql-server-ca.crt")
+            .withApplicationRoot((jar) -> jar.addClasses(BeanUsingPool.class));
+
+    @Inject
+    BeanUsingPool bean;
+
+    @Test
+    public void testPoolWorks() throws Exception {
+        RowSet<Row> rows = bean.executeQuery();
+        assertEquals(1, rows.size());
+        Row row = rows.iterator().next();
+        String encrypted = row.getString("encrypt_option");
+        assertEquals("true", encrypted.toLowerCase(Locale.ENGLISH));
+    }
+
+    @ApplicationScoped
+    static class BeanUsingPool {
+
+        @Inject
+        Pool pool;
+
+        public RowSet<Row> executeQuery() throws Exception {
+            return pool.query("SELECT encrypt_option FROM sys.dm_exec_connections WHERE session_id = @@SPID").execute()
+                    .await(10, TimeUnit.SECONDS);
+
+        }
+    }
+}

--- a/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/EncryptionModeStrictTest.java
+++ b/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/EncryptionModeStrictTest.java
@@ -1,0 +1,56 @@
+package io.quarkus.reactive.mssql.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vertx.sqlclient.Pool;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
+
+public class EncryptionModeStrictTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withConfigurationResource("application-default-datasource.properties")
+            .overrideConfigKey("quarkus.datasource.reactive.mssql.encryption-mode", "strict")
+            // We'll know for sure that encryption mode setting takes precedence
+            .overrideConfigKey("quarkus.datasource.reactive.mssql.ssl", "false")
+            .overrideConfigKey("quarkus.datasource.reactive.trust-certificate-pem", "true")
+            .overrideConfigKey("quarkus.datasource.reactive.trust-certificate-pem.certs",
+                    "target/certificates/mssql-server-ca.crt")
+            .withApplicationRoot((jar) -> jar.addClasses(BeanUsingPool.class));
+
+    @Inject
+    BeanUsingPool bean;
+
+    @Test
+    public void testPoolWorks() throws Exception {
+        RowSet<Row> rows = bean.executeQuery();
+        assertEquals(1, rows.size());
+        Row row = rows.iterator().next();
+        String encrypted = row.getString("encrypt_option");
+        assertEquals("true", encrypted.toLowerCase(Locale.ENGLISH));
+    }
+
+    @ApplicationScoped
+    static class BeanUsingPool {
+
+        @Inject
+        Pool pool;
+
+        public RowSet<Row> executeQuery() throws Exception {
+            return pool.query("SELECT encrypt_option FROM sys.dm_exec_connections WHERE session_id = @@SPID").execute()
+                    .await(10, TimeUnit.SECONDS);
+
+        }
+    }
+}

--- a/extensions/reactive-mssql-client/deployment/src/test/resources/tls/mssql-tls.conf
+++ b/extensions/reactive-mssql-client/deployment/src/test/resources/tls/mssql-tls.conf
@@ -1,0 +1,4 @@
+[network]
+tlscert = /etc/ssl/certs/mssql.pem
+tlskey = /etc/ssl/certs/mssql.key
+tlsprotocols = 1.2

--- a/extensions/reactive-mssql-client/runtime/src/main/java/io/quarkus/reactive/mssql/client/runtime/DataSourceReactiveMSSQLConfig.java
+++ b/extensions/reactive-mssql-client/runtime/src/main/java/io/quarkus/reactive/mssql/client/runtime/DataSourceReactiveMSSQLConfig.java
@@ -1,9 +1,11 @@
 package io.quarkus.reactive.mssql.client.runtime;
 
+import java.util.Optional;
 import java.util.OptionalInt;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
+import io.vertx.mssqlclient.EncryptionMode;
 
 @ConfigGroup
 public interface DataSourceReactiveMSSQLConfig {
@@ -18,5 +20,18 @@ public interface DataSourceReactiveMSSQLConfig {
      */
     @WithDefault("false")
     public boolean ssl();
+
+    /**
+     * The encryption mode for the connection.
+     * <p>
+     * Determines the TDS protocol version and whether TLS encryption is used:
+     * <ul>
+     * <li>{@link EncryptionMode#OFF} — no encryption, TDS 7.x.</li>
+     * <li>{@link EncryptionMode#ON} — optional encryption, TDS 7.x. Equivalent to setting {@code ssl=true}.</li>
+     * <li>{@link EncryptionMode#STRICT} — mandatory encryption, TDS 8.0.</li>
+     * </ul>
+     * When this option is set it takes precedence over {@link #ssl()}.
+     */
+    Optional<EncryptionMode> encryptionMode();
 
 }

--- a/extensions/reactive-mssql-client/runtime/src/main/java/io/quarkus/reactive/mssql/client/runtime/MSSQLPoolRecorder.java
+++ b/extensions/reactive-mssql-client/runtime/src/main/java/io/quarkus/reactive/mssql/client/runtime/MSSQLPoolRecorder.java
@@ -117,7 +117,9 @@ public class MSSQLPoolRecorder {
 
         ReactivePoolUtil.configureCredentials(mssqlConnectOptions, dataSourceRuntimeConfig);
 
-        if (dataSourceReactiveMSSQLConfig.ssl()) {
+        if (dataSourceReactiveMSSQLConfig.encryptionMode().isPresent()) {
+            mssqlConnectOptions.setEncryptionMode(dataSourceReactiveMSSQLConfig.encryptionMode().get());
+        } else if (dataSourceReactiveMSSQLConfig.ssl()) {
             mssqlConnectOptions.setSsl(true);
         } else if (dataSourceReactiveRuntimeConfig.tlsConfigurationName().isPresent()) {
             // Auto-enable SSL when a named TLS configuration is set


### PR DESCRIPTION
In Vert.x 5, TDS 8.0 protocol is available in the Reactive MSSQL client.

In short, it's an evolution of the database protocol that mandates encryption and performs the TLS handshake before any TDS protocol exchange.