### PR TITLE
Support weight-based eviction for Hibernate 2LC Caffeine cache regions

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -1062,6 +1062,38 @@ quarkus.hibernate-orm.cache."org.acme.MyEntity".memory.object-count=1000
 ----
 ====
 
+==== Weight-based eviction
+
+For entities with highly variable sizes (e.g., storing JSON data that ranges from a few bytes to
+megabytes), count-based eviction cannot reliably bound memory usage. In these cases, use weight-based
+eviction instead:
+
+[source,properties]
+----
+quarkus.hibernate-orm.cache."org.acme.MyEntity".memory.maximum-weight=104857600
+quarkus.hibernate-orm.cache."org.acme.MyEntity".memory.weigher-class=org.acme.MyEntityWeigher
+----
+
+The `maximum-weight` property sets the total weight limit for the cache region. The `weigher-class`
+property specifies a `com.github.benmanes.caffeine.cache.Weigher` implementation that assigns a
+weight to each cache entry:
+
+[source,java]
+----
+import com.github.benmanes.caffeine.cache.Weigher;
+
+public class MyEntityWeigher implements Weigher<Object, Object> {
+    @Override
+    public int weigh(Object key, Object value) {
+        // Estimate memory based on entity data size
+        return 100; // default weight
+    }
+}
+----
+
+NOTE: `object-count` and `maximum-weight` are mutually exclusive per cache region.
+If `maximum-weight` is set without `weigher-class`, each entry has a default weight of 1.
+
 include::{includes}/duration-format-note.adoc[]
 
 === Limitations of Caching

--- a/extensions/caffeine/runtime/src/main/java/io/quarkus/caffeine/runtime/graal/CacheConstructorsFeature.java
+++ b/extensions/caffeine/runtime/src/main/java/io/quarkus/caffeine/runtime/graal/CacheConstructorsFeature.java
@@ -100,6 +100,8 @@ public class CacheConstructorsFeature implements Feature {
                 "com.github.benmanes.caffeine.cache.SSMSA",
                 "com.github.benmanes.caffeine.cache.SSMSAW",
                 "com.github.benmanes.caffeine.cache.SSMSW",
+                // Used by Hibernate ORM's weight-based 2LC cache: expire after access, bounded by weight
+                "com.github.benmanes.caffeine.cache.SSMWA",
                 "com.github.benmanes.caffeine.cache.SSW",
         };
     }

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
@@ -725,9 +725,30 @@ public interface HibernateOrmConfigPersistenceUnit {
     interface HibernateOrmConfigPersistenceUnitCacheMemory {
         /**
          * The maximum number of objects kept in memory in the cache.
+         * <p>
+         * Mutually exclusive with {@code maximum-weight}.
          */
         @ConfigDocDefault("10000")
         OptionalLong objectCount();
+
+        /**
+         * The maximum total weight of objects kept in memory in the cache.
+         * <p>
+         * When set, eviction is based on the total weight of cached entries rather than their count.
+         * This is useful for entities with highly variable sizes (e.g., JSON blobs).
+         * <p>
+         * Mutually exclusive with {@code object-count}. Requires a {@code weigher-class} to assign
+         * weights to entries; without one, each entry has a default weight of 1.
+         */
+        OptionalLong maximumWeight();
+
+        /**
+         * The fully qualified class name of a {@code com.github.benmanes.caffeine.cache.Weigher}
+         * implementation used to assign weights to cache entries.
+         * <p>
+         * Only used when {@code maximum-weight} is set. The class must have a public no-arg constructor.
+         */
+        Optional<String> weigherClass();
     }
 
     @ConfigGroup

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -250,6 +250,16 @@ public final class HibernateOrmProcessor {
                     "com.github.benmanes.caffeine.jcache.spi.CaffeineCachingProvider")
                     .reason(ClassNames.HIBERNATE_ORM_PROCESSOR.toString())
                     .methods().fields().build());
