### PR TITLE
Fix warning in resteasy-reactive-kotlin/standard IT

### DIFF
--- a/integration-tests/resteasy-reactive-kotlin/standard/src/main/resources/application.properties
+++ b/integration-tests/resteasy-reactive-kotlin/standard/src/main/resources/application.properties
@@ -21,6 +21,6 @@ mp.messaging.incoming.countries-t2-in.connector=smallrye-kafka
 mp.messaging.incoming.countries-t2-in.topic=countries-t2
 mp.messaging.incoming.countries-t2-in.auto.offset.reset=earliest
 
-quarkus.package.decompiler.enabled=true
+quarkus.package.jar.decompiler.enabled=true
 
 test.prop=test


### PR DESCRIPTION
The warning in `main` is:

```
[WARNING] [io.quarkus.deployment.configuration] Configuration property 'quarkus.package.decompiler.enabled' has been deprecated and replaced by: [quarkus.package.jar.decompiler.enabled]
```