### PR TITLE
Upgrade OTel SDk to 1.62.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -29,7 +29,7 @@
         <resteasy-microprofile.version>3.0.1.Final</resteasy-microprofile.version>
         <resteasy-spring-web.version>3.2.0.Final</resteasy-spring-web.version>
         <resteasy.version>6.2.16.Final</resteasy.version>
-        <opentelemetry-instrumentation.version>2.26.1-alpha</opentelemetry-instrumentation.version> <!-- OTel SDk 1.60.1-->
+        <opentelemetry-instrumentation.version>2.28.1-alpha</opentelemetry-instrumentation.version> <!-- OTel SDk 1.62.0-->
         <opentelemetry-semconv.version>1.40.0-alpha</opentelemetry-semconv.version>
         <quarkus-http.version>6.0.0.Alpha4</quarkus-http.version>
         <micrometer.version>1.17.0</micrometer.version><!-- keep in sync with hdrhistogram: https://central.sonatype.com/artifact/io.micrometer/micrometer-core -->

--- a/extensions/opentelemetry/runtime/pom.xml
+++ b/extensions/opentelemetry/runtime/pom.xml
@@ -174,7 +174,7 @@
         </dependency>
         <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>
-            <artifactId>opentelemetry-runtime-telemetry-java17</artifactId>
+            <artifactId>opentelemetry-runtime-telemetry</artifactId>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxGrpcSender.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxGrpcSender.java
@@ -121,6 +121,11 @@ public final class VertxGrpcSender implements GrpcSender {
             return shutdownResult;
         }
 
