### PR TITLE
Fix JDK 21 profile in signals and websockets-next deployment modules

### DIFF
--- a/extensions/signals/deployment/pom.xml
+++ b/extensions/signals/deployment/pom.xml
@@ -69,11 +69,6 @@
                 <jdk>[21,)</jdk>
             </activation>
 
-            <properties>
-                <maven.compiler.target>21</maven.compiler.target>
-                <maven.compiler.source>21</maven.compiler.source>
-                <maven.compiler.release>21</maven.compiler.release>
-            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -90,6 +85,17 @@
                                     <sources>
                                         <source>src/test/java21</source>
                                     </sources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-testCompile</id>
+                                <configuration>
+                                    <release>21</release>
                                 </configuration>
                             </execution>
                         </executions>

--- a/extensions/websockets-next/deployment/pom.xml
+++ b/extensions/websockets-next/deployment/pom.xml
@@ -199,11 +199,6 @@
                 <jdk>[21,)</jdk>
             </activation>
 
-            <properties>
-                <maven.compiler.target>21</maven.compiler.target>
-                <maven.compiler.source>21</maven.compiler.source>
-                <maven.compiler.release>21</maven.compiler.release>
-            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -220,6 +215,17 @@
                                     <sources>
                                         <source>src/test/java21</source>
                                     </sources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-testCompile</id>
+                                <configuration>
+                                    <release>21</release>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
- set release 21 only for test compilation instead of module-wide, avoiding conflicts when JDK 17 is enforced during release builds