### PR TITLE
Opt-out Kotlin classes from generation of reflection-free Jackson serializers

### DIFF
--- a/docs/src/main/asciidoc/rest.adoc
+++ b/docs/src/main/asciidoc/rest.adoc
@@ -1757,6 +1757,11 @@ When enabled, {project-name} generates `StdSerializer` and `StdDeserializer` imp
 
 Developers can further customize JSON processing by implementing the `ObjectMapperCustomizer` interface. This interface allows fine-grained control over the `ObjectMapper`, enabling the registration of custom serializers and deserializers while ensuring compatibility with the reflection-free optimization. If additional configuration is needed, implement an `ObjectMapperCustomizer` bean and register any necessary modules or settings.
 
+[NOTE]
+====
+Reflection-free serializers are not compatible with Kotlin classes, since they break Kotlin-specific features such as default parameter values and non-null type enforcement. As a result, reflection-free serializers are not generated for Kotlin classes.
+====
+
 ===== Completely customized per method serialization/deserialization
 
 There are times when you need to completely customize the serialization/deserialization of a POJO on a per Jakarta REST method basis or on a per Jakarta REST resource basis. For such use cases, you can use the `@io.quarkus.resteasy.reactive.jackson.CustomSerialization` and `@io.quarkus.resteasy.reactive.jackson.CustomDeserialization` annotations in the REST method or in the REST resource at class level. These annotations allow you to fully configure the `com.fasterxml.jackson.databind.ObjectWriter`/`com.fasterxml.jackson.databind.ObjectReader`.

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
@@ -127,7 +127,11 @@ public abstract class JacksonCodeGenerator {
 
     public Collection<String> create(Collection<ClassInfo> classInfos) {
         Set<String> createdClasses = new HashSet<>();
-        toBeGenerated.addAll(classInfos);
+        for (ClassInfo classInfo : classInfos) {
+            if (shouldGenerateCodeFor(classInfo)) {
+                toBeGenerated.add(classInfo);
+            }
+        }
 
         while (!toBeGenerated.isEmpty()) {
             create(toBeGenerated.removeFirst()).ifPresent(createdClasses::add);
@@ -339,7 +343,7 @@ public abstract class JacksonCodeGenerator {
     }
 
     protected boolean shouldGenerateCodeFor(ClassInfo classInfo) {
-        return !classInfo.isEnum();
+        return !classInfo.isEnum() && !classInfo.hasDeclaredAnnotation(KOTLIN_METADATA);
     }
 
     protected static String anyGetterBackingFieldName(MethodInfo anyGetterMethod) {
@@ -354,8 +358,7 @@ public abstract class JacksonCodeGenerator {
         MethodInfo namedAccessor = findMethod(classInfo, fieldInfo.name());
         if (namedAccessor != null
                 && (classInfo.isRecord() || namedAccessor.hasAnnotation(JsonProperty.class)
-                        || fieldInfo.hasAnnotation(JsonProperty.class)
-                        || classInfo.hasDeclaredAnnotation(KOTLIN_METADATA))) {
+                        || fieldInfo.hasAnnotation(JsonProperty.class))) {
             return namedAccessor;
         }
         String methodName = (fieldInfo.type().name().toString().equals("boolean") ? "is" : "get") + ucFirst(fieldInfo.name());

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/KotlinBooleanIsPrefixReflectionFreeTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/KotlinBooleanIsPrefixReflectionFreeTest.java
@@ -1,8 +1,6 @@
 package io.quarkus.resteasy.reactive.jackson.deployment.test;
 
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 
 import java.util.function.Supplier;
 
@@ -15,6 +13,10 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 
+/**
+ * Verifies that Kotlin classes are NOT processed by the reflection-free serializer
+ * and instead fall back to standard Jackson serialization.
+ */
 public class KotlinBooleanIsPrefixReflectionFreeTest {
 
     @RegisterExtension
@@ -33,23 +35,14 @@ public class KotlinBooleanIsPrefixReflectionFreeTest {
             });
 
     @Test
-    public void testSerializationUsesKotlinPropertyName() {
+    public void testKotlinClassUsesStandardJackson() {
+        // Standard Jackson (without KotlinModule) strips the "is" prefix from boolean getters,
+        // so isEligible() becomes "eligible". This proves the reflection-free serializer
+        // (which would preserve "isEligible" from the field name) is NOT used for Kotlin classes.
         RestAssured.get("/kotlin-boolean-is-prefix")
                 .then()
                 .statusCode(200)
-                .body("isEligible", is(true))
-                .body(not(containsString("\"eligible\"")));
+                .body("eligible", is(true));
     }
 
-    @Test
-    public void testRoundTrip() {
-        RestAssured
-                .with()
-                .body("{\"isEligible\": true}")
-                .contentType("application/json")
-                .post("/kotlin-boolean-is-prefix")
-                .then()
-                .statusCode(200)
-                .body("isEligible", is(true));
-    }
 }

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/KotlinDefaultParamsReflectionFreeTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/KotlinDefaultParamsReflectionFreeTest.java
@@ -1,0 +1,79 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+
+import java.util.function.Supplier;
+
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.kotlin.KotlinModule;
+
+import io.quarkus.jackson.ObjectMapperCustomizer;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+
+/**
+ * Verifies that Kotlin classes with default parameter values and non-null types are
+ * handled correctly when reflection-free serializers are enabled. Kotlin classes are
+ * excluded from reflection-free generation and fall back to standard Jackson with
+ * KotlinModule, which properly supports default values and non-null validation.
+ */
+public class KotlinDefaultParamsReflectionFreeTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(KotlinDefaultParamsDto.class,
+                                    KotlinDefaultParamsResource.class,
+                                    KotlinModuleCustomizer.class)
+                            .addAsResource(
+                                    new StringAsset(
+                                            "quarkus.rest.jackson.optimization.enable-reflection-free-serializers=true\n"),
+                                    "application.properties");
+                }
+            });
+
+    @Test
+    public void testSerializationWithDefaults() {
+        RestAssured.get("/kotlin-default-params")
+                .then()
+                .statusCode(200)
+                .body("name", is("Alice"))
+                .body("greeting", is("Hello"))
+                .body("tags", empty());
+    }
+
+    @Test
+    public void testDeserializationAppliesDefaults() {
+        // Only sending "name" — "greeting" and "tags" should use Kotlin default values
+        RestAssured
+                .with()
+                .body("{\"name\": \"Bob\"}")
+                .contentType("application/json")
+                .post("/kotlin-default-params")
+                .then()
+                .statusCode(200)
+                .body("name", is("Bob"))
+                .body("greeting", is("Hello"))
+                .body("tags", empty());
+    }
+
+    @Singleton
+    public static class KotlinModuleCustomizer implements ObjectMapperCustomizer {
+        @Override
+        public void customize(ObjectMapper mapper) {
+            mapper.registerModule(new KotlinModule.Builder().build());
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/KotlinDefaultParamsResource.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/KotlinDefaultParamsResource.java
@@ -1,0 +1,27 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import java.util.List;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/kotlin-default-params")
+public class KotlinDefaultParamsResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public KotlinDefaultParamsDto get() {
+        return new KotlinDefaultParamsDto("Alice", "Hello", List.of());
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public KotlinDefaultParamsDto echo(KotlinDefaultParamsDto dto) {
+        return dto;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/kotlin/io/quarkus/resteasy/reactive/jackson/deployment/test/KotlinDefaultParamsDto.kt
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/kotlin/io/quarkus/resteasy/reactive/jackson/deployment/test/KotlinDefaultParamsDto.kt
@@ -1,0 +1,7 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test
+
+data class KotlinDefaultParamsDto(
+    val name: String,
+    val greeting: String = "Hello",
+    val tags: List<String> = emptyList()
+)


### PR DESCRIPTION
- Fixes: #55302 