### PR TITLE
"Keyed" build item and build steps: automatic per-key iteration for build steps

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/ExtensionLoader.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/ExtensionLoader.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.function.BiConsumer;
@@ -71,6 +72,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.annotations.Consume;
 import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Key;
 import io.quarkus.deployment.annotations.Overridable;
 import io.quarkus.deployment.annotations.Produce;
 import io.quarkus.deployment.annotations.ProduceWeak;
@@ -84,6 +86,9 @@ import io.quarkus.deployment.builditem.RuntimeConfigSetupCompleteBuildItem;
 import io.quarkus.deployment.builditem.StaticBytecodeRecorderBuildItem;
 import io.quarkus.deployment.configuration.BuildTimeConfigurationReader;
 import io.quarkus.deployment.configuration.ConfigMappingUtils;
+import io.quarkus.deployment.key.KeyDescriptor;
+import io.quarkus.deployment.key.KeyUtils;
+import io.quarkus.deployment.key.KeyedParam;
 import io.quarkus.deployment.recording.BytecodeRecorderImpl;
 import io.quarkus.deployment.recording.ObjectLoader;
 import io.quarkus.deployment.recording.RecorderContext;
@@ -255,7 +260,7 @@ public final class ExtensionLoader {
      * @return a consumer which adds the steps to the given chain builder
      */
     @SuppressWarnings("unchecked")
-    private static Consumer<BuildChainBuilder> loadStepsFromClass(Class<?> clazz,
+    static Consumer<BuildChainBuilder> loadStepsFromClass(Class<?> clazz,
             Map<Class<?>, Object> runTimeProxies,
             BooleanSupplierFactoryBuildItem supplierFactory) {
         final Constructor<?>[] constructors = clazz.getDeclaredConstructors();
@@ -468,6 +473,7 @@ public final class ExtensionLoader {
                 }
             }
             final List<BiFunction<BuildContext, BytecodeRecorderImpl, Object>> methodParamFns;
+            final List<KeyedParam> keyedParams;
             Consumer<BuildStepBuilder> methodStepConfig = Functions.discardingConsumer();
             BooleanSupplier addStep = () -> true;
             addStep = and(addStep, supplierFactory, classOnlyIf, false);
@@ -488,11 +494,34 @@ public final class ExtensionLoader {
                 });
             }
             EnumSet<ConfigPhase> methodConsumingConfigPhases = consumingConfigPhases.clone();
