### PR TITLE
Fix UriInfo matrix parameter handling in RESTEasy Reactive

### DIFF
--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/PathSegmentImpl.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/PathSegmentImpl.java
@@ -1,8 +1,5 @@
 package org.jboss.resteasy.reactive.common.util;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.PathSegment;
 
@@ -88,51 +85,6 @@ public class PathSegmentImpl implements PathSegment {
             }
         }
         return buf.toString();
-    }
-
-    public static List<PathSegment> parseSegments(String path, boolean decode) {
-        return parseSegmentsOptimization(path, decode).segments;
-    }
-
-    /**
-     * Used when creating the matching path in ResteasyUriInfo
-     *
-     */
-    public static class SegmentParse {
-        public List<PathSegment> segments;
-        public boolean hasMatrixParams;
-
-    }
-
-    /**
-     *
-     * @param path encoded full path
-     * @param decode whether or not to decode each segment
-     * @return {@link SegmentParse}
-     */
-    public static SegmentParse parseSegmentsOptimization(String path, boolean decode) {
-        SegmentParse parse = new SegmentParse();
-        List<PathSegment> pathSegments = new ArrayList<PathSegment>();
-        parse.segments = pathSegments;
-        int start = 0;
-        if (path.startsWith("/"))
-            start++;
-        int length = path.length();
-        do {
-            String p;
-            int slash = path.indexOf('/', start);
-            if (slash < 0) {
-                p = path.substring(start);
-                start = length;
-            } else {
-                p = path.substring(start, slash);
-                start = slash + 1;
-            }
-            PathSegmentImpl pathSegment = new PathSegmentImpl(p, decode);
-            parse.hasMatrixParams |= pathSegment.hasMatrixParams();
-            pathSegments.add(pathSegment);
-        } while (start < length);
-        return parse;
     }
 
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
@@ -525,7 +525,13 @@ public abstract class ResteasyReactiveRequestContext
         // Note: we could store our cache as normalised, but I'm not sure if the vertx one is normalised
         if (absoluteUri == null) {
             try {
-                absoluteUri = new URI(getScheme(), getAuthority(), path, query, null).toASCIIString();
+                if (scheme != null || authority != null || query != null) {
+                    absoluteUri = new URI(getScheme(), getAuthority(), path, query, null).toASCIIString();
+                } else {
+                    URI original = URI.create(serverRequest().getRequestAbsoluteUri());
+                    absoluteUri = new URI(original.getScheme(), original.getRawAuthority(), path,
+                            original.getRawQuery(), original.getRawFragment()).toASCIIString();
+                }
             } catch (URISyntaxException e) {
                 throw new RuntimeException(e);
             }
@@ -868,6 +874,7 @@ public abstract class ResteasyReactiveRequestContext
             }
             String newPath = sb.toString();
             this.path = newPath;
+            this.absoluteUri = null;
             if (this.remaining != null) {
                 this.remaining = newPath.substring(getPathWithoutPrefix().length() - this.remaining.length());
             }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/jaxrs/UriInfoImpl.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/jaxrs/UriInfoImpl.java
@@ -13,7 +13,6 @@ import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.UriInfo;
 
 import org.jboss.resteasy.reactive.common.jaxrs.UriBuilderImpl;
-import org.jboss.resteasy.reactive.common.util.PathSegmentImpl;
 import org.jboss.resteasy.reactive.common.util.QuarkusMultivaluedHashMap;
 import org.jboss.resteasy.reactive.common.util.URIDecoder;
 import org.jboss.resteasy.reactive.common.util.UnmodifiableMultivaluedMap;
@@ -76,7 +75,21 @@ public class UriInfoImpl implements UriInfo {
         if (!decode) {
             throw encodedNotSupported();
         }
-        return PathSegmentImpl.parseSegments(getPath(), decode);
+        List<PathSegment> segments = currentRequest.getPathSegments();
+        String prefix = currentRequest.getDeployment().getPrefix();
+        if (prefix.isEmpty()) {
+            return segments;
+        }
+        int skip = 0;
+        for (String part : prefix.split("/")) {
+            if (!part.isEmpty()) {
+                skip++;
+            }
+        }
+        if (skip > 0 && segments.size() > skip) {
+            return segments.subList(skip, segments.size());
+        }
+        return segments;
     }
 
     @Override

--- a/independent-projects/resteasy-reactive/server/runtime/src/test/java/org/jboss/resteasy/reactive/server/ResteasyReactiveRequestContextTest.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/test/java/org/jboss/resteasy/reactive/server/ResteasyReactiveRequestContextTest.java
@@ -49,11 +49,11 @@ public class ResteasyReactiveRequestContextTest {
             }
         };
         Mockito.when(request.getRequestNormalisedPath()).thenReturn("/path;a");
-        Mockito.when(request.getRequestScheme()).thenReturn("http");
-        Mockito.when(request.getRequestHostAndPort()).thenReturn("host:port");
+        Mockito.when(request.getRequestAbsoluteUri()).thenReturn("http://host:port/path;a?foo=bar");
 
         context.initPathSegments();
