### PR TITLE
Pulsar - Configure TLS hostname verification setting in Pulsar extension

### DIFF
--- a/extensions/smallrye-reactive-messaging-pulsar/runtime/src/main/java/io/quarkus/pulsar/PulsarClientConfigCustomizer.java
+++ b/extensions/smallrye-reactive-messaging-pulsar/runtime/src/main/java/io/quarkus/pulsar/PulsarClientConfigCustomizer.java
@@ -42,7 +42,10 @@ public class PulsarClientConfigCustomizer implements ClientCustomizer<ClientBuil
                 ClientSSLOptions sslOptions = configuration.getClientSSLOptions();
                 builder.tlsCiphers(sslOptions.getEnabledCipherSuites());
                 builder.tlsProtocols(sslOptions.getEnabledSecureTransportProtocols());
-                builder.allowTlsInsecureConnection(false);
+                builder.allowTlsInsecureConnection(configuration.isTrustAll());
+
+                String algorithm = configuration.getHostnameVerificationAlgorithm().orElse("HTTPS");
+                builder.enableTlsHostnameVerification(!"NONE".equalsIgnoreCase(algorithm));
 
                 KeyCertOptions keyStoreOptions = configuration.getKeyStoreOptions();
                 TrustOptions trustStoreOptions = configuration.getTrustStoreOptions();


### PR DESCRIPTION
The Pulsar client customizer configured ciphers, protocols, and disabled insecure connections but never called enableTlsHostnameVerification() on the ClientBuilder. Since Pulsar 4.x defaults this to false, hostname verification was silently skipped even when explicitly requested via the TLS registry's hostname-verification-algorithm.