+            int keyParamIdx = -1;
+            Class<?> keyType = null;
+            for (int i = 0; i < methodParameters.length; i++) {
+                Key keyAnn = methodParameters[i].getAnnotation(Key.class);
+                if (keyAnn != null) {
+                    if (keyParamIdx >= 0) {
+                        throw reportError(method,
+                                "Multiple @Key parameters found. Only one @Key parameter is supported per method.");
+                    }
+                    if (methodParameters[i].getType() != String.class) {
+                        throw reportError(methodParameters[i], "@Key parameter must be of type String");
+                    }
+                    keyParamIdx = i;
+                    keyType = keyAnn.value();
+                }
+            }
+            final int finalKeyParamIndex = keyParamIdx;
             if (methodParameters.length == 0) {
                 methodParamFns = Collections.emptyList();
+                keyedParams = Collections.emptyList();
             } else {
                 methodParamFns = new ArrayList<>(methodParameters.length);
+                List<KeyedParam> tmpKeyedParams = new ArrayList<>();
                 for (Parameter parameter : methodParameters) {
+                    if (parameter.isAnnotationPresent(Key.class)) {
+                        methodParamFns.add((bc, bri) -> null);
+                        continue;
+                    }
                     final boolean weak = parameter.isAnnotationPresent(Weak.class);
                     final boolean overridable = parameter.isAnnotationPresent(Overridable.class);
                     final Type parameterType = parameter.getParameterizedType();
@@ -512,7 +541,25 @@ public final class ExtensionLoader {
                         final Class<? extends MultiBuildItem> buildItemClass = rawTypeOfParameter(parameterType, 0)
                                 .asSubclass(MultiBuildItem.class);
                         methodStepConfig = methodStepConfig.andThen(bsb -> bsb.consumes(buildItemClass));
+                        if (keyType != null) {
+                            KeyDescriptor itemKey = KeyUtils.findKeyField(buildItemClass);
+                            if (itemKey != null && itemKey.keyType() == keyType) {
+                                tmpKeyedParams.add(new KeyedParam(methodParamFns.size(), itemKey, false));
+                            }
+                        }
                         methodParamFns.add((bc, bri) -> bc.consumeMulti(buildItemClass));
+                    } else if (keyType != null && rawTypeExtends(parameterType, MultiBuildItem.class)) {
+                        final Class<? extends MultiBuildItem> buildItemClass = parameterClass
+                                .asSubclass(MultiBuildItem.class);
+                        KeyDescriptor itemKey = KeyUtils.findKeyField(buildItemClass);
+                        if (itemKey != null && itemKey.keyType() == keyType) {
+                            methodStepConfig = methodStepConfig.andThen(bsb -> bsb.consumes(buildItemClass));
+                            tmpKeyedParams.add(new KeyedParam(methodParamFns.size(), itemKey, true));
+                            methodParamFns.add((bc, bri) -> bc.consumeMulti(buildItemClass));
+                        } else {
+                            throw reportError(parameter,
+                                    "Bare MultiBuildItem parameter requires a @Key field matching the method's key type");
+                        }
                     } else if (isConsumerOf(parameterType, BuildItem.class)) {
                         methodStepConfig = configureBuildStepFlags(methodStepConfig, weak, overridable,
                                 rawTypeOfParameter(parameterType, 0)
@@ -556,7 +603,8 @@ public final class ExtensionLoader {
                             }
                         } else if (phase.isReadAtMain()) {
                             if (isRecorder) {
-                                if (extensionLoaderConfig.reportRuntimeConfigAtDeployment().equals(warn)) {
+                                if (extensionLoaderConfig.reportRuntimeConfigAtDeployment()
+                                        .equals(warn)) {
                                     methodParamFns.add((bc, bri) -> {
                                         RunTimeConfigurationProxyBuildItem proxies = bc
                                                 .consume(RunTimeConfigurationProxyBuildItem.class);
@@ -617,7 +665,8 @@ public final class ExtensionLoader {
                                         } else {
                                             methodConsumingConfigPhases.add(annotation.phase());
                                             if (annotation.phase().isReadAtMain() && !isRuntimeValue) {
-                                                if (extensionLoaderConfig.reportRuntimeConfigAtDeployment().equals(warn)) {
+                                                if (extensionLoaderConfig
+                                                        .reportRuntimeConfigAtDeployment().equals(warn)) {
                                                     loadLog.warn(reportError(parameter, annotation.phase() + " configuration "
                                                             + type.getTypeName()
                                                             + " should be injected in a @Recorder constructor as a RuntimeValue<"
@@ -652,6 +701,7 @@ public final class ExtensionLoader {
                         throw reportError(parameter, "Unsupported method parameter " + parameterType);
                     }
                 }
+                keyedParams = tmpKeyedParams;
             }
 
             final BiConsumer<BuildContext, Object> resultConsumer;
@@ -806,17 +856,35 @@ public final class ExtensionLoader {
                                 for (int i = 0; i < methodArgs.length; i++) {
                                     methodArgs[i] = methodParamFns.get(i).apply(bc, bri);
                                 }
-                                Object result;
-                                try {
-                                    result = methodHandle.bindTo(instance).invokeWithArguments(methodArgs);
-                                } catch (IllegalAccessException e) {
-                                    throw ReflectUtil.toError(e);
-                                } catch (RuntimeException | Error e2) {
-                                    throw e2;
-                                } catch (Throwable t) {
-                                    throw new UndeclaredThrowableException(t);
+                                if (finalKeyParamIndex < 0) {
+                                    Object result = invokeStep(methodHandle, instance, methodArgs);
+                                    resultConsumer.accept(bc, result);
+                                } else {
+                                    Set<String> uniqueKeys = KeyUtils.collectUniqueKeys(methodArgs,
+                                            keyedParams);
+                                    if (!uniqueKeys.isEmpty()) {
+                                        RuntimeException firstFailure = null;
+                                        for (String keyValue : uniqueKeys) {
+                                            try {
+                                                Object[] perKeyArgs = KeyUtils.filterKeyedArgs(methodArgs,
+                                                        finalKeyParamIndex, keyedParams, keyValue);
+                                                Object result = invokeStep(methodHandle, instance, perKeyArgs);
+                                                resultConsumer.accept(bc, result);
+                                            } catch (RuntimeException | Error e) {
+                                                if (firstFailure == null) {
+                                                    firstFailure = (e instanceof RuntimeException re)
+                                                            ? re
+                                                            : new RuntimeException(e);
+                                                } else {
+                                                    firstFailure.addSuppressed(e);
+                                                }
+                                            }
+                                        }
+                                        if (firstFailure != null) {
+                                            throw firstFailure;
+                                        }
+                                    }
                                 }
-                                resultConsumer.accept(bc, result);
                                 if (isRecorder) {
                                     // commit recorded data
                                     if (recordAnnotation.value() == ExecutionTime.STATIC_INIT) {
@@ -824,7 +892,6 @@ public final class ExtensionLoader {
                                     } else {
                                         bc.produce(new MainBytecodeRecorderBuildItem(bri));
                                     }
-
                                 }
                             }
 
@@ -853,6 +920,18 @@ public final class ExtensionLoader {
             flags = weak ? ProduceFlags.of(ProduceFlag.WEAK) : ProduceFlags.NONE;
         }
         return methodStepConfig.andThen(bsb -> bsb.produces(buildItemClass, flags));
+    }
+
+    private static Object invokeStep(MethodHandle methodHandle, Object instance, Object[] methodArgs) {
+        try {
+            return methodHandle.bindTo(instance).invokeWithArguments(methodArgs);
+        } catch (IllegalAccessException e) {
+            throw ReflectUtil.toError(e);
+        } catch (RuntimeException | Error e2) {
+            throw e2;
+        } catch (Throwable t) {
+            throw new UndeclaredThrowableException(t);
+        }
     }
 
     private static MethodHandle unreflect(Method method, MethodHandles.Lookup lookup) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/annotations/Key.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/annotations/Key.java
@@ -1,0 +1,42 @@
+package io.quarkus.deployment.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a {@code String} element as a key dimension for per-key iteration of build steps.
+ * <p>
+ * On a <b>{@link BuildStep @BuildStep} method parameter</b> of type {@code String},
+ * this annotation enables per-key iteration: the engine discovers all unique key values
+ * from keyed {@link io.quarkus.builder.item.MultiBuildItem} lists consumed by the method,
+ * then invokes the method once per key value, injecting the current key and filtering
+ * keyed lists to only items whose key matches.
+ * <p>
+ * On a <b>{@link io.quarkus.builder.item.MultiBuildItem}</b> field, this annotation marks
+ * which field carries the key value. When such an item is consumed as a {@code List} by a
+ * build step method with a {@code @Key} parameter of the same key type, the engine
+ * automatically filters the list to only items whose key value matches.
+ * A keyed {@code MultiBuildItem} may also be consumed as a bare parameter (not wrapped in
+ * {@code List}); the engine filters to matching items and injects a single instance.
+ * <p>
+ * The {@link #value()} is any class that identifies this key dimension (the "key family").
+ * Matching happens between build step parameters and build item fields that share the same
+ * key type. The annotated element's value is the "key value" (e.g., the datasource name).
+ * <p>
+ * Only one {@code @Key} parameter is allowed per {@code @BuildStep} method, and only one
+ * {@code @Key} field is allowed per {@code MultiBuildItem} class.
+ * The annotated element must be of type {@code String}.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
+public @interface Key {
+
+    /**
+     * The class that identifies this key dimension.
+     *
+     * @return the key family class
+     */
+    Class<?> value();
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/key/KeyDescriptor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/key/KeyDescriptor.java
@@ -1,0 +1,20 @@
+package io.quarkus.deployment.key;
+
+import java.lang.reflect.Field;
+
+/**
+ * Describes a single {@code @Key}-annotated field on a {@link io.quarkus.builder.item.MultiBuildItem} class.
+ *
+ * @param keyType the key family type (any class identifying this key dimension)
+ * @param field the reflective field handle (already made accessible)
+ */
+public record KeyDescriptor(Class<?> keyType, Field field) {
+
+    public String getValue(Object instance) {
+        try {
+            return (String) field.get(instance);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException("Cannot read @Key field " + field + " on " + instance.getClass(), e);
+        }
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/key/KeyUtils.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/key/KeyUtils.java
@@ -1,0 +1,111 @@
+package io.quarkus.deployment.key;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import io.quarkus.builder.item.BuildItem;
+import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.deployment.annotations.Key;
+
+/**
+ * Utility for introspecting and filtering {@link Key @Key}-annotated fields.
+ */
+public final class KeyUtils {
+
+    private KeyUtils() {
+    }
+
+    /**
+     * Find the single {@code @Key}-annotated field on the given class, if any.
+     *
+     * @param clazz the class to inspect
+     * @return the key descriptor, or {@code null} if no {@code @Key} field is found
+     * @throws IllegalArgumentException if multiple {@code @Key} fields are found,
+     *         or if the annotated field is not of type {@code String}
+     */
+    public static KeyDescriptor findKeyField(Class<?> clazz) {
+        KeyDescriptor found = null;
+        for (Class<?> c = clazz; c != null && c != Object.class; c = c.getSuperclass()) {
+            for (Field field : c.getDeclaredFields()) {
+                if (Modifier.isStatic(field.getModifiers())) {
+                    continue;
+                }
+                Key keyAnn = field.getAnnotation(Key.class);
+                if (keyAnn == null) {
+                    continue;
+                }
+                if (found != null) {
+                    throw new IllegalArgumentException(
+                            "Multiple @Key fields found on " + clazz.getName()
+                                    + ": " + found.field().getName() + " and " + field.getName()
+                                    + ". Only one @Key field per class is supported.");
+                }
+                if (field.getType() != String.class) {
+                    throw new IllegalArgumentException(
+                            "@Key field must be of type String: " + field.getName()
+                                    + " on " + clazz.getName() + " is " + field.getType().getName());
+                }
+                if (!Modifier.isPublic(field.getModifiers())
+                        || !Modifier.isPublic(field.getDeclaringClass().getModifiers())) {
+                    field.setAccessible(true);
+                }
+                found = new KeyDescriptor(keyAnn.value(), field);
+            }
+        }
+        if (found != null && BuildItem.class.isAssignableFrom(clazz) && !MultiBuildItem.class.isAssignableFrom(clazz)) {
+            throw new IllegalArgumentException(
+                    "@Key is only supported on MultiBuildItem classes, but " + clazz.getName()
+                            + " is not a MultiBuildItem");
+        }
+        return found;
+    }
+
+    /**
+     * Collect unique key values from keyed multi build item lists.
+     */
+    public static Set<String> collectUniqueKeys(Object[] methodArgs, List<KeyedParam> keyedParams) {
+        Set<String> uniqueKeys = new LinkedHashSet<>();
+        for (KeyedParam kp : keyedParams) {
+            List<?> fullList = (List<?>) methodArgs[kp.index()];
+            for (Object item : fullList) {
+                String keyValue = kp.descriptor().getValue(item);
+                if (keyValue != null) {
+                    uniqueKeys.add(keyValue);
+                }
+            }
+        }
+        return uniqueKeys;
+    }
+
+    /**
+     * Build a per-key copy of method arguments: sets the key parameter and filters keyed multi lists.
+     * For singular keyed parameters (bare {@code MultiBuildItem}, not {@code List<>}), the filtered list
+     * is unwrapped to a single item.
+     */
+    public static Object[] filterKeyedArgs(Object[] methodArgs, int keyParamIndex,
+            List<KeyedParam> keyedParams, String keyValue) {
+        Object[] perKeyArgs = methodArgs.clone();
+        perKeyArgs[keyParamIndex] = keyValue;
+        for (KeyedParam kp : keyedParams) {
+            int paramIdx = kp.index();
+            List<?> fullList = (List<?>) methodArgs[paramIdx];
+            List<Object> filtered = new ArrayList<>();
+            for (Object item : fullList) {
+                if (keyValue.equals(kp.descriptor().getValue(item))) {
+                    filtered.add(item);
+                }
+            }
+            if (kp.singular()) {
+                perKeyArgs[paramIdx] = filtered.isEmpty() ? null : filtered.get(0);
+            } else {
+                perKeyArgs[paramIdx] = Collections.unmodifiableList(filtered);
+            }
+        }
+        return perKeyArgs;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/key/KeyedParam.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/key/KeyedParam.java
@@ -1,0 +1,12 @@
+package io.quarkus.deployment.key;
+
+/**
+ * Describes a keyed {@link io.quarkus.builder.item.MultiBuildItem} parameter in a per-key build step method.
+ *
+ * @param index the parameter index in the method's argument array
+ * @param descriptor the key descriptor for the build item class
+ * @param singular {@code true} if the parameter is a bare {@code MultiBuildItem} (not {@code List<>});
+ *        the filtered list will be unwrapped to a single item at execution time
+ */
+public record KeyedParam(int index, KeyDescriptor descriptor, boolean singular) {
+}

--- a/core/deployment/src/test/java/io/quarkus/deployment/KeyedBuildStepTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/KeyedBuildStepTest.java
@@ -1,0 +1,682 @@
+package io.quarkus.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.builder.BuildChain;
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildException;
+import io.quarkus.builder.BuildResult;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.builder.item.SimpleBuildItem;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildSteps;
+import io.quarkus.deployment.annotations.Key;
+import io.quarkus.deployment.key.KeyUtils;
+import io.quarkus.runtime.LaunchMode;
+import io.quarkus.runtime.configuration.QuarkusConfigFactory;
+import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.SmallRyeConfigBuilder;
+
+public class KeyedBuildStepTest {
+
+    @BeforeAll
+    static void setupConfig() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .addDefaultSources()
+                .withMapping(ExtensionLoaderConfig.class)
+                .build();
+        QuarkusConfigFactory.setConfig(config);
+    }
+
+    @AfterAll
+    static void tearDownConfig() {
+        QuarkusConfigFactory.setConfig(null);
+    }
+
+    // -- Test key types --
+    public static class TestDS {
+    }
+
+    public static class OtherQualifier {
+    }
+
+    // -- Test build items --
+
+    public static final class KeyedPropertyItem extends MultiBuildItem {
+        @Key(TestDS.class)
+        private final String dsName;
+        private final String property;
+
+        public KeyedPropertyItem(String dsName, String property) {
+            this.dsName = dsName;
+            this.property = property;
+        }
+
+        public String getDsName() {
+            return dsName;
+        }
+
+        public String getProperty() {
+            return property;
+        }
+    }
+
+    public static final class OutputItem extends MultiBuildItem implements Comparable<OutputItem> {
+        private final String value;
+
+        public OutputItem(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public int compareTo(OutputItem o) {
+            return value.compareTo(o.value);
+        }
+    }
+
+    public static final class UnkeyedItem extends MultiBuildItem {
+        private final String data;
+
+        public UnkeyedItem(String data) {
+            this.data = data;
+        }
+
+        public String getData() {
+            return data;
+        }
+    }
+
+    public static final class SharedConfigItem extends SimpleBuildItem {
+        private final String config;
+
+        public SharedConfigItem(String config) {
+            this.config = config;
+        }
+
+        public String getConfig() {
+            return config;
+        }
+    }
+
+    // -- Test build step classes with @Key --
+
+    public static class SimpleKeyedProcessor {
+        @io.quarkus.deployment.annotations.BuildStep
+        public List<OutputItem> process(@Key(TestDS.class) String name, List<KeyedPropertyItem> props) {
+            List<OutputItem> result = new ArrayList<>();
+            result.add(new OutputItem(name + ":" + props.size()));
+            return result;
+        }
+    }
+
+    public static class KeyedProcessorWithProducer {
+        @io.quarkus.deployment.annotations.BuildStep
+        public void produce(@Key(TestDS.class) String name, List<KeyedPropertyItem> props,
+                BuildProducer<OutputItem> producer) {
+            for (KeyedPropertyItem prop : props) {
+                producer.produce(new OutputItem(name + "=" + prop.getProperty()));
+            }
+        }
+    }
+
+    public static class KeyedProcessorWithNonKeyed {
+        @io.quarkus.deployment.annotations.BuildStep
+        public List<OutputItem> process(@Key(TestDS.class) String name, List<KeyedPropertyItem> props,
+                SharedConfigItem config) {
+            List<OutputItem> result = new ArrayList<>();
+            result.add(new OutputItem(name + ":" + props.size() + ":" + config.getConfig()));
+            return result;
+        }
+    }
+
+    public static class KeyedProcessorWithUnkeyedMulti {
+        @io.quarkus.deployment.annotations.BuildStep
+        public List<OutputItem> process(@Key(TestDS.class) String name, List<KeyedPropertyItem> props,
+                List<UnkeyedItem> unkeyed) {
+            List<OutputItem> result = new ArrayList<>();
+            result.add(new OutputItem(name + ":props=" + props.size() + ":unkeyed=" + unkeyed.size()));
+            return result;
+        }
+    }
+
+    public static class SingularKeyedProcessor {
+        @io.quarkus.deployment.annotations.BuildStep
+        public List<OutputItem> process(@Key(TestDS.class) String name, KeyedPropertyItem prop) {
+            return List.of(new OutputItem(name + "=" + prop.getProperty()));
+        }
+    }
+
+    public static class MixedSingularAndListProcessor {
+        @io.quarkus.deployment.annotations.BuildStep
+        public List<OutputItem> process(@Key(TestDS.class) String name, KeyedPropertyItem prop,
+                List<KeyedPropertyItem> allProps) {
+            return List.of(new OutputItem(name + ":singular=" + prop.getProperty() + ":list=" + allProps.size()));
+        }
+    }
+
+    public static class MultiKeyProcessor {
+        @io.quarkus.deployment.annotations.BuildStep
+        public List<OutputItem> process(@Key(TestDS.class) String name,
+                @Key(OtherQualifier.class) String other, List<KeyedPropertyItem> props) {
+            return List.of(new OutputItem(name));
+        }
+    }
+
+    // -- BooleanSupplier implementations for condition tests --
+
+    public static class AlwaysTrue implements BooleanSupplier {
+        @Override
+        public boolean getAsBoolean() {
+            return true;
+        }
+    }
+
+    public static class AlwaysFalse implements BooleanSupplier {
+        @Override
+        public boolean getAsBoolean() {
+            return false;
+        }
+    }
+
+    // -- Test build step classes with onlyIf / onlyIfNot --
+
+    @BuildSteps(onlyIf = AlwaysTrue.class)
+    public static class ClassOnlyIfTrueProcessor {
+        @io.quarkus.deployment.annotations.BuildStep
+        public List<OutputItem> process(@Key(TestDS.class) String name, List<KeyedPropertyItem> props) {
+            return List.of(new OutputItem(name + ":" + props.size()));
+        }
+    }
+
+    @BuildSteps(onlyIf = AlwaysFalse.class)
+    public static class ClassOnlyIfFalseProcessor {
+        @io.quarkus.deployment.annotations.BuildStep
+        public List<OutputItem> process(@Key(TestDS.class) String name, List<KeyedPropertyItem> props) {
+            return List.of(new OutputItem(name + ":" + props.size()));
+        }
+    }
+
+    @BuildSteps(onlyIfNot = AlwaysTrue.class)
+    public static class ClassOnlyIfNotTrueProcessor {
+        @io.quarkus.deployment.annotations.BuildStep
+        public List<OutputItem> process(@Key(TestDS.class) String name, List<KeyedPropertyItem> props) {
+            return List.of(new OutputItem(name + ":" + props.size()));
+        }
+    }
+
+    @BuildSteps(onlyIfNot = AlwaysFalse.class)
+    public static class ClassOnlyIfNotFalseProcessor {
+        @io.quarkus.deployment.annotations.BuildStep
+        public List<OutputItem> process(@Key(TestDS.class) String name, List<KeyedPropertyItem> props) {
+            return List.of(new OutputItem(name + ":" + props.size()));
+        }
+    }
+
+    public static class MethodOnlyIfFalseProcessor {
+        @io.quarkus.deployment.annotations.BuildStep
+        public List<OutputItem> alwaysRuns(@Key(TestDS.class) String name, List<KeyedPropertyItem> props) {
+            return List.of(new OutputItem("always:" + name));
+        }
+
+        @io.quarkus.deployment.annotations.BuildStep(onlyIf = AlwaysFalse.class)
+        public List<OutputItem> neverRuns(@Key(TestDS.class) String name, List<KeyedPropertyItem> props) {
+            return List.of(new OutputItem("never:" + name));
+        }
+    }
+
+    public static class MethodOnlyIfNotTrueProcessor {
+        @io.quarkus.deployment.annotations.BuildStep
+        public List<OutputItem> alwaysRuns(@Key(TestDS.class) String name, List<KeyedPropertyItem> props) {
+            return List.of(new OutputItem("always:" + name));
+        }
+
+        @io.quarkus.deployment.annotations.BuildStep(onlyIfNot = AlwaysTrue.class)
+        public List<OutputItem> neverRuns(@Key(TestDS.class) String name, List<KeyedPropertyItem> props) {
+            return List.of(new OutputItem("never:" + name));
+        }
+    }
+
+    public static class FailingKeyedProcessor {
+        @io.quarkus.deployment.annotations.BuildStep
+        public List<OutputItem> process(@Key(TestDS.class) String name, List<KeyedPropertyItem> props) {
+            throw new IllegalStateException("Failure for key: " + name);
+        }
+    }
+
+    // -- Helper --
+
+    private Consumer<BuildChainBuilder> loadSteps(Class<?> clazz) {
+        return ExtensionLoader.loadStepsFromClass(clazz, new HashMap<>(), null);
+    }
+
+    private Consumer<BuildChainBuilder> loadStepsWithConditions(Class<?> clazz) {
+        return ExtensionLoader.loadStepsFromClass(clazz, new HashMap<>(), createSupplierFactory());
+    }
+
+    private static BooleanSupplierFactoryBuildItem createSupplierFactory() {
+        try {
+            Constructor<BooleanSupplierFactoryBuildItem> ctor = BooleanSupplierFactoryBuildItem.class
+                    .getDeclaredConstructor(LaunchMode.class, io.quarkus.dev.spi.DevModeType.class);
+            ctor.setAccessible(true);
+            return ctor.newInstance(LaunchMode.NORMAL, null);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // -- Tests --
+
+    @Test
+    void testSingleKeyFiltering() throws Exception {
+        BuildChainBuilder builder = BuildChain.builder();
+
+        // producer step: emit keyed items
+        builder.addBuildStep(new BuildStep() {
+            @Override
+            public void execute(BuildContext bc) {
+                bc.produce(new KeyedPropertyItem("a", "p1"));
+                bc.produce(new KeyedPropertyItem("a", "p2"));
+                bc.produce(new KeyedPropertyItem("b", "p3"));
+            }
+        }).produces(KeyedPropertyItem.class).build();
+
+        // load the per-key build steps
+        loadSteps(SimpleKeyedProcessor.class).accept(builder);
+
+        builder.addFinal(OutputItem.class);
+        BuildChain chain = builder.build();
+        BuildResult result = chain.createExecutionBuilder("test").execute();
+
+        List<OutputItem> outputs = result.consumeMulti(OutputItem.class);
+        assertThat(outputs).extracting(OutputItem::getValue)
+                .containsExactlyInAnyOrder("a:2", "b:1");
+    }
+
+    @Test
+    void testBuildProducerInKeyedClass() throws Exception {
+        BuildChainBuilder builder = BuildChain.builder();
+
+        builder.addBuildStep(new BuildStep() {
+            @Override
+            public void execute(BuildContext bc) {
+                bc.produce(new KeyedPropertyItem("x", "val1"));
+                bc.produce(new KeyedPropertyItem("x", "val2"));
+                bc.produce(new KeyedPropertyItem("y", "val3"));
+            }
+        }).produces(KeyedPropertyItem.class).build();
+
+        loadSteps(KeyedProcessorWithProducer.class).accept(builder);
+
+        builder.addFinal(OutputItem.class);
+        BuildChain chain = builder.build();
+        BuildResult result = chain.createExecutionBuilder("test").execute();
+
+        List<OutputItem> outputs = result.consumeMulti(OutputItem.class);
+        assertThat(outputs).extracting(OutputItem::getValue)
+                .containsExactlyInAnyOrder("x=val1", "x=val2", "y=val3");
+    }
+
+    @Test
+    void testNonKeyedItemsPassThrough() throws Exception {
+        BuildChainBuilder builder = BuildChain.builder();
+
+        // produce keyed items and a shared config
+        builder.addBuildStep(new BuildStep() {
+            @Override
+            public void execute(BuildContext bc) {
+                bc.produce(new KeyedPropertyItem("a", "p1"));
+                bc.produce(new KeyedPropertyItem("b", "p2"));
+                bc.produce(new SharedConfigItem("global"));
+            }
+        }).produces(KeyedPropertyItem.class).produces(SharedConfigItem.class).build();
+
+        loadSteps(KeyedProcessorWithNonKeyed.class).accept(builder);
+
+        builder.addFinal(OutputItem.class);
+        BuildChain chain = builder.build();
+        BuildResult result = chain.createExecutionBuilder("test").execute();
+
+        List<OutputItem> outputs = result.consumeMulti(OutputItem.class);
+        assertThat(outputs).extracting(OutputItem::getValue)
+                .containsExactlyInAnyOrder("a:1:global", "b:1:global");
+    }
+
+    @Test
+    void testNoKeyedItemsProducesNothing() throws Exception {
+        BuildChainBuilder builder = BuildChain.builder();
+
+        // produce nothing for the keyed type — but we need the chain to work,
+        // so add a dummy step that produces the final item directly
+        builder.addBuildStep(new BuildStep() {
+            @Override
+            public void execute(BuildContext bc) {
+                bc.produce(new OutputItem("fallback"));
+            }
+        }).produces(OutputItem.class).build();
+
+        loadSteps(SimpleKeyedProcessor.class).accept(builder);
+
+        builder.addFinal(OutputItem.class);
+        BuildChain chain = builder.build();
+        BuildResult result = chain.createExecutionBuilder("test").execute();
+
+        List<OutputItem> outputs = result.consumeMulti(OutputItem.class);
+        // only the fallback item, keyed class produced nothing
+        assertThat(outputs).extracting(OutputItem::getValue)
+                .containsExactly("fallback");
+    }
+
+    @Test
+    void testNonKeyedMultiPassesThrough() throws Exception {
+        BuildChainBuilder builder = BuildChain.builder();
+
+        builder.addBuildStep(new BuildStep() {
+            @Override
+            public void execute(BuildContext bc) {
+                bc.produce(new KeyedPropertyItem("a", "p1"));
+                bc.produce(new KeyedPropertyItem("b", "p2"));
+                bc.produce(new UnkeyedItem("u1"));
+                bc.produce(new UnkeyedItem("u2"));
+                bc.produce(new UnkeyedItem("u3"));
+            }
+        }).produces(KeyedPropertyItem.class).produces(UnkeyedItem.class).build();
+
+        loadSteps(KeyedProcessorWithUnkeyedMulti.class).accept(builder);
+
+        builder.addFinal(OutputItem.class);
+        BuildChain chain = builder.build();
+        BuildResult result = chain.createExecutionBuilder("test").execute();
+
+        List<OutputItem> outputs = result.consumeMulti(OutputItem.class);
+        // each key gets all 3 unkeyed items
+        assertThat(outputs).extracting(OutputItem::getValue)
+                .containsExactlyInAnyOrder("a:props=1:unkeyed=3", "b:props=1:unkeyed=3");
+    }
+
+    @Test
+    void testSingularKeyedParameter() throws Exception {
+        BuildChainBuilder builder = BuildChain.builder();
+
+        builder.addBuildStep(new BuildStep() {
+            @Override
+            public void execute(BuildContext bc) {
+                bc.produce(new KeyedPropertyItem("a", "p1"));
+                bc.produce(new KeyedPropertyItem("b", "p2"));
+            }
+        }).produces(KeyedPropertyItem.class).build();
+
+        loadSteps(SingularKeyedProcessor.class).accept(builder);
+
+        builder.addFinal(OutputItem.class);
+        BuildChain chain = builder.build();
+        BuildResult result = chain.createExecutionBuilder("test").execute();
+
+        List<OutputItem> outputs = result.consumeMulti(OutputItem.class);
+        assertThat(outputs).extracting(OutputItem::getValue)
+                .containsExactlyInAnyOrder("a=p1", "b=p2");
+    }
+
+    @Test
+    void testMixedSingularAndListParameter() throws Exception {
+        BuildChainBuilder builder = BuildChain.builder();
+
+        builder.addBuildStep(new BuildStep() {
+            @Override
+            public void execute(BuildContext bc) {
+                bc.produce(new KeyedPropertyItem("a", "p1"));
+                bc.produce(new KeyedPropertyItem("a", "p2"));
+                bc.produce(new KeyedPropertyItem("b", "p3"));
+            }
+        }).produces(KeyedPropertyItem.class).build();
+
+        loadSteps(MixedSingularAndListProcessor.class).accept(builder);
+
+        builder.addFinal(OutputItem.class);
+        BuildChain chain = builder.build();
+        BuildResult result = chain.createExecutionBuilder("test").execute();
+
+        List<OutputItem> outputs = result.consumeMulti(OutputItem.class);
+        // singular gets the first matching item, list gets all matching items
+        assertThat(outputs).extracting(OutputItem::getValue)
+                .containsExactlyInAnyOrder("a:singular=p1:list=2", "b:singular=p3:list=1");
+    }
+
+    @Test
+    void testMultipleKeyParametersOnMethodFails() {
+        assertThatThrownBy(() -> loadSteps(MultiKeyProcessor.class))
+                .hasMessageContaining("Multiple @Key parameters");
+    }
+
+    @Test
+    void testMultipleKeyFieldsOnBuildItemFails() {
+        // create an item class with two @Key fields inline
+        assertThatThrownBy(() -> KeyUtils.findKeyField(DualKeyItem.class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Multiple @Key fields");
+    }
+
+    // -- onlyIf / onlyIfNot tests --
+
+    @Test
+    void testBuildStepsOnlyIfTrue() throws Exception {
+        BuildChainBuilder builder = BuildChain.builder();
+
+        builder.addBuildStep(new BuildStep() {
+            @Override
+            public void execute(BuildContext bc) {
+                bc.produce(new KeyedPropertyItem("a", "p1"));
+                bc.produce(new KeyedPropertyItem("b", "p2"));
+            }
+        }).produces(KeyedPropertyItem.class).build();
+
+        loadStepsWithConditions(ClassOnlyIfTrueProcessor.class).accept(builder);
+
+        builder.addFinal(OutputItem.class);
+        BuildResult result = builder.build().createExecutionBuilder("test").execute();
+
+        List<OutputItem> outputs = result.consumeMulti(OutputItem.class);
+        assertThat(outputs).extracting(OutputItem::getValue)
+                .containsExactlyInAnyOrder("a:1", "b:1");
+    }
+
+    @Test
+    void testBuildStepsOnlyIfFalse() throws Exception {
+        BuildChainBuilder builder = BuildChain.builder();
+
+        builder.addBuildStep(new BuildStep() {
+            @Override
+            public void execute(BuildContext bc) {
+                bc.produce(new KeyedPropertyItem("a", "p1"));
+                bc.produce(new OutputItem("fallback"));
+            }
+        }).produces(KeyedPropertyItem.class).produces(OutputItem.class).build();
+
+        loadStepsWithConditions(ClassOnlyIfFalseProcessor.class).accept(builder);
+
+        builder.addFinal(OutputItem.class);
+        BuildResult result = builder.build().createExecutionBuilder("test").execute();
+
+        List<OutputItem> outputs = result.consumeMulti(OutputItem.class);
+        assertThat(outputs).extracting(OutputItem::getValue)
+                .containsExactly("fallback");
+    }
+
+    @Test
+    void testBuildStepsOnlyIfNotTrue() throws Exception {
+        BuildChainBuilder builder = BuildChain.builder();
+
+        builder.addBuildStep(new BuildStep() {
+            @Override
+            public void execute(BuildContext bc) {
+                bc.produce(new KeyedPropertyItem("a", "p1"));
+                bc.produce(new OutputItem("fallback"));
+            }
+        }).produces(KeyedPropertyItem.class).produces(OutputItem.class).build();
+
+        loadStepsWithConditions(ClassOnlyIfNotTrueProcessor.class).accept(builder);
+
+        builder.addFinal(OutputItem.class);
+        BuildResult result = builder.build().createExecutionBuilder("test").execute();
+
+        List<OutputItem> outputs = result.consumeMulti(OutputItem.class);
+        assertThat(outputs).extracting(OutputItem::getValue)
+                .containsExactly("fallback");
+    }
+
+    @Test
+    void testBuildStepsOnlyIfNotFalse() throws Exception {
+        BuildChainBuilder builder = BuildChain.builder();
+
+        builder.addBuildStep(new BuildStep() {
+            @Override
+            public void execute(BuildContext bc) {
+                bc.produce(new KeyedPropertyItem("a", "p1"));
+                bc.produce(new KeyedPropertyItem("b", "p2"));
+            }
+        }).produces(KeyedPropertyItem.class).build();
+
+        loadStepsWithConditions(ClassOnlyIfNotFalseProcessor.class).accept(builder);
+
+        builder.addFinal(OutputItem.class);
+        BuildResult result = builder.build().createExecutionBuilder("test").execute();
+
+        List<OutputItem> outputs = result.consumeMulti(OutputItem.class);
+        assertThat(outputs).extracting(OutputItem::getValue)
+                .containsExactlyInAnyOrder("a:1", "b:1");
+    }
+
+    @Test
+    void testBuildStepMethodOnlyIfFalse() throws Exception {
+        BuildChainBuilder builder = BuildChain.builder();
+
+        builder.addBuildStep(new BuildStep() {
+            @Override
+            public void execute(BuildContext bc) {
+                bc.produce(new KeyedPropertyItem("a", "p1"));
+                bc.produce(new KeyedPropertyItem("b", "p2"));
+            }
+        }).produces(KeyedPropertyItem.class).build();
+
+        loadStepsWithConditions(MethodOnlyIfFalseProcessor.class).accept(builder);
+
+        builder.addFinal(OutputItem.class);
+        BuildResult result = builder.build().createExecutionBuilder("test").execute();
+
+        List<OutputItem> outputs = result.consumeMulti(OutputItem.class);
+        assertThat(outputs).extracting(OutputItem::getValue)
+                .containsExactlyInAnyOrder("always:a", "always:b");
+    }
+
+    @Test
+    void testBuildStepMethodOnlyIfNotTrue() throws Exception {
+        BuildChainBuilder builder = BuildChain.builder();
+
+        builder.addBuildStep(new BuildStep() {
+            @Override
+            public void execute(BuildContext bc) {
+                bc.produce(new KeyedPropertyItem("a", "p1"));
+                bc.produce(new KeyedPropertyItem("b", "p2"));
+            }
+        }).produces(KeyedPropertyItem.class).build();
+
+        loadStepsWithConditions(MethodOnlyIfNotTrueProcessor.class).accept(builder);
+
+        builder.addFinal(OutputItem.class);
+        BuildResult result = builder.build().createExecutionBuilder("test").execute();
+
+        List<OutputItem> outputs = result.consumeMulti(OutputItem.class);
+        assertThat(outputs).extracting(OutputItem::getValue)
+                .containsExactlyInAnyOrder("always:a", "always:b");
+    }
+
+    // -- exception collection tests --
+
+    @Test
+    void testMultipleKeyFailuresCollectSuppressed() throws Exception {
+        BuildChainBuilder builder = BuildChain.builder();
+
+        builder.addBuildStep(new BuildStep() {
+            @Override
+            public void execute(BuildContext bc) {
+                bc.produce(new KeyedPropertyItem("a", "p1"));
+                bc.produce(new KeyedPropertyItem("b", "p2"));
+                bc.produce(new KeyedPropertyItem("c", "p3"));
+            }
+        }).produces(KeyedPropertyItem.class).build();
+
+        loadSteps(FailingKeyedProcessor.class).accept(builder);
+
+        builder.addFinal(OutputItem.class);
+        BuildChain chain = builder.build();
+
+        assertThatThrownBy(() -> chain.createExecutionBuilder("test").execute())
+                .isInstanceOf(BuildException.class)
+                .hasCauseInstanceOf(IllegalStateException.class)
+                .satisfies(e -> {
+                    Throwable cause = e.getCause();
+                    assertThat(cause.getMessage()).contains("Failure for key:");
+                    assertThat(cause.getSuppressed()).hasSize(2);
+                    String allMessages = cause.getMessage();
+                    for (Throwable suppressed : cause.getSuppressed()) {
+                        allMessages += " " + suppressed.getMessage();
+                    }
+                    assertThat(allMessages).contains("a").contains("b").contains("c");
+                });
+    }
+
+    @Test
+    void testSingleKeyFailureNoSuppressed() throws Exception {
+        BuildChainBuilder builder = BuildChain.builder();
+
+        builder.addBuildStep(new BuildStep() {
+            @Override
+            public void execute(BuildContext bc) {
+                bc.produce(new KeyedPropertyItem("only", "p1"));
+            }
+        }).produces(KeyedPropertyItem.class).build();
+
+        loadSteps(FailingKeyedProcessor.class).accept(builder);
+
+        builder.addFinal(OutputItem.class);
+        BuildChain chain = builder.build();
+
+        assertThatThrownBy(() -> chain.createExecutionBuilder("test").execute())
+                .isInstanceOf(BuildException.class)
+                .hasCauseInstanceOf(IllegalStateException.class)
+                .satisfies(e -> {
+                    Throwable cause = e.getCause();
+                    assertThat(cause.getMessage()).isEqualTo("Failure for key: only");
+                    assertThat(cause.getSuppressed()).isEmpty();
+                });
+    }
+
+    public static final class DualKeyItem extends MultiBuildItem {
+        @Key(TestDS.class)
+        private final String dsName;
+        @Key(OtherQualifier.class)
+        private final String otherName;
+
+        public DualKeyItem(String dsName, String otherName) {
+            this.dsName = dsName;
+            this.otherName = otherName;
+        }
+    }
+}

--- a/core/deployment/src/test/java/io/quarkus/deployment/key/KeyUtilsTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/key/KeyUtilsTest.java
@@ -1,0 +1,139 @@
+package io.quarkus.deployment.key;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.builder.item.EmptyBuildItem;
+import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.builder.item.SimpleBuildItem;
+import io.quarkus.deployment.annotations.Key;
+
+public class KeyUtilsTest {
+
+    public static class TestQualifier {
+    }
+
+    public static class OtherQualifier {
+    }
+
+    public static class NoKeyClass {
+        String name;
+    }
+
+    public static class SingleKeyClass {
+        @Key(TestQualifier.class)
+        String name;
+    }
+
+    public static class TwoKeyClass {
+        @Key(TestQualifier.class)
+        String name;
+        @Key(OtherQualifier.class)
+        String other;
+    }
+
+    public static class NonStringKeyClass {
+        @Key(TestQualifier.class)
+        int name;
+    }
+
+    public static class StaticKeyClass {
+        @Key(TestQualifier.class)
+        static String name;
+    }
+
+    public static class KeyWithOtherFieldsClass {
+        @Key(TestQualifier.class)
+        String name;
+        String value;
+        int count;
+    }
+
+    @Test
+    void noKeyFieldReturnsNull() {
+        assertThat(KeyUtils.findKeyField(NoKeyClass.class)).isNull();
+    }
+
+    @Test
+    void singleKeyFieldIsFound() {
+        KeyDescriptor key = KeyUtils.findKeyField(SingleKeyClass.class);
+        assertThat(key).isNotNull();
+        assertThat(key.keyType()).isEqualTo(TestQualifier.class);
+        assertThat(key.field().getName()).isEqualTo("name");
+    }
+
+    @Test
+    void multipleKeyFieldsThrow() {
+        assertThatThrownBy(() -> KeyUtils.findKeyField(TwoKeyClass.class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Multiple @Key fields")
+                .hasMessageContaining("name")
+                .hasMessageContaining("other");
+    }
+
+    @Test
+    void nonStringKeyFieldThrows() {
+        assertThatThrownBy(() -> KeyUtils.findKeyField(NonStringKeyClass.class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must be of type String");
+    }
+
+    @Test
+    void staticKeyFieldIsIgnored() {
+        assertThat(KeyUtils.findKeyField(StaticKeyClass.class)).isNull();
+    }
+
+    @Test
+    void keyFieldFoundAmongOtherFields() {
+        KeyDescriptor key = KeyUtils.findKeyField(KeyWithOtherFieldsClass.class);
+        assertThat(key).isNotNull();
+        assertThat(key.keyType()).isEqualTo(TestQualifier.class);
+        assertThat(key.field().getName()).isEqualTo("name");
+    }
+
+    public static final class KeyedMultiBuildItem extends MultiBuildItem {
+        @Key(TestQualifier.class)
+        String name;
+    }
+
+    public static final class KeyedSimpleBuildItem extends SimpleBuildItem {
+        @Key(TestQualifier.class)
+        String name;
+    }
+
+    public static final class KeyedEmptyBuildItem extends EmptyBuildItem {
+        @Key(TestQualifier.class)
+        String name;
+    }
+
+    @Test
+    void keyOnMultiBuildItemIsAllowed() {
+        KeyDescriptor key = KeyUtils.findKeyField(KeyedMultiBuildItem.class);
+        assertThat(key).isNotNull();
+        assertThat(key.keyType()).isEqualTo(TestQualifier.class);
+    }
+
+    @Test
+    void keyOnSimpleBuildItemThrows() {
+        assertThatThrownBy(() -> KeyUtils.findKeyField(KeyedSimpleBuildItem.class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("only supported on MultiBuildItem");
+    }
+
+    @Test
+    void keyOnEmptyBuildItemThrows() {
+        assertThatThrownBy(() -> KeyUtils.findKeyField(KeyedEmptyBuildItem.class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("only supported on MultiBuildItem");
+    }
+
+    @Test
+    void getValue() throws Exception {
+        KeyDescriptor key = KeyUtils.findKeyField(SingleKeyClass.class);
+        SingleKeyClass instance = new SingleKeyClass();
+        instance.name = "test-value";
+        assertThat(key.getValue(instance)).isEqualTo("test-value");
+    }
+}

--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -740,6 +740,94 @@ public void produceServiceProviders(
 }
 ----
 
+[id='keyed-build-items']
+===== Keyed build items and per-key build steps
+
+When multiple extensions handle _named resources_ (e.g. datasources, persistence units, cache regions),
+build steps often follow the same loop-and-filter boilerplate: consume a full list of multi build items,
+iterate over unique names, and filter every list to the current name.
+
+A `@Key` parameter on a `@BuildStep` method eliminates this boilerplate.
+When a method has a `@Key`-annotated `String` parameter, the engine generates a synthetic
+build step that:
+
+1. Collects all keyed build items and discovers the set of unique key values.
+2. For each key value, injects the key value into the `@Key` parameter, filters every keyed list to matching items, and invokes the method.
+
+The `@io.quarkus.deployment.annotations.Key` annotation is placed on a `String` parameter.
+Its `value` attribute is any class that identifies this key dimension (e.g. `DataSource`, `SearchMapping`),
+grouping build items and build step methods into the same key family.
+Multi build items whose `@Key` has the same key type as the method parameter are filtered automatically;
+all other parameters (non-keyed multi lists, simple build items, producers) pass through unchanged.
+
+TIP: Methods without a `@Key` parameter in the same class remain regular (non-keyed) build steps.
+
+.Example of a keyed multi build item
+[source%nowrap,java]
+----
+public final class DataSourceConfiguredBuildItem extends MultiBuildItem {
+    @Key(DataSource.class)
+    private final String dataSourceName;
+    private final String url;
+
+    public DataSourceConfiguredBuildItem(String dataSourceName, String url) {
+        this.dataSourceName = dataSourceName;
+        this.url = url;
+    }
+
+    // getters...
+}
+----
+
+[source%nowrap,java]
+.Build step class *without* @Key: manual loop and filter
+----
+// Before: manual loop and filter
+@BuildStep
+void createBeans(List<DataSourceDefinedBuildItem> dataSources,
+        List<MigrationBuildItem> migrations,
+        BuildProducer<SyntheticBeanBuildItem> beans) {
+    for (DataSourceDefinedBuildItem dataSource : dataSources) {
+        String name = dataSource.getName();
+        List<MigrationBuildItem> filtered = new ArrayList<>();
+        for (MigrationBuildItem m : migrations) {
+            if (m.getDataSourceName().equals(name)) {
+                filtered.add(m);
+            }
+        }
+        // ... use name, item, and filtered
+    }
+}
+----
+
+[source%nowrap,java]
+.Build step class *with* @Key: implied loop and filter
+----
+class DataSourceProcessor {
+    @BuildStep
+    void createBeans(@Key(DataSource.class) String dataSourceName,
+            DataSourceDefinedBuildItem dataSource, // <1>
+            List<MigrationBuildItem> migrations, // <2>
+            BuildProducer<SyntheticBeanBuildItem> beans) {
+        // items and migrations are already filtered to this dataSourceName
+        // ... use dataSourceName, items, and migrations directly
+    }
+}
+----
+<1> If a keyed multi build item has exactly one instance per key value, you can declare it as a bare
+parameter instead of `List<>`. The engine will filter by key and inject the single matching item directly.
+<2> If a keyed multi build item may have more than one instance per key value, it must still be declared as a `List<>`.
+
+Only one `@Key` parameter per method and one `@Key` field per build item class is supported.
+The class may use `@BuildSteps(onlyIf = ...)` for conditional activation,
+and individual methods support `@Record`, `@Consume`, `@Produce`, and other standard annotations.
+
+If a per-key build step throws an exception for one key value, execution continues for the
+remaining keys.
+The first exception is rethrown after all keys have been processed, with any subsequent
+exceptions attached as suppressed exceptions.
+This ensures that all errors are reported together rather than stopping at the first failure.
+
 [id='empty-build-items']
 ===== Empty build items
 

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem.java
@@ -1,6 +1,9 @@
 package io.quarkus.hibernate.search.orm.elasticsearch.deployment;
 
+import org.hibernate.SessionFactory;
+
 import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.deployment.annotations.Key;
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit;
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchOrmElasticsearchMapperContext;
 
@@ -8,16 +11,19 @@ public final class HibernateSearchElasticsearchPersistenceUnitConfiguredBuildIte
 
     public final HibernateSearchOrmElasticsearchMapperContext mapperContext;
     private final HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit buildTimeConfig;
+    @Key(SessionFactory.class)
+    private final String persistenceUnitName;
 
     public HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem(
             HibernateSearchOrmElasticsearchMapperContext mapperContext,
             HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit buildTimeConfig) {
         this.mapperContext = mapperContext;
         this.buildTimeConfig = buildTimeConfig;
+        this.persistenceUnitName = mapperContext.persistenceUnitName;
     }
 
     public String getPersistenceUnitName() {
-        return mapperContext.persistenceUnitName;
+        return persistenceUnitName;
     }
 
     public HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit getBuildTimeConfig() {

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchProcessor.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchProcessor.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import org.hibernate.SessionFactory;
 import org.hibernate.search.backend.elasticsearch.ElasticsearchVersion;
 import org.hibernate.search.engine.reporting.FailureHandler;
 import org.hibernate.search.mapper.orm.automaticindexing.session.AutomaticIndexingSynchronizationStrategy;
@@ -36,6 +37,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Key;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.DevServicesAdditionalConfigBuildItem;
@@ -67,13 +69,17 @@ class HibernateSearchElasticsearchProcessor {
 
     @BuildStep
     @Record(ExecutionTime.STATIC_INIT)
-    public void build(HibernateSearchElasticsearchRecorder recorder,
+    public void build(RecorderContext recorderContext, HibernateSearchElasticsearchRecorder recorder,
             CombinedIndexBuildItem combinedIndexBuildItem,
             HibernateSearchElasticsearchBuildTimeConfig buildTimeConfig,
             List<PersistenceUnitDescriptorBuildItem> persistenceUnitDescriptorBuildItems,
             BuildProducer<HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem> configuredPersistenceUnits,
             BuildProducer<HibernateOrmIntegrationStaticConfiguredBuildItem> staticIntegrations,
             BuildProducer<HibernateOrmIntegrationRuntimeConfiguredBuildItem> runtimeIntegrations) {
+        // Make it possible to record the settings as bytecode:
+        recorderContext.registerSubstitution(ElasticsearchVersion.class,
+                String.class, ElasticsearchVersionSubstitution.class);
+
         IndexView index = combinedIndexBuildItem.getIndex();
         Collection<AnnotationInstance> indexedAnnotations = index.getAnnotations(INDEXED);
 
@@ -174,44 +180,39 @@ class HibernateSearchElasticsearchProcessor {
     }
 
     @BuildStep
+    RootAnnotationMappedClassNamesBuildItem produceRootAnnotationMappedClassNames(
+            CombinedIndexBuildItem combinedIndexBuildItem) {
+        return new RootAnnotationMappedClassNamesBuildItem(
+                collectRootAnnotationMappedClassNames(combinedIndexBuildItem.getIndex()));
+    }
+
+    @BuildStep
     @Record(ExecutionTime.STATIC_INIT)
-    void setStaticConfig(RecorderContext recorderContext, HibernateSearchElasticsearchRecorder recorder,
-            CombinedIndexBuildItem combinedIndexBuildItem,
+    void setStaticConfig(@Key(SessionFactory.class) String persistenceUnitName,
+            HibernateSearchElasticsearchRecorder recorder,
+            RootAnnotationMappedClassNamesBuildItem rootAnnotationMappedClassNames,
             List<HibernateSearchIntegrationStaticConfiguredBuildItem> integrationStaticConfigBuildItems,
-            List<HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem> configuredPersistenceUnits,
+            HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem configuredPersistenceUnit,
             BuildProducer<HibernateOrmIntegrationStaticConfiguredBuildItem> staticConfigured) {
-        // Make it possible to record the settings as bytecode:
-        recorderContext.registerSubstitution(ElasticsearchVersion.class,
-                String.class, ElasticsearchVersionSubstitution.class);
-
-        IndexView index = combinedIndexBuildItem.getIndex();
-        Set<String> rootAnnotationMappedClassNames = collectRootAnnotationMappedClassNames(index);
-
-        for (HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem configuredPersistenceUnit : configuredPersistenceUnits) {
-            String puName = configuredPersistenceUnit.getPersistenceUnitName();
-            List<HibernateOrmIntegrationStaticInitListener> integrationStaticInitListeners = new ArrayList<>();
-            boolean xmlMappingRequired = false;
-            for (HibernateSearchIntegrationStaticConfiguredBuildItem item : integrationStaticConfigBuildItems) {
-                if (item.getPersistenceUnitName().equals(puName)) {
-                    HibernateOrmIntegrationStaticInitListener listener = item.getInitListener();
-                    if (listener != null) {
-                        integrationStaticInitListeners.add(listener);
-                    }
-                }
-                if (item.isXmlMappingRequired()) {
-                    xmlMappingRequired = true;
-                }
+        List<HibernateOrmIntegrationStaticInitListener> integrationStaticInitListeners = new ArrayList<>();
+        boolean xmlMappingRequired = false;
+        for (HibernateSearchIntegrationStaticConfiguredBuildItem item : integrationStaticConfigBuildItems) {
+            HibernateOrmIntegrationStaticInitListener listener = item.getInitListener();
+            if (listener != null) {
+                integrationStaticInitListeners.add(listener);
             }
-            staticConfigured.produce(
-                    new HibernateOrmIntegrationStaticConfiguredBuildItem(HIBERNATE_SEARCH_ELASTICSEARCH, puName)
-                            .setInitListener(
-                                    // we cannot pass a config group to a recorder so passing the whole config
-                                    recorder.createStaticInitListener(
-                                            configuredPersistenceUnit.mapperContext,
-                                            rootAnnotationMappedClassNames,
-                                            integrationStaticInitListeners))
-                            .setXmlMappingRequired(xmlMappingRequired));
+            if (item.isXmlMappingRequired()) {
+                xmlMappingRequired = true;
+            }
         }
+        staticConfigured.produce(
+                new HibernateOrmIntegrationStaticConfiguredBuildItem(HIBERNATE_SEARCH_ELASTICSEARCH, persistenceUnitName)
+                        .setInitListener(
+                                recorder.createStaticInitListener(
+                                        configuredPersistenceUnit.mapperContext,
+                                        rootAnnotationMappedClassNames.getClassNames(),
+                                        integrationStaticInitListeners))
+                        .setXmlMappingRequired(xmlMappingRequired));
     }
 
     private static Set<String> collectRootAnnotationMappedClassNames(IndexView index) {
@@ -241,26 +242,22 @@ class HibernateSearchElasticsearchProcessor {
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
-    void setRuntimeConfig(HibernateSearchElasticsearchRecorder recorder,
+    void setRuntimeConfig(@Key(SessionFactory.class) String persistenceUnitName,
+            HibernateSearchElasticsearchRecorder recorder,
             List<HibernateSearchIntegrationRuntimeConfiguredBuildItem> integrationRuntimeConfigBuildItems,
-            List<HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem> configuredPersistenceUnits,
+            HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem configuredPersistenceUnit,
             BuildProducer<HibernateOrmIntegrationRuntimeConfiguredBuildItem> runtimeConfigured) {
-        for (HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem configuredPersistenceUnit : configuredPersistenceUnits) {
-            String puName = configuredPersistenceUnit.getPersistenceUnitName();
-            List<HibernateOrmIntegrationRuntimeInitListener> integrationRuntimeInitListeners = new ArrayList<>();
-            for (HibernateSearchIntegrationRuntimeConfiguredBuildItem item : integrationRuntimeConfigBuildItems) {
-                if (item.getPersistenceUnitName().equals(puName)) {
-                    HibernateOrmIntegrationRuntimeInitListener listener = item.getInitListener();
-                    if (listener != null) {
-                        integrationRuntimeInitListeners.add(listener);
-                    }
-                }
+        List<HibernateOrmIntegrationRuntimeInitListener> integrationRuntimeInitListeners = new ArrayList<>();
+        for (HibernateSearchIntegrationRuntimeConfiguredBuildItem item : integrationRuntimeConfigBuildItems) {
+            HibernateOrmIntegrationRuntimeInitListener listener = item.getInitListener();
+            if (listener != null) {
+                integrationRuntimeInitListeners.add(listener);
             }
-            runtimeConfigured.produce(
-                    new HibernateOrmIntegrationRuntimeConfiguredBuildItem(HIBERNATE_SEARCH_ELASTICSEARCH, puName)
-                            .setInitListener(recorder.createRuntimeInitListener(configuredPersistenceUnit.mapperContext,
-                                    integrationRuntimeInitListeners)));
         }
+        runtimeConfigured.produce(
+                new HibernateOrmIntegrationRuntimeConfiguredBuildItem(HIBERNATE_SEARCH_ELASTICSEARCH, persistenceUnitName)
+                        .setInitListener(recorder.createRuntimeInitListener(configuredPersistenceUnit.mapperContext,
+                                integrationRuntimeInitListeners)));
     }
 
     @BuildStep(onlyIf = IsDevServicesSupportedByLaunchMode.class)
@@ -292,30 +289,27 @@ class HibernateSearchElasticsearchProcessor {
     }
 
     @BuildStep(onlyIf = IsDevServicesSupportedByLaunchMode.class)
-    void devServicesDropAndCreateAndDropByDefault(
-            List<HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem> configuredPersistenceUnits,
+    void devServicesDropAndCreateAndDropByDefault(@Key(SessionFactory.class) String persistenceUnitName,
+            HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem configuredPersistenceUnit,
             BuildProducer<DevServicesAdditionalConfigBuildItem> devServicesAdditionalConfigProducer) {
-        for (HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem configuredPersistenceUnit : configuredPersistenceUnits) {
-            String puName = configuredPersistenceUnit.getPersistenceUnitName();
-            List<String> propertyKeysIndicatingHostsConfigured = defaultBackendPropertyKeys(puName, "hosts");
+        List<String> propertyKeysIndicatingHostsConfigured = defaultBackendPropertyKeys(persistenceUnitName, "hosts");
 
-            if (!ConfigUtils.isAnyPropertyPresent(propertyKeysIndicatingHostsConfigured)) {
-                String schemaManagementStrategyPropertyKey = mapperPropertyKey(puName, "schema-management.strategy");
-                if (!ConfigUtils.isPropertyPresent(schemaManagementStrategyPropertyKey)) {
-                    devServicesAdditionalConfigProducer
-                            .produce(new DevServicesAdditionalConfigBuildItem(devServicesConfig -> {
-                                // Only force DB generation if the datasource is configured through dev services
-                                if (propertyKeysIndicatingHostsConfigured.stream()
-                                        .anyMatch(devServicesConfig::containsKey)) {
-                                    String forcedValue = "drop-and-create-and-drop";
-                                    LOG.infof("Setting %s=%s to initialize Dev Services managed Elasticsearch server",
-                                            schemaManagementStrategyPropertyKey, forcedValue);
-                                    return Map.of(schemaManagementStrategyPropertyKey, forcedValue);
-                                } else {
-                                    return Map.of();
-                                }
-                            }));
-                }
+        if (!ConfigUtils.isAnyPropertyPresent(propertyKeysIndicatingHostsConfigured)) {
+            String schemaManagementStrategyPropertyKey = mapperPropertyKey(persistenceUnitName,
+                    "schema-management.strategy");
+            if (!ConfigUtils.isPropertyPresent(schemaManagementStrategyPropertyKey)) {
+                devServicesAdditionalConfigProducer
+                        .produce(new DevServicesAdditionalConfigBuildItem(devServicesConfig -> {
+                            if (propertyKeysIndicatingHostsConfigured.stream()
+                                    .anyMatch(devServicesConfig::containsKey)) {
+                                String forcedValue = "drop-and-create-and-drop";
+                                LOG.infof("Setting %s=%s to initialize Dev Services managed Elasticsearch server",
+                                        schemaManagementStrategyPropertyKey, forcedValue);
+                                return Map.of(schemaManagementStrategyPropertyKey, forcedValue);
+                            } else {
+                                return Map.of();
+                            }
+                        }));
             }
         }
     }

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchIntegrationRuntimeConfiguredBuildItem.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchIntegrationRuntimeConfiguredBuildItem.java
@@ -1,10 +1,14 @@
 package io.quarkus.hibernate.search.orm.elasticsearch.deployment;
 
+import org.hibernate.SessionFactory;
+
 import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.deployment.annotations.Key;
 import io.quarkus.hibernate.orm.runtime.integration.HibernateOrmIntegrationRuntimeInitListener;
 
 public final class HibernateSearchIntegrationRuntimeConfiguredBuildItem extends MultiBuildItem {
     private final String integrationName;
+    @Key(SessionFactory.class)
     private final String persistenceUnitName;
     private final HibernateOrmIntegrationRuntimeInitListener initListener;
 

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchIntegrationStaticConfiguredBuildItem.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchIntegrationStaticConfiguredBuildItem.java
@@ -1,10 +1,14 @@
 package io.quarkus.hibernate.search.orm.elasticsearch.deployment;
 
+import org.hibernate.SessionFactory;
+
 import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.deployment.annotations.Key;
 import io.quarkus.hibernate.orm.runtime.integration.HibernateOrmIntegrationStaticInitListener;
 
 public final class HibernateSearchIntegrationStaticConfiguredBuildItem extends MultiBuildItem {
     private final String integrationName;
+    @Key(SessionFactory.class)
     private final String persistenceUnitName;
     private final HibernateOrmIntegrationStaticInitListener initListener;
     private boolean xmlMappingRequired = false;

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/RootAnnotationMappedClassNamesBuildItem.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/RootAnnotationMappedClassNamesBuildItem.java
@@ -1,0 +1,18 @@
+package io.quarkus.hibernate.search.orm.elasticsearch.deployment;
+
+import java.util.Set;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+final class RootAnnotationMappedClassNamesBuildItem extends SimpleBuildItem {
+
+    private final Set<String> classNames;
+
+    RootAnnotationMappedClassNamesBuildItem(Set<String> classNames) {
+        this.classNames = classNames;
+    }
+
+    Set<String> getClassNames() {
+        return classNames;
+    }
+}


### PR DESCRIPTION
This follows up on a discussion started by @lucamolteni some time ago: https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/.40ForEachKey.20and.20build.20items/with/580620800

He suggested that we allow some syntax for build steps that need to iterate over build items, in particular when there are multiple lists sharing a common key, leading to relatively awkward filtering.

There were concerns from @dmlloyd and @gsmet that such a solution would possibly introduce too much complexity for what it's worth.

Here is a possible implementation, along with documentation and an example of how it can affect an extension. I don't think it's overly complex, especially with the limitations I kept (max 1 key per build item / build step), but let's see what others think.

I only converted the Hibernate Search extension because it's both relevant and simple, and I didn't touch Hibernate ORM and Datasources yet because I have another PR coming that will significantly rewrite relevant build steps in those (leading to conflicts).

How it works, in short:

- A new `@Key(SomeClass.class)` annotation serves dual purpose: on a `@BuildStep` method's `String` parameter, it declares the method as keyed; on a `MultiBuildItem` field, it marks which field carries the key value.
- The `value()` class (the "key family") ties them together — a keyed method iterates over the unique key values found in all consumed `MultiBuildItem` lists whose `@Key` field shares the same family.
- At execution time, `ExtensionLoader` resolves method arguments once (full lists), collects unique keys via `KeyUtils.collectUniqueKeys`, then invokes the method once per key with filtered argument copies  (`KeyUtils.filterKeyedArgs`).
- Keyed `MultiBuildItem` parameters can be declared as `List<MyItem>` (filtered list) or as a bare `MyItem` (engine unwraps the single matching item).
- Failures in individual key iterations are collected and rethrown with suppressed exceptions so that all keys are attempted before failing.
