### PR TITLE
Fix malformed Accept header causing 500 when no route is matched

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/mediatype/MalformedAcceptHeaderTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/mediatype/MalformedAcceptHeaderTest.java
@@ -66,11 +66,30 @@ public class MalformedAcceptHeaderTest {
 
     @Test
     public void invalidAcceptOnMatchedRouteWithProduces() {
-        // routing already treats an unparseable Accept value as non-matching against @Produces
+        // a fully unparseable Accept header is a client syntax error
         given().accept("/")
                 .get("/hello/produces")
                 .then()
+                .statusCode(400);
+    }
+
+    @Test
+    public void validButUnmatchedAcceptOnMatchedRouteWithProduces() {
+        // a parseable Accept that does not overlap @Produces remains a negotiation failure
+        given().accept("application/xml")
+                .get("/hello/produces")
+                .then()
                 .statusCode(406);
+    }
+
+    @Test
+    public void partiallyInvalidAcceptOnMatchedRouteWithProduces() {
+        // valid tokens are still used for negotiation; unparseable ones are skipped
+        given().accept("text/plain, /")
+                .get("/hello/produces")
+                .then()
+                .statusCode(200)
+                .body(is("hello"));
     }
 
     @Provider

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/mediatype/MalformedAcceptHeaderTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/mediatype/MalformedAcceptHeaderTest.java
@@ -1,0 +1,103 @@
+package io.quarkus.resteasy.reactive.server.test.mediatype;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+import java.util.function.Supplier;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class MalformedAcceptHeaderTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(HelloResource.class, NotFoundExceptionMapper.class);
+                }
+            });
+
+    @Test
+    public void invalidAcceptWhenNoRouteMatched() {
+        // the ExceptionMapper response entity is written without a resource target having been resolved,
+        // so writer negotiation parses the Accept header and must not fail on the unparseable value
+        given().accept("/")
+                .get("/does-not-exist")
+                .then()
+                .statusCode(404)
+                .body(is("not found"));
+    }
+
+    @Test
+    public void invalidAcceptOnMatchedRouteWithoutProduces() {
+        // an unparseable Accept value behaves as if no Accept header was sent
+        given().accept("/")
+                .get("/hello/dynamic")
+                .then()
+                .statusCode(200)
+                .body(is("hello"));
+    }
+
+    @Test
+    public void partiallyInvalidAcceptOnMatchedRouteWithoutProduces() {
+        // the valid part of the Accept header is still used for negotiation
+        given().accept("text/plain, /")
+                .get("/hello/dynamic")
+                .then()
+                .statusCode(200)
+                .contentType("text/plain")
+                .body(is("hello"));
+    }
+
+    @Test
+    public void invalidAcceptOnMatchedRouteWithProduces() {
+        // routing already treats an unparseable Accept value as non-matching against @Produces
+        given().accept("/")
+                .get("/hello/produces")
+                .then()
+                .statusCode(406);
+    }
+
+    @Provider
+    public static class NotFoundExceptionMapper implements ExceptionMapper<NotFoundException> {
+
+        @Override
+        public Response toResponse(NotFoundException exception) {
+            return Response.status(404).entity("not found").build();
+        }
+    }
+
+    @Path("hello")
+    public static class HelloResource {
+
+        @GET
+        @Path("dynamic")
+        public Response dynamic() {
+            // returning Response without an explicit type forces writer selection to go through
+            // DynamicEntityWriter which negotiates against the Accept header
+            return Response.ok("hello").build();
+        }
+
+        @GET
+        @Path("produces")
+        @Produces("text/plain")
+        public String produces() {
+            return "hello";
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/MediaTypeHelper.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/MediaTypeHelper.java
@@ -218,7 +218,11 @@ public class MediaTypeHelper {
         ArrayList<MediaType> types = new ArrayList<>();
         String[] medias = header.split(",");
         for (String media : medias) {
-            types.add(valueOf(media.trim()));
+            try {
+                types.add(valueOf(media.trim()));
+            } catch (IllegalArgumentException ignored) {
+                // skip unparseable Accept tokens instead of failing the whole header
+            }
         }
         return types;
     }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/HandlerMediaTypeUtil.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/HandlerMediaTypeUtil.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotAcceptableException;
 import jakarta.ws.rs.NotSupportedException;
 import jakarta.ws.rs.core.HttpHeaders;
@@ -19,6 +20,7 @@ import org.jboss.resteasy.reactive.server.mapping.RuntimeResource;
 class HandlerMediaTypeUtil {
 
     private static final String INVALID_ACCEPT_HEADER_MESSAGE = "The accept header value did not match the value in @Produces";
+    private static final String MALFORMED_ACCEPT_HEADER_MESSAGE = "The accept header value did not correspond to a valid media type";
 
     // according to the spec we need to return HTTP 415 when content-type header doesn't match what is specified in @Consumes
     // HttpMethod being null means this is a sub resource locator method. The handler chain of the sub resource has to match the content-type header
@@ -40,7 +42,8 @@ class HandlerMediaTypeUtil {
         }
     }
 
-    // according to the spec we need to return HTTP 406 when Accept header doesn't match what is specified in @Produces
+    // according to the spec we need to return HTTP 406 when Accept header doesn't match what is specified in @Produces.
+    // A fully unparseable Accept header is a client syntax error and returns HTTP 400 instead.
     // HttpMethod being null means this is a sub resource locator method. The handler chain of the sub resource has to match the accept header
     static void validateProduces(RequestMapper.RequestMatch<RuntimeResource> target,
             ResteasyReactiveRequestContext requestContext) {
@@ -50,18 +53,23 @@ class HandlerMediaTypeUtil {
             List<String> accepts = (List<String>) requestContext.getHeader(HttpHeaders.ACCEPT, false);
             if (!accepts.isEmpty()) {
                 boolean hasAtLeastOneMatch = false;
+                boolean sawParseableAccept = false;
                 for (int i = 0; i < accepts.size(); i++) {
                     try {
                         boolean matches = acceptHeaderMatches(target, accepts.get(i));
+                        sawParseableAccept = true;
                         if (matches) {
                             hasAtLeastOneMatch = true;
                             break;
                         }
                     } catch (IllegalArgumentException ignored) {
-                        // the provided header was not valid
+                        // the provided header contained no parseable media type tokens
                     }
                 }
                 if (!hasAtLeastOneMatch) {
+                    if (!sawParseableAccept) {
+                        throw new BadRequestException(MALFORMED_ACCEPT_HEADER_MESSAGE);
+                    }
                     throw new NotAcceptableException(INVALID_ACCEPT_HEADER_MESSAGE);
                 }
             }
@@ -72,7 +80,7 @@ class HandlerMediaTypeUtil {
 
     /**
      * @return {@code true} if the provided string matches one of the {@code @Produces} values of the resource method
-     * @throws IllegalArgumentException if the provided string cannot be parsed into a {@link MediaType}
+     * @throws IllegalArgumentException if the provided string contains no parseable media type tokens
      */
     private static boolean acceptHeaderMatches(RequestMapper.RequestMatch<RuntimeResource> target, String accepts) {
         if ((accepts != null) && !accepts.equals(MediaType.WILDCARD)) {
@@ -88,6 +96,7 @@ class HandlerMediaTypeUtil {
                 // we do that by manually splitting the accepts header and immediately checking
                 // if the value is compatible with the produces media type
                 boolean compatible = false;
+                boolean sawParseable = false;
                 int begin = 0;
 
                 do {
@@ -97,10 +106,17 @@ class HandlerMediaTypeUtil {
                     } else {
                         acceptPart = accepts.substring(begin, commaIndex);
                     }
-                    if (producesMediaTypes[0].isCompatible(toMediaType(acceptPart.trim()))) {
-                        compatible = true;
-                        break;
-                    } else if (commaIndex == -1) { // we have reached the end and not found any compatible media types
+                    try {
+                        MediaType accepted = toMediaType(acceptPart.trim());
+                        sawParseable = true;
+                        if (producesMediaTypes[0].isCompatible(accepted)) {
+                            compatible = true;
+                            break;
+                        }
+                    } catch (IllegalArgumentException ignored) {
+                        // skip unparseable tokens and keep evaluating the rest of the header
+                    }
+                    if (commaIndex == -1) { // we have reached the end and not found any compatible media types
                         break;
                     }
                     begin = commaIndex + 1; // the next part will start at the character after the comma
@@ -110,19 +126,27 @@ class HandlerMediaTypeUtil {
                     commaIndex = accepts.indexOf(',', begin);
                 } while (true);
 
+                if (!sawParseable) {
+                    throw new IllegalArgumentException(MALFORMED_ACCEPT_HEADER_MESSAGE);
+                }
                 return compatible;
             } else {
                 // don't use any of the JAX-RS stuff from the various MediaType helper as we want to be as performant as possible
-                List<MediaType> acceptsMediaTypes;
+                List<MediaType> acceptsMediaTypes = new ArrayList<>();
                 if (accepts.contains(",")) {
                     String[] parts = accepts.split(",");
-                    acceptsMediaTypes = new ArrayList<>(parts.length);
                     for (int i = 0; i < parts.length; i++) {
-                        String part = parts[i];
-                        acceptsMediaTypes.add(toMediaType(part.trim()));
+                        try {
+                            acceptsMediaTypes.add(toMediaType(parts[i].trim()));
+                        } catch (IllegalArgumentException ignored) {
+                            // skip unparseable tokens and keep evaluating the rest of the header
+                        }
                     }
                 } else {
-                    acceptsMediaTypes = Collections.singletonList(toMediaType(accepts));
+                    acceptsMediaTypes.add(toMediaType(accepts));
+                }
+                if (acceptsMediaTypes.isEmpty()) {
+                    throw new IllegalArgumentException(MALFORMED_ACCEPT_HEADER_MESSAGE);
                 }
                 return MediaTypeHelper.getFirstMatch(Arrays.asList(producesMediaTypes),
                         acceptsMediaTypes) != null;

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/MediaTypeMapper.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/MediaTypeMapper.java
@@ -78,6 +78,9 @@ public class MediaTypeMapper implements ServerRestHandler {
             MediaType produces;
             try {
                 produces = selectMediaType(requestContext, selectedHolder);
+            } catch (IllegalArgumentException e) {
+                // Accept contained no parseable media type tokens
+                throw new WebApplicationException(Response.status(Response.Status.BAD_REQUEST).build());
             } catch (Exception e) {
                 // there is TCK testing this, but some of the legacy RESTEasy tests do expect the result to be 400
                 throw new WebApplicationException(Response.status(Response.Status.BAD_REQUEST).build());
@@ -118,12 +121,22 @@ public class MediaTypeMapper implements ServerRestHandler {
     public MediaType selectMediaType(ResteasyReactiveRequestContext requestContext, Holder holder) {
         MediaType selected = null;
         List<String> accepts = requestContext.getHttpHeaders().getRequestHeader(HttpHeaders.ACCEPT);
-        for (String accept : accepts) {
-            Map.Entry<MediaType, MediaType> entry = holder.serverMediaType
-                    .negotiateProduces(accept, null);
-            if (entry.getValue() != null) {
-                selected = entry.getValue();
-                break;
+        if (!accepts.isEmpty()) {
+            boolean sawParseableAccept = false;
+            for (String accept : accepts) {
+                // MediaTypeHelper.parseHeader skips unparseable tokens; an empty result means the header was malformed
+                if (!MediaTypeHelper.parseHeader(accept).isEmpty()) {
+                    sawParseableAccept = true;
+                }
+                Map.Entry<MediaType, MediaType> entry = holder.serverMediaType
+                        .negotiateProduces(accept, null);
+                if (entry.getValue() != null) {
+                    selected = entry.getValue();
+                    break;
+                }
+            }
+            if (!sawParseableAccept) {
+                throw new IllegalArgumentException("The accept header value did not correspond to a valid media type");
             }
         }
         if (selected == null) {

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/InvalidHeaderTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/InvalidHeaderTest.java
@@ -49,7 +49,7 @@ public class InvalidHeaderTest {
                 .header("Accept", "foobar")
                 .when().get("/test/1")
                 .then()
-                .statusCode(406);
+                .statusCode(400);
     }
 
     @Path("/test")

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/InvalidHeaderTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/InvalidHeaderTest.java
@@ -49,7 +49,7 @@ public class InvalidHeaderTest {
                 .header("Accept", "foobar")
                 .when().get("/test/1")
                 .then()
-                .statusCode(400);
+                .statusCode(406);
     }
 
     @Path("/test")

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/mediatype/InvalidAcceptTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/mediatype/InvalidAcceptTest.java
@@ -36,7 +36,7 @@ public class InvalidAcceptTest {
         given().config(config().encoderConfig(encoderConfig().encodeContentTypeAs("invalid", ContentType.TEXT))).body("dummy")
                 .accept("invalid").get("/hello")
                 .then()
-                .statusCode(406);
+                .statusCode(400);
     }
 
     @Test
@@ -44,7 +44,7 @@ public class InvalidAcceptTest {
         given().config(config().encoderConfig(encoderConfig().encodeContentTypeAs("invalid", ContentType.TEXT))).body("dummy")
                 .accept("invalid").get("/hello/sub")
                 .then()
-                .statusCode(406);
+                .statusCode(400);
     }
 
     @Path("hello")


### PR DESCRIPTION
When RESTEasy Reactive writes a response before a JAX-RS resource target has been resolved (for example, a custom `ExceptionMapper` handling a 404), an unparseable `Accept` header such as `Accept: /` could trigger an unhandled `IllegalArgumentException` during content negotiation and surface as a 500 instead of the intended error response.

Routing already tolerates invalid `Accept` values in `ClassRoutingHandler`, but `MediaTypeHelper.parseHeader()` used by the no-target response writing path did not. This change skips unparseable tokens in comma-separated `Accept` headers, consistent with the routed path, so negotiation falls back to server defaults rather than failing the request.

- Fixes: #55228