### PR TITLE
Sanitize derived group name in container image build

### DIFF
--- a/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/ContainerImageProcessor.java
+++ b/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/ContainerImageProcessor.java
@@ -126,18 +126,22 @@ public class ContainerImageProcessor {
     }
 
     /**
-     * Since user.name which is default value can be uppercase and uppercase values
-     * are not allowed
-     * in the repository part of image references, we need to make the username
-     * lowercase.
-     * If spaces exist in the user name, we replace them with the dash character.
+     * Resolve the effective container image group.
      *
-     * We purposely don't change the value of an explicitly set group.
+     * If a group is provided, use it. Otherwise, unless a single-segment image
+     * was requested or the group property was explicitly specified, derive the
+     * group from user.name.
+     *
+     * The derived user.name value is sanitized to better align with container image
+     * group/namespace/registry naming rules.
+     *
+     * The resulting value is then lowercased and empty values are discarded.
      */
     static Optional<String> getEffectiveGroup(Optional<String> group, boolean isSingleSegmentRequested) {
         return group.or(() -> isSingleSegmentRequested || isGroupSpecified()
                 ? Optional.empty()
-                : Optional.ofNullable(System.getProperty("user.name")).map(s -> s.replace(' ', '-')))
+                : Optional.ofNullable(System.getProperty("user.name"))
+                        .map(ContainerImageProcessor::sanitizeDerivedGroupName))
                 .map(String::toLowerCase)
                 .filter(Predicate.not(StringUtil::isNullOrEmpty));
     }
@@ -154,5 +158,15 @@ public class ContainerImageProcessor {
     static boolean isGroupSpecified() {
         return StreamSupport.stream(ConfigProvider.getConfig().getPropertyNames().spliterator(), false)
                 .anyMatch(n -> n.equals("quarkus.container-image.group") || n.equals("QUARKUS_CONTAINER_IMAGE_GROUP"));
+    }
+
+    private static String sanitizeDerivedGroupName(String userName) {
+        return userName
+                // Replace any disallowed character(s) with a single dash
+                .replaceAll("[^A-Za-z0-9._-]+", "-")
+                // Collapse repeats of the same separator into one
+                .replaceAll("([._-])\\1+", "$1")
+                // Trim leading/trailing separators
+                .replaceAll("^[._-]+|[._-]+$", "");
     }
 }

