### PR TITLE
Bump SmallRye GraphQL to 2.18.3

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -51,7 +51,7 @@
         <smallrye-health.version>4.3.0</smallrye-health.version>
         <smallrye-modules.version>1.0.beta1</smallrye-modules.version>
         <smallrye-open-api.version>4.3.3</smallrye-open-api.version>
-        <smallrye-graphql.version>2.18.2</smallrye-graphql.version>
+        <smallrye-graphql.version>2.18.3</smallrye-graphql.version>
         <smallrye-fault-tolerance.version>6.11.2</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>4.6.3</smallrye-jwt.version>
         <smallrye-context-propagation.version>2.3.0</smallrye-context-propagation.version>

--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
@@ -132,6 +132,7 @@ import io.smallrye.graphql.schema.model.EnumValue;
 import io.smallrye.graphql.schema.model.Field;
 import io.smallrye.graphql.schema.model.InputType;
 import io.smallrye.graphql.schema.model.Operation;
+import io.smallrye.graphql.schema.model.ParametrizedTypeEntry;
 import io.smallrye.graphql.schema.model.Reference;
 import io.smallrye.graphql.schema.model.ReferenceType;
 import io.smallrye.graphql.schema.model.Scalars;
@@ -1106,11 +1107,9 @@ public class SmallRyeGraphQLProcessor {
     private Set<String> getAllReferenceClasses(Reference reference) {
         Set<String> classes = new HashSet<>();
         classes.add(reference.getClassName());
-        if (reference.getClassParametrizedTypes() != null && !reference.getClassParametrizedTypes().isEmpty()) {
-
-            Collection<Reference> parametrized = reference.getClassParametrizedTypes().values();
-            for (Reference r : parametrized) {
-                classes.addAll(getAllReferenceClasses(r));
+        if (reference.hasParametrizedTypes()) {
+            for (ParametrizedTypeEntry entry : reference.getParametrizedTypes().values()) {
+                classes.addAll(getAllReferenceClasses(entry.getReference()));
             }
         }
         return classes;


### PR DESCRIPTION
https://github.com/smallrye/smallrye-graphql/compare/2.18.2...2.18.3
This is technically a backport of https://github.com/quarkusio/quarkus/pull/55170, but with 2.18.3 (instead of 3.0.0.Beta4).

/cc @jmartisk

