### PR TITLE
Gradle/build: Use providers for settings environment reads

### DIFF
--- a/devtools/gradle/settings.gradle.kts
+++ b/devtools/gradle/settings.gradle.kts
@@ -3,7 +3,9 @@ plugins {
 }
 
 develocity {
-    val isAuthenticated = !System.getenv("DEVELOCITY_ACCESS_KEY").isNullOrEmpty()
+	val isAuthenticated = providers.environmentVariable("DEVELOCITY_ACCESS_KEY")
+		.map(String::isNotEmpty)
+		.getOrElse(false)
     if(isAuthenticated) {
         server = "https://ge.quarkus.io"
     }
@@ -14,7 +16,9 @@ develocity {
             termsOfUseAgree.set("yes")
         }
         publishing.onlyIf { it.buildResult.failures.isNotEmpty() }
-        uploadInBackground = System.getenv("CI").isNullOrEmpty()
+		uploadInBackground = providers.environmentVariable("CI")
+			.map(String::isEmpty)
+			.getOrElse(true)
     }
 }
 


### PR DESCRIPTION
The Develocity settings logic reads `DEVELOCITY_ACCESS_KEY` and `CI` while the settings script is being evaluated. Direct `System.getenv` calls make those inputs invisible to Gradle's provider tracking.

Use `providers.environmentVariable` for both values and preserve the previous null-or-empty behavior for authentication and background upload decisions.