### PR TITLE
Fix Gradle test maven repo property lookup

### DIFF
--- a/devtools/gradle/build-logic/src/main/kotlin/io.quarkus.devtools.java-library.gradle.kts
+++ b/devtools/gradle/build-logic/src/main/kotlin/io.quarkus.devtools.java-library.gradle.kts
@@ -39,7 +39,8 @@ tasks.named<Test>(JavaPlugin.TEST_TASK_NAME) {
     }
 
     // propagate the custom local maven repo, in case it's configured
-    if (System.getProperties().containsKey("maven.repo.local")) {
-        systemProperty("maven.repo.local", System.getProperty("maven.repo.local"))
-    }
+	val mavenRepoLocal = providers.systemProperty("maven.repo.local")
+	if (mavenRepoLocal.isPresent) {
+		systemProperty("maven.repo.local", mavenRepoLocal.get())
+	}
 }


### PR DESCRIPTION
A small change to make the build scripts eventually work seamlessly with Gradle's configuration cache. No functional change.