### PR TITLE
Upgrade aesh, enable native access, support args in console mode

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -200,8 +200,8 @@
         <!-- Check the compatibility matrix (https://github.com/opensearch-project/opensearch-testcontainers) before upgrading: -->
         <opensearch-testcontainers.version>2.1.3</opensearch-testcontainers.version>
         <com.dajudge.kindcontainer>2.0.0</com.dajudge.kindcontainer>
-        <aesh.version>3.16.1</aesh.version>
-        <aesh-readline.version>3.16.1</aesh-readline.version>
+        <aesh.version>3.16.4</aesh.version>
+        <aesh-readline.version>3.16.2</aesh-readline.version>
         <jline.version>4.2.1</jline.version> <!-- Keep in sync with dekorate -->
         <!-- these two artifacts needs to be compatible together -->
         <strimzi-oauth.version>0.16.1</strimzi-oauth.version>

--- a/docs/src/main/asciidoc/aesh.adoc
+++ b/docs/src/main/asciidoc/aesh.adoc
@@ -126,7 +126,8 @@ class CalcCommand implements Command<CommandInvocation> {
 }
 ----
 
-With two commands, console mode is auto-detected:
+With two commands, console mode is auto-detected. Without arguments, the interactive
+REPL starts:
 
 [source,shell]
 ----
@@ -137,6 +138,17 @@ Hello Aesh!
 Result: 8
 [quarkus]$ exit
 ----
+
+If command-line arguments are provided, the command is executed once and the application
+exits -- just like runtime mode:
+
+[source,shell]
+----
+$ java -jar myapp.jar greet --name=Aesh
+Hello Aesh!
+----
+
+This allows console mode applications to be used both interactively and in scripts.
 
 The prompt, exit command, and other console settings are configurable via `quarkus.aesh.*` properties.
 
@@ -628,6 +640,55 @@ public class MyCliSettings implements CliSettings {
 ----
 
 Multiple `CliSettings` beans can be registered. They are applied in arbitrary order, so avoid conflicting settings across implementations.
+
+== Command execution listener
+
+Implement `CommandExecutionListener` as a CDI bean to receive a callback after each command completes.
+This is useful for logging, metrics, or audit trails:
+
+[source,java]
+----
+package com.acme.aesh;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.aesh.command.CommandExecutionListener;
+import org.aesh.command.CommandResult;
+
+@ApplicationScoped
+public class CommandLogger implements CommandExecutionListener {
+
+    @Override
+    public void onCommandComplete(String commandLine, CommandResult result, long executionTimeMs) {
+        System.out.println("Executed: " + commandLine + " in " + executionTimeMs + "ms");
+    }
+}
+----
+
+The listener fires in both console mode (after each REPL command) and when arguments are provided on the command line.
+
+== Command not found handler
+
+Implement `CommandNotFoundHandler` as a CDI bean to customize the error message when an unknown command is typed:
+
+[source,java]
+----
+package com.acme.aesh;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.aesh.command.CommandNotFoundHandler;
+import org.aesh.command.shell.Shell;
+
+@ApplicationScoped
+public class MyNotFoundHandler implements CommandNotFoundHandler {
+
+    @Override
+    public void handleCommandNotFound(String line, Shell shell) {
+        shell.writeln("Unknown command: " + line + ". Type 'help' for available commands.");
+    }
+}
+----
 
 == Build-time validation
 

--- a/extensions/aesh/deployment/src/main/java/io/quarkus/aesh/deployment/AeshProcessor.java
+++ b/extensions/aesh/deployment/src/main/java/io/quarkus/aesh/deployment/AeshProcessor.java
@@ -12,6 +12,7 @@ import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
@@ -40,6 +41,7 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ApplicationIndexBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.ModuleEnableNativeAccessBuildItem;
 import io.quarkus.deployment.builditem.QuarkusApplicationClassBuildItem;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.runtime.annotations.QuarkusMain;
@@ -48,6 +50,8 @@ class AeshProcessor {
 
     private static final DotName AESH_COMMAND = DotName.createSimple("org.aesh.command.Command");
     private static final DotName COMMAND_DEFINITION = DotName.createSimple("org.aesh.command.CommandDefinition");
+    private static final DotName GROUP_COMMAND = DotName.createSimple("org.aesh.command.GroupCommand");
+    private static final DotName INJECT = DotName.createSimple("jakarta.inject.Inject");
     private static final DotName QUARKUS_MAIN = DotName.createSimple(QuarkusMain.class.getName());
     private static final DotName PARENT_COMMAND = DotName.createSimple("org.aesh.command.option.ParentCommand");
 
@@ -56,24 +60,35 @@ class AeshProcessor {
         return new FeatureBuildItem(Feature.AESH);
     }
 
+    @BuildStep
+    ModuleEnableNativeAccessBuildItem enableNativeAccess() {
+        // terminal-tty uses java.lang.foreign.Linker (FFM API) for native terminal access
+        return new ModuleEnableNativeAccessBuildItem("org.aesh.terminal.tty");
+    }
+
     /**
      * Discovers command classes from the application index only.
      * Only commands defined in the user's application are considered --
      * commands from third-party dependencies are not automatically registered.
+     * <p>
+     * After discovering all commands, enriches group commands that implement
+     * {@code GroupCommand} by detecting {@code @Inject} fields whose types
+     * are also discovered command classes. This handles the {@code getCommands()}
+     * pattern where sub-commands are injected via CDI rather than declared
+     * in the {@code groupCommands} annotation attribute.
      */
     @BuildStep
     void discoverCommands(ApplicationIndexBuildItem applicationIndex,
+            CombinedIndexBuildItem combinedIndex,
             BuildProducer<AeshCommandBuildItem> commands) {
         IndexView appIndex = applicationIndex.getIndex();
-        Set<DotName> discovered = new HashSet<>();
-        discoverFromIndex(appIndex, discovered, commands);
-    }
+        IndexView fullIndex = combinedIndex.getIndex();
 
-    private void discoverFromIndex(IndexView index, Set<DotName> discovered,
-            BuildProducer<AeshCommandBuildItem> commands) {
-        // Process @CommandDefinition classes (which may also define group commands
-        // via the groupCommands attribute, added in aesh 3.10)
-        for (AnnotationInstance ann : index.getAnnotations(COMMAND_DEFINITION)) {
+        // Pass 1: discover all @CommandDefinition classes
+        List<CommandCandidate> candidates = new ArrayList<>();
+        Set<DotName> discovered = new HashSet<>();
+
+        for (AnnotationInstance ann : appIndex.getAnnotations(COMMAND_DEFINITION)) {
             if (ann.target().kind() != AnnotationTarget.Kind.CLASS) {
                 continue;
             }
@@ -85,12 +100,62 @@ class AeshProcessor {
 
             String commandName = getAnnotationStringValue(ann, "name", "");
             String description = getAnnotationStringValue(ann, "description", "");
-            List<String> subCommandClassNames = extractGroupSubCommands(ann);
+            List<String> subCommandClassNames = new ArrayList<>(extractGroupSubCommands(ann));
             boolean isGroup = !subCommandClassNames.isEmpty();
 
-            commands.produce(new AeshCommandBuildItem(
+            candidates.add(new CommandCandidate(
                     className.toString(), commandName, description,
-                    isGroup, subCommandClassNames));
+                    isGroup, subCommandClassNames, classInfo));
+        }
+
+        // Pass 2: detect @Inject fields on GroupCommand implementations
+        // whose types are discovered command classes
+        Set<String> discoveredClassNames = candidates.stream()
+                .map(c -> c.className)
+                .collect(Collectors.toSet());
+
+        for (CommandCandidate candidate : candidates) {
+            if (implementsInterface(candidate.classInfo, GROUP_COMMAND, fullIndex)) {
+                for (FieldInfo field : candidate.classInfo.fields()) {
+                    if (field.hasAnnotation(INJECT)) {
+                        String fieldTypeName = field.type().name().toString();
+                        if (discoveredClassNames.contains(fieldTypeName)
+                                && !candidate.subCommandClassNames.contains(fieldTypeName)) {
+                            candidate.subCommandClassNames.add(fieldTypeName);
+                            candidate.isGroup = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Produce build items
+        for (CommandCandidate candidate : candidates) {
+            commands.produce(new AeshCommandBuildItem(
+                    candidate.className, candidate.commandName, candidate.description,
+                    candidate.isGroup, candidate.subCommandClassNames));
+        }
+    }
+
+    /**
+     * Intermediate holder for command data during the two-pass discovery.
+     */
+    private static class CommandCandidate {
+        final String className;
+        final String commandName;
+        final String description;
+        boolean isGroup;
+        final List<String> subCommandClassNames;
+        final ClassInfo classInfo;
+
+        CommandCandidate(String className, String commandName, String description,
+                boolean isGroup, List<String> subCommandClassNames, ClassInfo classInfo) {
+            this.className = className;
+            this.commandName = commandName;
+            this.description = description;
+            this.isGroup = isGroup;
+            this.subCommandClassNames = subCommandClassNames;
+            this.classInfo = classInfo;
         }
     }
 
@@ -232,9 +297,12 @@ class AeshProcessor {
                 DotName.createSimple("org.aesh.command.activator.OptionActivator"),
                 DotName.createSimple("org.aesh.command.result.ResultHandler"),
                 DotName.createSimple("org.aesh.command.renderer.OptionRenderer")));
-        // Also keep user implementations of the Quarkus CliSettings customizer
+        // Also keep user implementations of global aesh interfaces that are
+        // discovered via CDI Instance<> lookup (not via annotation attributes).
         unremovableBean.produce(UnremovableBeanBuildItem.beanTypes(
-                DotName.createSimple(io.quarkus.aesh.runtime.CliSettings.class.getName())));
+                DotName.createSimple(io.quarkus.aesh.runtime.CliSettings.class.getName()),
+                DotName.createSimple("org.aesh.command.CommandExecutionListener"),
+                DotName.createSimple("org.aesh.command.CommandNotFoundHandler")));
     }
 
     /**
@@ -415,5 +483,23 @@ class AeshProcessor {
     private String getAnnotationStringValue(AnnotationInstance annotation, String name, String defaultValue) {
         AnnotationValue value = annotation.value(name);
         return value != null ? value.asString() : defaultValue;
+    }
+
+    /**
+     * Checks whether the given class implements the specified interface,
+     * walking up the class hierarchy.
+     */
+    private boolean implementsInterface(ClassInfo classInfo, DotName interfaceName, IndexView index) {
+        if (classInfo.interfaceNames().contains(interfaceName)) {
+            return true;
+        }
+        DotName superName = classInfo.superName();
+        if (superName != null && !superName.equals(DotName.createSimple("java.lang.Object"))) {
+            ClassInfo superClass = index.getClassByName(superName);
+            if (superClass != null) {
+                return implementsInterface(superClass, interfaceName, index);
+            }
+        }
+        return false;
     }
 }

--- a/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/CommandExecutionListenerTest.java
+++ b/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/CommandExecutionListenerTest.java
@@ -1,0 +1,73 @@
+package io.quarkus.aesh.deployment;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.aesh.command.Command;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandExecutionListener;
+import org.aesh.command.CommandResult;
+import org.aesh.command.invocation.CommandInvocation;
+import org.aesh.command.option.Option;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusProdModeTest;
+
+/**
+ * Tests that a CDI bean implementing {@link CommandExecutionListener} is
+ * automatically discovered and receives callbacks after command execution.
+ */
+public class CommandExecutionListenerTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot(jar -> jar.addClasses(
+                    HelloCmd.class, CalcCmd.class, MyListener.class))
+            .setApplicationName("listener-app")
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .setExpectExit(true)
+            .setRun(true)
+            .setCommandLineParameters("hello", "--name=Listener");
+
+    @Test
+    public void testListenerReceivesCallback() {
+        Assertions.assertThat(config.getStartupConsoleOutput())
+                .contains("Hello Listener!")
+                .contains("[LISTENER] command completed");
+        Assertions.assertThat(config.getExitCode()).isZero();
+    }
+
+    @CommandDefinition(name = "hello", description = "Greet someone")
+    public static class HelloCmd implements Command<CommandInvocation> {
+
+        @Option(shortName = 'n', name = "name", defaultValue = "World")
+        String name;
+
+        @Override
+        public CommandResult execute(CommandInvocation invocation) {
+            invocation.println("Hello " + name + "!");
+            return CommandResult.SUCCESS;
+        }
+    }
+
+    @CommandDefinition(name = "calc", description = "Dummy second command")
+    public static class CalcCmd implements Command<CommandInvocation> {
+
+        @Override
+        public CommandResult execute(CommandInvocation invocation) {
+            return CommandResult.SUCCESS;
+        }
+    }
+
+    @ApplicationScoped
+    public static class MyListener implements CommandExecutionListener {
+
+        @Override
+        public void onCommandComplete(String commandLine, CommandResult result, long executionTimeMs) {
+            System.out.println("[LISTENER] command completed: " + commandLine
+                    + " result=" + (result.isSuccess() ? "SUCCESS" : "FAILURE")
+                    + " time=" + executionTimeMs + "ms");
+        }
+    }
+}

--- a/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/CommandNotFoundHandlerTest.java
+++ b/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/CommandNotFoundHandlerTest.java
@@ -1,0 +1,68 @@
+package io.quarkus.aesh.deployment;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.aesh.command.Command;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandNotFoundHandler;
+import org.aesh.command.CommandResult;
+import org.aesh.command.invocation.CommandInvocation;
+import org.aesh.command.shell.Shell;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusProdModeTest;
+
+/**
+ * Tests that a CDI bean implementing {@link CommandNotFoundHandler} is
+ * automatically discovered and called when an unknown command is typed.
+ */
+public class CommandNotFoundHandlerTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot(jar -> jar.addClasses(
+                    HelloCmd.class, CalcCmd.class, MyNotFoundHandler.class))
+            .setApplicationName("notfound-app")
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .setExpectExit(true)
+            .setRun(true)
+            .setCommandLineParameters("doesnotexist");
+
+    @Test
+    public void testNotFoundHandlerCalled() {
+        Assertions.assertThat(config.getStartupConsoleOutput())
+                .contains("Unknown command: doesnotexist. Try: hello, calc");
+        // Command not found should result in exit code 1
+        Assertions.assertThat(config.getExitCode()).isEqualTo(1);
+    }
+
+    @CommandDefinition(name = "hello", description = "Greet someone")
+    public static class HelloCmd implements Command<CommandInvocation> {
+
+        @Override
+        public CommandResult execute(CommandInvocation invocation) {
+            invocation.println("Hello!");
+            return CommandResult.SUCCESS;
+        }
+    }
+
+    @CommandDefinition(name = "calc", description = "Calculator")
+    public static class CalcCmd implements Command<CommandInvocation> {
+
+        @Override
+        public CommandResult execute(CommandInvocation invocation) {
+            return CommandResult.SUCCESS;
+        }
+    }
+
+    @ApplicationScoped
+    public static class MyNotFoundHandler implements CommandNotFoundHandler {
+
+        @Override
+        public void handleCommandNotFound(String line, Shell shell) {
+            shell.writeln("Unknown command: " + line + ". Try: hello, calc");
+        }
+    }
+}

--- a/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/ConsoleModeSingleExecutionTest.java
+++ b/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/ConsoleModeSingleExecutionTest.java
@@ -1,0 +1,75 @@
+package io.quarkus.aesh.deployment;
+
+import jakarta.inject.Inject;
+
+import org.aesh.command.Command;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandResult;
+import org.aesh.command.invocation.CommandInvocation;
+import org.aesh.command.option.Option;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusProdModeTest;
+
+/**
+ * Tests that a console mode application (multiple commands) can execute
+ * a single command and exit when command-line arguments are provided.
+ * <p>
+ * Without arguments, the application would start the REPL.
+ * With arguments, it executes the command and exits immediately.
+ */
+public class ConsoleModeSingleExecutionTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot(jar -> jar.addClasses(
+                    GreetCmd.class,
+                    CalcCmd.class,
+                    GreetingService.class))
+            .setApplicationName("console-single-exec-app")
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .setExpectExit(true)
+            .setRun(true)
+            .setCommandLineParameters("greet", "--name=Quarkus");
+
+    @Test
+    public void testSingleCommandExecution() {
+        Assertions.assertThat(config.getStartupConsoleOutput())
+                .containsOnlyOnce("Hello Quarkus from CDI!");
+        Assertions.assertThat(config.getExitCode()).isZero();
+    }
+
+    @CommandDefinition(name = "greet", description = "Greet someone")
+    public static class GreetCmd implements Command<CommandInvocation> {
+
+        @Option(shortName = 'n', name = "name", defaultValue = "World")
+        String name;
+
+        @Inject
+        GreetingService greetingService;
+
+        @Override
+        public CommandResult execute(CommandInvocation invocation) {
+            invocation.println(greetingService.greet(name));
+            return CommandResult.SUCCESS;
+        }
+    }
+
+    @CommandDefinition(name = "calc", description = "Add two numbers")
+    public static class CalcCmd implements Command<CommandInvocation> {
+
+        @Option(shortName = 'a', defaultValue = "0")
+        int a;
+
+        @Option(shortName = 'b', defaultValue = "0")
+        int b;
+
+        @Override
+        public CommandResult execute(CommandInvocation invocation) {
+            invocation.println(a + " + " + b + " = " + (a + b));
+            return CommandResult.SUCCESS;
+        }
+    }
+}

--- a/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/GetCommandsSubCommandNotTopLevelTest.java
+++ b/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/GetCommandsSubCommandNotTopLevelTest.java
@@ -1,0 +1,92 @@
+package io.quarkus.aesh.deployment;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.aesh.command.Command;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandResult;
+import org.aesh.command.GroupCommand;
+import org.aesh.command.invocation.CommandInvocation;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusProdModeTest;
+
+/**
+ * Tests that sub-commands discovered via {@code GroupCommand.getCommands()}
+ * (with {@code @Inject} fields) are NOT registered as top-level commands.
+ * <p>
+ * The build-time processor detects {@code @Inject} fields on {@code GroupCommand}
+ * implementations whose types are discovered {@code @CommandDefinition} classes,
+ * and excludes them from top-level registration.
+ */
+public class GetCommandsSubCommandNotTopLevelTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot(jar -> jar.addClasses(
+                    ToolsGroup.class, StatusSub.class, VersionSub.class, InfoService.class))
+            .setApplicationName("getcommands-subcmd-app")
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .setExpectExit(true)
+            .setRun(true)
+            .setCommandLineParameters("status");
+
+    @Test
+    public void testGetCommandsSubCommandViaParent() {
+        // With correct filtering, only "tools" is a top-level command,
+        // so runtime mode is auto-detected. "status" is a sub-command
+        // of "tools", accessible via "tools status".
+        Assertions.assertThat(config.getStartupConsoleOutput())
+                .contains("Info: status (from CDI)");
+        Assertions.assertThat(config.getExitCode()).isZero();
+    }
+
+    @CommandDefinition(name = "tools", description = "Developer tools")
+    public static class ToolsGroup implements GroupCommand<CommandInvocation> {
+
+        @Inject
+        StatusSub statusSub;
+
+        @Inject
+        VersionSub versionSub;
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public List<Command<CommandInvocation>> getCommands() {
+            return List.of(statusSub, versionSub);
+        }
+
+        @Override
+        public CommandResult execute(CommandInvocation invocation) {
+            invocation.println("Use: status, version");
+            return CommandResult.SUCCESS;
+        }
+    }
+
+    @CommandDefinition(name = "status", description = "Show status")
+    public static class StatusSub implements Command<CommandInvocation> {
+
+        @Inject
+        InfoService infoService;
+
+        @Override
+        public CommandResult execute(CommandInvocation invocation) {
+            invocation.println(infoService.getInfo("status"));
+            return CommandResult.SUCCESS;
+        }
+    }
+
+    @CommandDefinition(name = "version", description = "Show version")
+    public static class VersionSub implements Command<CommandInvocation> {
+
+        @Override
+        public CommandResult execute(CommandInvocation invocation) {
+            invocation.println("Version: 1.0.0");
+            return CommandResult.SUCCESS;
+        }
+    }
+}

--- a/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/NestedGetCommandsNotTopLevelTest.java
+++ b/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/NestedGetCommandsNotTopLevelTest.java
@@ -1,0 +1,98 @@
+package io.quarkus.aesh.deployment;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.aesh.command.Command;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandResult;
+import org.aesh.command.GroupCommand;
+import org.aesh.command.invocation.CommandInvocation;
+import org.aesh.command.option.Argument;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusProdModeTest;
+
+/**
+ * Tests nested {@code GroupCommand.getCommands()} with {@code @Inject} children.
+ * Verifies that nested sub-commands are NOT registered as top-level commands.
+ *
+ * Structure: root (GroupCommand) → mid (GroupCommand) → leaf
+ * All children are injected via CDI and returned from getCommands().
+ */
+public class NestedGetCommandsNotTopLevelTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot(jar -> jar.addClasses(
+                    RootGroup.class, MidGroup.class, LeafCmd.class))
+            .setApplicationName("nested-getcommands-app")
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .setExpectExit(true)
+            .setRun(true)
+            .setCommandLineParameters("mid", "leaf", "Nested");
+
+    @Test
+    public void testNestedGetCommandsSubCommandsNotTopLevel() {
+        // "root" is auto-detected as the top command because mid and leaf
+        // are detected as subcommands via @Inject field scanning.
+        // The args "mid leaf --name=Nested" resolve to root → mid → leaf.
+        Assertions.assertThat(config.getStartupConsoleOutput())
+                .contains("Leaf: Nested");
+        Assertions.assertThat(config.getExitCode()).isZero();
+    }
+
+    @CommandDefinition(name = "root", description = "Root group")
+    public static class RootGroup implements GroupCommand<CommandInvocation> {
+
+        @Inject
+        MidGroup midGroup;
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public List<Command<CommandInvocation>> getCommands() {
+            return List.of(midGroup);
+        }
+
+        @Override
+        public CommandResult execute(CommandInvocation invocation) {
+            invocation.println("Use: mid");
+            return CommandResult.SUCCESS;
+        }
+    }
+
+    @CommandDefinition(name = "mid", description = "Mid-level group")
+    public static class MidGroup implements GroupCommand<CommandInvocation> {
+
+        @Inject
+        LeafCmd leafCmd;
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public List<Command<CommandInvocation>> getCommands() {
+            return List.of(leafCmd);
+        }
+
+        @Override
+        public CommandResult execute(CommandInvocation invocation) {
+            invocation.println("Use: leaf");
+            return CommandResult.SUCCESS;
+        }
+    }
+
+    @CommandDefinition(name = "leaf", description = "Leaf command")
+    public static class LeafCmd implements Command<CommandInvocation> {
+
+        @Argument(description = "Name", required = true)
+        String name;
+
+        @Override
+        public CommandResult execute(CommandInvocation invocation) {
+            invocation.println("Leaf: " + name);
+            return CommandResult.SUCCESS;
+        }
+    }
+}

