### PR TITLE
Fix @PATCH silently dropping fields with quarkus-resteasy-jackson

### DIFF
--- a/extensions/resteasy-classic/resteasy-jackson/deployment/src/test/java/io/quarkus/resteasy/jackson/PatchMessage.java
+++ b/extensions/resteasy-classic/resteasy-jackson/deployment/src/test/java/io/quarkus/resteasy/jackson/PatchMessage.java
@@ -1,0 +1,25 @@
+package io.quarkus.resteasy.jackson;
+
+public class PatchMessage {
+
+    private String message;
+    private String author;
+
+    public String getMessage() {
+        return message;
+    }
+
+    public PatchMessage setMessage(String message) {
+        this.message = message;
+        return this;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public PatchMessage setAuthor(String author) {
+        this.author = author;
+        return this;
+    }
+}

--- a/extensions/resteasy-classic/resteasy-jackson/deployment/src/test/java/io/quarkus/resteasy/jackson/PatchResource.java
+++ b/extensions/resteasy-classic/resteasy-jackson/deployment/src/test/java/io/quarkus/resteasy/jackson/PatchResource.java
@@ -1,0 +1,25 @@
+package io.quarkus.resteasy.jackson;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PATCH;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/patch")
+public class PatchResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public PatchMessage get() {
+        return new PatchMessage().setMessage("Hello").setAuthor("Alice");
+    }
+
+    @PATCH
+    @Consumes("application/merge-patch+json")
+    @Produces(MediaType.APPLICATION_JSON)
+    public PatchMessage patch(PatchMessage message) {
+        return message;
+    }
+}

--- a/extensions/resteasy-classic/resteasy-jackson/deployment/src/test/java/io/quarkus/resteasy/jackson/PatchTest.java
+++ b/extensions/resteasy-classic/resteasy-jackson/deployment/src/test/java/io/quarkus/resteasy/jackson/PatchTest.java
@@ -1,0 +1,29 @@
+package io.quarkus.resteasy.jackson;
+
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+
+public class PatchTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest TEST = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(PatchResource.class, PatchMessage.class));
+
+    @Test
+    public void testMergePatchWithJacksonPreservesOmittedFields() {
+        RestAssured.given()
+                .contentType("application/merge-patch+json")
+                .body("{\"message\":\"Patched\"}")
+                .patch("/patch")
+                .then()
+                .statusCode(200)
+                .body("message", equalTo("Patched"))
+                .body("author", equalTo("Alice"));
+    }
+}

--- a/extensions/resteasy-classic/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
+++ b/extensions/resteasy-classic/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
@@ -65,10 +65,13 @@ import io.quarkus.arc.processor.BuiltinScope;
 import io.quarkus.arc.processor.DotNames;
 import io.quarkus.arc.processor.Transformation;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageProxyDefinitionBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBundleBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
@@ -197,6 +200,7 @@ public class ResteasyServerCommonProcessor {
             BuildProducer<ResteasyDeploymentBuildItem> resteasyDeployment,
             BuildProducer<UnremovableBeanBuildItem> unremovableBeans,
             BuildProducer<AnnotationsTransformerBuildItem> annotationsTransformer,
+            BuildProducer<RunTimeConfigurationDefaultBuildItem> runTimeConfigurationDefault,
             List<BuildTimeConditionBuildItem> buildTimeConditions,
             List<AutoInjectAnnotationBuildItem> autoInjectAnnotations,
             List<AdditionalJaxRsResourceDefiningAnnotationBuildItem> additionalJaxRsResourceDefiningAnnotations,
@@ -208,7 +212,8 @@ public class ResteasyServerCommonProcessor {
             CombinedIndexBuildItem combinedIndexBuildItem,
             BeanArchiveIndexBuildItem beanArchiveIndexBuildItem,
             Optional<ResteasyServletMappingBuildItem> resteasyServletMappingBuildItem,
-            CustomScopeAnnotationsBuildItem scopes) throws Exception {
+            CustomScopeAnnotationsBuildItem scopes,
+            Capabilities capabilities) throws Exception {
         IndexView index = combinedIndexBuildItem.getIndex();
 
         final AnnotationInstance applicationPath;
@@ -418,6 +423,11 @@ public class ResteasyServerCommonProcessor {
         if (commonConfig.gzip().enabled()) {
             resteasyInitParameters.put(ResteasyContextParameters.RESTEASY_GZIP_MAX_INPUT,
                     commonConfig.gzip().maxInput().toString(MemorySize.Scale.B));
+        }
+        if (capabilities.isCapabilityWithPrefixPresent(Capability.RESTEASY_JSON_JACKSON)) {
+            resteasyInitParameters.put(ResteasyContextParameters.RESTEASY_PREFER_JACKSON_OVER_JSONB, "true");
+            runTimeConfigurationDefault.produce(new RunTimeConfigurationDefaultBuildItem(
+                    ResteasyContextParameters.RESTEASY_PREFER_JACKSON_OVER_JSONB, "true"));
         }
         resteasyInitParameters.put(ResteasyContextParameters.RESTEASY_UNWRAPPED_EXCEPTIONS,
                 ArcUndeclaredThrowableException.class.getName());


### PR DESCRIPTION
RESTEasy's Jackson-based PATCH filter for `application/merge-patch+json`
and `application/json-patch+json` requests disables itself unless
explicitly told to prefer Jackson over JSON-B. Quarkus never set that
switch automatically, so on apps using only `quarkus-resteasy-jackson`
(no JSON-B), the filter silently skipped merge processing entirely —
any field omitted from a PATCH body was dropped from the resulting
resource instead of being preserved.

This detects the Jackson capability at build time and enables
`resteasy.preferJacksonOverJsonB` by default, covering both the
Servlet/Undertow deployment (`resteasyInitParameters`) and the default
standalone Vert.x deployment (`RunTimeConfigurationDefaultBuildItem`,
consumed via `ResteasyConfigurationMPConfig`).

- Fixes: #33186