### PR TITLE
Bail out of reflection-free deserializer when @JsonTypeInfo is used

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
@@ -355,6 +355,23 @@ public abstract class JacksonCodeGenerator {
         return shape != null && "ARRAY".equals(shape.asEnum());
     }
 
+    private static final DotName JSON_TYPE_INFO = DotName.createSimple(JsonTypeInfo.class);
+
+    protected boolean hasJsonTypeInfoInTypeChain(Type type) {
+        ClassInfo classInfo = jandexIndex.getClassByName(type.name());
+        if (classInfo != null && classInfo.hasDeclaredAnnotation(JSON_TYPE_INFO)) {
+            return true;
+        }
+        if (type instanceof ParameterizedType pType) {
+            for (Type arg : pType.arguments()) {
+                if (hasJsonTypeInfoInTypeChain(arg)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     protected static String anyGetterBackingFieldName(MethodInfo anyGetterMethod) {
         String methodName = anyGetterMethod.name();
         if (methodName.startsWith("get") && methodName.length() > 3) {

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonDeserializerFactory.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonDeserializerFactory.java
@@ -797,6 +797,10 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
             return readValueForPrimitiveFields(bytecode, fieldType, valueNode);
         }
 
+        if (hasJsonTypeInfoInTypeChain(fieldType)) {
+            return null;
+        }
+
         FieldKind fieldKind = registerTypeToBeGenerated(fieldType, fieldTypeName);
         ResultHandle typeHandle = switch (fieldKind) {
             case TYPE_VARIABLE -> {

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/PolymorphicListReflectionFreeSerializerTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/PolymorphicListReflectionFreeSerializerTest.java
@@ -1,0 +1,142 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import static org.hamcrest.Matchers.is;
+
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+
+public class PolymorphicListReflectionFreeSerializerTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(PolymorphicListResource.class,
+                                    Element.class, Course.class, Quiz.class,
+                                    Holder.class, PatchRequest.class)
+                            .addAsResource(
+                                    new StringAsset(
+                                            "quarkus.rest.jackson.optimization.enable-reflection-free-serializers=true\n"),
+                                    "application.properties");
+                }
+            });
+
+    @Test
+    public void testPolymorphicListInsideWrapper() {
+        RestAssured
+                .with()
+                .body("{\"elements\":{\"value\":[{\"kind\":\"COURSE\",\"title\":\"Intro\"},{\"kind\":\"QUIZ\",\"questionCount\":5}]}}")
+                .contentType("application/json")
+                .post("/poly-list/wrapped")
+                .then()
+                .statusCode(200)
+                .body("result", is("Intro,5"));
+    }
+
+    @Test
+    public void testPolymorphicListDirect() {
+        RestAssured
+                .with()
+                .body("[{\"kind\":\"COURSE\",\"title\":\"Intro\"},{\"kind\":\"QUIZ\",\"questionCount\":5}]")
+                .contentType("application/json")
+                .post("/poly-list/direct")
+                .then()
+                .statusCode(200)
+                .body("result", is("Intro,5"));
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "kind")
+    @JsonSubTypes({
+            @JsonSubTypes.Type(value = Course.class, name = "COURSE"),
+            @JsonSubTypes.Type(value = Quiz.class, name = "QUIZ"),
+    })
+    public sealed interface Element permits Course, Quiz {
+        String kind();
+    }
+
+    public record Course(String kind, String title) implements Element {
+    }
+
+    public record Quiz(String kind, int questionCount) implements Element {
+    }
+
+    public static class Holder<T> {
+        private T value;
+
+        public T getValue() {
+            return value;
+        }
+
+        public void setValue(T value) {
+            this.value = value;
+        }
+    }
+
+    public static class PatchRequest {
+        private Holder<List<Element>> elements;
+
+        public Holder<List<Element>> getElements() {
+            return elements;
+        }
+
+        public void setElements(Holder<List<Element>> elements) {
+            this.elements = elements;
+        }
+    }
+
+    @Path("/poly-list")
+    public static class PolymorphicListResource {
+
+        @POST
+        @Path("/wrapped")
+        @Consumes(MediaType.APPLICATION_JSON)
+        @Produces(MediaType.APPLICATION_JSON)
+        public String wrapped(PatchRequest request) {
+            String result = request.getElements().getValue().stream()
+                    .map(PolymorphicListReflectionFreeSerializerTest::describe)
+                    .collect(Collectors.joining(","));
+            return "{\"result\":\"" + result + "\"}";
+        }
+
+        @POST
+        @Path("/direct")
+        @Consumes(MediaType.APPLICATION_JSON)
+        @Produces(MediaType.APPLICATION_JSON)
+        public String direct(List<Element> elements) {
+            String result = elements.stream()
+                    .map(PolymorphicListReflectionFreeSerializerTest::describe)
+                    .collect(Collectors.joining(","));
+            return "{\"result\":\"" + result + "\"}";
+        }
+    }
+
+    private static String describe(Element e) {
+        if (e instanceof Course c) {
+            return c.title();
+        } else if (e instanceof Quiz q) {
+            return String.valueOf(q.questionCount());
+        }
+        throw new IllegalArgumentException("Unknown element type: " + e.getClass());
+    }
+}


### PR DESCRIPTION
The reflection-free deserializer codegen loses nested generic type parameters when constructing JavaType for wrapper types. For `Holder<List<Element>>` it builds `Holder<List>`, dropping the Element parameter. When Element is a `@JsonTypeInfo` polymorphic type, Jackson can no longer dispatch to subtypes and deserializes each element as a raw `LinkedHashMap`, causing `ClassCastException` at runtime.

Rather than fixing the recursive JavaType construction (which would still leave polymorphic dispatch entirely dependent on Jackson internals), this PR bails out of generating a reflection-free deserializer whenever a field's type chain contains a `@JsonTypeInfo`-annotated class. The containing class falls back to standard reflection-based Jackson, which handles polymorphic types correctly.

- Fixes: #55369