--- a/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/SubCommandNotTopLevelTest.java
+++ b/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/SubCommandNotTopLevelTest.java
@@ -1,0 +1,79 @@
+package io.quarkus.aesh.deployment;
+
+import org.aesh.command.Command;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandResult;
+import org.aesh.command.invocation.CommandInvocation;
+import org.aesh.command.option.Argument;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusProdModeTest;
+
+/**
+ * Tests that sub-commands declared via {@code groupCommands} annotation attribute
+ * are NOT registered as top-level commands. They should only be accessible
+ * through their parent group.
+ * <p>
+ * The app has a group command "app" with sub-commands "add" and "list".
+ * Running "app add test-item" should work because "add" is accessible
+ * as a sub-command of "app". If "add" were also registered as a top-level
+ * command, the mode auto-detection would pick up 3 top-level commands
+ * (app, add, list) and enter console mode instead of runtime mode.
+ */
+public class SubCommandNotTopLevelTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot(jar -> jar.addClasses(
+                    AppGroup.class, AddSub.class, ListSub.class))
+            .setApplicationName("subcmd-not-toplevel-app")
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .setExpectExit(true)
+            .setRun(true)
+            .setCommandLineParameters("add", "test-item");
+
+    @Test
+    public void testSubCommandViaParent() {
+        // With correct filtering, only "app" is a top-level command,
+        // so runtime mode is auto-detected with "app" as the top command.
+        // "add" is accessible as a sub-command of "app".
+        Assertions.assertThat(config.getStartupConsoleOutput())
+                .contains("Added: test-item");
+        Assertions.assertThat(config.getExitCode()).isZero();
+    }
+
+    @CommandDefinition(name = "app", description = "App group", groupCommands = { AddSub.class, ListSub.class })
+    public static class AppGroup implements Command<CommandInvocation> {
+
+        @Override
+        public CommandResult execute(CommandInvocation invocation) {
+            invocation.println("Use: add, list");
+            return CommandResult.SUCCESS;
+        }
+    }
+
+    @CommandDefinition(name = "add", description = "Add an item")
+    public static class AddSub implements Command<CommandInvocation> {
+
+        @Argument(description = "Item name", required = true)
+        String name;
+
+        @Override
+        public CommandResult execute(CommandInvocation invocation) {
+            invocation.println("Added: " + name);
+            return CommandResult.SUCCESS;
+        }
+    }
+
+    @CommandDefinition(name = "list", description = "List items")
+    public static class ListSub implements Command<CommandInvocation> {
+
+        @Override
+        public CommandResult execute(CommandInvocation invocation) {
+            invocation.println("Items: (none)");
+            return CommandResult.SUCCESS;
+        }
+    }
+}

