### PR TITLE
Fix test selection for nested test classes

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
@@ -1217,7 +1217,7 @@ public class JunitTestRunner {
         private record ClassMatcher(Pattern classPattern) implements Matcher {
             @Override
             public boolean matches(String className, String methodName) {
-                return classPattern.matcher(className).matches();
+                return matchesClassOrEnclosingClass(classPattern, className);
             }
         }
 
@@ -1236,7 +1236,7 @@ public class JunitTestRunner {
         private record ClassAndMethodMatcher(Pattern classPattern, Pattern[] methodPatterns) implements Matcher {
             @Override
             public boolean matches(String className, String methodName) {
-                if (classPattern.matcher(className).matches()) {
+                if (matchesClassOrEnclosingClass(classPattern, className)) {
                     for (Pattern methodPattern : methodPatterns) {
                         if (methodPattern.matcher(methodName).matches()) {
                             return true;
@@ -1245,6 +1245,14 @@ public class JunitTestRunner {
                 }
                 return false;
             }
+        }
+
+        private static boolean matchesClassOrEnclosingClass(Pattern classPattern, String className) {
+            if (classPattern.matcher(className).matches()) {
+                return true;
+            }
+            int index = className.indexOf('$');
+            return index > 0 && classPattern.matcher(className.substring(0, index)).matches();
         }
     }
 
@@ -1328,13 +1336,28 @@ public class JunitTestRunner {
                     }
 
                     Pattern include = includes[i];
-                    if (include.matcher(testedClassAndMethodName).matches() || include.matcher(testedClassName).matches()) {
+                    if (matchesClassOrMethodOrEnclosingClass(include, testedClassName, testedClassAndMethodName,
+                            methodName)) {
                         return FilterResult.included(null);
                     }
                 }
                 return FilterResult.excluded(null);
             }
             return FilterResult.included("not a method");
+        }
+
+        private static boolean matchesClassOrMethodOrEnclosingClass(Pattern include, String testedClassName,
+                String testedClassAndMethodName, String methodName) {
+            if (include.matcher(testedClassAndMethodName).matches() || include.matcher(testedClassName).matches()) {
+                return true;
+            }
+            int index = testedClassName.indexOf('$');
+            if (index <= 0) {
+                return false;
+            }
+            String outerClassName = testedClassName.substring(0, index);
+            return include.matcher(outerClassName + "." + methodName).matches()
+                    || include.matcher(outerClassName).matches();
         }
     }
 

--- a/core/deployment/src/test/java/io/quarkus/deployment/dev/testing/JunitTestRunnerSelectionFilterTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/dev/testing/JunitTestRunnerSelectionFilterTest.java
@@ -1,0 +1,83 @@
+package io.quarkus.deployment.dev.testing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Constructor;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.FilterResult;
+import org.junit.platform.engine.TestDescriptor.Type;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
+import org.junit.platform.engine.support.descriptor.MethodSource;
+import org.junit.platform.launcher.PostDiscoveryFilter;
+
+class JunitTestRunnerSelectionFilterTest {
+
+    private static final String NESTED_TEST_CLASS = "org.acme.QuarkusNestedTest$NestedClassTest";
+
+    @Test
+    void mavenClassSelectionIncludesNestedTestClass() throws Exception {
+        PostDiscoveryFilter filter = mavenFilter("QuarkusNestedTest");
+
+        assertThat(apply(filter, NESTED_TEST_CLASS, "nestedTest")).isTrue();
+        assertThat(apply(filter, "org.acme.QuarkusNestedTestFoo", "otherTest")).isFalse();
+    }
+
+    @Test
+    void mavenClassAndMethodSelectionIncludesNestedTestClass() throws Exception {
+        PostDiscoveryFilter filter = mavenFilter("QuarkusNestedTest#nestedTest");
+
+        assertThat(apply(filter, NESTED_TEST_CLASS, "nestedTest")).isTrue();
+        assertThat(apply(filter, NESTED_TEST_CLASS, "otherTest")).isFalse();
+    }
+
+    @Test
+    void gradleClassSelectionIncludesNestedTestClass() throws Exception {
+        PostDiscoveryFilter filter = gradleFilter("QuarkusNestedTest");
+
+        assertThat(apply(filter, NESTED_TEST_CLASS, "nestedTest")).isTrue();
+        assertThat(apply(filter, "org.acme.QuarkusNestedTestFoo", "otherTest")).isFalse();
+    }
+
+    @Test
+    void gradleClassAndMethodSelectionIncludesNestedTestClass() throws Exception {
+        PostDiscoveryFilter filter = gradleFilter("QuarkusNestedTest.nestedTest");
+
+        assertThat(apply(filter, NESTED_TEST_CLASS, "nestedTest")).isTrue();
+        assertThat(apply(filter, NESTED_TEST_CLASS, "otherTest")).isFalse();
+    }
+
+    private static PostDiscoveryFilter mavenFilter(String selection) throws Exception {
+        return filter("MavenSpecificSelectionFilter", selection);
+    }
+
+    private static PostDiscoveryFilter gradleFilter(String selection) throws Exception {
+        return filter("GradleSpecificSelectionFilter", selection);
+    }
+
+    private static PostDiscoveryFilter filter(String filterName, String selection) throws Exception {
+        Class<?> filterClass = Class.forName(JunitTestRunner.class.getName() + "$" + filterName);
+        Constructor<?> constructor = filterClass.getDeclaredConstructor(String.class);
+        constructor.setAccessible(true);
+        return (PostDiscoveryFilter) constructor.newInstance(selection);
+    }
+
+    private static boolean apply(PostDiscoveryFilter filter, String className, String methodName) {
+        FilterResult result = filter.apply(new MethodTestDescriptor(className, methodName));
+        return result.included();
+    }
+
+    private static final class MethodTestDescriptor extends AbstractTestDescriptor {
+
+        private MethodTestDescriptor(String className, String methodName) {
+            super(UniqueId.forEngine("test").append("method", className + "#" + methodName), methodName,
+                    MethodSource.from(className, methodName));
+        }
+
+        @Override
+        public Type getType() {
+            return Type.TEST;
+        }
+    }
+}


### PR DESCRIPTION
Fix continuous testing selection for JUnit nested test classes.

When continuous testing applies Maven `-Dtest=...` filters, JUnit reports methods in `@Nested` classes with binary class names such as `QuarkusNestedTest$NestedClassTest`. The existing class matcher required an exact full-class match, so selecting `QuarkusNestedTest` excluded methods declared in nested test classes.

This change makes the Maven-specific selection filter also match the outer class portion before the `$` boundary, aligning `quarkus test -Dtest=QuarkusNestedTest` with Maven Surefire behavior. The Gradle-specific selection filter gets the same handling for parity.

A regression test covers Maven and Gradle class-only and class-plus-method selection for nested test classes, while ensuring similarly named top-level classes are not overmatched.

* Fixes #55269

**PS:** Local Maven verification was blocked by a missing local `999-SNAPSHOT` artefact. I did use the documented Maven memory guidance by setting `MAVEN_OPTS` with `-Xmx4g` before running the verification. The failure was not the usual Maven heap `OutOfMemoryError`, but a JVM native memory allocation failure on Windows (`The paging file is too small for this operation to complete`), which apparently can't be fixed by increasing the Maven heap. I therefore reported the local verification as blocked instead of claiming tests passed.