### PR TITLE
Propagate gRPC exception cause chains via response trailers

### DIFF
--- a/docs/src/main/asciidoc/grpc-service-consumption.adoc
+++ b/docs/src/main/asciidoc/grpc-service-consumption.adoc
@@ -471,6 +471,19 @@ To disable the gRPC client metrics when `quarkus-micrometer` is used, add the fo
 quarkus.micrometer.binder.grpc-client.enabled=false
 ----
 
+=== Exception cause propagation
+
+When a gRPC service throws an exception with a cause chain, Quarkus can propagate the cause chain to clients using response trailers.
+This behavior is enabled by default and can be disabled when exposing services to untrusted clients:
+
+[source,properties]
+----
+quarkus.grpc.server.propagate-exception-causes=false
+quarkus.grpc.propagate-exception-causes=false
+----
+
+On the client, restored causes are represented as `GrpcRemoteException` instances that retain the original exception class name and message.
+
 == Custom exception handling
 
 If any of the gRPC services or server interceptors throw an (custom) exception, you can add your own https://github.com/quarkusio/quarkus/blob/main/extensions/grpc/api/src/main/java/io/quarkus/grpc/ExceptionHandlerProvider.java[ExceptionHandlerProvider]

--- a/extensions/grpc/api/src/main/java/io/quarkus/grpc/ExceptionCauseSupport.java
+++ b/extensions/grpc/api/src/main/java/io/quarkus/grpc/ExceptionCauseSupport.java
@@ -1,0 +1,257 @@
+package io.quarkus.grpc;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+
+/**
+ * Encodes and decodes exception cause chains in gRPC response trailers.
+ */
+public final class ExceptionCauseSupport {
+
+    public static final Metadata.Key<String> EXCEPTION_CAUSES_KEY = Metadata.Key.of("quarkus-grpc-exception-causes",
+            Metadata.ASCII_STRING_MARSHALLER);
+
+    private static volatile boolean propagateExceptionCauses = true;
+
+    private static final char ENTRY_SEPARATOR = '|';
+    private static final char FIELD_SEPARATOR = ':';
+    private static final int MAX_CAUSES = 16;
+    private static final int MAX_MESSAGE_LENGTH = 1024;
+    private static final int MAX_ENCODED_LENGTH = 4096;
+
+    private ExceptionCauseSupport() {
+    }
+
+    public static void setPropagateExceptionCauses(boolean propagateExceptionCauses) {
+        ExceptionCauseSupport.propagateExceptionCauses = propagateExceptionCauses;
+    }
+
+    public static boolean isPropagateExceptionCauses() {
+        return propagateExceptionCauses;
+    }
+
+    /**
+     * Encode the {@code getCause()} chain of the given throwable into the provided trailers.
+     *
+     * @param throwable the original server-side exception
+     * @param trailers the trailers to populate
+     */
+    public static void encodeCauses(Throwable throwable, Metadata trailers) {
+        if (throwable == null || trailers == null) {
+            return;
+        }
+        String encoded = encodeCauseChain(throwable.getCause());
+        if (!encoded.isEmpty()) {
+            trailers.put(EXCEPTION_CAUSES_KEY, encoded);
+        }
+    }
+
+    /**
+     * Restore a {@link StatusRuntimeException} with a populated cause chain when trailers contain encoded causes.
+     *
+     * @param status the response status
+     * @param trailers the response trailers
+     * @param propagateExceptionCauses whether cause restoration is enabled
+     * @return a status runtime exception, potentially with a restored cause chain
+     */
+    public static StatusRuntimeException toStatusRuntimeException(Status status, Metadata trailers,
+            boolean propagateExceptionCauses) {
+        StatusRuntimeException exception = status.asRuntimeException(trailers);
+        attachCausesFromMetadata(exception, propagateExceptionCauses);
+        return exception;
+    }
+
+    /**
+     * Restore the exception cause chain from the {@link StatusRuntimeException} trailers when present.
+     */
+    public static void attachCausesFromMetadata(StatusRuntimeException failure, boolean propagateExceptionCauses) {
+        restoreCauses(failure, propagateExceptionCauses);
+    }
+
+    /**
+     * Restore the exception cause chain from the {@link StatusRuntimeException} trailers when present.
+     */
+    public static void attachCausesFromMetadata(StatusRuntimeException failure) {
+        restoreCauses(failure, propagateExceptionCauses);
+    }
+
+    /**
+     * Restore the exception cause chain from gRPC trailers when present.
+     *
+     * @return the original failure or a new {@link StatusRuntimeException} with a restored cause chain
+     */
+    public static Throwable restoreCauses(Throwable failure, boolean propagateExceptionCauses) {
+        if (!propagateExceptionCauses || !(failure instanceof StatusRuntimeException statusRuntimeException)) {
+            return failure;
+        }
+        Metadata trailers = statusRuntimeException.getTrailers();
+        if (trailers == null || !trailers.containsKey(EXCEPTION_CAUSES_KEY)) {
+            return failure;
+        }
+        Throwable decoded = decodeCauseChain(trailers.get(EXCEPTION_CAUSES_KEY));
+        if (decoded == null) {
+            return failure;
+        }
+        Status status = Status.fromCode(statusRuntimeException.getStatus().getCode())
+                .withDescription(statusRuntimeException.getStatus().getDescription());
+        final Throwable remoteCause = decoded;
+        return new StatusRuntimeException(status, statusRuntimeException.getTrailers()) {
+            @Override
+            public synchronized Throwable getCause() {
+                return remoteCause;
+            }
+        };
+    }
+
+    /**
+     * Restore the exception cause chain from gRPC trailers when present.
+     */
+    public static Throwable restoreCauses(Throwable failure) {
+        return restoreCauses(failure, propagateExceptionCauses);
+    }
+
+    static String encodeCauseChain(Throwable cause) {
+        if (cause == null) {
+            return "";
+        }
+        StringBuilder builder = new StringBuilder();
+        int count = 0;
+        Throwable current = cause;
+        while (current != null && count < MAX_CAUSES) {
+            if (count > 0) {
+                builder.append(ENTRY_SEPARATOR);
+            }
+            appendEntry(builder, current.getClass().getName(), current.getMessage());
+            current = current.getCause();
+            count++;
+        }
+        String encoded = builder.toString();
+        if (encoded.length() > MAX_ENCODED_LENGTH) {
+            return encoded.substring(0, MAX_ENCODED_LENGTH);
+        }
+        return encoded;
+    }
+
+    static Throwable decodeCauseChain(String encoded) {
+        if (encoded == null || encoded.isEmpty()) {
+            return null;
+        }
+        List<GrpcRemoteException> causes = new ArrayList<>();
+        for (String entry : splitEntries(encoded)) {
+            GrpcRemoteException decoded = decodeEntry(entry);
+            if (decoded != null) {
+                causes.add(decoded);
+            }
+        }
+        if (causes.isEmpty()) {
+            return null;
+        }
+        Throwable root = causes.get(0);
+        Throwable current = root;
+        for (int i = 1; i < causes.size(); i++) {
+            current.initCause(causes.get(i));
+            current = causes.get(i);
+        }
+        return root;
+    }
+
+    private static List<String> splitEntries(String encoded) {
+        List<String> entries = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean escaping = false;
+        for (int i = 0; i < encoded.length(); i++) {
+            char value = encoded.charAt(i);
+            if (escaping) {
+                current.append(value);
+                escaping = false;
+            } else if (value == '\\') {
+                current.append(value);
+                escaping = true;
+            } else if (value == ENTRY_SEPARATOR) {
+                entries.add(current.toString());
+                current.setLength(0);
+            } else {
+                current.append(value);
+            }
+        }
+        entries.add(current.toString());
+        return entries;
+    }
+
+    private static void appendEntry(StringBuilder builder, String className, String message) {
+        builder.append(escape(className == null ? "java.lang.Throwable" : className));
+        builder.append(FIELD_SEPARATOR);
+        builder.append(escape(message == null ? "" : truncate(message)));
+    }
+
+    private static GrpcRemoteException decodeEntry(String entry) {
+        if (entry == null || entry.isEmpty()) {
+            return null;
+        }
+        int separatorIndex = indexOfUnescapedSeparator(entry, FIELD_SEPARATOR);
+        if (separatorIndex < 0) {
+            return null;
+        }
+        String className = unescape(entry.substring(0, separatorIndex));
+        String message = unescape(entry.substring(separatorIndex + 1));
+        if (className.isEmpty()) {
+            return null;
+        }
+        return new GrpcRemoteException(className, message);
+    }
+
+    private static int indexOfUnescapedSeparator(String value, char separator) {
+        boolean escaping = false;
+        for (int i = 0; i < value.length(); i++) {
+            char current = value.charAt(i);
+            if (escaping) {
+                escaping = false;
+            } else if (current == '\\') {
+                escaping = true;
+            } else if (current == separator) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static String truncate(String message) {
+        if (message.length() <= MAX_MESSAGE_LENGTH) {
+            return message;
+        }
+        return message.substring(0, MAX_MESSAGE_LENGTH);
+    }
+
+    private static String escape(String value) {
+        StringBuilder builder = new StringBuilder(value.length());
+        for (int i = 0; i < value.length(); i++) {
+            char current = value.charAt(i);
+            if (current == ENTRY_SEPARATOR || current == FIELD_SEPARATOR || current == '\\') {
+                builder.append('\\');
+            }
+            builder.append(current);
+        }
+        return builder.toString();
+    }
+
+    private static String unescape(String value) {
+        StringBuilder builder = new StringBuilder(value.length());
+        boolean escaping = false;
+        for (int i = 0; i < value.length(); i++) {
+            char current = value.charAt(i);
+            if (escaping) {
+                builder.append(current);
+                escaping = false;
+            } else if (current == '\\') {
+                escaping = true;
+            } else {
+                builder.append(current);
+            }
+        }
+        return builder.toString();
+    }
+}

--- a/extensions/grpc/api/src/main/java/io/quarkus/grpc/ExceptionHandlerProvider.java
+++ b/extensions/grpc/api/src/main/java/io/quarkus/grpc/ExceptionHandlerProvider.java
@@ -20,7 +20,7 @@ public interface ExceptionHandlerProvider {
             ServerCall<ReqT, RespT> serverCall, Metadata metadata);
 
     default Throwable transform(Throwable t) {
-        return toStatusException(t, false); // previous default was false
+        return toStatusException(t, true, true);
     }
 
     /**
@@ -31,6 +31,18 @@ public interface ExceptionHandlerProvider {
      * @return Status(Runtime)Exception
      */
     static Exception toStatusException(Throwable t, boolean runtime) {
+        return toStatusException(t, runtime, true);
+    }
+
+    /**
+     * Throw Status exception.
+     *
+     * @param t the throwable to transform
+     * @param runtime true if we should throw StatusRuntimeException, false for StatusException
+     * @param propagateCauses whether to encode the exception cause chain in response trailers
+     * @return Status(Runtime)Exception
+     */
+    static Exception toStatusException(Throwable t, boolean runtime, boolean propagateCauses) {
         if (t instanceof StatusException || t instanceof StatusRuntimeException) {
             if (runtime) {
                 if (t instanceof StatusRuntimeException) {
@@ -57,6 +69,13 @@ public interface ExceptionHandlerProvider {
                 status = Status.INVALID_ARGUMENT.withDescription(desc);
             } else {
                 status = Status.fromThrowable(t).withDescription(desc);
+            }
+            Metadata trailers = new Metadata();
+            if (propagateCauses) {
+                ExceptionCauseSupport.encodeCauses(t, trailers);
+            }
+            if (trailers.containsKey(ExceptionCauseSupport.EXCEPTION_CAUSES_KEY)) {
+                return runtime ? new StatusRuntimeException(status, trailers) : new StatusException(status, trailers);
             }
             return runtime ? status.asRuntimeException() : status.asException();
         }

--- a/extensions/grpc/api/src/main/java/io/quarkus/grpc/GrpcRemoteException.java
+++ b/extensions/grpc/api/src/main/java/io/quarkus/grpc/GrpcRemoteException.java
@@ -1,0 +1,35 @@
+package io.quarkus.grpc;
+
+/**
+ * Represents an exception thrown by a remote gRPC service.
+ * Instances are typically created on the client when restoring an exception cause chain from response trailers.
+ */
+public class GrpcRemoteException extends Exception {
+
+    private final String exceptionClassName;
+
+    public GrpcRemoteException(String exceptionClassName, String message) {
+        super(message);
+        this.exceptionClassName = exceptionClassName;
+    }
+
+    /**
+     * @return the fully qualified class name of the original remote exception
+     */
+    public String getExceptionClassName() {
+        return exceptionClassName;
+    }
+
+    @Override
+    public String toString() {
+        String message = getLocalizedMessage();
+        return message == null || message.isEmpty()
+                ? exceptionClassName
+                : exceptionClassName + ": " + message;
+    }
+
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        return this;
+    }
+}

--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcClientProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcClientProcessor.java
@@ -86,6 +86,7 @@ import io.quarkus.grpc.runtime.stork.VertxStorkMeasuringGrpcInterceptor;
 import io.quarkus.grpc.runtime.supports.Channels;
 import io.quarkus.grpc.runtime.supports.GrpcClientConfigProvider;
 import io.quarkus.grpc.runtime.supports.IOThreadClientInterceptor;
+import io.quarkus.grpc.runtime.supports.exc.ExceptionCausePropagationConfigurator;
 
 public class GrpcClientProcessor {
 
@@ -101,7 +102,8 @@ public class GrpcClientProcessor {
         // @GrpcClient is a CDI qualifier
         beans.produce(new AdditionalBeanBuildItem(GrpcClient.class, RegisterClientInterceptor.class));
         beans.produce(AdditionalBeanBuildItem.builder().setUnremovable().addBeanClasses(GrpcClientConfigProvider.class,
-                GrpcClientInterceptorContainer.class, IOThreadClientInterceptor.class).build());
+                GrpcClientInterceptorContainer.class, IOThreadClientInterceptor.class,
+                ExceptionCausePropagationConfigurator.class).build());
     }
 
     @BuildStep

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/exc/ExceptionCausePropagationDisabledTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/exc/ExceptionCausePropagationDisabledTest.java
@@ -1,0 +1,45 @@
+package io.quarkus.grpc.server.exc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.grpc.StatusRuntimeException;
+import io.grpc.examples.helloworld.Greeter;
+import io.grpc.examples.helloworld.GreeterBean;
+import io.grpc.examples.helloworld.GreeterGrpc;
+import io.grpc.examples.helloworld.HelloReply;
+import io.grpc.examples.helloworld.HelloRequest;
+import io.quarkus.grpc.GrpcClient;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.smallrye.mutiny.Uni;
+
+public class ExceptionCausePropagationDisabledTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .overrideConfigKey("quarkus.http.test-port", "0")
+            .overrideRuntimeConfigKey("quarkus.grpc.server.propagate-exception-causes", "false")
+            .overrideRuntimeConfigKey("quarkus.grpc.propagate-exception-causes", "false")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addPackage(GreeterGrpc.class.getPackage())
+                    .addClasses(ExceptionCausePropagationTest.FailingMutinyHelloService.class, GreeterBean.class,
+                            HelloRequest.class));
+
+    @GrpcClient
+    Greeter greeter;
+
+    @Test
+    void shouldNotPropagateCauseWhenDisabled() {
+        Uni<HelloReply> result = greeter.sayHello(HelloRequest.newBuilder().setName("fail-with-cause").build());
+        assertThatThrownBy(() -> result.await().atMost(Duration.ofSeconds(5)))
+                .isInstanceOf(StatusRuntimeException.class)
+                .satisfies(t -> assertThat(t.getCause()).isNull());
+    }
+}

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/exc/ExceptionCausePropagationTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/exc/ExceptionCausePropagationTest.java
@@ -1,0 +1,73 @@
+package io.quarkus.grpc.server.exc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.grpc.StatusRuntimeException;
+import io.grpc.examples.helloworld.Greeter;
+import io.grpc.examples.helloworld.GreeterBean;
+import io.grpc.examples.helloworld.GreeterGrpc;
+import io.grpc.examples.helloworld.HelloReply;
+import io.grpc.examples.helloworld.HelloRequest;
+import io.quarkus.grpc.GrpcClient;
+import io.quarkus.grpc.GrpcRemoteException;
+import io.quarkus.grpc.GrpcService;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.smallrye.mutiny.Uni;
+
+public class ExceptionCausePropagationTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .overrideConfigKey("quarkus.http.test-port", "0")
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class)
+                            .addPackage(GreeterGrpc.class.getPackage())
+                            .addClasses(FailingMutinyHelloService.class, GreeterBean.class, HelloRequest.class));
+
+    @GrpcClient
+    Greeter greeter;
+
+    @Test
+    void shouldPropagateExceptionCauseChain() {
+        Uni<HelloReply> result = greeter.sayHello(HelloRequest.newBuilder().setName("fail-with-cause").build());
+        assertThatThrownBy(() -> result.await().atMost(Duration.ofSeconds(5)))
+                .isInstanceOf(StatusRuntimeException.class)
+                .satisfies(t -> {
+                    StatusRuntimeException exception = (StatusRuntimeException) t;
+                    assertThat(exception.getCause()).isInstanceOf(GrpcRemoteException.class);
+                    assertThat(((GrpcRemoteException) exception.getCause()).getExceptionClassName())
+                            .isEqualTo(IllegalStateException.class.getName());
+                    assertThat(exception.getCause()).hasMessage("middle cause");
+                    assertThat(exception.getCause().getCause()).isInstanceOf(GrpcRemoteException.class);
+                    assertThat(((GrpcRemoteException) exception.getCause().getCause()).getExceptionClassName())
+                            .isEqualTo(IllegalArgumentException.class.getName());
+                    assertThat(exception.getCause().getCause()).hasMessage("root cause");
+                });
+    }
+
+    @GrpcService
+    public static class FailingMutinyHelloService implements Greeter {
+
+        @Override
+        public Uni<HelloReply> sayHello(HelloRequest request) {
+            if ("fail-with-cause".equals(request.getName())) {
+                return Uni.createFrom().failure(new RuntimeException("top level",
+                        new IllegalStateException("middle cause", new IllegalArgumentException("root cause"))));
+            }
+            return Uni.createFrom().item(HelloReply.newBuilder().setMessage("Hello " + request.getName()).build());
+        }
+
+        @Override
+        public Uni<HelloReply> wEIRD(HelloRequest request) {
+            return sayHello(request);
+        }
+    }
+}

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/GrpcConfiguration.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/GrpcConfiguration.java
@@ -7,6 +7,7 @@ import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithDefaults;
 
 /**
@@ -29,5 +30,13 @@ public interface GrpcConfiguration {
      */
     @ConfigDocSection(generated = true)
     GrpcServerConfiguration server();
