### PR TITLE
Fix documentation build

### DIFF
--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -695,7 +695,7 @@ quarkus.http.proxy.trusted-proxy[0].truststore-alias=cert-0 <2>
 <1> `proxy-ca.crt` becomes `cert-0`, `other-ca.crt` becomes `cert-1`.
 <2> References `proxy-ca.crt`.
 
-Since PEM aliases depend on ordering, we recommend using a xref:tls-registry-reference.adoc#_pkcs12_truststores[PKCS12 truststore] to avoid certificate list ordering issues.
+Since PEM aliases depend on ordering, we recommend using a xref:tls-registry-reference.adoc#pkcs12_truststores[PKCS12 truststore] to avoid certificate list ordering issues.
 
 WARNING: The configured Subject DN is trusted to be unique only among clients signed by the CA referenced by the truststore alias. Only reference a CA that you control or trust not to issue another certificate with the same Subject DN.
 

--- a/docs/src/main/asciidoc/tls-registry-reference.adoc
+++ b/docs/src/main/asciidoc/tls-registry-reference.adoc
@@ -569,6 +569,7 @@ To configure a PEM truststore:
 quarkus.tls.trust-store.pem.certs=ca.crt,ca2.pem
 ----
 
+[[pkcs12_truststores]]
 ==== PKCS12 truststores
 
 PKCS12 truststores are single-file containers for certificates.


### PR DESCRIPTION
Seems like a wrong link got in https://github.com/quarkusio/quarkus/pull/54517, sorry. That PR CI didn't show it though, maybe something has changed? I won't investigate it is unimportant thing. Fixes the documentation issue we saw in https://github.com/quarkusio/quarkus/pull/55181.