### PR TITLE
Clarify artifact-level exclusion for native image builds

### DIFF
--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -163,6 +163,13 @@ quarkus.arc.exclude-dependency.acme.artifact-id=acme-services <2>
 <1> Value is a group id for a dependency identified by name `acme`.
 <2> Value is an artifact id for a dependency identified by name `acme`.
 
+[NOTE]
+====
+`quarkus.arc.exclude-types` affects CDI bean discovery.
+It does not remove matching classes from the application artifact.
+If a class must be fully isolated from build-time processing or native image analysis, make sure that it is not included in the native build artifact.
+====
+
 [[string-based-qualifiers]]
 == String-Based Qualifiers
 

--- a/docs/src/main/asciidoc/writing-native-applications-tips.adoc
+++ b/docs/src/main/asciidoc/writing-native-applications-tips.adoc
@@ -401,6 +401,99 @@ is a clear indicator that your application might suffer from similar problems.
 These type of dependencies should be avoided,
 and instead code that interacts with optional dependencies should be moved into separate modules.
 
+[[ensuring-optional-classes-are-absent-from-native-build]]
+=== Ensuring optional classes are absent from the native build artifact
+
+Keeping optional features in separate modules is the preferred way to avoid pulling unnecessary or unsupported dependencies into native image analysis.
+
+In existing applications, however, optional features are sometimes implemented in the same application module.
+In this situation, disabling the feature at runtime might not be enough.
+If the classes are still present in the application artifact, they can still be indexed, processed by Quarkus build steps, or made reachable during native image analysis.
+
+This can happen with optional features that depend on libraries that rely heavily on reflection, dynamic class loading, generated metadata, static initialization, or service discovery.
+Examples include reporting, document generation, file format processing, image manipulation, or integrations that are not required in the native executable.
+
+CDI exclusion is not the same as artifact exclusion.
+For example, `quarkus.arc.exclude-types` affects CDI bean discovery.
+It does not remove the matching classes from the application artifact.
+
+Consider an optional service:
+
+[source,java]
+----
+package org.acme.optional;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.transaction.Transactional;
+
+@ApplicationScoped
+public class OptionalFeatureService {
+
+    @Transactional
+    public byte[] export() {
+        // Uses an optional dependency that is not required
+        // in the native executable.
+        return new byte[0];
+    }
+}
+----
+
+The following configuration excludes the type from CDI bean discovery:
+
+[source,properties]
+----
+quarkus.arc.exclude-types=org.acme.optional.**
+----
+
+However, the classes are still part of the application artifact.
+If the goal is to completely isolate this code path from native image analysis, make sure that the corresponding classes are not included in the native build artifact.
+
+For example, with Gradle:
+
+[source,groovy]
+----
+def isNativeBuild = System.getProperty("quarkus.native.enabled") == "true" ||
+        System.getProperty("quarkus.profile") == "native"
+
+if (isNativeBuild) {
+    sourceSets.main.java.exclude "**/optional/**"
+}
+----
+
+Or, with Maven, using a profile for the native build:
+
+[source,xml]
+----
+<profile>
+    <id>native</id>
+    <activation>
+        <property>
+            <name>native</name>
+        </property>
+    </activation>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**/optional/**</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</profile>
+----
+
+This ensures that the excluded classes are not present in the runner JAR.
+As a result, they cannot be indexed, processed by Quarkus build steps, or analyzed by `native-image`.
+
+Use this approach when an optional feature is not required in the native executable and runtime configuration alone does not prevent the problematic classes from becoming reachable.
+
+When possible, prefer moving the optional feature to a separate module.
+Source or class exclusion is most useful as an intermediate step for existing applications that cannot be modularized immediately.
+
 [[enforcing-singletons]]
 === Enforcing Singletons
 


### PR DESCRIPTION
## Summary

This PR clarifies that excluding a type from CDI bean discovery is not the same as excluding the corresponding classes from the native build artifact.

The native application tips guide already recommends modularity for optional features. This PR adds a related note for existing applications where optional code still lives in the same module.

## Motivation

I ran into this while working on a native build for an existing Quarkus application.

An optional feature was disabled for the native profile and its beans were excluded from CDI discovery, but the classes were still present in the application artifact. Because of that, they could still be indexed, processed during build time, or reached during native image analysis.

The fix in that case was to make sure the optional classes were not included in the native build artifact.

This PR documents that distinction so users do not assume that `quarkus.arc.exclude-types` is enough when the goal is to fully isolate code from native-image analysis.

## Changes

- Adds a section to the native application tips guide about excluding optional classes from the native build artifact.
- Adds a note to the CDI reference guide clarifying the scope of `quarkus.arc.exclude-types`.

## Validation

Documentation-only change. Reviewed the AsciiDoc diff locally.