### PR TITLE
Add apply-on-success option to quarkus.http.filter

### DIFF
--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -351,6 +351,17 @@ quarkus.http.filter.any-order.matches=/paths/order.*
 
 Will include the `Cache-Control: max-age=1` header when `/paths/order` is requested.
 
+When using aggressive cache headers (for example, for static assets behind a CDN), you can set `apply-on-success=true`
+to apply headers only on successful (2xx) responses.
+This prevents CDNs from caching error responses such as 403 or 500.
+
+[source, properties]
+----
+quarkus.http.filter.static.header."Cache-Control"=public, max-age=31536000, immutable
+quarkus.http.filter.static.matches=/static/.*
+quarkus.http.filter.static.apply-on-success=true
+----
+
 include::{generated-dir}/config/quarkus-vertx-http_quarkus.http.filter.adoc[leveloffset=+1, opts=optional]
 
 == Support 100-Continue in vert.x

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FilterConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FilterConfig.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.smallrye.config.WithDefault;
 
 public interface FilterConfig {
     /**
@@ -28,4 +29,11 @@ public interface FilterConfig {
      * Order in which this path config is applied. Higher priority takes precedence
      */
     OptionalInt order();
+
+    /**
+     * If enabled, headers are applied only when the response status code is in the 2xx range.
+     * This is useful to avoid caching error responses at CDNs when using aggressive {@code Cache-Control} headers.
+     */
+    @WithDefault("false")
+    boolean applyOnSuccess();
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerCommonHandlers.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerCommonHandlers.java
@@ -105,31 +105,45 @@ public class HttpServerCommonHandlers {
                 var order = filterConfig.order().orElse(Integer.MIN_VALUE);
                 var methods = filterConfig.methods();
                 var headers = filterConfig.header();
+                var applyOnSuccess = filterConfig.applyOnSuccess();
+                Handler<RoutingContext> handler = new Handler<RoutingContext>() {
+                    @Override
+                    public void handle(RoutingContext event) {
+                        applyFilterHeaders(event, headers, applyOnSuccess);
+                        event.next();
+                    }
+                };
                 if (methods.isEmpty()) {
                     httpRouteRouter.routeWithRegex(matches)
                             .order(order)
-                            .handler(new Handler<RoutingContext>() {
-                                @Override
-                                public void handle(RoutingContext event) {
-                                    addFilterHeaders(event, headers);
-                                    event.next();
-                                }
-
-                            });
+                            .handler(handler);
                 } else {
                     for (var method : methods.get()) {
                         httpRouteRouter.routeWithRegex(HttpMethod.valueOf(method.toUpperCase(Locale.ROOT)), matches)
                                 .order(order)
-                                .handler(new Handler<RoutingContext>() {
-                                    @Override
-                                    public void handle(RoutingContext event) {
-                                        addFilterHeaders(event, headers);
-                                        event.next();
-                                    }
-                                });
+                                .handler(handler);
                     }
                 }
             }
+        }
+    }
+
+    static void applyFilterHeaders(RoutingContext event, Map<String, String> headers, boolean applyOnSuccess) {
+        if (applyOnSuccess) {
+            event.addHeadersEndHandler(new Handler<Void>() {
+                @Override
+                public void handle(Void unused) {
+                    int status = event.response().getStatusCode();
+                    // Only final successful (2xx) responses — intentionally excludes 1xx informational
+                    // statuses (e.g. 100 Continue), which are interim and not the cacheable outcome.
+                    // addHeadersEndHandler runs against the completed response, which in practice is not 1xx.
+                    if (status >= 200 && status < 300) {
+                        addFilterHeaders(event, headers);
+                    }
+                }
+            });
+        } else {
+            addFilterHeaders(event, headers);
         }
     }
 

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/options/HttpServerCommonHandlersTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/options/HttpServerCommonHandlersTest.java
@@ -217,6 +217,7 @@ class HttpServerCommonHandlersTest {
         when(filterConfig.order()).thenReturn(OptionalInt.of(10));
         when(filterConfig.methods()).thenReturn(Optional.empty());
         when(filterConfig.header()).thenReturn(Map.of("X-Filter", "value"));
+        when(filterConfig.applyOnSuccess()).thenReturn(false);
 
         Route route = mock(Route.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
         Route orderedRoute = mock(Route.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
@@ -241,6 +242,7 @@ class HttpServerCommonHandlersTest {
         when(filterConfig.order()).thenReturn(OptionalInt.of(5));
         when(filterConfig.methods()).thenReturn(Optional.of(List.of("GET", "POST")));
         when(filterConfig.header()).thenReturn(Map.of("X-Filter", "value"));
+        when(filterConfig.applyOnSuccess()).thenReturn(false);
 
         Route getRoute = mock(Route.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
         Route getOrderedRoute = mock(Route.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
@@ -261,6 +263,150 @@ class HttpServerCommonHandlersTest {
         verify(router).routeWithRegex(HttpMethod.POST, "/api/.*");
         verify(getOrderedRoute).handler(any(Handler.class));
         verify(postOrderedRoute).handler(any(Handler.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void applyFilters_applyOnSuccess_registersHeadersEndHandler() {
+        FilterConfig filterConfig = mock(FilterConfig.class);
+        when(filterConfig.matches()).thenReturn("/api/.*");
+        when(filterConfig.order()).thenReturn(OptionalInt.of(10));
+        when(filterConfig.methods()).thenReturn(Optional.empty());
+        when(filterConfig.header()).thenReturn(Map.of("Cache-Control", "max-age=31536000"));
+        when(filterConfig.applyOnSuccess()).thenReturn(true);
+
+        Route route = mock(Route.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
+        Route orderedRoute = mock(Route.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
+        when(router.routeWithRegex("/api/.*")).thenReturn(route);
+        when(route.order(10)).thenReturn(orderedRoute);
+
+        ArgumentCaptor<Handler<RoutingContext>> handlerCaptor = ArgumentCaptor.forClass(Handler.class);
+        Map<String, FilterConfig> filters = new LinkedHashMap<>();
+        filters.put("filter1", filterConfig);
+
+        HttpServerCommonHandlers.applyFilters(filters, router);
+
+        verify(orderedRoute).handler(handlerCaptor.capture());
+        handlerCaptor.getValue().handle(routingContext);
+        verify(routingContext).addHeadersEndHandler(any(Handler.class));
+        verify(routingContext).next();
+    }
+
+    @Test
+    void applyFilterHeaders_applyOnSuccess_addsHeadersOn2xx() {
+        HttpServerResponse response = mock(HttpServerResponse.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
+        MultiMap responseHeaders = mock(MultiMap.class);
+        when(routingContext.response()).thenReturn(response);
+        when(response.getStatusCode()).thenReturn(200);
+        when(response.headers()).thenReturn(responseHeaders);
+        when(responseHeaders.getAll("Cache-Control")).thenReturn(Collections.emptyList());
+        when(responseHeaders.set(eq("Cache-Control"), eq("max-age=31536000"))).thenReturn(responseHeaders);
+
+        HttpServerCommonHandlers.applyFilterHeaders(routingContext, Map.of("Cache-Control", "max-age=31536000"), true);
+        ArgumentCaptor<Handler<Void>> headersEndHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
+        verify(routingContext).addHeadersEndHandler(headersEndHandlerCaptor.capture());
+        headersEndHandlerCaptor.getValue().handle(null);
+
+        verify(responseHeaders).set("Cache-Control", "max-age=31536000");
+    }
+
+    @Test
+    void applyFilterHeaders_applyOnSuccess_skipsHeadersOnNon2xx() {
+        HttpServerResponse response = mock(HttpServerResponse.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
+        MultiMap responseHeaders = mock(MultiMap.class);
+        when(routingContext.response()).thenReturn(response);
+        when(response.getStatusCode()).thenReturn(403);
+        when(response.headers()).thenReturn(responseHeaders);
+
+        HttpServerCommonHandlers.applyFilterHeaders(routingContext, Map.of("Cache-Control", "max-age=31536000"), true);
+        ArgumentCaptor<Handler<Void>> headersEndHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
+        verify(routingContext).addHeadersEndHandler(headersEndHandlerCaptor.capture());
+        headersEndHandlerCaptor.getValue().handle(null);
+
+        verify(responseHeaders, never()).set(anyString(), anyString());
+    }
+
+    @Test
+    void applyFilterHeaders_applyOnSuccess_addsHeadersOn204() {
+        HttpServerResponse response = mock(HttpServerResponse.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
+        MultiMap responseHeaders = mock(MultiMap.class);
+        when(routingContext.response()).thenReturn(response);
+        when(response.getStatusCode()).thenReturn(204);
+        when(response.headers()).thenReturn(responseHeaders);
+        when(responseHeaders.getAll("Cache-Control")).thenReturn(Collections.emptyList());
+        when(responseHeaders.set(eq("Cache-Control"), eq("max-age=31536000"))).thenReturn(responseHeaders);
+
+        HttpServerCommonHandlers.applyFilterHeaders(routingContext, Map.of("Cache-Control", "max-age=31536000"), true);
+        ArgumentCaptor<Handler<Void>> headersEndHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
+        verify(routingContext).addHeadersEndHandler(headersEndHandlerCaptor.capture());
+        headersEndHandlerCaptor.getValue().handle(null);
+
+        verify(responseHeaders).set("Cache-Control", "max-age=31536000");
+    }
+
+    @Test
+    void applyFilterHeaders_applyOnSuccess_addsHeadersOnCustom2xx() {
+        HttpServerResponse response = mock(HttpServerResponse.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
+        MultiMap responseHeaders = mock(MultiMap.class);
+        when(routingContext.response()).thenReturn(response);
+        when(response.getStatusCode()).thenReturn(267);
+        when(response.headers()).thenReturn(responseHeaders);
+        when(responseHeaders.getAll("Cache-Control")).thenReturn(Collections.emptyList());
+        when(responseHeaders.set(eq("Cache-Control"), eq("max-age=31536000"))).thenReturn(responseHeaders);
+
+        HttpServerCommonHandlers.applyFilterHeaders(routingContext, Map.of("Cache-Control", "max-age=31536000"), true);
+        ArgumentCaptor<Handler<Void>> headersEndHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
+        verify(routingContext).addHeadersEndHandler(headersEndHandlerCaptor.capture());
+        headersEndHandlerCaptor.getValue().handle(null);
+
+        verify(responseHeaders).set("Cache-Control", "max-age=31536000");
+    }
+
+    @Test
+    void applyFilterHeaders_applyOnSuccess_skipsHeadersOn199() {
+        HttpServerResponse response = mock(HttpServerResponse.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
+        MultiMap responseHeaders = mock(MultiMap.class);
+        when(routingContext.response()).thenReturn(response);
+        when(response.getStatusCode()).thenReturn(199);
+        when(response.headers()).thenReturn(responseHeaders);
+
+        HttpServerCommonHandlers.applyFilterHeaders(routingContext, Map.of("Cache-Control", "max-age=31536000"), true);
+        ArgumentCaptor<Handler<Void>> headersEndHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
+        verify(routingContext).addHeadersEndHandler(headersEndHandlerCaptor.capture());
+        headersEndHandlerCaptor.getValue().handle(null);
+
+        verify(responseHeaders, never()).set(anyString(), anyString());
+    }
+
+    @Test
+    void applyFilterHeaders_applyOnSuccess_skipsHeadersOn500() {
+        HttpServerResponse response = mock(HttpServerResponse.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
+        MultiMap responseHeaders = mock(MultiMap.class);
+        when(routingContext.response()).thenReturn(response);
+        when(response.getStatusCode()).thenReturn(500);
+        when(response.headers()).thenReturn(responseHeaders);
+
+        HttpServerCommonHandlers.applyFilterHeaders(routingContext, Map.of("Cache-Control", "max-age=31536000"), true);
+        ArgumentCaptor<Handler<Void>> headersEndHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
+        verify(routingContext).addHeadersEndHandler(headersEndHandlerCaptor.capture());
+        headersEndHandlerCaptor.getValue().handle(null);
+
+        verify(responseHeaders, never()).set(anyString(), anyString());
+    }
+
+    @Test
+    void applyFilterHeaders_withoutApplyOnSuccess_addsHeadersImmediately() {
+        HttpServerResponse response = mock(HttpServerResponse.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
+        MultiMap responseHeaders = mock(MultiMap.class);
+        when(routingContext.response()).thenReturn(response);
+        when(response.headers()).thenReturn(responseHeaders);
+        when(responseHeaders.getAll("Cache-Control")).thenReturn(Collections.emptyList());
+        when(responseHeaders.set(eq("Cache-Control"), eq("max-age=31536000"))).thenReturn(responseHeaders);
+
+        HttpServerCommonHandlers.applyFilterHeaders(routingContext, Map.of("Cache-Control", "max-age=31536000"), false);
+
+        verify(routingContext, never()).addHeadersEndHandler(any(Handler.class));
+        verify(responseHeaders).set("Cache-Control", "max-age=31536000");
     }
 
     @SuppressWarnings("unchecked")

--- a/integration-tests/vertx-http/src/main/java/io/quarkus/it/vertx/FilterResource.java
+++ b/integration-tests/vertx-http/src/main/java/io/quarkus/it/vertx/FilterResource.java
@@ -37,4 +37,34 @@ public class FilterResource {
         return "ok";
     }
 
+    @GET
+    @Path("/apply-on-success/ok")
+    public String applyOnSuccessOk() {
+        return "ok";
+    }
+
+    @GET
+    @Path("/apply-on-success/no-content")
+    public Response applyOnSuccessNoContent() {
+        return Response.noContent().build();
+    }
+
+    @GET
+    @Path("/apply-on-success/custom-in-range")
+    public Response applyOnSuccessCustomInRange() {
+        return Response.status(267).entity("custom-success").build();
+    }
+
+    @GET
+    @Path("/apply-on-success/error")
+    public Response applyOnSuccessError() {
+        return Response.status(403).entity("forbidden").build();
+    }
+
+    @GET
+    @Path("/apply-on-success/server-error")
+    public Response applyOnSuccessServerError() {
+        return Response.status(500).entity("error").build();
+    }
+
 }

--- a/integration-tests/vertx-http/src/main/resources/application.properties
+++ b/integration-tests/vertx-http/src/main/resources/application.properties
@@ -54,3 +54,8 @@ quarkus.http.filter.just-order.matches=/filter/order
 quarkus.http.filter.any-order.order=11
 quarkus.http.filter.any-order.header."Cache-Control"=max-age=1
 quarkus.http.filter.any-order.matches=/filter/order.*
+
+# See io.quarkus.it.vertx.FilterTestCase.testApplyOnSuccessFilter
+quarkus.http.filter.apply-on-success.header."Cache-Control"=max-age=31536000
+quarkus.http.filter.apply-on-success.matches=/filter/apply-on-success/.*
+quarkus.http.filter.apply-on-success.apply-on-success=true

--- a/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/FilterTestCase.java
+++ b/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/FilterTestCase.java
@@ -3,6 +3,7 @@ package io.quarkus.it.vertx;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 import java.util.List;
 
@@ -106,6 +107,55 @@ public class FilterTestCase {
                 .header("Cache-Control", is("max-age=1"))
                 .body(is("ok"));
 
+    }
+
+    @Test
+    void testApplyOnSuccessFilterOnSuccess() {
+        given()
+                .get("/filter/apply-on-success/ok")
+                .then()
+                .statusCode(200)
+                .header("Cache-Control", is("max-age=31536000"))
+                .body(is("ok"));
+    }
+
+    @Test
+    void testApplyOnSuccessFilterOnNoContent() {
+        given()
+                .get("/filter/apply-on-success/no-content")
+                .then()
+                .statusCode(204)
+                .header("Cache-Control", is("max-age=31536000"));
+    }
+
+    @Test
+    void testApplyOnSuccessFilterOnCustomInRangeStatus() {
+        given()
+                .get("/filter/apply-on-success/custom-in-range")
+                .then()
+                .statusCode(267)
+                .header("Cache-Control", is("max-age=31536000"))
+                .body(is("custom-success"));
+    }
+
+    @Test
+    void testApplyOnSuccessFilterOnError() {
+        given()
+                .get("/filter/apply-on-success/error")
+                .then()
+                .statusCode(403)
+                .header("Cache-Control", nullValue())
+                .body(is("forbidden"));
+    }
+
+    @Test
+    void testApplyOnSuccessFilterOnServerError() {
+        given()
+                .get("/filter/apply-on-success/server-error")
+                .then()
+                .statusCode(500)
+                .header("Cache-Control", nullValue())
+                .body(is("error"));
     }
 
 }


### PR DESCRIPTION
`quarkus.http.filter` headers are currently applied before the response status is known, which can cause CDNs to cache error responses when aggressive `Cache-Control` headers are configured.

This adds an `apply-on-success` option that defers header application until the response is finalized and only applies headers on 2xx responses.

- Fixes: #54272

Release note: `quarkus.http.filter` now supports `apply-on-success=true` to apply path-based response headers only on successful (2xx) responses, preventing CDNs from caching error responses with aggressive cache headers.