### PR TITLE
Add gRPC stress integration tests for Vert.x and Netty clients

### DIFF
--- a/integration-tests/grpc-stress/pom.xml
+++ b/integration-tests/grpc-stress/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-integration-test-grpc-stress</artifactId>
+    <name>Quarkus - Integration Tests - gRPC - Stress</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-grpc</artifactId>
+            <version>${project.version}</version> <!--kept here to not pollute the BOM-->
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate-code</goal>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/integration-tests/grpc-stress/src/main/java/io/quarkus/grpc/examples/stress/StressService.java
+++ b/integration-tests/grpc-stress/src/main/java/io/quarkus/grpc/examples/stress/StressService.java
@@ -1,0 +1,27 @@
+package io.quarkus.grpc.examples.stress;
+
+import io.quarkus.grpc.GrpcService;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+
+@GrpcService
+public class StressService extends MutinyStressGrpc.StressImplBase {
+
+    @Override
+    public Uni<IdReply> echoId(IdRequest request) {
+        return Uni.createFrom().item(IdReply.newBuilder().setId(request.getId()).build());
+    }
+
+    @Override
+    public Uni<PayloadReply> echoPayload(PayloadRequest request) {
+        return Uni.createFrom().item(PayloadReply.newBuilder()
+                .setId(request.getId())
+                .setSize(request.getData().size())
+                .build());
+    }
+
+    @Override
+    public Multi<IdReply> streamIds(Multi<IdRequest> request) {
+        return request.map(r -> IdReply.newBuilder().setId(r.getId()).build());
+    }
+}

--- a/integration-tests/grpc-stress/src/main/proto/stress.proto
+++ b/integration-tests/grpc-stress/src/main/proto/stress.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.quarkus.grpc.examples.stress";
+option java_outer_classname = "StressProto";
+
+package stress;
+
+service Stress {
+    rpc EchoId (IdRequest) returns (IdReply) {}
+    rpc EchoPayload (PayloadRequest) returns (PayloadReply) {}
+    rpc StreamIds (stream IdRequest) returns (stream IdReply) {}
+}
+
+message IdRequest {
+    int64 id = 1;
+}
+
+message IdReply {
+    int64 id = 1;
+}
+
+message PayloadRequest {
+    int64 id = 1;
+    bytes data = 2;
+}
+
+message PayloadReply {
+    int64 id = 1;
+    int32 size = 2;
+}

--- a/integration-tests/grpc-stress/src/main/resources/application.properties
+++ b/integration-tests/grpc-stress/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+quarkus.grpc.clients.stress.host=localhost
+quarkus.grpc.clients.stress.port=8081
+
+# Allow 16 MiB payloads for large-message stress scenarios.
+quarkus.grpc.server.max-inbound-message-size=16777216
+quarkus.grpc.clients.stress.max-inbound-message-size=16777216

