### PR TITLE
Fix serialization of java.time fields with custom format in generated reflection-free Jackson serializers

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
@@ -485,7 +485,9 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
             } else if (fieldSpecs.isFormatShapeNumber() && isEnumType(typeName)) {
                 writeFormattedValue(fieldSpecs, bytecode, ctx, pkgName, arg);
             } else if (fieldSpecs.formatPattern() != null && isJavaUtilDateType(typeName)) {
-                writeFormattedDateValue(fieldSpecs, bytecode, ctx, pkgName, arg);
+                writeFormattedDateValue(fieldSpecs, bytecode, ctx, pkgName, arg, false);
+            } else if (fieldSpecs.formatPattern() != null && isJavaTimeDateType(typeName)) {
+                writeFormattedDateValue(fieldSpecs, bytecode, ctx, pkgName, arg, true);
             } else {
                 writeFieldValue(fieldSpecs, bytecode, ctx, typeName, arg, pkgName);
             }
@@ -522,11 +524,12 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
     }
 
     private static void writeFormattedDateValue(FieldSpecs fieldSpecs, BytecodeCreator bytecode, SerializationContext ctx,
-            String pkgName, ResultHandle arg) {
+            String pkgName, ResultHandle arg, boolean temporal) {
         writeFieldName(fieldSpecs, bytecode, ctx, pkgName);
         String timezone = fieldSpecs.formatTimezone();
+        String methodName = temporal ? "serializeFormattedTemporal" : "serializeFormattedDate";
         MethodDescriptor serializeFormatted = MethodDescriptor.ofMethod(JacksonMapperUtil.class.getName(),
-                "serializeFormattedDate", void.class, Object.class, String.class, String.class, JsonGenerator.class);
+                methodName, void.class, Object.class, String.class, String.class, JsonGenerator.class);
         bytecode.invokeStaticMethod(serializeFormatted, arg,
                 bytecode.load(fieldSpecs.formatPattern()),
                 timezone != null ? bytecode.load(timezone) : bytecode.loadNull(),
@@ -639,6 +642,10 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
         return "java.util.Date".equals(typeName)
                 || "java.sql.Date".equals(typeName)
                 || "java.sql.Timestamp".equals(typeName);
+    }
+
+    private static boolean isJavaTimeDateType(String typeName) {
+        return typeName.startsWith("java.time.");
     }
 
     private String writeMethodForPrimitiveFields(String typeName) {

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/AbstractGeneratedAnnotationTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/AbstractGeneratedAnnotationTest.java
@@ -603,6 +603,18 @@ public abstract class AbstractGeneratedAnnotationTest {
                 .body("date", Matchers.is("2025-06-15"));
     }
 
+    // --- @JsonFormat with ZonedDateTime ---
+
+    @Test
+    public void testFormatZonedDateTimePatternSerialization() {
+        RestAssured.get("/generated/zoned-date-format")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("name", Matchers.is("zoned-date-test"))
+                .body("dateTime", Matchers.is("2024-03-13T10:05:01.000Z"));
+    }
+
     // --- @JsonFormat ---
 
     @Test

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationResource.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationResource.java
@@ -2,6 +2,7 @@ package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
 
 import java.time.LocalDate;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.List;
 
@@ -323,6 +324,17 @@ public class GeneratedAnnotationResource {
         DateFormatBean bean = new DateFormatBean();
         bean.setName("date-test");
         bean.setDate(Date.from(LocalDate.of(2025, 6, 15).atStartOfDay().toInstant(ZoneOffset.UTC)));
+        return bean;
+    }
+
+    // --- ZonedDateTimeFormatBean: @JsonFormat with ZonedDateTime ---
+
+    @GET
+    @Path("/zoned-date-format")
+    public ZonedDateTimeFormatBean getZonedDateFormat() {
+        ZonedDateTimeFormatBean bean = new ZonedDateTimeFormatBean();
+        bean.setName("zoned-date-test");
+        bean.setDateTime(ZonedDateTime.of(2024, 3, 13, 10, 5, 1, 0, ZoneOffset.UTC));
         return bean;
     }
 

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationTest.java
@@ -41,6 +41,7 @@ public class GeneratedAnnotationTest extends AbstractGeneratedAnnotationTest {
                                     ManagedReferenceParent.class,
                                     ManagedReferenceChild.class,
                                     DateFormatBean.class,
+                                    ZonedDateTimeFormatBean.class,
                                     FormatShape.class,
                                     FormatBean.class,
                                     GetterSetterBean.class,

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationWithReflectionFreeSerializersTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationWithReflectionFreeSerializersTest.java
@@ -44,6 +44,7 @@ public class GeneratedAnnotationWithReflectionFreeSerializersTest extends Abstra
                                     ManagedReferenceParent.class,
                                     ManagedReferenceChild.class,
                                     DateFormatBean.class,
+                                    ZonedDateTimeFormatBean.class,
                                     FormatShape.class,
                                     FormatBean.class,
                                     GetterSetterBean.class,

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/ZonedDateTimeFormatBean.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/ZonedDateTimeFormatBean.java
@@ -1,0 +1,29 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import java.time.ZonedDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+public class ZonedDateTimeFormatBean {
+
+    private String name;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "UTC")
+    private ZonedDateTime dateTime;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public ZonedDateTime getDateTime() {
+        return dateTime;
+    }
+
+    public void setDateTime(ZonedDateTime dateTime) {
+        this.dateTime = dateTime;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/mappers/JacksonMapperUtil.java
+++ b/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/mappers/JacksonMapperUtil.java
@@ -5,6 +5,9 @@ import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.text.SimpleDateFormat;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -71,6 +74,19 @@ public class JacksonMapperUtil {
             sdf.setTimeZone(TimeZone.getTimeZone(timezone));
         }
         generator.writeString(sdf.format(value));
+    }
+
+    public static void serializeFormattedTemporal(Object value, String pattern, String timezone,
+            JsonGenerator generator) throws IOException {
+        if (value == null) {
+            generator.writeNull();
+            return;
+        }
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(pattern);
+        if (timezone != null) {
+            formatter = formatter.withZone(ZoneId.of(timezone));
+        }
+        generator.writeString(formatter.format((TemporalAccessor) value));
     }
 
     public static boolean isViewIncluded(Class<?> activeView, Class<?>[] viewClasses) {


### PR DESCRIPTION
- Fixes: #55318