### PR TITLE
OIDC: include `invalid_dpop_proof` in `AuthenticationFailedException` to clarify why exception was thrown

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BearerAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BearerAuthenticationMechanism.java
@@ -78,11 +78,11 @@ public class BearerAuthenticationMechanism extends AbstractOidcAuthenticationMec
             List<String> proofs = context.request().headers().getAll(OidcConstants.DPOP_SCHEME);
             if (proofs == null || proofs.isEmpty()) {
                 LOG.warn("DPoP proof header must be present to verify the DPoP access token binding");
-                throw new AuthenticationFailedException(tokenMap(token));
+                throw new AuthenticationFailedException(invalidDPoPProofMap(token));
             }
             if (proofs.size() != 1) {
                 LOG.warnf("Only a single DPoP proof header is accepted, %d headers are available", proofs.size());
-                throw new AuthenticationFailedException(tokenMap(token));
+                throw new AuthenticationFailedException(invalidDPoPProofMap(token));
             }
             String proof = proofs.get(0);
 
@@ -92,28 +92,28 @@ public class BearerAuthenticationMechanism extends AbstractOidcAuthenticationMec
 
             if (!OidcConstants.DPOP_TOKEN_TYPE.equals(proofJwtHeaders.getString(OidcConstants.TOKEN_TYPE_HEADER))) {
                 LOG.warn("Invalid DPoP proof token type ('typ') header");
-                throw new AuthenticationFailedException(tokenMap(token));
+                throw new AuthenticationFailedException(invalidDPoPProofMap(token));
             }
 
             // Check HTTP method and request URI
             String proofHttpMethod = proofJwtClaims.getString(OidcConstants.DPOP_HTTP_METHOD);
             if (proofHttpMethod == null) {
                 LOG.warn("DPoP proof HTTP method claim is missing");
-                throw new AuthenticationFailedException(tokenMap(token));
+                throw new AuthenticationFailedException(invalidDPoPProofMap(token));
             }
 
             String httpMethod = context.request().method().name();
             if (!httpMethod.equals(proofHttpMethod)) {
                 LOG.warnf("DPoP proof HTTP method claim %s does not match the request HTTP method %s", proofHttpMethod,
                         httpMethod);
-                throw new AuthenticationFailedException(tokenMap(token));
+                throw new AuthenticationFailedException(invalidDPoPProofMap(token));
             }
 
             // Check HTTP request URI
             String proofHttpRequestUri = proofJwtClaims.getString(OidcConstants.DPOP_HTTP_REQUEST_URI);
             if (proofHttpRequestUri == null) {
                 LOG.warn("DPoP proof HTTP request uri claim is missing");
-                throw new AuthenticationFailedException(tokenMap(token));
+                throw new AuthenticationFailedException(invalidDPoPProofMap(token));
             }
 
             String httpRequestUri = context.request().absoluteURI();
@@ -124,7 +124,7 @@ public class BearerAuthenticationMechanism extends AbstractOidcAuthenticationMec
             if (!httpRequestUri.equals(proofHttpRequestUri)) {
                 LOG.warnf("DPoP proof HTTP request uri claim %s does not match the request HTTP uri %s", proofHttpRequestUri,
                         httpRequestUri);
-                throw new AuthenticationFailedException(tokenMap(token));
+                throw new AuthenticationFailedException(invalidDPoPProofMap(token));
             }
 
             if (dPoPNonceProvider != null) {
@@ -170,6 +170,10 @@ public class BearerAuthenticationMechanism extends AbstractOidcAuthenticationMec
         return Map.of(OidcConstants.ACCESS_TOKEN_VALUE, token);
     }
 
