### PR TITLE
Warn about Gradle DSL changes for Quarkus 4

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -654,7 +654,7 @@ public class QuarkusPlugin implements Plugin<Project> {
         task.getNativeSourcesOnly().set(quarkusExt.nativeConfig().sourcesOnly());
         task.getRunnerSuffix().set(quarkusExt.packageConfig().computedRunnerSuffix());
         task.getRunnerName().set(
-                quarkusExt.packageConfig().outputName().orElseGet(quarkusExt::finalName));
+                quarkusExt.packageConfig().outputName().orElseGet(() -> quarkusExt.getFinalName().get()));
         task.getOutputDirectory()
                 .set(Path.of(quarkusExt.packageConfig().outputDirectory().map(Path::toString)
                         .orElse(QuarkusPlugin.DEFAULT_OUTPUT_DIRECTORY)));

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/extension/QuarkusPluginExtension.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/extension/QuarkusPluginExtension.java
@@ -82,7 +82,13 @@ public abstract class QuarkusPluginExtension extends AbstractQuarkusExtension {
         return cleanupBuildOutput;
     }
 
+    /**
+     * @deprecated Use {@code quarkus.cleanupBuildOutput.set(...)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public void setCleanupBuildOutput(boolean cleanupBuildOutput) {
+        recordDeprecatedDslUsage("QuarkusPluginExtension.setCleanupBuildOutput(boolean)",
+                "Use quarkus.cleanupBuildOutput.set(...) instead");
         this.cleanupBuildOutput.set(cleanupBuildOutput);
     }
 
@@ -94,11 +100,23 @@ public abstract class QuarkusPluginExtension extends AbstractQuarkusExtension {
         return cacheLargeArtifacts;
     }
 
+    /**
+     * @deprecated Use {@code quarkus.cacheLargeArtifacts.set(...)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public void setCacheLargeArtifacts(boolean cacheLargeArtifacts) {
+        recordDeprecatedDslUsage("QuarkusPluginExtension.setCacheLargeArtifacts(boolean)",
+                "Use quarkus.cacheLargeArtifacts.set(...) instead");
         this.cacheLargeArtifacts.set(cacheLargeArtifacts);
     }
 
+    /**
+     * @deprecated Use {@code quarkus.codeGenerationInputs.set(...)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public void setCodeGenerationInputs(List<String> codeGenerationInputs) {
+        recordDeprecatedDslUsage("QuarkusPluginExtension.setCodeGenerationInputs(List<String>)",
+                "Use quarkus.codeGenerationInputs.set(...) instead");
         this.codeGenerationInputs.set(codeGenerationInputs);
     }
 
@@ -110,7 +128,13 @@ public abstract class QuarkusPluginExtension extends AbstractQuarkusExtension {
         return codeGenerationInputs;
     }
 
+    /**
+     * @deprecated Use {@code quarkus.codeGenerationProviders.set(...)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public void setCodeGenerationProviders(List<String> codeGenerationProviders) {
+        recordDeprecatedDslUsage("QuarkusPluginExtension.setCodeGenerationProviders(List<String>)",
+                "Use quarkus.codeGenerationProviders.set(...) instead");
         this.codeGenerationProviders.set(codeGenerationProviders);
     }
 
@@ -122,11 +146,22 @@ public abstract class QuarkusPluginExtension extends AbstractQuarkusExtension {
         return codeGenerationProviders;
     }
 
+    /**
+     * @deprecated Use {@code quarkus.finalName.get()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public String finalName() {
+        recordDeprecatedDslUsage("QuarkusPluginExtension.finalName()", "Use quarkus.finalName.get() instead");
         return getFinalName().get();
     }
 
+    /**
+     * @deprecated Use {@code quarkus.finalName.set(...)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public void setFinalName(String finalName) {
+        recordDeprecatedDslUsage("QuarkusPluginExtension.setFinalName(String)",
+                "Use quarkus.finalName.set(...) instead");
         getFinalName().set(finalName);
     }
 
@@ -138,7 +173,13 @@ public abstract class QuarkusPluginExtension extends AbstractQuarkusExtension {
         return sourceSetExtension;
     }
 
+    /**
+     * @deprecated This method exposes live Gradle project state and is not intended as build-script DSL.
+     */
+    @Deprecated(forRemoval = true)
     public Set<File> resourcesDir() {
+        recordDeprecatedDslUsage("QuarkusPluginExtension.resourcesDir()",
+                "Use the Gradle source set APIs directly instead");
         return getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME).getResources().getSrcDirs();
     }
 
@@ -150,7 +191,13 @@ public abstract class QuarkusPluginExtension extends AbstractQuarkusExtension {
         return classesDirs;
     }
 
+    /**
+     * @deprecated This method exposes live Gradle project state and is not intended as build-script DSL.
+     */
+    @Deprecated(forRemoval = true)
     public Set<File> combinedOutputSourceDirs() {
+        recordDeprecatedDslUsage("QuarkusPluginExtension.combinedOutputSourceDirs()",
+                "Use the Gradle source set APIs directly instead");
         Set<File> sourcesDirs = new LinkedHashSet<>();
         SourceSetContainer sourceSets = getSourceSets();
         sourcesDirs.addAll(sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME).getOutput().getClassesDirs().getFiles());
