### PR TITLE
[3.33] Upgrade to Keycloak 26.0.10

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -177,7 +177,7 @@
         <mockito.version>5.21.0</mockito.version>
         <jna.version>5.8.0</jna.version><!-- should satisfy both testcontainers and mongodb -->
         <quarkus-security.version>2.3.2</quarkus-security.version>
-        <keycloak-client.version>26.0.8</keycloak-client.version>
+        <keycloak-client.version>26.0.10</keycloak-client.version>
         <logstash-gelf.version>1.15.1</logstash-gelf.version>
         <checker-qual.version>3.53.1</checker-qual.version>
         <error-prone-annotations.version>2.47.0</error-prone-annotations.version>


### PR DESCRIPTION
Fixes https://access.redhat.com/security/cve/cve-2026-9800 ([GHSA-f5p5-6xmx-p252](https://github.com/keycloak/keycloak/security/advisories/GHSA-f5p5-6xmx-p252))