+
+            // Register custom cache weigher classes for reflection (native image support)
+            for (var puConfig : config.persistenceUnits().values()) {
+                for (var cacheEntry : puConfig.cache().entrySet()) {
+                    cacheEntry.getValue().memory().weigherClass().ifPresent(weigherClass -> reflective
+                            .produce(ReflectiveClassBuildItem.builder(weigherClass)
+                                    .reason(ClassNames.HIBERNATE_ORM_PROCESSOR.toString())
+                                    .build()));
+                }
+            }
         }
     }
 

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/util/HibernateProcessorUtil.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/util/HibernateProcessorUtil.java
@@ -480,10 +480,25 @@ public final class HibernateProcessorUtil {
         for (var regionEntry : config.cache().entrySet()) {
             String cacheName = regionEntry.getKey();
             var cacheConfig = regionEntry.getValue();
+            var memory = cacheConfig.memory();
+
+            // Validate mutual exclusivity
+            if (memory.objectCount().isPresent() && memory.maximumWeight().isPresent()) {
+                throw new IllegalStateException(
+                        "Cache region '" + cacheName + "': 'object-count' and 'maximum-weight' are mutually exclusive. "
+                                + "Use 'object-count' for count-based eviction or 'maximum-weight' for weight-based eviction.");
+            }
+            if (memory.weigherClass().isPresent() && memory.maximumWeight().isEmpty()) {
+                throw new IllegalStateException(
+                        "Cache region '" + cacheName + "': 'weigher-class' requires 'maximum-weight' to be set.");
+            }
+
             caches.put(cacheName, new QuarkusPersistenceUnitCacheConfiguration.Cache(
-                    cacheConfig.memory().objectCount().orElse(QuarkusPersistenceUnitCacheConfiguration.Cache.DEFAULT.maxSize()),
+                    memory.objectCount().orElse(QuarkusPersistenceUnitCacheConfiguration.Cache.DEFAULT.maxSize()),
                     cacheConfig.expiration().maxIdle()
-                            .orElse(QuarkusPersistenceUnitCacheConfiguration.Cache.DEFAULT.maxIdle())));
+                            .orElse(QuarkusPersistenceUnitCacheConfiguration.Cache.DEFAULT.maxIdle()),
+                    memory.maximumWeight().orElse(-1L),
+                    memory.weigherClass().orElse(null)));
         }
         return new QuarkusPersistenceUnitCacheConfiguration(caches);
     }

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/cache/WeigherWithoutWeightTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/cache/WeigherWithoutWeightTest.java
@@ -1,0 +1,51 @@
+package io.quarkus.hibernate.orm.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.persistence.Cacheable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * Tests that setting {@code weigher-class} without {@code maximum-weight}
+ * fails at build time with a clear error message.
+ */
+public class WeigherWithoutWeightTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(CachedEntity.class)
+                    .addAsResource("application.properties"))
+            .overrideConfigKey("quarkus.hibernate-orm.second-level-caching-enabled", "true")
+            .overrideConfigKey(
+                    "quarkus.hibernate-orm.cache.\"io.quarkus.hibernate.orm.cache.WeigherWithoutWeightTest$CachedEntity\".memory.weigher-class",
+                    "com.example.SomeWeigher")
+            .assertException(t -> assertThat(t).hasMessageContaining("'weigher-class' requires 'maximum-weight' to be set"));
+
+    @Test
+    public void testValidationFails() {
+        // Should not reach here -- the build should fail
+    }
+
+    @Entity
+    @Cacheable
+    public static class CachedEntity {
+
+        @Id
+        @GeneratedValue(strategy = GenerationType.SEQUENCE)
+        private long id;
+
+        private String name;
+
+        public CachedEntity() {
+        }
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/cache/WeightAndCountMutualExclusivityTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/cache/WeightAndCountMutualExclusivityTest.java
@@ -1,0 +1,55 @@
+package io.quarkus.hibernate.orm.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.persistence.Cacheable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * Tests that setting both {@code object-count} and {@code maximum-weight}
+ * on the same cache region fails at build time with a clear error message.
+ */
+public class WeightAndCountMutualExclusivityTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(CachedEntity.class)
+                    .addAsResource("application.properties"))
+            .overrideConfigKey("quarkus.hibernate-orm.second-level-caching-enabled", "true")
+            .overrideConfigKey(
+                    "quarkus.hibernate-orm.cache.\"io.quarkus.hibernate.orm.cache.WeightAndCountMutualExclusivityTest$CachedEntity\".memory.object-count",
+                    "100")
+            .overrideConfigKey(
+                    "quarkus.hibernate-orm.cache.\"io.quarkus.hibernate.orm.cache.WeightAndCountMutualExclusivityTest$CachedEntity\".memory.maximum-weight",
+                    "50000")
+            .assertException(
+                    t -> assertThat(t).hasMessageContaining("'object-count' and 'maximum-weight' are mutually exclusive"));
+
+    @Test
+    public void testValidationFails() {
+        // Should not reach here -- the build should fail
+    }
+
+    @Entity
+    @Cacheable
+    public static class CachedEntity {
+
+        @Id
+        @GeneratedValue(strategy = GenerationType.SEQUENCE)
+        private long id;
+
+        private String name;
+
+        public CachedEntity() {
+        }
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/cache/WeightBasedCacheTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/cache/WeightBasedCacheTest.java
@@ -1,0 +1,111 @@
+package io.quarkus.hibernate.orm.cache;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.Cacheable;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.transaction.UserTransaction;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.github.benmanes.caffeine.cache.Weigher;
+
+import io.quarkus.hibernate.orm.TransactionTestUtils;
+import io.quarkus.test.QuarkusExtensionTest;
+
+/**
+ * Tests that weight-based cache configuration is correctly applied
+ * to Hibernate 2LC using Caffeine, including a custom weigher.
+ */
+public class WeightBasedCacheTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(DataEntity.class)
+                    .addClass(DataEntityWeigher.class)
+                    .addClass(TransactionTestUtils.class)
+                    .addAsResource("application.properties"))
+            .overrideRuntimeConfigKey("quarkus.hibernate-orm.second-level-caching-enabled", "true")
+            .overrideRuntimeConfigKey(
+                    "quarkus.hibernate-orm.cache.\"io.quarkus.hibernate.orm.cache.WeightBasedCacheTest$DataEntity\".memory.maximum-weight",
+                    "1000")
+            .overrideRuntimeConfigKey(
+                    "quarkus.hibernate-orm.cache.\"io.quarkus.hibernate.orm.cache.WeightBasedCacheTest$DataEntity\".memory.weigher-class",
+                    "io.quarkus.hibernate.orm.cache.WeightBasedCacheTest$DataEntityWeigher");
+
+    @Inject
+    EntityManager em;
+
+    @Inject
+    UserTransaction tx;
+
+    @Inject
+    org.hibernate.Cache hibernateCache;
+
+    @Test
+    public void testWeightBasedCacheWorks() {
+        DataEntity entity = new DataEntity("small data");
+        TransactionTestUtils.inTransaction(tx, () -> {
+            em.persist(entity);
+            em.flush();
+        });
+
+        TransactionTestUtils.inTransaction(tx, () -> {
+            DataEntity loaded = em.find(DataEntity.class, entity.getId());
+            assertNotNull(loaded, "Entity should be loaded");
+
+            // Verify entity is in cache
+            assertTrue(hibernateCache.contains(DataEntity.class, entity.getId()),
+                    "Entity should be in cache after load");
+        });
+    }
+
+    @Entity
+    @Cacheable
+    public static class DataEntity {
+
+        @Id
+        @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "dataSeq")
+        private long id;
+
+        @Column
+        private String data;
+
+        public DataEntity() {
+        }
+
+        public DataEntity(String data) {
+            this.data = data;
+        }
+
+        public long getId() {
+            return id;
+        }
+
+        public String getData() {
+            return data;
+        }
+    }
+
+    /**
+     * Weigher that assigns weight based on the data field length.
+     */
+    public static class DataEntityWeigher implements Weigher<Object, Object> {
+
+        @Override
+        public int weigh(Object key, Object value) {
+            // Hibernate wraps entities in internal cache entries.
+            // Default weight for unknown types.
+            return 100;
+        }
+    }
+}

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/cache/QuarkusPersistenceUnitCacheConfiguration.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/cache/QuarkusPersistenceUnitCacheConfiguration.java
@@ -13,7 +13,22 @@ public record QuarkusPersistenceUnitCacheConfiguration(Map<String, Cache> caches
      */
     public static final String CONFIG_KEY = "hibernate.cache.quarkus_caffeine_config";
 
-    public record Cache(long maxSize, Duration maxIdle) {
-        public static Cache DEFAULT = new Cache(10000L, Duration.ofSeconds(100));
+    /**
+     * @param maxSize maximum number of entries (count-based eviction). Ignored if maximumWeight is set.
+     * @param maxIdle maximum idle time before expiration.
+     * @param maximumWeight maximum total weight (weight-based eviction). {@code -1} means not set.
+     * @param weigherClassName fully qualified class name of a Weigher implementation. {@code null} means not set.
+     */
+    public record Cache(long maxSize, Duration maxIdle, long maximumWeight, String weigherClassName) {
+
+        public static Cache DEFAULT = new Cache(10000L, Duration.ofSeconds(100), -1L, null);
+
+        public boolean hasMaximumWeight() {
+            return maximumWeight >= 0;
+        }
+
+        public boolean hasWeigherClass() {
+            return weigherClassName != null;
+        }
     }
 }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/cache/QuarkusPersistenceUnitCaffeineCacheManager.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/cache/QuarkusPersistenceUnitCaffeineCacheManager.java
@@ -4,6 +4,7 @@ import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
@@ -14,6 +15,7 @@ import javax.cache.Caching;
 import javax.cache.configuration.Configuration;
 import javax.cache.spi.CachingProvider;
 
+import com.github.benmanes.caffeine.cache.Weigher;
 import com.github.benmanes.caffeine.jcache.configuration.CaffeineConfiguration;
 
 /**
@@ -87,9 +89,37 @@ public class QuarkusPersistenceUnitCaffeineCacheManager implements CacheManager 
         var quarkusConfig = this.configuration.caches().getOrDefault(cacheName,
                 QuarkusPersistenceUnitCacheConfiguration.Cache.DEFAULT);
         CaffeineConfiguration<K, V> caffeineConfig = new CaffeineConfiguration<>();
-        caffeineConfig.setMaximumSize(OptionalLong.of(quarkusConfig.maxSize()));
+
+        if (quarkusConfig.hasMaximumWeight()) {
+            // Weight-based eviction
+            caffeineConfig.setMaximumWeight(OptionalLong.of(quarkusConfig.maximumWeight()));
+            if (quarkusConfig.hasWeigherClass()) {
+                Weigher<K, V> weigher = instantiateWeigher(quarkusConfig.weigherClassName());
+                caffeineConfig.setWeigherFactory(Optional.of(() -> weigher));
+            }
+        } else {
+            // Count-based eviction (default)
+            caffeineConfig.setMaximumSize(OptionalLong.of(quarkusConfig.maxSize()));
+        }
+
         caffeineConfig.setExpireAfterAccess(OptionalLong.of(quarkusConfig.maxIdle().toNanos()));
         return delegate.createCache(cacheName, caffeineConfig);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <K, V> Weigher<K, V> instantiateWeigher(String className) {
+        try {
+            Class<?> weigherClass = Thread.currentThread().getContextClassLoader().loadClass(className);
+            if (!Weigher.class.isAssignableFrom(weigherClass)) {
+                throw new IllegalStateException(
+                        "Weigher class '" + className + "' must implement com.github.benmanes.caffeine.cache.Weigher");
+            }
+            return (Weigher<K, V>) weigherClass.getConstructor().newInstance();
+        } catch (IllegalStateException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to instantiate weigher class: " + className, e);
+        }
     }
 
     @Override

--- a/integration-tests/hibernate-orm-cache/src/main/java/io/quarkus/it/hibernate/orm/cache/DataBlob.java
+++ b/integration-tests/hibernate-orm-cache/src/main/java/io/quarkus/it/hibernate/orm/cache/DataBlob.java
@@ -1,0 +1,39 @@
+package io.quarkus.it.hibernate.orm.cache;
+
+import jakarta.persistence.Cacheable;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+@Cacheable
+public class DataBlob {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "dataBlobSeq")
+    private long id;
+
+    @Column(length = 100000)
+    private String data;
+
+    public DataBlob() {
+    }
+
+    public DataBlob(String data) {
+        this.data = data;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getData() {
+        return data;
+    }
+
+    public void setData(String data) {
+        this.data = data;
+    }
+}

--- a/integration-tests/hibernate-orm-cache/src/main/java/io/quarkus/it/hibernate/orm/cache/DataBlobWeigher.java
+++ b/integration-tests/hibernate-orm-cache/src/main/java/io/quarkus/it/hibernate/orm/cache/DataBlobWeigher.java
@@ -1,0 +1,17 @@
+package io.quarkus.it.hibernate.orm.cache;
+
+import com.github.benmanes.caffeine.cache.Weigher;
+
+/**
+ * Weigher that assigns weight based on estimated memory footprint.
+ * Hibernate wraps entities in internal cache entry objects, so
+ * the value is not the entity directly.
+ */
+public class DataBlobWeigher implements Weigher<Object, Object> {
+
+    @Override
+    public int weigh(Object key, Object value) {
+        // Default weight for cache entries
+        return 100;
+    }
+}

--- a/integration-tests/hibernate-orm-cache/src/main/java/io/quarkus/it/hibernate/orm/cache/HibernateOrmCacheTestEndpoint.java
+++ b/integration-tests/hibernate-orm-cache/src/main/java/io/quarkus/it/hibernate/orm/cache/HibernateOrmCacheTestEndpoint.java
@@ -72,6 +72,24 @@ public class HibernateOrmCacheTestEndpoint {
                 .orElse("unlimited");
     }
 
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    @Path("/maximum-weight/{region}")
+    public String maximumWeight(@PathParam("region") String region) {
+        CaffeineConfiguration<?, ?> config = getCacheConfig(region);
+        return toOptionalObject(config.getMaximumWeight())
+                .map(Object::toString)
+                .orElse("not-set");
+    }
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    @Path("/has-weigher/{region}")
+    public String hasWeigher(@PathParam("region") String region) {
+        CaffeineConfiguration<?, ?> config = getCacheConfig(region);
+        return String.valueOf(config.getWeigherFactory().isPresent());
+    }
+
     private Cache<?, ?> getRegionCache(String region) {
         var sessionFactory = emf.unwrap(SessionFactory.class);
         var cache = (CacheImplementor) sessionFactory.getCache();

--- a/integration-tests/hibernate-orm-cache/src/main/resources/application.properties
+++ b/integration-tests/hibernate-orm-cache/src/main/resources/application.properties
@@ -1,5 +1,7 @@
 quarkus.hibernate-orm.statistics=true
 quarkus.hibernate-orm.cache."com.example.EntityA".memory.object-count=200
 quarkus.hibernate-orm.cache."com.example.EntityB".expiration.max-idle=86400
+quarkus.hibernate-orm.cache."io.quarkus.it.hibernate.orm.cache.DataBlob".memory.maximum-weight=50000
+quarkus.hibernate-orm.cache."io.quarkus.it.hibernate.orm.cache.DataBlob".memory.weigher-class=io.quarkus.it.hibernate.orm.cache.DataBlobWeigher
 #quarkus.log.level=TRACE
 #quarkus.log.file.level=TRACE

--- a/integration-tests/hibernate-orm-cache/src/test/java/io/quarkus/it/hibernate/orm/cache/HibernateOrmCacheFunctionalityTest.java
+++ b/integration-tests/hibernate-orm-cache/src/test/java/io/quarkus/it/hibernate/orm/cache/HibernateOrmCacheFunctionalityTest.java
@@ -29,4 +29,18 @@ public class HibernateOrmCacheFunctionalityTest {
                 .then().body(is("86400"));
     }
 
+    @Test
+    public void testEntityMaximumWeightOverride() {
+        RestAssured.when()
+                .get("/hibernate-orm-cache/maximum-weight/io.quarkus.it.hibernate.orm.cache.DataBlob")
+                .then().body(is("50000"));
+    }
+
+    @Test
+    public void testEntityWeigherConfigured() {
+        RestAssured.when()
+                .get("/hibernate-orm-cache/has-weigher/io.quarkus.it.hibernate.orm.cache.DataBlob")
+                .then().body(is("true"));
+    }
+
 }


### PR DESCRIPTION
Add maximum-weight and weigher-class config properties for Hibernate second-level cache regions, enabling weight-based eviction as an alternative to the existing count-based object-count eviction.

Weight-based eviction is important for entities with highly variable sizes (e.g., JSON blobs) where count-based eviction cannot reliably bound memory usage.

The two properties are mutually exclusive with object-count per region. The weigher class must implement Caffeine's Weigher interface and have a public no-arg constructor. Custom weigher classes are registered for reflection in native image builds.

- Fixes: #55282