### PR TITLE
Change OpenTelemetry default sampling ration to 10%

### DIFF
--- a/docs/src/main/asciidoc/opentelemetry-tracing.adoc
+++ b/docs/src/main/asciidoc/opentelemetry-tracing.adoc
@@ -375,6 +375,13 @@ quarkus.otel.traces.sampler=traceidratio
 # Runtime property:
 quarkus.otel.traces.sampler.arg=0.5
 ----
+
+[NOTE]
+====
+As of Quarkus 4, the default sampling ratio changed from 100% (1.0d) to 10% (0.1d) to reduce overhead in production environments.
+In development mode, sampling defaults to 100% (1.0d) to ensure all traces are captured for debugging.
+====
+
 [TIP]
 ====
 
@@ -383,7 +390,7 @@ An interesting use case for the sampler is to activate and deactivate tracing ex
 ----
 # build time property only:
 quarkus.otel.traces.sampler=traceidratio
-# On (default). All traces are exported:
+# On. All traces are exported:
 quarkus.otel.traces.sampler.arg=1.0
 # Off. No traces are exported:
 quarkus.otel.traces.sampler.arg=0.0

--- a/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/tracing/TracerProcessor.java
+++ b/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/tracing/TracerProcessor.java
@@ -43,17 +43,22 @@ import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
 import io.quarkus.gizmo2.Expr;
 import io.quarkus.gizmo2.Var;
 import io.quarkus.gizmo2.creator.BlockCreator;
 import io.quarkus.gizmo2.desc.MethodDesc;
 import io.quarkus.opentelemetry.runtime.config.build.OTelBuildConfig;
 import io.quarkus.opentelemetry.runtime.config.build.OTelBuildConfig.SecurityEvents.SecurityEventType;
+import io.quarkus.opentelemetry.runtime.config.build.SamplerType;
+import io.quarkus.opentelemetry.runtime.config.build.TracesBuildConfig;
 import io.quarkus.opentelemetry.runtime.tracing.TracerRecorder;
 import io.quarkus.opentelemetry.runtime.tracing.cdi.TracerProducer;
 import io.quarkus.opentelemetry.runtime.tracing.instrumentation.websockets.WebSocketTracesInterceptorImpl;
 import io.quarkus.opentelemetry.runtime.tracing.security.EndUserSpanProcessor;
 import io.quarkus.opentelemetry.runtime.tracing.security.SecurityEventUtil;
+import io.quarkus.runtime.LaunchMode;
 import io.quarkus.vertx.http.deployment.spi.FrameworkEndpointsBuildItem;
 import io.quarkus.vertx.http.deployment.spi.StaticResourcesBuildItem;
 
@@ -127,6 +132,33 @@ public class TracerProcessor {
         }
 
         return new UnremovableBeanBuildItem(new UnremovableBeanBuildItem.BeanClassNamesExclusion(retainProducers));
+    }
+
+    /**
+     * Checks the {@link LaunchModeBuildItem} to see if we are in {@linkplain LaunchMode#DEVELOPMENT development mode}.
+     * <p>
+     * Checks the {@link TracesBuildConfig#sampler()} for a value of {@code parentbased_traceidratio} or
+     * {@code traceidration}. If set to one of those values, the {@code quarkus.otel.traces.sampler.arg} is defaulted
+     * to 100% (1.0d) in dev mode.
+     * </p>
+     *
+     * @param launchMode the current launch mode
+     * @param buildConfig the build configuration used to determine if the sampler arg needs to be overridden in dev mode
+     *
+     * @return a new build item setting the sampler argument to 100% if we are in dev mode, otherwise returns {@code null}
+     */
+    @BuildStep
+    RunTimeConfigurationDefaultBuildItem setDevModeSamplerDefault(LaunchModeBuildItem launchMode, OTelBuildConfig buildConfig) {
+        // In dev mode, use 100% sampling for better debugging experience
+        if (launchMode.getLaunchMode() == LaunchMode.DEVELOPMENT) {
+            final String sampler = buildConfig.traces().sampler();
+            if (SamplerType.PARENT_BASED_TRACE_ID_RATIO.getValue().equals(sampler)
+                    || SamplerType.TRACE_ID_RATIO.getValue().equals(sampler)) {
+                return new RunTimeConfigurationDefaultBuildItem("quarkus.otel.traces.sampler.arg", "1.0d");
+            }
+        }
+        // Let the default configuration apply
+        return null;
     }
 
     @BuildStep

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryServiceNameAppNameTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryServiceNameAppNameTest.java
@@ -18,5 +18,6 @@ public class OpenTelemetryServiceNameAppNameTest extends OpenTelemetryServiceNam
                     .addClass(TestSpanExporterProvider.class)
                     .addAsResource(new StringAsset("" +
                             "quarkus.otel.bsp.schedule.delay=50\n" +
+                            "quarkus.otel.traces.sampler.arg=1.0d\n" +
                             "quarkus.application.name=" + SERVICE_NAME + "\n"), "application.properties"));
 }

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryServiceNameCombinedResourceWinsTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryServiceNameCombinedResourceWinsTest.java
@@ -18,5 +18,6 @@ public class OpenTelemetryServiceNameCombinedResourceWinsTest extends OpenTeleme
             .overrideConfigKey("quarkus.application.name", "application-name-must-fail")
             .overrideRuntimeConfigKey("quarkus.otel.bsp.schedule.delay", "50")// speed up test
             .overrideRuntimeConfigKey("quarkus.otel.service.name", SERVICE_NAME)
