### PR TITLE
Gradle: Declare local state for cacheable Quarkus app parts

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildCacheableAppParts.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildCacheableAppParts.java
@@ -4,11 +4,13 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import javax.inject.Inject;
 
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.LocalState;
 import org.gradle.api.tasks.OutputDirectories;
 import org.gradle.api.tasks.TaskAction;
 
@@ -58,6 +60,19 @@ public abstract class QuarkusBuildCacheableAppParts extends QuarkusBuildTask {
             }
         }
         return outputs;
+    }
+
+    @LocalState
+    public Set<File> getLocalStateFiles() {
+        return Set.of(
+                genBuildDir().toFile(),
+                fastJar(),
+                gradleBuildDir().resolve("lib").toFile(),
+                runnerJar(),
+                nativeRunner(),
+                nativeSources(),
+                gradleBuildDir().resolve(nativeImageSourceJarDirName()).toFile(),
+                artifactProperties());
     }
 
     @SuppressWarnings("deprecation") // legacy JAR


### PR DESCRIPTION
The cacheable app-parts task runs the Quarkus build in the regular Gradle build directory and then copies the reusable application parts into `build/quarkus-build/app`.

That leaves several intermediate paths under `build/` that are neither task outputs nor ordinary inputs. Declare those paths as local state so Gradle knows they are task-owned scratch data and can clean or ignore them for cache restoration without treating them as reusable outputs.