### PR TITLE
Reenable the doc build for main

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -4,41 +4,39 @@ permissions:
   contents: read
   actions: write
 
-# CI disabled for Vert.x 5 experimental branch - uncomment the 'on' triggers below to re-enable
-#on:
-#  push:
-#    branches-ignore:
-#      - 'dependabot/**'
-#      - '3.0'
-#    paths:
-#      - 'core/processor/**'
-#      - 'devtools/config-doc-maven-plugin/**'
-#      - 'docs/**'
-#      - 'extensions/**/pom.xml'
-#      - 'extensions/**/*Config*.java'
-#      - 'extensions/core/runtime/pom.xml'
-#      - 'extensions/core/runtime/**/*Config*.java'
-#      - 'extensions/core/deployment/pom.xml'
-#      - 'extensions/core/deployment/**/*Config*.java'
-#      - 'test-framework/jacoco/**/pom.xml'
-#      - 'test-framework/jacoco/**/*Config*.java'
-#      - '.github/workflows/doc-build.yml'
-#  pull_request:
-#    types: [opened, synchronize, reopened]
-#    paths:
-#      - 'core/processor/**'
-#      - 'devtools/config-doc-maven-plugin/**'
-#      - 'docs/**'
-#      - 'extensions/**/pom.xml'
-#      - 'extensions/**/*Config*.java'
-#      - 'extensions/core/runtime/pom.xml'
-#      - 'extensions/core/runtime/**/*Config*.java'
-#      - 'extensions/core/deployment/pom.xml'
-#      - 'extensions/core/deployment/**/*Config*.java'
-#      - 'test-framework/jacoco/**/pom.xml'
-#      - 'test-framework/jacoco/**/*Config*.java'
-#      - '.github/workflows/doc-build.yml'
-on: [workflow_dispatch]
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+      - '3.0'
+    paths:
+      - 'core/processor/**'
+      - 'devtools/config-doc-maven-plugin/**'
+      - 'docs/**'
+      - 'extensions/**/pom.xml'
+      - 'extensions/**/*Config*.java'
+      - 'extensions/core/runtime/pom.xml'
+      - 'extensions/core/runtime/**/*Config*.java'
+      - 'extensions/core/deployment/pom.xml'
+      - 'extensions/core/deployment/**/*Config*.java'
+      - 'test-framework/jacoco/**/pom.xml'
+      - 'test-framework/jacoco/**/*Config*.java'
+      - '.github/workflows/doc-build.yml'
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'core/processor/**'
+      - 'devtools/config-doc-maven-plugin/**'
+      - 'docs/**'
+      - 'extensions/**/pom.xml'
+      - 'extensions/**/*Config*.java'
+      - 'extensions/core/runtime/pom.xml'
+      - 'extensions/core/runtime/**/*Config*.java'
+      - 'extensions/core/deployment/pom.xml'
+      - 'extensions/core/deployment/**/*Config*.java'
+      - 'test-framework/jacoco/**/pom.xml'
+      - 'test-framework/jacoco/**/*Config*.java'
+      - '.github/workflows/doc-build.yml'
 
 concurrency:
   group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}, pr = ${{ github.event.pull_request.id }}"


### PR DESCRIPTION
It has been disabled during the 4.x work but we need it back.
