### PR TITLE
Avoid duplicate fields when using @JsonProperty + improve Kotlin support + obey visibility defined in ObjectMapperCustomizer in reflection-free Jackson serializers

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/pom.xml
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/pom.xml
@@ -60,6 +60,17 @@
             <artifactId>quarkus-security-test-utils</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-kotlin</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -77,6 +88,25 @@
                                     <version>${project.version}</version>
                                 </path>
                             </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>test-compile</id>
+                        <phase>process-test-sources</phase>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                            </sourceDirs>
                         </configuration>
                     </execution>
                 </executions>

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
@@ -74,6 +74,7 @@ public abstract class JacksonCodeGenerator {
     private static final Logger log = Logger.getLogger(JacksonCodeGenerator.class);
 
     private static final String[] EMPTY_STRING_ARRAY = new String[0];
+    private static final DotName KOTLIN_METADATA = DotName.createSimple("kotlin.Metadata");
 
     private static final Set<String> SUPPORTED_JACKSON_ANNOTATIONS = Set.of(
             JacksonAnnotation.class.getName(),
@@ -351,7 +352,8 @@ public abstract class JacksonCodeGenerator {
         MethodInfo namedAccessor = findMethod(classInfo, fieldInfo.name());
         if (namedAccessor != null
                 && (classInfo.isRecord() || namedAccessor.hasAnnotation(JsonProperty.class)
-                        || fieldInfo.hasAnnotation(JsonProperty.class))) {
+                        || fieldInfo.hasAnnotation(JsonProperty.class)
+                        || classInfo.hasDeclaredAnnotation(KOTLIN_METADATA))) {
             return namedAccessor;
         }
         String methodName = (fieldInfo.type().name().toString().equals("boolean") ? "is" : "get") + ucFirst(fieldInfo.name());
@@ -461,8 +463,9 @@ public abstract class JacksonCodeGenerator {
         return null;
     }
 
-    protected FieldSpecs fieldSpecsFromFieldParam(MethodParameterInfo paramInfo, PropertyNamingStrategy namingStrategy) {
-        return new FieldSpecs(paramInfo, namingStrategy);
+    protected FieldSpecs fieldSpecsFromFieldParam(ClassInfo classInfo, MethodParameterInfo paramInfo,
+            PropertyNamingStrategy namingStrategy) {
+        return new FieldSpecs(classInfo, paramInfo, namingStrategy);
     }
 
     protected static class FieldSpecs {
@@ -507,7 +510,14 @@ public abstract class JacksonCodeGenerator {
             this.aliases = jsonAliases();
         }
 
-        FieldSpecs(MethodParameterInfo paramInfo, PropertyNamingStrategy namingStrategy) {
+        FieldSpecs(ClassInfo classInfo, MethodParameterInfo paramInfo, PropertyNamingStrategy namingStrategy) {
+            if (classInfo != null) {
+                FieldInfo field = classInfo.field(paramInfo.name());
+                if (field != null) {
+                    this.fieldInfo = field;
+                    readAnnotations(field);
+                }
+            }
             readAnnotations(paramInfo);
             this.fieldType = paramInfo.type();
             this.fieldName = paramInfo.name();
@@ -592,6 +602,12 @@ public abstract class JacksonCodeGenerator {
                 return methodName.substring(3, 4).toLowerCase() + methodName.substring(4);
             }
             return methodName;
+        }
+
+        boolean isAutoDetectedGetter() {
+            return fieldInfo == null && methodInfo != null
+                    && annotations.get(JsonProperty.class.getName()) == null
+                    && annotations.get(JsonGetter.class.getName()) == null;
         }
 
         boolean isIgnoredField() {

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonDeserializerFactory.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonDeserializerFactory.java
@@ -303,7 +303,7 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
         ResultHandle[] params = new ResultHandle[deserData.constructor.parameters().size()];
         int i = 0;
         for (MethodParameterInfo paramInfo : deserData.constructor.parameters()) {
-            FieldSpecs fieldSpecs = fieldSpecsFromFieldParam(paramInfo, deserData.namingStrategy);
+            FieldSpecs fieldSpecs = fieldSpecsFromFieldParam(deserData.classInfo, paramInfo, deserData.namingStrategy);
             deserData.constructorFields.add(fieldSpecs.jsonName);
             for (String alias : fieldSpecs.aliases) {
                 deserData.constructorFields.add(alias);
@@ -500,7 +500,7 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
         Set<String> names = new HashSet<>();
         if (constructor.parametersCount() > 0) {
             for (MethodParameterInfo paramInfo : constructor.parameters()) {
-                FieldSpecs fieldSpecs = fieldSpecsFromFieldParam(paramInfo, namingStrategy);
+                FieldSpecs fieldSpecs = fieldSpecsFromFieldParam(classInfo, paramInfo, namingStrategy);
                 if (!fieldSpecs.hasExplicitJsonName) {
                     names.add(fieldSpecs.fieldName);
                 }
@@ -579,17 +579,25 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
             ResultHandle objHandle, ResultHandle fieldValue, Set<String> deserializedFields, Switch.StringSwitch strSwitch) {
 
         AtomicBoolean valid = new AtomicBoolean(true);
+        Set<String> boundFieldNames = new HashSet<>();
 
         for (FieldInfo fieldInfo : classFields(deserData.classInfo)) {
+            FieldSpecs fieldSpecs = fieldSpecsFromField(deserData.classInfo, deserData.constructor, fieldInfo,
+                    deserData.namingStrategy);
+            if (fieldSpecs != null) {
+                boundFieldNames.add(fieldSpecs.fieldName);
+            }
             deserializeFieldSpecs(deserData, deserializationContext, objHandle, fieldValue,
-                    deserializedFields, strSwitch,
-                    fieldSpecsFromField(deserData.classInfo, deserData.constructor, fieldInfo, deserData.namingStrategy),
-                    valid);
+                    deserializedFields, strSwitch, fieldSpecs, valid);
         }
 
         for (MethodInfo methodInfo : classMethods(deserData.classInfo)) {
+            FieldSpecs fieldSpecs = fieldSpecsFromMethod(methodInfo, deserData.namingStrategy);
+            if (fieldSpecs != null && boundFieldNames.contains(fieldSpecs.fieldName)) {
+                continue;
+            }
             deserializeFieldSpecs(deserData, deserializationContext, objHandle, fieldValue,
-                    deserializedFields, strSwitch, fieldSpecsFromMethod(methodInfo, deserData.namingStrategy), valid);
+                    deserializedFields, strSwitch, fieldSpecs, valid);
         }
 
         return valid.get();

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
@@ -317,14 +317,48 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
         }
 
         List<FieldSpecs> allFieldSpecs = collectAllFieldSpecs(classInfo, namingStrategy);
+
+        boolean hasAutoDetectedGetters = false;
+        boolean hasAutoDetectedIsGetters = false;
+        for (FieldSpecs fieldSpecs : allFieldSpecs) {
+            if (fieldSpecs.isAutoDetectedGetter()) {
+                if (fieldSpecs.methodInfo.name().startsWith("is")) {
+                    hasAutoDetectedIsGetters = true;
+                } else {
+                    hasAutoDetectedGetters = true;
+                }
+            }
+        }
+
+        ResultHandle getterVisibleHandle = null;
+        if (hasAutoDetectedGetters) {
+            getterVisibleHandle = bytecode.invokeStaticMethod(
+                    MethodDescriptor.ofMethod(JacksonMapperUtil.class, "isPublicGetterVisible",
+                            boolean.class, SerializerProvider.class),
+                    ctx.serializerProvider);
+        }
+        ResultHandle isGetterVisibleHandle = null;
+        if (hasAutoDetectedIsGetters) {
+            isGetterVisibleHandle = bytecode.invokeStaticMethod(
+                    MethodDescriptor.ofMethod(JacksonMapperUtil.class, "isPublicIsGetterVisible",
+                            boolean.class, SerializerProvider.class),
+                    ctx.serializerProvider);
+        }
+
         for (FieldSpecs fieldSpecs : allFieldSpecs) {
             if (serializedFields.add(fieldSpecs.jsonName)) {
                 if (fieldSpecs.isIgnoredField() || ignoredProperties.contains(fieldSpecs.jsonName)
                         || fieldSpecs.isBackReference() || isFieldTypeIgnored(fieldSpecs)) {
                     continue;
                 }
-                writeField(classInfo, fieldSpecs, writeFieldBranch(classCreator, bytecode, fieldSpecs, ctx), ctx,
-                        classInclude);
+                BytecodeCreator writeBranch = writeFieldBranch(classCreator, bytecode, fieldSpecs, ctx);
+                if (fieldSpecs.isAutoDetectedGetter()) {
+                    ResultHandle visibleHandle = fieldSpecs.methodInfo.name().startsWith("is")
+                            ? isGetterVisibleHandle
+                            : getterVisibleHandle;
+                    writeBranch = writeBranch.ifTrue(visibleHandle).trueBranch();
+                }
+                writeField(classInfo, fieldSpecs, writeBranch, ctx, classInclude);
             }
         }
 
@@ -334,15 +368,22 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
     private List<FieldSpecs> collectAllFieldSpecs(ClassInfo classInfo, PropertyNamingStrategy namingStrategy) {
         List<FieldSpecs> allSpecs = new ArrayList<>();
         MethodInfo constructor = findConstructor(classInfo).orElse(null);
+        Set<MethodInfo> boundMethods = new HashSet<>();
 
         for (FieldInfo fieldInfo : classFields(classInfo)) {
             FieldSpecs fieldSpecs = fieldSpecsFromField(classInfo, constructor, fieldInfo, namingStrategy);
             if (fieldSpecs != null) {
                 allSpecs.add(fieldSpecs);
+                if (fieldSpecs.methodInfo != null) {
+                    boundMethods.add(fieldSpecs.methodInfo);
+                }
             }
         }
 
         for (MethodInfo methodInfo : classMethods(classInfo)) {
+            if (boundMethods.contains(methodInfo)) {
+                continue;
+            }
             FieldSpecs fieldSpecs = fieldSpecsFromMethod(methodInfo, namingStrategy);
             if (fieldSpecs != null) {
                 allSpecs.add(fieldSpecs);

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/FieldVisibilityReflectionFreeTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/FieldVisibilityReflectionFreeTest.java
@@ -1,0 +1,123 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import java.util.function.Supplier;
+
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkus.jackson.ObjectMapperCustomizer;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+
+public class FieldVisibilityReflectionFreeTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(FieldOnlyVisibilityCustomizer.class,
+                                    Item.class,
+                                    ItemResource.class)
+                            .addAsResource(
+                                    new StringAsset(
+                                            "quarkus.rest.jackson.optimization.enable-reflection-free-serializers=true\n"),
+                                    "application.properties");
+                }
+            });
+
+    @Test
+    public void testSerializationUsesFieldNotGetter() {
+        RestAssured.get("/field-visibility")
+                .then()
+                .statusCode(200)
+                .body("secret", is("hidden"))
+                .body(not(containsString("\"exposed\"")));
+    }
+
+    @Test
+    public void testRoundTrip() {
+        RestAssured
+                .with()
+                .body("{\"secret\": \"value\"}")
+                .contentType("application/json")
+                .post("/field-visibility")
+                .then()
+                .statusCode(200)
+                .body("secret", is("value"))
+                .body(not(containsString("\"exposed\"")));
+    }
+
+    @Singleton
+    public static class FieldOnlyVisibilityCustomizer implements ObjectMapperCustomizer {
+        @Override
+        public void customize(ObjectMapper mapper) {
+            mapper.setVisibility(
+                    mapper.getSerializationConfig().getDefaultVisibilityChecker()
+                            .withFieldVisibility(JsonAutoDetect.Visibility.ANY)
+                            .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                            .withIsGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                            .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
+                            .withCreatorVisibility(JsonAutoDetect.Visibility.NONE));
+        }
+    }
+
+    public static class Item {
+        private String secret;
+
+        public Item() {
+        }
+
+        public Item(String secret) {
+            this.secret = secret;
+        }
+
+        public String getExposed() {
+            return secret;
+        }
+
+        public String getSecret() {
+            return secret;
+        }
+
+        public void setSecret(String secret) {
+            this.secret = secret;
+        }
+    }
+
+    @Path("/field-visibility")
+    public static class ItemResource {
+
+        @GET
+        @Produces(MediaType.APPLICATION_JSON)
+        public Item get() {
+            return new Item("hidden");
+        }
+
+        @POST
+        @Consumes(MediaType.APPLICATION_JSON)
+        @Produces(MediaType.APPLICATION_JSON)
+        public Item echo(Item item) {
+            return item;
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/KotlinBooleanIsPrefixReflectionFreeTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/KotlinBooleanIsPrefixReflectionFreeTest.java
@@ -1,0 +1,55 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import java.util.function.Supplier;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+
+public class KotlinBooleanIsPrefixReflectionFreeTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(KotlinBooleanIsPrefixDto.class,
+                                    KotlinBooleanIsPrefixResource.class)
+                            .addAsResource(
+                                    new StringAsset(
+                                            "quarkus.rest.jackson.optimization.enable-reflection-free-serializers=true\n"),
+                                    "application.properties");
+                }
+            });
+
+    @Test
+    public void testSerializationUsesKotlinPropertyName() {
+        RestAssured.get("/kotlin-boolean-is-prefix")
+                .then()
+                .statusCode(200)
+                .body("isEligible", is(true))
+                .body(not(containsString("\"eligible\"")));
+    }
+
+    @Test
+    public void testRoundTrip() {
+        RestAssured
+                .with()
+                .body("{\"isEligible\": true}")
+                .contentType("application/json")
+                .post("/kotlin-boolean-is-prefix")
+                .then()
+                .statusCode(200)
+                .body("isEligible", is(true));
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/KotlinBooleanIsPrefixResource.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/KotlinBooleanIsPrefixResource.java
@@ -1,0 +1,25 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/kotlin-boolean-is-prefix")
+public class KotlinBooleanIsPrefixResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public KotlinBooleanIsPrefixDto get() {
+        return new KotlinBooleanIsPrefixDto(true);
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public KotlinBooleanIsPrefixDto echo(KotlinBooleanIsPrefixDto dto) {
+        return dto;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/KotlinJsonPropertyReflectionFreeTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/KotlinJsonPropertyReflectionFreeTest.java
@@ -1,0 +1,56 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import java.util.function.Supplier;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+
+public class KotlinJsonPropertyReflectionFreeTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(KotlinJsonPropertyDto.class,
+                                    KotlinJsonPropertyResource.class)
+                            .addAsResource(
+                                    new StringAsset(
+                                            "quarkus.rest.jackson.optimization.enable-reflection-free-serializers=true\n"),
+                                    "application.properties");
+                }
+            });
+
+    @Test
+    public void testSerializationUsesJsonPropertyName() {
+        RestAssured.get("/kotlin-json-property")
+                .then()
+                .statusCode(200)
+                .body("name", is("Alice"))
+                .body(not(containsString("\"field\"")));
+    }
+
+    @Test
+    public void testRoundTrip() {
+        RestAssured
+                .with()
+                .body("{\"name\": \"Bob\"}")
+                .contentType("application/json")
+                .post("/kotlin-json-property")
+                .then()
+                .statusCode(200)
+                .body("name", is("Bob"))
+                .body(not(containsString("\"field\"")));
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/KotlinJsonPropertyResource.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/KotlinJsonPropertyResource.java
@@ -1,0 +1,25 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/kotlin-json-property")
+public class KotlinJsonPropertyResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public KotlinJsonPropertyDto get() {
+        return new KotlinJsonPropertyDto("Alice");
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public KotlinJsonPropertyDto echo(KotlinJsonPropertyDto dto) {
+        return dto;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/AbstractGeneratedAnnotationTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/AbstractGeneratedAnnotationTest.java
@@ -766,6 +766,32 @@ public abstract class AbstractGeneratedAnnotationTest {
                 .body("normal_name", Matchers.is("hello"));
     }
 
+    // --- @JsonProperty renames field ---
+
+    @Test
+    public void testJsonPropertyRenameSerialization() {
+        RestAssured.get("/generated/json-property-rename")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("name", Matchers.is("Alice"))
+                .body(not(containsString("\"field\"")));
+    }
+
+    @Test
+    public void testJsonPropertyRenameRoundTrip() {
+        given()
+                .contentType("application/json")
+                .body("{\"name\":\"Bob\"}")
+                .when()
+                .post("/generated/json-property-rename")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("name", Matchers.is("Bob"))
+                .body(not(containsString("\"field\"")));
+    }
+
     // --- @JsonRawValue ---
 
     @Test

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationResource.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationResource.java
@@ -450,6 +450,21 @@ public class GeneratedAnnotationResource {
         return bean;
     }
 
+    // --- TestWithJsonPropertyDto: @JsonProperty renames field ---
+
+    @GET
+    @Path("/json-property-rename")
+    public TestWithJsonPropertyDto getJsonPropertyRename() {
+        return new TestWithJsonPropertyDto("Alice");
+    }
+
+    @POST
+    @Path("/json-property-rename")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public TestWithJsonPropertyDto echoJsonPropertyRename(TestWithJsonPropertyDto dto) {
+        return dto;
+    }
+
     // --- SpecialCharPropertyBean: @JsonProperty with special characters (hyphens, dots) ---
 
     @GET

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationTest.java
@@ -51,6 +51,7 @@ public class GeneratedAnnotationTest extends AbstractGeneratedAnnotationTest {
                                     RawValueBean.class,
                                     PackageProtectedBean.class,
                                     SpecialCharPropertyBean.class,
+                                    TestWithJsonPropertyDto.class,
                                     UnwrappedIgnorePropertiesBean.class,
                                     UnwrappedIgnorePropertiesBean.User.class)
                             .addAsResource(new StringAsset(

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationWithReflectionFreeSerializersTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationWithReflectionFreeSerializersTest.java
@@ -54,6 +54,7 @@ public class GeneratedAnnotationWithReflectionFreeSerializersTest extends Abstra
                                     RawValueBean.class,
                                     PackageProtectedBean.class,
                                     SpecialCharPropertyBean.class,
+                                    TestWithJsonPropertyDto.class,
                                     UnwrappedIgnorePropertiesBean.class,
                                     UnwrappedIgnorePropertiesBean.User.class)
                             .addAsResource(new StringAsset(

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/TestWithJsonPropertyDto.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/TestWithJsonPropertyDto.java
@@ -1,0 +1,17 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class TestWithJsonPropertyDto {
+
+    @JsonProperty("name")
+    private final String field;
+
+    public TestWithJsonPropertyDto(String field) {
+        this.field = field;
+    }
+
+    public String getField() {
+        return field;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/kotlin/io/quarkus/resteasy/reactive/jackson/deployment/test/KotlinBooleanIsPrefixDto.kt
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/kotlin/io/quarkus/resteasy/reactive/jackson/deployment/test/KotlinBooleanIsPrefixDto.kt
@@ -1,0 +1,3 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test
+
+data class KotlinBooleanIsPrefixDto(val isEligible: Boolean)

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/kotlin/io/quarkus/resteasy/reactive/jackson/deployment/test/KotlinJsonPropertyDto.kt
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/kotlin/io/quarkus/resteasy/reactive/jackson/deployment/test/KotlinJsonPropertyDto.kt
@@ -1,0 +1,8 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class KotlinJsonPropertyDto(
+    @JsonProperty("name")
+    val field: String
+)

--- a/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/mappers/JacksonMapperUtil.java
+++ b/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/mappers/JacksonMapperUtil.java
@@ -2,6 +2,7 @@ package io.quarkus.resteasy.reactive.jackson.runtime.mappers;
 
 import java.io.IOException;
 import java.lang.reflect.Array;
+import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.text.SimpleDateFormat;
 import java.util.Collection;
@@ -34,6 +35,25 @@ import io.quarkus.resteasy.reactive.jackson.runtime.security.RolesAllowedConfigE
 import io.quarkus.security.identity.SecurityIdentity;
 
 public class JacksonMapperUtil {
+
+    private static final Method VISIBILITY_TEST_METHOD;
+    static {
+        try {
+            VISIBILITY_TEST_METHOD = Object.class.getMethod("getClass");
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static boolean isPublicGetterVisible(SerializerProvider provider) {
+        return provider.getConfig().getDefaultVisibilityChecker()
+                .isGetterVisible(VISIBILITY_TEST_METHOD);
+    }
+
+    public static boolean isPublicIsGetterVisible(SerializerProvider provider) {
+        return provider.getConfig().getDefaultVisibilityChecker()
+                .isIsGetterVisible(VISIBILITY_TEST_METHOD);
+    }
 
     public static void serializeFormattedDate(Object value, String pattern, String timezone,
             JsonGenerator generator) throws IOException {


### PR DESCRIPTION
* Fixes #55142
* Fixes #55214
