### PR TITLE
Implement getter-as-setter pattern when deserializing private collection in reflection-free Jackson serializers

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonCodeGenerator.java
@@ -260,9 +260,9 @@ public abstract class JacksonCodeGenerator {
         }
     }
 
-    private static final DotName COLLECTION_NAME = DotName.createSimple(Collection.class);
+    protected static final DotName COLLECTION_NAME = DotName.createSimple(Collection.class);
     private static final DotName SET_NAME = DotName.createSimple(Set.class);
-    private static final DotName MAP_NAME = DotName.createSimple(Map.class);
+    protected static final DotName MAP_NAME = DotName.createSimple(Map.class);
 
     protected FieldKind registerTypeToBeGenerated(Type fieldType, String typeName) {
         if (fieldType instanceof TypeVariable) {
@@ -295,7 +295,7 @@ public abstract class JacksonCodeGenerator {
         return FieldKind.OBJECT;
     }
 
-    private boolean isAssignableTo(String typeName, DotName targetName) {
+    protected boolean isAssignableTo(String typeName, DotName targetName) {
         if (typeName.equals(targetName.toString())) {
             return true;
         }

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonDeserializerFactory.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonDeserializerFactory.java
@@ -789,7 +789,37 @@ public class JacksonDeserializerFactory extends JacksonCodeGenerator {
                 } else {
                     bytecode.invokeVirtualMethod(setterMethod, objHandle, valueHandle);
                 }
+            } else if (fieldSpecs.methodInfo != null && fieldSpecs.methodInfo.parametersCount() == 0) {
+                writeValueViaGetterAsSetter(objHandle, fieldSpecs, bytecode, valueHandle);
             }
+        }
+    }
+
+    private void writeValueViaGetterAsSetter(ResultHandle objHandle, FieldSpecs fieldSpecs,
+            BytecodeCreator bytecode, ResultHandle valueHandle) {
+        String typeName = fieldSpecs.fieldType.name().toString();
+        boolean isCollection = isAssignableTo(typeName, COLLECTION_NAME);
+        boolean isMap = !isCollection && isAssignableTo(typeName, MAP_NAME);
+        if (!isCollection && !isMap) {
+            return;
+        }
+
+        BytecodeCreator valueNotNull = bytecode.ifNotNull(valueHandle).trueBranch();
+        ResultHandle existingValue;
+        if (fieldSpecs.methodInfo.declaringClass().isInterface()) {
+            existingValue = valueNotNull.invokeInterfaceMethod(fieldSpecs.methodInfo, objHandle);
+        } else {
+            existingValue = valueNotNull.invokeVirtualMethod(fieldSpecs.methodInfo, objHandle);
+        }
+        BytecodeCreator existingNotNull = valueNotNull.ifNotNull(existingValue).trueBranch();
+        if (isCollection) {
+            existingNotNull.invokeInterfaceMethod(
+                    ofMethod(Collection.class, "addAll", boolean.class, Collection.class),
+                    existingValue, valueHandle);
+        } else {
+            existingNotNull.invokeInterfaceMethod(
+                    ofMethod(Map.class, "putAll", void.class, Map.class),
+                    existingValue, valueHandle);
         }
     }
 

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/AbstractSimpleJsonTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/AbstractSimpleJsonTest.java
@@ -1343,6 +1343,24 @@ public abstract class AbstractSimpleJsonTest {
     }
 
     @Test
+    void finalCollectionField_shouldDeserializeWithoutSetter() {
+        given()
+                .contentType("application/json")
+                .body("""
+                        {"name": "test", "items": ["a", "b", "c"]}
+                        """)
+                .when()
+                .post("/simple/final-collection")
+                .then()
+                .statusCode(200)
+                .body("name", CoreMatchers.is("test"))
+                .body("items.size()", CoreMatchers.is(3))
+                .body("items[0]", CoreMatchers.is("a"))
+                .body("items[1]", CoreMatchers.is("b"))
+                .body("items[2]", CoreMatchers.is("c"));
+    }
+
+    @Test
     void sensor_metadata_shouldDeserialize() {
         given()
                 .when()

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/FinalCollectionHolder.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/FinalCollectionHolder.java
@@ -1,0 +1,22 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FinalCollectionHolder {
+
+    private String name;
+    private final List<String> items = new ArrayList<>();
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<String> getItems() {
+        return items;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonResource.java
@@ -752,6 +752,14 @@ public class SimpleJsonResource extends SuperClass<Person> {
         return body;
     }
 
+    @POST
+    @Path("/final-collection")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public FinalCollectionHolder echoFinalCollection(FinalCollectionHolder holder) {
+        return holder;
+    }
+
     @GET
     @Path("/sensor-metadata")
     public SensorMetadata sensorMetadata() {

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonTest.java
@@ -34,7 +34,8 @@ public class SimpleJsonTest extends AbstractSimpleJsonTest {
                                     ProductPrice.class, DefaultValueHolder.class, OptionalHolder.class, AnySetterRequest.class,
                                     UnwrappedResult.class, UnwrappedResultsResponse.class, Detail.class, ErrorInfo.class,
                                     PolymorphicItemResponse.class, PolymorphicItem.class,
-                                    SensorMetadata.class, SensorMetadata.ComponentMetadata.class, SensorUnit.class)
+                                    SensorMetadata.class, SensorMetadata.ComponentMetadata.class, SensorUnit.class,
+                                    FinalCollectionHolder.class)
                             .addAsResource(new StringAsset("admin-expression=admin\n" +
                                     "user-expression=user\n" +
                                     "birth-date-roles=alice,bob\n" +

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonWithReflectionFreeSerializersTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/SimpleJsonWithReflectionFreeSerializersTest.java
@@ -37,7 +37,8 @@ public class SimpleJsonWithReflectionFreeSerializersTest extends AbstractSimpleJ
                                     ProductPrice.class, DefaultValueHolder.class, OptionalHolder.class, AnySetterRequest.class,
                                     UnwrappedResult.class, UnwrappedResultsResponse.class, Detail.class, ErrorInfo.class,
                                     PolymorphicItemResponse.class, PolymorphicItem.class,
-                                    SensorMetadata.class, SensorMetadata.ComponentMetadata.class, SensorUnit.class)
+                                    SensorMetadata.class, SensorMetadata.ComponentMetadata.class, SensorUnit.class,
+                                    FinalCollectionHolder.class)
                             .addAsResource(new StringAsset("admin-expression=admin\n" +
                                     "user-expression=user\n" +
                                     "birth-date-roles=alice,bob\n" +


### PR DESCRIPTION
Standard Jackson handles a `private final` collection field initialized inline with only a getter (no setter) via the "getter-as-setter" pattern: it calls the getter to obtain the pre-initialized collection instance, then adds the deserialized elements into it. This pull request implements the same pattern within the reflection-free deserializer.

- Fixes: #55363