+    private static Map<String, Object> invalidDPoPProofMap(String token) {
+        return Map.of(OidcConstants.ACCESS_TOKEN_VALUE, token, OidcConstants.INVALID_DPOP_PROOF, Boolean.TRUE);
+    }
+
     public Uni<ChallengeData> getChallenge(RoutingContext context) {
         Uni<TenantConfigContext> tenantContext = resolver.resolveContext(context);
         return tenantContext.onItem().transformToUni(new Function<TenantConfigContext, Uni<? extends ChallengeData>>() {
@@ -181,14 +185,8 @@ public class BearerAuthenticationMechanism extends AbstractOidcAuthenticationMec
                             StepUpAuthenticationPolicy.getAuthRequirementChallenge(context);
                 } else {
                     wwwAuthHeaderValue = tenantContext.oidcConfig().token().authorizationScheme();
-                    if (isInvalidOrMissingDpopNonce(context)) {
-                        final String errorAttributeValue;
-                        if (getAuthenticationFailureFromEvent(context).getAttribute(OidcConstants.USE_DPOP_NONCE) != null) {
-                            errorAttributeValue = OidcConstants.USE_DPOP_NONCE;
-                        } else {
-                            errorAttributeValue = OidcConstants.INVALID_DPOP_PROOF;
-                        }
-                        wwwAuthHeaderValue += " error=\"%s\"".formatted(errorAttributeValue);
+                    if (isMissingOrMismatchedDpopNonce(context)) {
+                        wwwAuthHeaderValue += " error=\"%s\"".formatted(OidcConstants.USE_DPOP_NONCE);
                         return Uni.createFrom().item(new ChallengeData(HttpResponseStatus.UNAUTHORIZED.code(),
                                 Map.of(
                                         HttpHeaderNames.WWW_AUTHENTICATE, wwwAuthHeaderValue,
@@ -205,11 +203,10 @@ public class BearerAuthenticationMechanism extends AbstractOidcAuthenticationMec
         });
     }
 
-    private boolean isInvalidOrMissingDpopNonce(RoutingContext context) {
+    private boolean isMissingOrMismatchedDpopNonce(RoutingContext context) {
         if (dPoPNonceProvider != null) {
             final AuthenticationFailedException authFailure = getAuthenticationFailureFromEvent(context);
-            return authFailure != null && (authFailure.getAttribute(OidcConstants.USE_DPOP_NONCE) != null
-                    || authFailure.getAttribute(OidcConstants.INVALID_DPOP_PROOF) != null);
+            return authFailure != null && authFailure.getAttribute(OidcConstants.USE_DPOP_NONCE) != null;
         }
         return false;
     }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -256,7 +256,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                             if (dpopJwkThumbprint == null) {
                                 LOG.warn(
                                         "DPoP access token does not contain a confirmation 'cnf' claim with the JWK thumbprint");
-                                throw new AuthenticationFailedException(tokenMap(request.getToken()));
+                                throw new AuthenticationFailedException(invalidDPoPProofMap(request.getToken()));
                             }
 
                             JsonObject proofHeaders = (JsonObject) requestData.get(OidcUtils.DPOP_PROOF_JWT_HEADERS);
@@ -264,7 +264,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                             JsonObject jwkProof = proofHeaders.getJsonObject(OidcConstants.DPOP_JWK_HEADER);
                             if (jwkProof == null) {
                                 LOG.warn("DPoP proof jwk header is missing");
-                                throw new AuthenticationFailedException(tokenMap(request.getToken()));
+                                throw new AuthenticationFailedException(invalidDPoPProofMap(request.getToken()));
                             }
 
                             PublicJsonWebKey publicJsonWebKey = null;
@@ -272,12 +272,12 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                                 publicJsonWebKey = PublicJsonWebKey.Factory.newPublicJwk(jwkProof.getMap());
                             } catch (JoseException ex) {
                                 LOG.warn("DPoP proof jwk header does not represent a valid JWK key");
-                                throw new AuthenticationFailedException(ex, tokenMap(request.getToken()));
+                                throw new AuthenticationFailedException(ex, invalidDPoPProofMap(request.getToken()));
                             }
 
                             if (publicJsonWebKey.getPrivateKey() != null) {
                                 LOG.warn("DPoP proof JWK key is a private key but it must be a public key");
-                                throw new AuthenticationFailedException(tokenMap(request.getToken()));
+                                throw new AuthenticationFailedException(invalidDPoPProofMap(request.getToken()));
                             }
 
                             byte[] jwkProofDigest = publicJsonWebKey.calculateThumbprint("SHA-256");
@@ -285,7 +285,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
 
                             if (!dpopJwkThumbprint.equals(jwkProofThumbprint)) {
                                 LOG.warn("DPoP access token JWK thumbprint does not match the DPoP proof JWK thumbprint");
-                                throw new AuthenticationFailedException(tokenMap(request.getToken()));
+                                throw new AuthenticationFailedException(invalidDPoPProofMap(request.getToken()));
                             }
 
                             try {
@@ -295,11 +295,11 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                                 jws.setKey(publicJsonWebKey.getPublicKey());
                                 if (!jws.verifySignature()) {
                                     LOG.warn("DPoP proof token signature is invalid");
-                                    throw new AuthenticationFailedException(tokenMap(request.getToken()));
+                                    throw new AuthenticationFailedException(invalidDPoPProofMap(request.getToken()));
                                 }
                             } catch (JoseException ex) {
                                 LOG.warn("DPoP proof token signature can not be verified");
-                                throw new AuthenticationFailedException(ex, tokenMap(request.getToken()));
+                                throw new AuthenticationFailedException(ex, invalidDPoPProofMap(request.getToken()));
                             }
 
                             JsonObject proofClaims = (JsonObject) requestData.get(OidcUtils.DPOP_PROOF_JWT_CLAIMS);
@@ -309,7 +309,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                             String accessTokenProof = proofClaims.getString(OidcConstants.DPOP_ACCESS_TOKEN_THUMBPRINT);
                             if (accessTokenProof == null) {
                                 LOG.warn("DPoP proof access token hash is missing");
-                                throw new AuthenticationFailedException(tokenMap(request.getToken()));
+                                throw new AuthenticationFailedException(invalidDPoPProofMap(request.getToken()));
                             }
 
                             String accessTokenHash = null;
@@ -322,7 +322,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
 
                             if (!accessTokenProof.equals(accessTokenHash)) {
                                 LOG.warn("DPoP access token hash does not match the DPoP proof access token hash");
-                                throw new AuthenticationFailedException(tokenMap(request.getToken()));
+                                throw new AuthenticationFailedException(invalidDPoPProofMap(request.getToken()));
                             }
 
                             return t;
@@ -566,6 +566,11 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
     private static Map<String, Object> tokenMap(TokenCredential tokenCred) {
         final String tokenType = isIdToken(tokenCred) ? OidcConstants.ID_TOKEN_VALUE : OidcConstants.ACCESS_TOKEN_VALUE;
         return Map.of(tokenType, tokenCred.getToken());
+    }
+
+    private static Map<String, Object> invalidDPoPProofMap(TokenCredential tokenCred) {
+        return Map.of(OidcConstants.ACCESS_TOKEN_VALUE, tokenCred.getToken(),
+                OidcConstants.INVALID_DPOP_PROOF, Boolean.TRUE);
     }
 
     private static boolean isInternalIdToken(TokenAuthenticationRequest request) {

--- a/integration-tests/oidc-dpop/src/main/java/io/quarkus/it/keycloak/DPoPAuthFailureEventResource.java
+++ b/integration-tests/oidc-dpop/src/main/java/io/quarkus/it/keycloak/DPoPAuthFailureEventResource.java
@@ -1,0 +1,28 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+
+@Path("/dpop-auth-failure")
+public class DPoPAuthFailureEventResource {
+
+    @Inject
+    DPoPAuthFailureObserver observer;
+
+    @GET
+    @Path("/last-error")
+    @Produces("text/plain")
+    public String getLastError() {
+        final String error = observer.getLastDPoPErrorAttribute();
+        return error != null ? error : "";
+    }
+
+    @DELETE
+    @Path("/last-error")
+    public void resetLastError() {
+        observer.reset();
+    }
+}

--- a/integration-tests/oidc-dpop/src/main/java/io/quarkus/it/keycloak/DPoPAuthFailureObserver.java
+++ b/integration-tests/oidc-dpop/src/main/java/io/quarkus/it/keycloak/DPoPAuthFailureObserver.java
@@ -1,0 +1,36 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import io.quarkus.oidc.common.runtime.OidcConstants;
+import io.quarkus.security.AuthenticationFailedException;
+import io.quarkus.security.spi.runtime.AuthenticationFailureEvent;
+
+@ApplicationScoped
+public class DPoPAuthFailureObserver {
+
+    static final String NO_DPOP_ERROR_ATTRIBUTE = "no_dpop_error_attribute";
+
+    private volatile String lastDPoPErrorAttribute;
+
+    void observe(@Observes AuthenticationFailureEvent event) {
+        if (event.getAuthenticationFailure() instanceof AuthenticationFailedException ex) {
+            if (Boolean.TRUE.equals(ex.getAttribute(OidcConstants.INVALID_DPOP_PROOF))) {
+                lastDPoPErrorAttribute = OidcConstants.INVALID_DPOP_PROOF;
+            } else if (Boolean.TRUE.equals(ex.getAttribute(OidcConstants.USE_DPOP_NONCE))) {
+                lastDPoPErrorAttribute = OidcConstants.USE_DPOP_NONCE;
+            } else {
+                lastDPoPErrorAttribute = NO_DPOP_ERROR_ATTRIBUTE;
+            }
+        }
+    }
+
+    String getLastDPoPErrorAttribute() {
+        return lastDPoPErrorAttribute;
+    }
+
+    void reset() {
+        lastDPoPErrorAttribute = null;
+    }
+}

--- a/integration-tests/oidc-dpop/src/main/java/io/quarkus/it/keycloak/FrontendResource.java
+++ b/integration-tests/oidc-dpop/src/main/java/io/quarkus/it/keycloak/FrontendResource.java
@@ -59,6 +59,71 @@ public class FrontendResource {
     }
 
     @GET
+    @Path("login-jwt-wrong-dpop-http-method-with-nonce/{nonce}")
+    public Response loginJwtWrongDpopHttpMethodWithNonce(@RestPath String nonce) {
+        return redirect("dpop-jwt", "callback-jwt-wrong-dpop-http-method-with-nonce/" + nonce);
+    }
+
+    @GET
+    @Path("callback-jwt-wrong-dpop-http-method-with-nonce/{nonce}")
+    public Response callbackWrongDpopHttpMethodWithNonce(@RestQuery String code, @RestPath String nonce) throws Exception {
+        return callProtectedEndpoint(code, "dpop-jwt", "callback-jwt-wrong-dpop-http-method-with-nonce/" + nonce, "POST",
+                "dpop-jwt", "dpop-jwt", false, false, false, nonce);
+    }
+
+    @GET
+    @Path("login-jwt-wrong-dpop-http-uri-with-nonce/{nonce}")
+    public Response loginJwtWrongDpopHttpUriWithNonce(@RestPath String nonce) {
+        return redirect("dpop-jwt", "callback-jwt-wrong-dpop-http-uri-with-nonce/" + nonce);
+    }
+
+    @GET
+    @Path("callback-jwt-wrong-dpop-http-uri-with-nonce/{nonce}")
+    public Response callbackWrongDpopHttpUriWithNonce(@RestQuery String code, @RestPath String nonce) throws Exception {
+        return callProtectedEndpoint(code, "dpop-jwt", "callback-jwt-wrong-dpop-http-uri-with-nonce/" + nonce, "GET",
+                "dpop-jwt-wrong-uri", "dpop-jwt", false, false, false, nonce);
+    }
+
+    @GET
+    @Path("login-jwt-wrong-dpop-signature-with-nonce/{nonce}")
+    public Response loginJwtWrongDpopSignatureWithNonce(@RestPath String nonce) {
+        return redirect("dpop-jwt", "callback-jwt-wrong-dpop-signature-with-nonce/" + nonce);
+    }
+
+    @GET
+    @Path("callback-jwt-wrong-dpop-signature-with-nonce/{nonce}")
+    public Response callbackWrongDpopSignatureWithNonce(@RestQuery String code, @RestPath String nonce) throws Exception {
+        return callProtectedEndpoint(code, "dpop-jwt", "callback-jwt-wrong-dpop-signature-with-nonce/" + nonce, "GET",
+                "dpop-jwt", "dpop-jwt", true, false, false, nonce);
+    }
+
+    @GET
+    @Path("login-jwt-wrong-dpop-jwk-key-with-nonce/{nonce}")
+    public Response loginJwtWrongDpopJwkKeyWithNonce(@RestPath String nonce) {
+        return redirect("dpop-jwt", "callback-jwt-wrong-dpop-jwk-key-with-nonce/" + nonce);
+    }
+
+    @GET
+    @Path("callback-jwt-wrong-dpop-jwk-key-with-nonce/{nonce}")
+    public Response callbackWrongDpopJwkKeyWithNonce(@RestQuery String code, @RestPath String nonce) throws Exception {
+        return callProtectedEndpoint(code, "dpop-jwt", "callback-jwt-wrong-dpop-jwk-key-with-nonce/" + nonce, "GET",
+                "dpop-jwt-wrong-uri", "dpop-jwt", false, true, false, nonce);
+    }
+
+    @GET
+    @Path("login-jwt-wrong-dpop-token-hash-with-nonce/{nonce}")
+    public Response loginJwtWrongDpopTokenHashWithNonce(@RestPath String nonce) {
+        return redirect("dpop-jwt", "callback-jwt-wrong-dpop-token-hash-with-nonce/" + nonce);
+    }
+
+    @GET
+    @Path("callback-jwt-wrong-dpop-token-hash-with-nonce/{nonce}")
+    public Response callbackWrongDpopTokenHashWithNonce(@RestQuery String code, @RestPath String nonce) throws Exception {
+        return callProtectedEndpoint(code, "dpop-jwt", "callback-jwt-wrong-dpop-token-hash-with-nonce/" + nonce, "GET",
+                "dpop-jwt", "dpop-jwt", false, false, true, nonce);
+    }
+
+    @GET
     @Path("login-jwt")
     public Response loginJwt() {
         return redirect("dpop-jwt", "callback-jwt");

--- a/integration-tests/oidc-dpop/src/test/java/io/quarkus/it/keycloak/OidcDPopNonceTest.java
+++ b/integration-tests/oidc-dpop/src/test/java/io/quarkus/it/keycloak/OidcDPopNonceTest.java
@@ -1,6 +1,9 @@
 package io.quarkus.it.keycloak;
 
 import static io.netty.handler.codec.http.HttpHeaders.Values.NO_STORE;
+import static io.quarkus.it.keycloak.OidcDPopTest.assertInvalidDPoPProofAuthFailureEvent;
+import static io.quarkus.it.keycloak.OidcDPopTest.loginAndClick;
+import static io.quarkus.it.keycloak.OidcDPopTest.resetDPoPAuthFailureObserver;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -12,8 +15,6 @@ import jakarta.inject.Inject;
 import org.htmlunit.SilentCssErrorHandler;
 import org.htmlunit.TextPage;
 import org.htmlunit.WebClient;
-import org.htmlunit.html.HtmlForm;
-import org.htmlunit.html.HtmlPage;
 import org.junit.jupiter.api.Test;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
@@ -34,17 +35,7 @@ public class OidcDPopNonceTest {
     public void testDPopProofWithCorrectNonce() throws Exception {
         try (final WebClient webClient = createWebClient()) {
             dummyDPoPNonceProvider.setNonce("correct-nonce-scenario");
-            HtmlPage page = webClient
-                    .getPage("http://localhost:8081/single-page-app/login-jwt-with-nonce/correct-nonce-scenario");
-
-            assertEquals("Sign in to quarkus", page.getTitleText());
-
-            HtmlForm loginForm = page.getForms().get(0);
-
-            loginForm.getInputByName("username").setValueAttribute("alice");
-            loginForm.getInputByName("password").setValueAttribute("alice");
-
-            TextPage textPage = loginForm.getButtonByName("login").click();
+            TextPage textPage = loginAndClick(webClient, "login-jwt-with-nonce/correct-nonce-scenario");
 
             assertEquals("Hello, alice; JWK thumbprint in JWT: true, JWK thumbprint in introspection: false",
                     textPage.getContent());
@@ -58,17 +49,7 @@ public class OidcDPopNonceTest {
         try (final WebClient webClient = createWebClient()) {
             String expectedNonce = "another-correct-nonce-scenario";
             dummyDPoPNonceProvider.setNonce(expectedNonce);
-            HtmlPage page = webClient
-                    .getPage("http://localhost:8081/single-page-app/login-jwt-with-nonce/wrong-nonce-scenario");
-
-            assertEquals("Sign in to quarkus", page.getTitleText());
-
-            HtmlForm loginForm = page.getForms().get(0);
-
-            loginForm.getInputByName("username").setValueAttribute("alice");
-            loginForm.getInputByName("password").setValueAttribute("alice");
-
-            TextPage textPage = loginForm.getButtonByName("login").click();
+            TextPage textPage = loginAndClick(webClient, "login-jwt-with-nonce/wrong-nonce-scenario");
 
             assertEquals("401 status from ProtectedResource", textPage.getContent());
 
@@ -92,16 +73,7 @@ public class OidcDPopNonceTest {
         try (final WebClient webClient = createWebClient()) {
             String expectedNonce = "some-correct-nonce-scenario";
             dummyDPoPNonceProvider.setNonce(expectedNonce);
-            HtmlPage page = webClient.getPage("http://localhost:8081/single-page-app/login-jwt");
-
-            assertEquals("Sign in to quarkus", page.getTitleText());
-
-            HtmlForm loginForm = page.getForms().get(0);
-
-            loginForm.getInputByName("username").setValueAttribute("alice");
-            loginForm.getInputByName("password").setValueAttribute("alice");
-
-            TextPage textPage = loginForm.getButtonByName("login").click();
+            TextPage textPage = loginAndClick(webClient, "login-jwt");
 
             assertEquals("401 status from ProtectedResource", textPage.getContent());
 
@@ -115,6 +87,44 @@ public class OidcDPopNonceTest {
             assertEquals(expectedNonce, dpopNonce);
             String cacheControl = textPage.getWebResponse().getResponseHeaderValue(HttpHeaders.CACHE_CONTROL.toString());
             assertEquals(NO_STORE, cacheControl);
+
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    @Test
+    public void testDPopProofWrongHttpMethodWithNonce() throws Exception {
+        assertInvalidDPoPProofWithNonce("login-jwt-wrong-dpop-http-method-with-nonce/", "nonce-wrong-method");
+    }
+
+    @Test
+    public void testDPopProofWrongHttpUriWithNonce() throws Exception {
+        assertInvalidDPoPProofWithNonce("login-jwt-wrong-dpop-http-uri-with-nonce/", "nonce-wrong-uri");
+    }
+
+    @Test
+    public void testDPopProofWrongSignatureWithNonce() throws Exception {
+        assertInvalidDPoPProofWithNonce("login-jwt-wrong-dpop-signature-with-nonce/", "nonce-wrong-signature");
+    }
+
+    @Test
+    public void testDPopProofWrongJwkKeyWithNonce() throws Exception {
+        assertInvalidDPoPProofWithNonce("login-jwt-wrong-dpop-jwk-key-with-nonce/", "nonce-wrong-jwk-key");
+    }
+
+    @Test
+    public void testDPopProofWrongTokenHashWithNonce() throws Exception {
+        assertInvalidDPoPProofWithNonce("login-jwt-wrong-dpop-token-hash-with-nonce/", "nonce-wrong-token-hash");
+    }
+
+    private void assertInvalidDPoPProofWithNonce(String loginPathPrefix, String nonce) throws Exception {
+        try (final WebClient webClient = createWebClient()) {
+            resetDPoPAuthFailureObserver();
+            dummyDPoPNonceProvider.setNonce(nonce);
+            TextPage textPage = loginAndClick(webClient, loginPathPrefix + nonce);
+
+            assertEquals("401 status from ProtectedResource", textPage.getContent());
+            assertInvalidDPoPProofAuthFailureEvent();
 
             webClient.getCookieManager().clearCookies();
         }

--- a/integration-tests/oidc-dpop/src/test/java/io/quarkus/it/keycloak/OidcDPopTest.java
+++ b/integration-tests/oidc-dpop/src/test/java/io/quarkus/it/keycloak/OidcDPopTest.java
@@ -2,6 +2,7 @@ package io.quarkus.it.keycloak;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.hamcrest.Matchers;
 import org.htmlunit.SilentCssErrorHandler;
 import org.htmlunit.TextPage;
 import org.htmlunit.WebClient;
@@ -9,6 +10,7 @@ import org.htmlunit.html.HtmlForm;
 import org.htmlunit.html.HtmlPage;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
@@ -20,16 +22,7 @@ public class OidcDPopTest {
     @Test
     public void testDPopProof() throws Exception {
         try (final WebClient webClient = createWebClient()) {
-            HtmlPage page = webClient.getPage("http://localhost:8081/single-page-app/login-jwt");
-
-            assertEquals("Sign in to quarkus", page.getTitleText());
-
-            HtmlForm loginForm = page.getForms().get(0);
-
-            loginForm.getInputByName("username").setValueAttribute("alice");
-            loginForm.getInputByName("password").setValueAttribute("alice");
-
-            TextPage textPage = loginForm.getButtonByName("login").click();
+            TextPage textPage = loginAndClick(webClient, "login-jwt");
 
             assertEquals("Hello, alice; JWK thumbprint in JWT: true, JWK thumbprint in introspection: false",
                     textPage.getContent());
@@ -54,107 +47,57 @@ public class OidcDPopTest {
 
     @Test
     public void testDPopProofWrongHttpMethod() throws Exception {
-        try (final WebClient webClient = createWebClient()) {
-            HtmlPage page = webClient.getPage("http://localhost:8081/single-page-app/login-jwt-wrong-dpop-http-method");
-
-            assertEquals("Sign in to quarkus", page.getTitleText());
-
-            HtmlForm loginForm = page.getForms().get(0);
-
-            loginForm.getInputByName("username").setValueAttribute("alice");
-            loginForm.getInputByName("password").setValueAttribute("alice");
-
-            TextPage textPage = loginForm.getButtonByName("login").click();
-
-            assertEquals("401 status from ProtectedResource",
-                    textPage.getContent());
-
-            webClient.getCookieManager().clearCookies();
-        }
+        assertInvalidDPoPProof("login-jwt-wrong-dpop-http-method");
     }
 
     @Test
     public void testDPopProofWrongHttpUri() throws Exception {
-        try (final WebClient webClient = createWebClient()) {
-            HtmlPage page = webClient.getPage("http://localhost:8081/single-page-app/login-jwt-wrong-dpop-http-uri");
-
-            assertEquals("Sign in to quarkus", page.getTitleText());
-
-            HtmlForm loginForm = page.getForms().get(0);
-
-            loginForm.getInputByName("username").setValueAttribute("alice");
-            loginForm.getInputByName("password").setValueAttribute("alice");
-
-            TextPage textPage = loginForm.getButtonByName("login").click();
-
-            assertEquals("401 status from ProtectedResource",
-                    textPage.getContent());
-
-            webClient.getCookieManager().clearCookies();
-        }
+        assertInvalidDPoPProof("login-jwt-wrong-dpop-http-uri");
     }
 
     @Test
     public void testDPopProofWrongSignature() throws Exception {
-        try (final WebClient webClient = createWebClient()) {
-            HtmlPage page = webClient.getPage("http://localhost:8081/single-page-app/login-jwt-wrong-dpop-signature");
-
-            assertEquals("Sign in to quarkus", page.getTitleText());
-
-            HtmlForm loginForm = page.getForms().get(0);
-
-            loginForm.getInputByName("username").setValueAttribute("alice");
-            loginForm.getInputByName("password").setValueAttribute("alice");
-
-            TextPage textPage = loginForm.getButtonByName("login").click();
-
-            assertEquals("401 status from ProtectedResource",
-                    textPage.getContent());
-
-            webClient.getCookieManager().clearCookies();
-        }
+        assertInvalidDPoPProof("login-jwt-wrong-dpop-signature");
     }
 
     @Test
     public void testDPopProofWrongJwkKey() throws Exception {
+        assertInvalidDPoPProof("login-jwt-wrong-dpop-jwk-key");
+    }
+
+    @Test
+    public void testDPopProofWrongTokenHash() throws Exception {
+        assertInvalidDPoPProof("login-jwt-wrong-dpop-token-hash");
+    }
+
+    private void assertInvalidDPoPProof(String loginPath) throws Exception {
         try (final WebClient webClient = createWebClient()) {
-            HtmlPage page = webClient.getPage("http://localhost:8081/single-page-app/login-jwt-wrong-dpop-jwk-key");
+            resetDPoPAuthFailureObserver();
+            TextPage textPage = loginAndClick(webClient, loginPath);
 
-            assertEquals("Sign in to quarkus", page.getTitleText());
-
-            HtmlForm loginForm = page.getForms().get(0);
-
-            loginForm.getInputByName("username").setValueAttribute("alice");
-            loginForm.getInputByName("password").setValueAttribute("alice");
-
-            TextPage textPage = loginForm.getButtonByName("login").click();
-
-            assertEquals("401 status from ProtectedResource",
-                    textPage.getContent());
+            assertEquals("401 status from ProtectedResource", textPage.getContent());
+            assertInvalidDPoPProofAuthFailureEvent();
 
             webClient.getCookieManager().clearCookies();
         }
     }
 
-    @Test
-    public void testDPopProofWrongTokenHash() throws Exception {
-        try (final WebClient webClient = createWebClient()) {
-            HtmlPage page = webClient.getPage("http://localhost:8081/single-page-app/login-jwt-wrong-dpop-token-hash");
+    static TextPage loginAndClick(WebClient webClient, String loginPath) throws Exception {
+        HtmlPage page = webClient.getPage("http://localhost:8081/single-page-app/" + loginPath);
+        assertEquals("Sign in to quarkus", page.getTitleText());
+        HtmlForm loginForm = page.getForms().get(0);
+        loginForm.getInputByName("username").setValueAttribute("alice");
+        loginForm.getInputByName("password").setValueAttribute("alice");
+        return loginForm.getButtonByName("login").click();
+    }
 
-            assertEquals("Sign in to quarkus", page.getTitleText());
+    static void resetDPoPAuthFailureObserver() {
+        RestAssured.delete("http://localhost:8081/dpop-auth-failure/last-error");
+    }
 
-            HtmlForm loginForm = page.getForms().get(0);
-
-            loginForm.getInputByName("username").setValueAttribute("alice");
-            loginForm.getInputByName("password").setValueAttribute("alice");
-
-            TextPage textPage = loginForm.getButtonByName("login").click();
-
-            assertEquals("401 status from ProtectedResource",
-                    textPage.getContent());
-
-            webClient.getCookieManager().clearCookies();
-        }
+    static void assertInvalidDPoPProofAuthFailureEvent() {
+        RestAssured.get("http://localhost:8081/dpop-auth-failure/last-error")
+                .then().statusCode(200).body(Matchers.equalTo(OidcConstants.INVALID_DPOP_PROOF));
     }
 
     private WebClient createWebClient() {


### PR DESCRIPTION
follow up to https://github.com/quarkusio/quarkus/pull/54855 which removed all usages of 'invalid_dpop_proof' and left a dead code that is supposed to add it to the HTTP response headers in case the auth failure exception has 'invalid_dpop_proof' (which never happens now).

What this PR does:

* include information about reason why the exception was thrown ('invalid_dpop_proof') according to https://datatracker.ietf.org/doc/html/rfc9449 which defines `invalid_dpop_proof` for `resource access error response` as well
* remove code that added 'invalid_dpop_proof' to response headers, which would become active after this PR and scenarios with a custom DPoP nonce provider would include the header, unlike scenarios without the custom DPoP nonce provider

I have considered adding 'invalid_dpop_proof' to the response headers as specified by https://datatracker.ietf.org/doc/html/rfc9449#name-the-dpop-authentication-sch which says: 'An error parameter ([RFC6750], Section 3) SHOULD be included to ... Additionally, invalid_dpop_proof is used to indicate that the DPoP proof itself was deemed invalid based on the criteria of Section 4.3.'. But it says "SHOULD" not "MUST" and as I am not certain why we are not signalling it at the first place, so I went with improving at least bit by adding this information to the exception which users can observe.