-        assertEquals("http://host:port/path", context.getAbsoluteURI());
+        // validate that we keep all parts of the request except the matrix parameters
+        assertEquals("http://host:port/path?foo=bar", context.getAbsoluteURI());
 
         context.setRequestUri(URI.create("https://host1:port1/path1"));
         assertEquals("https://host1:port1/path1", context.getAbsoluteURI());

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/resource/basic/UriInfoTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/resource/basic/UriInfoTest.java
@@ -1,5 +1,8 @@
 package org.jboss.resteasy.reactive.server.vertx.test.resource.basic;
 
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.containsString;
+
 import java.util.function.Supplier;
 
 import jakarta.ws.rs.client.Client;
@@ -15,6 +18,7 @@ import org.jboss.resteasy.reactive.server.vertx.test.resource.basic.resource.Get
 import org.jboss.resteasy.reactive.server.vertx.test.resource.basic.resource.UriInfoEncodedQueryResource;
 import org.jboss.resteasy.reactive.server.vertx.test.resource.basic.resource.UriInfoEncodedTemplateResource;
 import org.jboss.resteasy.reactive.server.vertx.test.resource.basic.resource.UriInfoEscapedMatrParamResource;
+import org.jboss.resteasy.reactive.server.vertx.test.resource.basic.resource.UriInfoMatrixParamResource;
 import org.jboss.resteasy.reactive.server.vertx.test.resource.basic.resource.UriInfoQueryParamsResource;
 import org.jboss.resteasy.reactive.server.vertx.test.resource.basic.resource.UriInfoRelativizeResource;
 import org.jboss.resteasy.reactive.server.vertx.test.resource.basic.resource.UriInfoResolveResource;
@@ -58,7 +62,8 @@ public class UriInfoTest {
                             UriInfoQueryParamsResource.class, UriInfoSimpleSingletonResource.class,
                             UriInfoEncodedTemplateResource.class, UriInfoEscapedMatrParamResource.class,
                             UriInfoEncodedTemplateResource.class, GetAbsolutePathResource.class,
-                            UriInfoRelativizeResource.class, UriInfoResolveResource.class);
+                            UriInfoRelativizeResource.class, UriInfoResolveResource.class,
+                            UriInfoMatrixParamResource.class);
                     return war;
                 }
             });
@@ -158,6 +163,22 @@ public class UriInfoTest {
         WebTarget target = client.target(PortProviderUtil.generateURL("/"));
         String result = target.path("resolve").queryParam("to", "a/d/e").request().get(String.class);
         Assertions.assertEquals(PortProviderUtil.generateURL("/a/d/e"), result);
+    }
+
+    @Test
+    @DisplayName("Test matrix params in UriInfo")
+    public void testMatrixParamsInUriInfo() {
+        given()
+                .urlEncodingEnabled(false)
+                .when()
+                .get("/UriInfoMatrixParamResource/ex;m1;m2=foo?q1&q2=bar")
+                .then()
+                .statusCode(200)
+                .body(containsString("http://localhost:8080/UriInfoMatrixParamResource/ex"))
+                .body(containsString("m1: null m2: foo"))
+                .body(containsString("q1: null q2: bar"))
+                .body(containsString("query params: {q1=[], q2=[bar]}"))
+                .body(containsString("matrix params: {m1=[], m2=[foo]}"));
     }
 
     private static void basicTest(String path, String testName) throws Exception {

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/resource/basic/resource/UriInfoMatrixParamResource.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/resource/basic/resource/UriInfoMatrixParamResource.java
@@ -1,0 +1,26 @@
+package org.jboss.resteasy.reactive.server.vertx.test.resource.basic.resource;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.UriInfo;
+
+import org.jboss.resteasy.reactive.RestMatrix;
+import org.jboss.resteasy.reactive.RestQuery;
+
+@Path("/UriInfoMatrixParamResource")
+public class UriInfoMatrixParamResource {
+
+    @Path("ex")
+    @GET
+    public String ex(UriInfo uriInfo, @RestMatrix String m1, @RestMatrix String m2, @RestQuery String q1,
+            @RestQuery String q2) {
+        return "ex: " + uriInfo.getRequestUri()
+                + " m1: " + m1
+                + " m2: " + m2
+                + " q1: " + q1
+                + " q2: " + q2
+                + " query params: " + uriInfo.getQueryParameters()
+                + " segments: " + uriInfo.getPathSegments()
+                + " matrix params: " + uriInfo.getPathSegments().get(1).getMatrixParameters();
+    }
+}


### PR DESCRIPTION
When a request path contains matrix parameters, RESTEasy Reactive strips them from the path used for routing. `UriInfo` was re-parsing that stripped path, so `getPathSegments().getMatrixParameters()` returned an empty map even though `@RestMatrix` injection worked. `getRequestUri()` could also lose scheme, host, and query string after the path was rewritten.

This delegates `UriInfo.getPathSegments()` to the cached segments on the request context and rebuilds the absolute URI from the original server request when only the path was matrix-stripped.

- Fixes: #47598

