### PR TITLE
Update Spring extensions for Spring Framework 7 / Spring Data 4 compa…

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -173,11 +173,11 @@
         <proton-j.version>0.34.1</proton-j.version>
         <javaparser.version>3.28.2</javaparser.version>
         <flapdoodle.mongo.version>4.24.0</flapdoodle.mongo.version>
-        <quarkus-spring-api.version>6.2.SP3</quarkus-spring-api.version>
-        <quarkus-spring-data-api.version>3.5</quarkus-spring-data-api.version>
-        <quarkus-spring-security-api.version>6.4</quarkus-spring-security-api.version>
-        <quarkus-spring-boot-api.version>3.4</quarkus-spring-boot-api.version>
-        <quarkus-spring-test-api.version>3.5.Alpha1</quarkus-spring-test-api.version>
+        <quarkus-spring-api.version>7.0.SP1</quarkus-spring-api.version>
+        <quarkus-spring-data-api.version>4.1</quarkus-spring-data-api.version>
+        <quarkus-spring-security-api.version>7.1.SP1</quarkus-spring-security-api.version>
+        <quarkus-spring-boot-api.version>4.1.SP1</quarkus-spring-boot-api.version>
+        <quarkus-spring-test-api.version>4.1</quarkus-spring-test-api.version>
         <mockito.version>5.21.0</mockito.version>
         <jna.version>5.8.0</jna.version><!-- should satisfy both testcontainers and mongodb -->
         <quarkus-security.version>2.3.2</quarkus-security.version>

--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/DotNames.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/DotNames.java
@@ -9,6 +9,8 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
+import java.time.Year;
+import java.time.YearMonth;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -156,6 +158,8 @@ public final class DotNames {
     public static final DotName DURATION = DotName.createSimple(Duration.class.getName());
     public static final DotName INSTANT = DotName.createSimple(Instant.class.getName());
     public static final DotName ZONED_DATETIME = DotName.createSimple(ZonedDateTime.class.getName());
+    public static final DotName YEAR = DotName.createSimple(Year.class.getName());
+    public static final DotName YEAR_MONTH = DotName.createSimple(YearMonth.class.getName());
 
     // https://docs.hibernate.org/stable/orm/userguide/html_single/#basic
     // Should be in sync with org.hibernate.type.BasicTypeRegistry
@@ -175,7 +179,7 @@ public final class DotNames {
             LOCAL_DATE, LOCAL_TIME, LOCAL_DATETIME,
             OFFSET_TIME, OFFSET_DATETIME,
             DURATION, INSTANT,
-            ZONED_DATETIME, TIMEZONE,
+            ZONED_DATETIME, YEAR, YEAR_MONTH, TIMEZONE,
             LOCALE, URL, UUID,
             BLOB, CLOB, NCLOB));
 

