### PR TITLE
Register gRPC codegen configuration properties

### DIFF
--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcBuildTimeConfig.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcBuildTimeConfig.java
@@ -1,5 +1,7 @@
 package io.quarkus.grpc.deployment;
 
+import java.util.Optional;
+
 import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigPhase;
@@ -17,6 +19,12 @@ public interface GrpcBuildTimeConfig {
     @ConfigDocSection(generated = true)
     GrpcDevModeConfig devMode();
 
+    /**
+     * gRPC code generation configuration.
+     */
+    @ConfigDocSection(generated = true)
+    GrpcCodegenConfig codegen();
+
     @ConfigGroup
     interface GrpcDevModeConfig {
 
@@ -26,5 +34,25 @@ public interface GrpcBuildTimeConfig {
          */
         @WithDefault("true")
         boolean forceServerStart();
+    }
+
+    @ConfigGroup
+    interface GrpcCodegenConfig {
+
+        /**
+         * Directory containing the proto files to compile.
+         * <p>
+         * By default, proto files are expected in {@code src/main/proto}.
+         * <p>
+         * This property is typically set in the build descriptor (Maven plugin properties or Gradle
+         * {@code quarkusBuildProperties}).
+         */
+        Optional<String> protoDirectory();
+
+        /**
+         * Skip gRPC code generation.
+         */
+        @WithDefault("false")
+        boolean skip();
     }
 }


### PR DESCRIPTION
`quarkus.grpc.codegen.proto-directory` and `quarkus.grpc.codegen.skip` were consumed by the gRPC code generator but not registered in Quarkus configuration, which caused an "Unrecognized configuration key" warning at build time and excluded them from the generated configuration reference.

This registers both properties under `quarkus.grpc.codegen` as build-time configuration and adds a deployment test that verifies they are recognized.


- Fixes: #48106