+        if (client == null) {
+            logger.log(Level.FINE, "Client is null. Cannot close.");
+            return shutdownResult;
+        }
+
         try {
             client.close()
                     .onSuccess(

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxHttpSender.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/sender/VertxHttpSender.java
@@ -181,6 +181,11 @@ public final class VertxHttpSender implements HttpSender {
             return shutdownResult;
         }
 
+        if (client == null) {
+            throttlingLogger.log(Level.FINE, "Client is null. Cannot close.");
+            return shutdownResult;
+        }
+
         try {
             client.close()
                     .onSuccess(

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/metrics/instrumentation/JvmMetricsService.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/metrics/instrumentation/JvmMetricsService.java
@@ -1,22 +1,12 @@
 package io.quarkus.opentelemetry.runtime.metrics.instrumentation;
 
-import static io.opentelemetry.instrumentation.runtimemetrics.java17.JfrFeature.CLASS_LOAD_METRICS;
-import static io.opentelemetry.instrumentation.runtimemetrics.java17.JfrFeature.CONTEXT_SWITCH_METRICS;
-import static io.opentelemetry.instrumentation.runtimemetrics.java17.JfrFeature.CPU_COUNT_METRICS;
-import static io.opentelemetry.instrumentation.runtimemetrics.java17.JfrFeature.CPU_UTILIZATION_METRICS;
-import static io.opentelemetry.instrumentation.runtimemetrics.java17.JfrFeature.GC_DURATION_METRICS;
-import static io.opentelemetry.instrumentation.runtimemetrics.java17.JfrFeature.LOCK_METRICS;
-import static io.opentelemetry.instrumentation.runtimemetrics.java17.JfrFeature.MEMORY_ALLOCATION_METRICS;
-import static io.opentelemetry.instrumentation.runtimemetrics.java17.JfrFeature.MEMORY_POOL_METRICS;
-import static io.opentelemetry.instrumentation.runtimemetrics.java17.JfrFeature.NETWORK_IO_METRICS;
-import static io.opentelemetry.instrumentation.runtimemetrics.java17.JfrFeature.THREAD_METRICS;
-
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.instrumentation.runtimemetrics.java17.RuntimeMetrics;
-import io.opentelemetry.instrumentation.runtimemetrics.java17.RuntimeMetricsBuilder;
+import io.opentelemetry.instrumentation.runtimetelemetry.RuntimeTelemetry;
+import io.opentelemetry.instrumentation.runtimetelemetry.RuntimeTelemetryBuilder;
+import io.opentelemetry.instrumentation.runtimetelemetry.internal.Internal;
 import io.quarkus.opentelemetry.runtime.config.runtime.OTelRuntimeConfig;
 import io.quarkus.runtime.ImageMode;
 import io.quarkus.runtime.Startup;
@@ -25,43 +15,45 @@ import io.quarkus.runtime.Startup;
 @ApplicationScoped
 public class JvmMetricsService {
 
-    private final RuntimeMetrics runtimeMetrics;
+    private final RuntimeTelemetry runtimeTelemetry;
 
     public JvmMetricsService(final OpenTelemetry openTelemetry, final OTelRuntimeConfig runtimeConfig) {
 
         if (runtimeConfig.sdkDisabled() || !runtimeConfig.instrument().jvmMetrics()) {
-            runtimeMetrics = RuntimeMetrics.builder(openTelemetry).disableAllMetrics().build();
+            runtimeTelemetry = null;
             return;
         }
 
-        RuntimeMetricsBuilder builder = RuntimeMetrics.builder(openTelemetry)
-                .enableFeature(CONTEXT_SWITCH_METRICS)
-                .enableFeature(CPU_COUNT_METRICS)
-                .enableFeature(LOCK_METRICS)
-                .enableFeature(NETWORK_IO_METRICS)
-                .disableFeature(MEMORY_POOL_METRICS);
+        RuntimeTelemetryBuilder builder = RuntimeTelemetry.builder(openTelemetry);
+
+        Internal.setEnableJfrFeature(builder, "CONTEXT_SWITCH_METRICS");
+        Internal.setEnableJfrFeature(builder, "CPU_COUNT_METRICS");
+        Internal.setEnableJfrFeature(builder, "LOCK_METRICS");
+        Internal.setEnableJfrFeature(builder, "NETWORK_IO_METRICS");
+        Internal.setDisableJfrFeature(builder, "MEMORY_POOL_METRICS");
+        Internal.setUseLegacyJfrCpuCountMetric(builder, true);
 
         if (ImageMode.current().isNativeImage()) {
-            builder.enableFeature(THREAD_METRICS);
-            builder.enableFeature(CLASS_LOAD_METRICS);
-            builder.enableFeature(GC_DURATION_METRICS);
-            builder.enableFeature(CPU_UTILIZATION_METRICS);
-            builder.enableFeature(MEMORY_ALLOCATION_METRICS);
+            Internal.setEnableJfrFeature(builder, "THREAD_METRICS");
+            Internal.setEnableJfrFeature(builder, "CLASS_LOAD_METRICS");
+            Internal.setEnableJfrFeature(builder, "GC_DURATION_METRICS");
+            Internal.setEnableJfrFeature(builder, "CPU_UTILIZATION_METRICS");
+            Internal.setEnableJfrFeature(builder, "MEMORY_ALLOCATION_METRICS");
         } else {
-            builder.disableFeature(THREAD_METRICS);
-            builder.disableFeature(CLASS_LOAD_METRICS);
-            builder.disableFeature(GC_DURATION_METRICS);
-            builder.disableFeature(CPU_UTILIZATION_METRICS);
-            builder.disableFeature(MEMORY_ALLOCATION_METRICS);
+            Internal.setDisableJfrFeature(builder, "THREAD_METRICS");
+            Internal.setDisableJfrFeature(builder, "CLASS_LOAD_METRICS");
+            Internal.setDisableJfrFeature(builder, "GC_DURATION_METRICS");
+            Internal.setDisableJfrFeature(builder, "CPU_UTILIZATION_METRICS");
+            Internal.setDisableJfrFeature(builder, "MEMORY_ALLOCATION_METRICS");
         }
 
-        runtimeMetrics = builder.build();
+        runtimeTelemetry = builder.build();
     }
 
     @PreDestroy
     public void close() {
-        if (runtimeMetrics != null) {
-            runtimeMetrics.close();
+        if (runtimeTelemetry != null) {
+            runtimeTelemetry.close();
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/54670

Had to add a dirty workaround to overcome package private methods by creating the RuntimeTelemetryHelper. This ensures the same OTel Metrics behavior as before.

Requires the merge of https://github.com/smallrye/smallrye-reactive-messaging/pull/3439 and the release of smallrye-reactive-messaging v. 4.36.0

Related with 3.x PR: https://github.com/quarkusio/quarkus/pull/54794