--- a/extensions/spring-web/core/common-runtime/src/main/java/io/quarkus/spring/web/runtime/common/ResponseEntityConverter.java
+++ b/extensions/spring-web/core/common-runtime/src/main/java/io/quarkus/spring/web/runtime/common/ResponseEntityConverter.java
@@ -18,7 +18,7 @@ public class ResponseEntityConverter {
 
     @SuppressWarnings("rawtypes")
     public static Response toResponse(ResponseEntity responseEntity, MediaType defaultMediaType) {
-        Response.ResponseBuilder responseBuilder = Response.status(responseEntity.getStatusCodeValue())
+        Response.ResponseBuilder responseBuilder = Response.status(responseEntity.getStatusCode().value())
                 .entity(responseEntity.getBody());
         var jaxRsHeaders = toJaxRsHeaders(responseEntity.getHeaders());
         if (!jaxRsHeaders.containsKey(HttpHeaders.CONTENT_TYPE) && (defaultMediaType != null)) {
@@ -36,6 +36,10 @@ public class ResponseEntityConverter {
     }
 
     private static Map<String, List<String>> toJaxRsHeaders(HttpHeaders springHeaders) {
-        return new HashMap<>(springHeaders);
+        Map<String, List<String>> result = new HashMap<>();
+        for (String name : springHeaders.headerNames()) {
+            result.put(name, springHeaders.getValuesAsList(name));
+        }
+        return result;
     }
 }

--- a/extensions/spring-web/core/common-runtime/src/main/java/io/quarkus/spring/web/runtime/common/ResponseStatusExceptionMapper.java
+++ b/extensions/spring-web/core/common-runtime/src/main/java/io/quarkus/spring/web/runtime/common/ResponseStatusExceptionMapper.java
@@ -1,8 +1,5 @@
 package io.quarkus.spring.web.runtime.common;
 
-import java.util.List;
-import java.util.Map;
-
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
@@ -21,9 +18,9 @@ public class ResponseStatusExceptionMapper implements ExceptionMapper<ResponseSt
     }
 
     private void addHeaders(Response.ResponseBuilder responseBuilder, HttpHeaders springHeaders) {
-        for (Map.Entry<String, List<String>> entry : springHeaders.entrySet()) {
-            for (String headerValue : entry.getValue()) {
-                responseBuilder.header(entry.getKey(), headerValue);
+        for (String name : springHeaders.headerNames()) {
+            for (String headerValue : springHeaders.getValuesAsList(name)) {
+                responseBuilder.header(name, headerValue);
             }
         }
     }

--- a/extensions/spring-web/resteasy-classic/deployment/src/main/java/io/quarkus/spring/web/resteasy/classic/deployment/SpringWebResteasyClassicProcessor.java
+++ b/extensions/spring-web/resteasy-classic/deployment/src/main/java/io/quarkus/spring/web/resteasy/classic/deployment/SpringWebResteasyClassicProcessor.java
@@ -25,8 +25,6 @@ import org.jboss.resteasy.core.MediaTypeMap;
 import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
 import org.jboss.resteasy.spi.ResteasyDeployment;
 import org.jboss.resteasy.spi.metadata.SpringResourceBuilder;
-import org.jboss.resteasy.spring.web.ResponseEntityFeature;
-import org.jboss.resteasy.spring.web.ResponseStatusFeature;
 
 import io.quarkus.arc.deployment.BeanArchiveIndexBuildItem;
 import io.quarkus.deployment.IsDevelopment;
@@ -41,6 +39,8 @@ import io.quarkus.resteasy.runtime.NonJaxRsClassMappings;
 import io.quarkus.resteasy.server.common.deployment.ResteasyDeploymentCustomizerBuildItem;
 import io.quarkus.resteasy.server.common.spi.AdditionalJaxRsResourceDefiningAnnotationBuildItem;
 import io.quarkus.resteasy.server.common.spi.AdditionalJaxRsResourceMethodParamAnnotations;
+import io.quarkus.spring.web.resteasy.classic.runtime.ResponseEntityFeature;
+import io.quarkus.spring.web.resteasy.classic.runtime.ResponseStatusFeature;
 import io.quarkus.spring.web.runtime.common.ResponseStatusExceptionMapper;
 import io.quarkus.undertow.deployment.IgnoredServletContainerInitializerBuildItem;
 import io.quarkus.undertow.deployment.ServletInitParamBuildItem;

--- a/extensions/spring-web/resteasy-classic/runtime/src/main/java/io/quarkus/spring/web/resteasy/classic/runtime/ResponseEntityContainerResponseFilter.java
+++ b/extensions/spring-web/resteasy-classic/runtime/src/main/java/io/quarkus/spring/web/resteasy/classic/runtime/ResponseEntityContainerResponseFilter.java
@@ -1,0 +1,30 @@
+package io.quarkus.spring.web.resteasy.classic.runtime;
+
+import java.io.IOException;
+import java.util.List;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+
+public class ResponseEntityContainerResponseFilter implements ContainerResponseFilter {
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+        Object entity = responseContext.getEntity();
+        if (!(entity instanceof ResponseEntity)) {
+            return;
+        }
+        ResponseEntity<?> responseEntity = (ResponseEntity<?>) entity;
+        responseContext.setStatus(responseEntity.getStatusCode().value());
+        responseContext.setEntity(responseEntity.getBody());
+        HttpHeaders headers = responseEntity.getHeaders();
+        for (String name : headers.headerNames()) {
+            List<String> values = headers.getValuesAsList(name);
+            responseContext.getHeaders().addAll(name, values.toArray(new Object[0]));
+        }
+    }
+}

--- a/extensions/spring-web/resteasy-classic/runtime/src/main/java/io/quarkus/spring/web/resteasy/classic/runtime/ResponseEntityFeature.java
+++ b/extensions/spring-web/resteasy-classic/runtime/src/main/java/io/quarkus/spring/web/resteasy/classic/runtime/ResponseEntityFeature.java
@@ -1,0 +1,24 @@
+package io.quarkus.spring.web.resteasy.classic.runtime;
+
+import jakarta.ws.rs.ConstrainedTo;
+import jakarta.ws.rs.RuntimeType;
+import jakarta.ws.rs.container.DynamicFeature;
+import jakarta.ws.rs.container.ResourceInfo;
+import jakarta.ws.rs.core.FeatureContext;
+import jakarta.ws.rs.ext.Provider;
+
+import org.springframework.http.ResponseEntity;
+
+@Provider
+@ConstrainedTo(RuntimeType.SERVER)
+public class ResponseEntityFeature implements DynamicFeature {
+
+    @Override
+    public void configure(ResourceInfo resourceInfo, FeatureContext context) {
+        if (!ResponseEntity.class.equals(resourceInfo.getResourceMethod().getReturnType())) {
+            return;
+        }
+
+        context.register(new ResponseEntityContainerResponseFilter());
+    }
+}

--- a/extensions/spring-web/resteasy-classic/runtime/src/main/java/io/quarkus/spring/web/resteasy/classic/runtime/ResponseStatusContainerResponseFilter.java
+++ b/extensions/spring-web/resteasy-classic/runtime/src/main/java/io/quarkus/spring/web/resteasy/classic/runtime/ResponseStatusContainerResponseFilter.java
@@ -1,0 +1,26 @@
+package io.quarkus.spring.web.resteasy.classic.runtime;
+
+import java.io.IOException;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+
+public class ResponseStatusContainerResponseFilter implements ContainerResponseFilter {
+
+    private final int defaultStatusCode;
+    private final int newStatusCode;
+
+    public ResponseStatusContainerResponseFilter(final int defaultStatusCode, final int newStatusCode) {
+        this.defaultStatusCode = defaultStatusCode;
+        this.newStatusCode = newStatusCode;
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+            throws IOException {
+        if (responseContext.getStatus() == defaultStatusCode) {
+            responseContext.setStatus(newStatusCode);
+        }
+    }
+}

--- a/extensions/spring-web/resteasy-classic/runtime/src/main/java/io/quarkus/spring/web/resteasy/classic/runtime/ResponseStatusFeature.java
+++ b/extensions/spring-web/resteasy-classic/runtime/src/main/java/io/quarkus/spring/web/resteasy/classic/runtime/ResponseStatusFeature.java
@@ -1,0 +1,36 @@
+package io.quarkus.spring.web.resteasy.classic.runtime;
+
+import jakarta.ws.rs.ConstrainedTo;
+import jakarta.ws.rs.RuntimeType;
+import jakarta.ws.rs.container.DynamicFeature;
+import jakarta.ws.rs.container.ResourceInfo;
+import jakarta.ws.rs.core.FeatureContext;
+import jakarta.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.spi.HttpResponseCodes;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@Provider
+@ConstrainedTo(RuntimeType.SERVER)
+public class ResponseStatusFeature implements DynamicFeature {
+
+    @Override
+    public void configure(ResourceInfo resourceInfo, FeatureContext context) {
+        ResponseStatus responseStatus = resourceInfo.getResourceMethod().getAnnotation(ResponseStatus.class);
+        if (responseStatus == null) {
+            return;
+        }
+
+        HttpStatus httpStatus = responseStatus.code();
+        if (httpStatus == HttpStatus.INTERNAL_SERVER_ERROR) {
+            httpStatus = responseStatus.value();
+        }
+
+        context.register(new ResponseStatusContainerResponseFilter(
+                void.class.equals(resourceInfo.getResourceMethod().getReturnType())
+                        ? HttpResponseCodes.SC_NO_CONTENT
+                        : HttpResponseCodes.SC_OK,
+                httpStatus.value()));
+    }
+}

--- a/integration-tests/spring-web/src/main/java/io/quarkus/it/spring/web/GreetingController.java
+++ b/integration-tests/spring-web/src/main/java/io/quarkus/it/spring/web/GreetingController.java
@@ -2,6 +2,8 @@ package io.quarkus.it.spring.web;
 
 import jakarta.validation.Valid;
 
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -29,6 +31,14 @@ public class GreetingController {
     @GetMapping(path = "/re/json/{message}")
     public ResponseEntity<Greeting> responseEntityGreeting(@PathVariable String message, @RequestParam String suffix) {
         return ResponseEntity.ok(greetingService.greet(message + suffix));
+    }
+
+    @GetMapping(path = "/re/headers/{message}")
+    public ResponseEntity<Greeting> responseEntityWithHeaders(@PathVariable String message) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("X-Custom-Header", "custom-value");
+        headers.add("X-Request-Id", "12345");
+        return new ResponseEntity<>(greetingService.greet(message), headers, HttpStatus.CREATED);
     }
 
     @PostMapping(path = "/person")

--- a/integration-tests/spring-web/src/test/java/io/quarkus/it/spring/web/SpringControllerTest.java
+++ b/integration-tests/spring-web/src/test/java/io/quarkus/it/spring/web/SpringControllerTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.it.spring.web;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 
@@ -42,6 +43,16 @@ public class SpringControllerTest {
         RestAssured.given().contentType("application/json").body("{\"name\":\"George\"}").post("/greeting/person").then()
                 .contentType("application/json")
                 .body(containsString("hello George"));
+    }
+
+    @Test
+    public void testResponseEntityWithCustomHeadersAndStatus() {
+        RestAssured.when().get("/greeting/re/headers/hello").then()
+                .statusCode(201)
+                .header("X-Custom-Header", is("custom-value"))
+                .header("X-Request-Id", is("12345"))
+                .contentType("application/json")
+                .body(containsString("hello"));
     }
 
     @Test


### PR DESCRIPTION
Depends on:

https://github.com/quarkusio/quarkus-spring-data-api/pull/72
https://github.com/quarkusio/quarkus-spring-api/pull/86
https://github.com/quarkusio/quarkus-spring-security-api/pull/49
https://github.com/quarkusio/quarkus-spring-test-api/pull/45

<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
and the AI/LLM usage policy at https://github.com/quarkusio/quarkus/blob/main/AI_POLICY.md
-->

 Release note: The Quarkus Spring compatibility extensions now target Spring Framework 7 and Spring Boot 4. Users of these extensions must migrate from Spring 6 APIs to Spring 7 APIs. See the Migration Guide for details.

 I can not edit the Migration Guide neither add labels here. 

Entry for the Migration Guide (Wiki)
```
  === Spring Compatibility Extensions — Spring Framework 7 / Spring Boot 4

  The Quarkus Spring compatibility extensions (`quarkus-spring-web`, `quarkus-spring-data-jpa`,
  `quarkus-spring-security`, `quarkus-spring-boot-properties`, `quarkus-spring-di`, etc.)
  have been upgraded to target **Spring Framework 7** ,  **Spring Boot 4** , **Spring Data 4** and **Spring Data Rest 5**

  **This is a breaking change.** Applications using Quarkus Spring compatibility extensions
  must update their Spring API usage from Spring 6 / Spring Boot 3 to Spring 7 / Spring Boot 4.

  ==== What changed

  [cols="2,2,2", options="header"]
  |===
  | API artifact | Previous version | New version

  | `quarkus-spring-api` (Spring Framework)
  | 6.2
  | 7.0

  | `quarkus-spring-data-api` (Spring Data)
  | 3.5
  | 4.1

  | `quarkus-spring-security-api` (Spring Security)
  | 6.4
  | 7.1

  | `quarkus-spring-boot-api` (Spring Boot)
  | 3.4
  | 4.1
  |===

  ==== Notable API changes that may affect your code

  * `ResponseEntity.getStatusCodeValue()` has been removed — use `responseEntity.getStatusCode().value()` instead.
  * `HttpHeaders` no longer implements `Map<String, List<String>>` directly — use `headerNames()` and `getValuesAsList(name)` to iterate headers.
  * Spring Data repositories may require adjustments for Spring Data 4.1 API changes (e.g., new `java.time.Year` and `YearMonth` types are now supported as basic types).

  ==== How to migrate

  1. Update any direct Spring API usage in your application code to the Spring 7 / Spring Boot 4 equivalents.
  2. Consult the upstream Spring Framework migration guides:
     - https://github.com/spring-projects/spring-framework/wiki/Upgrading-to-Spring-Framework-7.x[Spring Framework 6 → 7 Migration Guide]
     - https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Migration-Guide[Spring Boot 3 → 4 Migration Guide]
  3. If your project depends directly on Spring API jars (not managed by Quarkus BOM), update those dependencies accordingly.

```

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

