### PR TITLE
Avoid container reuse on CI -- take 2

### DIFF
--- a/.github/ci-prerequisites.sh
+++ b/.github/ci-prerequisites.sh
@@ -32,6 +32,20 @@
 # alpine           3.14        dd53f409bf0b   4 months ago   5.6MB
 # alpine           3.15        c4fc93816858   4 months ago   5.58MB
 
+# Stop all running containers to prevent cross-job container reuse on self-hosted runners.
+# A container left running by a killed/interrupted previous job could be picked up
+# by Testcontainers in this job if it has a matching hash.
+time sudo docker container stop -a 2>/dev/null || true
+
+# Remove stopped containers so that they are not reused by Testcontainers.
+time sudo docker container prune -f || true
+
+# Remove any testcontainers configuration left over from a previous job.
+# IsContainerRuntimeWorking temporarily enables testcontainers.reuse.enable in this
+# file; if the JVM was killed before restoring it, the setting persists
+# and enables unintended container reuse in subsequent jobs.
+rm -f ~/.testcontainers.properties
+
 time sudo docker image prune --all --force || true
 
 sudo apt-get remove -y '^dotnet-.*'

--- a/core/deployment/pom.xml
+++ b/core/deployment/pom.xml
@@ -176,6 +176,17 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.shrinkwrap</groupId>
             <artifactId>shrinkwrap-depchain</artifactId>
             <scope>test</scope>

