### PR TITLE
Gradle IT: Fix `quarkus-junit` module reference

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/test/resources/io/quarkus/gradle/tasks/jvmargs/main/build.gradle.kts
+++ b/devtools/gradle/gradle-application-plugin/src/test/resources/io/quarkus/gradle/tasks/jvmargs/main/build.gradle.kts
@@ -18,6 +18,6 @@ repositories {
 dependencies {
     implementation(enforcedPlatform("io.quarkus:quarkus-bom:${project.property("version")}"))
     implementation("io.quarkus:quarkus-arc")
-    testImplementation("io.quarkus:quarkus-junit5")
+    testImplementation("io.quarkus:quarkus-junit")
 }
 


### PR DESCRIPTION
A minor change to let the Gradle IT refer to the new Maven coordinates: `quarkus-junit5` is now `quarkus-junit`.