### PR TITLE
Avoid generating reflection-free Jackson serializers for classes in the jackson.databind package

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
@@ -223,7 +223,9 @@ public abstract class JacksonCodeGenerator {
     }
 
     private static boolean vetoedClassName(String className) {
-        return className.startsWith("java.") || className.startsWith("jakarta.") || className.startsWith("io.vertx.core.json.");
+        return className.startsWith("java.") || className.startsWith("jakarta.")
+                || className.startsWith("io.vertx.core.json.")
+                || className.startsWith("com.fasterxml.jackson.databind.");
     }
 
     private static Optional<String> findUnknownAnnotation(ClassInfo classInfo) {

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/AbstractSimpleJsonTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/AbstractSimpleJsonTest.java
@@ -1281,6 +1281,20 @@ public abstract class AbstractSimpleJsonTest {
     }
 
     @Test
+    void objectNode_shouldPreserveFieldNames() {
+        given()
+                .body("{\"name\":\"\",\"limit\":42}")
+                .contentType("application/json")
+                .when()
+                .post("/simple/object-node")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("name", is(""))
+                .body("limit", is(42));
+    }
+
+    @Test
     void sensor_metadata_shouldDeserialize() {
         given()
                 .when()

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
@@ -36,6 +36,7 @@ import com.fasterxml.jackson.core.json.JsonWriteFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import io.quarkus.resteasy.reactive.jackson.CustomDeserialization;
 import io.quarkus.resteasy.reactive.jackson.CustomSerialization;
@@ -741,6 +742,14 @@ public class SimpleJsonResource extends SuperClass<Person> {
     @Path("/polymorphic-item-ser")
     public PolymorphicItemResponse polymorphicItemSer() {
         return new PolymorphicItemResponse(new PolymorphicItem.TypeA("hello"));
+    }
+
+    @POST
+    @Path("/object-node")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public ObjectNode objectNode(ObjectNode body) {
+        return body;
     }
 
     @GET


### PR DESCRIPTION
- Fixes: #55254