-            .overrideRuntimeConfigKey("quarkus.otel.resource.attributes", "service.name=" + "attributes-must-fail");
+            .overrideRuntimeConfigKey("quarkus.otel.resource.attributes", "service.name=" + "attributes-must-fail")
+            .overrideRuntimeConfigKey("quarkus.otel.traces.sampler.arg", "1.0d");
 }

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryServiceNameCombinedServiceWinsTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryServiceNameCombinedServiceWinsTest.java
@@ -17,5 +17,6 @@ public class OpenTelemetryServiceNameCombinedServiceWinsTest extends OpenTelemet
                     .addClass(TestSpanExporterProvider.class))
             .overrideConfigKey("quarkus.application.name", "application-name-must-fail")
             .overrideRuntimeConfigKey("quarkus.otel.bsp.schedule.delay", "50")// speed up test
-            .overrideRuntimeConfigKey("quarkus.otel.resource.attributes", "service.name=" + SERVICE_NAME);
+            .overrideRuntimeConfigKey("quarkus.otel.resource.attributes", "service.name=" + SERVICE_NAME)
+            .overrideRuntimeConfigKey("quarkus.otel.traces.sampler.arg", "1.0d");
 }

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryServiceNameNoResourceAttrsTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryServiceNameNoResourceAttrsTest.java
@@ -16,5 +16,6 @@ public class OpenTelemetryServiceNameNoResourceAttrsTest extends OpenTelemetrySe
                     .addClass(TestSpanExporter.class)
                     .addClass(TestSpanExporterProvider.class))
             .overrideConfigKey("quarkus.otel.service.name", SERVICE_NAME)
-            .overrideRuntimeConfigKey("quarkus.otel.bsp.schedule.delay", "50");// speed up test
+            .overrideRuntimeConfigKey("quarkus.otel.bsp.schedule.delay", "50")// speed up test
+            .overrideRuntimeConfigKey("quarkus.otel.traces.sampler.arg", "1.0d");
 }

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryServiceNameResourceAttrTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryServiceNameResourceAttrTest.java
@@ -16,5 +16,6 @@ public class OpenTelemetryServiceNameResourceAttrTest extends OpenTelemetryServi
                     .addClass(TestSpanExporter.class)
                     .addClass(TestSpanExporterProvider.class))
             .overrideRuntimeConfigKey("quarkus.otel.bsp.schedule.delay", "50")// speed up test
