### PR TITLE
Apply DevUI CORS and Host checks to DevMCP

### DIFF
--- a/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/MCPProcessor.java
+++ b/extensions/devui/deployment/src/main/java/io/quarkus/devui/deployment/menu/MCPProcessor.java
@@ -10,6 +10,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.devui.deployment.DevUIConfig;
 import io.quarkus.devui.runtime.DevUIRecorder;
 import io.quarkus.devui.runtime.mcp.McpDevUIJsonRpcService;
 import io.quarkus.devui.runtime.mcp.McpResourcesService;
@@ -20,6 +21,7 @@ import io.quarkus.devui.spi.page.SettingPageBuildItem;
 import io.quarkus.devui.spi.page.UnlistedPageBuildItem;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
+import io.quarkus.vertx.http.runtime.security.SecurityHandlerPriorities;
 
 public class MCPProcessor {
 
@@ -63,6 +65,7 @@ public class MCPProcessor {
     @BuildStep(onlyIf = IsDevelopment.class)
     @io.quarkus.deployment.annotations.Record(ExecutionTime.STATIC_INIT)
     void registerStreamableHTTPHandlers(
+            DevUIConfig devUIConfig,
             BuildProducer<RouteBuildItem> routeProducer,
             DevUIRecorder recorder,
             LaunchModeBuildItem launchModeBuildItem,
@@ -70,6 +73,18 @@ public class MCPProcessor {
 
         if (launchModeBuildItem.isNotLocalDevModeType()) {
             return;
+        }
+
+        routeProducer.produce(nonApplicationRootPathBuildItem.routeBuilder()
+                .orderedRoute(DEVMCP, -2 * SecurityHandlerPriorities.CORS)
+                .handler(recorder.createLocalHostOnlyFilter(devUIConfig.hosts().orElse(null)))
+                .build());
+
+        if (devUIConfig.cors().enabled()) {
+            routeProducer.produce(nonApplicationRootPathBuildItem.routeBuilder()
+                    .orderedRoute(DEVMCP, -1 * SecurityHandlerPriorities.CORS)
+                    .handler(recorder.createDevUICorsFilter(devUIConfig.hosts().orElse(null)))
+                    .build());
         }
 
         // Streamable HTTP for JsonRPC comms

--- a/extensions/devui/deployment/src/test/java/io/quarkus/devui/devmcp/DevMcpCorsTest.java
+++ b/extensions/devui/deployment/src/test/java/io/quarkus/devui/devmcp/DevMcpCorsTest.java
@@ -1,0 +1,129 @@
+package io.quarkus.devui.devmcp;
+
+import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Comparator;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.devui.testrunner.HelloResource;
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
+public class DevMcpCorsTest {
+
+    private static Path TEMP_HOME;
+    private static String OLD_USER_HOME;
+
+    @RegisterExtension
+    static final QuarkusDevModeTest test = createDevModeTest();
+
+    private static QuarkusDevModeTest createDevModeTest() {
+        try {
+            TEMP_HOME = Files.createTempDirectory("devmcp-home-");
+            Path quarkusDir = TEMP_HOME.resolve(".quarkus");
+            Files.createDirectories(quarkusDir);
+            Path props = quarkusDir.resolve("dev-mcp.properties");
+            Files.writeString(props, "enabled=true\n",
+                    StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+
+            OLD_USER_HOME = System.getProperty("user.home");
+            System.setProperty("user.home", TEMP_HOME.toString());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to set up Dev MCP CORS test HOME", e);
+        }
+
+        return new QuarkusDevModeTest()
+                .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                        .addClasses(HelloResource.class));
+    }
+
+    @AfterAll
+    static void cleanupHome() {
+        // Restore original user.home
+        if (OLD_USER_HOME != null) {
+            System.setProperty("user.home", OLD_USER_HOME);
+        }
+        if (TEMP_HOME != null) {
+            try {
+                Files.walk(TEMP_HOME)
+                        .sorted(Comparator.reverseOrder())
+                        .forEach(p -> {
+                            try {
+                                Files.deleteIfExists(p);
+                            } catch (IOException ignored) {
+                            }
+                        });
+            } catch (IOException ignored) {
+            }
+        }
+    }
+
+    @Test
+    public void testPreflightNonLocalhostOriginRejected() {
+        String methods = "GET,POST";
+        RestAssured.given()
+                .header("Origin", "https://evil.example.com")
+                .header("Access-Control-Request-Method", methods)
+                .when()
+                .options("/q/dev-mcp").then()
+                .statusCode(403)
+                .header("Access-Control-Allow-Origin", nullValue())
+                .header("Access-Control-Allow-Methods", nullValue())
+                .body(emptyOrNullString());
+    }
+
+    @Test
+    public void testSimpleRequestNonLocalhostOriginRejected() {
+        String jsonBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 1,
+                      "method": "initialize",
+                      "params": {
+                        "protocolVersion": "2025-03-26",
+                        "capabilities": {},
+                        "clientInfo": {
+                          "name": "EvilClient",
+                          "version": "1.0.0"
+                        }
+                      }
+                    }
+                """;
+
+        RestAssured.given()
+                .header("Origin", "https://evil.example.com")
+                .contentType(ContentType.JSON)
+                .body(jsonBody)
+                .when()
+                .post("/q/dev-mcp").then()
+                .statusCode(403)
+                .header("Access-Control-Allow-Origin", nullValue())
+                .body(emptyOrNullString());
+    }
+
+    @Test
+    public void testPreflightLocalhostOriginAllowed() {
+        String origin = "http://localhost:8080";
+        String methods = "GET,POST";
+        RestAssured.given()
+                .header("Origin", origin)
+                .header("Access-Control-Request-Method", methods)
+                .when()
+                .options("/q/dev-mcp").then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", origin)
+                .header("Access-Control-Allow-Methods", methods)
+                .body(emptyOrNullString());
+    }
+}

--- a/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpHttpHandler.java
+++ b/extensions/devui/runtime/src/main/java/io/quarkus/devui/runtime/mcp/McpHttpHandler.java
@@ -33,11 +33,6 @@ public class McpHttpHandler implements Handler<RoutingContext> {
     public void handle(RoutingContext ctx) {
         McpServerConfiguration mcpServerConfiguration = CDI.current().select(McpServerConfiguration.class).get();
         if (mcpServerConfiguration.isEnabled()) {
-            // TODO:
-            // Servers MUST validate the Origin header on all incoming connections to prevent DNS rebinding attacks
-            // When running locally, servers SHOULD bind only to localhost (127.0.0.1) rather than all network interfaces (0.0.0.0)
-            // Servers SHOULD implement proper authentication for all connections
-
             //The client MUST use HTTP POST to send JSON-RPC messages to the MCP endpoint.
             //The client MUST include an Accept header, listing both application/json and text/event-stream as supported content types.
             // The body of the POST request MUST be a single JSON-RPC request, notification, or response.


### PR DESCRIPTION
We need to have DevMCP covered with the CORS and Host pair of check, restricting them to localhost by default, exactly the same it is done for the rest of the devmode endpoints.

As far as `LocalHostOnlyFilter` is concerned, it is designed to complement the browser request CORS checks; however we will likely consider removing it once another Host Validation filter which is in the works now is introduced.

This PR adds a test that follows the same pattern as the `DevMcpTest` and does CORS checks.

Thanks to Mike Read for pointing out to this omission

 