### PR TITLE
Fix client-auth reset to NONE after TLS config reload

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/certReload/MainHttpServerMtlsPKCS12CertificateReloadWithTlsRegistryTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/certReload/MainHttpServerMtlsPKCS12CertificateReloadWithTlsRegistryTest.java
@@ -1,0 +1,95 @@
+package io.quarkus.vertx.http.certReload;
+
+import static io.quarkus.vertx.http.certReload.CertReloadTestHelper.assertTlsFails;
+import static io.quarkus.vertx.http.certReload.CertReloadTestHelper.httpsGet;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URL;
+import java.security.cert.X509Certificate;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.vertx.http.runtime.options.TlsCertificateReloader;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.junit5.Certificate;
+import io.smallrye.certs.junit5.Certificates;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.net.PfxOptions;
+import io.vertx.ext.web.Router;
+
+@Certificates(baseDir = "target/certificates", certificates = {
+        @Certificate(name = "mtls-registry-reload", formats = Format.PKCS12, password = "password", client = true),
+})
+@DisabledOnOs(OS.WINDOWS)
+class MainHttpServerMtlsPKCS12CertificateReloadWithTlsRegistryTest {
+
+    private static final String CERTS_DIR = "target/certificates/";
+    private static final String CERT_NAME = "mtls-registry-reload";
+    private static final String PASSWORD = "password";
+
+    @TestHTTPResource(value = "/hello", tls = true)
+    URL url;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar.addClasses(MyBean.class, CertReloadTestHelper.class))
+            .overrideConfigKey("quarkus.http.tls-configuration-name", "http")
+            .overrideConfigKey("quarkus.http.ssl.certificate.reload-period", "30s")
+            .overrideConfigKey("quarkus.tls.http.key-store.p12.path", CERTS_DIR + CERT_NAME + "-keystore.p12")
+            .overrideConfigKey("quarkus.tls.http.key-store.p12.password", PASSWORD)
+            .overrideConfigKey("quarkus.tls.http.trust-store.p12.path", CERTS_DIR + CERT_NAME + "-server-truststore.p12")
+            .overrideConfigKey("quarkus.tls.http.trust-store.p12.password", PASSWORD)
+            .overrideConfigKey("quarkus.http.ssl.client-auth", "required");
+
+    @Inject
+    Vertx vertx;
+
+    @Test
+    void mTlsSurvivesReload() throws Exception {
+        var withClientCert = new HttpClientOptions()
+                .setSsl(true)
+                .setDefaultPort(url.getPort())
+                .setDefaultHost(url.getHost())
+                .setKeyCertOptions(
+                        new PfxOptions().setPath(CERTS_DIR + CERT_NAME + "-client-keystore.p12").setPassword(PASSWORD))
+                .setTrustOptions(
+                        new PfxOptions().setPath(CERTS_DIR + CERT_NAME + "-client-truststore.p12").setPassword(PASSWORD));
+
+        var withoutClientCert = new HttpClientOptions()
+                .setSsl(true)
+                .setDefaultPort(url.getPort())
+                .setDefaultHost(url.getHost())
+                .setTrustOptions(
+                        new PfxOptions().setPath(CERTS_DIR + CERT_NAME + "-client-truststore.p12").setPassword(PASSWORD));
+
+        assertThat(httpsGet(vertx, withClientCert, "/hello")).startsWith("Hello");
+
+        assertTlsFails(vertx, withoutClientCert, "/hello");
+
+        TlsCertificateReloader.reload().toCompletableFuture().get(10, TimeUnit.SECONDS);
+
+        assertTlsFails(vertx, withoutClientCert, "/hello");
+
+        assertThat(httpsGet(vertx, withClientCert, "/hello")).startsWith("Hello");
+    }
+
+    static class MyBean {
+        void onStart(@Observes Router router) {
+            router.get("/hello").handler(rc -> {
+                var exp = ((X509Certificate) rc.request().connection().sslSession().getLocalCertificates()[0])
+                        .getNotAfter().toInstant().toEpochMilli();
+                rc.response().end("Hello " + exp);
+            });
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/certReload/ManagementHttpServerMtlsCertificateReloadWithTlsRegistryTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/certReload/ManagementHttpServerMtlsCertificateReloadWithTlsRegistryTest.java
@@ -1,0 +1,96 @@
+package io.quarkus.vertx.http.certReload;
+
+import static io.quarkus.vertx.http.certReload.CertReloadTestHelper.assertTlsFails;
+import static io.quarkus.vertx.http.certReload.CertReloadTestHelper.httpsGet;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URL;
+import java.security.cert.X509Certificate;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.vertx.http.ManagementInterface;
+import io.quarkus.vertx.http.runtime.options.TlsCertificateReloader;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.junit5.Certificate;
+import io.smallrye.certs.junit5.Certificates;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.net.PfxOptions;
+
+@Certificates(baseDir = "target/certificates", certificates = {
+        @Certificate(name = "mtls-registry-reload", formats = Format.PKCS12, password = "password", client = true),
+})
+@DisabledOnOs(OS.WINDOWS)
+class ManagementHttpServerMtlsCertificateReloadWithTlsRegistryTest {
+
+    private static final String CERTS_DIR = "target/certificates/";
+    private static final String CERT_NAME = "mtls-registry-reload";
+    private static final String PASSWORD = "password";
+
+    @TestHTTPResource(value = "/hello", management = true, tls = true)
+    URL url;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar.addClasses(MyBean.class, CertReloadTestHelper.class))
+            .overrideConfigKey("quarkus.management.enabled", "true")
+            .overrideConfigKey("quarkus.management.tls-configuration-name", "mgmt")
+            .overrideConfigKey("quarkus.management.ssl.certificate.reload-period", "30s")
+            .overrideConfigKey("quarkus.management.ssl.client-auth", "required")
+            .overrideConfigKey("quarkus.tls.mgmt.key-store.p12.path", CERTS_DIR + CERT_NAME + "-keystore.p12")
+            .overrideConfigKey("quarkus.tls.mgmt.key-store.p12.password", PASSWORD)
+            .overrideConfigKey("quarkus.tls.mgmt.trust-store.p12.path", CERTS_DIR + CERT_NAME + "-server-truststore.p12")
+            .overrideConfigKey("quarkus.tls.mgmt.trust-store.p12.password", PASSWORD);
+
+    @Inject
+    Vertx vertx;
+
+    @Test
+    void mTlsSurvivesReload() throws Exception {
+        var withClientCert = new HttpClientOptions()
+                .setSsl(true)
+                .setDefaultPort(url.getPort())
+                .setDefaultHost(url.getHost())
+                .setKeyCertOptions(
+                        new PfxOptions().setPath(CERTS_DIR + CERT_NAME + "-client-keystore.p12").setPassword(PASSWORD))
+                .setTrustOptions(
+                        new PfxOptions().setPath(CERTS_DIR + CERT_NAME + "-client-truststore.p12").setPassword(PASSWORD));
+
+        var withoutClientCert = new HttpClientOptions()
+                .setSsl(true)
+                .setDefaultPort(url.getPort())
+                .setDefaultHost(url.getHost())
+                .setTrustOptions(
+                        new PfxOptions().setPath(CERTS_DIR + CERT_NAME + "-client-truststore.p12").setPassword(PASSWORD));
+
+        assertThat(httpsGet(vertx, withClientCert, "/q/hello")).startsWith("Hello");
+
+        assertTlsFails(vertx, withoutClientCert, "/q/hello");
+
+        TlsCertificateReloader.reload().toCompletableFuture().get(10, TimeUnit.SECONDS);
+
+        assertTlsFails(vertx, withoutClientCert, "/q/hello");
+
+        assertThat(httpsGet(vertx, withClientCert, "/q/hello")).startsWith("Hello");
+    }
+
+    static class MyBean {
+        void onStart(@Observes ManagementInterface mi) {
+            mi.router().get("/q/hello").handler(rc -> {
+                var exp = ((X509Certificate) rc.request().connection().sslSession().getLocalCertificates()[0])
+                        .getNotAfter().toInstant().toEpochMilli();
+                rc.response().end("Hello Management " + exp);
+            });
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedProxyTruststoreReloadTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedProxyTruststoreReloadTest.java
@@ -15,7 +15,6 @@ import java.security.KeyStore;
 import jakarta.inject.Inject;
 
 import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -36,7 +35,6 @@ import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.net.PfxOptions;
 
-@Disabled("https://github.com/quarkusio/quarkus/issues/55130") // TODO: enable when #55130 is fixed
 @Certificates(certificates = {
         @Certificate(subjectAlternativeNames = "DNS:localhost", client = true, aliases = {
                 @Alias(name = "proxy-a", cn = "proxy-a", client = true, password = PASSWORD),

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpCertificateUpdateEventListener.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpCertificateUpdateEventListener.java
@@ -1,5 +1,7 @@
 package io.quarkus.vertx.http.runtime;
 
+import static io.quarkus.vertx.http.runtime.options.HttpServerOptionsUtils.createServerSslOptions;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -15,7 +17,9 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.tls.CertificateUpdatedEvent;
 import io.quarkus.tls.TlsConfiguration;
+import io.vertx.core.http.ClientAuth;
 import io.vertx.core.http.HttpServer;
+import io.vertx.core.net.ServerSSLOptions;
 
 /**
  * A listener that listens for certificate updates and updates the HTTP server accordingly.
@@ -39,11 +43,12 @@ public class HttpCertificateUpdateEventListener {
         });
     }
 
-    public void register(HttpServer server, String tlsConfigurationName, String id) {
+    public void register(HttpServer server, String tlsConfigurationName, String id, ClientAuth clientAuth) {
         registrations.add(new CertificateUpdateRegistration(tlsConfigurationName) {
             @Override
             void notify(CertificateUpdatedEvent event, CountDownLatch latch) {
-                server.updateSSLOptions(event.tlsConfiguration().getServerSSLOptions())
+                ServerSSLOptions serverSSLOptions = createServerSslOptions(event.tlsConfiguration(), clientAuth);
+                server.updateSSLOptions(serverSSLOptions)
                         .toCompletionStage().whenComplete(new BiConsumer<Boolean, Throwable>() {
                             @Override
                             public void accept(Boolean v, Throwable t) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -118,6 +118,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Verticle;
 import io.vertx.core.Vertx;
+import io.vertx.core.http.ClientAuth;
 import io.vertx.core.http.Cookie;
 import io.vertx.core.http.CookieSameSite;
 import io.vertx.core.http.Http1ServerConfig;
@@ -827,10 +828,11 @@ public class VertxHttpRecorder {
                             if (httpManagementSslOptions != null
                                     && (managementConfig.ssl().certificate().reloadPeriod().isPresent())) {
                                 try {
+                                    ClientAuth clientAuth = managementBuildTimeConfig.tlsClientAuth();
                                     long l = TlsCertificateReloader.initCertReloadingAction(
                                             vertx, ar.result(), httpManagementServerConfig, httpManagementSslOptions,
                                             managementConfig.ssl(), registry,
-                                            managementConfig.tlsConfigurationName());
+                                            managementConfig.tlsConfigurationName(), clientAuth);
                                     if (l != -1) {
                                         refresTaskIds.add(l);
                                     }
@@ -841,10 +843,11 @@ public class VertxHttpRecorder {
                             }
 
                             if (httpManagementSslOptions != null) {
+                                ClientAuth clientAuth = managementBuildTimeConfig.tlsClientAuth();
                                 CDI.current().select(HttpCertificateUpdateEventListener.class).get()
                                         .register(ar.result(),
                                                 managementConfig.tlsConfigurationName().orElse(TlsConfig.DEFAULT_NAME),
-                                                "management interface");
+                                                "management interface", clientAuth);
                             }
 
                             actualManagementPort = ar.result().actualPort();
@@ -1447,9 +1450,10 @@ public class VertxHttpRecorder {
 
                         if (https && (httpConfig.ssl().certificate().reloadPeriod().isPresent())) {
                             try {
+                                ClientAuth clientAuth = getTlsClientAuth(httpConfig, httpBuildTimeConfig, launchMode);
                                 long l = TlsCertificateReloader.initCertReloadingAction(
                                         vertx, httpsServer, httpsConfig_server, sslOptions, httpConfig.ssl(), registry,
-                                        getHttpServerTlsConfigName(httpConfig, httpBuildTimeConfig, launchMode));
+                                        getHttpServerTlsConfigName(httpConfig, httpBuildTimeConfig, launchMode), clientAuth);
                                 if (l != -1) {
                                     reloadingTasks.add(l);
                                 }
@@ -1460,11 +1464,12 @@ public class VertxHttpRecorder {
                         }
 
                         if (https) {
+                            ClientAuth clientAuth = getTlsClientAuth(httpConfig, httpBuildTimeConfig, launchMode);
                             container.instance(HttpCertificateUpdateEventListener.class).get()
                                     .register(event.result(),
                                             getHttpServerTlsConfigName(httpConfig, httpBuildTimeConfig, launchMode)
                                                     .orElse(TlsConfig.DEFAULT_NAME),
-                                            "http server");
+                                            "http server", clientAuth);
                         }
 
                         if (notifyStartObservers) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtils.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtils.java
@@ -111,8 +111,8 @@ public class HttpServerOptionsUtils {
         Optional<String> tlsConfigurationName = getHttpServerTlsConfigName(httpConfig, httpBuildTimeConfig, launchMode);
         TlsConfiguration bucket = getTlsConfiguration(tlsConfigurationName, registry);
         if (bucket != null) {
-            ServerSSLOptions sslOptions = createSslOptionsFromTlsConfiguration(bucket);
-            sslOptions.setClientAuth(getTlsClientAuth(httpConfig, httpBuildTimeConfig, launchMode));
+            ClientAuth clientAuth = getTlsClientAuth(httpConfig, httpBuildTimeConfig, launchMode);
+            ServerSSLOptions sslOptions = createServerSslOptions(bucket, clientAuth);
             applyCommonOptions(config, httpBuildTimeConfig, httpConfig, websocketSubProtocols);
             return new ServerConfig(config, sslOptions);
         }
@@ -149,8 +149,8 @@ public class HttpServerOptionsUtils {
 
         TlsConfiguration bucket = getTlsConfiguration(managementConfig.tlsConfigurationName(), registry);
         if (bucket != null) {
-            ServerSSLOptions sslOptions = createSslOptionsFromTlsConfiguration(bucket);
-            sslOptions.setClientAuth(managementBuildTimeConfig.tlsClientAuth());
+            ClientAuth clientAuth = managementBuildTimeConfig.tlsClientAuth();
+            ServerSSLOptions sslOptions = createServerSslOptions(bucket, clientAuth);
             applyCommonOptionsForManagementInterface(config, managementBuildTimeConfig, managementConfig,
                     websocketSubProtocols);
             return new ServerConfig(config, sslOptions);
@@ -168,9 +168,9 @@ public class HttpServerOptionsUtils {
     }
 
     /**
-     * Create {@link ServerSSLOptions} from a Quarkus TLS registry configuration.
+     * Create {@link ServerSSLOptions} for a server from a TLS registry configuration and client authentication setting.
      */
-    public static ServerSSLOptions createSslOptionsFromTlsConfiguration(TlsConfiguration bucket) {
+    public static ServerSSLOptions createServerSslOptions(TlsConfiguration bucket, ClientAuth clientAuth) {
         ServerSSLOptions sslOptions = new ServerSSLOptions();
 
         KeyCertOptions keyStoreOptions = bucket.getKeyStoreOptions();
@@ -196,6 +196,8 @@ public class HttpServerOptionsUtils {
             sslOptions.setUseAlpn(false);
         }
         sslOptions.setEnabledSecureTransportProtocols(other.getEnabledSecureTransportProtocols());
+
+        sslOptions.setClientAuth(clientAuth);
 
         return sslOptions;
     }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/TlsCertificateReloader.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/TlsCertificateReloader.java
@@ -1,5 +1,6 @@
 package io.quarkus.vertx.http.runtime.options;
 
+import static io.quarkus.vertx.http.runtime.options.HttpServerOptionsUtils.createServerSslOptions;
 import static io.quarkus.vertx.http.runtime.options.HttpServerOptionsUtils.getFileContent;
 
 import java.io.IOException;
@@ -25,6 +26,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.ClientAuth;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.net.KeyStoreOptions;
 import io.vertx.core.net.PemKeyCertOptions;
@@ -49,7 +51,7 @@ public class TlsCertificateReloader {
     public static long initCertReloadingAction(Vertx vertx, HttpServer server,
             io.vertx.core.http.HttpServerConfig httpServerConfig, ServerSSLOptions sslOptions,
             ServerSslConfig sslConfig,
-            TlsConfigurationRegistry registry, Optional<String> tlsConfigurationName) {
+            TlsConfigurationRegistry registry, Optional<String> tlsConfigurationName, ClientAuth clientAuth) {
 
         if (httpServerConfig == null) {
             throw new IllegalArgumentException(
@@ -103,7 +105,7 @@ public class TlsCertificateReloader {
                     public ServerSSLOptions call() throws Exception {
                         if (reloadFromRegistry) {
                             if (registryConfiguration.reload()) {
-                                return registryConfiguration.getServerSSLOptions();
+                                return createServerSslOptions(registryConfiguration, clientAuth);
                             } else {
                                 return null;
                             }

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/options/TlsCertificateReloaderTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/options/TlsCertificateReloaderTest.java
@@ -26,6 +26,7 @@ import io.quarkus.vertx.http.runtime.CertificateConfig;
 import io.quarkus.vertx.http.runtime.ServerSslConfig;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.http.ClientAuth;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerConfig;
 import io.vertx.core.net.PemKeyCertOptions;
@@ -63,7 +64,7 @@ class TlsCertificateReloaderTest {
 
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
                 () -> TlsCertificateReloader.initCertReloadingAction(
-                        vertx, server, config, sslOptions, sslConfig, registry, Optional.empty()));
+                        vertx, server, config, sslOptions, sslConfig, registry, Optional.empty(), ClientAuth.REQUIRED));
 
         assertEquals("Unable to configure TLS reloading - The reload period cannot be less than 30 seconds",
                 ex.getMessage());
@@ -80,7 +81,7 @@ class TlsCertificateReloaderTest {
 
         assertDoesNotThrow(() -> {
             lastTimerId = TlsCertificateReloader.initCertReloadingAction(
-                    vertx, server, config, sslOptions, sslConfig, registry, Optional.empty());
+                    vertx, server, config, sslOptions, sslConfig, registry, Optional.empty(), ClientAuth.REQUIRED);
         });
     }
 
@@ -93,7 +94,7 @@ class TlsCertificateReloaderTest {
 
         assertThrows(IllegalArgumentException.class,
                 () -> TlsCertificateReloader.initCertReloadingAction(
-                        vertx, server, config, sslOptions, sslConfig, registry, Optional.empty()));
+                        vertx, server, config, sslOptions, sslConfig, registry, Optional.empty(), ClientAuth.REQUIRED));
     }
 
     @Test
@@ -104,7 +105,7 @@ class TlsCertificateReloaderTest {
         sslOptions.setKeyCertOptions(new PemKeyCertOptions());
 
         long result = TlsCertificateReloader.initCertReloadingAction(
-                vertx, server, config, sslOptions, sslConfig, registry, Optional.empty());
+                vertx, server, config, sslOptions, sslConfig, registry, Optional.empty(), ClientAuth.REQUIRED);
 
         assertEquals(-1L, result);
     }
@@ -115,7 +116,7 @@ class TlsCertificateReloaderTest {
 
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
                 () -> TlsCertificateReloader.initCertReloadingAction(
-                        vertx, server, null, null, sslConfig, registry, Optional.empty()));
+                        vertx, server, null, null, sslConfig, registry, Optional.empty(), ClientAuth.REQUIRED));
 
         assertEquals("Unable to configure TLS reloading - The HTTP server configuration was not provided",
                 ex.getMessage());
@@ -138,7 +139,7 @@ class TlsCertificateReloaderTest {
         when(vertx.setPeriodic(anyLong(), any(Handler.class))).thenReturn(200L);
 
         lastTimerId = TlsCertificateReloader.initCertReloadingAction(
-                vertx, server, config, null, sslConfig, registry, Optional.of("my-tls"));
+                vertx, server, config, null, sslConfig, registry, Optional.of("my-tls"), ClientAuth.REQUIRED);
 
         assertEquals(200L, lastTimerId);
     }
@@ -153,7 +154,7 @@ class TlsCertificateReloaderTest {
         when(vertx.setPeriodic(anyLong(), any(Handler.class))).thenReturn(555L);
 
         lastTimerId = TlsCertificateReloader.initCertReloadingAction(
-                vertx, server, config, sslOptions, sslConfig, registry, Optional.empty());
+                vertx, server, config, sslOptions, sslConfig, registry, Optional.empty(), ClientAuth.REQUIRED);
 
         assertEquals(555L, lastTimerId);
     }


### PR DESCRIPTION
The idea here is that we should create the server SSL options in one way, wherever we use it. For that reason I used existing method in `HttpServerOptionsUtils` which is used to configure HTTP server / Management interface, even though I am not confident about it's working (e.g. I don't understand why it sets the alpn the way it does it?).

* Closes: https://github.com/quarkusio/quarkus/issues/55130