-            .overrideRuntimeConfigKey("quarkus.otel.resource.attributes", "service.name=" + SERVICE_NAME);
+            .overrideRuntimeConfigKey("quarkus.otel.resource.attributes", "service.name=" + SERVICE_NAME)
+            .overrideRuntimeConfigKey("quarkus.otel.traces.sampler.arg", "1.0d");
 }

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/GraphQLOpenTelemetryTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/GraphQLOpenTelemetryTest.java
@@ -65,6 +65,7 @@ public class GraphQLOpenTelemetryTest {
                             smallrye.graphql.events.enabled=true
                             quarkus.otel.metrics.exporter=none
                             quarkus.otel.traces.exporter=test-span-exporter
+                            quarkus.otel.traces.sampler.arg=1.0d
                             """),
                             "application.properties")
                     .addAsResource(new StringAsset(TestSpanExporterProvider.class.getCanonicalName()),

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/VertxEventBusInstrumentationDisabledTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/VertxEventBusInstrumentationDisabledTest.java
@@ -38,6 +38,7 @@ public class VertxEventBusInstrumentationDisabledTest {
                     .addAsResource(new StringAsset(TestSpanExporterProvider.class.getCanonicalName()),
                             "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider"))
             .overrideConfigKey("quarkus.otel.traces.exporter", "test-span-exporter")
+            .overrideConfigKey("quarkus.otel.traces.sampler.arg", "1.0d")
             .overrideConfigKey("quarkus.otel.metrics.exporter", "none")
             .overrideConfigKey("quarkus.otel.logs.exporter", "none")
             .overrideConfigKey("quarkus.otel.bsp.schedule.delay", "200")

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/VertxHttpInstrumentationDisabledTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/VertxHttpInstrumentationDisabledTest.java
@@ -38,6 +38,7 @@ public class VertxHttpInstrumentationDisabledTest {
                     .addAsResource(new StringAsset(TestSpanExporterProvider.class.getCanonicalName()),
                             "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider"))
             .overrideConfigKey("quarkus.otel.traces.exporter", "test-span-exporter")
+            .overrideConfigKey("quarkus.otel.traces.sampler.arg", "1.0d")
             .overrideConfigKey("quarkus.otel.metrics.exporter", "none")
             .overrideConfigKey("quarkus.otel.logs.exporter", "none")
             .overrideConfigKey("quarkus.otel.bsp.schedule.delay", "200")

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/VertxOpenTelemetryTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/VertxOpenTelemetryTest.java
@@ -62,6 +62,7 @@ public class VertxOpenTelemetryTest {
                     .addAsResource(new StringAsset(TestSpanExporterProvider.class.getCanonicalName()),
                             "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider"))
             .overrideConfigKey("quarkus.otel.traces.exporter", "test-span-exporter")
+            .overrideConfigKey("quarkus.otel.traces.sampler.arg", "1.0d")
             .overrideConfigKey("quarkus.otel.metrics.exporter", "none")
             .overrideConfigKey("quarkus.otel.logs.exporter", "none")
             .overrideConfigKey("quarkus.otel.bsp.schedule.delay", "200");

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLoggingTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/logs/OtelLoggingTest.java
@@ -55,6 +55,7 @@ public class OtelLoggingTest {
                             .add(new StringAsset(
                                     "quarkus.otel.logs.enabled=true\n" +
                                             "quarkus.otel.traces.enabled=true\n" +
+                                            "quarkus.otel.traces.sampler.arg=1.0d\n" +
                                             "quarkus.log.category.\"io.quarkus.opentelemetry\".level=INFO\n"),
                                     "application.properties"));
 

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/JvmMetricsTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/metrics/JvmMetricsTest.java
@@ -42,6 +42,7 @@ public class JvmMetricsTest extends BaseJvmMetricsTest {
                             .add(new StringAsset(
                                     "quarkus.otel.metrics.enabled=true\n" +
                                             "quarkus.otel.traces.exporter=none\n" +
+                                            "quarkus.otel.traces.sampler.arg=1.0d\n" +
                                             "quarkus.otel.logs.exporter=none\n" +
                                             "quarkus.otel.metrics.exporter=in-memory\n" +
                                             "quarkus.otel.metric.export.interval=300ms\n"),

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/MutinyTracingHelperTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/MutinyTracingHelperTest.java
@@ -45,7 +45,8 @@ class MutinyTracingHelperTest {
                             .addAsResource(new StringAsset(TestSpanExporterProvider.class.getCanonicalName()),
                                     "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider")
                             .addAsResource(new StringAsset(
-                                    "quarkus.otel.bsp.schedule.delay=50ms\n"),
+                                    "quarkus.otel.bsp.schedule.delay=50ms\n"
+                                            + "quarkus.otel.traces.sampler.arg=1.0d\n"),
                                     "application.properties"));
 
     @Inject

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetrySpanSecurityEventsTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/OpenTelemetrySpanSecurityEventsTest.java
@@ -41,6 +41,7 @@ public class OpenTelemetrySpanSecurityEventsTest {
                             quarkus.otel.security-events.enabled=true
                             quarkus.otel.metrics.exporter=none
                             quarkus.otel.security-events.event-types=AUTHENTICATION_SUCCESS,AUTHORIZATION_SUCCESS,OTHER
+                            quarkus.otel.traces.sampler.arg=1.0d
                             """), "application.properties"));
 
     @Inject

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/SimpleSpanProcessorTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/traces/SimpleSpanProcessorTest.java
@@ -45,6 +45,7 @@ public class SimpleSpanProcessorTest {
                             "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider"))
             .overrideConfigKey("quarkus.otel.simple", "true")
             .overrideConfigKey("quarkus.otel.traces.exporter", "test-span-exporter")
