### PR TITLE
Enforcer Rules: make them usable in Quarkiverse

### DIFF
--- a/independent-projects/enforcer-rules/src/it/smoketest/integration-tests/pom.xml
+++ b/independent-projects/enforcer-rules/src/it/smoketest/integration-tests/pom.xml
@@ -44,4 +44,40 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>CustomGroupIdPrefix</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>enforce-deployment-deps</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requiresMinimalDeploymentDependency>
+                                            <groupIdPrefix>com.example</groupIdPrefix>
+                                        </requiresMinimalDeploymentDependency>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <dependencies>
+                            <dependency>
+                                <groupId>@project.groupId@</groupId>
+                                <artifactId>@project.artifactId@</artifactId>
+                                <version>@project.version@</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/independent-projects/enforcer-rules/src/it/smoketest/invoker.properties
+++ b/independent-projects/enforcer-rules/src/it/smoketest/invoker.properties
@@ -13,3 +13,7 @@ invoker.buildResult.3 = failure
 invoker.name.4 = Test RequiresMinimalDeploymentDependency failure: superfluous dependency
 invoker.goals.4 = package -PSuperfluousDeploymentDep
 invoker.buildResult.4 = failure
+
+invoker.name.5 = Test RequiresMinimalDeploymentDependency with custom groupIdPrefix skips non-matching artifacts
+invoker.goals.5 = package -PCustomGroupIdPrefix
+invoker.buildResult.5 = success

--- a/independent-projects/enforcer-rules/src/main/java/io/quarkus/enforcer/DeploymentDependencyRuleSupport.java
+++ b/independent-projects/enforcer-rules/src/main/java/io/quarkus/enforcer/DeploymentDependencyRuleSupport.java
@@ -25,14 +25,23 @@ import org.apache.maven.project.MavenProject;
 
 public abstract class DeploymentDependencyRuleSupport extends AbstractEnforcerRule {
 
-    protected static final String GROUP_ID_PREFIX = "io.quarkus";
     protected static final String DEPLOYMENT_ARTIFACT_ID_SUFFIX = "-deployment";
 
     private static final String EXT_PROPERTIES_PATH = "META-INF/quarkus-extension.properties";
     private static final Map<String, Optional<String>> DEPLOYMENT_GAV_CACHE = new ConcurrentHashMap<>();
 
+    /**
+     * Only artifacts whose group ID starts with this prefix are checked.
+     * Defaults to {@code io.quarkus}.
+     */
+    private String groupIdPrefix = "io.quarkus";
+
     @Inject
     private MavenProject project;
+
+    public void setGroupIdPrefix(String groupIdPrefix) {
+        this.groupIdPrefix = groupIdPrefix;
+    }
 
     @Override
     public final void execute() throws EnforcerRuleException {
@@ -48,7 +57,7 @@ public abstract class DeploymentDependencyRuleSupport extends AbstractEnforcerRu
 
         Map<String, Artifact> nonDeploymentArtifactsByGAV = project.getArtifacts().stream()
                 .filter(artifact -> "jar".equals(artifact.getType()))
-                .filter(artifact -> artifact.getGroupId().startsWith(GROUP_ID_PREFIX))
+                .filter(artifact -> artifact.getGroupId().startsWith(groupIdPrefix))
                 .filter(artifact -> !artifact.getArtifactId().endsWith(DEPLOYMENT_ARTIFACT_ID_SUFFIX))
                 .collect(Collectors.toMap(this::buildGAVKey, a -> a));
 
@@ -62,7 +71,7 @@ public abstract class DeploymentDependencyRuleSupport extends AbstractEnforcerRu
         }
 
         Map<String, Dependency> directDepsByGAV = project.getDependencies().stream()
-                .filter(d -> d.getGroupId().startsWith(GROUP_ID_PREFIX))
+                .filter(d -> d.getGroupId().startsWith(groupIdPrefix))
                 .collect(Collectors.toMap(d -> d.getGroupId() + ":" + d.getArtifactId() + ":" + d.getVersion(), d -> d,
                         (a, b) -> a));
 


### PR DESCRIPTION
The enforcer rules used to check group IDs starting with `io.quarkus`. This commit makes the group ID prefix configurable, so that Quarkiverse extensions can use the rules as well, with their own group ID prefixes. This is particularly useful to allow running tests concurrently, for which the `RequiresMinimalDeploymentDependency` rule is super useful.