### PR TITLE
Set a default GraphQL query depth limit of 10

### DIFF
--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLRuntimeConfig.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLRuntimeConfig.java
@@ -155,7 +155,8 @@ public interface SmallRyeGraphQLRuntimeConfig {
     OptionalInt instrumentationQueryComplexity();
 
     /**
-     * Abort a query if the total depth of the query exceeds the defined limit. Default to no limit
+     * Abort a query if the total depth of the query exceeds the defined limit.
      */
+    @WithDefault("10")
     OptionalInt instrumentationQueryDepth();
 }


### PR DESCRIPTION
The SmallRye GraphQL extension ships `MaxQueryDepthInstrumentation` from graphql-java, but the `quarkus.smallrye-graphql.instrumentation-query-depth` property had no default value — leaving applications with cyclic type graphs (e.g. `User { friends: [User] }`) exposed to memory exhaustion from a single deeply nested query.

A depth-20 query against such a schema can drive multi-gigabyte heap allocation from one unauthenticated request, because the result tree expands exponentially while the request itself is only a few hundred parser tokens (well under the existing parser limits).

This adds `@WithDefault("10")` to `instrumentationQueryDepth()`, which covers virtually all legitimate query patterns. Users can override via `quarkus.smallrye-graphql.instrumentation-query-depth` if they need deeper nesting.