### PR TITLE
OIDC: deduplicate concurrent token refresh requests within a single Quarkus instance

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
@@ -1636,6 +1636,10 @@ If the `quarkus.oidc.token.refresh-expired` is set to `true`, then the expired I
 This refresh token might also be recycled (refreshed) itself as part of this process.
 As a result, the new session cookie is created, and the session is extended.
 
+When multiple concurrent requests arrive with the same expired session and an OIDC provider restricts how many times a refresh token can be used, duplicate refresh attempts may be rejected.
+Set `quarkus.oidc.token.refresh-token-cache-time-to-live` to a short duration (for example, `5S`) to cache the tokens returned in the refresh token grant response so that only one request performs the refresh and the others reuse it.
+Avoid setting this property unless concurrent refresh requests are expected and the provider restricts refresh token reuse.
+
 [NOTE]
 ====
 In instances where the user is not very active, you can use the `quarkus.oidc.authentication.session-age-extension` property to help handle expired ID tokens.

--- a/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
+++ b/docs/src/main/asciidoc/security-oidc-expanded-configuration.adoc
@@ -608,6 +608,7 @@ Session cookie is created after an authorizaion code flow is completed. An expir
 
 |quarkus.oidc.token.refresh-expired |false| Allow refreshing token
 |quarkus.oidc.token.refresh-token-time-skew || Refresh token time skew
+|quarkus.oidc.token.refresh-token-cache-time-to-live |0 (disabled)| Duration for which a completed refresh result is cached to deduplicate concurrent requests
 |quarkus.oidc.authentication.session-age-extension |5 minutes| Session age extension
 |quarkus.oidc.authentication.session-expired-path || Session expired path
 |quarkus.oidc.authentication.cache-control || Set of Cache-Control header directives
@@ -623,6 +624,8 @@ You can use this property to request the refresh if a still valid ID token is du
 For example, let's assume the ID token age is 6 hours and therefore the session cookie age is also 6 hours. If the user accessed Quarkus 1 hour before it was about to expire, and then stayed idle for 2 hours, then, after the user accesses Quarkus again, 7 hours after the session cookie was created and 1 hour after it and the ID token got expired and removed by the browser, Quarkus OIDC can only request the user re-authentication since it can no longer see the session cookie. To minimize a number of re-authentication attempts, consider extending the session age, for example, by 3 hours. Now, given the last example, Quarkus OIDC may still get access to the expired ID token and do somethnig useful with it if required - refresh it or offer a user a session expired page, instead of immediately requesting a new authentication.
 
 The `quarkus.oidc.token.refresh-token` property is automatically enabled if the `quarkus.oidc.token.refresh-token-time-skew` property is configured.
+
+`quarkus.oidc.token.refresh-token-cache-time-to-live` controls how long the tokens returned in the refresh token grant response are kept in memory. When multiple concurrent requests carry the same expired session and the OIDC provider restricts how many times a refresh token can be used, duplicate refresh attempts may be rejected. Set this property to a short duration (for example, `5S`) to ensure only one refresh call is made and subsequent requests reuse the cached result. Avoid setting this property unless concurrent refresh requests are expected and the provider restricts refresh token reuse.
 
 `quarkus.oidc.authentication.session-expired-path` can be used to present the user whose session has expired with the page explaining that the session has expired and letting user follow a link to re-authenticate. It improves the user experience, since otherwise, the authenticated user, whose session has expired, may get surprised after getting an unexpected OIDC provider's authentication challenge screen, when accessing the Quarkus application, following some delay after successfully authenticating earlier.
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -2383,6 +2383,8 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
          */
         public Optional<Duration> refreshTokenTimeSkew = Optional.empty();
 
+        private Duration refreshTokenCacheTimeToLive = Duration.ZERO;
+
         /**
          * The forced JWK set refresh interval in minutes.
          */
@@ -2663,6 +2665,7 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
             principalClaim = mapping.principalClaim();
             refreshExpired = mapping.refreshExpired();
             refreshTokenTimeSkew = mapping.refreshTokenTimeSkew();
