### PR TITLE
Move bcpkix-jdk18on to kubernetes-client to enable flawless native compilations

### DIFF
--- a/extensions/kubernetes-client/runtime/pom.xml
+++ b/extensions/kubernetes-client/runtime/pom.xml
@@ -49,6 +49,10 @@
             <artifactId>kubernetes-httpclient-vertx</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.graalvm.sdk</groupId>
             <artifactId>nativeimage</artifactId>
             <scope>provided</scope>

--- a/integration-tests/kubernetes-client/pom.xml
+++ b/integration-tests/kubernetes-client/pom.xml
@@ -41,10 +41,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk18on</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
- Fixes: https://github.com/quarkusio/quarkus/issues/55288