### PR TITLE
Changing how connection closure is handled to avoid a race condition

### DIFF
--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/core/AbstractResteasyReactiveContext.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/core/AbstractResteasyReactiveContext.java
@@ -144,6 +144,9 @@ public abstract class AbstractResteasyReactiveContext<T extends AbstractResteasy
                 int pos = position;
                 position++; //increment before, as reset may reset it to zero
                 try {
+                    if (isHandlerCanceled(pos)) {
+                        continue;
+                    }
                     invokeHandler(pos);
                     if (suspended) {
                         synchronized (this) {
@@ -190,7 +193,7 @@ public abstract class AbstractResteasyReactiveContext<T extends AbstractResteasy
         } finally {
             // we need to make sure we don't close the underlying stream in the event loop if the task
             // has been offloaded to the executor
-            if ((position == handlers.length && !processingSuspended) || aborted) {
+            if ((position >= handlers.length && !processingSuspended) || aborted) {
                 if (requestScopeActivated) {
                     requestScopeDeactivated();
                     currentRequestScope.deactivate();
@@ -225,6 +228,10 @@ public abstract class AbstractResteasyReactiveContext<T extends AbstractResteasy
 
             }
         }
+    }
+
+    protected boolean isHandlerCanceled(int pos) {
+        return false;
     }
 
     protected void invokeHandler(int pos) throws Exception {

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
@@ -162,6 +162,7 @@ public abstract class ResteasyReactiveRequestContext
     private boolean producesChecked;
 
     private RequestMapper.RequestMatch<RestInitialHandler.InitialMatch> initialMatch;
+    private volatile boolean connectionClosed;
 
     public ResteasyReactiveRequestContext(Deployment deployment,
             ThreadSetupAction requestContext, ServerRestHandler[] handlerChain, ServerRestHandler[] abortHandlerChain) {
@@ -436,16 +437,6 @@ public abstract class ResteasyReactiveRequestContext
             log.debug("Failed to close stream", e);
         }
         super.close();
-    }
-
-    /**
-     * This method ensures that no more handlers will run and that all the resources tied to the request are closed
-     */
-    private void discardRemaining() {
-        int length = getHandlers().length;
-        if (length > 0) {
-            setPosition(length);
-        }
     }
 
     public LazyResponse getResponse() {
@@ -1216,6 +1207,11 @@ public abstract class ResteasyReactiveRequestContext
     }
 
     @Override
+    protected boolean isHandlerCanceled(int pos) {
+        return connectionClosed && handlers[pos].isCancellable();
+    }
+
+    @Override
     protected abstract Executor getEventLoop();
 
     public abstract Runnable registerTimer(long millis, Runnable task);
@@ -1358,24 +1354,7 @@ public abstract class ResteasyReactiveRequestContext
 
         @Override
         public void run() {
-            ServerRestHandler[] handlers = context.getHandlers();
-            int pos = context.getPosition();
-            List<ServerRestHandler> nonCancellable = new ArrayList<>();
-            for (int i = pos; i < handlers.length; i++) {
-                if (!handlers[i].isCancellable()) {
-                    nonCancellable.add(handlers[i]);
-                }
-            }
-            if (nonCancellable.isEmpty()) {
-                context.discardRemaining();
-            } else {
-                ServerRestHandler[] newHandlers = new ServerRestHandler[pos + nonCancellable.size()];
-                System.arraycopy(handlers, 0, newHandlers, 0, pos);
-                for (int i = 0; i < nonCancellable.size(); i++) {
-                    newHandlers[pos + i] = nonCancellable.get(i);
-                }
-                context.handlers = newHandlers;
-            }
+            context.connectionClosed = true;
             context = null;
         }
     }


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
and the AI/LLM usage policy at https://github.com/quarkusio/quarkus/blob/main/AI_POLICY.md
-->

Effectively moves the connection close handling into the main abstract context loop to avoid a race condition with the abort handling.

* Fixes #55116

@geoand are you ok with adding a method like isHandlerCanceled? With that I don't believe the close handler needs to manipulate the handlers - they will remain as is whether its been set to the abort chain or the normal chain, and only execute the ones that are non-cancellable.
