### PR TITLE
Mailer: clarify that Uni returned from send() must be subscribed to

### DIFF
--- a/docs/src/main/asciidoc/mailer-reference.adoc
+++ b/docs/src/main/asciidoc/mailer-reference.adoc
@@ -205,6 +205,8 @@ we will use the `src/main/resources/templates/MailingResource/hello.html` and `s
 <3> Create a mail template instance and set the recipient.
 <4> `MailTemplate.send()` triggers the rendering and, once finished, sends the e-mail via a `Mailer` instance.
 
+IMPORTANT: `MailTemplateInstance.send()` returns a `Uni<Void>` that *must be subscribed to* — otherwise no e-mail will be sent. If you return the `Uni` from a RESTEasy Reactive resource method, the framework subscribes automatically. In other contexts, make sure the `Uni` is part of a reactive pipeline that is eventually subscribed to, or use `sendAndAwait()` for a blocking alternative.
+
 Alternatively, use a Java record that implements `io.quarkus.mailer.MailTemplate`.
 The record components represent the template parameters.
 

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/MailTemplate.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/MailTemplate.java
@@ -114,6 +114,10 @@ public interface MailTemplate {
         /**
          * Sends all e-mail definitions based on available template variants, i.e. {@code text/html} and {@code text/plain}
          * template variants.
+         * <p>
+         * <strong>Important:</strong> The returned {@link Uni} must be subscribed to, otherwise no e-mail will be sent. In
+         * a reactive context, this typically means chaining it in a reactive pipeline. In frameworks like RESTEasy Reactive,
+         * returning the {@link Uni} from a resource method is sufficient because the framework subscribes automatically.
          *
          * @return a {@link Uni} indicating when the mails have been sent
          * @see ReactiveMailer#send(Mail...)


### PR DESCRIPTION
- add javadoc note to MailTemplateInstance.send() and an IMPORTANT admonition in reference
