### PR TITLE
Quickstarts compilation: test against 3.x branch instead

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -1244,7 +1244,7 @@ jobs:
             }
 
             const branch = process.env.GITHUB_BASE_REF ? process.env.GITHUB_BASE_REF : process.env.GITHUB_REF_NAME
-            if (branch == 'main') {
+            if (branch == '3.x') {
               return 'development'
             } else {
               return branch


### PR DESCRIPTION
Because of the main branch rename