--- a/extensions/container-image/deployment/src/test/java/io/quarkus/container/image/deployment/ContainerImageConfigEffectiveGroupTest.java
+++ b/extensions/container-image/deployment/src/test/java/io/quarkus/container/image/deployment/ContainerImageConfigEffectiveGroupTest.java
@@ -12,34 +12,140 @@ class ContainerImageConfigEffectiveGroupTest {
     private final Optional<String> EMPTY = Optional.empty();
 
     @Test
+    void testSingleSegmentRequestedYieldsEmpty() {
+        testWithNewUsername("test", () -> {
+            assertEquals(EMPTY,
+                    ContainerImageProcessor.getEffectiveGroup(EMPTY, true));
+        });
+    }
+
+    @Test
+    void testExplicitGroupOverridesUsername() {
+        testWithNewUsername("test", () -> {
+            Optional<String> group = Optional.of("other");
+            assertEquals(Optional.of("other"),
+                    ContainerImageProcessor.getEffectiveGroup(group, false));
+        });
+    }
+
+    @Test
+    void testExplicitGroupIsLowercasedButNotSanitized() {
+        testWithNewUsername("test", () -> {
+            Optional<String> group = Optional.of("USER@domain.com");
+            assertEquals(Optional.of("user@domain.com"),
+                    ContainerImageProcessor.getEffectiveGroup(group, false));
+        });
+    }
+
+    @Test
     void testFromLowercaseUsername() {
         testWithNewUsername("test", () -> {
-            Optional<String> group = Optional.of(System.getProperty(USER_NAME_SYSTEM_PROPERTY));
-            assertEquals(ContainerImageProcessor.getEffectiveGroup(EMPTY, false), Optional.of("test"));
+            assertEquals(Optional.of("test"),
+                    ContainerImageProcessor.getEffectiveGroup(EMPTY, false));
         });
     }
 
     @Test
     void testFromUppercaseUsername() {
         testWithNewUsername("TEST", () -> {
-            Optional<String> group = Optional.of(System.getProperty(USER_NAME_SYSTEM_PROPERTY));
-            assertEquals(ContainerImageProcessor.getEffectiveGroup(EMPTY, false), Optional.of("test"));
+            assertEquals(Optional.of("test"),
+                    ContainerImageProcessor.getEffectiveGroup(EMPTY, false));
+        });
+    }
+
+    @Test
+    void testPreservesDotsUnderscoresAndHyphensInUsername() {
+        testWithNewUsername("t.e-s_t", () -> {
+            assertEquals(Optional.of("t.e-s_t"),
+                    ContainerImageProcessor.getEffectiveGroup(EMPTY, false));
+        });
+    }
+
+    @Test
+    void testPreservesDigitsInUsername() {
+        testWithNewUsername("t3st", () -> {
+            assertEquals(Optional.of("t3st"),
+                    ContainerImageProcessor.getEffectiveGroup(EMPTY, false));
         });
     }
 
     @Test
     void testFromSpaceInUsername() {
-        testWithNewUsername("user name", () -> {
-            Optional<String> group = Optional.of(System.getProperty(USER_NAME_SYSTEM_PROPERTY));
-            assertEquals(ContainerImageProcessor.getEffectiveGroup(EMPTY, false), Optional.of("user-name"));
+        testWithNewUsername("test user", () -> {
+            assertEquals(Optional.of("test-user"),
+                    ContainerImageProcessor.getEffectiveGroup(EMPTY, false));
         });
     }
 
     @Test
-    void testFromOther() {
-        testWithNewUsername("WhateveR", () -> {
-            Optional<String> group = Optional.of("OtheR");
-            assertEquals(ContainerImageProcessor.getEffectiveGroup(group, false), Optional.of("other"));
+    void testFromFullyQualifiedDomainNameInUsername() {
+        testWithNewUsername("test@domain.com", () -> {
+            assertEquals(Optional.of("test-domain.com"),
+                    ContainerImageProcessor.getEffectiveGroup(EMPTY, false));
+        });
+    }
+
+    @Test
+    void testCollapsesRepeatedUnderscores() {
+        testWithNewUsername("test__user", () -> {
+            assertEquals(Optional.of("test_user"),
+                    ContainerImageProcessor.getEffectiveGroup(EMPTY, false));
+        });
+    }
+
+    @Test
+    void testCollapsesRepeatedHyphens() {
+        testWithNewUsername("test--user", () -> {
+            assertEquals(Optional.of("test-user"),
+                    ContainerImageProcessor.getEffectiveGroup(EMPTY, false));
+        });
+    }
+
+    @Test
+    void testCollapsesRepeatedDots() {
+        testWithNewUsername("test..user", () -> {
+            assertEquals(Optional.of("test.user"),
+                    ContainerImageProcessor.getEffectiveGroup(EMPTY, false));
+        });
+    }
+
+    @Test
+    void testReplacesRunOfInvalidCharactersWithSingleDash() {
+        testWithNewUsername("test@#*user", () -> {
+            assertEquals(Optional.of("test-user"),
+                    ContainerImageProcessor.getEffectiveGroup(EMPTY, false));
+        });
+    }
+
+    @Test
+    void testTrimsLeadingSeparators() {
+        testWithNewUsername("__test", () -> {
+            assertEquals(Optional.of("test"),
+                    ContainerImageProcessor.getEffectiveGroup(EMPTY, false));
+        });
+    }
+
+    @Test
+    void testTrimsTrailingSeparators() {
+        testWithNewUsername("test__", () -> {
+            assertEquals(Optional.of("test"),
+                    ContainerImageProcessor.getEffectiveGroup(EMPTY, false));
+        });
+    }
+
+    @Test
+    void testTrimsLeadingAndTrailingMixedSeparators() {
+        testWithNewUsername("_-test-_", () -> {
+            assertEquals(Optional.of("test"),
+                    ContainerImageProcessor.getEffectiveGroup(EMPTY, false));
+        });
+    }
+
+    @Test
+    void testSeparatorOnlyUsernameYieldsEmpty() {
+        testWithNewUsername("._-", () -> {
+            assertEquals(EMPTY,
+                    ContainerImageProcessor.getEffectiveGroup(EMPTY, false));
         });
     }
 


### PR DESCRIPTION
Sanitize the derived container image group from `user.name` by replacing invalid characters with `-` when `quarkus.container-image.group` is not explicitly set. 

This prevents failures for usernames like `user@domain.com` while preserving existing explicit group behavior.

* Fixes #55226 