### PR TITLE
Add quarkus.http.ssl-host to bind HTTPS independently from HTTP

### DIFF
--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -307,6 +307,23 @@ By default, Quarkus listens to port 8443 for SSL secured connections and 8444 wh
 
 These ports can be configured in your `application.properties` with the properties `quarkus.http.ssl-port` and `quarkus.http.test-ssl-port`.
 
+=== Configure the HTTPS host independently
+
+By default, both the plain HTTP and HTTPS listeners bind to the host configured with `quarkus.http.host`.
+When you need to bind them to different network interfaces, set `quarkus.http.ssl-host` for the HTTPS listener.
+When not set, HTTPS uses the same host as plain HTTP.
+
+This is useful when HTTP should only be reachable locally (for example local administration) while HTTPS
+should be reachable from remote clients:
+
+[source,properties]
+----
+quarkus.http.host=127.0.0.1
+quarkus.http.ssl-host=0.0.0.0
+quarkus.http.ssl.certificate.files=/path/to/certificate
+quarkus.http.ssl.certificate.key-files=/path/to/key
+----
+
 === Disable the HTTP port
 
 It is possible to disable the HTTP port and only support secure requests. This is done via the

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ssl/IndependentSslHostTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ssl/IndependentSslHostTest.java
@@ -1,0 +1,93 @@
+package io.quarkus.vertx.http.ssl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import java.io.File;
+import java.net.URL;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.event.ObservesAsync;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.vertx.http.HttpServerStart;
+import io.quarkus.vertx.http.HttpsServerStart;
+import io.restassured.RestAssured;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.junit5.Certificate;
+import io.smallrye.certs.junit5.Certificates;
+import io.vertx.ext.web.Router;
+
+@Certificates(baseDir = "target/certs", certificates = @Certificate(name = "ssl-test", password = "secret", formats = {
+        Format.JKS, Format.PKCS12, Format.PEM }))
+public class IndependentSslHostTest {
+
+    @TestHTTPResource(value = "/ssl", tls = true)
+    URL httpsUrl;
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyBean.class, HostListener.class)
+                    .addAsResource(new File("target/certs/ssl-test.key"), "server-key.pem")
+                    .addAsResource(new File("target/certs/ssl-test.crt"), "server-cert.pem"))
+            .overrideConfigKey("quarkus.http.host", "127.0.0.1")
+            .overrideConfigKey("quarkus.http.ssl-host", "0.0.0.0")
+            .overrideConfigKey("quarkus.http.ssl.certificate.files", "server-cert.pem")
+            .overrideConfigKey("quarkus.http.ssl.certificate.key-files", "server-key.pem");
+
+    @Test
+    public void testIndependentSslHost() throws InterruptedException {
+        assertThat(HostListener.HTTP.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(HostListener.HTTPS.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(HostListener.httpHost).isEqualTo("127.0.0.1");
+        assertThat(HostListener.httpsHost).isEqualTo("0.0.0.0");
+
+        RestAssured.given().get("http://127.0.0.1:8081/ssl").then().statusCode(200).body(is("plain"));
+        RestAssured
+                .given()
+                .trustStore(new File("target/certs/ssl-test-truststore.jks"), "secret")
+                .get(httpsUrl).then().statusCode(200).body(is("ssl"));
+    }
+
+    @ApplicationScoped
+    static class MyBean {
+
+        public void register(@Observes Router router) {
+            router.get("/ssl").handler(rc -> {
+                if (rc.request().isSSL()) {
+                    rc.response().end("ssl");
+                } else {
+                    rc.response().end("plain");
+                }
+            });
+        }
+    }
+
+    @Dependent
+    public static class HostListener {
+
+        static final CountDownLatch HTTP = new CountDownLatch(1);
+        static final CountDownLatch HTTPS = new CountDownLatch(1);
+        static volatile String httpHost;
+        static volatile String httpsHost;
+
+        void httpStarted(@ObservesAsync HttpServerStart start) {
+            httpHost = start.config().getTcpHost();
+            HTTP.countDown();
+        }
+
+        void httpsStarted(@ObservesAsync HttpsServerStart start) {
+            httpsHost = start.config().getTcpHost();
+            HTTPS.countDown();
+        }
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpConfig.java
@@ -53,6 +53,16 @@ public interface VertxHttpConfig {
     String host();
 
     /**
+     * The HTTPS host.
+     * <p>
+     * When not set, defaults to the value of {@link #host()}.
+     * <p>
+     * This allows binding plain HTTP and HTTPS to different network interfaces. For example, HTTP can listen on
+     * {@code 127.0.0.1} for local administration while HTTPS listens on {@code 0.0.0.0} for remote clients.
+     */
+    Optional<String> sslHost();
+
+    /**
      * Used when {@code QuarkusIntegrationTest} is meant to execute against an application that is already running and
      * listening on the host specified by this property.
      */
@@ -456,6 +466,10 @@ public interface VertxHttpConfig {
 
     default int determineSslPort(LaunchMode launchMode) {
         return launchMode == LaunchMode.TEST ? testSslPort() : sslPort();
+    }
+
+    default String determineSslHost() {
+        return sslHost().orElse(host());
     }
 
     enum InsecureRequests {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtils.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtils.java
@@ -118,7 +118,8 @@ public class HttpServerOptionsUtils {
             ClientAuth clientAuth = getTlsClientAuth(httpConfig, httpBuildTimeConfig, launchMode);
             ServerSSLOptions sslOptions = createServerSslOptions(bucket, clientAuth);
             SSLEngineOptions engineOptions = bucket.getSslEngineOptions().orElse(null);
-            applyCommonOptions(config, httpBuildTimeConfig, httpConfig, websocketSubProtocols);
+            applyCommonOptions(config, httpBuildTimeConfig, httpConfig, websocketSubProtocols,
+                    httpConfig.determineSslHost());
             return new ServerConfig(config, sslOptions, engineOptions);
         }
 
@@ -128,7 +129,8 @@ public class HttpServerOptionsUtils {
             return null;
         }
         sslOptions.setClientAuth(getTlsClientAuth(httpConfig, httpBuildTimeConfig, launchMode));
-        applyCommonOptions(config, httpBuildTimeConfig, httpConfig, websocketSubProtocols);
+        applyCommonOptions(config, httpBuildTimeConfig, httpConfig, websocketSubProtocols,
+                httpConfig.determineSslHost());
         return new ServerConfig(config, sslOptions);
     }
 
@@ -234,7 +236,7 @@ public class HttpServerOptionsUtils {
         int port = httpConfig.determinePort(launchMode);
         config.setPort(port);
 
-        applyCommonOptions(config, buildTimeConfig, httpConfig, websocketSubProtocols);
+        applyCommonOptions(config, buildTimeConfig, httpConfig, websocketSubProtocols, httpConfig.host());
         return config;
     }
 
@@ -268,7 +270,7 @@ public class HttpServerOptionsUtils {
             return null;
         }
         HttpServerConfig config = new HttpServerConfig();
-        applyCommonOptions(config, buildTimeConfig, httpConfig, websocketSubProtocols);
+        applyCommonOptions(config, buildTimeConfig, httpConfig, websocketSubProtocols, httpConfig.host());
         config.setHost(httpConfig.domainSocket());
         return config;
     }
@@ -296,8 +298,9 @@ public class HttpServerOptionsUtils {
             HttpServerConfig config,
             VertxHttpBuildTimeConfig httpBuildTimeConfig,
             VertxHttpConfig httpConfig,
-            List<String> websocketSubProtocols) {
-        config.setHost(httpConfig.host());
+            List<String> websocketSubProtocols,
+            String host) {
+        config.setHost(host);
         setIdleTimeout(httpConfig, config);
 
         // HTTP/1.1 config

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtilsTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtilsTest.java
@@ -39,7 +39,7 @@ class HttpServerOptionsUtilsTest {
         VertxHttpBuildTimeConfig buildTimeConfig = buildTimeConfig(true, Optional.of(List.of("gzip")), OptionalInt.empty());
         VertxHttpConfig httpConfig = minimalHttpConfig();
 
-        HttpServerOptionsUtils.applyCommonOptions(config, buildTimeConfig, httpConfig, Collections.emptyList());
+        HttpServerOptionsUtils.applyCommonOptions(config, buildTimeConfig, httpConfig, Collections.emptyList(), "localhost");
 
         assertThat(config.getCompressionConfig()).isNotNull();
         assertThat(config.getCompressionConfig().isCompressionEnabled()).isTrue();
@@ -51,7 +51,7 @@ class HttpServerOptionsUtilsTest {
         VertxHttpBuildTimeConfig buildTimeConfig = buildTimeConfig(false, Optional.empty(), OptionalInt.empty());
         VertxHttpConfig httpConfig = minimalHttpConfig();
 
-        HttpServerOptionsUtils.applyCommonOptions(config, buildTimeConfig, httpConfig, Collections.emptyList());
+        HttpServerOptionsUtils.applyCommonOptions(config, buildTimeConfig, httpConfig, Collections.emptyList(), "localhost");
 
         assertThat(config.getCompressionConfig().isCompressionEnabled()).isFalse();
     }
@@ -62,7 +62,7 @@ class HttpServerOptionsUtilsTest {
         VertxHttpBuildTimeConfig buildTimeConfig = buildTimeConfig(false, Optional.empty(), OptionalInt.empty());
         VertxHttpConfig httpConfig = minimalHttpConfig(true);
 
-        HttpServerOptionsUtils.applyCommonOptions(config, buildTimeConfig, httpConfig, Collections.emptyList());
+        HttpServerOptionsUtils.applyCommonOptions(config, buildTimeConfig, httpConfig, Collections.emptyList(), "localhost");
 
         assertThat(config.getHttp2Config()).isNotNull();
         assertThat(config.getHttp2Config().getInitialSettings()).isNotNull();
@@ -75,7 +75,7 @@ class HttpServerOptionsUtilsTest {
         VertxHttpBuildTimeConfig buildTimeConfig = buildTimeConfig(false, Optional.empty(), OptionalInt.empty());
         VertxHttpConfig httpConfig = minimalHttpConfig();
 
-        HttpServerOptionsUtils.applyCommonOptions(config, buildTimeConfig, httpConfig, Collections.emptyList());
+        HttpServerOptionsUtils.applyCommonOptions(config, buildTimeConfig, httpConfig, Collections.emptyList(), "localhost");
 
         assertThat(config.getHttp1Config().getMaxHeaderSize()).isEqualTo(20480);
         assertThat(config.getHttp1Config().getMaxChunkSize()).isEqualTo(8192);
@@ -91,7 +91,7 @@ class HttpServerOptionsUtilsTest {
         VertxHttpConfig httpConfig = minimalHttpConfig();
         List<String> subProtocols = List.of("graphql-ws", "subscriptions-transport-ws");
 
-        HttpServerOptionsUtils.applyCommonOptions(config, buildTimeConfig, httpConfig, subProtocols);
+        HttpServerOptionsUtils.applyCommonOptions(config, buildTimeConfig, httpConfig, subProtocols, "localhost");
 
         assertThat(config.getWebSocketConfig().getSubProtocols()).containsExactlyElementsOf(subProtocols);
     }
@@ -111,9 +111,56 @@ class HttpServerOptionsUtilsTest {
         when(trafficShaping.peakOutboundGlobalBandwidth()).thenReturn(Optional.empty());
         when(httpConfig.trafficShaping()).thenReturn(trafficShaping);
 
-        HttpServerOptionsUtils.applyCommonOptions(config, buildTimeConfig, httpConfig, Collections.emptyList());
+        HttpServerOptionsUtils.applyCommonOptions(config, buildTimeConfig, httpConfig, Collections.emptyList(), "localhost");
 
         assertThat(config.getTcpConfig().getTrafficShapingOptions()).isNotNull();
+    }
+
+    @Test
+    void createHttpServerConfigSetsHost() {
+        VertxHttpBuildTimeConfig buildTimeConfig = buildTimeConfig(false, Optional.empty(), OptionalInt.empty());
+        VertxHttpConfig httpConfig = minimalHttpConfig();
+        when(httpConfig.hostEnabled()).thenReturn(true);
+        when(httpConfig.determinePort(LaunchMode.NORMAL)).thenReturn(8080);
+
+        HttpServerConfig config = HttpServerOptionsUtils.createHttpServerConfig(
+                buildTimeConfig, httpConfig, LaunchMode.NORMAL, Collections.emptyList());
+
+        assertThat(config).isNotNull();
+        assertThat(config.getTcpHost()).isEqualTo("localhost");
+    }
+
+    @Test
+    void createHttpAndSslServerConfigsUseDifferentHosts() {
+        VertxHttpBuildTimeConfig buildTimeConfig = buildTimeConfig(false, Optional.empty(), OptionalInt.empty());
+        VertxHttpConfig httpConfig = minimalHttpConfig();
+        when(httpConfig.host()).thenReturn("127.0.0.1");
+        when(httpConfig.sslHost()).thenReturn(Optional.of("0.0.0.0"));
+        when(httpConfig.determineSslHost()).thenReturn("0.0.0.0");
+
+        HttpServerConfig httpServerConfig = new HttpServerConfig();
+        HttpServerOptionsUtils.applyCommonOptions(httpServerConfig, buildTimeConfig, httpConfig, Collections.emptyList(),
+                httpConfig.host());
+        assertThat(httpServerConfig.getTcpHost()).isEqualTo("127.0.0.1");
+
+        HttpServerConfig httpsServerConfig = new HttpServerConfig();
+        HttpServerOptionsUtils.applyCommonOptions(httpsServerConfig, buildTimeConfig, httpConfig, Collections.emptyList(),
+                httpConfig.determineSslHost());
+        assertThat(httpsServerConfig.getTcpHost()).isEqualTo("0.0.0.0");
+    }
+
+    @Test
+    void createSslServerConfigFallsBackToHostWhenSslHostNotSet() {
+        VertxHttpBuildTimeConfig buildTimeConfig = buildTimeConfig(false, Optional.empty(), OptionalInt.empty());
+        VertxHttpConfig httpConfig = minimalHttpConfig();
+        when(httpConfig.sslHost()).thenReturn(Optional.empty());
+        when(httpConfig.determineSslHost()).thenReturn("localhost");
+
+        HttpServerConfig config = new HttpServerConfig();
+        HttpServerOptionsUtils.applyCommonOptions(config, buildTimeConfig, httpConfig, Collections.emptyList(),
+                httpConfig.determineSslHost());
+
+        assertThat(config.getTcpHost()).isEqualTo("localhost");
     }
 
     @Test


### PR DESCRIPTION
Applications that serve both plain HTTP and HTTPS currently bind both listeners to the same host (`quarkus.http.host`). This makes it impossible to expose HTTPS on all interfaces while restricting HTTP to localhost—for example when running local health checks or admin tools over HTTP without exposing unencrypted traffic to the network.

This change adds `quarkus.http.ssl-host`, which defaults to the value of `quarkus.http.host` when unset, so existing deployments are unaffected.

- Fixes: #47531


