### PR TITLE
Add Gradle component variant regression tests

### DIFF
--- a/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/QuarkusExtensionPluginTest.java
+++ b/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/QuarkusExtensionPluginTest.java
@@ -5,8 +5,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileSystem;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 
 import org.assertj.core.api.Assertions;
@@ -85,5 +88,157 @@ public class QuarkusExtensionPluginTest {
                 .withArguments("build", ":deployment:dependencies", "--configuration", "annotationProcessor")
                 .build();
         assertThat(dependencies.getOutput()).contains(QuarkusExtensionPlugin.QUARKUS_ANNOTATION_PROCESSOR);
+    }
+
+    @Test
+    public void deploymentTestShouldGenerateApplicationModelWithComponentVariants() throws IOException {
+        createExtensionProjectWithDeploymentTest();
+
+        BuildResult test = runGradle(":deployment:test");
+
+        assertThat(test.task(":deployment:test").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(test.getOutput()).doesNotContain("cannot choose between the following variants");
+        assertDeploymentTestApplicationModelMarker();
+    }
+
+    @Test
+    public void deploymentTestShouldGenerateApplicationModelWithoutComponentVariants() throws IOException {
+        createExtensionProjectWithDeploymentTest();
+
+        BuildResult test = runGradle(":deployment:test", "-PdisableQuarkusComponentVariants=true");
+
+        assertThat(test.task(":deployment:test").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertDeploymentTestApplicationModelMarker();
+    }
+
+    @Test
+    public void noArgApplicationModelBuilderShouldResolveDeploymentProjectWithComponentVariants() throws IOException {
+        createExtensionProjectWithDeploymentTest();
+
+        BuildResult model = runGradle(":runtime:resolveDeploymentTestApplicationModel");
+
+        assertThat(model.task(":runtime:resolveDeploymentTestApplicationModel").getOutcome())
+                .isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(model.getOutput()).contains("resolved deployment test application model");
+    }
+
+    private BuildResult runGradle(String... arguments) {
+        List<String> gradleArguments = new ArrayList<>(List.of(arguments));
+        gradleArguments.add("-S");
+        return GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(testProjectDir)
+                .withArguments(gradleArguments)
+                .build();
+    }
+
+    private void createExtensionProjectWithDeploymentTest() throws IOException {
+        File runtimeModule = new File(testProjectDir, "runtime");
+        runtimeModule.mkdir();
+        TestUtils.writeFile(new File(runtimeModule, "build.gradle"), runtimeBuildFile());
+        File runtimeClass = new File(runtimeModule, "src/main/java/runtime/Test.java");
+        runtimeClass.getParentFile().mkdirs();
+        TestUtils.writeFile(runtimeClass, "package runtime; public class Test {}\n");
+
+        File deploymentModule = new File(testProjectDir, "deployment");
+        deploymentModule.mkdir();
+        TestUtils.writeFile(new File(deploymentModule, "build.gradle"), deploymentBuildFile());
+        File deploymentClass = new File(deploymentModule, "src/main/java/deployment/Test.java");
+        deploymentClass.getParentFile().mkdirs();
+        TestUtils.writeFile(deploymentClass, "package deployment; public class Test {}\n");
+        File deploymentTest = new File(deploymentModule, "src/test/java/deployment/GeneratedModelTest.java");
+        deploymentTest.getParentFile().mkdirs();
+        TestUtils.writeFile(deploymentTest, """
+                package deployment;
+
+                import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+                import java.nio.file.Files;
+                import java.nio.file.Path;
+
+                import org.junit.jupiter.api.Test;
+
+                public class GeneratedModelTest {
+
+                    @Test
+                    public void serializedTestApplicationModelIsAvailable() throws Exception {
+                        String model = System.getProperty("quarkus-internal-test.serialized-app-model.path");
+                        assertNotNull(model);
+                        Files.writeString(Path.of(System.getProperty("model.marker.file")), "true");
+                    }
+                }
+                """);
+
+        TestUtils.writeFile(new File(testProjectDir, "settings.gradle"), "include 'runtime', 'deployment'\n");
+    }
+
+    private String runtimeBuildFile() throws IOException {
+        return """
+                plugins {
+                    id 'java'
+                    id 'io.quarkus.extension'
+                }
+
+                group = 'org.acme'
+                version = '1.0.0'
+
+                repositories {
+                    mavenCentral()
+                    mavenLocal()
+                }
+
+                quarkusExtension {
+                    disableValidation = true
+                }
+
+                dependencies {
+                    implementation enforcedPlatform("io.quarkus:quarkus-bom:%1$s")
+                    implementation "io.quarkus:quarkus-arc"
+                }
+
+                tasks.register("resolveDeploymentTestApplicationModel") {
+                    dependsOn(":deployment:testClasses")
+                    doLast {
+                        def mode = io.quarkus.runtime.LaunchMode.TEST
+                        io.quarkus.gradle.tooling.ToolingUtils.create(project(":deployment"), mode)
+                        println "resolved deployment test application model"
+                    }
+                }
+                """.formatted(TestUtils.getCurrentQuarkusVersion());
+    }
+
+    private String deploymentBuildFile() throws IOException {
+        return """
+                plugins {
+                    id 'java'
+                }
+
+                group = 'org.acme'
+                version = '1.0.0'
+
+                repositories {
+                    mavenCentral()
+                    mavenLocal()
+                }
+
+                dependencies {
+                    implementation enforcedPlatform("io.quarkus:quarkus-bom:%1$s")
+                    implementation "io.quarkus:quarkus-arc-deployment"
+                    implementation project(":runtime")
+                    testImplementation "org.junit.jupiter:junit-jupiter-api"
+                    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
+                }
+
+                test {
+                    def markerFile = layout.buildDirectory.file("model-marker.txt").get().asFile
+                    systemProperty "model.marker.file", markerFile.absolutePath
+                }
+                """.formatted(TestUtils.getCurrentQuarkusVersion());
+    }
+
+    private void assertDeploymentTestApplicationModelMarker() throws IOException {
+        Path marker = testProjectDir.toPath().resolve("deployment/build/model-marker.txt");
+        assertThat(marker).exists();
+        assertThat(Files.readString(marker)).isEqualTo("true");
     }
 }

--- a/integration-tests/gradle/src/main/resources/multi-composite-build-extensions-project/application/src/main/java/org/acme/quarkus/sample/HelloResource.java
+++ b/integration-tests/gradle/src/main/resources/multi-composite-build-extensions-project/application/src/main/java/org/acme/quarkus/sample/HelloResource.java
@@ -6,12 +6,14 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
-import org.acme.libb.LibB;
-import org.acme.liba.LibA;
 import org.acme.example.extension.runtime.QuarkusExampleExtensionConfig;
+import org.acme.liba.LibA;
+import org.acme.libb.LibB;
 
 @Path("/hello")
 public class HelloResource {
+
+    private static final String BUILD_MESSAGE_PROPERTY = "org.acme.example.extension.build-message";
 
     @Inject
     LibB libB;
@@ -24,6 +26,7 @@ public class HelloResource {
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     public String hello() {
-        return "hello from " + libB.getName()+" and "+libA.getName()+" extension enabled: "+config.enabled();
+        return "hello from " + libB.getName() + " and " + libA.getName() + " extension enabled: " + config.enabled()
+                + " build message: " + System.getProperty(BUILD_MESSAGE_PROPERTY);
     }
 }

--- a/integration-tests/gradle/src/main/resources/multi-composite-build-extensions-project/application/src/main/resources/application.properties
+++ b/integration-tests/gradle/src/main/resources/multi-composite-build-extensions-project/application/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 # Configuration file
 # key = value
 quarkus.example.extension.enabled=false
+quarkus.example.extension.build-message=source extension config loaded
 quarkus.another-example.extension.enabled=false

--- a/integration-tests/gradle/src/main/resources/multi-composite-build-extensions-project/application/src/test/java/org/acme/quarkus/sample/GreetingResourceTest.java
+++ b/integration-tests/gradle/src/main/resources/multi-composite-build-extensions-project/application/src/test/java/org/acme/quarkus/sample/GreetingResourceTest.java
@@ -11,10 +11,10 @@ class GreetingResourceTest {
     @Test
     void testHelloEndpoint() {
         given()
-          .when().get("/hello")
-          .then()
-             .statusCode(200)
-             .body(is("hello from LibB and LibA extension enabled: false"));
+                .when().get("/hello")
+                .then()
+                .statusCode(200)
+                .body(is("hello from LibB and LibA extension enabled: false"
+                        + " build message: source extension config loaded"));
     }
-
 }

--- a/integration-tests/gradle/src/main/resources/multi-composite-build-extensions-project/extensions/example-extension/deployment/src/main/java/org/acme/example/extension/deployment/QuarkusExampleBuildConfig.java
+++ b/integration-tests/gradle/src/main/resources/multi-composite-build-extensions-project/extensions/example-extension/deployment/src/main/java/org/acme/example/extension/deployment/QuarkusExampleBuildConfig.java
@@ -1,0 +1,16 @@
+package org.acme.example.extension.deployment;
+
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+@ConfigMapping(prefix = "quarkus.example.extension")
+@ConfigRoot
+public interface QuarkusExampleBuildConfig {
+
+    /**
+     * Value produced during augmentation to verify build-time config loading.
+     */
+    @WithDefault("default build message")
+    String buildMessage();
+}

--- a/integration-tests/gradle/src/main/resources/multi-composite-build-extensions-project/extensions/example-extension/deployment/src/main/java/org/acme/example/extension/deployment/QuarkusExampleProcessor.java
+++ b/integration-tests/gradle/src/main/resources/multi-composite-build-extensions-project/extensions/example-extension/deployment/src/main/java/org/acme/example/extension/deployment/QuarkusExampleProcessor.java
@@ -1,13 +1,13 @@
 package org.acme.example.extension.deployment;
 
-import io.quarkus.deployment.annotations.BuildStep;
-import io.quarkus.deployment.annotations.ExecutionTime;
-import io.quarkus.deployment.builditem.FeatureBuildItem;
-import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import org.acme.liba.LibA;
-import org.jboss.jandex.DotName;
-import io.quarkus.deployment.annotations.BuildProducer;
+
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.processor.DotNames;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 
 
 
@@ -15,20 +15,26 @@ import io.quarkus.arc.processor.DotNames;
 
 class QuarkusExampleProcessor {
 
-	private static final String FEATURE = "example";
+    private static final String BUILD_MESSAGE_PROPERTY = "org.acme.example.extension.build-message";
+    private static final String FEATURE = "example";
 
-	@BuildStep
-	FeatureBuildItem feature() {
-		return new FeatureBuildItem(FEATURE);
-	}
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
 
-	@BuildStep
-	void addLibABean(BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
-		additionalBeans.produce(new AdditionalBeanBuildItem.Builder()
-				.addBeanClasses(LibA.class)
-				.setUnremovable()
-				.setDefaultScope(DotNames.APPLICATION_SCOPED)
-				.build());
-	}
+    @BuildStep
+    SystemPropertyBuildItem buildMessage(QuarkusExampleBuildConfig config) {
+        return new SystemPropertyBuildItem(BUILD_MESSAGE_PROPERTY, config.buildMessage());
+    }
+
+    @BuildStep
+    void addLibABean(BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+        additionalBeans.produce(new AdditionalBeanBuildItem.Builder()
+                .addBeanClasses(LibA.class)
+                .setUnremovable()
+                .setDefaultScope(DotNames.APPLICATION_SCOPED)
+                .build());
+    }
 
 }


### PR DESCRIPTION
Add regression coverage for Gradle extension component variant behavior.

The tests cover source extension ambiguity and ToolingUtils application-model resolution cases related to #49470 / PR #49514 and #52063 / PR #52097, plus the source extension config classloader scenario reported in #49684 and fixed by PR #49762.