### PR TITLE
Limit HTTP/2 concurrent streams by default to prevent gRPC OOM

### DIFF
--- a/docs/src/main/asciidoc/grpc-reference.adoc
+++ b/docs/src/main/asciidoc/grpc-reference.adoc
@@ -66,7 +66,12 @@ When working with large gRPC messages, you may need to tune the HTTP/2 flow cont
 
 === Unified server mode (Vert.x-based)
 
-When using the unified server mode (`quarkus.grpc.server.use-separate-server=false`), you can configure the HTTP/2 connection window size:
+When using the unified server mode (`quarkus.grpc.server.use-separate-server=false`), gRPC traffic is served over the main HTTP server using HTTP/2.
+By default, Quarkus limits the number of concurrent HTTP/2 streams to `200` via `quarkus.http.limits.max-concurrent-streams`.
+This provides backpressure under high load and prevents `OutOfMemoryError` when many requests arrive in a short period of time.
+If clients observe `REFUSED_STREAM` errors under load, increase this value.
+
+You can also configure the HTTP/2 connection window size:
 
 [source,properties,subs=attributes+]
 ----

--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -378,6 +378,7 @@ quarkus.http.http2=false
 
 Note that some configuration attributes are specific to HTTP/2.
 For example, to configure the max header list size (~ header), you need to configure the `quarkus.http.limits.max-header-list-size` attribute.
+The maximum number of concurrent HTTP/2 streams defaults to `200` and can be configured using `quarkus.http.limits.max-concurrent-streams`.
 You can also enable or disable HTTP/2 push using `quarkus.http.http2-push-enabled`.
 
 == HTTP/3 Support

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ServerLimitsConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ServerLimitsConfig.java
@@ -80,9 +80,13 @@ public interface ServerLimitsConfig {
      * Set SETTINGS_MAX_CONCURRENT_STREAMS HTTP/2 setting.
      * <p>
      * Indicates the maximum number of concurrent streams that the sender will allow. This limit is directional: it
-     * applies to the number of streams that the sender permits the receiver to create. Initially, there is no limit to
-     * this value. It is recommended that this value be no smaller than 100, to not unnecessarily limit parallelism.
+     * applies to the number of streams that the sender permits the receiver to create. It is recommended that this
+     * value be no smaller than 100, to not unnecessarily limit parallelism.
+     * <p>
+     * Limiting concurrent streams provides backpressure under high load and prevents {@code OutOfMemoryError} when
+     * using gRPC over HTTP/2. Increase this value if clients observe {@code REFUSED_STREAM} errors under load.
      */
+    @WithDefault("200")
     OptionalLong maxConcurrentStreams();
 
     /**

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtils.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtils.java
@@ -362,9 +362,7 @@ public class HttpServerOptionsUtils {
                 settings.setHeaderTableSize(httpConfig.limits().headerTableSize().getAsLong());
             }
             settings.setPushEnabled(httpConfig.http2PushEnabled());
-            if (httpConfig.limits().maxConcurrentStreams().isPresent()) {
-                settings.setMaxConcurrentStreams(httpConfig.limits().maxConcurrentStreams().getAsLong());
-            }
+            settings.setMaxConcurrentStreams(httpConfig.limits().maxConcurrentStreams().orElse(200L));
             if (httpConfig.initialWindowSize().isPresent()) {
                 settings.setInitialWindowSize(httpConfig.initialWindowSize().getAsInt());
             }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtils.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtils.java
@@ -362,7 +362,9 @@ public class HttpServerOptionsUtils {
                 settings.setHeaderTableSize(httpConfig.limits().headerTableSize().getAsLong());
             }
             settings.setPushEnabled(httpConfig.http2PushEnabled());
-            settings.setMaxConcurrentStreams(httpConfig.limits().maxConcurrentStreams().orElse(200L));
+            if (httpConfig.limits().maxConcurrentStreams().isPresent()) {
+                settings.setMaxConcurrentStreams(httpConfig.limits().maxConcurrentStreams().getAsLong());
+            }
             if (httpConfig.initialWindowSize().isPresent()) {
                 settings.setInitialWindowSize(httpConfig.initialWindowSize().getAsInt());
             }

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtilsTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtilsTest.java
@@ -304,7 +304,7 @@ class HttpServerOptionsUtilsTest {
         when(limits.maxFormBufferedBytes()).thenReturn(MemorySize.of("1k"));
         when(limits.maxInitialLineLength()).thenReturn(4096);
         when(limits.headerTableSize()).thenReturn(OptionalLong.empty());
-        when(limits.maxConcurrentStreams()).thenReturn(OptionalLong.empty());
+        when(limits.maxConcurrentStreams()).thenReturn(OptionalLong.of(200L));
         when(limits.maxFrameSize()).thenReturn(OptionalInt.empty());
         when(limits.maxHeaderListSize()).thenReturn(OptionalLong.empty());
         when(limits.rstFloodMaxRstFramePerWindow()).thenReturn(OptionalInt.empty());

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtilsTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtilsTest.java
@@ -67,6 +67,20 @@ class HttpServerOptionsUtilsTest {
         assertThat(config.getHttp2Config()).isNotNull();
         assertThat(config.getHttp2Config().getInitialSettings()).isNotNull();
         assertThat(config.getHttp2Config().getInitialSettings().isPushEnabled()).isTrue();
+        assertThat(config.getHttp2Config().getInitialSettings().getMaxConcurrentStreams()).isEqualTo(200L);
+    }
+
+    @Test
+    void applyCommonOptionsNewApiHttp2MaxConcurrentStreamsConfigured() {
+        HttpServerConfig config = new HttpServerConfig();
+        VertxHttpBuildTimeConfig buildTimeConfig = buildTimeConfig(false, Optional.empty(), OptionalInt.empty());
+        VertxHttpConfig httpConfig = minimalHttpConfig(true);
+        ServerLimitsConfig limits = httpConfig.limits();
+        when(limits.maxConcurrentStreams()).thenReturn(OptionalLong.of(500L));
+
+        HttpServerOptionsUtils.applyCommonOptions(config, buildTimeConfig, httpConfig, Collections.emptyList());
+
+        assertThat(config.getHttp2Config().getInitialSettings().getMaxConcurrentStreams()).isEqualTo(500L);
     }
 
     @Test


### PR DESCRIPTION
Quarkus gRPC is served over the main HTTP server with HTTP/2 enabled. When `quarkus.http.limits.max-concurrent-streams` is unset, the server accepts an unlimited number of concurrent HTTP/2 streams. Under burst load, each stream retains memory (Netty buffers, headers, gRPC interceptors, CDI contexts), which can lead to `OutOfMemoryError` 

This change defaults `quarkus.http.limits.max-concurrent-streams` to `200`, providing HTTP/2 backpressure instead of unbounded memory growth. Users who need higher parallelism can increase the value; clients that exceed the limit receive `REFUSED_STREAM` rather than crashing the server.

Release note: HTTP/2 servers now default to a maximum of 200 concurrent streams (`quarkus.http.limits.max-concurrent-streams`). Increase this value if clients observe `REFUSED_STREAM` errors under load.

Fixes #46618