+            .overrideConfigKey("quarkus.otel.traces.sampler.arg", "1.0d")
             .overrideConfigKey("quarkus.otel.metrics.exporter", "none")
             .overrideConfigKey("quarkus.otel.logs.exporter", "none");
 

--- a/extensions/opentelemetry/deployment/src/test/resources/application-default.properties
+++ b/extensions/opentelemetry/deployment/src/test/resources/application-default.properties
@@ -1,5 +1,7 @@
 # Traces
 quarkus.otel.traces.exporter=test-span-exporter
+# Sampler should be at 100% for testing purposes
+quarkus.otel.traces.sampler.arg=1.0d
 quarkus.otel.bsp.schedule.delay=50ms
 quarkus.otel.bsp.export.timeout=1s
 

--- a/extensions/opentelemetry/deployment/src/test/resources/resource-config/application-no-metrics.properties
+++ b/extensions/opentelemetry/deployment/src/test/resources/resource-config/application-no-metrics.properties
@@ -2,6 +2,8 @@ quarkus.application.name=resource-test
 quarkus.otel.resource.attributes=service.name=authservice,service.instance.id=${quarkus.uuid}
 
 quarkus.otel.traces.exporter=test-span-exporter
+# Sampler should be at 100% for testing purposes
+quarkus.otel.traces.sampler.arg=1.0d
 quarkus.otel.bsp.schedule.delay=50ms
 quarkus.otel.metrics.exporter=none
 

--- a/extensions/opentelemetry/deployment/src/test/resources/resource-config/application.properties
+++ b/extensions/opentelemetry/deployment/src/test/resources/resource-config/application.properties
@@ -2,6 +2,8 @@ quarkus.application.name=resource-test
 quarkus.otel.resource.attributes=service.name=authservice,service.instance.id=${quarkus.uuid}
 
 quarkus.otel.traces.exporter=test-span-exporter