--- a/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/ThreeLevelNestedGroupCommandTest.java
+++ b/extensions/aesh/deployment/src/test/java/io/quarkus/aesh/deployment/ThreeLevelNestedGroupCommandTest.java
@@ -1,0 +1,78 @@
+package io.quarkus.aesh.deployment;
+
+import org.aesh.command.Command;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandResult;
+import org.aesh.command.invocation.CommandInvocation;
+import org.aesh.command.option.Argument;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusProdModeTest;
+
+/**
+ * Tests 3-level nesting of group commands using the {@code groupCommands}
+ * annotation attribute. Verifies that:
+ * <ul>
+ * <li>Only the root command is registered as top-level</li>
+ * <li>Mid-level and leaf commands are NOT top-level</li>
+ * <li>The full command path {@code root mid leaf --name=...} works</li>
+ * </ul>
+ *
+ * Structure: root → mid → leaf
+ */
+public class ThreeLevelNestedGroupCommandTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot(jar -> jar.addClasses(
+                    RootCmd.class, MidCmd.class, LeafCmd.class))
+            .setApplicationName("three-level-nested-app")
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .setExpectExit(true)
+            .setRun(true)
+            .setCommandLineParameters("mid", "leaf", "Deep");
+
+    @Test
+    public void testThreeLevelNesting() {
+        // "root" is auto-detected as top command (it covers mid and leaf).
+        // "mid leaf --name=Deep" is resolved as root → mid → leaf.
+        Assertions.assertThat(config.getStartupConsoleOutput())
+                .contains("Leaf: Deep");
+        Assertions.assertThat(config.getExitCode()).isZero();
+    }
+
+    @CommandDefinition(name = "root", description = "Root group", groupCommands = { MidCmd.class })
+    public static class RootCmd implements Command<CommandInvocation> {
+
+        @Override
+        public CommandResult execute(CommandInvocation invocation) {
+            invocation.println("Use: mid");
+            return CommandResult.SUCCESS;
+        }
+    }
+
+    @CommandDefinition(name = "mid", description = "Mid-level group", groupCommands = { LeafCmd.class })
+    public static class MidCmd implements Command<CommandInvocation> {
+
+        @Override
+        public CommandResult execute(CommandInvocation invocation) {
+            invocation.println("Use: leaf");
+            return CommandResult.SUCCESS;
+        }
+    }
+
+    @CommandDefinition(name = "leaf", description = "Leaf command")
+    public static class LeafCmd implements Command<CommandInvocation> {
+
+        @Argument(description = "Name", required = true)
+        String name;
+
+        @Override
+        public CommandResult execute(CommandInvocation invocation) {
+            invocation.println("Leaf: " + name);
+            return CommandResult.SUCCESS;
+        }
+    }
+}

