### PR TITLE
Upgrade Jackson to version 2.22.1

### DIFF
--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -61,7 +61,7 @@
         <vertx.version>5.1.3</vertx.version>
         <rest-assured.version>6.0.0</rest-assured.version>
         <commons-logging-jboss-logging.version>2.0.0.Final</commons-logging-jboss-logging.version>
-        <jackson-bom.version>2.22.0</jackson-bom.version>
+        <jackson-bom.version>2.22.1</jackson-bom.version>
         <smallrye-stork.version>3.0.0</smallrye-stork.version>
         <jakarta.validation-api.version>3.1.1</jakarta.validation-api.version>
         <yasson.version>3.0.4</yasson.version>


### PR DESCRIPTION
Due to CVE https://www.cve.org/CVERecord?id=CVE-2026-54515

