### PR TITLE
Fix remote dev file deletion handling

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
@@ -2,6 +2,7 @@ package io.quarkus.deployment.dev;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static java.util.Objects.requireNonNull;
 
 import java.io.ByteArrayInputStream;
 import java.io.Closeable;
@@ -430,9 +431,8 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
 
     @Override
     public void updateFile(String file, byte[] data) {
-        if (file.startsWith("/")) {
-            file = file.substring(1);
-        }
+        file = normalizeFile(file);
+        requireNonNull(data, "data");
         try {
             Path resolve = applicationRoot.resolve(file).normalize();
             if (!resolve.startsWith(applicationRoot)) {
@@ -450,6 +450,25 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Override
+    public void deleteFile(String file) {
+        file = normalizeFile(file);
+        try {
+            Path resolve = applicationRoot.resolve(file);
+            Files.deleteIfExists(resolve);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static String normalizeFile(String file) {
+        requireNonNull(file, "file");
+        if (file.startsWith("/")) {
+            file = file.substring(1);
+        }
+        return file;
     }
 
     @Override

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
@@ -14,6 +14,7 @@ import java.lang.instrument.ClassDefinition;
 import java.nio.file.FileSystems;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
@@ -431,22 +432,14 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
 
     @Override
     public void updateFile(String file, byte[] data) {
-        file = normalizeFile(file);
         requireNonNull(data, "data");
+        Path resolve = resolveApplicationPath(file);
         try {
-            Path resolve = applicationRoot.resolve(file).normalize();
-            if (!resolve.startsWith(applicationRoot)) {
-                log.errorf("Path traversal attempt blocked: %s", file);
-                return;
+            if (!Files.exists(resolve.getParent())) {
+                Files.createDirectories(resolve.getParent());
             }
-            if (data != null) {
-                if (!Files.exists(resolve.getParent())) {
-                    Files.createDirectories(resolve.getParent());
-                }
-                Files.write(resolve, data);
-            } else {
-                Files.deleteIfExists(resolve);
-            }
+            validateExistingPathComponents(applicationRoot.toAbsolutePath().normalize(), resolve, file);
+            Files.write(resolve, data);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -454,17 +447,57 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
 
     @Override
     public void deleteFile(String file) {
-        file = normalizeFile(file);
+        Path resolve = resolveApplicationPath(file);
         try {
-            Path resolve = applicationRoot.resolve(file);
             Files.deleteIfExists(resolve);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
+    private Path resolveApplicationPath(String file) {
+        file = normalizeFile(file);
+        Path normalizedRoot = applicationRoot.toAbsolutePath().normalize();
+        Path relativePath = Path.of(file);
+        Path resolved = normalizedRoot.resolve(relativePath).normalize();
+        if (relativePath.isAbsolute() || resolved.equals(normalizedRoot) || !resolved.startsWith(normalizedRoot)
+                || file.length() >= 2 && file.charAt(1) == ':') {
+            throw new IllegalArgumentException("Path is not below the application root: " + file);
+        }
+        validateExistingPathComponents(normalizedRoot, resolved, file);
+        return resolved;
+    }
+
+    private static void validateExistingPathComponents(Path normalizedRoot, Path resolved, String file) {
+        final Path realRoot;
+        try {
+            realRoot = normalizedRoot.toRealPath();
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Unable to validate the application root for remote-dev path: " + file, e);
+        }
+        Path current = normalizedRoot;
+        for (Path element : normalizedRoot.relativize(resolved)) {
+            current = current.resolve(element);
+            if (Files.isSymbolicLink(current)) {
+                throw new IllegalArgumentException("Symbolic links are not allowed in remote-dev paths: " + file);
+            }
+            if (Files.exists(current, LinkOption.NOFOLLOW_LINKS)) {
+                try {
+                    if (!current.toRealPath().startsWith(realRoot)) {
+                        throw new IllegalArgumentException("Path leaves the application root: " + file);
+                    }
+                } catch (IOException e) {
+                    throw new IllegalArgumentException("Unable to validate remote-dev path: " + file, e);
+                }
+            } else {
+                break;
+            }
+        }
+    }
+
     private static String normalizeFile(String file) {
         requireNonNull(file, "file");
+        file = file.replace('\\', '/');
         if (file.startsWith("/")) {
             file = file.substring(1);
         }

--- a/core/deployment/src/test/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessorUpdateFileTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessorUpdateFileTest.java
@@ -1,0 +1,67 @@
+package io.quarkus.deployment.dev;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.quarkus.dev.spi.DevModeType;
+
+class RuntimeUpdatesProcessorUpdateFileTest {
+
+    @TempDir
+    Path applicationRoot;
+
+    @SuppressWarnings("resource")
+    @Test
+    void writesNestedFile() {
+        var processor = newProcessor();
+
+        processor.updateFile("nested/file.txt", "content".getBytes(StandardCharsets.UTF_8));
+
+        assertThat(applicationRoot.resolve("nested/file.txt")).hasContent("content");
+
+        processor.deleteFile("nested/file.txt");
+
+        assertThat(applicationRoot.resolve("nested/file.txt")).doesNotExist();
+    }
+
+    @SuppressWarnings("resource")
+    @Test
+    void stripsSingleLeadingSlashBeforeWriting() {
+        var processor = newProcessor();
+
+        processor.updateFile("/nested/file.txt", "content".getBytes(StandardCharsets.UTF_8));
+
+        assertThat(applicationRoot.resolve("nested/file.txt")).hasContent("content");
+
+        processor.deleteFile("/nested/file.txt");
+
+        assertThat(applicationRoot.resolve("nested/file.txt")).doesNotExist();
+    }
+
+    @SuppressWarnings("resource")
+    @Test
+    void nullHandling() {
+        var processor = newProcessor();
+
+        assertThatThrownBy(() -> processor.updateFile("nested/file.txt", null))
+                .isInstanceOf(NullPointerException.class);
+        assertThat(Files.exists(applicationRoot.resolve("nested/file.txt"))).isFalse();
+        assertThatThrownBy(() -> processor.updateFile(null, "content".getBytes(StandardCharsets.UTF_8)))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> processor.deleteFile(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    private RuntimeUpdatesProcessor newProcessor() {
+        return new RuntimeUpdatesProcessor(applicationRoot, null, null, DevModeType.LOCAL, null, null, null, null,
+                new AtomicReference<>());
+    }
+}

--- a/core/deployment/src/test/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessorUpdateFileTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessorUpdateFileTest.java
@@ -3,11 +3,13 @@ package io.quarkus.deployment.dev;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -58,6 +60,49 @@ class RuntimeUpdatesProcessorUpdateFileTest {
                 .isInstanceOf(NullPointerException.class);
         assertThatThrownBy(() -> processor.deleteFile(null))
                 .isInstanceOf(NullPointerException.class);
+    }
+
+    @SuppressWarnings("resource")
+    @Test
+    void rejectsWritesAndDeletesOutsideApplicationRoot() throws Exception {
+        var processor = newProcessor();
+        Path outside = applicationRoot.resolveSibling("outside.txt");
+        Files.writeString(outside, "keep");
+
+        assertThatThrownBy(() -> processor.updateFile("../outside.txt", "replace".getBytes(StandardCharsets.UTF_8)))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> processor.deleteFile("../outside.txt")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> processor.updateFile("..\\outside.txt", "replace".getBytes(StandardCharsets.UTF_8)))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> processor.deleteFile("..\\outside.txt")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> processor.deleteFile("C:outside.txt")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> processor.deleteFile("a:b/file.txt")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> processor.deleteFile("/")).isInstanceOf(IllegalArgumentException.class);
+
+        assertThat(outside).hasContent("keep");
+        assertThat(applicationRoot).isDirectory();
+    }
+
+    @SuppressWarnings("resource")
+    @Test
+    void rejectsSymbolicLinksBelowApplicationRoot() throws Exception {
+        Path outside = applicationRoot.resolveSibling("outside-directory");
+        Files.createDirectories(outside);
+        Path link = applicationRoot.resolve("link");
+        try {
+            Files.createSymbolicLink(link, outside);
+        } catch (UnsupportedOperationException | IOException | SecurityException e) {
+            Assumptions.abort("Symbolic links are unavailable: " + e.getMessage());
+        }
+        Path outsideFile = outside.resolve("file.txt");
+        Files.writeString(outsideFile, "keep");
+        var processor = newProcessor();
+
+        assertThatThrownBy(() -> processor.updateFile("link/file.txt", "replace".getBytes(StandardCharsets.UTF_8)))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> processor.deleteFile("link/file.txt")).isInstanceOf(IllegalArgumentException.class);
+
+        assertThat(outsideFile).hasContent("keep");
     }
 
     private RuntimeUpdatesProcessor newProcessor() {

--- a/core/devmode-spi/src/main/java/io/quarkus/dev/spi/HotReplacementContext.java
+++ b/core/devmode-spi/src/main/java/io/quarkus/dev/spi/HotReplacementContext.java
@@ -22,6 +22,8 @@ public interface HotReplacementContext {
 
     void updateFile(String file, byte[] data);
 
+    void deleteFile(String file);
+
     /**
      * If this is true then this is a dev mode test case, rather than a user actually using Quarkus.
      *

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/RemoteSyncHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/RemoteSyncHandler.java
@@ -253,7 +253,7 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
     private void handleDelete(HttpServerRequest event) {
         if (checkSession(event, event.path().getBytes(StandardCharsets.UTF_8)))
             return;
-        hotReplacementContext.updateFile(stripRootPath(event.path()), null);
+        hotReplacementContext.deleteFile(stripRootPath(event.path()));
         event.response().end();
     }
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/RemoteSyncHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/RemoteSyncHandler.java
@@ -229,8 +229,14 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
                 try {
                     String path = stripRootPath(event.path());
                     hotReplacementContext.updateFile(path, buffer.getBytes());
+                } catch (IllegalArgumentException e) {
+                    log.warn("Rejected remote-dev file update", e);
+                    event.response().setStatusCode(400).end();
+                    return;
                 } catch (Exception e) {
                     log.error("Failed to update file", e);
+                    event.response().setStatusCode(500).end();
+                    return;
                 }
                 event.response().end();
             }
@@ -253,8 +259,16 @@ public class RemoteSyncHandler implements Handler<HttpServerRequest> {
     private void handleDelete(HttpServerRequest event) {
         if (checkSession(event, event.path().getBytes(StandardCharsets.UTF_8)))
             return;
-        hotReplacementContext.deleteFile(stripRootPath(event.path()));
-        event.response().end();
+        try {
+            hotReplacementContext.deleteFile(stripRootPath(event.path()));
+            event.response().end();
+        } catch (IllegalArgumentException e) {
+            log.warn("Rejected remote-dev file deletion", e);
+            event.response().setStatusCode(400).end();
+        } catch (Exception e) {
+            log.error("Failed to delete file", e);
+            event.response().setStatusCode(500).end();
+        }
     }
 
     private boolean checkSession(HttpServerRequest event, byte[] data) {

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/devmode/RemoteSyncHandlerTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/devmode/RemoteSyncHandlerTest.java
@@ -1,0 +1,120 @@
+package io.quarkus.vertx.http.runtime.devmode;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.dev.spi.HotReplacementContext;
+import io.quarkus.runtime.util.HashUtil;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+
+class RemoteSyncHandlerTest {
+
+    private static final String PASSWORD = "secret";
+    private static final String SESSION = "session";
+
+    @AfterEach
+    void resetRemoteSyncState() {
+        RemoteSyncHandler.currentSession = null;
+        RemoteSyncHandler.currentSessionCounter = 0;
+        RemoteSyncHandler.currentSessionTimeout = 0;
+        RemoteSyncHandler.remoteProblem = null;
+        RemoteSyncHandler.checkForChanges = false;
+    }
+
+    @Test
+    void putStripsConfiguredRootPathBeforeUpdatingFile() throws Exception {
+        byte[] data = "content".getBytes(StandardCharsets.UTF_8);
+        var context = mock(HotReplacementContext.class);
+        var handler = new RemoteSyncHandler(PASSWORD, ignored -> {
+        }, context, "/root");
+
+        invokeHandlePut(handler, request("/root/app/classes/com/acme/Foo.class", data));
+
+        verify(context).updateFile("/app/classes/com/acme/Foo.class", data);
+    }
+
+    @Test
+    void putLeavesPathUnchangedWhenRootPathDoesNotMatch() throws Exception {
+        byte[] data = "content".getBytes(StandardCharsets.UTF_8);
+        var context = mock(HotReplacementContext.class);
+        var handler = new RemoteSyncHandler(PASSWORD, ignored -> {
+        }, context, "/root");
+
+        invokeHandlePut(handler, request("/other/app/classes/com/acme/Foo.class", data));
+
+        verify(context).updateFile("/other/app/classes/com/acme/Foo.class", data);
+    }
+
+    @Test
+    void deletePassesRawRequestPathToUpdateFile() throws Exception {
+        var context = mock(HotReplacementContext.class);
+        var handler = new RemoteSyncHandler(PASSWORD, ignored -> {
+        }, context, "/root");
+
+        invokeHandleDelete(handler, request("/root/app/classes/com/acme/Foo.class", null));
+
+        verify(context).deleteFile("/app/classes/com/acme/Foo.class");
+    }
+
+    private HttpServerRequest request(String path, byte[] body) {
+        RemoteSyncHandler.currentSession = SESSION;
+        RemoteSyncHandler.currentSessionCounter = 0;
+        var request = mock(HttpServerRequest.class);
+        var response = mock(HttpServerResponse.class);
+        when(request.path()).thenReturn(path);
+        when(request.response()).thenReturn(response);
+        when(request.headers()).thenReturn(headers(path, body));
+        when(request.bodyHandler(any())).thenAnswer(invocation -> {
+            Handler<Buffer> bodyHandler = invocation.getArgument(0);
+            bodyHandler.handle(Buffer.buffer(body));
+            return request;
+        });
+        when(request.exceptionHandler(any())).thenReturn(request);
+        when(request.resume()).thenReturn(request);
+        return request;
+    }
+
+    private MultiMap headers(String path, byte[] body) {
+        var sessionCounter = 1;
+        var passwordHashInput = body == null ? path.getBytes(StandardCharsets.UTF_8) : body;
+        return MultiMap.caseInsensitiveMultiMap()
+                .add(RemoteSyncHandler.QUARKUS_SESSION, SESSION)
+                .add(RemoteSyncHandler.QUARKUS_SESSION_COUNT, String.valueOf(sessionCounter))
+                .add(RemoteSyncHandler.QUARKUS_PASSWORD,
+                        HashUtil.sha256(HashUtil.sha256(passwordHashInput) + SESSION + sessionCounter + PASSWORD));
+    }
+
+    private void invokeHandlePut(RemoteSyncHandler handler, HttpServerRequest request) throws Exception {
+        invoke(handler, "handlePut", request);
+    }
+
+    private void invokeHandleDelete(RemoteSyncHandler handler, HttpServerRequest request) throws Exception {
+        invoke(handler, "handleDelete", request);
+    }
+
+    private void invoke(RemoteSyncHandler handler, String methodName, HttpServerRequest request) throws Exception {
+        Method method = RemoteSyncHandler.class.getDeclaredMethod(methodName, HttpServerRequest.class);
+        method.setAccessible(true);
+        try {
+            method.invoke(handler, request);
+        } catch (InvocationTargetException e) {
+            if (e.getCause() instanceof Exception exception) {
+                throw exception;
+            }
+            throw e;
+        }
+    }
+}

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/devmode/RemoteSyncHandlerTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/devmode/RemoteSyncHandlerTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.vertx.http.runtime.devmode;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -69,6 +70,68 @@ class RemoteSyncHandlerTest {
         verify(context).deleteFile("/app/classes/com/acme/Foo.class");
     }
 
+    @Test
+    void rejectedPutReturnsBadRequest() throws Exception {
+        byte[] data = "content".getBytes(StandardCharsets.UTF_8);
+        var context = mock(HotReplacementContext.class);
+        doThrow(new IllegalArgumentException("outside root")).when(context)
+                .updateFile("/app/classes/com/acme/Foo.class", data);
+        var handler = new RemoteSyncHandler(PASSWORD, ignored -> {
+        }, context, "/root");
+        HttpServerRequest request = request("/root/app/classes/com/acme/Foo.class", data);
+
+        invokeHandlePut(handler, request);
+
+        verify(request.response()).setStatusCode(400);
+        verify(request.response()).end();
+    }
+
+    @Test
+    void rejectedDeleteReturnsBadRequest() throws Exception {
+        var context = mock(HotReplacementContext.class);
+        doThrow(new IllegalArgumentException("outside root")).when(context)
+                .deleteFile("/app/classes/com/acme/Foo.class");
+        var handler = new RemoteSyncHandler(PASSWORD, ignored -> {
+        }, context, "/root");
+        HttpServerRequest request = request("/root/app/classes/com/acme/Foo.class", null);
+
+        invokeHandleDelete(handler, request);
+
+        verify(request.response()).setStatusCode(400);
+        verify(request.response()).end();
+    }
+
+    @Test
+    void failedPutReturnsInternalServerError() throws Exception {
+        byte[] data = "content".getBytes(StandardCharsets.UTF_8);
+        var context = mock(HotReplacementContext.class);
+        doThrow(new IllegalStateException("write failed")).when(context)
+                .updateFile("/app/classes/com/acme/Foo.class", data);
+        var handler = new RemoteSyncHandler(PASSWORD, ignored -> {
+        }, context, "/root");
+        HttpServerRequest request = request("/root/app/classes/com/acme/Foo.class", data);
+
+        invokeHandlePut(handler, request);
+
+        verify(request.response()).setStatusCode(500);
+        verify(request.response()).end();
+    }
+
+    @Test
+    void failedDeleteReturnsInternalServerError() throws Exception {
+        var context = mock(HotReplacementContext.class);
+        doThrow(new IllegalStateException("delete failed")).when(context)
+                .deleteFile("/app/classes/com/acme/Foo.class");
+        var handler = new RemoteSyncHandler(PASSWORD, ignored -> {
+        }, context, "/root");
+        HttpServerRequest request = request("/root/app/classes/com/acme/Foo.class", null);
+
+        invokeHandleDelete(handler, request);
+
+        verify(request.response()).setStatusCode(500);
+        verify(request.response()).end();
+    }
+
     private HttpServerRequest request(String path, byte[] body) {
         RemoteSyncHandler.currentSession = SESSION;
         RemoteSyncHandler.currentSessionCounter = 0;
@@ -76,6 +139,8 @@ class RemoteSyncHandlerTest {
         var response = mock(HttpServerResponse.class);
         when(request.path()).thenReturn(path);
         when(request.response()).thenReturn(response);
+        when(response.setStatusCode(400)).thenReturn(response);
+        when(response.setStatusCode(500)).thenReturn(response);
         when(request.headers()).thenReturn(headers(path, body));
         when(request.bodyHandler(any())).thenAnswer(invocation -> {
             Handler<Buffer> bodyHandler = invocation.getArgument(0);


### PR DESCRIPTION
Remote dev currently routes deleted files through `updateFile(path, null)`. `RuntimeUpdatesProcessor.updateFile(...)` treats the payload as write data, so DELETE requests run into NPEs.

Add `HotReplacementContext.deleteFile(...)` and route remote dev `DELETE` requests through it. The runtime processor now keeps update/write handling separate from delete handling, while preserving the existing path normalization behavior.

Add focused tests for remote dev PUT/DELETE handling and `RuntimeUpdatesProcessor` file update/delete behavior.