+# Sampler should be at 100% for testing purposes
+quarkus.otel.traces.sampler.arg=1.0d
 quarkus.otel.bsp.schedule.delay=50ms
 quarkus.otel.metrics.enabled=true
 quarkus.otel.metrics.exporter=in-memory

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/build/TracesBuildConfig.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/build/TracesBuildConfig.java
@@ -48,9 +48,9 @@ public interface TracesBuildConfig {
      * {@link io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSamplerProvider}.
      * <p>
      * Fallbacks to the legacy property <code>quarkus.opentelemetry.tracer.sampler.sampler.name</code> or
-     * defaults to {@value SamplerType.Constants#PARENT_BASED_ALWAYS_ON}.
+     * defaults to {@value SamplerType.Constants#PARENT_BASED_TRACE_ID_RATIO}.
      */
-    @WithDefault(SamplerType.Constants.PARENT_BASED_ALWAYS_ON)
+    @WithDefault(SamplerType.Constants.PARENT_BASED_TRACE_ID_RATIO)
     String sampler();
 
     /**

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/TracesRuntimeConfig.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/TracesRuntimeConfig.java
@@ -61,6 +61,6 @@ public interface TracesRuntimeConfig {
      * Defaults to `1.0d`.
      */
     @WithName("sampler.arg")
-    @WithDefault("1.0d")
+    @WithDefault("0.1d")
     Optional<String> samplerArg();
 }

--- a/integration-tests/micrometer-prometheus/src/main/resources/application.properties
+++ b/integration-tests/micrometer-prometheus/src/main/resources/application.properties
@@ -20,6 +20,9 @@ quarkus.micrometer.binder.vertx.ignore-patterns=/fruit/create
 quarkus.micrometer.binder.http-server.match-patterns=/message/match/\\\\d+/[0-9]+=/message/match/{id}/{sub},\
 /message/match/.*=/message/match/{other}
 
+# Sampler should be at 100% for testing purposes
+quarkus.otel.traces.sampler.arg=1.0d
+
 quarkus.rest-client.pingpong.url=${test.url}
 quarkus.rest-client.read-timeout=1000
 

--- a/integration-tests/observability-lgtm-fixedports/src/main/resources/application.properties
+++ b/integration-tests/observability-lgtm-fixedports/src/main/resources/application.properties
@@ -3,6 +3,8 @@ quarkus.log.category."io.quarkus.devservices".level=DEBUG
 
 #opentelemetry
 quarkus.otel.metric.export.interval=1s
+# Sampler should be at 100% for testing purposes
+quarkus.otel.traces.sampler.arg=1.0d
 
 #quarkus.observability.lgtm.image-name=grafana/otel-lgtm
 #quarkus.observability.lgtm.logging=ALL

--- a/integration-tests/observability-lgtm/src/main/resources/application.properties
+++ b/integration-tests/observability-lgtm/src/main/resources/application.properties
@@ -3,6 +3,8 @@ quarkus.log.category."io.quarkus.devservices".level=DEBUG
 
 #opentelemetry
 quarkus.otel.metric.export.interval=1s
+# Sampler should be at 100% for testing purposes
+quarkus.otel.traces.sampler.arg=1.0d
 
 #quarkus.observability.lgtm.image-name=grafana/otel-lgtm
 #quarkus.observability.lgtm.logging=ALL

--- a/integration-tests/opentelemetry-grpc/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-grpc/src/main/resources/application.properties
@@ -3,3 +3,5 @@ quarkus.grpc.clients.hello.port=8081
 
 quarkus.otel.bsp.schedule.delay=100
 quarkus.otel.bsp.export.timeout=5s
+# Sampler should be at 100% for testing purposes
+quarkus.otel.traces.sampler.arg=1.0d

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/main/resources/application.properties
@@ -52,3 +52,6 @@ quarkus.datasource.h2.jdbc.telemetry=true
 # speed up build
 quarkus.otel.bsp.schedule.delay=100
 quarkus.otel.bsp.export.timeout=5s
+
+# Sampler should be at 100% for testing purposes
+quarkus.otel.traces.sampler.arg=1.0d

--- a/integration-tests/opentelemetry-mongodb-client-instrumentation/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-mongodb-client-instrumentation/src/main/resources/application.properties
@@ -10,6 +10,10 @@ quarkus.mongodb.connection-string=mongodb://localhost:27017
 # speed up build
 quarkus.otel.bsp.schedule.delay=100
 quarkus.otel.bsp.export.timeout=5s
+
+# Sampler should be at 100% for testing purposes
+quarkus.otel.traces.sampler.arg=1.0d
+
 quarkus.mongodb.tracing.enabled=true
 # FULL to preserve existing BookResourceTest behavior; sanitized/off profiles override
 quarkus.mongodb.tracing.command-detail-level=FULL

--- a/integration-tests/opentelemetry-quartz/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-quartz/src/main/resources/application.properties
@@ -3,3 +3,5 @@ quarkus.otel.bsp.schedule.delay=100
 quarkus.otel.bsp.export.timeout=5s
 
 quarkus.scheduler.tracing.enabled=true
+# Sampler should be at 100% for testing purposes
+quarkus.otel.traces.sampler.arg=1.0d

--- a/integration-tests/opentelemetry-quickstart/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-quickstart/src/main/resources/application.properties
@@ -1,3 +1,5 @@
 # speed up build
 quarkus.otel.bsp.schedule.delay=0
 quarkus.otel.bsp.export.timeout=5s
+# Sampler should be at 100% for testing purposes
+quarkus.otel.traces.sampler.arg=1.0d

--- a/integration-tests/opentelemetry-reactive-messaging/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-reactive-messaging/src/main/resources/application.properties
@@ -9,3 +9,6 @@ mp.messaging.incoming.traces-in2.auto.offset.reset=earliest
 
 quarkus.otel.bsp.schedule.delay=100
 quarkus.otel.bsp.export.timeout=5s
+
+# Sampler should be at 100% for testing purposes
+quarkus.otel.traces.sampler.arg=1.0d

--- a/integration-tests/opentelemetry-reactive/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-reactive/src/main/resources/application.properties
@@ -2,6 +2,8 @@ quarkus.rest-client.client.url=${test.url}
 
 quarkus.otel.bsp.schedule.delay=100
 quarkus.otel.bsp.export.timeout=5s
+# Sampler should be at 100% for testing purposes
+quarkus.otel.traces.sampler.arg=1.0d
 
 quarkus.security.users.embedded.enabled=true
 quarkus.security.users.embedded.plain-text=true

--- a/integration-tests/opentelemetry-redis-instrumentation/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-redis-instrumentation/src/main/resources/application.properties
@@ -8,3 +8,6 @@ quarkus.redis.devservices.port=16379
 # speed up build
 quarkus.otel.bsp.schedule.delay=100
 quarkus.otel.bsp.export.timeout=5s
+
+# Sampler should be at 100% for testing purposes
+quarkus.otel.traces.sampler.arg=1.0d

--- a/integration-tests/opentelemetry-scheduler/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-scheduler/src/main/resources/application.properties
@@ -3,3 +3,5 @@ quarkus.otel.bsp.schedule.delay=100
 quarkus.otel.bsp.export.timeout=5s
 
 quarkus.scheduler.tracing.enabled=true
+# Sampler should be at 100% for testing purposes
+quarkus.otel.traces.sampler.arg=1.0d

--- a/integration-tests/opentelemetry-vertx-exporter/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-vertx-exporter/src/main/resources/application.properties
@@ -2,3 +2,5 @@ quarkus.application.name=integration test
 quarkus.otel.metrics.enabled=true
 quarkus.otel.metric.export.interval=1000ms
 quarkus.otel.logs.enabled=true
+# Sampler should be at 100% for testing purposes
+quarkus.otel.traces.sampler.arg=1.0d

--- a/integration-tests/opentelemetry-vertx/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-vertx/src/main/resources/application.properties
@@ -3,3 +3,6 @@ quarkus.micrometer.binder-enabled-default=false
 
 quarkus.otel.bsp.schedule.delay=100
 quarkus.otel.bsp.export.timeout=5s
+
+# Sampler should be at 100% for testing purposes
+quarkus.otel.traces.sampler.arg=1.0d

--- a/integration-tests/opentelemetry/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry/src/main/resources/application.properties
@@ -22,3 +22,5 @@ quarkus.security.users.embedded.enabled=true
 quarkus.http.auth.basic=true
 
 quarkus.otel.traces.suppress-application-uris=/suppress-app-uri
+# Sampler should be at 100% for testing purposes
+quarkus.otel.traces.sampler.arg=1.0d

--- a/integration-tests/rest-client-reactive/src/main/resources/application.properties
+++ b/integration-tests/rest-client-reactive/src/main/resources/application.properties
@@ -12,3 +12,6 @@ quarkus.rest-client."remote-resource".url=${test.url}
 
 # speed up build
 quarkus.otel.bsp.schedule.delay=10
+
+# Sampler should be at 100% for testing purposes
+quarkus.otel.traces.sampler.arg=1.0d

--- a/tcks/microprofile-opentelemetry/src/test/java/io/quarkus/tck/opentelemetry/DeploymentProcessor.java
+++ b/tcks/microprofile-opentelemetry/src/test/java/io/quarkus/tck/opentelemetry/DeploymentProcessor.java
@@ -32,7 +32,8 @@ public class DeploymentProcessor implements ApplicationArchiveProcessor {
             }
 
             war.addAsResource(new StringAsset(
-                    "quarkus.otel.sdk.disabled=" + (otelSdkDisabled ? "true" : "false") + "\n"),
+                    "quarkus.otel.sdk.disabled=" + (otelSdkDisabled ? "true" : "false") + "\n"
+                            + "quarkus.otel.traces.sampler.arg=1.0d\n"),
                     "application.properties");
 
             war.addClass(ExecutorProvider.class);


### PR DESCRIPTION
Change the default sampling from 100% to 10% for performance in production environments. This does require changing most tests to use 100% sampling to ensure we see the traces we need for testing.

- Closes: #53075