+            refreshTokenCacheTimeToLive = mapping.refreshTokenCacheTimeToLive();
             forcedJwkRefreshInterval = mapping.forcedJwkRefreshInterval();
             header = mapping.header();
             authorizationScheme = mapping.authorizationScheme();
@@ -2731,6 +2734,11 @@ public class OidcTenantConfig extends OidcClientCommonConfig implements io.quark
         @Override
         public Optional<Duration> refreshTokenTimeSkew() {
             return refreshTokenTimeSkew;
+        }
+
+        @Override
+        public Duration refreshTokenCacheTimeToLive() {
+            return refreshTokenCacheTimeToLive;
         }
 
         @Override

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/MemoryCache.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/MemoryCache.java
@@ -1,11 +1,13 @@
 package io.quarkus.oidc.runtime;
 
 import java.time.Duration;
-import java.util.Iterator;
+import java.util.ArrayList;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
@@ -17,32 +19,46 @@ public class MemoryCache<T> {
     private final AtomicInteger size = new AtomicInteger();
     private final Duration cacheTimeToLive;
     private final int cacheSize;
+    private final Runnable startTimer;
 
     public MemoryCache(Vertx vertx, Optional<Duration> cleanUpTimerInterval,
             Duration cacheTimeToLive, int cacheSize) {
         this.cacheTimeToLive = cacheTimeToLive;
         this.cacheSize = cacheSize;
-        init(vertx, cleanUpTimerInterval);
-    }
-
-    private void init(Vertx vertx, Optional<Duration> cleanUpTimerInterval) {
         if (vertx != null && cleanUpTimerInterval.isPresent()) {
-            timerId = vertx.setPeriodic(cleanUpTimerInterval.get().toMillis(), new Handler<Long>() {
-                @Override
-                public void handle(Long event) {
-                    // Remove all the entries which have expired
-                    removeInvalidEntries();
+            this.startTimer = () -> {
+                synchronized (MemoryCache.this) {
+                    if (timerId == null) {
+                        timerId = vertx.setPeriodic(cleanUpTimerInterval.get().toMillis(), new Handler<Long>() {
+                            @Override
+                            public void handle(Long event) {
+                                if (!cacheMap.isEmpty()) {
+                                    // Remove all the entries which have expired
+                                    removeInvalidEntries();
+                                }
+                            }
+                        });
+                    }
                 }
-            });
+            };
+        } else {
+            this.startTimer = null;
         }
     }
 
     public void add(String key, T result) {
         if (cacheSize > 0) {
+            startTimerIfNotRunning();
             if (!prepareSpaceForNewCacheEntry()) {
                 clearCache();
             }
-            cacheMap.put(key, new CacheEntry<T>(result));
+            cacheMap.put(key, new CacheEntry<>(result, now()));
+        }
+    }
+
+    private void startTimerIfNotRunning() {
+        if (!isTimerRunning() && startTimer != null) {
+            startTimer.run();
         }
     }
 
@@ -60,21 +76,55 @@ public class MemoryCache<T> {
         return cacheMap.containsKey(key);
     }
 
+    T getOrComputeDeferredValue(String key, Function<CacheEntryAction, T> itemFactory) {
+        return new DeferredCacheValue(key).computeIfAbsent(itemFactory);
+    }
+
     private void removeInvalidEntries() {
         long now = now();
-        for (Iterator<Map.Entry<String, CacheEntry<T>>> it = cacheMap.entrySet().iterator(); it.hasNext();) {
-            Map.Entry<String, CacheEntry<T>> next = it.next();
+        for (Map.Entry<String, CacheEntry<T>> next : cacheMap.entrySet()) {
             if (next != null) {
                 if (isEntryExpired(next.getValue(), now)) {
-                    try {
-                        it.remove();
-                        size.decrementAndGet();
-                    } catch (IllegalStateException ex) {
-                        // continue
-                    }
+                    removeCacheEntry(next.getKey(), next.getValue());
                 }
             }
         }
+    }
+
+    private void removeCacheEntry(String key, CacheEntry<T> entry) {
+        if (cacheMap.remove(key, entry)) {
+            size.decrementAndGet();
+        }
+    }
+
+    private void evictEldest() {
+        int overflow = cacheMap.size() - cacheSize;
+        if (overflow <= 0) {
+            return;
+        }
+        long[] times = new long[overflow];
+        var entries = new ArrayList<Map.Entry<String, CacheEntry<T>>>(overflow);
+        int found = 0;
+        for (var next : cacheMap.entrySet()) {
+            long createdTime = next.getValue().createdTime();
+            if (found < overflow) {
+                times[found] = createdTime;
+                entries.add(next);
+                found++;
+            } else {
+                int youngest = 0;
+                for (int i = 1; i < overflow; i++) {
+                    if (times[i] > times[youngest]) {
+                        youngest = i;
+                    }
+                }
+                if (createdTime < times[youngest]) {
+                    times[youngest] = createdTime;
+                    entries.set(youngest, next);
+                }
+            }
+        }
+        entries.forEach(e -> removeCacheEntry(e.getKey(), e.getValue()));
     }
 
     private boolean prepareSpaceForNewCacheEntry() {
@@ -104,15 +154,6 @@ public class MemoryCache<T> {
         return System.currentTimeMillis();
     }
 
-    private static class CacheEntry<T> {
-        volatile T result;
-        long createdTime = System.currentTimeMillis();
-
-        public CacheEntry(T result) {
-            this.result = result;
-        }
-    }
-
     public int getCacheSize() {
         return cacheMap.size();
     }
@@ -132,4 +173,79 @@ public class MemoryCache<T> {
         return timerId != null;
     }
 
+    private record CacheEntry<S>(S result, long createdTime) {
+
+    }
+
+    private final class DeferredCacheValue implements CacheEntryAction {
+
+        // give time to resolve the deferred value before we start TTL
+        private static final long GRACE_PERIOD_MILLIS = 5_000L;
+
+        private final String key;
+        private volatile CacheEntry<T> cacheEntry;
+
+        private DeferredCacheValue(String key) {
+            this.key = Objects.requireNonNull(key);
+            this.cacheEntry = null;
+        }
+
+        private T computeIfAbsent(Function<CacheEntryAction, T> valueFactory) {
+            if (cacheSize <= 0) {
+                return valueFactory.apply(this);
+            }
+            if (cacheEntry == null) {
+                if (cacheMap.size() >= cacheSize) {
+                    removeInvalidEntries();
+                }
+                var createIfAbsent = new Function<String, CacheEntry<T>>() {
+
+                    private boolean applied = false;
+
+                    @Override
+                    public CacheEntry<T> apply(String k) {
+                        applied = true;
+                        long entryCreated = now() + GRACE_PERIOD_MILLIS;
+                        return new CacheEntry<>(valueFactory.apply(DeferredCacheValue.this), entryCreated);
+                    }
+                };
+                cacheEntry = cacheMap.computeIfAbsent(key, createIfAbsent);
+                if (createIfAbsent.applied) {
+                    startTimerIfNotRunning();
+                    size.incrementAndGet();
+                    if (cacheMap.size() > cacheSize) {
+                        evictEldest();
+                    }
+                }
+            }
+            return cacheEntry.result();
+        }
+
+        @Override
+        public void remove() {
+            var e = cacheEntry;
+            if (e != null) {
+                removeCacheEntry(key, e);
+            }
+        }
+
+        // must be called after the old entry was created, otherwise it is no-op
+        @Override
+        public void startCachingPeriod() {
+            var oldEntry = cacheEntry;
+            if (oldEntry != null) {
+                var newEntry = cacheEntry = new CacheEntry<>(oldEntry.result(), now());
+                cacheMap.replace(key, oldEntry, newEntry);
+            }
+        }
+
+    }
+
+    interface CacheEntryAction {
+
+        void remove();
+
+        void startCachingPeriod();
+
+    }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClientImpl.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClientImpl.java
@@ -6,10 +6,11 @@ import static io.quarkus.oidc.common.runtime.OidcCommonUtils.getClientAssertionP
 import java.io.Closeable;
 import java.net.SocketException;
 import java.security.Key;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -99,7 +100,7 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
     private final Map<OidcEndpoint.Type, List<OidcRequestFilter>> requestFilters;
     private final Map<OidcEndpoint.Type, List<OidcResponseFilter>> responseFilters;
     private final boolean clientSecretQueryAuthentication;
-    private final Map<String, Uni<AuthorizationCodeTokens>> refreshTokenToTokensUni;
+    private final MemoryCache<Uni<AuthorizationCodeTokens>> refreshTokenCache;
     private final String jwtSecret;
     private volatile String clientSecret;
     private volatile String clientSecretBasicAuthScheme;
@@ -124,7 +125,12 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
         this.clientSecretQueryAuthentication = clientCredentials.clientSecretQueryAuthentication;
         this.clientSecret = clientCredentials.clientSecret;
         this.jwtSecret = clientCredentials.jwtSecret;
-        this.refreshTokenToTokensUni = new ConcurrentHashMap<>();
+        Duration refreshTokenCacheTtl = oidcConfig.token().refreshTokenCacheTimeToLive();
+        if (refreshTokenCacheTtl.isZero()) {
+            this.refreshTokenCache = null;
+        } else {
+            this.refreshTokenCache = new MemoryCache<>(vertx, Optional.of(refreshTokenCacheTtl), refreshTokenCacheTtl, 10_000);
+        }
     }
 
     void setOidcProvider(OidcProvider oidcProvider) {
@@ -326,27 +332,31 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
     }
 
     Uni<AuthorizationCodeTokens> refreshAuthorizationCodeTokens(String refreshToken) {
+        if (refreshTokenCache == null) {
+            return refreshAuthorizationCodeTokensWithoutCaching(refreshToken);
+        }
+
+        Uni<AuthorizationCodeTokens> refreshUni = refreshTokenCache.getOrComputeDeferredValue(refreshToken,
+                cacheEntry -> refreshAuthorizationCodeTokensWithoutCaching(refreshToken)
+                        .invoke(cacheEntry::startCachingPeriod)
+                        .onFailure().invoke(cacheEntry::remove)
+                        .memoize().indefinitely());
+
         var ctx = Vertx.currentContext();
-        Uni<AuthorizationCodeTokens> refreshUni = refreshTokenToTokensUni.computeIfAbsent(refreshToken, rt -> {
-            final MultiMap refreshGrantParams = MultiMap.caseInsensitiveMultiMap();
-            refreshGrantParams.add(OidcConstants.GRANT_TYPE, OidcConstants.REFRESH_TOKEN_GRANT);
-            refreshGrantParams.add(OidcConstants.REFRESH_TOKEN_VALUE, rt);
-            final OidcRequestContextProperties requestProps = getRequestProps(OidcConstants.REFRESH_TOKEN_GRANT);
-            try {
-                return getHttpResponse(requestProps, metadata.getTokenUri(), refreshGrantParams, TokenOperation.REFRESH,
-                        OidcEndpoint.Type.TOKEN)
-                        .transformToUni(resp -> getAuthorizationCodeTokens(requestProps, resp))
-                        .onTermination().invoke(() -> refreshTokenToTokensUni.remove(rt))
-                        .memoize().indefinitely();
-            } catch (Throwable t) {
-                refreshTokenToTokensUni.remove(rt);
-                throw t;
-            }
-        });
         if (ctx != null) {
             return refreshUni.emitOn(command -> ctx.runOnContext(ignored -> command.run()));
         }
         return refreshUni;
+    }
+
+    private Uni<AuthorizationCodeTokens> refreshAuthorizationCodeTokensWithoutCaching(String refreshToken) {
+        final MultiMap refreshGrantParams = MultiMap.caseInsensitiveMultiMap();
+        refreshGrantParams.add(OidcConstants.GRANT_TYPE, OidcConstants.REFRESH_TOKEN_GRANT);
+        refreshGrantParams.add(OidcConstants.REFRESH_TOKEN_VALUE, refreshToken);
+        final OidcRequestContextProperties requestProps = getRequestProps(OidcConstants.REFRESH_TOKEN_GRANT);
+        return getHttpResponse(requestProps, metadata.getTokenUri(), refreshGrantParams, TokenOperation.REFRESH,
+                OidcEndpoint.Type.TOKEN)
+                .transformToUni(resp -> getAuthorizationCodeTokens(requestProps, resp));
     }
 
     public Uni<Boolean> revokeAccessToken(String accessToken) {
@@ -358,7 +368,10 @@ public class OidcProviderClientImpl implements OidcProviderClient, Closeable {
     }
 
     public Uni<AuthorizationCodeTokens> getRefreshTokenRequest(String refreshToken) {
-        return refreshTokenToTokensUni.get(refreshToken);
+        if (refreshTokenCache == null) {
+            return null;
+        }
+        return refreshTokenCache.get(refreshToken);
     }
 
     private Uni<Boolean> revokeToken(String token, String tokenTypeHint) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
@@ -1196,6 +1196,26 @@ public interface OidcTenantConfig extends OidcClientCommonConfig {
         Optional<Duration> refreshTokenTimeSkew();
 
         /**
+         * Duration for which a completed token refresh result is kept in memory.
+         * <p>
+         * When multiple concurrent requests carry the same expired session, each independently
+         * attempts to refresh the token. If the OIDC provider restricts how many times a refresh
+         * token can be used, duplicate refresh attempts may be rejected. Set this property to a
+         * short duration (for example, 5 seconds) to ensure only one refresh call is made and
+         * subsequent requests reuse the cached result.
+         * <p>
+         * Keep the value short (a few seconds) — it only needs to cover the window between
+         * concurrent requests arriving at the server. The cached tokens begin aging immediately,
+         * so longer values serve increasingly stale tokens without benefit.
+         * <p>
+         * The cache is per application instance with up to 10,000 entries.
+         * <p>
+         * This property is only effective when {@link #refreshExpired()} is enabled.
+         */
+        @WithDefault("0S")
+        Duration refreshTokenCacheTimeToLive();
+
+        /**
          * The forced JWK set refresh interval in minutes.
          */
         @WithDefault("10M")

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantContextFactory.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantContextFactory.java
@@ -301,6 +301,14 @@ final class TenantContextFactory {
                 LOG.warn(
                         "Session age extension will not be effective because 'quarkus.oidc.token.refresh-expired=true' is not set");
             }
+            if (!oidcConfig.token().refreshExpired()
+                    && !oidcConfig.token().refreshTokenCacheTimeToLive().isZero()) {
+                throw new ConfigurationException(
+                        "'" + getConfigPropertyForTenant(tenantId, "token.refresh-expired")
+                                + "' must be enabled to use '"
+                                + getConfigPropertyForTenant(tenantId, "token.refresh-token-cache-time-to-live")
+                                + "'");
+            }
         }
 
         if (oidcConfig.tokenStateManager()

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/builders/TokenConfigBuilder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/builders/TokenConfigBuilder.java
@@ -25,7 +25,8 @@ public final class TokenConfigBuilder {
     private record TokenImpl(Optional<String> issuer, Optional<List<String>> audience, boolean subjectRequired,
             Map<String, Set<String>> requiredClaims, Optional<String> tokenType, OptionalInt lifespanGrace,
             Optional<Duration> age, boolean issuedAtRequired, Optional<String> principalClaim, boolean refreshExpired,
-            Optional<Duration> refreshTokenTimeSkew, Duration forcedJwkRefreshInterval, Optional<String> header,
+            Optional<Duration> refreshTokenTimeSkew, Duration refreshTokenCacheTimeToLive,
+            Duration forcedJwkRefreshInterval, Optional<String> header,
             String authorizationScheme, Optional<OidcTenantConfig.SignatureAlgorithm> signatureAlgorithm,
             Optional<String> decryptionKeyLocation, Optional<Boolean> decryptIdToken, boolean decryptAccessToken,
             boolean allowJwtIntrospection, boolean requireJwtIntrospectionOnly,
@@ -45,6 +46,7 @@ public final class TokenConfigBuilder {
     private Optional<String> principalClaim;
     private boolean refreshExpired;
     private Optional<Duration> refreshTokenTimeSkew;
+    private Duration refreshTokenCacheTimeToLive;
     private Duration forcedJwkRefreshInterval;
     private Optional<String> header;
     private String authorizationScheme;
@@ -81,6 +83,7 @@ public final class TokenConfigBuilder {
         this.principalClaim = token.principalClaim();
         this.refreshExpired = token.refreshExpired();
         this.refreshTokenTimeSkew = token.refreshTokenTimeSkew();
+        this.refreshTokenCacheTimeToLive = token.refreshTokenCacheTimeToLive();
         this.forcedJwkRefreshInterval = token.forcedJwkRefreshInterval();
         this.header = token.header();
         this.authorizationScheme = token.authorizationScheme();
@@ -293,6 +296,15 @@ public final class TokenConfigBuilder {
     }
 
     /**
+     * @param refreshTokenCacheTimeToLive {@link OidcTenantConfig.Token#refreshTokenCacheTimeToLive()}
+     * @return this builder
+     */
+    public TokenConfigBuilder refreshTokenCacheTimeToLive(Duration refreshTokenCacheTimeToLive) {
+        this.refreshTokenCacheTimeToLive = Objects.requireNonNull(refreshTokenCacheTimeToLive);
+        return this;
+    }
+
+    /**
      * @param forcedJwkRefreshInterval {@link OidcTenantConfig.Token#forcedJwkRefreshInterval()}
      * @return this builder
      */
@@ -487,6 +499,7 @@ public final class TokenConfigBuilder {
                 : Optional.of(List.copyOf(audience));
         return new TokenImpl(issuer, optionalAudience, subjectRequired, Map.copyOf(requiredClaims), tokenType,
                 lifespanGrace, age, issuedAtRequired, principalClaim, refreshExpired, refreshTokenTimeSkew,
+                refreshTokenCacheTimeToLive,
                 forcedJwkRefreshInterval, header, authorizationScheme, signatureAlgorithm, decryptionKeyLocation,
                 decryptIdToken,
                 decryptAccessToken, allowJwtIntrospection, requireJwtIntrospectionOnly, allowOpaqueTokenIntrospection,

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigBuilderTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigBuilderTest.java
@@ -100,6 +100,7 @@ public class OidcTenantConfigBuilderTest {
         assertTrue(token.allowOpaqueTokenIntrospection());
         assertTrue(token.customizerName().isEmpty());
         assertTrue(token.verifyAccessTokenWithUserInfo().isEmpty());
+        assertEquals(Duration.ZERO, token.refreshTokenCacheTimeToLive());
 
         var logout = config.logout();
         assertNotNull(logout);
@@ -279,6 +280,7 @@ public class OidcTenantConfigBuilderTest {
                 .introspectionCredentials().name("i-name").secret("i-secret").includeClientId(false).end()
                 .roles().roleClaimSeparator("@#$").roleClaimPath("separator-23").source(idtoken).end()
                 .token()
+                .refreshTokenCacheTimeToLive(Duration.ofSeconds(30))
                 .verifyAccessTokenWithUserInfo()
                 .customizerName("customizer-name-8")
                 .allowOpaqueTokenIntrospection(false)
@@ -491,6 +493,7 @@ public class OidcTenantConfigBuilderTest {
         assertFalse(token.allowOpaqueTokenIntrospection());
         assertEquals("customizer-name-8", token.customizerName().orElse(null));
         assertTrue(token.verifyAccessTokenWithUserInfo().orElseThrow());
+        assertEquals(Duration.ofSeconds(30), token.refreshTokenCacheTimeToLive());
 
         var logout = config.logout();
         assertNotNull(logout);

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcTenantConfigImpl.java
@@ -20,10 +20,6 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
         this.tenantId = null;
     }
 
-    OidcTenantConfigImpl(String tenantId) {
-        this.tenantId = tenantId;
-    }
-
     enum ConfigMappingMethods {
         AUTH_SERVER_URL,
         DISCOVERY_PATH,
@@ -223,6 +219,7 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
         RAR_SIMPLE,
         RAR_ARRAY,
         RAR_TYPE,
+        REFRESH_TOKEN_CACHE_TIME_TO_LIVE,
         PAR_PATH
     }
 
@@ -404,6 +401,12 @@ final class OidcTenantConfigImpl implements OidcTenantConfig {
             public Optional<Duration> refreshTokenTimeSkew() {
                 invocationsRecorder.put(ConfigMappingMethods.TOKEN_REFRESH_TOKEN_TIME_SKEW, true);
                 return Optional.empty();
+            }
+
+            @Override
+            public Duration refreshTokenCacheTimeToLive() {
+                invocationsRecorder.put(ConfigMappingMethods.REFRESH_TOKEN_CACHE_TIME_TO_LIVE, true);
+                return null;
             }
 
             @Override

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantRefreshTokenResource.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantRefreshTokenResource.java
@@ -2,6 +2,7 @@ package io.quarkus.it.keycloak;
 
 import java.time.Duration;
 
+import jakarta.annotation.security.PermitAll;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
@@ -10,10 +11,8 @@ import jakarta.ws.rs.QueryParam;
 
 import org.eclipse.microprofile.jwt.JsonWebToken;
 
-import io.quarkus.arc.ClientProxy;
 import io.quarkus.oidc.AuthorizationCodeTokens;
 import io.quarkus.oidc.IdToken;
-import io.quarkus.oidc.OidcProviderClient;
 import io.quarkus.oidc.RefreshToken;
 import io.quarkus.oidc.runtime.OidcProvider;
 import io.quarkus.oidc.runtime.OidcProviderClientImpl;
@@ -39,9 +38,6 @@ public class TenantRefreshTokenResource {
     @Inject
     OidcResource oidcResource;
 
-    @Inject
-    OidcProviderClient oidcProviderClient;
-
     @GET
     @Path("/tenant-web-app-refresh/api/user")
     @RolesAllowed("user")
@@ -55,17 +51,20 @@ public class TenantRefreshTokenResource {
 
     @GET
     @Path("/concurrent-token-refresh")
-    @RolesAllowed("user")
-    public ConcurrentRefreshResult getConcurrentRefreshResult(@QueryParam("refresh_token") String originalRefreshToken) {
-        OidcProviderClientImpl client = (OidcProviderClientImpl) ClientProxy.unwrap(oidcProviderClient);
-        OidcProvider oidcProvider = tenantConfigBean.getStaticTenant("concurrent-token-refresh").provider();
+    @PermitAll
+    public ConcurrentRefreshResult getConcurrentRefreshResult(@QueryParam("refresh_token") String originalRefreshToken,
+            @QueryParam("expected_count_before") int expectedCountBefore,
+            @QueryParam("expected_count_after") int expectedCountAfter) {
+        var tenantConfigContext = tenantConfigBean.getStaticTenant("concurrent-token-refresh");
+        var client = tenantConfigContext.getOidcProviderClient();
+        OidcProvider oidcProvider = tenantConfigContext.provider();
         oidcResource.refreshEndpointWait = true;
-        assertCount(client, originalRefreshToken, 0);
+        assertCount(client, originalRefreshToken, expectedCountBefore);
         var result = Uni.join().all(
                 oidcProvider.refreshTokens(originalRefreshToken),
                 Uni.createFrom().nullItem().onItem().delayIt().by(Duration.ofMillis(300))
                         .chain(() -> {
-                            assertCount(client, originalRefreshToken, 1);
+                            assertCount(client, originalRefreshToken, expectedCountAfter);
                             var req = oidcProvider.refreshTokens(originalRefreshToken);
                             oidcResource.refreshEndpointWait = false;
                             return req;
@@ -73,7 +72,7 @@ public class TenantRefreshTokenResource {
                 .andFailFast().await().indefinitely();
         AuthorizationCodeTokens tokens1 = result.get(0);
         AuthorizationCodeTokens tokens2 = result.get(1);
-        assertCount(client, originalRefreshToken, 0);
+        assertCount(client, originalRefreshToken, expectedCountAfter);
         return new ConcurrentRefreshResult(tokens1.getAccessToken(), tokens2.getAccessToken());
     }
 

--- a/integration-tests/oidc-tenancy/src/main/resources/application.properties
+++ b/integration-tests/oidc-tenancy/src/main/resources/application.properties
@@ -231,6 +231,11 @@ quarkus.oidc.step-up-auth-custom-validator.introspection-path=${quarkus.oidc.ste
 
 quarkus.oidc.concurrent-token-refresh.client-id=client
 quarkus.oidc.concurrent-token-refresh.allow-token-introspection-cache=false
-quarkus.oidc.concurrent-token-refresh.jwks-path=jwks
+quarkus.oidc.concurrent-token-refresh.discovery-enabled=false
+quarkus.oidc.concurrent-token-refresh.token-path=token
+quarkus.oidc.concurrent-token-refresh.authorization-path=token
 quarkus.oidc.concurrent-token-refresh.auth-server-url=http://localhost:${quarkus.http.test-port}/oidc
 quarkus.oidc.concurrent-token-refresh.introspection-path=${quarkus.oidc.step-up-auth-annotation-selection.auth-server-url}
+quarkus.oidc.concurrent-token-refresh.application-type=web-app
+quarkus.oidc.concurrent-token-refresh.token.refresh-expired=true
+quarkus.oidc.concurrent-token-refresh.token.refresh-token-cache-time-to-live=5S

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -1199,15 +1199,26 @@ public class BearerTokenAuthorizationTest {
     }
 
     @Test
-    public void testConcurrentTokenRefresh() {
-        var result = RestAssured.given().auth().oauth2(getAccessTokenWithAcr(Set.of()))
+    public void testConcurrentTokenRefresh() throws InterruptedException {
+        var result1 = refreshTokenConcurrently(0, 1);
+        assertEquals(result1.accessToken1(), result1.accessToken2());
+        Thread.sleep(150); // just so that there is a small delay
+        var result2 = refreshTokenConcurrently(1, 1);
+        assertEquals(result2.accessToken1(), result2.accessToken2());
+        assertEquals(result1.accessToken1(), result2.accessToken1());
+    }
+
+    private static TenantRefreshTokenResource.ConcurrentRefreshResult refreshTokenConcurrently(int expectedCountBefore,
+            int expectedCountAfter) {
+        return RestAssured.given()
                 .queryParam("refresh_token", "refresh_token_1")
+                .queryParam("expected_count_before", expectedCountBefore)
+                .queryParam("expected_count_after", expectedCountAfter)
                 .when().get("/tenant-refresh/concurrent-token-refresh")
                 .then()
                 .statusCode(200)
                 .body(Matchers.notNullValue())
                 .extract().as(TenantRefreshTokenResource.ConcurrentRefreshResult.class);
-        assertEquals(result.accessToken1(), result.accessToken2());
     }
 
     private String getAccessToken(String userName, String clientId) {


### PR DESCRIPTION
* Closes: https://github.com/quarkusio/quarkus/issues/55196
* basically introduce really short-lived in-memory cache for refresh tokens so that concurrent requests can share same token refresh result