### PR TITLE
[3.x] Backport - In QuarkusDevModeTest, only clear the RESTAssured state if it was set

### DIFF
--- a/test-framework/junit-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
+++ b/test-framework/junit-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
@@ -394,7 +394,12 @@ public class QuarkusDevModeTest
                 FileUtil.deleteDirectory(deploymentDir);
             }
         }
-        RestAssuredStateManager.clearState();
+
+        // Only reset if we actually set something. ValueRegistry can be null if Quarkus failed to start
+        if (Optional.ofNullable(ValueRegistryInjector.get(context))
+                .map(valueRegistry -> valueRegistry.containsKey(LOCAL_BASE_URI)).orElse(false)) {
+            RestAssuredStateManager.clearState();
+        }
         ThreadLocalConfigSourceProvider.reset();
         ConfigInjector.clear(context);
         ValueRegistryInjector.clear(context);


### PR DESCRIPTION
Backport https://github.com/quarkusio/quarkus/pull/55084/ to 3.x

