### PR TITLE
Remove workarounds for Hibernate region factory warnings

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateLogFilterBuildStep.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateLogFilterBuildStep.java
@@ -44,10 +44,6 @@ public final class HibernateLogFilterBuildStep {
         //property (we have a custom DialectFactory already so this could be trivial), however even in this case ORM
         //can't guess things since there is no connection, so even if we did so, this message wouldn't be applicable.
         filters.produce(new LogCleanupFilterBuildItem("org.hibernate.orm.deprecation", "HHH90000025"));
-
-        // This is issued during static init, but it's a false positive: Hibernate ORM is confusing
-        // start > stop > stop with a stop without a prior start (which is expected in our case, and harmless).
-        filters.produce(new LogCleanupFilterBuildItem("org.hibernate.orm.cache", "HHH90001002"));
     }
 
     @BuildStep(onlyIf = HibernateSpatialAvailable.class)

--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/config/packages/ConfigEntityPUAssigmentUsingOnlyPanacheEntityBaseTest.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/config/packages/ConfigEntityPUAssigmentUsingOnlyPanacheEntityBaseTest.java
@@ -32,10 +32,7 @@ public class ConfigEntityPUAssigmentUsingOnlyPanacheEntityBaseTest {
             // In a real-world scenario, this would be used only if there are multiple PUs,
             // but this is simpler and enough to reproduce the issue.
             .overrideConfigKey("quarkus.hibernate-orm.packages", EntityExtendingOnlyPanacheEntityBase.class.getPackageName())
-            .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue()
-                    // Ignore logs about JCache region factory being closed "twice": the log filter is apparently ignored,
-                    // see https://github.com/quarkusio/quarkus/issues/48346
-                    && !record.getMessage().contains("HHH90001002"))
+            .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue())
             // We don't expect any warning, in particular not:
             // "Could not find a suitable persistence unit for model classes:"
             .assertLogRecords(records -> assertThat(records).extracting(LOG_FORMATTER::format).isEmpty());

--- a/integration-tests/jpa-db2/src/test/java/io/quarkus/it/jpa/db2/HibernateOrmNoWarningsTest.java
+++ b/integration-tests/jpa-db2/src/test/java/io/quarkus/it/jpa/db2/HibernateOrmNoWarningsTest.java
@@ -25,9 +25,7 @@ import io.quarkus.test.junit.QuarkusTest;
         // Ignore logs about schema management:
         // they are unfortunate (https://github.com/quarkusio/quarkus/issues/16204)
         // but for now we have to live with them.