--- a/integration-tests/grpc-stress/src/test/java/io/quarkus/grpc/examples/stress/GrpcStressSupport.java
+++ b/integration-tests/grpc-stress/src/test/java/io/quarkus/grpc/examples/stress/GrpcStressSupport.java
@@ -1,0 +1,156 @@
+package io.quarkus.grpc.examples.stress;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import io.grpc.Channel;
+import io.grpc.StatusRuntimeException;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+
+final class GrpcStressSupport {
+
+    static final int CONCURRENT_THREADS = 32;
+    static final int CALLS_PER_THREAD = 64;
+    static final int TOTAL_UNARY_CALLS = CONCURRENT_THREADS * CALLS_PER_THREAD;
+    static final Duration CALL_TIMEOUT = Duration.ofMinutes(2);
+    static final int LARGE_PAYLOAD_BYTES = 1024 * 1024;
+    static final int LARGE_PAYLOAD_CALLS = 20;
+    static final int STREAM_MESSAGES_PER_CALL = 50;
+    static final int CONCURRENT_STREAMS = 32;
+
+    private GrpcStressSupport() {
+    }
+
+    static void runConcurrentUnaryEcho(StressGrpc.StressBlockingStub stub) throws InterruptedException {
+        Set<Long> received = ConcurrentHashMap.newKeySet();
+        List<String> errors = Collections.synchronizedList(new ArrayList<>());
+        ExecutorService executor = Executors.newFixedThreadPool(CONCURRENT_THREADS);
+        CountDownLatch latch = new CountDownLatch(CONCURRENT_THREADS);
+
+        try {
+            for (int thread = 0; thread < CONCURRENT_THREADS; thread++) {
+                final int threadIndex = thread;
+                executor.submit(() -> {
+                    try {
+                        for (int call = 0; call < CALLS_PER_THREAD; call++) {
+                            long id = ((long) threadIndex * CALLS_PER_THREAD) + call;
+                            try {
+                                IdReply reply = stub.echoId(IdRequest.newBuilder().setId(id).build());
+                                if (!received.add(reply.getId())) {
+                                    errors.add("duplicate id " + reply.getId());
+                                }
+                            } catch (StatusRuntimeException e) {
+                                errors.add("id " + id + ": " + e.getStatus());
+                            }
+                        }
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            assertThat(latch.await(2, TimeUnit.MINUTES)).isTrue();
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertThat(errors).isEmpty();
+        assertThat(received).hasSize(TOTAL_UNARY_CALLS);
+        assertThat(received).containsExactlyInAnyOrderElementsOf(expectedIds());
+    }
+
+    static void runConcurrentUnaryEcho(MutinyStressGrpc.MutinyStressStub stub) {
+        List<Uni<IdReply>> calls = new ArrayList<>(TOTAL_UNARY_CALLS);
+        for (long id = 0; id < TOTAL_UNARY_CALLS; id++) {
+            long requestId = id;
+            calls.add(stub.echoId(IdRequest.newBuilder().setId(requestId).build()));
+        }
+
+        List<IdReply> replies = Uni.join().all(calls).andFailFast().await().atMost(CALL_TIMEOUT);
+
+        Set<Long> received = ConcurrentHashMap.newKeySet();
+        for (IdReply reply : replies) {
+            assertThat(received.add(reply.getId())).isTrue();
+        }
+        assertThat(received).hasSize(TOTAL_UNARY_CALLS);
+        assertThat(received).containsExactlyInAnyOrderElementsOf(expectedIds());
+    }
+
+    static void runLargePayloadEcho(StressGrpc.StressBlockingStub stub, byte[] payload) {
+        for (int i = 0; i < LARGE_PAYLOAD_CALLS; i++) {
+            PayloadReply reply = stub.echoPayload(PayloadRequest.newBuilder()
+                    .setId(i)
+                    .setData(com.google.protobuf.ByteString.copyFrom(payload))
+                    .build());
+            assertThat(reply.getId()).isEqualTo(i);
+            assertThat(reply.getSize()).isEqualTo(payload.length);
+        }
+    }
+
+    static void runConcurrentClientStreaming(Channel channel) throws InterruptedException {
+        Set<Long> received = ConcurrentHashMap.newKeySet();
+        List<String> errors = Collections.synchronizedList(new ArrayList<>());
+        ExecutorService executor = Executors.newFixedThreadPool(CONCURRENT_STREAMS);
+        CountDownLatch latch = new CountDownLatch(CONCURRENT_STREAMS);
+
+        try {
+            for (int stream = 0; stream < CONCURRENT_STREAMS; stream++) {
+                final int streamIndex = stream;
+                executor.submit(() -> {
+                    try {
+                        MutinyStressGrpc.MutinyStressStub stub = MutinyStressGrpc.newMutinyStub(channel);
+                        List<IdRequest> requests = new ArrayList<>(STREAM_MESSAGES_PER_CALL);
+                        for (int message = 0; message < STREAM_MESSAGES_PER_CALL; message++) {
+                            long id = ((long) streamIndex * STREAM_MESSAGES_PER_CALL) + message;
+                            requests.add(IdRequest.newBuilder().setId(id).build());
+                        }
+
+                        List<IdReply> replies = stub.streamIds(Multi.createFrom().iterable(requests))
+                                .collect().asList()
+                                .await().atMost(CALL_TIMEOUT);
+
+                        for (IdReply reply : replies) {
+                            if (!received.add(reply.getId())) {
+                                errors.add("duplicate id " + reply.getId());
+                            }
+                        }
+                    } catch (Exception e) {
+                        errors.add("stream " + streamIndex + ": " + e);
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            assertThat(latch.await(2, TimeUnit.MINUTES)).isTrue();
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertThat(errors).isEmpty();
+        assertThat(received).hasSize(CONCURRENT_STREAMS * STREAM_MESSAGES_PER_CALL);
+    }
+
+    static byte[] oneMegabytePayload() {
+        return new byte[LARGE_PAYLOAD_BYTES];
+    }
+
+    private static List<Long> expectedIds() {
+        List<Long> ids = new ArrayList<>(TOTAL_UNARY_CALLS);
+        for (long id = 0; id < TOTAL_UNARY_CALLS; id++) {
+            ids.add(id);
+        }
+        return Collections.unmodifiableList(ids);
+    }
+}

--- a/integration-tests/grpc-stress/src/test/java/io/quarkus/grpc/examples/stress/LargeHttp2WindowStressTest.java
+++ b/integration-tests/grpc-stress/src/test/java/io/quarkus/grpc/examples/stress/LargeHttp2WindowStressTest.java
@@ -1,0 +1,33 @@
+package io.quarkus.grpc.examples.stress;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.grpc.GrpcClient;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+/**
+ * Large-payload stress with an enlarged HTTP/2 connection window (unified Vert.x server).
+ */
+@QuarkusTest
+@TestProfile(LargeHttp2WindowStressTest.Profile.class)
+class LargeHttp2WindowStressTest {
+
+    public static class Profile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("quarkus.http.http2-connection-window-size", "104857600");
+        }
+    }
+
+    @GrpcClient("stress")
+    StressGrpc.StressBlockingStub blockingStub;
+
+    @Test
+    void largePayloadUnaryCallsSucceedWithEnlargedWindow() {
+        GrpcStressSupport.runLargePayloadEcho(blockingStub, GrpcStressSupport.oneMegabytePayload());
+    }
+}

--- a/integration-tests/grpc-stress/src/test/java/io/quarkus/grpc/examples/stress/NettyClientUnaryConcurrencyStressTest.java
+++ b/integration-tests/grpc-stress/src/test/java/io/quarkus/grpc/examples/stress/NettyClientUnaryConcurrencyStressTest.java
@@ -1,0 +1,42 @@
+package io.quarkus.grpc.examples.stress;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.grpc.Channel;
+import io.quarkus.grpc.test.utils.GRPCTestUtils;
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * Stress test using the classic gRPC Java (Netty) client via {@link GRPCTestUtils}.
+ * <p>
+ * This complements {@link VertxClientUnaryConcurrencyStressTest} to compare transport
+ * reliability under concurrent unary load (see <a href="https://github.com/quarkusio/quarkus/issues/53847">#53847</a>).
+ */
+@QuarkusTest
+class NettyClientUnaryConcurrencyStressTest {
+
+    private Channel channel;
+
+    @BeforeEach
+    void setUp() {
+        channel = GRPCTestUtils.channel(null);
+    }
+
+    @AfterEach
+    void tearDown() {
+        GRPCTestUtils.close(channel);
+    }
+
+    @Test
+    void concurrentBlockingUnaryCallsDoNotDropMessages() throws InterruptedException {
+        GrpcStressSupport.runConcurrentUnaryEcho(StressGrpc.newBlockingStub(channel));
+    }
+
+    @Test
+    void largePayloadUnaryCallsSucceed() {
+        GrpcStressSupport.runLargePayloadEcho(StressGrpc.newBlockingStub(channel),
+                GrpcStressSupport.oneMegabytePayload());
+    }
+}

--- a/integration-tests/grpc-stress/src/test/java/io/quarkus/grpc/examples/stress/StreamingConcurrencyStressTest.java
+++ b/integration-tests/grpc-stress/src/test/java/io/quarkus/grpc/examples/stress/StreamingConcurrencyStressTest.java
@@ -1,0 +1,40 @@
+package io.quarkus.grpc.examples.stress;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import io.grpc.Channel;
+import io.quarkus.grpc.test.utils.GRPCTestUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import io.vertx.core.Vertx;
+
+/**
+ * Concurrent client-streaming stress using both Vert.x and Netty gRPC clients.
+ */
+@QuarkusTest
+class StreamingConcurrencyStressTest {
+
+    @Inject
+    Vertx vertx;
+
+    @Test
+    void concurrentClientStreamingWithVertxClient() throws InterruptedException {
+        Channel channel = GRPCTestUtils.channel(vertx);
+        try {
+            GrpcStressSupport.runConcurrentClientStreaming(channel);
+        } finally {
+            GRPCTestUtils.close(channel);
+        }
+    }
+
+    @Test
+    void concurrentClientStreamingWithNettyClient() throws InterruptedException {
+        Channel channel = GRPCTestUtils.channel(null);
+        try {
+            GrpcStressSupport.runConcurrentClientStreaming(channel);
+        } finally {
+            GRPCTestUtils.close(channel);
+        }
+    }
+}

--- a/integration-tests/grpc-stress/src/test/java/io/quarkus/grpc/examples/stress/VertxClientUnaryConcurrencyStressTest.java
+++ b/integration-tests/grpc-stress/src/test/java/io/quarkus/grpc/examples/stress/VertxClientUnaryConcurrencyStressTest.java
@@ -1,0 +1,34 @@
+package io.quarkus.grpc.examples.stress;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.grpc.GrpcClient;
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * Stress test using the Quarkus Vert.x-based gRPC client ({@code @GrpcClient}).
+ */
+@QuarkusTest
+class VertxClientUnaryConcurrencyStressTest {
+
+    @GrpcClient("stress")
+    StressGrpc.StressBlockingStub blockingStub;
+
+    @GrpcClient("stress")
+    MutinyStressGrpc.MutinyStressStub mutinyStub;
+
+    @Test
+    void concurrentBlockingUnaryCallsDoNotDropMessages() throws InterruptedException {
+        GrpcStressSupport.runConcurrentUnaryEcho(blockingStub);
+    }
+
+    @Test
+    void concurrentMutinyUnaryCallsDoNotDropMessages() {
+        GrpcStressSupport.runConcurrentUnaryEcho(mutinyStub);
+    }
+
+    @Test
+    void largePayloadUnaryCallsSucceed() {
+        GrpcStressSupport.runLargePayloadEcho(blockingStub, GrpcStressSupport.oneMegabytePayload());
+    }
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -451,6 +451,7 @@
                 <module>grpc-proto4</module>
                 <module>grpc-encoding</module>
                 <module>grpc-domain-socket</module>
+                <module>grpc-stress</module>
                 <module>google-cloud-functions-http</module>
                 <module>google-cloud-functions</module>
                 <module>istio</module>


### PR DESCRIPTION
Fix https://github.com/quarkusio/quarkus/issues/53847 by adding an initial
`integration-tests/grpc-stress` module that exercises concurrent unary RPCs,
client streaming, and large payloads against the unified Vert.x gRPC server.

The module compares the Quarkus Vert.x client (`@GrpcClient`) with the classic
gRPC Java (Netty) client (`GRPCTestUtils`) under concurrent load, and includes
a large-payload scenario with an enlarged HTTP/2 connection window.

This is scaffolding for reliability baselines ahead of Quarkus 4; throughput
benchmarks and heavier stress profiles can build on top of this harness.
