### PR TITLE
Spring Data REST: fix duplicate list method for ListCrudRepository

### DIFF
--- a/extensions/spring-data-rest/deployment/src/main/java/io/quarkus/spring/data/rest/deployment/RepositoryMethodsImplementor.java
+++ b/extensions/spring-data-rest/deployment/src/main/java/io/quarkus/spring/data/rest/deployment/RepositoryMethodsImplementor.java
@@ -75,7 +75,8 @@ public class RepositoryMethodsImplementor implements ResourceMethodsImplementor 
     //    CrudRepository Iterable<T> findAll();
     public void implementIterable(ClassCreator classCreator, String repositoryInterfaceName) {
         if (entityClassHelper.isCrudRepository(repositoryInterfaceName)
-                && !entityClassHelper.isPagingAndSortingRepository(repositoryInterfaceName)) {
+                && !entityClassHelper.isPagingAndSortingRepository(repositoryInterfaceName)
+                && !entityClassHelper.isListCrudRepository(repositoryInterfaceName)) {
             classCreator.method("list", mc -> {
                 mc.public_();
                 mc.returning(List.class);

--- a/extensions/spring-data-rest/deployment/src/test/java/io/quarkus/spring/data/rest/crud/DefaultListCrudRecordsRepository.java
+++ b/extensions/spring-data-rest/deployment/src/test/java/io/quarkus/spring/data/rest/crud/DefaultListCrudRecordsRepository.java
@@ -1,0 +1,6 @@
+package io.quarkus.spring.data.rest.crud;
+
+import org.springframework.data.repository.ListCrudRepository;
+
+public interface DefaultListCrudRecordsRepository extends ListCrudRepository<Record, Long> {
+}

--- a/extensions/spring-data-rest/deployment/src/test/java/io/quarkus/spring/data/rest/crud/DefaultListCrudResourceTest.java
+++ b/extensions/spring-data-rest/deployment/src/test/java/io/quarkus/spring/data/rest/crud/DefaultListCrudResourceTest.java
@@ -1,0 +1,39 @@
+package io.quarkus.spring.data.rest.crud;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.spring.data.rest.AbstractEntity;
+import io.quarkus.test.QuarkusExtensionTest;
+
+class DefaultListCrudResourceTest {
+    @RegisterExtension
+    static final QuarkusExtensionTest TEST = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(AbstractEntity.class, Record.class, DefaultListCrudRecordsRepository.class)
+                    .addAsResource("application.properties")
+                    .addAsResource("import.sql"));
+
+    @Test
+    void shouldGet() {
+        given().accept("application/json")
+                .when().get("/default-list-crud-records/1")
+                .then().statusCode(200)
+                .and().body("id", is(equalTo(1)))
+                .and().body("name", is(equalTo("first")));
+    }
+
+    @Test
+    void shouldList() {
+        given().accept("application/json")
+                .when().get("/default-list-crud-records")
+                .then().statusCode(200)
+                .and().body("id", hasItems(1, 2))
+                .and().body("name", hasItems("first", "second"));
+    }
+}


### PR DESCRIPTION
## Summary

- Fix `IllegalArgumentException: Duplicate method added` when a repository extends `ListCrudRepository` (without also extending `PagingAndSortingRepository`)
- The bug was introduced in #54991 (Gizmo 2 migration): both `implementIterable()` and `implementList()` generate a `list(Page, Sort, String, Map)` method for `ListCrudRepository` subtypes. Gizmo 1 silently allowed duplicate method definitions but Gizmo 2 strictly rejects them.
- The fix adds a `!entityClassHelper.isListCrudRepository()` guard to `implementIterable()` so that `ListCrudRepository` instances use only the `implementList()` path.
- Added a `DefaultListCrudResourceTest` to cover the `ListCrudRepository` case.

## How to reproduce

Define a repository extending `ListCrudRepository` with `@RepositoryRestResource` and build the application. The build fails with:

```
Build step SpringDataRestProcessor#registerRepositories threw an exception:
java.lang.IllegalArgumentException: Duplicate method added:
  ClassMethod[...#list(Page;Sort;String;Map;)List;]
```

Failing job: https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/28528745010/job/84580320071

## Test plan

- [x] New `DefaultListCrudResourceTest` reproduces the issue without the fix and passes with it
- [x] All 76 existing `spring-data-rest` deployment tests pass