--- a/extensions/aesh/runtime/src/main/java/io/quarkus/aesh/runtime/CliRunner.java
+++ b/extensions/aesh/runtime/src/main/java/io/quarkus/aesh/runtime/CliRunner.java
@@ -9,7 +9,13 @@ import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Instance;
 
 import org.aesh.AeshConsoleRunner;
+import org.aesh.command.AeshCommandRuntimeBuilder;
+import org.aesh.command.CommandExecutionListener;
+import org.aesh.command.CommandNotFoundHandler;
+import org.aesh.command.CommandResult;
+import org.aesh.command.CommandRuntime;
 import org.aesh.command.impl.registry.AeshCommandRegistryBuilder;
+import org.aesh.command.invocation.CommandInvocation;
 import org.aesh.command.settings.SubCommandModeSettings;
 import org.jboss.logging.Logger;
 
@@ -18,6 +24,10 @@ import io.quarkus.runtime.QuarkusApplication;
 /**
  * Quarkus application runner that uses AeshConsoleRunner for interactive shell mode.
  * This provides a REPL (Read-Eval-Print Loop) where users can type multiple commands.
+ * <p>
+ * If command-line arguments are provided, the command is executed once and the
+ * application exits (like runtime mode). If no arguments are provided, the
+ * interactive REPL starts.
  */
 @Dependent
 public class CliRunner implements QuarkusApplication {
@@ -27,18 +37,98 @@ public class CliRunner implements QuarkusApplication {
     private final CliCommandRegistryFactory registryFactory;
     private final CliConfig configuration;
     private final Instance<CliSettings> customizers;
+    private final Instance<CommandExecutionListener> executionListener;
+    private final Instance<CommandNotFoundHandler> commandNotFoundHandler;
 
     public CliRunner(CliCommandRegistryFactory registryFactory,
             CliConfig configuration,
-            Instance<CliSettings> customizers) {
+            Instance<CliSettings> customizers,
+            Instance<CommandExecutionListener> executionListener,
+            Instance<CommandNotFoundHandler> commandNotFoundHandler) {
         this.registryFactory = registryFactory;
         this.configuration = configuration;
         this.customizers = customizers;
+        this.executionListener = executionListener;
+        this.commandNotFoundHandler = commandNotFoundHandler;
     }
 
     @Override
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public int run(String... args) {
+        if (args != null && args.length > 0) {
+            return executeAndExit(args);
+        }
+        return startRepl();
+    }
+
+    /**
+     * Execute a single command from the provided arguments and exit.
+     * The arguments are joined into a single command line string
+     * (quoting args that contain spaces) and executed against the
+     * console mode command registry.
+     */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private int executeAndExit(String... args) {
+        try {
+            var registryBuilder = registryFactory.create();
+            var registry = ((AeshCommandRegistryBuilder) registryBuilder).create();
+
+            var runtimeBuilder = AeshCommandRuntimeBuilder.<CommandInvocation> builder()
+                    .commandRegistry(registry);
+
+            if (commandNotFoundHandler.isResolvable()) {
+                runtimeBuilder.commandNotFoundHandler(commandNotFoundHandler.get());
+            }
+
+            CommandRuntime<CommandInvocation> runtime = runtimeBuilder.build();
+
+            String commandLine = joinArgs(args);
+            long startTime = System.currentTimeMillis();
+            CommandResult result = runtime.executeCommand(commandLine);
+            long executionTime = System.currentTimeMillis() - startTime;
+
+            if (result == null) {
+                result = CommandResult.SUCCESS;
+            }
+
+            if (executionListener.isResolvable()) {
+                executionListener.get().onCommandComplete(commandLine, result, executionTime);
+            }
+
+            if (result.isSuccess()) {
+                return 0;
+            }
+            return result.getExitCode();
+        } catch (Exception e) {
+            LOG.error("Error executing command", e);
+            return 1;
+        }
+    }
+
+    /**
+     * Join command-line arguments into a single command string,
+     * quoting arguments that contain spaces.
+     */
+    private static String joinArgs(String[] args) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < args.length; i++) {
+            if (i > 0) {
+                sb.append(' ');
+            }
+            if (args[i].contains(" ")) {
+                sb.append('"').append(args[i]).append('"');
+            } else {
+                sb.append(args[i]);
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Start the interactive REPL (Read-Eval-Print Loop).
+     */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private int startRepl() {
         try {
             var registryBuilder = registryFactory.create();
 
@@ -63,6 +153,10 @@ public class CliRunner implements QuarkusApplication {
                 settingsBuilder.historyFile(new File(configuration.historyFile().get()));
             }
 
+            if (commandNotFoundHandler.isResolvable()) {
+                settingsBuilder.commandNotFoundHandler(commandNotFoundHandler.get());
+            }
+
             var settings = settingsBuilder.build();
 
             AeshConsoleRunner runner = AeshConsoleRunner.builder()
@@ -70,20 +164,44 @@ public class CliRunner implements QuarkusApplication {
                     .settings(settings)
                     .prompt(configuration.prompt());
 
-            // Wire test connection and listener if set by the test framework.
-            // The AeshTestThread carries the streams and signal queue directly,
-            // avoiding System.getProperties() which breaks libraries like Narayana
-            // that iterate all property names.
-            InputStream testInput = AeshTestConnectionHolder.getInput();
-            OutputStream testOutput = AeshTestConnectionHolder.getOutput();
-            LinkedBlockingQueue<Object> signalQueue = AeshTestConnectionHolder.getSignalQueue();
+            // Wire user-provided CommandExecutionListener
+            if (executionListener.isResolvable()) {
+                CommandExecutionListener userListener = executionListener.get();
 
-            if (testInput != null && testOutput != null) {
-                LOG.debug("Test mode: using stream-based connection");
-                runner.connection(new AeshStreamConnection(testInput, testOutput));
+                // Wire test connection and listener if set by the test framework
+                InputStream testInput = AeshTestConnectionHolder.getInput();
+                OutputStream testOutput = AeshTestConnectionHolder.getOutput();
+                LinkedBlockingQueue<Object> signalQueue = AeshTestConnectionHolder.getSignalQueue();
 
-                if (signalQueue != null) {
-                    runner.onCommandComplete(result -> signalQueue.offer("done"));
+                if (testInput != null && testOutput != null) {
+                    LOG.debug("Test mode: using stream-based connection");
+                    runner.connection(new AeshStreamConnection(testInput, testOutput));
+
+                    if (signalQueue != null) {
+                        // Compose user listener with test signal
+                        runner.commandExecutionListener((commandLine, result, executionTime) -> {
+                            userListener.onCommandComplete(commandLine, result, executionTime);
+                            signalQueue.offer("done");
+                        });
+                    } else {
+                        runner.commandExecutionListener(userListener);
+                    }
+                } else {
+                    runner.commandExecutionListener(userListener);
+                }
+            } else {
+                // No user listener -- only wire test connection if present
+                InputStream testInput = AeshTestConnectionHolder.getInput();
+                OutputStream testOutput = AeshTestConnectionHolder.getOutput();
+                LinkedBlockingQueue<Object> signalQueue = AeshTestConnectionHolder.getSignalQueue();
+
+                if (testInput != null && testOutput != null) {
+                    LOG.debug("Test mode: using stream-based connection");
+                    runner.connection(new AeshStreamConnection(testInput, testOutput));
+
+                    if (signalQueue != null) {
+                        runner.onCommandComplete(result -> signalQueue.offer("done"));
+                    }
                 }
             }
 

--- a/extensions/aesh/runtime/src/main/java/io/quarkus/aesh/runtime/DefaultCliCommandRegistryFactory.java
+++ b/extensions/aesh/runtime/src/main/java/io/quarkus/aesh/runtime/DefaultCliCommandRegistryFactory.java
@@ -1,5 +1,8 @@
 package io.quarkus.aesh.runtime;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 
@@ -8,22 +11,30 @@ import org.aesh.command.DefaultValueProvider;
 import org.aesh.command.impl.registry.AeshCommandRegistryBuilder;
 import org.aesh.command.invocation.CommandInvocation;
 
+import io.quarkus.arc.ClientProxy;
+
 /**
  * Default implementation of CliCommandRegistryFactory that resolves commands from CDI.
- * It collects all {@code Command} beans and registers them in the command registry
- * for console (interactive shell) mode.
+ * It collects all {@code Command} beans and registers only top-level commands
+ * in the command registry. Sub-commands (declared via {@code groupCommands}
+ * annotation attribute or detected as {@code @Inject} fields on
+ * {@code GroupCommand} implementations) are excluded -- they are registered
+ * automatically by aesh when processing their parent group command.
  */
 @ApplicationScoped
 public class DefaultCliCommandRegistryFactory implements CliCommandRegistryFactory {
 
     private final Instance<Command<? extends CommandInvocation>> commands;
     private final Instance<DefaultValueProvider> defaultValueProvider;
+    private final AeshContext aeshContext;
 
     @SuppressWarnings("unchecked")
     public DefaultCliCommandRegistryFactory(Instance<Command<? extends CommandInvocation>> commands,
-            Instance<DefaultValueProvider> defaultValueProvider) {
+            Instance<DefaultValueProvider> defaultValueProvider,
+            AeshContext aeshContext) {
         this.commands = commands;
         this.defaultValueProvider = defaultValueProvider;
+        this.aeshContext = aeshContext;
     }
 
     @Override
@@ -36,15 +47,36 @@ public class DefaultCliCommandRegistryFactory implements CliCommandRegistryFacto
             builder.defaultValueProvider(defaultValueProvider.get());
         }
 
+        // Collect all subcommand class names so we only register top-level commands.
+        // Subcommands are registered by aesh when processing their parent group.
+        Set<String> subCommandClasses = new HashSet<>();
+        for (AeshCommandMetadata meta : aeshContext.getCommands()) {
+            subCommandClasses.addAll(meta.getSubCommandClassNames());
+        }
+
         for (Command command : commands) {
+            String className = unwrapClassName(command);
+            if (subCommandClasses.contains(className)) {
+                continue;
+            }
             try {
                 builder.command(command);
             } catch (Exception e) {
                 throw new RuntimeException(
-                        "Failed to register command: " + command.getClass().getName(), e);
+                        "Failed to register command: " + className, e);
             }
         }
 
         return builder;
+    }
+
+    /**
+     * Unwrap CDI proxy class names to get the actual bean class name.
+     */
+    private static String unwrapClassName(Object bean) {
+        if (bean instanceof ClientProxy) {
+            return bean.getClass().getSuperclass().getName();
+        }
+        return bean.getClass().getName();
     }
 }

--- a/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketAuthenticatedTest.java
+++ b/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketAuthenticatedTest.java
@@ -35,6 +35,7 @@ public class AeshWebSocketAuthenticatedTest {
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .withApplicationRoot(jar -> jar.addClasses(
+                    AeshWebSocketTestHelper.class,
                     HelloCommand.class,
                     GoodbyeCommand.class,
                     TestIdentityProvider.class,
@@ -79,7 +80,7 @@ public class AeshWebSocketAuthenticatedTest {
 
     @Test
     public void testAuthenticatedConnectionSucceeds() throws Exception {
-        CopyOnWriteArrayList<String> messages = new CopyOnWriteArrayList<>();
+        StringBuilder output = new StringBuilder();
         CountDownLatch latch = new CountDownLatch(1);
 
         WebSocketClient client = vertx.createWebSocketClient();
@@ -95,28 +96,16 @@ public class AeshWebSocketAuthenticatedTest {
                 return;
             }
             var ws = ar.result();
-
-            ws.textMessageHandler(msg -> {
-                messages.add(msg);
-                if (msg.contains("Hello World!")) {
-                    latch.countDown();
-                }
-            });
-
+            AeshWebSocketTestHelper.sendCommandOnPrompt(ws, "hello", "Hello World!", output, latch);
             ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
-
-            vertx.setTimer(500, id -> {
-                ws.writeTextMessage("{\"action\":\"read\",\"data\":\"hello\\r\"}");
-            });
         });
 
-        boolean completed = latch.await(10, TimeUnit.SECONDS);
-        String allOutput = String.join("", messages);
+        boolean completed = latch.await(30, TimeUnit.SECONDS);
 
         Assertions.assertThat(completed)
-                .as("Expected to receive 'Hello World!' in WebSocket output within 10s. Received: %s", allOutput)
+                .as("Expected to receive 'Hello World!' in WebSocket output within 30s. Received: %s", output)
                 .isTrue();
-        Assertions.assertThat(allOutput).contains("Hello World!");
+        Assertions.assertThat(output.toString()).contains("Hello World!");
     }
 
     private static String basicAuth(String username, String password) {

--- a/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketConcurrentSessionsTest.java
+++ b/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketConcurrentSessionsTest.java
@@ -32,7 +32,8 @@ public class AeshWebSocketConcurrentSessionsTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
-            .withApplicationRoot(jar -> jar.addClasses(HelloCommand.class));
+            .withApplicationRoot(jar -> jar.addClasses(
+                    AeshWebSocketTestHelper.class, HelloCommand.class));
 
     @TestHTTPResource("/aesh/terminal")
     URI wsUri;
@@ -62,19 +63,24 @@ public class AeshWebSocketConcurrentSessionsTest {
                         return;
                     }
                     var ws = ar.result();
-
-                    ws.textMessageHandler(msg -> {
-                        if (msg.contains("Hello World!")) {
-                            results.add(msg);
-                            allDone.countDown();
+                    // Each session gets its own output buffer for reliable prompt detection
+                    StringBuilder sessionOutput = new StringBuilder();
+                    CountDownLatch sessionLatch = new CountDownLatch(1);
+                    AeshWebSocketTestHelper.sendCommandOnPrompt(ws, "hello", "Hello World!",
+                            sessionOutput, sessionLatch);
+                    // When this session's command completes, add to shared results
+                    new Thread(() -> {
+                        try {
+                            if (sessionLatch.await(30, TimeUnit.SECONDS)) {
+                                results.add(sessionOutput.toString());
+                            }
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
                         }
-                    });
+                        allDone.countDown();
+                    }).start();
 
-                    // Initialize terminal then send command
                     ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
-                    vertx.setTimer(500, id -> {
-                        ws.writeTextMessage("{\"action\":\"read\",\"data\":\"hello\\r\"}");
-                    });
                 });
             }
 

--- a/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketConnectionTest.java
+++ b/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketConnectionTest.java
@@ -1,7 +1,6 @@
 package io.quarkus.aesh.websocket.deployment;
 
 import java.net.URI;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -24,16 +23,13 @@ import io.vertx.core.http.WebSocketConnectOptions;
 
 /**
  * End-to-end integration test for the aesh WebSocket terminal extension.
- * <p>
- * Connects a Vert.x WebSocket client to the {@code /aesh/terminal} endpoint,
- * sends an init message followed by a command, and verifies the expected output
- * appears in the terminal response.
  */
 public class AeshWebSocketConnectionTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .withApplicationRoot(jar -> jar.addClasses(
+                    AeshWebSocketTestHelper.class,
                     HelloCommand.class,
                     GoodbyeCommand.class));
 
@@ -45,7 +41,7 @@ public class AeshWebSocketConnectionTest {
 
     @Test
     public void testWebSocketConnection() throws Exception {
-        CopyOnWriteArrayList<String> messages = new CopyOnWriteArrayList<>();
+        StringBuilder output = new StringBuilder();
         CountDownLatch latch = new CountDownLatch(1);
 
         WebSocketClient client = vertx.createWebSocketClient();
@@ -60,30 +56,16 @@ public class AeshWebSocketConnectionTest {
                 return;
             }
             var ws = ar.result();
-
-            ws.textMessageHandler(msg -> {
-                messages.add(msg);
-                if (msg.contains("Hello World!")) {
-                    latch.countDown();
-                }
-            });
-
-            // Send init message to set up the terminal
+            AeshWebSocketTestHelper.sendCommandOnPrompt(ws, "hello", "Hello World!", output, latch);
             ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
-
-            // After a short delay, send the hello command
-            vertx.setTimer(500, id -> {
-                ws.writeTextMessage("{\"action\":\"read\",\"data\":\"hello\\r\"}");
-            });
         });
 
-        boolean completed = latch.await(10, TimeUnit.SECONDS);
-        String allOutput = String.join("", messages);
+        boolean completed = latch.await(30, TimeUnit.SECONDS);
 
         Assertions.assertThat(completed)
-                .as("Expected to receive 'Hello World!' in WebSocket output within 10s. Received: %s", allOutput)
+                .as("Expected to receive 'Hello World!' in WebSocket output within 30s. Received: %s", output)
                 .isTrue();
-        Assertions.assertThat(allOutput).contains("Hello World!");
+        Assertions.assertThat(output.toString()).contains("Hello World!");
     }
 
     @CommandDefinition(name = "hello", description = "Say hello")

--- a/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketIdleTimeoutTest.java
+++ b/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketIdleTimeoutTest.java
@@ -3,7 +3,6 @@ package io.quarkus.aesh.websocket.deployment;
 import java.net.URI;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import jakarta.inject.Inject;
 
@@ -29,7 +28,8 @@ public class AeshWebSocketIdleTimeoutTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
-            .withApplicationRoot(jar -> jar.addClasses(HelloCommand.class))
+            .withApplicationRoot(jar -> jar.addClasses(
+                    AeshWebSocketTestHelper.class, HelloCommand.class))
             .overrideConfigKey("quarkus.aesh.websocket.idle-timeout", "2s");
 
     @TestHTTPResource("/aesh/terminal")
@@ -40,9 +40,9 @@ public class AeshWebSocketIdleTimeoutTest {
 
     @Test
     public void testIdleSessionIsClosed() throws Exception {
-        AtomicBoolean commandWorked = new AtomicBoolean(false);
         CountDownLatch commandLatch = new CountDownLatch(1);
         CountDownLatch closedLatch = new CountDownLatch(1);
+        StringBuilder output = new StringBuilder();
 
         WebSocketClient client = vertx.createWebSocketClient();
         try {
@@ -59,26 +59,18 @@ public class AeshWebSocketIdleTimeoutTest {
                 }
                 var ws = ar.result();
 
-                ws.textMessageHandler(msg -> {
-                    if (msg.contains("Hello World!")) {
-                        commandWorked.set(true);
-                        commandLatch.countDown();
-                    }
-                });
+                AeshWebSocketTestHelper.sendCommandOnPrompt(ws, "hello", "Hello World!",
+                        output, commandLatch);
 
                 ws.closeHandler(v -> closedLatch.countDown());
 
-                // Initialize and send a command
                 ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
-                vertx.setTimer(500, id -> {
-                    ws.writeTextMessage("{\"action\":\"read\",\"data\":\"hello\\r\"}");
-                });
             });
 
             // Verify the command works
-            boolean cmdOk = commandLatch.await(10, TimeUnit.SECONDS);
+            boolean cmdOk = commandLatch.await(30, TimeUnit.SECONDS);
             Assertions.assertThat(cmdOk).as("Command should produce output").isTrue();
-            Assertions.assertThat(commandWorked.get()).isTrue();
+            Assertions.assertThat(output.toString()).contains("Hello World!");
 
             // Now wait for idle timeout (2s timeout + up to 1s check + buffer)
             boolean closed = closedLatch.await(6, TimeUnit.SECONDS);

--- a/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketMaxConnectionsTest.java
+++ b/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketMaxConnectionsTest.java
@@ -1,7 +1,8 @@
 package io.quarkus.aesh.websocket.deployment;
 
 import java.net.URI;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -20,11 +21,17 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.vertx.core.Vertx;
+import io.vertx.core.http.WebSocket;
 import io.vertx.core.http.WebSocketClient;
 import io.vertx.core.http.WebSocketConnectOptions;
 
 /**
  * Verifies that the WebSocket endpoint enforces the max-connections limit.
+ * <p>
+ * The test opens connections sequentially (not concurrently) to avoid
+ * race conditions. Each connection is fully established before the next
+ * one is attempted. The third connection should be rejected because
+ * the max-connections limit (2) has been reached.
  */
 public class AeshWebSocketMaxConnectionsTest {
 
@@ -41,75 +48,82 @@ public class AeshWebSocketMaxConnectionsTest {
 
     @Test
     public void testMaxConnectionsEnforced() throws Exception {
-        CopyOnWriteArrayList<String> results = new CopyOnWriteArrayList<>();
-        CountDownLatch twoConnected = new CountDownLatch(2);
-        AtomicBoolean thirdClosed = new AtomicBoolean(false);
-        CountDownLatch thirdDone = new CountDownLatch(1);
+        List<WebSocket> openSockets = new ArrayList<>();
+        WebSocketClient client = vertx.createWebSocketClient();
 
-        // Open two connections that should succeed
-        for (int i = 0; i < 2; i++) {
-            WebSocketClient client = vertx.createWebSocketClient();
-            WebSocketConnectOptions options = new WebSocketConnectOptions()
+        try {
+            // Open two connections sequentially -- each must succeed
+            for (int i = 0; i < 2; i++) {
+                CountDownLatch connected = new CountDownLatch(1);
+                AtomicBoolean success = new AtomicBoolean(false);
+
+                WebSocketConnectOptions options = new WebSocketConnectOptions()
+                        .setHost(wsUri.getHost())
+                        .setPort(wsUri.getPort())
+                        .setURI(wsUri.getPath());
+
+                client.connect(options).onComplete(ar -> {
+                    if (ar.succeeded()) {
+                        var ws = ar.result();
+                        openSockets.add(ws);
+                        // Send init to register the session on the server
+                        ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
+                        success.set(true);
+                    }
+                    connected.countDown();
+                });
+
+                boolean ok = connected.await(30, TimeUnit.SECONDS);
+                Assertions.assertThat(ok).as("Connection %d should complete within 30s", i + 1).isTrue();
+                Assertions.assertThat(success.get()).as("Connection %d should succeed", i + 1).isTrue();
+
+                // Small delay to ensure the server processes the init message
+                // and registers the session before opening the next connection
+                Thread.sleep(500);
+            }
+
+            // Third connection should be rejected or closed by the server
+            CountDownLatch thirdDone = new CountDownLatch(1);
+            AtomicBoolean thirdRejected = new AtomicBoolean(false);
+
+            WebSocketConnectOptions options3 = new WebSocketConnectOptions()
                     .setHost(wsUri.getHost())
                     .setPort(wsUri.getPort())
                     .setURI(wsUri.getPath());
 
-            client.connect(options).onComplete(ar -> {
+            client.connect(options3).onComplete(ar -> {
                 if (ar.failed()) {
-                    results.add("CONNECT_FAILED");
-                    twoConnected.countDown();
+                    // Connection rejected at handshake level
+                    thirdRejected.set(true);
+                    thirdDone.countDown();
                     return;
                 }
                 var ws = ar.result();
-                AtomicBoolean commandSent = new AtomicBoolean(false);
-                ws.textMessageHandler(msg -> {
-                    // Wait for the prompt before sending the command
-                    if (!commandSent.get() && msg.contains("$")) {
-                        commandSent.set(true);
-                        ws.writeTextMessage("{\"action\":\"read\",\"data\":\"hello\\r\"}");
-                    }
-                    if (msg.contains("Hello World!")) {
-                        results.add(msg);
-                        twoConnected.countDown();
-                    }
+                ws.closeHandler(v -> {
+                    // Server closed the connection after init
+                    thirdRejected.set(true);
+                    thirdDone.countDown();
                 });
+                // Send init to trigger the max-connections check on the server
                 ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
             });
-        }
 
-        boolean twoOk = twoConnected.await(15, TimeUnit.SECONDS);
-        Assertions.assertThat(twoOk)
-                .as("First two connections should succeed. Got: %s", results)
-                .isTrue();
-        Assertions.assertThat(results).hasSize(2);
+            boolean done = thirdDone.await(30, TimeUnit.SECONDS);
+            Assertions.assertThat(done).as("Third connection attempt should complete within 30s").isTrue();
+            Assertions.assertThat(thirdRejected.get())
+                    .as("Third connection should be rejected by server (max-connections=2)")
+                    .isTrue();
 
-        // Third connection should be rejected
-        WebSocketClient client3 = vertx.createWebSocketClient();
-        WebSocketConnectOptions options3 = new WebSocketConnectOptions()
-                .setHost(wsUri.getHost())
-                .setPort(wsUri.getPort())
-                .setURI(wsUri.getPath());
-
-        client3.connect(options3).onComplete(ar -> {
-            if (ar.failed()) {
-                thirdClosed.set(true);
-                thirdDone.countDown();
-                return;
+        } finally {
+            for (WebSocket ws : openSockets) {
+                try {
+                    ws.close();
+                } catch (Exception e) {
+                    // ignore cleanup errors
+                }
             }
-            var ws = ar.result();
-            ws.closeHandler(v -> {
-                thirdClosed.set(true);
-                thirdDone.countDown();
-            });
-            // Send init to trigger the max-connections check
-            ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
-        });
-
-        boolean done = thirdDone.await(30, TimeUnit.SECONDS);
-        Assertions.assertThat(done).as("Third connection attempt should complete").isTrue();
-        Assertions.assertThat(thirdClosed.get())
-                .as("Third connection should be closed by server")
-                .isTrue();
+            client.close();
+        }
     }
 
     @CommandDefinition(name = "hello", description = "Say hello")

--- a/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketRolesAllowedTest.java
+++ b/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketRolesAllowedTest.java
@@ -35,6 +35,7 @@ public class AeshWebSocketRolesAllowedTest {
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .withApplicationRoot(jar -> jar.addClasses(
+                    AeshWebSocketTestHelper.class,
                     HelloCommand.class,
                     GoodbyeCommand.class,
                     TestIdentityProvider.class,
@@ -81,7 +82,7 @@ public class AeshWebSocketRolesAllowedTest {
 
     @Test
     public void testCorrectRoleSucceeds() throws Exception {
-        CopyOnWriteArrayList<String> messages = new CopyOnWriteArrayList<>();
+        StringBuilder output = new StringBuilder();
         CountDownLatch latch = new CountDownLatch(1);
 
         WebSocketClient client = vertx.createWebSocketClient();
@@ -97,28 +98,16 @@ public class AeshWebSocketRolesAllowedTest {
                 return;
             }
             var ws = ar.result();
-
-            ws.textMessageHandler(msg -> {
-                messages.add(msg);
-                if (msg.contains("Hello World!")) {
-                    latch.countDown();
-                }
-            });
-
+            AeshWebSocketTestHelper.sendCommandOnPrompt(ws, "hello", "Hello World!", output, latch);
             ws.writeTextMessage("{\"action\":\"init\",\"cols\":80,\"rows\":24}");
-
-            vertx.setTimer(500, id -> {
-                ws.writeTextMessage("{\"action\":\"read\",\"data\":\"hello\\r\"}");
-            });
         });
 
-        boolean completed = latch.await(10, TimeUnit.SECONDS);
-        String allOutput = String.join("", messages);
+        boolean completed = latch.await(30, TimeUnit.SECONDS);
 
         Assertions.assertThat(completed)
-                .as("Expected to receive 'Hello World!' in WebSocket output within 10s. Received: %s", allOutput)
+                .as("Expected to receive 'Hello World!' in WebSocket output within 30s. Received: %s", output)
                 .isTrue();
-        Assertions.assertThat(allOutput).contains("Hello World!");
+        Assertions.assertThat(output.toString()).contains("Hello World!");
     }
 
     private static String basicAuth(String username, String password) {

--- a/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketTestHelper.java
+++ b/extensions/aesh/websocket/deployment/src/test/java/io/quarkus/aesh/websocket/deployment/AeshWebSocketTestHelper.java
@@ -1,0 +1,54 @@
+package io.quarkus.aesh.websocket.deployment;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
+
+import io.vertx.core.http.WebSocket;
+
+/**
+ * Helper for aesh WebSocket tests that handles prompt detection reliably.
+ * <p>
+ * Terminal output arrives as fragmented WebSocket messages. The prompt
+ * characters may be split across multiple messages or embedded in ANSI
+ * escape sequences. This helper accumulates all output in a thread-safe
+ * buffer and checks the full buffer for the prompt.
+ */
+final class AeshWebSocketTestHelper {
+
+    private static final Pattern ANSI_PATTERN = Pattern.compile("\\u001B\\[[;\\d]*[a-zA-Z]");
+
+    private AeshWebSocketTestHelper() {
+    }
+
+    /**
+     * Sets up a text message handler on the WebSocket that:
+     * <ol>
+     * <li>Accumulates all output in {@code outputBuffer}</li>
+     * <li>Sends the command once the prompt is detected in the accumulated output</li>
+     * <li>Counts down the latch when {@code expectedOutput} appears</li>
+     * </ol>
+     */
+    static void sendCommandOnPrompt(WebSocket ws, String command, String expectedOutput,
+            StringBuilder outputBuffer, CountDownLatch latch) {
+        AtomicBoolean commandSent = new AtomicBoolean(false);
+        AtomicBoolean resultFound = new AtomicBoolean(false);
+
+        ws.textMessageHandler(msg -> {
+            outputBuffer.append(msg);
+            String stripped = ANSI_PATTERN.matcher(outputBuffer.toString()).replaceAll("");
+
+            if (!commandSent.get() && stripped.contains("$ ")) {
+                if (commandSent.compareAndSet(false, true)) {
+                    ws.writeTextMessage("{\"action\":\"read\",\"data\":\"" + command + "\\r\"}");
+                }
+            }
+
+            if (!resultFound.get() && stripped.contains(expectedOutput)) {
+                if (resultFound.compareAndSet(false, true)) {
+                    latch.countDown();
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
Bump aesh to 3.16.3 and aesh-readline to 3.16.2

Add ModuleEnableNativeAccessBuildItem for terminal-tty to suppress the java.lang.foreign.Linker restricted method warning on JDK 22+.

When command-line arguments are provided in console mode, execute the command and exit instead of entering the REPL. Without arguments, the interactive REPL starts as before.