-        // Ignore logs about JCache region factory being closed "twice", too: the log filter is apparently ignored,
-        // see https://github.com/quarkusio/quarkus/issues/48346
-        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*,org\\.hibernate\\.orm\\.cache.*")
+        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*")
 })
 public class HibernateOrmNoWarningsTest {
     @Test

--- a/integration-tests/jpa-h2-embedded/src/test/java/io/quarkus/it/jpa/h2/HibernateOrmNoWarningsTest.java
+++ b/integration-tests/jpa-h2-embedded/src/test/java/io/quarkus/it/jpa/h2/HibernateOrmNoWarningsTest.java
@@ -25,9 +25,7 @@ import io.quarkus.test.junit.QuarkusTest;
         // Ignore logs about schema management:
         // they are unfortunate (https://github.com/quarkusio/quarkus/issues/16204)
         // but for now we have to live with them.
-        // Ignore logs about JCache region factory being closed "twice", too: the log filter is apparently ignored,
-        // see https://github.com/quarkusio/quarkus/issues/48346
-        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*,org\\.hibernate\\.orm\\.cache.*")
+        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*")
 })
 public class HibernateOrmNoWarningsTest {
     @Test

--- a/integration-tests/jpa-h2/src/test/java/io/quarkus/it/jpa/h2/HibernateOrmNoWarningsTest.java
+++ b/integration-tests/jpa-h2/src/test/java/io/quarkus/it/jpa/h2/HibernateOrmNoWarningsTest.java
@@ -23,9 +23,7 @@ import io.quarkus.test.junit.QuarkusTest;
         @ResourceArg(name = LogCollectingTestResource.LEVEL, value = "WARNING"),
         @ResourceArg(name = LogCollectingTestResource.INCLUDE, value = "org\\.hibernate\\..*"),
         //We actually have a single warning, caused by the intentional peculiarities of io.quarkus.it.jpa.h2.CompanyCustomer:
-        // Ignore logs about JCache region factory being closed "twice", too: the log filter is apparently ignored,
-        // see https://github.com/quarkusio/quarkus/issues/48346
-        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.metamodel\\.internal\\.EntityRepresentationStrategyPojoStandard,org\\.hibernate\\.orm\\.cache.*"),
+        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.metamodel\\.internal\\.EntityRepresentationStrategyPojoStandard"),
 })
 public class HibernateOrmNoWarningsTest {
     @Test

--- a/integration-tests/jpa-mariadb/src/test/java/io/quarkus/it/jpa/mariadb/HibernateOrmNoWarningsTest.java
+++ b/integration-tests/jpa-mariadb/src/test/java/io/quarkus/it/jpa/mariadb/HibernateOrmNoWarningsTest.java
@@ -25,9 +25,7 @@ import io.quarkus.test.junit.QuarkusTest;
         // Ignore logs about schema management:
         // they are unfortunate (https://github.com/quarkusio/quarkus/issues/16204)
         // but for now we have to live with them.
-        // Ignore logs about JCache region factory being closed "twice", too: the log filter is apparently ignored,
-        // see https://github.com/quarkusio/quarkus/issues/48346
-        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*,org\\.hibernate\\.orm\\.cache.*")
+        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*")
 })
 public class HibernateOrmNoWarningsTest {
     @Test

--- a/integration-tests/jpa-mssql/src/test/java/io/quarkus/it/jpa/mssql/HibernateOrmNoWarningsTest.java
+++ b/integration-tests/jpa-mssql/src/test/java/io/quarkus/it/jpa/mssql/HibernateOrmNoWarningsTest.java
@@ -25,9 +25,7 @@ import io.quarkus.test.junit.QuarkusTest;
         // Ignore logs about schema management:
         // they are unfortunate (https://github.com/quarkusio/quarkus/issues/16204)
         // but for now we have to live with them.
-        // Ignore logs about JCache region factory being closed "twice", too: the log filter is apparently ignored,
-        // see https://github.com/quarkusio/quarkus/issues/48346
-        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*,org\\.hibernate\\.orm\\.cache.*")
+        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*")
 })
 public class HibernateOrmNoWarningsTest {
     @Test

--- a/integration-tests/jpa-mysql/src/test/java/io/quarkus/it/jpa/mysql/HibernateOrmNoWarningsTest.java
+++ b/integration-tests/jpa-mysql/src/test/java/io/quarkus/it/jpa/mysql/HibernateOrmNoWarningsTest.java
@@ -25,9 +25,7 @@ import io.quarkus.test.junit.QuarkusTest;
         // Ignore logs about schema management:
         // they are unfortunate (https://github.com/quarkusio/quarkus/issues/16204)
         // but for now we have to live with them.
-        // Ignore logs about JCache region factory being closed "twice", too: the log filter is apparently ignored,
-        // see https://github.com/quarkusio/quarkus/issues/48346
-        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*,org\\.hibernate\\.orm\\.cache.*")
+        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*")
 })
 public class HibernateOrmNoWarningsTest {
     @Test

--- a/integration-tests/jpa-oracle/src/test/java/io/quarkus/it/jpa/oracle/HibernateOrmNoWarningsTest.java
+++ b/integration-tests/jpa-oracle/src/test/java/io/quarkus/it/jpa/oracle/HibernateOrmNoWarningsTest.java
@@ -25,9 +25,7 @@ import io.quarkus.test.junit.QuarkusTest;
         // Ignore logs about schema management:
         // they are unfortunate (https://github.com/quarkusio/quarkus/issues/16204)
         // but for now we have to live with them.
-        // Ignore logs about JCache region factory being closed "twice", too: the log filter is apparently ignored,
-        // see https://github.com/quarkusio/quarkus/issues/48346
-        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*,org\\.hibernate\\.orm\\.cache.*")
+        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*")
 })
 public class HibernateOrmNoWarningsTest {
     @Test

--- a/integration-tests/jpa-postgresql/src/test/java/io/quarkus/it/jpa/postgresql/HibernateOrmNoWarningsTest.java
+++ b/integration-tests/jpa-postgresql/src/test/java/io/quarkus/it/jpa/postgresql/HibernateOrmNoWarningsTest.java
@@ -25,9 +25,7 @@ import io.quarkus.test.junit.QuarkusTest;
         // Ignore logs about schema management:
         // they are unfortunate (https://github.com/quarkusio/quarkus/issues/16204)
         // but for now we have to live with them.
-        // Ignore logs about JCache region factory being closed "twice", too: the log filter is apparently ignored,
-        // see https://github.com/quarkusio/quarkus/issues/48346
-        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*,org\\.hibernate\\.orm\\.cache.*")
+        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*")
 })
 public class HibernateOrmNoWarningsTest {
     @Test

--- a/integration-tests/jpa/src/test/java/io/quarkus/it/jpa/proxy/ProxyTest.java
+++ b/integration-tests/jpa/src/test/java/io/quarkus/it/jpa/proxy/ProxyTest.java
@@ -19,9 +19,7 @@ import io.restassured.RestAssured;
         // Ignore logs about schema management:
         // they are unfortunate (https://github.com/quarkusio/quarkus/issues/16204)
         // but for now we have to live with them.
-        // Ignore logs about JCache region factory being closed "twice", too: the log filter is apparently ignored,
-        // see https://github.com/quarkusio/quarkus/issues/48346
-        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*,org\\.hibernate\\.orm\\.cache.*")
+        @ResourceArg(name = LogCollectingTestResource.EXCLUDE, value = "org\\.hibernate\\.tool\\.schema.*")
 })
 public class ProxyTest {
 


### PR DESCRIPTION
Reverts #54891 + #54918, and removes a log filter.

To be merged after the upgrade to 7.4.2.Final or later which fixes https://hibernate.atlassian.net/browse/HHH-20587. That upgrade is currently #54994 , but who knows, dependabot upgrade PRs come and go these days :)

EDIT: Here we go, the upgrade is now https://github.com/quarkusio/quarkus/pull/55165

EDIT: The upgrade was merged.