+
+    /**
+     * Whether gRPC clients should restore exception cause chains from server response trailers.
+     * <p>
+     * Disable when calling untrusted gRPC services.
+     */
+    @WithDefault("true")
+    boolean propagateExceptionCauses();
 
 }

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/GrpcServerConfiguration.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/GrpcServerConfiguration.java
@@ -26,4 +26,12 @@ public interface GrpcServerConfiguration {
      * gRPC compression, e.g. "gzip"
      */
     Optional<String> compression();
+
+    /**
+     * Whether to propagate the exception cause chain to gRPC clients using response trailers.
+     * <p>
+     * Disable for externally exposed services to avoid leaking internal error details.
+     */
+    @WithDefault("true")
+    boolean propagateExceptionCauses();
 }

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/exc/DefaultExceptionHandlerProvider.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/exc/DefaultExceptionHandlerProvider.java
@@ -5,24 +5,28 @@ import jakarta.enterprise.inject.Instance;
 
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
-import io.grpc.StatusException;
+import io.grpc.Status;
 import io.quarkus.arc.DefaultBean;
 import io.quarkus.grpc.ExceptionHandler;
 import io.quarkus.grpc.ExceptionHandlerProvider;
 import io.quarkus.grpc.auth.AuthExceptionHandlerProvider;
