### PR TITLE
Add `Flow.Publisher` to GraphQL auto-transactional reactive type detection

### DIFF
--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
@@ -232,7 +232,8 @@ public class SmallRyeGraphQLProcessor {
                 DotName.createSimple("io.smallrye.mutiny.Multi"),
                 DotName.createSimple("java.util.concurrent.CompletionStage"),
                 DotName.createSimple("java.util.concurrent.CompletableFuture"),
-                DotName.createSimple("org.reactivestreams.Publisher"));
+                DotName.createSimple("org.reactivestreams.Publisher"),
+                DotName.createSimple("java.util.concurrent.Flow.Publisher"));
 
         annotationsTransformer.produce(new AnnotationsTransformerBuildItem(new AnnotationsTransformer() {
             @Override


### PR DESCRIPTION
The auto-`@Transactional` build step added in #54981 detects reactive return types to skip adding `@Transactional` to non-blocking resolvers. The reactive type list included `org.reactivestreams.Publisher` but was missing `java.util.concurrent.Flow.Publisher`, which is the JDK standard reactive streams type also supported by SmallRye GraphQL. This adds it alongside the existing entry.

Follow-up from @Ladicek's [post-merge review](https://github.com/quarkusio/quarkus/pull/54981#discussion_r3489759731) on #54981.