### PR TITLE
Disable automatic workflow approval after 10 PRs

### DIFF
--- a/.github/quarkus-github-bot.yml
+++ b/.github/quarkus-github-bot.yml
@@ -11,8 +11,6 @@ develocity:
 workflows:
   rules:
     - allow:
-        users:
-          minContributions: 10
         files:
           - "**/*.md"
           - "**/*.adoc"


### PR DESCRIPTION
With AI around, it's easy to get there and we need to be more cautious about this.

I think it's a lot better to make people part of the team when we think they are committed enough.