### PR TITLE
Don't reset Quarkus system properties on in-process Gradle workers

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/BuildAotEnhancedImage.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/BuildAotEnhancedImage.java
@@ -74,6 +74,7 @@ public abstract class BuildAotEnhancedImage extends QuarkusBuildTask {
         workQueue.submit(BuildAotEnhancedImageWorker.class, params -> {
             params.getBuildSystemProperties().putAll(buildSystemProperties(appModel.getAppArtifact(), quarkusProperties));
             params.getForkedSystemProperties().putAll(quarkusProperties);
+            params.getProcessIsolated().set(isWorkerProcessIsolated());
             params.getBaseName().set(getExtensionView().getFinalName());
             params.getTargetDirectory().set(buildDirectory);
             params.getAppModel().set(appModel);

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildTask.java
@@ -307,6 +307,7 @@ public abstract class QuarkusBuildTask extends QuarkusTaskWithExtensionView {
         workQueue.submit(BuildWorker.class, params -> {
             params.getBuildSystemProperties().putAll(buildSystemProperties(appModel.getAppArtifact(), quarkusProperties));
             params.getForkedSystemProperties().putAll(quarkusProperties);
+            params.getProcessIsolated().set(isWorkerProcessIsolated());
             params.getBaseName().set(getExtensionView().getFinalName());
             params.getTargetDirectory().set(buildDir.toFile());
             params.getAppModel().set(appModel);

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
@@ -122,6 +122,7 @@ public abstract class QuarkusGenerateCode extends QuarkusTaskWithExtensionView {
         workQueue.submit(CodeGenWorker.class, params -> {
             params.getBuildSystemProperties().putAll(configMap);
             params.getForkedSystemProperties().putAll(configMap);
+            params.getProcessIsolated().set(isWorkerProcessIsolated());
             params.getBaseName().set(getExtensionView().getFinalName());
             params.getTargetDirectory().set(buildDir);
             params.getAppModel().set(appModel);

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusTask.java
@@ -52,12 +52,20 @@ public abstract class QuarkusTask extends DefaultTask {
         return extension;
     }
 
+    /**
+     * Whether Quarkus workers run in a forked JVM (process isolation) rather than in-process in the
+     * Gradle daemon (class-loader isolation).
+     */
+    static boolean isWorkerProcessIsolated() {
+        // Use process isolation by default, unless Gradle's started with its debugging system property or the
+        // system property `gradle.quarkus.gradle-worker.no-process` is set to `true`.
+        return !(Boolean.getBoolean("org.gradle.debug") || Boolean.getBoolean("gradle.quarkus.gradle-worker.no-process"));
+    }
+
     WorkQueue workQueue(Map<String, String> configMap, List<Action<? super JavaForkOptions>> forkOptionsSupplier) {
         WorkerExecutor workerExecutor = getWorkerExecutor();
 
-        // Use process isolation by default, unless Gradle's started with its debugging system property or the
-        // system property `gradle.quarkus.gradle-worker.no-process` is set to `true`.
-        if (Boolean.getBoolean("org.gradle.debug") || Boolean.getBoolean("gradle.quarkus.gradle-worker.no-process")) {
+        if (!isWorkerProcessIsolated()) {
             return workerExecutor.classLoaderIsolation();
         }
 

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/worker/QuarkusParams.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/worker/QuarkusParams.java
@@ -21,12 +21,17 @@ public interface QuarkusParams extends WorkParameters {
      *
      * <p>
      * This map does not seed
-     * {@link io.quarkus.bootstrap.app.QuarkusBootstrap#setBuildSystemProperties};
+     * {@link io.quarkus.bootstrap.app.QuarkusBootstrap.Builder#setBuildSystemProperties};
      * {@link #getBuildSystemProperties()} does, and so feeds the on-disk
      * {@code build-system.properties}. Keeping the two maps separate leaves that artifact
      * unchanged.
      */
     MapProperty<String, String> getForkedSystemProperties();
+
+    /**
+     * Whether this worker runs in a forked JVM rather than in-process in the Gradle daemon.
+     */
+    Property<Boolean> getProcessIsolated();
 
     Property<String> getBaseName();
 

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/worker/QuarkusWorker.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/worker/QuarkusWorker.java
@@ -45,6 +45,12 @@ public abstract class QuarkusWorker<P extends QuarkusParams> implements WorkActi
      * of bootstrap; nothing is restored on exit. A symmetric tear-down would erase legitimate
      * inter-task state, for example properties a build step set via
      * {@link System#setProperty(String, String)} during augmentation.
+     *
+     * <p>
+     * Runs only in a forked worker, where the JVM is throwaway; the caller gates this on
+     * {@link QuarkusParams#getProcessIsolated()}.
+     * In-process, the worker shares the daemon's {@link System} properties, so scrubbing them would
+     * <a href="https://github.com/quarkusio/quarkus/issues/55131">corrupt the running build</a>.
      */
     void resetQuarkusSystemProperties() {
         Map<String, String> intended = getParameters().getForkedSystemProperties().getOrElse(Map.of());
@@ -63,7 +69,9 @@ public abstract class QuarkusWorker<P extends QuarkusParams> implements WorkActi
     }
 
     CuratedApplication createAppCreationContext() throws BootstrapException {
-        resetQuarkusSystemProperties();
+        if (getParameters().getProcessIsolated().get()) {
+            resetQuarkusSystemProperties();
+        }
         QuarkusParams params = getParameters();
         Path buildDir = params.getTargetDirectory().getAsFile().get().toPath();
         String baseName = params.getBaseName().get();

--- a/integration-tests/gradle/src/main/resources/no-process-worker-profile-config/build.gradle
+++ b/integration-tests/gradle/src/main/resources/no-process-worker-profile-config/build.gradle
@@ -1,0 +1,35 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+}
+
+repositories {
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+            includeGroup 'org.hibernate.orm'
+        }
+    }
+    mavenCentral()
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-resteasy'
+}
+
+group = 'org.acme'
+version = '1.0.0-SNAPSHOT'
+
+compileJava {
+    options.encoding = 'UTF-8'
+    options.compilerArgs << '-parameters'
+}
+
+compileTestJava {
+    options.encoding = 'UTF-8'
+}
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/no-process-worker-profile-config/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/no-process-worker-profile-config/gradle.properties
@@ -1,0 +1,6 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus
+
+# Run Quarkus workers in-process (class-loader isolation) instead of forking a worker JVM.
+# This exercises the path of https://github.com/quarkusio/quarkus/issues/55131.
+systemProp.gradle.quarkus.gradle-worker.no-process=true

--- a/integration-tests/gradle/src/main/resources/no-process-worker-profile-config/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/no-process-worker-profile-config/settings.gradle
@@ -1,0 +1,16 @@
+pluginManagement {
+    repositories {
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+                includeGroup 'org.hibernate.orm'
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+      id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+rootProject.name='code-with-quarkus'

--- a/integration-tests/gradle/src/main/resources/no-process-worker-profile-config/src/main/java/org/acme/GreetingResource.java
+++ b/integration-tests/gradle/src/main/resources/no-process-worker-profile-config/src/main/java/org/acme/GreetingResource.java
@@ -1,0 +1,21 @@
+package org.acme;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@Path("/hello")
+public class GreetingResource {
+
+    @ConfigProperty(name = "greeting.message")
+    String message;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return message;
+    }
+}

--- a/integration-tests/gradle/src/main/resources/no-process-worker-profile-config/src/main/resources/application-dev.properties
+++ b/integration-tests/gradle/src/main/resources/no-process-worker-profile-config/src/main/resources/application-dev.properties
@@ -1,0 +1,1 @@
+greeting.message=hello-from-dev-profile

--- a/integration-tests/gradle/src/main/resources/no-process-worker-profile-config/src/main/resources/application.properties
+++ b/integration-tests/gradle/src/main/resources/no-process-worker-profile-config/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+# greeting.message is intentionally defined only in application-dev.properties, so a passing
+# /hello proves the profile-aware file was loaded for the active dev profile (issue #55131).

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/NoProcessWorkerProfileConfigDevModeTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/NoProcessWorkerProfileConfigDevModeTest.java
@@ -1,0 +1,25 @@
+package io.quarkus.gradle.devmode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for https://github.com/quarkusio/quarkus/issues/55131.
+ *
+ * <p>
+ * The project sets {@code gradle.quarkus.gradle-worker.no-process=true}, so Quarkus workers run in-process inside the
+ * Gradle daemon (class-loader isolation). {@code greeting.message} is defined only in
+ * {@code application-dev.properties}, so a {@code /hello} response proves the profile-aware config file was loaded for
+ * the active dev profile. Before the fix, the in-process worker scrubbed the daemon's system properties, the dev
+ * profile was dropped, and the application failed to start with {@code SRCFG00014}.
+ */
+public class NoProcessWorkerProfileConfigDevModeTest extends QuarkusDevGradleTestBase {
+    @Override
+    protected String projectDirectoryName() {
+        return "no-process-worker-profile-config";
+    }
+
+    @Override
+    protected void testDevMode() throws Exception {
+        assertThat(getHttpResponse("/hello")).contains("hello-from-dev-profile");
+    }
+}


### PR DESCRIPTION
Fixes #55131

As described in the issue above, when the Gradle plugin runs dev mode "in-process", `quarkusDev` no longer loads profile properties properly. That's because in #54447, I added `QuarkusWorker.resetQuarkusSystemProperties()` which scrubs stale `quarkus.*` / `platform.quarkus.*` system properties at worker bootstrap. That is safe in a forked worker JVM, but when the worker runs *inside* the Gradle daemon, this changes the daemon's own system properties and drops the dev profile.

This PR adds a check `QuarkusParams#getProcessIsolated()`, set from a single `QuarkusTask.isWorkerProcessIsolated()`, so the reset runs only in a forked worker. The in-process path no longer touches the daemon's system properties, restoring 3.36.0 behaviour, while the #54447 fix is preserved for the default forked-worker path.

Added a new `NoProcessWorkerProfileConfigDevModeTest` test as well.

