### PR TITLE
Safer testcontainers.reuse.enable restoration + more resilient tests

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/IsContainerRuntimeWorking.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/IsContainerRuntimeWorking.java
@@ -66,6 +66,10 @@ public abstract class IsContainerRuntimeWorking implements BooleanSupplier {
                 StartupLogCompressor compressor = new StartupLogCompressor("Checking Docker Environment",
                         Optional.empty(), null,
                         (s) -> s.getName().startsWith("ducttape"));
+                Object configurationInstance = null;
+                Method updateUserConfigMethod = null;
+                String oldReusePropertyValue = null;
+                boolean restoreReusePropertyValue = false;
                 try {
                     Class<?> dockerClientFactoryClass = Thread.currentThread().getContextClassLoader()
                             .loadClass("org.testcontainers.DockerClientFactory");
@@ -73,12 +77,13 @@ public abstract class IsContainerRuntimeWorking implements BooleanSupplier {
 
                     Class<?> configurationClass = Thread.currentThread().getContextClassLoader()
                             .loadClass("org.testcontainers.utility.TestcontainersConfiguration");
-                    Object configurationInstance = configurationClass.getMethod("getInstance").invoke(null);
-                    String oldReusePropertyValue = (String) configurationClass
+                    configurationInstance = configurationClass.getMethod("getInstance").invoke(null);
+                    oldReusePropertyValue = (String) configurationClass
                             .getMethod("getEnvVarOrUserProperty", String.class, String.class)
                             .invoke(configurationInstance, "testcontainers.reuse.enable", "false"); // use the default provided in TestcontainersConfiguration#environmentSupportsReuse
-                    Method updateUserConfigMethod = configurationClass.getMethod("updateUserConfig", String.class,
+                    updateUserConfigMethod = configurationClass.getMethod("updateUserConfig", String.class,
                             String.class);
+                    restoreReusePropertyValue = true;
                     // this will ensure that testcontainers does not start ryuk - see https://github.com/quarkusio/quarkus/issues/25852 for why this is important
                     updateUserConfigMethod.invoke(configurationInstance, "testcontainers.reuse.enable", "true");
 
@@ -96,8 +101,6 @@ public abstract class IsContainerRuntimeWorking implements BooleanSupplier {
                         compressor.closeAndDumpCaptured();
                     }
 
-                    // restore the previous value
-                    updateUserConfigMethod.invoke(configurationInstance, "testcontainers.reuse.enable", oldReusePropertyValue);
                     return isAvailable ? Result.AVAILABLE : Result.UNAVAILABLE;
                 } catch (ClassNotFoundException | NoSuchMethodException | InvocationTargetException | IllegalAccessException
                         | NoSuchFieldException e) {
@@ -107,6 +110,14 @@ public abstract class IsContainerRuntimeWorking implements BooleanSupplier {
                     }
                     return Result.UNKNOWN;
                 } finally {
+                    if (restoreReusePropertyValue) {
+                        try {
+                            updateUserConfigMethod.invoke(configurationInstance, "testcontainers.reuse.enable",
+                                    oldReusePropertyValue);
+                        } catch (IllegalAccessException | InvocationTargetException e) {
+                            LOGGER.debug("Unable to restore testcontainers.reuse.enable", e);
+                        }
+                    }
                     compressor.close();
                 }
             }

--- a/integration-tests/hibernate-reactive-mysql-agroal-flyway/src/main/resources/application.properties
+++ b/integration-tests/hibernate-reactive-mysql-agroal-flyway/src/main/resources/application.properties
@@ -8,3 +8,5 @@ quarkus.hibernate-orm.schema-management.strategy=none
 
 # Check that one can use Flyway alongside Hibernate Reactive
 quarkus.flyway.migrate-at-start=true
+#Reset Flyway metadata at boot, as the database might have been tainted by previous integration tests:
+quarkus.flyway.clean-at-start=true


### PR DESCRIPTION
Attempt to fix problems mentioned at https://github.com/quarkusio/quarkus/pull/55191?email_source=notifications&email_token=AADEZTRGM5NSGDRBWQ5EY6D5CPW2VA5CNFSNUABFM5UWIORPF5TWS5BNNB2WEL2JONZXKZKDN5WW2ZLOOQXTIOBUGU4TQOBVGI32M4TFMFZW63VHNVSW45DJN5XKKZLWMVXHJLDGN5XXIZLSL5RWY2LDNM#issuecomment-4845988527

@gsmet I'm not entirely sure this will fix things, but it looks like a step in the right direction?

In short we have some... questionable... code that changes the user's "reuse" config in dev services, and might have not cleaned up behind itself correctly. And also some tests were not as resilient as we'd like to a schema (wrongly) already being present on the DB.