+import io.quarkus.grpc.runtime.config.GrpcConfiguration;
 
 @ApplicationScoped
 @DefaultBean
 public class DefaultExceptionHandlerProvider implements ExceptionHandlerProvider {
 
     private final AuthExceptionHandlerProvider authExceptionHandlerProvider;
+    private final GrpcConfiguration grpcConfiguration;
 
-    public DefaultExceptionHandlerProvider(Instance<AuthExceptionHandlerProvider> authExceptionHandlerProviderInstance) {
+    public DefaultExceptionHandlerProvider(Instance<AuthExceptionHandlerProvider> authExceptionHandlerProviderInstance,
+            GrpcConfiguration grpcConfiguration) {
         if (authExceptionHandlerProviderInstance.isResolvable()) {
             this.authExceptionHandlerProvider = authExceptionHandlerProviderInstance.get();
         } else {
             this.authExceptionHandlerProvider = null;
         }
+        this.grpcConfiguration = grpcConfiguration;
     }
 
     @Override
@@ -36,15 +40,15 @@ public class DefaultExceptionHandlerProvider implements ExceptionHandlerProvider
         return toStatusException(authExceptionHandlerProvider, t);
     }
 
-    private static Throwable toStatusException(AuthExceptionHandlerProvider authExceptionHandlerProvider, Throwable t) {
+    private Throwable toStatusException(AuthExceptionHandlerProvider authExceptionHandlerProvider, Throwable t) {
         if (authExceptionHandlerProvider != null && authExceptionHandlerProvider.handlesException(t)) {
             return authExceptionHandlerProvider.transformToStatusException(t);
         } else {
-            return ExceptionHandlerProvider.toStatusException(t, false);
+            return ExceptionHandlerProvider.toStatusException(t, true, grpcConfiguration.server().propagateExceptionCauses());
         }
     }
 
-    private static class DefaultExceptionHandler<ReqT, RespT> extends ExceptionHandler<ReqT, RespT> {
+    private class DefaultExceptionHandler<ReqT, RespT> extends ExceptionHandler<ReqT, RespT> {
 
         private final AuthExceptionHandlerProvider authExceptionHandlerProvider;
 
@@ -56,10 +60,11 @@ public class DefaultExceptionHandlerProvider implements ExceptionHandlerProvider
 
         @Override
         protected void handleException(Throwable exception, ServerCall<ReqT, RespT> call, Metadata metadata) {
-            StatusException se = (StatusException) toStatusException(authExceptionHandlerProvider, exception);
-            Metadata trailers = se.getTrailers() != null ? se.getTrailers() : metadata;
+            Throwable transformed = toStatusException(authExceptionHandlerProvider, exception);
+            Status status = ExceptionHandlerProvider.toStatus(transformed);
+            Metadata trailers = ExceptionHandlerProvider.toTrailers(transformed).orElse(metadata);
             try {
-                call.close(se.getStatus(), trailers);
+                call.close(status, trailers);
             } catch (IllegalStateException ise) {
                 // Ignore the exception if the server is already closed
                 // Since we don't have a specific exception type for this case, we need to check the message

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/exc/ExceptionCausePropagationConfigurator.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/exc/ExceptionCausePropagationConfigurator.java
@@ -1,0 +1,20 @@
+package io.quarkus.grpc.runtime.supports.exc;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import io.quarkus.grpc.ExceptionCauseSupport;
+import io.quarkus.grpc.runtime.config.GrpcConfiguration;
+
+@ApplicationScoped
+public class ExceptionCausePropagationConfigurator {
+
+    @Inject
+    GrpcConfiguration grpcConfiguration;
+
+    @PostConstruct
+    void init() {
+        ExceptionCauseSupport.setPropagateExceptionCauses(grpcConfiguration.propagateExceptionCauses());
+    }
+}

--- a/extensions/grpc/runtime/src/test/java/io/quarkus/grpc/ExceptionCauseSupportTest.java
+++ b/extensions/grpc/runtime/src/test/java/io/quarkus/grpc/ExceptionCauseSupportTest.java
@@ -1,0 +1,56 @@
+package io.quarkus.grpc;
+
+import static io.quarkus.grpc.ExceptionCauseSupport.encodeCauses;
+import static io.quarkus.grpc.ExceptionCauseSupport.restoreCauses;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+
+class ExceptionCauseSupportTest {
+
+    @Test
+    void shouldAttachCausesFromMetadata() {
+        Metadata trailers = new Metadata();
+        encodeCauses(new RuntimeException("top", new IllegalStateException("middle")), trailers);
+
+        StatusRuntimeException exception = Status.UNKNOWN.withDescription("top").asRuntimeException(trailers);
+        Throwable restored = restoreCauses(exception);
+
+        assertThat(restored).isInstanceOf(StatusRuntimeException.class);
+        assertThat(restored.getCause()).isInstanceOf(GrpcRemoteException.class);
+        assertThat(restored.getCause()).hasMessage("middle");
+    }
+
+    @Test
+    void shouldEncodeAndDecodeCauseChain() {
+        Throwable root = new RuntimeException("outer",
+                new IllegalStateException("middle", new IllegalArgumentException("inner")));
+
+        String encoded = ExceptionCauseSupport.encodeCauseChain(root.getCause());
+        Throwable decoded = ExceptionCauseSupport.decodeCauseChain(encoded);
+
+        assertThat(decoded).isInstanceOf(GrpcRemoteException.class);
+        assertThat(((GrpcRemoteException) decoded).getExceptionClassName())
+                .isEqualTo(IllegalStateException.class.getName());
+        assertThat(decoded).hasMessage("middle");
+        assertThat(decoded.getCause()).isInstanceOf(GrpcRemoteException.class);
+        assertThat(((GrpcRemoteException) decoded.getCause()).getExceptionClassName())
+                .isEqualTo(IllegalArgumentException.class.getName());
+        assertThat(decoded.getCause()).hasMessage("inner");
+    }
+
+    @Test
+    void shouldEscapeSpecialCharacters() {
+        Throwable cause = new RuntimeException("line1\\line2|:");
+
+        String encoded = ExceptionCauseSupport.encodeCauseChain(cause);
+        Throwable decoded = ExceptionCauseSupport.decodeCauseChain(encoded);
+
+        assertThat(decoded).isInstanceOf(GrpcRemoteException.class);
+        assertThat(decoded).hasMessage("line1\\line2|:");
+    }
+}

--- a/extensions/grpc/stubs/src/main/java/io/quarkus/grpc/stubs/MultiStreamObserver.java
+++ b/extensions/grpc/stubs/src/main/java/io/quarkus/grpc/stubs/MultiStreamObserver.java
@@ -5,6 +5,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import io.grpc.stub.ClientCallStreamObserver;
 import io.grpc.stub.ClientResponseObserver;
+import io.quarkus.grpc.ExceptionCauseSupport;
 import io.smallrye.mutiny.subscription.MultiEmitter;
 
 public class MultiStreamObserver<I, O> implements ClientResponseObserver<I, O> {
@@ -85,6 +86,7 @@ public class MultiStreamObserver<I, O> implements ClientResponseObserver<I, O> {
 
     @Override
     public void onError(Throwable failure) {
+        failure = ExceptionCauseSupport.restoreCauses(failure);
         if (terminated.compareAndSet(false, true)) {
             emitter.fail(failure);
         } else {

--- a/extensions/grpc/stubs/src/main/java/io/quarkus/grpc/stubs/UniStreamObserver.java
+++ b/extensions/grpc/stubs/src/main/java/io/quarkus/grpc/stubs/UniStreamObserver.java
@@ -5,6 +5,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import io.grpc.stub.ClientCallStreamObserver;
 import io.grpc.stub.ClientResponseObserver;
+import io.quarkus.grpc.ExceptionCauseSupport;
 import io.smallrye.mutiny.subscription.UniEmitter;
 
 public class UniStreamObserver<I, O> implements ClientResponseObserver<I, O> {
@@ -54,6 +55,7 @@ public class UniStreamObserver<I, O> implements ClientResponseObserver<I, O> {
 
     @Override
     public void onError(Throwable failure) {
+        failure = ExceptionCauseSupport.restoreCauses(failure);
         if (terminated.compareAndSet(false, true)) {
             emitter.fail(failure);
         } else {


### PR DESCRIPTION
Fixes #48929

gRPC clients only received the top-level exception message in `StatusRuntimeException`, with no `getCause()` chain. This change makes Quarkus gRPC exception handling symmetric with REST: the server encodes the cause chain into response trailers, and Mutiny clients restore it when failures are received.

Server-side failures now serialize each `getCause()` level (class name + message) into the `quarkus-grpc-exception-causes` trailer. Mutiny clients rebuild the chain as `GrpcRemoteException` instances via `ExceptionCauseSupport.restoreCauses()`.

Propagation is enabled by default and can be disabled for externally exposed services:

```
quarkus.grpc.server.propagate-exception-causes=false
quarkus.grpc.propagate-exception-causes=false
```

Release note: gRPC clients can now restore remote exception cause chains from server response trailers, improving debuggability for internal service-to-service calls.
