### PR TITLE
Fix performance regression in AotQuarkusEntryPoint

### DIFF
--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/AotQuarkusEntryPoint.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/AotQuarkusEntryPoint.java
@@ -40,9 +40,7 @@ public class AotQuarkusEntryPoint {
     }
 
     private static void doRun(String... args) throws Throwable {
-        Path jarPath = QuarkusEntryPoint.resolveJarPath(
-                AotQuarkusEntryPoint.class.getProtectionDomain().getCodeSource().getLocation(),
-                AotQuarkusEntryPoint.class.getResource(AotQuarkusEntryPoint.class.getSimpleName() + ".class"));
+        Path jarPath = QuarkusEntryPoint.resolveJarPath(AotQuarkusEntryPoint.class);
         if (jarPath == null) {
             throw new IllegalStateException("Unable to determine launch jar path");
         }

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/QuarkusEntryPoint.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/QuarkusEntryPoint.java
@@ -44,9 +44,7 @@ public class QuarkusEntryPoint {
     }
 
     private static void doRun(String... args) throws Throwable {
-        Path jarPath = resolveJarPath(
-                QuarkusEntryPoint.class.getProtectionDomain().getCodeSource().getLocation(),
-                QuarkusEntryPoint.class.getResource(QuarkusEntryPoint.class.getSimpleName() + ".class"));
+        Path jarPath = resolveJarPath(QuarkusEntryPoint.class);
         if (jarPath == null) {
             throw new IllegalStateException("Unable to determine launch jar path");
         }
@@ -77,12 +75,19 @@ public class QuarkusEntryPoint {
         }
     }
 
-    // Visible for testing
-    static Path resolveJarPath(URL location, URL classResource) throws URISyntaxException {
+    static Path resolveJarPath(Class<?> entryPointClass) throws URISyntaxException {
+        URL location = entryPointClass.getProtectionDomain().getCodeSource().getLocation();
         if (location != null) {
             return Path.of(location.toURI());
         }
+
         // account for https://bugs.openjdk.org/browse/JDK-8376576
+        return resolveJarPathFromClassResource(
+                entryPointClass.getResource(entryPointClass.getSimpleName() + ".class"));
+    }
+
+    // Visible for testing
+    static Path resolveJarPathFromClassResource(URL classResource) throws URISyntaxException {
         if (classResource != null) {
             String fullPath = classResource.toString();
             if (fullPath.startsWith("jar:")) {

--- a/independent-projects/bootstrap/runner/src/test/java/io/quarkus/bootstrap/runner/ResolveJarPathTest.java
+++ b/independent-projects/bootstrap/runner/src/test/java/io/quarkus/bootstrap/runner/ResolveJarPathTest.java
@@ -15,7 +15,7 @@ public class ResolveJarPathTest {
     public void plusInPathIsPreserved() throws Exception {
         URL location = new URI("file:///opt/packages/myapp/1.0.0+build123/quarkus-app/quarkus-run.jar").toURL();
 
-        Path resolved = QuarkusEntryPoint.resolveJarPath(location, null);
+        Path resolved = Path.of(location.toURI());
 
         assertThat(resolved).isEqualTo(Path.of("/opt/packages/myapp/1.0.0+build123/quarkus-app/quarkus-run.jar"));
     }
@@ -24,7 +24,7 @@ public class ResolveJarPathTest {
     public void spacesInPathAreDecoded() throws Exception {
         URL location = new URI("file:///opt/my%20app/quarkus-app/quarkus-run.jar").toURL();
 
-        Path resolved = QuarkusEntryPoint.resolveJarPath(location, null);
+        Path resolved = Path.of(location.toURI());
 
         assertThat(resolved).isEqualTo(Path.of("/opt/my app/quarkus-app/quarkus-run.jar"));
     }
@@ -35,7 +35,7 @@ public class ResolveJarPathTest {
                 "jar:file:///opt/packages/1.0.0+build123/quarkus-app/quarkus-run.jar!/io/quarkus/bootstrap/runner/QuarkusEntryPoint.class")
                 .toURL();
 
-        Path resolved = QuarkusEntryPoint.resolveJarPath(null, classResource);
+        Path resolved = QuarkusEntryPoint.resolveJarPathFromClassResource(classResource);
 
         assertThat(resolved).isEqualTo(Path.of("/opt/packages/1.0.0+build123/quarkus-app/quarkus-run.jar"));
     }
@@ -46,13 +46,13 @@ public class ResolveJarPathTest {
                 "jar:file:///opt/my%20app/quarkus-run.jar!/io/quarkus/bootstrap/runner/QuarkusEntryPoint.class")
                 .toURL();
 
-        Path resolved = QuarkusEntryPoint.resolveJarPath(null, classResource);
+        Path resolved = QuarkusEntryPoint.resolveJarPathFromClassResource(classResource);
 
         assertThat(resolved).isEqualTo(Path.of("/opt/my app/quarkus-run.jar"));
     }
 
     @Test
-    public void returnsNullWhenBothArgumentsAreNull() throws URISyntaxException {
-        assertThat(QuarkusEntryPoint.resolveJarPath(null, null)).isNull();
+    public void returnsNullWhenArgumentIsNull() throws URISyntaxException {
+        assertThat(QuarkusEntryPoint.resolveJarPathFromClassResource(null)).isNull();
     }
 }


### PR DESCRIPTION
The regression was introduced by #53885.
When using AOT,
AotQuarkusEntryPoint.class.getResource(AotQuarkusEntryPoint.class.getSimpleName()
+ ".class") is actually quite costly so we should avoid calling it when it's not needed.

Which should always be the case at some point, once the bug we are working around is fixed.

<img width="1584" height="781" alt="Screenshot From 2026-06-29 10-04-53" src="https://github.com/user-attachments/assets/18df2b9c-a13e-4fb6-99f6-885547c9de49" />