--- a/core/deployment/src/main/java/io/quarkus/deployment/IsContainerRuntimeWorking.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/IsContainerRuntimeWorking.java
@@ -3,7 +3,6 @@ package io.quarkus.deployment;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.URI;
@@ -12,6 +11,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
@@ -66,8 +66,7 @@ public abstract class IsContainerRuntimeWorking implements BooleanSupplier {
                 StartupLogCompressor compressor = new StartupLogCompressor("Checking Docker Environment",
                         Optional.empty(), null,
                         (s) -> s.getName().startsWith("ducttape"));
-                Object configurationInstance = null;
-                Method updateUserConfigMethod = null;
+                Properties userProperties = null;
                 String oldReusePropertyValue = null;
                 boolean restoreReusePropertyValue = false;
                 try {
@@ -77,15 +76,14 @@ public abstract class IsContainerRuntimeWorking implements BooleanSupplier {
 
                     Class<?> configurationClass = Thread.currentThread().getContextClassLoader()
                             .loadClass("org.testcontainers.utility.TestcontainersConfiguration");
-                    configurationInstance = configurationClass.getMethod("getInstance").invoke(null);
-                    oldReusePropertyValue = (String) configurationClass
-                            .getMethod("getEnvVarOrUserProperty", String.class, String.class)
-                            .invoke(configurationInstance, "testcontainers.reuse.enable", "false"); // use the default provided in TestcontainersConfiguration#environmentSupportsReuse
-                    updateUserConfigMethod = configurationClass.getMethod("updateUserConfig", String.class,
-                            String.class);
+                    Object configurationInstance = configurationClass.getMethod("getInstance").invoke(null);
+                    // Modify userProperties in-memory only, without writing to ~/.testcontainers.properties on disk
+                    userProperties = (Properties) configurationClass.getMethod("getUserProperties")
+                            .invoke(configurationInstance);
+                    oldReusePropertyValue = userProperties.getProperty("testcontainers.reuse.enable");
                     restoreReusePropertyValue = true;
                     // this will ensure that testcontainers does not start ryuk - see https://github.com/quarkusio/quarkus/issues/25852 for why this is important
-                    updateUserConfigMethod.invoke(configurationInstance, "testcontainers.reuse.enable", "true");
+                    userProperties.setProperty("testcontainers.reuse.enable", "true");
 
                     // ensure that Testcontainers doesn't take previous failures into account
                     Class<?> dockerClientProviderStrategyClass = Thread.currentThread().getContextClassLoader()
@@ -112,9 +110,13 @@ public abstract class IsContainerRuntimeWorking implements BooleanSupplier {
                 } finally {
                     if (restoreReusePropertyValue) {
                         try {
-                            updateUserConfigMethod.invoke(configurationInstance, "testcontainers.reuse.enable",
-                                    oldReusePropertyValue);
-                        } catch (IllegalAccessException | InvocationTargetException e) {
+                            if (oldReusePropertyValue != null) {
+                                userProperties.setProperty("testcontainers.reuse.enable",
+                                        oldReusePropertyValue);
+                            } else {
+                                userProperties.remove("testcontainers.reuse.enable");
+                            }
+                        } catch (Exception e) {
                             LOGGER.debug("Unable to restore testcontainers.reuse.enable", e);
                         }
                     }

--- a/core/deployment/src/test/java/io/quarkus/deployment/IsContainerRuntimeWorkingTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/IsContainerRuntimeWorkingTest.java
@@ -1,0 +1,61 @@
+package io.quarkus.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.utility.TestcontainersConfiguration;
+
+/**
+ * Regression test for <a href="https://github.com/quarkusio/quarkus/pull/28702">#28702</a>:
+ * checking Docker availability must not leave testcontainers configuration behind,
+ * either in-memory (in {@link TestcontainersConfiguration#getUserProperties()})
+ * or on disk ({@code ~/.testcontainers.properties}).
+ */
+class IsContainerRuntimeWorkingTest {
+
+    private static final File TESTCONTAINERS_PROPS_FILE = new File(System.getProperty("user.home"),
+            ".testcontainers.properties");
+
+    @Test
+    void dockerAvailabilityCheckDoesNotLeaveConfigBehind() throws Exception {
+        TestcontainersConfiguration config = TestcontainersConfiguration.getInstance();
+        Properties userProperties = config.getUserProperties();
+
+        String originalPropertyValue = userProperties.getProperty("testcontainers.reuse.enable");
+        boolean fileExistedBefore = TESTCONTAINERS_PROPS_FILE.exists();
+        byte[] originalFileContent = fileExistedBefore ? Files.readAllBytes(TESTCONTAINERS_PROPS_FILE.toPath()) : null;
+
+        try {
+            new IsContainerRuntimeWorking.TestContainersStrategy(true).get();
+
+            assertThat(userProperties.getProperty("testcontainers.reuse.enable"))
+                    .as("testcontainers.reuse.enable in-memory property should be restored after Docker check")
+                    .isEqualTo(originalPropertyValue);
+
+            if (fileExistedBefore) {
+                assertThat(Files.readAllBytes(TESTCONTAINERS_PROPS_FILE.toPath()))
+                        .as("~/.testcontainers.properties content should be unchanged after Docker check")
+                        .isEqualTo(originalFileContent);
+            } else {
+                assertThat(TESTCONTAINERS_PROPS_FILE)
+                        .as("~/.testcontainers.properties should not be created by Docker check")
+                        .doesNotExist();
+            }
+        } finally {
+            if (originalPropertyValue != null) {
+                userProperties.setProperty("testcontainers.reuse.enable", originalPropertyValue);
+            } else {
+                userProperties.remove("testcontainers.reuse.enable");
+            }
+            if (!fileExistedBefore && TESTCONTAINERS_PROPS_FILE.exists()) {
+                TESTCONTAINERS_PROPS_FILE.delete();
+            } else if (fileExistedBefore) {
+                Files.write(TESTCONTAINERS_PROPS_FILE.toPath(), originalFileContent);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Follows up on #55231

See https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/Hibernate.20test.20failures.20on.20CI/with/608400804

1. Make sure to drop any still-running container before starting CI. In theory that could happen on self-hosted runners... though I sure hope we avoid it by forbidding reuse. But who knows.
2. Make sure we never update the `~/.testcontainers.properties` of developers! We used to, because `updateUserConfig` actually writes config to disk.

Could this solve our problem? Not sure. The call to `updateUserConfig` might have left `~/.testcontainers.properties` files behind which enable container reuse, but that's only before #55231, so we would only still see the effects of that if there are still PRs running with the old code (not rebased on `main` after I opened my PR), and then only on CI runs for those PRs + any subsequent run on the same machine (which, as explained above, I hope never happens).

So, yeah, it might not solve our problem. But still, it solves *a* problem.

