### PR TITLE
Fix `@RunOnVirtualThread` annotation in combination with blocking endpoints

### DIFF
--- a/docs/src/main/asciidoc/messaging-virtual-threads.adoc
+++ b/docs/src/main/asciidoc/messaging-virtual-threads.adoc
@@ -135,7 +135,7 @@ using `@RunOnVirtualThread` enforces concurrent message processing without prese
 
 === Methods signatures eligible to @RunOnVirtualThread
 
-Only method can be annotated with `@Blocking` can use `@RunOnVirtualThreads`.
+Only a method that can be annotated with `@Blocking` can use `@RunOnVirtualThread`.
 The eligible method signatures are:
 
 -  `@Outgoing("channel-out") O generator()`

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/ApplicationWithRunOnVirtualThreadNonBlockingTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/ApplicationWithRunOnVirtualThreadNonBlockingTest.java
@@ -15,15 +15,18 @@ import org.jboss.resteasy.reactive.common.processor.TargetJavaVersion;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.resteasy.reactive.server.spi.TargetJavaVersionBuildItem;
 import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
-import io.smallrye.common.annotation.Blocking;
+import io.smallrye.common.annotation.NonBlocking;
 import io.smallrye.common.annotation.RunOnVirtualThread;
 
-public class ApplicationWithRunOnVirtualThreadTest {
+@EnabledForJreRange(min = JRE.JAVA_19)
+public class ApplicationWithRunOnVirtualThreadNonBlockingTest {
 
     @RegisterExtension
     static QuarkusExtensionTest test = new QuarkusExtensionTest()
@@ -34,7 +37,10 @@ public class ApplicationWithRunOnVirtualThreadTest {
             .setLogRecordPredicate(record -> record.getLevel().equals(Level.SEVERE)
                     && record.getLoggerName()
                             .equals("org.jboss.resteasy.reactive.server.core.startup.RuntimeResourceDeployment"))
-            .assertLogRecords(records -> assertThat(records).extracting(LogRecord::getMessage).isEmpty())
+            .assertLogRecords(records -> assertThat(records).extracting(LogRecord::getMessage)
+                    .isNotEmpty()
+                    .allMatch(msg -> msg.startsWith(
+                            "a method was both @NonBlocking and @RunOnVirtualThread, it is now considered @RunOnVirtualThread and @Blocking")))
             .setArchiveProducer(new Supplier<>() {
                 @Override
                 public JavaArchive get() {
@@ -45,13 +51,7 @@ public class ApplicationWithRunOnVirtualThreadTest {
 
     @Test
     public void test() {
-        RestAssured.get("/tname/default")
-                .then().body(Matchers.containsString("virtual"), Matchers.not(Matchers.containsString("executor")));
-
-        RestAssured.get("/tname/blocking")
-                .then().body(Matchers.containsString("executor"), Matchers.not(Matchers.containsString("virtual")));
-
-        RestAssured.get("/tname/virtual")
+        RestAssured.get("/tname/nonblocking")
                 .then().body(Matchers.containsString("virtual"), Matchers.not(Matchers.containsString("executor")));
     }
 
@@ -63,23 +63,10 @@ public class ApplicationWithRunOnVirtualThreadTest {
     @Path("tname")
     public static class ThreadNameResource {
 
-        @Path("default")
+        @Path("nonblocking")
         @GET
+        @NonBlocking
         public String threadName() {
-            return Thread.currentThread().getName();
-        }
-
-        @Blocking
-        @Path("blocking")
-        @GET
-        public String blocking() {
-            return Thread.currentThread().getName();
-        }
-
-        @RunOnVirtualThread
-        @Path("virtual")
-        @GET
-        public String virtual() {
             return Thread.currentThread().getName();
         }
     }

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
@@ -943,7 +943,7 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
         if (defaultValue == BlockingDefault.BLOCKING) {
             return true;
         } else if (defaultValue == BlockingDefault.RUN_ON_VIRTUAL_THREAD) {
-            return false;
+            return true;
         } else if (defaultValue == BlockingDefault.NON_BLOCKING) {
             return false;
         }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
@@ -216,8 +216,8 @@ public class RuntimeResourceDeployment {
             } else {
                 if (method.isRunOnVirtualThread()) {
                     //should not happen
-                    log.error("a method was both non-blocking and @RunOnVirtualThread, it is now considered " +
-                            "@RunOnVirtual and blocking");
+                    log.error("a method was both @NonBlocking and @RunOnVirtualThread, it is now considered " +
+                            "@RunOnVirtualThread and @Blocking");
                     handlers.add(blockingHandlerVirtualThread);
                     score.add(ScoreSystem.Category.Execution, ScoreSystem.Diagnostic.ExecutionVirtualThread);
                 } else {


### PR DESCRIPTION
We recently learned that it is possible to configure all REST endpoints to use virtual threads without annotating every single endpoint with `@RunOnVirtualThread` by creating a JAX RS Application class in your application:

```java
import jakarta.ws.rs.core.Application;
import io.smallrye.common.annotation.RunOnVirtualThread;

@RunOnVirtualThread
public class RestApplication extends Application {
}
```

Also see the discussion on Zulip here https://quarkusio.zulipchat.com/#narrow/channel/187032-zulip-.26-coffee/topic/global-virtual-threads-config/near/609277909

However when your application starts your are spammed with the following errors:
`a method was both @NonBlocking and @RunOnVirtualThread, it is now considered @RunOnVirtualThread and @Blocking`

This is weird and probably a regression after #49218 got merged. `@RunOnVirtualThread` is already handled as blocking in the actual code for resteasy. And this is also mentioned in the reactive messaging guide here https://quarkus.io/guides/messaging-virtual-threads#use-the-runonvirtualthread-annotation

After this fix the error is only logged if you start combining `@RunOnVirtualThread` with `@NonBlocking` on an endpoint which is indeed legit according to the logic.

Also found two small misspellings of the annotation `@RunOnVirtualThread`
- Plural form -> `@RunOnVirtualThreads`
- Partial form - `@RunOnVirtual`

And this actually triggered me to have a deeper look into the error message.
