### PR TITLE
Pre-init Maven resolver HTTP transport classes to avoid class loading deadlock

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/core/Reflections.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/core/Reflections.java
@@ -15,8 +15,6 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
         org.apache.maven.repository.internal.DefaultVersionResolver.class,
         org.apache.maven.repository.internal.SnapshotMetadataGeneratorFactory.class,
         org.apache.maven.repository.internal.VersionsMetadataGeneratorFactory.class,
-        org.apache.maven.wagon.providers.http.HttpWagon.class,
-        org.apache.maven.wagon.shared.http.AbstractHttpClientWagon.class,
         org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory.class,
         org.eclipse.aether.internal.impl.DefaultArtifactResolver.class,
         org.eclipse.aether.internal.impl.DefaultChecksumPolicyProvider.class,
@@ -38,7 +36,6 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
         org.eclipse.aether.internal.impl.Maven2RepositoryLayoutFactory.class,
         org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory.class,
         org.eclipse.aether.internal.impl.collect.DefaultDependencyCollector.class,
-        org.eclipse.aether.transport.wagon.WagonTransporterFactory.class
 }, ignoreNested = true)
 public class Reflections {
 }

--- a/devtools/maven/pom.xml
+++ b/devtools/maven/pom.xml
@@ -43,6 +43,14 @@
                   <groupId>org.apache.maven.wagon</groupId>
                   <artifactId>*</artifactId>
               </exclusion>
+              <exclusion>
+                  <groupId>org.apache.httpcomponents</groupId>
+                  <artifactId>httpclient</artifactId>
+              </exclusion>
+              <exclusion>
+                  <groupId>org.apache.httpcomponents</groupId>
+                  <artifactId>httpcore</artifactId>
+              </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/independent-projects/bootstrap/bom/pom.xml
+++ b/independent-projects/bootstrap/bom/pom.xml
@@ -260,7 +260,22 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.maven.resolver</groupId>
-                <artifactId>maven-resolver-transport-wagon</artifactId>
+                <artifactId>maven-resolver-transport-http</artifactId>
+                <version>${maven-resolver.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>jcl-over-slf4j</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.resolver</groupId>
+                <artifactId>maven-resolver-transport-file</artifactId>
                 <version>${maven-resolver.version}</version>
                 <exclusions>
                     <exclusion>

--- a/independent-projects/bootstrap/maven-resolver/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/pom.xml
@@ -49,6 +49,22 @@
                     <groupId>org.jsoup</groupId>
                     <artifactId>jsoup</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.maven.resolver</groupId>
+                    <artifactId>maven-resolver-transport-wagon</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.maven.wagon</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpcore</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -108,37 +124,17 @@
         </dependency>
         <dependency>
             <groupId>org.apache.maven.resolver</groupId>
-            <artifactId>maven-resolver-transport-wagon</artifactId>
-            <exclusions>
-                <exclusion><!-- let's prefer the wagon-provider-api pulled by wagon-http and wagon-file -->
-                    <groupId>org.apache.maven.wagon</groupId>
-                    <artifactId>wagon-provider-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.wagon</groupId>
-            <artifactId>wagon-http</artifactId>
+            <artifactId>maven-resolver-transport-http</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>jcl-over-slf4j</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-simple</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.apache.maven.wagon</groupId>
-            <artifactId>wagon-file</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-simple</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-transport-file</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContext.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContext.java
@@ -939,6 +939,30 @@ public class BootstrapMavenContext {
         if (settingsDecrypter == null) {
             settingsDecrypter = factory.getContainer().requireBean(SettingsDecrypter.class);
         }
+        ensureHttpTransportClassesInitialized();
+    }
+
+    /**
+     * Eagerly triggers class initialization of Apache HttpClient SSL classes that are
+     * used by maven-resolver-transport-http's GlobalState.getConnectionManager().
+     * <p>
+     * GlobalState uses ConcurrentHashMap.computeIfAbsent() to lazily create connection
+     * managers, and the mapping function triggers first-time class initialization of
+     * SSLConnectionSocketFactory → AbstractVerifier → commons-logging Class.forName().
+     * Under parallel resolution, multiple threads entering computeIfAbsent() concurrently
+     * can deadlock: one thread holds the CHM bin lock while blocked on a HotSpot
+     * class-initialization lock held by another thread that is blocked on the same bin lock.
+     * <p>
+     * Pre-loading these classes on a single thread eliminates the race.
+     *
+     * @see <a href="https://github.com/quarkusio/quarkus/issues/55317">quarkusio/quarkus#55317</a>
+     */
+    private static void ensureHttpTransportClassesInitialized() {
+        try {
+            Class.forName("org.apache.http.conn.ssl.SSLConnectionSocketFactory", true, RepositorySystem.class.getClassLoader());
+        } catch (ClassNotFoundException e) {
+            // transport-http not on the classpath — nothing to pre-initialize
+        }
     }
 
     protected MavenFactory configureMavenFactory() {

--- a/independent-projects/extension-maven-plugin/pom.xml
+++ b/independent-projects/extension-maven-plugin/pom.xml
@@ -259,6 +259,24 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-bootstrap-maven-resolver</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.maven.resolver</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.maven.wagon</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpcore</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
This change pre-initializes Maven resolver's HTTP transport classes eagerly before handling artifact resolution requests to avoid a possible class initialization deadlocks.

It also removes dependencies on the Wagon transport implementation, that weren't actually used, since the HTTP transport was winning by priority anyway.

- Fixes: https://github.com/quarkusio/quarkus/issues/55317
- Fixes: https://github.com/quarkusio/quarkus/issues/54885