### PR TITLE
Address cross-process dev service lookup ignoring config (fixed port from config in particular)

### DIFF
--- a/extensions/devservices/common/pom.xml
+++ b/extensions/devservices/common/pom.xml
@@ -39,5 +39,15 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-datasource-common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ComposeLocator.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ComposeLocator.java
@@ -2,10 +2,12 @@ package io.quarkus.devservices.common;
 
 import static io.quarkus.devservices.common.ContainerUtil.getShortId;
 import static io.quarkus.devservices.common.Labels.DOCKER_COMPOSE_SERVICE;
+import static java.util.Arrays.stream;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import org.jboss.logging.Logger;
 import org.testcontainers.DockerClientFactory;
@@ -23,8 +25,18 @@ public class ComposeLocator {
 
     public static Optional<ContainerAddress> locateContainer(DevServicesComposeProjectBuildItem composeProject,
             List<String> images, int port, LaunchMode launchMode, boolean useSharedNetwork) {
+        return locateContainer(composeProject, images, port, launchMode, useSharedNetwork, OptionalInt.empty());
+    }
+
+    public static Optional<ContainerAddress> locateContainer(DevServicesComposeProjectBuildItem composeProject,
+            List<String> images, int port, LaunchMode launchMode, boolean useSharedNetwork,
+            OptionalInt fixedExposedPort) {
         if (launchMode.isDevServicesSupported()) {
             return composeProject.locate(images, port)
+                    .filter(rc -> fixedExposedPort.isEmpty()
+                            || rc.getPortMapping(port)
+                                    .map(publicPort -> publicPort == fixedExposedPort.getAsInt())
+                                    .orElse(false))
                     .map(runningContainer -> {
                         String serviceName = getServiceName(runningContainer);
                         ContainerAddress containerAddress = new ContainerAddress(runningContainer,
@@ -48,8 +60,20 @@ public class ComposeLocator {
 
     public static List<RunningContainer> locateContainer(DevServicesComposeProjectBuildItem composeProject,
             List<String> images, LaunchMode launchMode) {
+        return locateContainer(composeProject, images, launchMode, OptionalInt.empty());
+    }
+
+    public static List<RunningContainer> locateContainer(DevServicesComposeProjectBuildItem composeProject,
+            List<String> images, LaunchMode launchMode, OptionalInt fixedExposedPort) {
         if (launchMode.isDevServicesSupported()) {
-            return composeProject.locate(images);
+            List<RunningContainer> containers = composeProject.locate(images);
+            if (fixedExposedPort.isPresent()) {
+                return containers.stream()
+                        .filter(rc -> stream(rc.containerInfo().exposedPorts())
+                                .anyMatch(p -> p.publicPort() == fixedExposedPort.getAsInt()))
+                        .toList();
+            }
+            return containers;
         }
         return Collections.emptyList();
     }

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ContainerLocator.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ContainerLocator.java
@@ -1,6 +1,7 @@
 package io.quarkus.devservices.common;
 
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
@@ -74,8 +75,14 @@ public class ContainerLocator {
     }
 
     public Optional<ContainerAddress> locateContainer(String serviceName, boolean shared, LaunchMode launchMode) {
+        return locateContainer(serviceName, shared, launchMode, Map.of());
+    }
+
+    public Optional<ContainerAddress> locateContainer(String serviceName, boolean shared, LaunchMode launchMode,
+            Map<String, String> expectedConfig) {
         if (shared && launchMode == LaunchMode.DEVELOPMENT) {
             return lookup(serviceName)
+                    .filter(container -> matchesExpectedConfig(container, expectedConfig))
                     .flatMap(container -> getMappedPort(container, port).stream()
                             .flatMap(containerPort -> Optional.ofNullable(containerPort.getPublicPort())
                                     .map(port -> {
@@ -95,13 +102,37 @@ public class ContainerLocator {
         }
     }
 
+    private static boolean matchesExpectedConfig(Container container, Map<String, String> expectedConfig) {
+        if (expectedConfig == null || expectedConfig.isEmpty()) {
+            return true;
+        }
+        Map<String, String> labels = container.getLabels();
+        for (Map.Entry<String, String> entry : expectedConfig.entrySet()) {
+            String labelValue = labels.get(entry.getKey());
+            if (labelValue == null || !labelValue.equals(entry.getValue())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     /**
      * @return container id, if exists
      */
     public Optional<String> locateContainer(String serviceName, boolean shared, LaunchMode launchMode,
             BiConsumer<Integer, ContainerAddress> consumer) {
+        return locateContainer(serviceName, shared, launchMode, Map.of(), consumer);
+    }
+
+    /**
+     * @return container id, if exists
+     */
+    public Optional<String> locateContainer(String serviceName, boolean shared, LaunchMode launchMode,
+            Map<String, String> expectedConfig, BiConsumer<Integer, ContainerAddress> consumer) {
         if (shared && launchMode == LaunchMode.DEVELOPMENT) {
-            return lookup(serviceName).findAny()
+            return lookup(serviceName)
+                    .filter(container -> matchesExpectedConfig(container, expectedConfig))
+                    .findAny()
                     .map(container -> {
                         if (container.getPorts() == null) {
                             return container.getId();

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/Labels.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/Labels.java
@@ -1,5 +1,8 @@
 package io.quarkus.devservices.common;
 
+import java.util.Map;
+import java.util.OptionalInt;
+
 import org.testcontainers.containers.GenericContainer;
 
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
@@ -7,6 +10,8 @@ import io.quarkus.datasource.common.runtime.DataSourceUtil;
 public final class Labels {
 
     public static final String QUARKUS_DEV_SERVICE = "io.quarkus.devservice";
+    public static final String QUARKUS_DEV_SERVICE_CONFIG = QUARKUS_DEV_SERVICE + ".config.";
+    public static final String QUARKUS_DEV_SERVICE_CONFIG_PORT = QUARKUS_DEV_SERVICE_CONFIG + "port";
     public static final String DOCKER_COMPOSE_PROJECT = "com.docker.compose.project";
     public static final String DOCKER_COMPOSE_NETWORK = "com.docker.compose.network";
     public static final String DOCKER_COMPOSE_SERVICE = "com.docker.compose.service";
@@ -48,6 +53,19 @@ public final class Labels {
 
     public static void addDataSourceLabel(GenericContainer<?> container, String datasourceName) {
         container.withLabel(DATASOURCE, DataSourceUtil.isDefault(datasourceName) ? "default" : datasourceName);
+    }
+
+    public static void addPortConfigLabel(GenericContainer<?> container, OptionalInt fixedPort) {
+        if (fixedPort.isPresent()) {
+            container.withLabel(QUARKUS_DEV_SERVICE_CONFIG_PORT, String.valueOf(fixedPort.getAsInt()));
+        }
+    }
+
+    public static Map<String, String> expectedPortConfig(OptionalInt fixedPort) {
+        if (fixedPort.isEmpty()) {
+            return Map.of();
+        }
+        return Map.of(QUARKUS_DEV_SERVICE_CONFIG_PORT, String.valueOf(fixedPort.getAsInt()));
     }
 
     private Labels() {

--- a/extensions/devservices/common/src/test/java/io/quarkus/devservices/common/ContainerLocatorConfigFilterTest.java
+++ b/extensions/devservices/common/src/test/java/io/quarkus/devservices/common/ContainerLocatorConfigFilterTest.java
@@ -1,0 +1,108 @@
+package io.quarkus.devservices.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import io.quarkus.runtime.LaunchMode;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ContainerLocatorConfigFilterTest {
+
+    private static final String TEST_LABEL = "io.quarkus.devservice.test";
+    private static final String SERVICE_NAME = "config-filter-test";
+    private static final int CONTAINER_PORT = 6379;
+    private static final int FIXED_PORT_A = 16371;
+
+    private GenericContainer<?> containerWithPortLabel;
+    private GenericContainer<?> containerWithoutPortLabel;
+
+    @BeforeAll
+    void startContainers() {
+        assumeTrue(DockerClientFactory.instance().isDockerAvailable());
+
+        try {
+            containerWithPortLabel = new FixedPortContainer(DockerImageName.parse("redis:8.8"), FIXED_PORT_A,
+                    CONTAINER_PORT)
+                    .withLabel(TEST_LABEL, SERVICE_NAME)
+                    .withLabel(Labels.QUARKUS_DEV_SERVICE_CONFIG + "port", String.valueOf(FIXED_PORT_A));
+            containerWithPortLabel.start();
+
+            containerWithoutPortLabel = new GenericContainer<>(DockerImageName.parse("redis:8.8"))
+                    .withLabel(TEST_LABEL, SERVICE_NAME)
+                    .withExposedPorts(CONTAINER_PORT);
+            containerWithoutPortLabel.start();
+
+        } catch (Exception e) {
+            stopContainers();
+        }
+    }
+
+    private static class FixedPortContainer extends GenericContainer<FixedPortContainer> {
+        FixedPortContainer(DockerImageName image, int hostPort, int containerPort) {
+            super(image);
+            addFixedExposedPort(hostPort, containerPort);
+        }
+    }
+
+    @AfterAll
+    void stopContainers() {
+        if (containerWithPortLabel != null) {
+            containerWithPortLabel.stop();
+        }
+        if (containerWithoutPortLabel != null) {
+            containerWithoutPortLabel.stop();
+        }
+    }
+
+    @Test
+    void emptyExpectedConfigMatchesAnyContainer() {
+        ContainerLocator locator = new ContainerLocator(TEST_LABEL, CONTAINER_PORT);
+        Optional<ContainerAddress> result = locator.locateContainer(SERVICE_NAME, true, LaunchMode.DEVELOPMENT, Map.of());
+        assertThat(result).isPresent();
+    }
+
+    @Test
+    void matchingPortConfigFindsContainer() {
+        ContainerLocator locator = new ContainerLocator(TEST_LABEL, CONTAINER_PORT);
+        Optional<ContainerAddress> result = locator.locateContainer(SERVICE_NAME, true, LaunchMode.DEVELOPMENT,
+                Labels.expectedPortConfig(OptionalInt.of(FIXED_PORT_A)));
+        assertThat(result).isPresent();
+        assertThat(result.get().getPort()).isEqualTo(FIXED_PORT_A);
+    }
+
+    @Test
+    void mismatchedPortConfigSkipsContainer() {
+        ContainerLocator locator = new ContainerLocator(TEST_LABEL, CONTAINER_PORT);
+        Optional<ContainerAddress> result = locator.locateContainer(SERVICE_NAME, true, LaunchMode.DEVELOPMENT,
+                Labels.expectedPortConfig(OptionalInt.of(FIXED_PORT_A + 100)));
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void containerWithoutLabelNotFoundByPortFilter() {
+        ContainerLocator locator = new ContainerLocator(TEST_LABEL, CONTAINER_PORT);
+        int randomPort = containerWithoutPortLabel.getMappedPort(CONTAINER_PORT);
+        Optional<ContainerAddress> result = locator.locateContainer(SERVICE_NAME, true, LaunchMode.DEVELOPMENT,
+                Labels.expectedPortConfig(OptionalInt.of(randomPort)));
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void noConfigFilterStillFindsContainerWithLabel() {
+        ContainerLocator locator = new ContainerLocator(TEST_LABEL, CONTAINER_PORT);
+        Optional<ContainerAddress> result = locator.locateContainer(SERVICE_NAME, true, LaunchMode.DEVELOPMENT);
+        assertThat(result).isPresent();
+    }
+}

--- a/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
+++ b/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
@@ -140,7 +140,9 @@ public class DB2DevServicesProcessor {
                 List<String> images = List.of(containerConfig.getImageName()
                         .orElseGet(() -> ConfigureUtil.getDefaultImageNameFor("db2")),
                         "db2");
-                return ComposeLocator.locateContainer(composeProjectBuildItem, images, DB2_PORT, launchMode, useSharedNetwork)
+                return ComposeLocator
+                        .locateContainer(composeProjectBuildItem, images, DB2_PORT, launchMode, useSharedNetwork,
+                                containerConfig.getFixedExposedPort())
                         .map(containerAddress -> configurator.composeRunningService(containerAddress, containerConfig));
             }
         });
@@ -161,6 +163,7 @@ public class DB2DevServicesProcessor {
             this.useSharedNetwork = useSharedNetwork;
             this.podman = podman;
             this.hostName = ConfigureUtil.configureNetwork(this, defaultNetworkId, useSharedNetwork, "db2");
+            Labels.addPortConfigLabel(this, fixedExposedPort);
         }
 
         @Override

--- a/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesProcessor.java
+++ b/extensions/devservices/keycloak/src/main/java/io/quarkus/devservices/keycloak/KeycloakDevServicesProcessor.java
@@ -3,6 +3,7 @@ package io.quarkus.devservices.keycloak;
 import static io.quarkus.devservices.common.ConfigureUtil.getDefaultImageNameFor;
 import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
 import static io.quarkus.devservices.common.Labels.QUARKUS_DEV_SERVICE;
+import static io.quarkus.devservices.common.Labels.expectedPortConfig;
 import static io.quarkus.devservices.keycloak.KeycloakDevServicesRequiredBuildItem.getDevServicesConfigurator;
 import static io.quarkus.devservices.keycloak.KeycloakDevServicesUtils.createWebClient;
 import static io.quarkus.devservices.keycloak.KeycloakDevServicesUtils.getPasswordAccessToken;
@@ -64,6 +65,7 @@ import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerAddress;
 import io.quarkus.devservices.common.ContainerLocator;
+import io.quarkus.devservices.common.Labels;
 import io.quarkus.devservices.common.StartableContainer;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
@@ -150,9 +152,10 @@ public class KeycloakDevServicesProcessor {
 
         final String serviceConfigHashCode = getServiceConfigIdentifier(config);
         DevServicesResultBuildItem devServicesResultBuildItem = KEYCLOAK_DEV_MODE_CONTAINER_LOCATOR
-                .locateContainer(config.serviceName(), config.shared(), LaunchMode.current())
+                .locateContainer(config.serviceName(), config.shared(), LaunchMode.current(),
+                        expectedPortConfig(config.port()))
                 .or(() -> ComposeLocator.locateContainer(composeProjectBuildItem, List.of(imageName, "keycloak"),
-                        KEYCLOAK_PORT, LaunchMode.current(), useSharedNetwork))
+                        KEYCLOAK_PORT, LaunchMode.current(), useSharedNetwork, config.port()))
                 .map(containerAddress -> {
                     String sharedContainerUrl = getSharedContainerUrl(containerAddress);
                     Map<String, String> configs = prepareConfiguration(config, sharedContainerUrl,
@@ -563,6 +566,7 @@ public class KeycloakDevServicesProcessor {
             if (sharedContainer && LaunchMode.current() == LaunchMode.DEVELOPMENT) {
                 withLabel(DEV_SERVICE_LABEL, containerLabelValue);
                 withLabel(QUARKUS_DEV_SERVICE, containerLabelValue);
+                Labels.addPortConfigLabel(this, fixedExposedPort);
             }
 
             if (javaOpts.isPresent()) {

--- a/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDevServicesProcessor.java
+++ b/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDevServicesProcessor.java
@@ -95,7 +95,8 @@ public class MariaDBDevServicesProcessor {
                 List<String> images = List.of(
                         containerConfig.getImageName().orElseGet(() -> ConfigureUtil.getDefaultImageNameFor("mariadb")),
                         "maria");
-                return ComposeLocator.locateContainer(composeProjectBuildItem, images, PORT, launchMode, useSharedNetwork)
+                return ComposeLocator.locateContainer(composeProjectBuildItem, images, PORT, launchMode, useSharedNetwork,
+                        containerConfig.getFixedExposedPort())
                         .map(containerAddress -> configurator.composeRunningService(containerAddress, containerConfig));
             }
         });
@@ -116,6 +117,7 @@ public class MariaDBDevServicesProcessor {
             this.fixedExposedPort = fixedExposedPort;
             this.useSharedNetwork = useSharedNetwork;
             this.hostName = ConfigureUtil.configureNetwork(this, defaultNetworkId, useSharedNetwork, "mariadb");
+            Labels.addPortConfigLabel(this, fixedExposedPort);
         }
 
         @Override

--- a/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
+++ b/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
@@ -90,7 +90,8 @@ public class MSSQLDevServicesProcessor {
                         containerConfig.getImageName().orElseGet(() -> ConfigureUtil.getDefaultImageNameFor("mssql")),
                         "mssql");
                 return ComposeLocator
-                        .locateContainer(composeProjectBuildItem, images, MS_SQL_SERVER_PORT, launchMode, useSharedNetwork)
+                        .locateContainer(composeProjectBuildItem, images, MS_SQL_SERVER_PORT, launchMode, useSharedNetwork,
+                                containerConfig.getFixedExposedPort())
                         .map(containerAddress -> configurator.composeRunningService(containerAddress, containerConfig));
             }
         });
@@ -110,6 +111,7 @@ public class MSSQLDevServicesProcessor {
             this.fixedExposedPort = fixedExposedPort;
             this.useSharedNetwork = useSharedNetwork;
             this.hostName = ConfigureUtil.configureNetwork(this, defaultNetworkId, useSharedNetwork, "mssql");
+            Labels.addPortConfigLabel(this, fixedExposedPort);
         }
 
         @Override

--- a/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/mysql/deployment/MySQLDevServicesProcessor.java
+++ b/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/mysql/deployment/MySQLDevServicesProcessor.java
@@ -96,7 +96,9 @@ public class MySQLDevServicesProcessor {
                 List<String> images = List.of(
                         containerConfig.getImageName().orElseGet(() -> ConfigureUtil.getDefaultImageNameFor("mysql")),
                         "mysql");
-                return ComposeLocator.locateContainer(composeProjectBuildItem, images, MYSQL_PORT, launchMode, useSharedNetwork)
+                return ComposeLocator
+                        .locateContainer(composeProjectBuildItem, images, MYSQL_PORT, launchMode, useSharedNetwork,
+                                containerConfig.getFixedExposedPort())
                         .map(containerAddress -> configurator.composeRunningService(containerAddress, containerConfig));
             }
         });
@@ -116,6 +118,7 @@ public class MySQLDevServicesProcessor {
             this.fixedExposedPort = fixedExposedPort;
             this.useSharedNetwork = useSharedNetwork;
             this.hostName = ConfigureUtil.configureNetwork(this, defaultNetworkId, useSharedNetwork, "mssql");
+            Labels.addPortConfigLabel(this, fixedExposedPort);
         }
 
         @Override

--- a/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
+++ b/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
@@ -112,7 +112,8 @@ public class OracleDevServicesProcessor {
                         containerConfig.getImageName().orElseGet(() -> ConfigureUtil.getDefaultImageNameFor("oracle")),
                         "oracle");
 
-                return ComposeLocator.locateContainer(composeProjectBuildItem, images, PORT, launchMode, useSharedNetwork)
+                return ComposeLocator.locateContainer(composeProjectBuildItem, images, PORT, launchMode, useSharedNetwork,
+                        containerConfig.getFixedExposedPort())
                         .map(containerAddress -> configurator.composeRunningService(containerAddress, containerConfig));
             }
 
@@ -133,6 +134,7 @@ public class OracleDevServicesProcessor {
             this.fixedExposedPort = fixedExposedPort;
             this.useSharedNetwork = useSharedNetwork;
             this.hostName = ConfigureUtil.configureNetwork(this, defaultNetworkId, useSharedNetwork, "oracle");
+            Labels.addPortConfigLabel(this, fixedExposedPort);
         }
 
         @Override

--- a/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
+++ b/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
@@ -120,7 +120,8 @@ public class PostgresqlDevServicesProcessor {
                         CPU.host());
                 List<String> images = List.of(selectedImage, "postgres");
                 return ComposeLocator
-                        .locateContainer(composeProjectBuildItem, images, POSTGRESQL_PORT, launchMode, useSharedNetwork)
+                        .locateContainer(composeProjectBuildItem, images, POSTGRESQL_PORT, launchMode, useSharedNetwork,
+                                containerConfig.getFixedExposedPort())
                         .map(containerAddress -> configurator.composeRunningService(containerAddress, containerConfig));
             }
 
@@ -160,6 +161,7 @@ public class PostgresqlDevServicesProcessor {
                     .withStrategy(Wait.forListeningPort())
                     .withStartupTimeout(Duration.of(60L, ChronoUnit.SECONDS));
             this.hostName = ConfigureUtil.configureNetwork(this, defaultNetworkId, useSharedNetwork, "postgres");
+            Labels.addPortConfigLabel(this, fixedExposedPort);
         }
 
         @Override

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
@@ -1,6 +1,7 @@
 package io.quarkus.elasticsearch.restclient.common.deployment;
 
 import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
+import static io.quarkus.devservices.common.Labels.expectedPortConfig;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -8,6 +9,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -115,10 +117,12 @@ public class DevServicesElasticsearchProcessor {
                         container.withLabel(DEV_SERVICE_LABEL, config.serviceName());
                         container.withLabel(Labels.QUARKUS_DEV_SERVICE, config.serviceName());
                     }
-                    if (config.port().isPresent()) {
+                    OptionalInt fixedPort = config.port().map(OptionalInt::of).orElse(OptionalInt.empty());
+                    if (fixedPort.isPresent()) {
                         container.setPortBindings(
-                                List.of(config.port().get() + ":" + ELASTICSEARCH_PORT));
+                                List.of(fixedPort.getAsInt() + ":" + ELASTICSEARCH_PORT));
                     }
+                    Labels.addPortConfigLabel(container, fixedPort);
 
                     container.withEnv(config.containerEnv());
                     container.withReuse(config.reuse());
@@ -144,11 +148,13 @@ public class DevServicesElasticsearchProcessor {
             DevservicesElasticsearchBuildItemsConfiguration buildItemsConfig,
             LaunchMode launchMode,
             boolean useSharedNetwork) {
+        OptionalInt fixedPort = config.port().map(OptionalInt::of).orElse(OptionalInt.empty());
         return ELASTICSEARCH_CONTAINER_LOCATOR
-                .locateContainer(config.serviceName(), config.shared(), launchMode)
+                .locateContainer(config.serviceName(), config.shared(), launchMode,
+                        expectedPortConfig(fixedPort))
                 .or(() -> ComposeLocator.locateContainer(composeProjectBuildItem,
                         List.of(resolvedImageName.getUnversionedPart(), "elasticsearch", "opensearch"),
-                        ELASTICSEARCH_PORT, launchMode, useSharedNetwork))
+                        ELASTICSEARCH_PORT, launchMode, useSharedNetwork, fixedPort))
                 .map(containerAddress -> DevServicesResultBuildItem.discovered()
                         .feature(Feature.ELASTICSEARCH_REST_CLIENT_COMMON)
                         .containerId(containerAddress.getId())

--- a/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devservices/InfinispanDevServiceProcessor.java
+++ b/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devservices/InfinispanDevServiceProcessor.java
@@ -3,6 +3,7 @@ package io.quarkus.infinispan.client.deployment.devservices;
 import static io.quarkus.devservices.common.ConfigureUtil.configureSharedServiceLabel;
 import static io.quarkus.devservices.common.ConfigureUtil.getDefaultImageNameFor;
 import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
+import static io.quarkus.devservices.common.Labels.expectedPortConfig;
 import static org.infinispan.testcontainers.InfinispanContainer.DEFAULT_USERNAME;
 
 import java.time.Duration;
@@ -34,6 +35,7 @@ import io.quarkus.deployment.dev.devservices.RunningContainer;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerLocator;
+import io.quarkus.devservices.common.Labels;
 import io.quarkus.infinispan.client.runtime.InfinispanClientBuildTimeConfig;
 import io.quarkus.infinispan.client.runtime.InfinispanClientUtil;
 import io.quarkus.infinispan.client.runtime.InfinispanClientsBuildTimeConfig;
@@ -133,11 +135,12 @@ public class InfinispanDevServiceProcessor {
             log.infof("Applying Dev Services config %s", namedDevServiceConfig);
 
             return infinispanContainerLocator
-                    .locateContainer(namedDevServiceConfig.serviceName(), namedDevServiceConfig.shared(), launchMode)
+                    .locateContainer(namedDevServiceConfig.serviceName(), namedDevServiceConfig.shared(), launchMode,
+                            expectedPortConfig(namedDevServiceConfig.port()))
                     .or(() -> ComposeLocator.locateContainer(composeProjectBuildItem,
                             List.of(namedDevServiceConfig.imageName().orElseGet(() -> getDefaultImageNameFor("infinispan")),
                                     "infinispan", "datagrid"),
-                            DEFAULT_INFINISPAN_PORT, launchMode, useSharedNetwork))
+                            DEFAULT_INFINISPAN_PORT, launchMode, useSharedNetwork, namedDevServiceConfig.port()))
                     .map(containerAddress -> {
                         RunningContainer container = containerAddress.getRunningContainer();
                         String username = container != null ? container.tryGetEnv("USER").orElse(DEFAULT_USERNAME)
@@ -253,6 +256,7 @@ public class InfinispanDevServiceProcessor {
             withCommand(command);
 
             this.hostName = ConfigureUtil.configureNetwork(this, defaultNetworkId, useSharedNetwork, "infinispan");
+            Labels.addPortConfigLabel(this, fixedExposedPort);
         }
 
         @Override

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/DevServicesKafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/DevServicesKafkaProcessor.java
@@ -2,10 +2,12 @@ package io.quarkus.kafka.client.deployment;
 
 import static io.quarkus.devservices.common.ConfigureUtil.configureSharedServiceLabel;
 import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
+import static io.quarkus.devservices.common.Labels.expectedPortConfig;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -37,6 +39,7 @@ import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerLocator;
+import io.quarkus.devservices.common.Labels;
 import io.quarkus.devservices.common.StartableContainer;
 import io.quarkus.runtime.configuration.ConfigUtils;
 import io.strimzi.test.container.StrimziKafkaCluster;
@@ -74,11 +77,14 @@ public class DevServicesKafkaProcessor {
             return null;
         }
         boolean useSharedNetwork = DevServicesSharedNetworkBuildItem.isSharedNetworkRequired(devServicesConfig, sharedNetwork);
+        OptionalInt fixedExposedPort = config.port().map(OptionalInt::of).orElse(OptionalInt.empty());
 
-        return kafkaContainerLocator.locateContainer(config.serviceName(), config.shared(), launchMode.getLaunchMode())
+        return kafkaContainerLocator
+                .locateContainer(config.serviceName(), config.shared(), launchMode.getLaunchMode(),
+                        expectedPortConfig(fixedExposedPort))
                 .or(() -> ComposeLocator.locateContainer(compose,
                         List.of(config.effectiveImageName(), "kafka", "strimzi", "redpanda"),
-                        KAFKA_PORT, launchMode.getLaunchMode(), useSharedNetwork))
+                        KAFKA_PORT, launchMode.getLaunchMode(), useSharedNetwork, fixedExposedPort))
                 .map(containerAddress -> {
                     createTopicPartitions(containerAddress.getUrl(), config);
                     return DevServicesResultBuildItem.discovered()
@@ -124,6 +130,8 @@ public class DevServicesKafkaProcessor {
                             strimzi.withKafkaConfigurationMap(config.strimzi().serverConfigs());
                             configureSharedServiceLabel(strimzi, launchMode.getLaunchMode(), DEV_SERVICE_LABEL,
                                     config.serviceName());
+                            Labels.addPortConfigLabel(strimzi,
+                                    config.port().map(OptionalInt::of).orElse(OptionalInt.empty()));
                         })
                         .build();
                 StrimziKafkaContainer strimzi = cluster.getBrokers().stream().findFirst().get();

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaContainer.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaContainer.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
 
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -18,6 +19,7 @@ import com.github.dockerjava.api.command.InspectContainerResponse;
 
 import io.quarkus.deployment.builditem.Startable;
 import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.devservices.common.Labels;
 import io.quarkus.runtime.LaunchMode;
 
 public class KafkaContainer extends GenericContainer<KafkaContainer> implements Startable {
@@ -157,6 +159,7 @@ public class KafkaContainer extends GenericContainer<KafkaContainer> implements 
             throw new IllegalArgumentException("The fixed Kafka port must be greater than 0");
         } else if (fixedPort > 0) {
             addFixedExposedPort(fixedPort, 9092);
+            Labels.addPortConfigLabel(this, OptionalInt.of(fixedPort));
         }
         return this;
     }

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaNativeContainer.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaNativeContainer.java
@@ -5,6 +5,7 @@ import static io.quarkus.kafka.client.deployment.DevServicesKafkaProcessor.DEV_S
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.OptionalInt;
 
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -14,6 +15,7 @@ import com.github.dockerjava.api.command.InspectContainerResponse;
 
 import io.quarkus.deployment.builditem.Startable;
 import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.devservices.common.Labels;
 import io.quarkus.runtime.LaunchMode;
 
 public class KafkaNativeContainer extends GenericContainer<KafkaNativeContainer> implements Startable {
@@ -37,6 +39,7 @@ public class KafkaNativeContainer extends GenericContainer<KafkaNativeContainer>
         withCommand("sh", "-c", cmd);
         waitingFor(Wait.forLogMessage(".*Kafka broker started.*", 1));
         this.hostName = ConfigureUtil.configureNetwork(this, defaultNetworkId, useSharedNetwork, "kafka");
+        Labels.addPortConfigLabel(this, fixedExposedPort > 0 ? OptionalInt.of(fixedExposedPort) : OptionalInt.empty());
     }
 
     public KafkaNativeContainer withSharedServiceLabel(LaunchMode launchMode, String serviceName) {

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/RedpandaKafkaContainer.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/RedpandaKafkaContainer.java
@@ -6,6 +6,7 @@ import static io.quarkus.kafka.client.deployment.DevServicesKafkaProcessor.DEV_S
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.OptionalInt;
 
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -16,6 +17,7 @@ import com.github.dockerjava.api.command.InspectContainerResponse;
 
 import io.quarkus.deployment.builditem.Startable;
 import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.devservices.common.Labels;
 import io.quarkus.runtime.LaunchMode;
 
 /**
@@ -49,6 +51,7 @@ final class RedpandaKafkaContainer extends GenericContainer<RedpandaKafkaContain
                 STARTER_SCRIPT);
         waitingFor(Wait.forLogMessage(".*Started Kafka API server.*", 1));
         this.hostName = ConfigureUtil.configureNetwork(this, defaultNetworkId, useSharedNetwork, "redpanda");
+        Labels.addPortConfigLabel(this, fixedExposedPort > 0 ? OptionalInt.of(fixedExposedPort) : OptionalInt.empty());
     }
 
     public RedpandaKafkaContainer withSharedServiceLabel(LaunchMode launchMode, String serviceName) {

--- a/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/DevServicesKubernetesProcessor.java
+++ b/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/DevServicesKubernetesProcessor.java
@@ -67,6 +67,7 @@ import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerAddress;
 import io.quarkus.devservices.common.ContainerLocator;
+import io.quarkus.devservices.common.Labels;
 import io.quarkus.kubernetes.client.runtime.internal.KubernetesClientBuildTimeConfig;
 import io.quarkus.kubernetes.client.runtime.internal.KubernetesDevServicesBuildTimeConfig;
 import io.quarkus.kubernetes.client.runtime.internal.KubernetesDevServicesBuildTimeConfig.Flavor;
@@ -196,6 +197,7 @@ public class DevServicesKubernetesProcessor {
             container.withLabel(DEV_SERVICE_LABEL, config.serviceName);
             container.withLabel(QUARKUS_DEV_SERVICE, config.serviceName);
         }
+        Labels.addPortConfigLabel(container, OptionalInt.empty());
         timeout.ifPresent(container::withStartupTimeout);
         container.withEnv(config.containerEnv);
 

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/DevServicesMongoProcessor.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/DevServicesMongoProcessor.java
@@ -1,6 +1,7 @@
 package io.quarkus.mongodb.deployment;
 
 import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
+import static io.quarkus.devservices.common.Labels.expectedPortConfig;
 import static io.quarkus.mongodb.runtime.MongoConfig.isDefaultClient;
 
 import java.nio.charset.StandardCharsets;
@@ -9,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -135,10 +137,14 @@ public class DevServicesMongoProcessor {
     private DevServicesResultBuildItem discoverRunningService(DevServicesComposeProjectBuildItem composeProjectBuildItem,
             String connectionName, CapturedProperties captured, LaunchMode launchMode, boolean useSharedNetwork) {
         String configPrefix = getConfigPrefix(connectionName);
+        OptionalInt fixedPort = captured.fixedExposedPort != null ? OptionalInt.of(captured.fixedExposedPort)
+                : OptionalInt.empty();
         return MONGO_CONTAINER_LOCATOR
-                .locateContainer(captured.serviceName(), captured.shared(), launchMode)
+                .locateContainer(captured.serviceName(), captured.shared(), launchMode,
+                        expectedPortConfig(fixedPort))
                 .or(() -> ComposeLocator.locateContainer(composeProjectBuildItem,
-                        List.of(captured.imageName, "mongo"), MONGO_EXPOSED_PORT, launchMode, useSharedNetwork))
+                        List.of(captured.imageName, "mongo"), MONGO_EXPOSED_PORT, launchMode, useSharedNetwork,
+                        fixedPort))
                 .map(containerAddress -> {
                     String effectiveUrl = getEffectiveUrl(configPrefix, containerAddress.getHost(),
                             containerAddress.getPort(), captured);
@@ -236,6 +242,8 @@ public class DevServicesMongoProcessor {
             this.useSharedNetwork = useSharedNetwork;
             this.hostName = ConfigureUtil.configureNetwork(this, defaultNetworkId, useSharedNetwork, "mongo");
             this.withLabel(Labels.QUARKUS_DEV_SERVICE, launchMode == LaunchMode.DEVELOPMENT ? serviceName : null);
+            Labels.addPortConfigLabel(this,
+                    fixedExposedPort != null ? OptionalInt.of(fixedExposedPort) : OptionalInt.empty());
         }
 
         private QuarkusMongoDBContainer(DockerImageName dockerImageName, Integer fixedExposedPort,
@@ -246,6 +254,8 @@ public class DevServicesMongoProcessor {
             this.useSharedNetwork = useSharedNetwork;
             this.hostName = ConfigureUtil.configureNetwork(this, defaultNetworkId, useSharedNetwork, "mongo");
             this.withLabel(Labels.QUARKUS_DEV_SERVICE, launchMode == LaunchMode.DEVELOPMENT ? serviceName : null);
+            Labels.addPortConfigLabel(this,
+                    fixedExposedPort != null ? OptionalInt.of(fixedExposedPort) : OptionalInt.empty());
         }
 
         @Override

--- a/extensions/narayana-lra/deployment/src/main/java/io/quarkus/narayana/lra/deployment/devservice/DevServicesLRAProcessor.java
+++ b/extensions/narayana-lra/deployment/src/main/java/io/quarkus/narayana/lra/deployment/devservice/DevServicesLRAProcessor.java
@@ -2,6 +2,7 @@ package io.quarkus.narayana.lra.deployment.devservice;
 
 import static io.quarkus.devservices.common.ConfigureUtil.getDefaultImageNameFor;
 import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
+import static io.quarkus.devservices.common.Labels.expectedPortConfig;
 
 import java.util.List;
 import java.util.Map;
@@ -62,10 +63,11 @@ public class DevServicesLRAProcessor {
         }
 
         return lraCoordinatorContainerLocator
-                .locateContainer(config.serviceName(), config.shared(), launchMode.getLaunchMode())
+                .locateContainer(config.serviceName(), config.shared(), launchMode.getLaunchMode(),
+                        expectedPortConfig(config.port()))
                 .or(() -> ComposeLocator.locateContainer(compose,
                         List.of(config.imageName().orElseGet(() -> getDefaultImageNameFor("narayana-lra")), "lra-coordinator"),
-                        LRA_COORDINATOR_CONTAINER_PORT, launchMode.getLaunchMode(), useSharedNetwork))
+                        LRA_COORDINATOR_CONTAINER_PORT, launchMode.getLaunchMode(), useSharedNetwork, config.port()))
                 .map(containerAddress -> DevServicesResultBuildItem.discovered()
                         .feature(Feature.NARAYANA_LRA)
                         .containerId(containerAddress.getId())

--- a/extensions/narayana-lra/deployment/src/main/java/io/quarkus/narayana/lra/deployment/devservice/LRACoordinatorContainer.java
+++ b/extensions/narayana-lra/deployment/src/main/java/io/quarkus/narayana/lra/deployment/devservice/LRACoordinatorContainer.java
@@ -3,6 +3,8 @@ package io.quarkus.narayana.lra.deployment.devservice;
 import static io.quarkus.devservices.common.ConfigureUtil.configureSharedServiceLabel;
 import static io.quarkus.narayana.lra.deployment.devservice.DevServicesLRAProcessor.DEV_SERVICE_LABEL;
 
+import java.util.OptionalInt;
+
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
@@ -11,6 +13,7 @@ import com.github.dockerjava.api.command.InspectContainerResponse;
 
 import io.quarkus.deployment.builditem.Startable;
 import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.devservices.common.Labels;
 import io.quarkus.runtime.LaunchMode;
 
 public class LRACoordinatorContainer extends GenericContainer<LRACoordinatorContainer> implements Startable {
@@ -24,6 +27,8 @@ public class LRACoordinatorContainer extends GenericContainer<LRACoordinatorCont
         super(imageName);
         this.fixedExposedPort = fixedExposedPort;
         ConfigureUtil.configureNetwork(this, defaultNetworkId, useSharedNetwork, "lra-coordinator");
+        Labels.addPortConfigLabel(this,
+                fixedExposedPort != null && fixedExposedPort > 0 ? OptionalInt.of(fixedExposedPort) : OptionalInt.empty());
         waitingFor(Wait.forLogMessage(".*lra-coordinator-quarkus.*started in.*", 1));
     }
 

--- a/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/DevServicesRedisProcessor.java
+++ b/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/DevServicesRedisProcessor.java
@@ -3,6 +3,7 @@ package io.quarkus.redis.deployment.client;
 import static io.quarkus.devservices.common.ConfigureUtil.configureSharedServiceLabel;
 import static io.quarkus.devservices.common.ConfigureUtil.getDefaultImageNameFor;
 import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
+import static io.quarkus.devservices.common.Labels.expectedPortConfig;
 import static io.quarkus.redis.runtime.client.config.RedisConfig.HOSTS;
 import static io.quarkus.redis.runtime.client.config.RedisConfig.getPropertyName;
 
@@ -31,6 +32,7 @@ import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerLocator;
+import io.quarkus.devservices.common.Labels;
 import io.quarkus.redis.runtime.client.config.RedisConfig;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ConfigUtils;
@@ -128,10 +130,12 @@ public class DevServicesRedisProcessor {
             io.quarkus.redis.deployment.client.DevServicesConfig devServicesConfig,
             LaunchMode launchMode,
             boolean useSharedNetwork) {
-        return redisContainerLocator.locateContainer(devServicesConfig.serviceName(), devServicesConfig.shared(), launchMode)
+        return redisContainerLocator
+                .locateContainer(devServicesConfig.serviceName(), devServicesConfig.shared(), launchMode,
+                        expectedPortConfig(devServicesConfig.port()))
                 .or(() -> ComposeLocator.locateContainer(composeProjectBuildItem,
                         List.of(devServicesConfig.imageName().orElseGet(() -> getDefaultImageNameFor("redis"))),
-                        REDIS_EXPOSED_PORT, launchMode, useSharedNetwork))
+                        REDIS_EXPOSED_PORT, launchMode, useSharedNetwork, devServicesConfig.port()))
                 .map(containerAddress -> {
                     String redisUrl = REDIS_SCHEME + containerAddress.getUrl();
                     return DevServicesResultBuildItem.discovered()
@@ -181,6 +185,7 @@ public class DevServicesRedisProcessor {
             this.useSharedNetwork = useSharedNetwork;
 
             this.hostName = ConfigureUtil.configureNetwork(this, defaultNetworkId, useSharedNetwork, "redis");
+            Labels.addPortConfigLabel(this, fixedExposedPort);
         }
 
         public QuarkusPortRedisContainer withSharedServiceLabel(LaunchMode launchMode, String serviceName) {

--- a/extensions/schema-registry/devservice/deployment/src/main/java/io/quarkus/apicurio/registry/devservice/DevServicesApicurioRegistryProcessor.java
+++ b/extensions/schema-registry/devservice/deployment/src/main/java/io/quarkus/apicurio/registry/devservice/DevServicesApicurioRegistryProcessor.java
@@ -3,11 +3,13 @@ package io.quarkus.apicurio.registry.devservice;
 import static io.quarkus.devservices.common.ConfigureUtil.getDefaultImageNameFor;
 import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
 import static io.quarkus.devservices.common.Labels.QUARKUS_DEV_SERVICE;
+import static io.quarkus.devservices.common.Labels.expectedPortConfig;
 
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -30,6 +32,7 @@ import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerLocator;
+import io.quarkus.devservices.common.Labels;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ConfigUtils;
 
@@ -108,10 +111,11 @@ public class DevServicesApicurioRegistryProcessor {
         }
 
         return apicurioRegistryContainerLocator
-                .locateContainer(config.serviceName(), config.shared(), launchMode.getLaunchMode())
+                .locateContainer(config.serviceName(), config.shared(), launchMode.getLaunchMode(),
+                        expectedPortConfig(config.port()))
                 .or(() -> ComposeLocator.locateContainer(composeProjectBuildItem,
                         List.of(config.imageName().orElseGet(() -> getDefaultImageNameFor("apicurio-registry")), "apicurio"),
-                        APICURIO_REGISTRY_PORT, launchMode.getLaunchMode(), useSharedNetwork))
+                        APICURIO_REGISTRY_PORT, launchMode.getLaunchMode(), useSharedNetwork, config.port()))
                 .map(address -> DevServicesResultBuildItem.discovered()
                         .feature(Feature.APICURIO_REGISTRY_AVRO)
                         .containerId(address.getId())
@@ -186,6 +190,7 @@ public class DevServicesApicurioRegistryProcessor {
                 throw new IllegalArgumentException("Only apicurio/apicurio-registry images are supported");
             }
             this.hostName = ConfigureUtil.configureNetwork(this, defaultNetworkId, useSharedNetwork, "apicurio-registry");
+            Labels.addPortConfigLabel(this, fixedExposedPort > 0 ? OptionalInt.of(fixedExposedPort) : OptionalInt.empty());
             withEnv(containerEnv);
             timeout.ifPresent(this::withStartupTimeout);
         }

--- a/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/amqp/deployment/AmqpDevServicesProcessor.java
+++ b/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/amqp/deployment/AmqpDevServicesProcessor.java
@@ -3,9 +3,11 @@ package io.quarkus.smallrye.reactivemessaging.amqp.deployment;
 import static io.quarkus.devservices.common.ConfigureUtil.getDefaultImageNameFor;
 import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
 import static io.quarkus.devservices.common.Labels.QUARKUS_DEV_SERVICE;
+import static io.quarkus.devservices.common.Labels.expectedPortConfig;
 
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -29,6 +31,7 @@ import io.quarkus.deployment.dev.devservices.RunningContainer;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerLocator;
+import io.quarkus.devservices.common.Labels;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ConfigUtils;
 
@@ -76,12 +79,14 @@ public class AmqpDevServicesProcessor {
         }
 
         boolean useSharedNetwork = DevServicesSharedNetworkBuildItem.isSharedNetworkRequired(devServicesConfig, sharedNetwork);
+        OptionalInt fixedPort = config.port().map(OptionalInt::of).orElse(OptionalInt.empty());
 
-        return amqpContainerLocator.locateContainer(config.serviceName(), config.shared(), launchMode.getLaunchMode())
+        return amqpContainerLocator.locateContainer(config.serviceName(), config.shared(), launchMode.getLaunchMode(),
+                expectedPortConfig(fixedPort))
                 .or(() -> ComposeLocator.locateContainer(compose,
                         List.of(config.imageName().orElse(getDefaultImageNameFor("amqp")),
                                 "amqp", "activemq-artemis", "amq-broker", "rabbitmq"),
-                        AMQP_PORT, launchMode.getLaunchMode(), useSharedNetwork))
+                        AMQP_PORT, launchMode.getLaunchMode(), useSharedNetwork, fixedPort))
                 .map(containerAddress -> {
                     // Discovered service
                     RunningContainer container = containerAddress.getRunningContainer();
@@ -110,7 +115,7 @@ public class AmqpDevServicesProcessor {
                                 DockerImageName.parse(config.imageName().orElse(getDefaultImageNameFor("amqp")))
                                         .asCompatibleSubstituteFor("artemiscloud/activemq-artemis-broker"),
                                 config.extraArgs(),
-                                config.port().orElse(0),
+                                fixedPort,
                                 launchMode.getLaunchMode() == LaunchMode.DEVELOPMENT ? config.serviceName() : null,
                                 compose.getDefaultNetworkId(),
                                 useSharedNetwork)
@@ -188,15 +193,15 @@ public class AmqpDevServicesProcessor {
      */
     private static final class ArtemisContainer extends GenericContainer<ArtemisContainer> implements Startable {
 
-        private final int port;
+        private final OptionalInt fixedExposedPort;
         private final boolean useSharedNetwork;
 
         private final String hostName;
 
-        private ArtemisContainer(DockerImageName dockerImageName, String extra, int fixedExposedPort, String serviceName,
-                String defaultNetworkId, boolean useSharedNetwork) {
+        private ArtemisContainer(DockerImageName dockerImageName, String extra, OptionalInt fixedExposedPort,
+                String serviceName, String defaultNetworkId, boolean useSharedNetwork) {
             super(dockerImageName);
-            this.port = fixedExposedPort;
+            this.fixedExposedPort = fixedExposedPort;
             this.useSharedNetwork = useSharedNetwork;
 
             withExposedPorts(AMQP_PORT, AMQP_CONSOLE_PORT);
@@ -218,13 +223,14 @@ public class AmqpDevServicesProcessor {
                 log.info("Skipping startup probe for the Dev Service for AMQP as it does not use the default image.");
             }
             this.hostName = ConfigureUtil.configureNetwork(this, defaultNetworkId, useSharedNetwork, "artemis");
+            Labels.addPortConfigLabel(this, fixedExposedPort);
         }
 
         @Override
         protected void configure() {
             super.configure();
-            if (port > 0) {
-                addFixedExposedPort(port, AMQP_PORT);
+            if (fixedExposedPort.isPresent()) {
+                addFixedExposedPort(fixedExposedPort.getAsInt(), AMQP_PORT);
             }
         }
 

--- a/extensions/smallrye-reactive-messaging-mqtt/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/mqtt/deployment/MqttDevServicesProcessor.java
+++ b/extensions/smallrye-reactive-messaging-mqtt/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/mqtt/deployment/MqttDevServicesProcessor.java
@@ -2,10 +2,12 @@ package io.quarkus.smallrye.reactivemessaging.mqtt.deployment;
 
 import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
 import static io.quarkus.devservices.common.Labels.QUARKUS_DEV_SERVICE;
+import static io.quarkus.devservices.common.Labels.expectedPortConfig;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -29,6 +31,7 @@ import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerLocator;
+import io.quarkus.devservices.common.Labels;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ConfigUtils;
 
@@ -71,7 +74,8 @@ public class MqttDevServicesProcessor {
 
         // Handle ComposeLocator differently - MQTT has custom port detection logic
 
-        return mqttContainerLocator.locateContainer(config.serviceName(), config.shared(), launchMode.getLaunchMode())
+        return mqttContainerLocator.locateContainer(config.serviceName(), config.shared(), launchMode.getLaunchMode(),
+                expectedPortConfig(config.port()))
                 .map(containerAddress -> DevServicesResultBuildItem.discovered()
                         .feature(Feature.MESSAGING_MQTT)
                         .containerId(containerAddress.getId())
@@ -81,7 +85,7 @@ public class MqttDevServicesProcessor {
                         .build())
                 .or(() -> ComposeLocator.locateContainer(compose,
                         List.of(config.imageName(), "hivemq", "eclipse-mosquitto"),
-                        launchMode.getLaunchMode()).stream()
+                        launchMode.getLaunchMode(), config.port()).stream()
                         .filter(r -> Arrays.stream(r.containerInfo().exposedPorts())
                                 .anyMatch(c -> c.privatePort() == MQTT_PORT || c.privatePort() == MQTT_TLS_PORT))
                         .findFirst()
@@ -181,6 +185,8 @@ public class MqttDevServicesProcessor {
                 withLabel(DEV_SERVICE_LABEL, serviceName);
                 withLabel(QUARKUS_DEV_SERVICE, serviceName);
             }
+            Labels.addPortConfigLabel(this,
+                    fixedExposedPort > 0 ? OptionalInt.of(fixedExposedPort) : OptionalInt.empty());
             withClasspathResourceMapping("mosquitto.conf",
                     "/mosquitto/config/mosquitto.conf",
                     BindMode.READ_ONLY);

--- a/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/PulsarDevServicesProcessor.java
+++ b/extensions/smallrye-reactive-messaging-pulsar/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/pulsar/deployment/PulsarDevServicesProcessor.java
@@ -3,9 +3,11 @@ package io.quarkus.smallrye.reactivemessaging.pulsar.deployment;
 import static io.quarkus.devservices.common.ConfigureUtil.getDefaultImageNameFor;
 import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
 import static io.quarkus.devservices.common.Labels.QUARKUS_DEV_SERVICE;
+import static io.quarkus.devservices.common.Labels.expectedPortConfig;
 
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -25,6 +27,7 @@ import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.deployment.dev.devservices.RunningContainer;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ContainerLocator;
+import io.quarkus.devservices.common.Labels;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ConfigUtils;
 
@@ -66,8 +69,10 @@ public class PulsarDevServicesProcessor {
 
         boolean useSharedNetwork = DevServicesSharedNetworkBuildItem.isSharedNetworkRequired(devServicesConfig,
                 sharedNetwork);
+        OptionalInt fixedPort = config.port().map(OptionalInt::of).orElse(OptionalInt.empty());
 
-        return pulsarContainerLocator.locateContainer(config.serviceName(), config.shared(), launchMode.getLaunchMode())
+        return pulsarContainerLocator.locateContainer(config.serviceName(), config.shared(), launchMode.getLaunchMode(),
+                expectedPortConfig(fixedPort))
                 .map(containerAddress -> {
                     int httpPort = pulsarContainerLocator
                             .locatePublicPort(config.serviceName(), config.shared(),
@@ -85,7 +90,7 @@ public class PulsarDevServicesProcessor {
                 })
                 .or(() -> ComposeLocator.locateContainer(compose,
                         List.of(config.imageName().orElse(getDefaultImageNameFor("pulsar")), "pulsar"),
-                        PulsarContainer.BROKER_PORT, launchMode.getLaunchMode(), useSharedNetwork)
+                        PulsarContainer.BROKER_PORT, launchMode.getLaunchMode(), useSharedNetwork, fixedPort)
                         .map(containerAddress -> {
                             RunningContainer container = containerAddress.getRunningContainer();
                             if (container == null) {
@@ -112,6 +117,8 @@ public class PulsarDevServicesProcessor {
 
                     // Apply broker configuration
                     config.brokerConfig().forEach((key, value) -> container.addEnv("PULSAR_PREFIX_" + key, value));
+
+                    Labels.addPortConfigLabel(container, fixedPort);
 
                     // Add labels in dev mode
                     if (launchMode.getLaunchMode() == LaunchMode.DEVELOPMENT) {

--- a/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/RabbitMQDevServicesProcessor.java
+++ b/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/RabbitMQDevServicesProcessor.java
@@ -3,10 +3,12 @@ package io.quarkus.smallrye.reactivemessaging.rabbitmq.deployment;
 import static io.quarkus.devservices.common.ConfigureUtil.getDefaultImageNameFor;
 import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
 import static io.quarkus.devservices.common.Labels.QUARKUS_DEV_SERVICE;
+import static io.quarkus.devservices.common.Labels.expectedPortConfig;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -29,6 +31,7 @@ import io.quarkus.deployment.dev.devservices.RunningContainer;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerLocator;
+import io.quarkus.devservices.common.Labels;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ConfigUtils;
 
@@ -75,10 +78,12 @@ public class RabbitMQDevServicesProcessor {
 
         boolean useSharedNetwork = DevServicesSharedNetworkBuildItem.isSharedNetworkRequired(devServicesConfig, sharedNetwork);
 
-        return rabbitmqContainerLocator.locateContainer(config.serviceName(), config.shared(), launchMode.getLaunchMode())
+        return rabbitmqContainerLocator
+                .locateContainer(config.serviceName(), config.shared(), launchMode.getLaunchMode(),
+                        expectedPortConfig(config.port()))
                 .or(() -> ComposeLocator.locateContainer(compose,
                         List.of(config.imageName().orElse(getDefaultImageNameFor("rabbitmq")), "rabbitmq"),
-                        RABBITMQ_PORT, launchMode.getLaunchMode(), useSharedNetwork))
+                        RABBITMQ_PORT, launchMode.getLaunchMode(), useSharedNetwork, config.port()))
                 .map(containerAddress -> {
                     // Discovered service path
                     RunningContainer container = containerAddress.getRunningContainer();
@@ -225,6 +230,7 @@ public class RabbitMQDevServicesProcessor {
                 throw new IllegalArgumentException("Only official rabbitmq images are supported");
             }
             hostName = ConfigureUtil.configureNetwork(this, defaultNetworkId, useSharedNetwork, "rabbitmq");
+            Labels.addPortConfigLabel(this, fixedExposedPort > 0 ? OptionalInt.of(fixedExposedPort) : OptionalInt.empty());
         }
 
         @Override


### PR DESCRIPTION
* from https://github.com/quarkusio/quarkus/pull/51422#discussion_r3159704399

When we use a locator, we do not consider ports (the ones to which we bind the internal port to), and we can end up "locating" a service that has a different "public-facing" port. If that happens we end can end up failing the tests as those expect a certain port and it's not there ...

The idea is: let's have extra labels for config properties we care about during the lookup. My original approach in the linked ES/HS PR was just looking at the actual mapped ports "at runtime" but that doesn't scale well if we would need to check any other configs coming from the devserivce.config properties... so  I thought let's go with extra labels ?

For "compose" I don't think we can add labels from our side? so just a port filter there ...