@@ -158,18 +205,34 @@ public abstract class QuarkusPluginExtension extends AbstractQuarkusExtension {
         return sourcesDirs;
     }
 
+    /**
+     * @deprecated This method resolves a live application model and is not configuration-cache friendly.
+     */
+    @Deprecated(forRemoval = true)
     public AppModelResolver getAppModelResolver() {
         return getAppModelResolver(NORMAL);
     }
 
+    /**
+     * @deprecated This method resolves a live application model and is not configuration-cache friendly.
+     */
+    @Deprecated(forRemoval = true)
     public AppModelResolver getAppModelResolver(LaunchMode mode) {
         return new AppModelGradleResolver(project, mode);
     }
 
+    /**
+     * @deprecated This method resolves a live application model and is not configuration-cache friendly.
+     */
+    @Deprecated(forRemoval = true)
     public ApplicationModel getApplicationModel() {
         return getApplicationModel(NORMAL);
     }
 
+    /**
+     * @deprecated This method resolves a live application model and is not configuration-cache friendly.
+     */
+    @Deprecated(forRemoval = true)
     public ApplicationModel getApplicationModel(LaunchMode mode) {
         return ToolingUtils.create(project, mode);
     }
@@ -219,7 +282,13 @@ public abstract class QuarkusPluginExtension extends AbstractQuarkusExtension {
         return project.getExtensions().getByType(SourceSetContainer.class);
     }
 
