### PR TITLE
Rest Client - Add support for Unix domain socket connections

### DIFF
--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -2030,6 +2030,24 @@ The port the proxy is listening can be found in startup logs. An example entry i
 Started HTTP proxy server on http://localhost:38227 for REST Client 'org.acme.SomeClient'
 ----
 
+== Unix domain socket
+
+The REST client can connect to a server listening on a Unix domain socket instead of using a network connection.
+This is useful when communicating with services co-located on the same host (for example, a local daemon or sidecar) without going through the network stack.
+
+To use a domain socket, set the `domain-socket` property to the path of the socket file.
+The `url` (or `uri`) property is still required — it provides the HTTP `Host` header and request path:
+
+[source,properties]
+----
+quarkus.rest-client.my-client.url=http://localhost
+quarkus.rest-client.my-client.domain-socket=/var/run/my-service.sock
+----
+
+The network connection is replaced by the socket; `host` and `port` from the URL are used only for the HTTP `Host` header.
+
+NOTE: Unix domain sockets are not available on Windows.
+
 == Package and run the application
 
 Run the application with:

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
@@ -791,6 +791,17 @@ public interface RestClientsConfig {
         Boolean disableDefaultMapper();
 
         /**
+         * The path to a Unix domain socket. When set, the client connects to the server
+         * using a Unix domain socket instead of a network connection. The {@code url} or {@code uri}
+         * property is still required for the request path and HTTP {@code Host} header.
+         * <p>
+         * Unix domain sockets are not available on Windows.
+         * <p>
+         * This property is not applicable to the RESTEasy Client.
+         */
+        Optional<String> domainSocket();
+
+        /**
          * Logging configuration.
          */
         Optional<RestClientLoggingConfig> logging();

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/QuarkusRestClientBuilder.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/QuarkusRestClientBuilder.java
@@ -324,6 +324,16 @@ public interface QuarkusRestClientBuilder extends Configurable<QuarkusRestClient
     QuarkusRestClientBuilder enableCompression(boolean enableCompression);
 
     /**
+     * Specifies the path to a Unix domain socket. When set, the client connects to the server
+     * using a Unix domain socket instead of a network connection. The {@code url} or {@code uri}
+     * property is still required for the request path and HTTP {@code Host} header.
+     *
+     * @param path the path to the Unix domain socket
+     * @return the current builder with the domain socket path set
+     */
+    QuarkusRestClientBuilder domainSocket(String path);
+
+    /**
      * Based on the configured QuarkusRestClientBuilder, creates a new instance of the given REST interface to invoke API calls
      * against.
      *

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/QuarkusRestClientBuilderImpl.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/QuarkusRestClientBuilderImpl.java
@@ -306,6 +306,12 @@ public class QuarkusRestClientBuilderImpl implements QuarkusRestClientBuilder {
     }
 
     @Override
+    public QuarkusRestClientBuilder domainSocket(String path) {
+        delegate.domainSocket(path);
+        return this;
+    }
+
+    @Override
     public <T> T build(Class<T> clazz) throws IllegalStateException, RestClientDefinitionException {
         return delegate.build(clazz);
     }

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientBuilderImpl.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientBuilderImpl.java
@@ -104,6 +104,7 @@ public class RestClientBuilderImpl implements RestClientBuilder, VertxRequestCus
     private String userAgent;
     private Boolean disableDefaultMapper;
     private Boolean enableCompression;
+    private String domainSocketPath;
     private Consumer<HttpClientOptions> clientOptionsCustomizer;
 
     @Override
@@ -312,6 +313,11 @@ public class RestClientBuilderImpl implements RestClientBuilder, VertxRequestCus
 
     public RestClientBuilderImpl enableCompression(boolean enableCompression) {
         this.enableCompression = enableCompression;
+        return this;
+    }
+
+    public RestClientBuilderImpl domainSocket(String path) {
+        this.domainSocketPath = path;
         return this;
     }
 
@@ -659,6 +665,10 @@ public class RestClientBuilderImpl implements RestClientBuilder, VertxRequestCus
         }
         if (effectiveEnableCompression != null) {
             clientBuilder.enableCompression(effectiveEnableCompression);
+        }
+
+        if (domainSocketPath != null) {
+            clientBuilder.domainSocket(domainSocketPath);
         }
 
         if (proxyHost != null) {

--- a/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilder.java
+++ b/extensions/resteasy-reactive/rest-client/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilder.java
@@ -89,6 +89,7 @@ public class RestClientCDIDelegateBuilder<T> {
         configureShared(builder);
         configureLogging(builder);
         configureCustomProperties(builder);
+        configureDomainSocket(builder);
         configureClientOptionsCustomizer(builder);
     }
 
@@ -449,6 +450,10 @@ public class RestClientCDIDelegateBuilder<T> {
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException("The value of URL was invalid " + baseUrl, e);
         }
+    }
+
+    private void configureDomainSocket(QuarkusRestClientBuilder builder) {
+        restClientConfig.domainSocket().ifPresent(builder::domainSocket);
     }
 
     private void configureClientOptionsCustomizer(QuarkusRestClientBuilder builder) {

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSendRequestHandler.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSendRequestHandler.java
@@ -67,6 +67,7 @@ import io.vertx.core.http.HttpVersion;
 import io.vertx.core.http.RequestOptions;
 import io.vertx.core.internal.buffer.BufferInternal;
 import io.vertx.core.internal.http.HttpClientInternal;
+import io.vertx.core.net.SocketAddress;
 import io.vertx.core.streams.Pipe;
 
 public class ClientSendRequestHandler implements ClientRestHandler {
@@ -79,6 +80,7 @@ public class ClientSendRequestHandler implements ClientRestHandler {
     private final ClientLogger clientLogger;
     private final Map<Class<?>, MultipartResponseData> multipartResponseDataMap;
     private final List<Consumer<HttpClientRequest>> clientRequestCustomizers;
+    private final String domainSocketPath;
     private final int maxChunkSize;
     private final int inputStreamChunkSize;
 
@@ -86,7 +88,8 @@ public class ClientSendRequestHandler implements ClientRestHandler {
             boolean followRedirects,
             LoggingScope loggingScope, ClientLogger logger,
             Map<Class<?>, MultipartResponseData> multipartResponseDataMap,
-            List<Consumer<HttpClientRequest>> clientRequestCustomizers) {
+            List<Consumer<HttpClientRequest>> clientRequestCustomizers,
+            String domainSocketPath) {
         this.maxChunkSize = httpClientOptions.getMaxChunkSize();
         this.inputStreamChunkSize = httpClientOptions.getMaxChunkSize();
         this.httpClientOptions = httpClientOptions;
@@ -95,6 +98,7 @@ public class ClientSendRequestHandler implements ClientRestHandler {
         this.clientLogger = logger;
         this.multipartResponseDataMap = multipartResponseDataMap;
         this.clientRequestCustomizers = clientRequestCustomizers;
+        this.domainSocketPath = domainSocketPath;
     }
 
     @Override
@@ -513,6 +517,16 @@ public class ClientSendRequestHandler implements ClientRestHandler {
         int port = getPort(isHttps, uri.getPort());
         requestOptions = Uni.createFrom().item(new RequestOptions().setHost(uri.getHost())
                 .setPort(port).setSsl(isHttps));
+
+        if (domainSocketPath != null) {
+            requestOptions = requestOptions.onItem().invoke(
+                    new Consumer<RequestOptions>() {
+                        @Override
+                        public void accept(RequestOptions requestOptions) {
+                            requestOptions.setServer(SocketAddress.domainSocketAddress(domainSocketPath));
+                        }
+                    });
+        }
 
         return requestOptions.onItem()
                 .transform(r -> {

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientBuilderImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientBuilderImpl.java
@@ -93,6 +93,7 @@ public class ClientBuilderImpl extends ClientBuilder {
     private MultiQueryParamMode multiQueryParamMode;
 
     private String userAgent = RestClientRequestContext.DEFAULT_USER_AGENT_VALUE;
+    private String domainSocketPath;
 
     private Boolean enableCompression;
     private Integer http2UpgradeMaxContentLength;
@@ -365,7 +366,8 @@ public class ClientBuilderImpl extends ClientBuilder {
                 loggingScope,
                 clientLogger, userAgent, tlsConfig != null ? tlsConfig.getName().orElse(null) : null,
                 clientRequestCustomizers,
-                http3);
+                http3,
+                domainSocketPath);
 
     }
 
@@ -543,6 +545,11 @@ public class ClientBuilderImpl extends ClientBuilder {
 
     public ClientBuilderImpl setUserAgent(String userAgent) {
         this.userAgent = userAgent;
+        return this;
+    }
+
+    public ClientBuilderImpl domainSocket(String path) {
+        this.domainSocketPath = path;
         return this;
     }
 

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientImpl.java
@@ -113,7 +113,8 @@ public class ClientImpl implements Client {
             ClientLogger clientLogger, String userAgent,
             String tlsConfigName,
             List<Consumer<HttpClientRequest>> clientRequestCustomizers,
-            boolean http3) {
+            boolean http3,
+            String domainSocketPath) {
         this.userAgent = userAgent;
         this.tlsConfigName = tlsConfigName;
         configuration = configuration != null ? configuration : new ConfigurationImpl(RuntimeType.CLIENT);
@@ -236,7 +237,8 @@ public class ClientImpl implements Client {
                 loggingScope,
                 clientContext.getMultipartResponsesData(),
                 clientLogger,
-                clientRequestCustomizers);
+                clientRequestCustomizers,
+                domainSocketPath);
     }
 
     public HttpClient getVertxHttpClient() {

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/HandlerChain.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/HandlerChain.java
@@ -45,13 +45,15 @@ class HandlerChain {
             LoggingScope loggingScope,
             Map<Class<?>, MultipartResponseData> multipartData,
             ClientLogger clientLogger,
-            List<Consumer<HttpClientRequest>> clientRequestCustomizers) {
+            List<Consumer<HttpClientRequest>> clientRequestCustomizers,
+            String domainSocketPath) {
         this.clientCaptureCurrentContextRestHandler = new ClientCaptureCurrentContextRestHandler(captureStacktrace);
         this.clientSwitchToRequestContextRestHandler = new ClientSwitchToRequestContextRestHandler();
         this.clientSendHandler = new ClientSendRequestHandler(httpClientOptions, followRedirects, loggingScope,
                 clientLogger,
                 multipartData,
-                clientRequestCustomizers);
+                clientRequestCustomizers,
+                domainSocketPath);
         this.clientSetResponseEntityRestHandler = new ClientSetResponseEntityRestHandler();
         this.clientResponseCompleteRestHandler = new ClientResponseCompleteRestHandler();
         this.clientErrorHandler = new ClientErrorHandler(loggingScope);

--- a/independent-projects/resteasy-reactive/client/runtime/src/test/java/org/jboss/resteasy/reactive/client/impl/HandlerChainTest.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/test/java/org/jboss/resteasy/reactive/client/impl/HandlerChainTest.java
@@ -24,7 +24,7 @@ public class HandlerChainTest {
     public void preSendHandlerIsAlwaysFirst() throws Exception {
 
         var initialChain = new HandlerChain(new HttpClientOptions(), false, true, LoggingScope.NONE, Collections.emptyMap(),
-                new DefaultClientLogger(), Collections.emptyList());
+                new DefaultClientLogger(), Collections.emptyList(), null);
 
         ClientRestHandler preHandler = ctx -> {
         };

--- a/integration-tests/vertx-http/pom.xml
+++ b/integration-tests/vertx-http/pom.xml
@@ -16,7 +16,7 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy</artifactId>
+            <artifactId>quarkus-rest</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -25,6 +25,10 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client</artifactId>
         </dependency>
 
         <dependency>
@@ -74,7 +78,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-deployment</artifactId>
+            <artifactId>quarkus-rest-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>
@@ -88,6 +92,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx-http-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/vertx-http/src/main/java/io/quarkus/it/vertx/UdsClient.java
+++ b/integration-tests/vertx-http/src/main/java/io/quarkus/it/vertx/UdsClient.java
@@ -1,0 +1,18 @@
+package io.quarkus.it.vertx;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@Path("/uds")
+@RegisterRestClient(configKey = "uds")
+public interface UdsClient {
+
+    @GET
+    @Path("/test")
+    @Produces(MediaType.TEXT_PLAIN)
+    String test();
+}

--- a/integration-tests/vertx-http/src/main/java/io/quarkus/it/vertx/UdsClientResource.java
+++ b/integration-tests/vertx-http/src/main/java/io/quarkus/it/vertx/UdsClientResource.java
@@ -1,0 +1,21 @@
+package io.quarkus.it.vertx;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+@Path("/uds-client-test")
+public class UdsClientResource {
+
+    @RestClient
+    UdsClient client;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String test() {
+        return client.test();
+    }
+}

--- a/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/AccessLogTestCase.java
+++ b/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/AccessLogTestCase.java
@@ -43,7 +43,7 @@ public class AccessLogTestCase {
                         Assertions.assertTrue(Files.exists(accessLogFilePath),
                                 "access log file " + accessLogFilePath + " is missing");
                         String line = Files.readString(accessLogFilePath);
-                        Assertions.assertTrue(line.startsWith("127.0.0.1 - - ["),
+                        Assertions.assertTrue(line.contains("127.0.0.1 - - ["),
                                 "access log doesn't contain request IP or does not wrap the date with []: " + line);
                         Assertions.assertTrue(line.contains("] \"GET"),
                                 "access log doesn't contain the HTTP method or does not wrap the date with []: " + line);

--- a/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/UnixDomainSocketRestClientIT.java
+++ b/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/UnixDomainSocketRestClientIT.java
@@ -1,0 +1,62 @@
+package io.quarkus.it.vertx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.vertx.core.http.RequestOptions;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.mutiny.core.Vertx;
+import io.vertx.mutiny.core.http.HttpClient;
+import io.vertx.mutiny.core.http.HttpClientResponse;
+
+@QuarkusIntegrationTest
+@WithTestResource(UnixDomainSocketTestResource.class)
+@DisabledOnOs(OS.WINDOWS)
+public class UnixDomainSocketRestClientIT {
+
+    Vertx vertx;
+    HttpClient httpClient;
+
+    @BeforeEach
+    void setUp() {
+        vertx = Vertx.vertx();
+        httpClient = vertx.createHttpClient();
+    }
+
+    @Test
+    public void testRestClientOverDomainSocket() {
+        String address = ConfigProvider.getConfig().getValue("quarkus.http.domain-socket", String.class);
+        SocketAddress socketAddress = SocketAddress.domainSocketAddress(address);
+
+        RequestOptions requestOptions = new RequestOptions()
+                .setAbsoluteURI("http://localhost:8080/uds-client-test")
+                .setServer(socketAddress);
+
+        HttpClientResponse response = httpClient.request(requestOptions).onItem().transformToUni(req -> {
+            return req.send().onItem().transformToUni(resp -> resp.body().replaceWith(resp));
+        }).await().atMost(Duration.ofSeconds(10));
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.bodyAndAwait().toString()).isEqualTo("Unix Domain Socket Test");
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (httpClient != null) {
+            httpClient.close().await().atMost(Duration.ofSeconds(10));
+        }
+        if (vertx != null) {
+            vertx.close().await().atMost(Duration.ofSeconds(10));
+        }
+    }
+}

--- a/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/UnixDomainSocketRestClientTest.java
+++ b/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/UnixDomainSocketRestClientTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.it.vertx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+@WithTestResource(UnixDomainSocketTestResource.class)
+@DisabledOnOs(OS.WINDOWS)
+public class UnixDomainSocketRestClientTest {
+
+    @RestClient
+    UdsClient client;
+
+    @Test
+    public void testRestClientOverDomainSocket() {
+        String result = client.test();
+        assertThat(result).isEqualTo("Unix Domain Socket Test");
+    }
+}

--- a/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/UnixDomainSocketTestResource.java
+++ b/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/UnixDomainSocketTestResource.java
@@ -27,7 +27,9 @@ public class UnixDomainSocketTestResource implements QuarkusTestResourceLifecycl
                 "quarkus.http.domain-socket-enabled", "true",
                 "quarkus.http.domain-socket", udsPath.toAbsolutePath().toString(),
                 "quarkus.http.host-enabled", "false",
-                "quarkus.vertx.native-transport", "disabled");
+                "quarkus.vertx.native-transport", "disabled",
+                "quarkus.rest-client.uds.url", "http://localhost:8080",
+                "quarkus.rest-client.uds.domain-socket", udsPath.toAbsolutePath().toString());
     }
 
     @Override


### PR DESCRIPTION
In addition:
- adds an integration test (both JVM and native) that verifies that the REST client can connect to a server over a Unix domain socket.
- adds a new configuration property `quarkus.rest-client.domain-socket` that allows users to specify the path to the Unix domain socket for the REST client.
- updates the documentation to include information about the new configuration property and how to use it.

