### PR TITLE
gRPC - Add Unix domain socket support for server and client

### DIFF
--- a/.github/native-tests.json
+++ b/.github/native-tests.json
@@ -141,7 +141,7 @@
         {
             "category": "gRPC",
             "timeout": 80,
-            "test-modules": "grpc-health, grpc-encoding, grpc-interceptors, grpc-mutual-auth, grpc-plain-text-gzip, grpc-plain-text-mutiny, grpc-proto-v2, grpc-streaming, grpc-streaming-native, grpc-tls, grpc-tls-p12, grpc-test-random-port",
+            "test-modules": "grpc-domain-socket, grpc-health, grpc-encoding, grpc-interceptors, grpc-mutual-auth, grpc-plain-text-gzip, grpc-plain-text-mutiny, grpc-proto-v2, grpc-streaming, grpc-streaming-native, grpc-tls, grpc-tls-p12, grpc-test-random-port",
             "os-name": "ubuntu-latest"
         },
         {

--- a/docs/src/main/asciidoc/grpc-service-consumption.adoc
+++ b/docs/src/main/asciidoc/grpc-service-consumption.adoc
@@ -217,6 +217,41 @@ Don't forget to replace it with the name you used in the `@GrpcClient` annotatio
 
 IMPORTANT: When you enable `quarkus.grpc.clients."client-name".xds.enabled`, it's the xDS that should handle most of the configuration above.
 
+=== Domain Socket
+
+To connect a gRPC client to a server listening on a Unix domain socket, set the `domain-socket` property to the socket path:
+
+[source,properties]
+----
+quarkus.grpc.clients.hello.domain-socket=/var/run/grpc.sock
+----
+
+When `domain-socket` is set, the `host` and `port` properties are ignored. The client connects directly to the specified socket file.
+
+The HTTP/2 `:authority` pseudo-header defaults to `localhost` when using a domain socket. You can override it with:
+
+[source,properties]
+----
+quarkus.grpc.clients.hello.domain-socket-authority=my-service
+----
+
+Here is a full example with both the server and client configured to use the same domain socket:
+
+[source,properties]
+----
+# Server: listen on domain socket only
+quarkus.http.domain-socket-enabled=true
+quarkus.http.domain-socket=/var/run/grpc.sock
+quarkus.http.host-enabled=false
+
+# Client: connect via domain socket
+quarkus.grpc.clients.hello.domain-socket=/var/run/grpc.sock
+----
+
+IMPORTANT: The Stork name resolver is incompatible with domain sockets. Setting both `domain-socket` and `name-resolver=stork` will result in a startup error.
+
+NOTE: Unix domain sockets require JDK 16+ and are not available on Windows.
+
 === Custom Channel building
 
 When Quarkus builds a gRPC Channel instance (the way gRPC clients communicate with gRPC services on a lower network level), users can apply their own Channel(Builder) customizers. The customizers are applied by `priority`, the higher the number the later customizer is applied. The customizers are applied before Quarkus applies user's client configuration; e.g. ideal for some initial defaults per all clients.

--- a/docs/src/main/asciidoc/grpc-service-implementation.adoc
+++ b/docs/src/main/asciidoc/grpc-service-implementation.adoc
@@ -294,6 +294,27 @@ public interface ServerBuilderCustomizer<T extends ServerBuilder<T>> {
 }
 ----
 
+=== Domain Socket
+
+The gRPC server uses the Quarkus HTTP server, so you can configure it to listen on a Unix domain socket using the standard HTTP configuration properties:
+
+[source,properties]
+----
+quarkus.http.domain-socket-enabled=true
+quarkus.http.domain-socket=/var/run/grpc.sock
+----
+
+When a domain socket is enabled, the gRPC server automatically accepts gRPC requests on it — no gRPC-specific configuration is required.
+
+To listen *only* on the domain socket (disabling TCP), set:
+
+[source,properties]
+----
+quarkus.http.host-enabled=false
+----
+
+NOTE: Unix domain sockets require JDK 16+ and are not available on Windows. Native transport (`quarkus.vertx.native-transport`) is not required.
+
 == Server Interceptors
 
 gRPC server interceptors let you perform logic, such as authentication, before your service is invoked.

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/GrpcClientConfiguration.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/GrpcClientConfiguration.java
@@ -37,6 +37,22 @@ public interface GrpcClientConfiguration {
     String host();
 
     /**
+     * The path to a Unix domain socket. When set, the client connects to the gRPC server
+     * using a Unix domain socket instead of a TCP connection. The {@code host} and {@code port}
+     * properties are ignored in this case.
+     * <p>
+     * Unix domain sockets are not available on Windows.
+     */
+    Optional<String> domainSocket();
+
+    /**
+     * The HTTP/2 {@code :authority} pseudo-header value used when connecting via a Unix domain socket.
+     * This is only used when {@code domain-socket} is set.
+     */
+    @WithDefault("localhost")
+    String domainSocketAuthority();
+
+    /**
      * The name of the TLS configuration to use.
      * <p>
      * If not set and the default TLS configuration is configured ({@code quarkus.tls.*}) then that will be used.

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/Channels.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/Channels.java
@@ -115,6 +115,11 @@ public class Channels {
         String nameResolver = clientConfig.nameResolver();
 
         boolean stork = Stork.STORK.equalsIgnoreCase(nameResolver);
+        boolean useDomainSocket = clientConfig.domainSocket().isPresent();
+        if (useDomainSocket && stork) {
+            throw new IllegalArgumentException(
+                    "gRPC client '" + name + "' cannot use both domain-socket and Stork name resolver");
+        }
 
         String[] resolverSplit = nameResolver.split(":");
         String resolver = resolverSplit[0];
@@ -217,13 +222,22 @@ public class Channels {
                 options);
 
         Channel channel;
+        String authority;
         if (stork) {
             ManagedExecutor executor = container.instance(ManagedExecutor.class).get();
-            channel = new StorkGrpcChannel(client, clientConfig.host(), clientConfig.stork(), executor); // host = service-name
+            channel = new StorkGrpcChannel(client, clientConfig.host(), clientConfig.stork(), executor);
+            authority = host + ":" + port;
+            LOGGER.debugf("Target for client '%s': %s (stork)", name, host);
+        } else if (useDomainSocket) {
+            String socketPath = clientConfig.domainSocket().get();
+            authority = clientConfig.domainSocketAuthority();
+            channel = new GrpcIoClientChannel(client, new DomainSocketAddressWithAuthority(socketPath, authority));
+            LOGGER.debugf("Target for client '%s': unix:%s", name, socketPath);
         } else {
             channel = new GrpcIoClientChannel(client, SocketAddress.inetSocketAddress(port, host));
+            authority = host + ":" + port;
+            LOGGER.debugf("Target for client '%s': %s", name, authority);
         }
-        LOGGER.debugf("Target for client '%s': %s", name, host + ":" + port);
 
         List<ClientInterceptor> interceptors = new ArrayList<>();
         interceptors.addAll(interceptorContainer.getSortedPerServiceInterceptors(perClientInterceptors));
@@ -232,7 +246,7 @@ public class Channels {
         LOGGER.debug("Creating Vert.x gRPC channel ...");
 
         return new InternalGrpcChannel(client, channel, ClientInterceptors.intercept(channel, interceptors),
-                host + ":" + port);
+                authority);
 
     }
 
@@ -329,6 +343,71 @@ public class Channels {
         @Override
         public String authority() {
             return authority;
+        }
+    }
+
+    private static class DomainSocketAddressWithAuthority implements SocketAddress {
+
+        private final String path;
+        private final String authority;
+
+        DomainSocketAddressWithAuthority(String path, String authority) {
+            this.path = path;
+            this.authority = authority;
+        }
+
+        @Override
+        public boolean isDomainSocket() {
+            return true;
+        }
+
+        @Override
+        public String path() {
+            return path;
+        }
+
+        @Override
+        public String host() {
+            return authority;
+        }
+
+        @Override
+        public String hostName() {
+            return authority;
+        }
+
+        @Override
+        public int port() {
+            return 0;
+        }
+
+        @Override
+        public boolean isInetSocket() {
+            return false;
+        }
+
+        @Override
+        public String hostAddress() {
+            return null;
+        }
+
+        @Override
+        public String toString() {
+            return path;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o)
+                return true;
+            if (!(o instanceof DomainSocketAddressWithAuthority that))
+                return false;
+            return path.equals(that.path) && authority.equals(that.authority);
+        }
+
+        @Override
+        public int hashCode() {
+            return 31 * path.hashCode() + authority.hashCode();
         }
     }
 }

--- a/integration-tests/grpc-domain-socket/pom.xml
+++ b/integration-tests/grpc-domain-socket/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>quarkus-integration-tests-parent</artifactId>
+    <groupId>io.quarkus</groupId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>quarkus-integration-test-grpc-domain-socket</artifactId>
+  <name>Quarkus - Integration Tests - gRPC - Domain Socket</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-grpc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-arc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-grpc-deployment</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate-code</goal>
+              <goal>build</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/integration-tests/grpc-domain-socket/src/main/java/io/quarkus/it/grpc/uds/HelloWorldService.java
+++ b/integration-tests/grpc-domain-socket/src/main/java/io/quarkus/it/grpc/uds/HelloWorldService.java
@@ -1,0 +1,15 @@
+package io.quarkus.it.grpc.uds;
+
+import io.quarkus.grpc.GrpcService;
+import io.smallrye.mutiny.Uni;
+
+@GrpcService
+public class HelloWorldService extends MutinyGreeterGrpc.GreeterImplBase {
+
+    @Override
+    public Uni<HelloReply> sayHello(HelloRequest request) {
+        String name = request.getName();
+        return Uni.createFrom().item(
+                HelloReply.newBuilder().setMessage("Hello " + name).build());
+    }
+}

--- a/integration-tests/grpc-domain-socket/src/main/proto/helloworld.proto
+++ b/integration-tests/grpc-domain-socket/src/main/proto/helloworld.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.quarkus.it.grpc.uds";
+
+package helloworld;
+
+service Greeter {
+    rpc SayHello (HelloRequest) returns (HelloReply) {}
+}
+
+message HelloRequest {
+    string name = 1;
+}
+
+message HelloReply {
+    string message = 1;
+}

--- a/integration-tests/grpc-domain-socket/src/test/java/io/quarkus/it/grpc/uds/GrpcDomainSocketIT.java
+++ b/integration-tests/grpc-domain-socket/src/test/java/io/quarkus/it/grpc/uds/GrpcDomainSocketIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.grpc.uds;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class GrpcDomainSocketIT extends GrpcDomainSocketTest {
+}

--- a/integration-tests/grpc-domain-socket/src/test/java/io/quarkus/it/grpc/uds/GrpcDomainSocketTest.java
+++ b/integration-tests/grpc-domain-socket/src/test/java/io/quarkus/it/grpc/uds/GrpcDomainSocketTest.java
@@ -1,0 +1,30 @@
+package io.quarkus.it.grpc.uds;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.grpc.GrpcClient;
+import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+@WithTestResource(GrpcDomainSocketTestResource.class)
+@DisabledOnOs(OS.WINDOWS)
+public class GrpcDomainSocketTest {
+
+    @GrpcClient("hello")
+    Greeter greeter;
+
+    @Test
+    public void testGrpcOverDomainSocket() {
+        HelloReply reply = greeter.sayHello(
+                HelloRequest.newBuilder().setName("World").build())
+                .await().atMost(Duration.ofSeconds(10));
+        assertThat(reply.getMessage()).isEqualTo("Hello World");
+    }
+}

--- a/integration-tests/grpc-domain-socket/src/test/java/io/quarkus/it/grpc/uds/GrpcDomainSocketTestResource.java
+++ b/integration-tests/grpc-domain-socket/src/test/java/io/quarkus/it/grpc/uds/GrpcDomainSocketTestResource.java
@@ -1,0 +1,43 @@
+package io.quarkus.it.grpc.uds;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+public class GrpcDomainSocketTestResource implements QuarkusTestResourceLifecycleManager {
+
+    private Path socketPath;
+
+    @Override
+    public void init(Map<String, String> initArgs) {
+        try {
+            socketPath = Files.createTempFile(Path.of("/tmp"), "quarkus-grpc-test", ".sock");
+            Files.delete(socketPath);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Map<String, String> start() {
+        String path = socketPath.toAbsolutePath().toString();
+        return Map.of(
+                "quarkus.http.domain-socket-enabled", "true",
+                "quarkus.http.domain-socket", path,
+                "quarkus.http.host-enabled", "false",
+                "quarkus.vertx.native-transport", "disabled",
+                "quarkus.grpc.clients.hello.domain-socket", path);
+    }
+
+    @Override
+    public void stop() {
+        try {
+            Files.deleteIfExists(socketPath);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -446,6 +446,7 @@
                 <module>grpc-proto3</module>
                 <module>grpc-proto4</module>
                 <module>grpc-encoding</module>
+                <module>grpc-domain-socket</module>
                 <module>google-cloud-functions-http</module>
                 <module>google-cloud-functions</module>
                 <module>istio</module>


### PR DESCRIPTION
The gRPC server inherits domain socket support from the Quarkus HTTP server, so users just need to configure
quarkus.http.domain-socket-enabled and quarkus.http.domain-socket.

The gRPC client gets two new config properties:
- quarkus.grpc.clients.<name>.domain-socket (socket path)
- quarkus.grpc.clients.<name>.domain-socket-authority (HTTP/2 authority, defaults to localhost)