+    /**
+     * @deprecated This method exposes live Gradle project state and is not intended as build-script DSL.
+     */
+    @Deprecated(forRemoval = true)
     public Path appJarOrClasses() {
+        recordDeprecatedDslUsage("QuarkusPluginExtension.appJarOrClasses()",
+                "Use the Gradle Java plugin outputs directly instead");
         final Jar jarTask = (Jar) project.getTasks().findByName(JavaPlugin.JAR_TASK_NAME);
         if (jarTask == null) {
             throw new RuntimeException("Failed to locate task 'jar' in the project.");
@@ -250,6 +319,13 @@ public abstract class QuarkusPluginExtension extends AbstractQuarkusExtension {
         return quarkusBuildProperties;
     }
 
+    /**
+     * Native-image build arguments configured through the Gradle extension.
+     */
+    public MapProperty<String, String> getNativeArguments() {
+        return nativeArguments;
+    }
+
     public ListProperty<String> getCachingRelevantProperties() {
         return cachingRelevantProperties;
     }
@@ -264,5 +340,9 @@ public abstract class QuarkusPluginExtension extends AbstractQuarkusExtension {
 
     private String addQuarkusBuildPropertyPrefix(String name) {
         return String.format("quarkus.%s", name);
+    }
+
+    private void recordDeprecatedDslUsage(String api, String replacement) {
+        recordDeprecatedDslUsageInternal(api, replacement);
     }
 }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/AbstractQuarkusExtension.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/AbstractQuarkusExtension.java
@@ -40,7 +40,9 @@ public abstract class AbstractQuarkusExtension {
     protected final File projectDir;
     protected final Property<String> finalName;
     private final MapProperty<String, String> forcedPropertiesProperty;
+    private final DeprecatedGradleDslUsageReporter deprecatedDslUsageReporter = new DeprecatedGradleDslUsageReporter();
     protected final MapProperty<String, String> quarkusBuildProperties;
+    protected final MapProperty<String, String> nativeArguments;
     protected final ListProperty<String> cachingRelevantProperties;
     private final ListProperty<String> ignoredEntries;
     private final FileCollection classpath;
@@ -55,6 +57,7 @@ public abstract class AbstractQuarkusExtension {
         this.finalName.convention(project.provider(() -> String.format("%s-%s", project.getName(), project.getVersion())));
         this.forcedPropertiesProperty = project.getObjects().mapProperty(String.class, String.class);
         this.quarkusBuildProperties = project.getObjects().mapProperty(String.class, String.class);
+        this.nativeArguments = project.getObjects().mapProperty(String.class, String.class);
         this.cachingRelevantProperties = project.getObjects().listProperty(String.class)
                 .value(List.of("quarkus[.].*", "platform[.]quarkus[.].*"));
         this.ignoredEntries = project.getObjects().listProperty(String.class);
@@ -113,6 +116,17 @@ public abstract class AbstractQuarkusExtension {
 
     protected MapProperty<String, String> forcedPropertiesProperty() {
         return forcedPropertiesProperty;
+    }
+
+    /**
+     * Internal diagnostic delegate. Not intended as build-script DSL.
+     */
+    public DeprecatedGradleDslUsageReporter deprecatedDslUsageReporterInternal() {
+        return deprecatedDslUsageReporter;
+    }
+
+    protected void recordDeprecatedDslUsageInternal(String api, String replacement) {
+        deprecatedDslUsageReporter.record(api, replacement);
     }
 
     protected ListProperty<String> ignoredEntriesProperty() {

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/AdditionalForcedProperties.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/AdditionalForcedProperties.java
@@ -1,0 +1,29 @@
+package io.quarkus.gradle.tasks;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.runtime.util.StringUtil;
+
+final class AdditionalForcedProperties {
+
+    private static final String NATIVE_PROPERTY_NAMESPACE = "quarkus.native";
+
+    private AdditionalForcedProperties() {
+    }
+
+    static Map<String, String> of(Map<String, String> nativeArguments, Map<String, String> taskProperties) {
+        Map<String, String> result = new HashMap<>();
+        nativeArguments.forEach((key, value) -> result.put(expandNativeArgumentKey(key), value));
+        result.putAll(taskProperties);
+        return result;
+    }
+
+    static String expandNativeArgumentKey(String key) {
+        String hyphenatedKey = StringUtil.hyphenate(key);
+        if (hyphenatedKey.startsWith(NATIVE_PROPERTY_NAMESPACE)) {
+            return hyphenatedKey;
+        }
+        return NATIVE_PROPERTY_NAMESPACE + "." + hyphenatedKey;
+    }
+}

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/DeprecatedGradleDslUsageReporter.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/DeprecatedGradleDslUsageReporter.java
@@ -1,0 +1,86 @@
+package io.quarkus.gradle.tasks;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.Serializable;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.gradle.api.logging.Logger;
+
+final class DeprecatedGradleDslUsageReporter implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    static final String MIGRATION_GUIDE_URL = "https://quarkus.io/version/3.37/guides/gradle-tooling#quarkus-4-gradle-dsl-migration";
+    static final String REPORT_PATH = "reports/quarkus/deprecated-gradle-dsl.txt";
+
+    private final Map<String, Usage> usages = new LinkedHashMap<>();
+
+    synchronized void record(String api, String replacement) {
+        Usage usage = new Usage(api, replacement, Thread.currentThread().getStackTrace());
+        usages.putIfAbsent(usage.key(), usage);
+    }
+
+    synchronized void report(Logger logger, File reportFile) {
+        if (usages.isEmpty()) {
+            return;
+        }
+
+        List<Usage> usageSnapshot = new ArrayList<>(usages.values());
+        writeReport(reportFile, usageSnapshot);
+
+        StringBuilder warning = new StringBuilder();
+        warning.append(
+                "Deprecated Quarkus Gradle DSL/API usage detected. The following APIs are deprecated for removal in Quarkus 4:");
+        for (Usage usage : usageSnapshot) {
+            warning.append(System.lineSeparator()).append("  - ").append(usage.api());
+            warning.append(" (").append(usage.replacement()).append(")");
+        }
+        warning.append(System.lineSeparator()).append("Migration guide: ").append(MIGRATION_GUIDE_URL);
+        warning.append(System.lineSeparator()).append("Call-site diagnostics: ").append(reportFile);
+        logger.warn(warning.toString());
+    }
+
+    private static void writeReport(File reportFile, List<Usage> usages) {
+        try {
+            Files.createDirectories(reportFile.toPath().getParent());
+            try (PrintWriter writer = new PrintWriter(Files.newBufferedWriter(reportFile.toPath(), StandardCharsets.UTF_8))) {
+                writer.println("Deprecated Quarkus Gradle DSL/API usage detected");
+                writer.println();
+                writer.println("The following APIs are deprecated for removal in Quarkus 4:");
+                for (Usage usage : usages) {
+                    writer.printf("- %s%n", usage.api());
+                    writer.printf("  Replacement: %s%n", usage.replacement());
+                }
+                writer.println();
+                writer.printf("Migration guide: %s%n", MIGRATION_GUIDE_URL);
+                writer.println();
+                writer.println("Call-site stack traces:");
+                for (Usage usage : usages) {
+                    writer.println();
+                    writer.printf("%s%n", usage.api());
+                    for (StackTraceElement frame : usage.stackTrace()) {
+                        writer.printf("\tat %s%n", frame);
+                    }
+                }
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to write deprecated Quarkus Gradle DSL diagnostics to " + reportFile, e);
+        }
+    }
+
+    private record Usage(String api, String replacement, StackTraceElement[] stackTrace) implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        String key() {
+            return api + '\n' + List.of(stackTrace);
+        }
+    }
+}

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
@@ -29,12 +29,10 @@ import org.gradle.api.tasks.options.Option;
 
 import io.quarkus.deployment.pkg.PackageConfig;
 import io.quarkus.gradle.dsl.Manifest;
-import io.quarkus.runtime.util.StringUtil;
 
 @CacheableTask
 public abstract class QuarkusBuild extends QuarkusBuildTask {
 
-    private static final String NATIVE_PROPERTY_NAMESPACE = "quarkus.native";
     public static final String QUARKUS_IGNORE_LEGACY_DEPLOY_BUILD = "quarkus.ignore.legacy.deploy.build";
 
     @Inject
@@ -42,13 +40,18 @@ public abstract class QuarkusBuild extends QuarkusBuildTask {
         super("Builds a Quarkus application.", true);
     }
 
+    /**
+     * @deprecated Use {@code quarkus.nativeArguments} instead.
+     */
+    @Deprecated(forRemoval = true)
     @SuppressWarnings("unused")
     public QuarkusBuild nativeArgs(Action<Map<String, ?>> action) {
+        extension().deprecatedDslUsageReporterInternal().record("QuarkusBuild.nativeArgs(Action<Map<String, ?>>)",
+                "Use quarkus.nativeArguments instead");
         Map<String, ?> nativeArgsMap = new HashMap<>();
         action.execute(nativeArgsMap);
         for (Map.Entry<String, ?> nativeArg : nativeArgsMap.entrySet()) {
-            getAdditionalForcedProperties().get().getProperties().put(expandConfigurationKey(nativeArg.getKey()),
-                    nativeArg.getValue().toString());
+            extension().getNativeArguments().put(nativeArg.getKey(), nativeArg.getValue().toString());
         }
         return this;
     }
@@ -203,6 +206,7 @@ public abstract class QuarkusBuild extends QuarkusBuildTask {
     @SuppressWarnings("deprecation") // legacy JAR
     @TaskAction
     public void finalizeQuarkusBuild() {
+        reportDeprecatedDslUsages();
         if (getExtensionView().getForcedProperties().get().containsKey(QUARKUS_IGNORE_LEGACY_DEPLOY_BUILD)) {
             getLogger().info("SKIPPING finalizedBy deploy build");
             return;
@@ -232,6 +236,11 @@ public abstract class QuarkusBuild extends QuarkusBuildTask {
                 }
             }
         }
+    }
+
+    void reportDeprecatedDslUsages() {
+        getExtensionView().deprecatedDslUsageReporter().report(getLogger(),
+                gradleBuildDir().resolve(DeprecatedGradleDslUsageReporter.REPORT_PATH).toFile());
     }
 
     private void assembleLegacyJar() {
@@ -358,14 +367,6 @@ public abstract class QuarkusBuild extends QuarkusBuildTask {
                                     NATIVE_SOURCES,
                                     nativeImageSourceJarDirName() + "/**");
                 });
-    }
-
-    private String expandConfigurationKey(String shortKey) {
-        final String hyphenatedKey = StringUtil.hyphenate(shortKey);
-        if (hyphenatedKey.startsWith(NATIVE_PROPERTY_NAMESPACE)) {
-            return hyphenatedKey;
-        }
-        return String.format("%s.%s", NATIVE_PROPERTY_NAMESPACE, hyphenatedKey);
     }
 
     static GradleException nativeAndJar() {

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildTask.java
@@ -281,7 +281,7 @@ public abstract class QuarkusBuildTask extends QuarkusTaskWithExtensionView {
 
         ApplicationModel appModel = resolveAppModelForBuild();
         Map<String, String> quarkusProperties = effectiveProvider()
-                .buildEffectiveConfiguration(appModel, getAdditionalForcedProperties().get().getProperties())
+                .buildEffectiveConfiguration(appModel, additionalForcedProperties())
                 .getQuarkusValues();
 
         if (nativeEnabled()) {
@@ -350,6 +350,12 @@ public abstract class QuarkusBuildTask extends QuarkusTaskWithExtensionView {
                 }
             }
         });
+    }
+
+    Map<String, String> additionalForcedProperties() {
+        return AdditionalForcedProperties.of(
+                getExtensionView().getNativeArguments().get(),
+                getAdditionalForcedProperties().get().getProperties());
     }
 
     void abort(String message, Object... args) {

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusPluginExtensionView.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusPluginExtensionView.java
@@ -33,9 +33,11 @@ import io.quarkus.gradle.extension.QuarkusPluginExtension;
  * Configuration cache compatible view of Quarkus extension
  */
 public abstract class QuarkusPluginExtensionView {
+    private final DeprecatedGradleDslUsageReporter deprecatedDslUsageReporter;
 
     @Inject
     public QuarkusPluginExtensionView(Project project, QuarkusPluginExtension extension) {
+        this.deprecatedDslUsageReporter = extension.deprecatedDslUsageReporterInternal();
         project.getGradle().getTaskGraph().whenReady(taskGraph -> {
             if (taskGraph.hasTask(project.getPath() + BUILD_NATIVE_TASK_NAME)
                     || taskGraph.hasTask(project.getPath() + TEST_NATIVE_TASK_NAME)) {
@@ -58,7 +60,12 @@ public abstract class QuarkusPluginExtensionView {
         getQuarkusProfileEnvVariable().set(getProviderFactory().environmentVariable("QUARKUS_PROFILE"));
         getCachingRelevantProperties().set(extension.getCachingRelevantProperties());
         getForcedProperties().set(extension.forcedPropertiesProperty());
+        getNativeArguments().set(extension.getNativeArguments());
         getProjectProperties().set(getQuarkusAndPlatformProjectProperties(project));
+    }
+
+    DeprecatedGradleDslUsageReporter deprecatedDslUsageReporter() {
+        return deprecatedDslUsageReporter;
     }
 
     private Provider<Map<String, String>> getQuarkusAndPlatformProjectProperties(Project project) {
@@ -143,5 +150,9 @@ public abstract class QuarkusPluginExtensionView {
     @Input
     @Optional
     public abstract MapProperty<String, String> getForcedProperties();
+
+    @Input
+    @Optional
+    public abstract MapProperty<String, String> getNativeArguments();
 
 }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusShowEffectiveConfig.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusShowEffectiveConfig.java
@@ -51,8 +51,7 @@ public abstract class QuarkusShowEffectiveConfig extends QuarkusBuildTask {
         try {
             ApplicationModel appModel = resolveAppModelForBuild();
             EffectiveConfig effectiveConfig = effectiveProvider()
-                    .buildEffectiveConfiguration(appModel,
-                            getAdditionalForcedProperties().get().getProperties());
+                    .buildEffectiveConfiguration(appModel, additionalForcedProperties());
             SmallRyeConfig config = effectiveConfig.getConfig();
             List<String> sourceNames = new ArrayList<>();
             config.getConfigSources().forEach(configSource -> sourceNames.add(configSource.getName()));

--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/QuarkusPluginTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/QuarkusPluginTest.java
@@ -11,6 +11,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.gradle.api.Project;
@@ -26,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import io.quarkus.gradle.extension.QuarkusPluginExtension;
+import io.quarkus.gradle.tasks.QuarkusBuild;
 
 public class QuarkusPluginTest {
 
@@ -47,6 +49,26 @@ public class QuarkusPluginTest {
         assertNotNull(tasks.getByName(QuarkusPlugin.IMAGE_BUILD_TASK_NAME));
         assertNotNull(tasks.getByName(QuarkusPlugin.IMAGE_PUSH_TASK_NAME));
         assertNotNull(tasks.getByName(QuarkusPlugin.DEPLOY_TASK_NAME));
+    }
+
+    @Test
+    @SuppressWarnings("removal")
+    public void nativeArgsShouldPopulateExtensionNativeArguments() {
+        Project project = ProjectBuilder.builder().build();
+        project.getPluginManager().apply(QuarkusPlugin.ID);
+
+        QuarkusBuild quarkusBuild = (QuarkusBuild) project.getTasks().getByName(QUARKUS_BUILD_TASK_NAME);
+        quarkusBuild.nativeArgs(args -> {
+            @SuppressWarnings({ "rawtypes", "unchecked" })
+            Map<String, Object> mutableArgs = (Map) args;
+            mutableArgs.put("containerBuild", true);
+            mutableArgs.put("quarkus.native.builderImage", "builder-image");
+        });
+
+        QuarkusPluginExtension extension = project.getExtensions().getByType(QuarkusPluginExtension.class);
+        assertThat(extension.getNativeArguments().get()).containsOnly(
+                Map.entry("containerBuild", "true"),
+                Map.entry("quarkus.native.builderImage", "builder-image"));
     }
 
     @Test

--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/AdditionalForcedPropertiesTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/AdditionalForcedPropertiesTest.java
@@ -1,0 +1,28 @@
+package io.quarkus.gradle.tasks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class AdditionalForcedPropertiesTest {
+
+    @Test
+    void nativeArgumentsShouldBeNormalizedAndOverriddenByTaskProperties() {
+        Map<String, String> result = AdditionalForcedProperties.of(
+                Map.of(
+                        "containerBuild", "true",
+                        "quarkus.native.builderImage", "builder-image",
+                        "debug.enabled", "true"),
+                Map.of(
+                        "quarkus.native.container-build", "false",
+                        "quarkus.package.jar.enabled", "false"));
+
+        assertThat(result).containsOnly(
+                Map.entry("quarkus.native.container-build", "false"),
+                Map.entry("quarkus.native.builder-image", "builder-image"),
+                Map.entry("quarkus.native.debug.enabled", "true"),
+                Map.entry("quarkus.package.jar.enabled", "false"));
+    }
+}

--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/DeprecatedGradleDslUsageReporterTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/DeprecatedGradleDslUsageReporterTest.java
@@ -1,0 +1,50 @@
+package io.quarkus.gradle.tasks;
+
+import static io.quarkus.gradle.QuarkusPlugin.QUARKUS_BUILD_TASK_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.quarkus.gradle.QuarkusPlugin;
+import io.quarkus.gradle.extension.QuarkusPluginExtension;
+
+class DeprecatedGradleDslUsageReporterTest {
+
+    @Test
+    @SuppressWarnings("removal")
+    void nativeArgsWritesDeprecatedDslDiagnostics(@TempDir Path projectDir) throws IOException {
+        Project project = ProjectBuilder.builder()
+                .withProjectDir(projectDir.toFile())
+                .build();
+        project.getPluginManager().apply(QuarkusPlugin.ID);
+
+        QuarkusPluginExtension extension = project.getExtensions().getByType(QuarkusPluginExtension.class);
+        extension.setFinalName("custom-name");
+
+        QuarkusBuild quarkusBuild = (QuarkusBuild) project.getTasks().getByName(QUARKUS_BUILD_TASK_NAME);
+        quarkusBuild.nativeArgs(args -> {
+            @SuppressWarnings({ "rawtypes", "unchecked" })
+            Map<String, Object> mutableArgs = (Map) args;
+            mutableArgs.put("containerBuild", true);
+        });
+        quarkusBuild.reportDeprecatedDslUsages();
+
+        Path report = projectDir.resolve("build").resolve(DeprecatedGradleDslUsageReporter.REPORT_PATH);
+        assertThat(report).exists();
+        assertThat(Files.readString(report))
+                .contains("Deprecated Quarkus Gradle DSL/API usage detected")
+                .contains("QuarkusBuild.nativeArgs(Action<Map<String, ?>>)")
+                .contains("QuarkusPluginExtension.setFinalName(String)")
+                .contains("Use quarkus.nativeArguments instead")
+                .contains(DeprecatedGradleDslUsageReporter.MIGRATION_GUIDE_URL)
+                .contains("nativeArgsWritesDeprecatedDslDiagnostics");
+    }
+}

--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionConfiguration.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionConfiguration.java
@@ -46,18 +46,34 @@ public class QuarkusExtensionConfiguration {
         dependencyCondition = project.getObjects().listProperty(String.class);
     }
 
+    /**
+     * @deprecated Use {@code getDisableValidation().set(...)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public void setDisableValidation(boolean disableValidation) {
-        this.disableValidation.set(disableValidation);
+        getDisableValidation().set(disableValidation);
     }
 
-    public Property<Boolean> isValidationDisabled() {
+    public Property<Boolean> getDisableValidation() {
         return disableValidation;
+    }
+
+    /**
+     * @deprecated Use {@link #getDisableValidation()} instead.
+     */
+    @Deprecated(forRemoval = true)
+    public Property<Boolean> isValidationDisabled() {
+        return getDisableValidation();
     }
 
     public Property<String> getDeploymentArtifact() {
         return deploymentArtifact;
     }
 
+    /**
+     * @deprecated Use {@code getDeploymentArtifact().set(...)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public void setDeploymentArtifact(String deploymentArtifact) {
         this.deploymentArtifact.set(deploymentArtifact);
     }
@@ -66,6 +82,10 @@ public class QuarkusExtensionConfiguration {
         return deploymentModule;
     }
 
+    /**
+     * @deprecated Use {@code getDeploymentModule().set(...)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public void setDeploymentModule(String deploymentModule) {
         this.deploymentModule.set(deploymentModule);
     }
@@ -74,6 +94,10 @@ public class QuarkusExtensionConfiguration {
         return excludedArtifacts;
     }
 
+    /**
+     * @deprecated Use {@code getExcludedArtifacts().addAll(...)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public void setExcludedArtifacts(List<String> excludedArtifacts) {
         this.excludedArtifacts.addAll(excludedArtifacts);
     }
@@ -82,6 +106,10 @@ public class QuarkusExtensionConfiguration {
         return parentFirstArtifacts;
     }
 
+    /**
+     * @deprecated Use {@code getParentFirstArtifacts().addAll(...)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public void setParentFirstArtifacts(List<String> parentFirstArtifacts) {
         this.parentFirstArtifacts.addAll(parentFirstArtifacts);
     }
@@ -90,6 +118,10 @@ public class QuarkusExtensionConfiguration {
         return runnerParentFirstArtifacts;
     }
 
+    /**
+     * @deprecated Use {@code getRunnerParentFirstArtifacts().addAll(...)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public void setRunnerParentFirstArtifacts(List<String> runnerParentFirstArtifacts) {
         this.runnerParentFirstArtifacts.addAll(runnerParentFirstArtifacts);
     }
@@ -98,6 +130,10 @@ public class QuarkusExtensionConfiguration {
         return lesserPriorityArtifacts;
     }
 
+    /**
+     * @deprecated Use {@code getLesserPriorityArtifacts().addAll(...)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public void setLesserPriorityArtifacts(List<String> lesserPriorityArtifacts) {
         this.lesserPriorityArtifacts.addAll(lesserPriorityArtifacts);
     }
@@ -106,6 +142,10 @@ public class QuarkusExtensionConfiguration {
         return conditionalDependencies;
     }
 
+    /**
+     * @deprecated Use {@code getConditionalDependencies().addAll(...)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public void setConditionalDependencies(List<String> conditionalDependencies) {
         this.conditionalDependencies.addAll(conditionalDependencies);
     }
@@ -114,6 +154,10 @@ public class QuarkusExtensionConfiguration {
         return conditionalDevDependencies;
     }
 
+    /**
+     * @deprecated Use {@code getConditionalDevDependencies().addAll(...)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public void setConditionalDevDependencies(List<String> conditionalDependencies) {
         this.conditionalDevDependencies.addAll(conditionalDependencies);
     }
@@ -122,6 +166,10 @@ public class QuarkusExtensionConfiguration {
         return dependencyCondition;
     }
 
+    /**
+     * @deprecated Use {@code getDependencyConditions().addAll(...)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public void setDependencyConditions(List<String> dependencyCondition) {
         this.dependencyCondition.addAll(dependencyCondition);
     }

--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/tasks/ValidateExtensionTask.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/tasks/ValidateExtensionTask.java
@@ -43,7 +43,7 @@ public class ValidateExtensionTask extends DefaultTask {
 
         this.project = getProject();
         this.runtimeModuleClasspath = runtimeModuleClasspath;
-        this.onlyIf(t -> !quarkusExtensionConfiguration.isValidationDisabled().get());
+        this.onlyIf(t -> !quarkusExtensionConfiguration.getDisableValidation().get());
 
         // Calling this method tells Gradle that it should not fail the build. Side effect is that the configuration
         // cache will be at least degraded, but the build will not fail.

--- a/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/QuarkusExtensionPluginTest.java
+++ b/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/QuarkusExtensionPluginTest.java
@@ -10,6 +10,8 @@ import java.util.Collections;
 import java.util.Properties;
 
 import org.assertj.core.api.Assertions;
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
@@ -33,6 +35,16 @@ public class QuarkusExtensionPluginTest {
         File settingFile = new File(testProjectDir, "settings.gradle");
         String settingsContent = "rootProject.name = 'test'";
         TestUtils.writeFile(settingFile, settingsContent);
+    }
+
+    @Test
+    public void disableValidationShouldExposeManagedProperty() {
+        Project project = ProjectBuilder.builder().build();
+        QuarkusExtensionConfiguration configuration = new QuarkusExtensionConfiguration(project);
+
+        configuration.getDisableValidation().set(true);
+
+        assertThat(configuration.isValidationDisabled().get()).isTrue();
     }
 
     @Test

--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -507,19 +507,18 @@ include::{includes}/devtools/build-native.adoc[]
 
 A native executable will be present in `build/`.
 
-Native related properties can either be added in `application.properties` file, as command line arguments or in the `quarkusBuild` task.
-Configuring the `quarkusBuild` task can be done as following:
+Native related properties can either be added in the `application.properties` file, as command line arguments or on the
+`quarkus` extension.
+Configuring the `quarkus` extension can be done as following:
 
 [role="primary asciidoc-tabs-sync-groovy"]
 .Groovy DSL
 ****
 [source,groovy,subs=attributes+]
 ----
-quarkusBuild {
-    nativeArgs {
-        containerBuild = true <1>
-        builderImage = "quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor}" <2>
-    }
+quarkus {
+    nativeArguments.put("container-build", "true") <1>
+    nativeArguments.put("builder-image", "quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor}") <2>
 }
 ----
 
@@ -532,11 +531,9 @@ quarkusBuild {
 ****
 [source,kotlin,subs=attributes+]
 ----
-tasks.quarkusBuild {
-    nativeArgs {
-        "container-build" to true <1>
-        "builder-image" to "quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor}" <2>
-    }
+quarkus {
+    nativeArguments.put("container-build", "true") <1>
+    nativeArguments.put("builder-image", "quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:{mandrel-flavor}") <2>
 }
 ----
 
@@ -546,10 +543,162 @@ tasks.quarkusBuild {
 
 [WARNING]
 ====
-When using the Gradle Groovy DSL, property keys must follow lower camel case notation.
-e.g. `container-build` is not valid, and should be replaced by `containerBuild`.
-This limitation does not apply to the Gradle Kotlin DSL.
+Native argument keys are normalized to the `quarkus.native.*` namespace.
+For example, `container-build` is interpreted as `quarkus.native.container-build`.
 ====
+
+[[quarkus-4-gradle-dsl-migration]]
+=== Gradle DSL migration for Quarkus 4
+
+Quarkus 4 removes deprecated Gradle build-script entry points where JavaBean-style getters and setters duplicate Gradle
+managed properties.
+Build scripts should use the managed-property DSL shape because it works with Gradle's configuration cache and isolated
+projects more reliably, and it is the Gradle-native way to configure plugin extensions.
+
+The replacement syntax can already be used with Quarkus 3.
+
+[role="primary asciidoc-tabs-sync-groovy"]
+.Groovy DSL
+****
+[source,groovy]
+----
+quarkus {
+    finalName.set("my-application")
+    cleanupBuildOutput.set(false)
+    cacheLargeArtifacts.set(true)
+    codeGenerationInputs.add("proto")
+    codeGenerationProviders.add("grpc")
+    nativeArguments.put("container-build", "true")
+}
+
+quarkusExtension {
+    disableValidation.set(true)
+    deploymentArtifact.set("com.example:my-extension-deployment:${project.version}")
+    excludedArtifacts.add("com.example:excluded-artifact")
+    parentFirstArtifacts.add("com.example:parent-first-artifact")
+    runnerParentFirstArtifacts.add("com.example:runner-parent-first-artifact")
+    lesserPriorityArtifacts.add("com.example:lesser-priority-artifact")
+    conditionalDependencies.add("com.example:conditional-dependency")
+    conditionalDevDependencies.add("com.example:conditional-dev-dependency")
+    dependencyConditions.add("com.example:dependency-condition")
+}
+----
+****
+
+[role="secondary asciidoc-tabs-sync-kotlin"]
+.Kotlin DSL
+****
+[source,kotlin]
+----
+quarkus {
+    finalName.set("my-application")
+    cleanupBuildOutput.set(false)
+    cacheLargeArtifacts.set(true)
+    codeGenerationInputs.add("proto")
+    codeGenerationProviders.add("grpc")
+    nativeArguments.put("container-build", "true")
+}
+
+quarkusExtension {
+    disableValidation.set(true)
+    deploymentArtifact.set("com.example:my-extension-deployment:${project.version}")
+    excludedArtifacts.add("com.example:excluded-artifact")
+    parentFirstArtifacts.add("com.example:parent-first-artifact")
+    runnerParentFirstArtifacts.add("com.example:runner-parent-first-artifact")
+    lesserPriorityArtifacts.add("com.example:lesser-priority-artifact")
+    conditionalDependencies.add("com.example:conditional-dependency")
+    conditionalDevDependencies.add("com.example:conditional-dev-dependency")
+    dependencyConditions.add("com.example:dependency-condition")
+}
+----
+****
+
+The most common replacements are listed below.
+In Groovy DSL, assignments such as `quarkus { finalName = "my-application" }` call the corresponding JavaBean setter,
+so they should be migrated to the managed property as well.
+
+[cols="1,1,1", options="header"]
+|===
+|Old build-script shape
+|Groovy DSL replacement
+|Kotlin DSL replacement
+
+|`quarkus { finalName = "my-application" }` or `quarkus.setFinalName("my-application")`
+|`quarkus { finalName.set("my-application") }`
+|`quarkus { finalName.set("my-application") }`
+
+|`quarkus.finalName()`
+|`quarkus.finalName.get()`
+|`quarkus.finalName.get()`
+
+|`quarkus { cleanupBuildOutput = false }` or `quarkus.setCleanupBuildOutput(false)`
+|`quarkus { cleanupBuildOutput.set(false) }`
+|`quarkus { cleanupBuildOutput.set(false) }`
+
+|`quarkus { cacheLargeArtifacts = true }` or `quarkus.setCacheLargeArtifacts(true)`
+|`quarkus { cacheLargeArtifacts.set(true) }`
+|`quarkus { cacheLargeArtifacts.set(true) }`
+
+|`quarkus { codeGenerationInputs = listOfInputs }` or `quarkus.setCodeGenerationInputs(listOfInputs)`
+|`quarkus { codeGenerationInputs.set(listOfInputs) }`
+|`quarkus { codeGenerationInputs.set(listOfInputs) }`
+
+|`quarkus { codeGenerationProviders = listOfProviders }` or `quarkus.setCodeGenerationProviders(listOfProviders)`
+|`quarkus { codeGenerationProviders.set(listOfProviders) }`
+|`quarkus { codeGenerationProviders.set(listOfProviders) }`
+
+|`quarkusBuild.nativeArgs { ... }`
+|`quarkus { nativeArguments.put("container-build", "true") }`
+|`quarkus { nativeArguments.put("container-build", "true") }`
+
+|`quarkusExtension { disableValidation = true }` or `quarkusExtension.setDisableValidation(true)`
+|`quarkusExtension { disableValidation.set(true) }`
+|`quarkusExtension { disableValidation.set(true) }`
+
+|`quarkusExtension.isValidationDisabled().get()`
+|`quarkusExtension.disableValidation.get()`
+|`quarkusExtension.disableValidation.get()`
+
+|`quarkusExtension { deploymentArtifact = notation }` or `quarkusExtension.setDeploymentArtifact(notation)`
+|`quarkusExtension { deploymentArtifact.set(notation) }`
+|`quarkusExtension { deploymentArtifact.set(notation) }`
+
+|`quarkusExtension { deploymentModule = path }` or `quarkusExtension.setDeploymentModule(path)`
+|`quarkusExtension { deploymentModule.set(path) }`
+|`quarkusExtension { deploymentModule.set(path) }`
+
+|`quarkusExtension { excludedArtifacts = artifacts }` or `quarkusExtension.setExcludedArtifacts(artifacts)`
+|`quarkusExtension { excludedArtifacts.set(artifacts) }`
+|`quarkusExtension { excludedArtifacts.set(artifacts) }`
+
+|`quarkusExtension { parentFirstArtifacts = artifacts }` or `quarkusExtension.setParentFirstArtifacts(artifacts)`
+|`quarkusExtension { parentFirstArtifacts.set(artifacts) }`
+|`quarkusExtension { parentFirstArtifacts.set(artifacts) }`
+
+|`quarkusExtension { runnerParentFirstArtifacts = artifacts }` or `quarkusExtension.setRunnerParentFirstArtifacts(artifacts)`
+|`quarkusExtension { runnerParentFirstArtifacts.set(artifacts) }`
+|`quarkusExtension { runnerParentFirstArtifacts.set(artifacts) }`
+
+|`quarkusExtension { lesserPriorityArtifacts = artifacts }` or `quarkusExtension.setLesserPriorityArtifacts(artifacts)`
+|`quarkusExtension { lesserPriorityArtifacts.set(artifacts) }`
+|`quarkusExtension { lesserPriorityArtifacts.set(artifacts) }`
+
+|`quarkusExtension { conditionalDependencies = dependencies }` or `quarkusExtension.setConditionalDependencies(dependencies)`
+|`quarkusExtension { conditionalDependencies.set(dependencies) }`
+|`quarkusExtension { conditionalDependencies.set(dependencies) }`
+
+|`quarkusExtension { conditionalDevDependencies = dependencies }` or `quarkusExtension.setConditionalDevDependencies(dependencies)`
+|`quarkusExtension { conditionalDevDependencies.set(dependencies) }`
+|`quarkusExtension { conditionalDevDependencies.set(dependencies) }`
+
+|`quarkusExtension { dependencyConditions = conditions }` or `quarkusExtension.setDependencyConditions(conditions)`
+|`quarkusExtension { dependencyConditions.set(conditions) }`
+|`quarkusExtension { dependencyConditions.set(conditions) }`
+|===
+
+Public Java visibility does not necessarily mean that a method is intended as stable build-script DSL.
+Some public getters and methods exist for Gradle task modeling or plugin internals.
+Use the DSL documented in this guide as the supported Gradle build-script surface.
 
 === Build a container friendly executable
 


### PR DESCRIPTION
The Gradle plugins are being prepared for better configuration-cache and isolated-projects compatibility in Quarkus 4. Part of that work removes legacy build-script entry points that either duplicate Gradle managed properties or mutate native-image arguments through the quarkusBuild task instead of the plugin extension.

Give Quarkus 3 users an upgrade path before those removals happen: expose the replacement managed-property DSL shape where it was missing, route the existing nativeArgs(Action) task method into the new extension property, and emit execution-time diagnostics when deprecated application-plugin DSL is used. The diagnostic report includes stack traces so users can find the build-script call sites without making the deprecated usage part of task outputs.

Also document the Groovy and Kotlin migration patterns in the Gradle tooling guide, including Groovy assignment forms that call JavaBean setters today.
