### PR TITLE
Add conditional test execution based on application properties

### DIFF
--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -706,6 +706,115 @@ match the value of `quarkus.test.profile.tags`.
 * `quarkus.test.profile.tags=test2,test3`: In this case only `MultipleTagsTest` will be run because `MultipleTagsTest` is the only `QuarkusTestProfile` implementation whose `tags` method
 matches the value of `quarkus.test.profile.tags`.
 
+== Conditional test execution based on application configuration
+
+Quarkus provides `@EnabledIfConfig` and `@DisabledIfConfig` annotations to conditionally enable or disable tests based on application configuration.
+These work similarly to JUnit's https://docs.junit.org/6.1.2/writing-tests/conditional-test-execution.html[`@EnabledIfSystemProperty` and `@DisabledIfSystemProperty`], but resolve values through the full MicroProfile Config system.
+This means that any registered `ConfigSource` is consulted, including `application.properties`, system properties, environment variables, and any custom config sources.
+
+Both annotations accept the following attributes:
+
+* `named` — the configuration key to look up
+* `matches` — a regular expression to match against the resolved value
+* `disabledReason` (optional) — a custom reason to display when the test is skipped
+
+=== `@EnabledIfConfig`
+
+`@EnabledIfConfig` enables a test only when the specified configuration key exists and its value matches the given regular expression.
+If the key is not defined, the test is **disabled**.
+
+[source,java]
+----
+@QuarkusTest
+@EnabledIfConfig(named = "my.feature.enabled", matches = "true") <1>
+public class FeatureEnabledTest {
+
+    @Test
+    public void testFeature() {
+        // runs only when my.feature.enabled=true
+    }
+}
+----
+<1> The test class is enabled only when `my.feature.enabled` resolves to `true`.
+
+You can also apply the annotation to individual methods:
+
+[source,java]
+----
+@QuarkusTest
+public class MixedTest {
+
+    @Test
+    @EnabledIfConfig(named = "db.type", matches = "postgresql")
+    public void postgresOnly() {
+        // runs only when db.type=postgresql
+    }
+
+    @Test
+    public void alwaysRuns() {
+        // runs regardless of configuration
+    }
+}
+----
+
+=== `@DisabledIfConfig`
+
+`@DisabledIfConfig` disables a test when the specified configuration key exists and its value matches the given regular expression.
+If the key is not defined, the test remains **enabled**.
+
+[source,java]
+----
+@QuarkusTest
+@DisabledIfConfig(named = "ci.slow.tests.skip", matches = "true",
+    disabledReason = "Slow tests are skipped in this CI environment") <1>
+public class SlowTest {
+
+    @Test
+    public void longRunningTest() {
+        // skipped when ci.slow.tests.skip=true
+    }
+}
+----
+<1> The optional `disabledReason` provides context when the test is skipped.
+
+=== Repeatable annotations
+
+Both annotations are `@Repeatable` and can be stacked on the same class or method, but the evaluation semantics differ:
+
+* **Multiple `@EnabledIfConfig`**: the test is enabled only when **all** conditions match (AND semantics). If any single condition does not match, the test is disabled.
+* **Multiple `@DisabledIfConfig`**: the test is disabled when **any** condition matches (OR semantics). The first matching condition disables the test.
+
+[source,java]
+----
+@QuarkusTest
+@EnabledIfConfig(named = "db.type", matches = "postgresql")
+@EnabledIfConfig(named = "test.integration", matches = "true")
+public class PostgresIntegrationTest {
+
+    @Test
+    public void test() {
+        // runs only when BOTH conditions are satisfied
+    }
+}
+----
+
+[source,java]
+----
+@QuarkusTest
+@DisabledIfConfig(named = "ci.skip.slow", matches = "true")
+@DisabledIfConfig(named = "ci.skip.db", matches = "true")
+public class SlowDatabaseTest {
+
+    @Test
+    public void test() {
+        // skipped if EITHER condition matches
+    }
+}
+----
+
+NOTE: These annotations are not `@Inherited`.
+If you need the same conditions on a subclass, redeclare the annotations on the subclass.
+
 == Nested Tests
 
 JUnit https://docs.junit.org/current/writing-tests/nested-tests.html[@Nested tests] are useful for structuring more complex test scenarios.

--- a/test-framework/junit-common/pom.xml
+++ b/test-framework/junit-common/pom.xml
@@ -32,6 +32,21 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.config</groupId>
+            <artifactId>smallrye-config</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/test-framework/junit-common/src/main/java/io/quarkus/test/junit/condition/DisabledIfConfig.java
+++ b/test-framework/junit-common/src/main/java/io/quarkus/test/junit/condition/DisabledIfConfig.java
@@ -1,0 +1,99 @@
+package io.quarkus.test.junit.condition;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.quarkus.test.junit.condition.DisabledIfConfig.DisabledIfConfigs;
+
+/**
+ * {@code @DisabledIfConfig} is used to signal that the annotated test
+ * class or test method is <em>disabled</em> if the value of the specified
+ * {@linkplain #named application property} matches the specified
+ * {@linkplain #matches regular expression}.
+ *
+ * <p>
+ * When declared at the class level, the result will apply to all test methods
+ * within that class as well.
+ *
+ * <p>
+ * This annotation is not {@link java.lang.annotation.Inherited @Inherited}.
+ * Consequently, if you wish to apply the same semantics to a subclass, this
+ * annotation must be redeclared on the subclass.
+ *
+ * <p>
+ * If a test method is disabled via this annotation, that prevents execution
+ * of the test method and method-level lifecycle callbacks such as
+ * {@code @BeforeEach} methods, {@code @AfterEach} methods, and corresponding
+ * extension APIs. However, that does not prevent the test class from being
+ * instantiated, and it does not prevent the execution of class-level lifecycle
+ * callbacks such as {@code @BeforeAll} methods, {@code @AfterAll} methods, and
+ * corresponding extension APIs.
+ *
+ * <p>
+ * If the specified application property is undefined, the presence of this
+ * annotation will have no effect on whether or not the class or method
+ * is disabled.
+ *
+ * <p>
+ * This annotation may be used as a meta-annotation in order to create a
+ * custom <em>composed annotation</em> that inherits the semantics of this
+ * annotation.
+ *
+ * <p>
+ * This annotation is a {@linkplain Repeatable repeatable} annotation and may
+ * be declared multiple times on an {@link java.lang.reflect.AnnotatedElement
+ * AnnotatedElement} such as a test interface, test class, or test method.
+ * Specifically, this annotation will be found if it is directly present,
+ * indirectly present, or meta-present on a given element.
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Repeatable(DisabledIfConfigs.class)
+@ExtendWith(DisabledIfConfigCondition.class)
+public @interface DisabledIfConfig {
+    /**
+     * Specifies the name of the application property that will be used
+     * as a condition for enabling the annotated element.
+     *
+     * @return the name of the application property to be evaluated for conditional activation
+     */
+    String named();
+
+    /**
+     * A regular expression that will be used to match against the retrieved
+     * value of the {@link #named} property.
+     *
+     * @return the regular expression; never <em>blank</em>
+     * @see String#matches(String)
+     * @see java.util.regex.Pattern
+     */
+    String matches();
+
+    /**
+     * Custom reason to provide if the test or container is disabled.
+     *
+     * <p>
+     * If a custom reason is supplied, it will be combined with the default
+     * reason for this annotation. If a custom reason is not supplied, the default
+     * reason will be used.
+     */
+    String disabledReason() default "";
+
+    @Target({ ElementType.TYPE, ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    @interface DisabledIfConfigs {
+        /**
+         * An array of {@link DisabledIfConfig} annotations that are used
+         * to specify conditional activation criteria based on application properties.
+         */
+        DisabledIfConfig[] value();
+    }
+}

--- a/test-framework/junit-common/src/main/java/io/quarkus/test/junit/condition/DisabledIfConfigCondition.java
+++ b/test-framework/junit-common/src/main/java/io/quarkus/test/junit/condition/DisabledIfConfigCondition.java
@@ -1,0 +1,51 @@
+package io.quarkus.test.junit.condition;
+
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
+
+import java.util.NoSuchElementException;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.platform.commons.util.Preconditions;
+
+class DisabledIfConfigCondition extends RepeatableAnnotationCondition<DisabledIfConfig> {
+    private static final ConditionEvaluationResult ENABLED = ConditionEvaluationResult.enabled(
+            "No @DisabledIfConfig conditions resulting in 'disabled' execution encountered");
+
+    DisabledIfConfigCondition() {
+        super(DisabledIfConfig.class);
+    }
+
+    @Override
+    protected ConditionEvaluationResult evaluate(DisabledIfConfig annotation) {
+        var name = annotation.named().strip();
+        var regex = annotation.matches();
+        Preconditions.notBlank(name, () -> "The 'named' attribute must not be blank in " + annotation);
+        Preconditions.notBlank(regex, () -> "The 'matches' attribute must not be blank in " + annotation);
+
+        try {
+            var actual = ConfigProvider.getConfig().getValue(name, String.class);
+
+            if (actual == null) {
+                return enabled("System property [%s] does not exist".formatted(name));
+            }
+
+            if (actual.matches(regex)) {
+                return disabled(
+                        "System property [%s] with value [%s] matches regular expression [%s]".formatted(name, actual, regex),
+                        annotation.disabledReason());
+            }
+
+            return enabled("System property [%s] with value [%s] does not match regular expression [%s]".formatted(name, actual,
+                    regex));
+        } catch (NoSuchElementException ex) {
+            return enabled("System property [%s] does not exist".formatted(name));
+        }
+    }
+
+    @Override
+    protected ConditionEvaluationResult getNoDisabledConditionsEncounteredResult() {
+        return ENABLED;
+    }
+}

--- a/test-framework/junit-common/src/main/java/io/quarkus/test/junit/condition/EnabledIfConfig.java
+++ b/test-framework/junit-common/src/main/java/io/quarkus/test/junit/condition/EnabledIfConfig.java
@@ -1,0 +1,98 @@
+package io.quarkus.test.junit.condition;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.quarkus.test.junit.condition.EnabledIfConfig.EnabledIfConfigs;
+
+/**
+ * {@code @EnabledIfConfig} is used to signal that the annotated test
+ * class or test method is only <em>enabled</em> if the value of the specified
+ * {@linkplain #named application property} matches the specified
+ * {@linkplain #matches regular expression}.
+ *
+ * <p>
+ * When declared at the class level, the result will apply to all test methods
+ * within that class as well.
+ *
+ * <p>
+ * This annotation is not {@link java.lang.annotation.Inherited @Inherited}.
+ * Consequently, if you wish to apply the same semantics to a subclass, this
+ * annotation must be redeclared on the subclass.
+ *
+ * <p>
+ * If a test method is disabled via this annotation, that prevents execution
+ * of the test method and method-level lifecycle callbacks such as
+ * {@code @BeforeEach} methods, {@code @AfterEach} methods, and corresponding
+ * extension APIs. However, that does not prevent the test class from being
+ * instantiated, and it does not prevent the execution of class-level lifecycle
+ * callbacks such as {@code @BeforeAll} methods, {@code @AfterAll} methods, and
+ * corresponding extension APIs.
+ *
+ * <p>
+ * If the specified application property is undefined, the annotated class or
+ * method will be disabled.
+ *
+ * <p>
+ * This annotation may be used as a meta-annotation in order to create a
+ * custom <em>composed annotation</em> that inherits the semantics of this
+ * annotation.
+ *
+ * <p>
+ * This annotation is a {@linkplain Repeatable repeatable} annotation and may
+ * be declared multiple times on an {@link java.lang.reflect.AnnotatedElement
+ * AnnotatedElement} such as a test interface, test class, or test method.
+ * Specifically, this annotation will be found if it is directly present,
+ * indirectly present, or meta-present on a given element.
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Repeatable(EnabledIfConfigs.class)
+@ExtendWith(EnabledIfConfigCondition.class)
+public @interface EnabledIfConfig {
+    /**
+     * Specifies the name of the application property that will be used
+     * as a condition for enabling the annotated element.
+     *
+     * @return the name of the application property to be evaluated for conditional activation
+     */
+    String named();
+
+    /**
+     * A regular expression that will be used to match against the retrieved
+     * value of the {@link #named} property.
+     *
+     * @return the regular expression; never <em>blank</em>
+     * @see String#matches(String)
+     * @see java.util.regex.Pattern
+     */
+    String matches();
+
+    /**
+     * Custom reason to provide if the test or container is disabled.
+     *
+     * <p>
+     * If a custom reason is supplied, it will be combined with the default
+     * reason for this annotation. If a custom reason is not supplied, the default
+     * reason will be used.
+     */
+    String disabledReason() default "";
+
+    @Target({ ElementType.TYPE, ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    @interface EnabledIfConfigs {
+        /**
+         * An array of {@link EnabledIfConfig} annotations that are used
+         * to specify conditional activation criteria based on application properties.
+         */
+        EnabledIfConfig[] value();
+    }
+}

--- a/test-framework/junit-common/src/main/java/io/quarkus/test/junit/condition/EnabledIfConfigCondition.java
+++ b/test-framework/junit-common/src/main/java/io/quarkus/test/junit/condition/EnabledIfConfigCondition.java
@@ -1,0 +1,42 @@
+package io.quarkus.test.junit.condition;
+
+import java.util.NoSuchElementException;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.platform.commons.util.Preconditions;
+
+class EnabledIfConfigCondition extends RepeatableAnnotationCondition<EnabledIfConfig> {
+    private static final ConditionEvaluationResult ENABLED = ConditionEvaluationResult
+            .enabled("No @EnabledIfConfig conditions resulting in 'disabled' execution encountered");
+
+    EnabledIfConfigCondition() {
+        super(EnabledIfConfig.class);
+    }
+
+    @Override
+    protected ConditionEvaluationResult evaluate(EnabledIfConfig annotation) {
+        var name = annotation.named();
+        var regex = annotation.matches();
+        Preconditions.notBlank(name, () -> "The 'named' attribute must not be blank in " + annotation);
+        Preconditions.notBlank(regex, () -> "The 'matches' attribute must not be blank in " + annotation);
+
+        try {
+            var actual = ConfigProvider.getConfig().getValue(name, String.class);
+
+            return actual.matches(regex)
+                    ? ConditionEvaluationResult.enabled(
+                            "Property [%s] with value [%s] matches regular expression [%s]".formatted(name, actual, regex))
+                    : ConditionEvaluationResult.disabled("Property [%s] with value [%s] does not match regular expression [%s]"
+                            .formatted(name, actual, regex), annotation.disabledReason());
+        } catch (NoSuchElementException ex) {
+            return ConditionEvaluationResult.disabled("Property [%s] does not exist".formatted(name),
+                    annotation.disabledReason());
+        }
+    }
+
+    @Override
+    protected ConditionEvaluationResult getNoDisabledConditionsEncounteredResult() {
+        return ENABLED;
+    }
+}

--- a/test-framework/junit-common/src/main/java/io/quarkus/test/junit/condition/RepeatableAnnotationCondition.java
+++ b/test-framework/junit-common/src/main/java/io/quarkus/test/junit/condition/RepeatableAnnotationCondition.java
@@ -1,0 +1,49 @@
+package io.quarkus.test.junit.condition;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Repeatable;
+import java.lang.reflect.AnnotatedElement;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.support.AnnotationSupport;
+
+/**
+ * Base class for {@link ExecutionCondition} implementations that support {@linkplain Repeatable repeatable} annotations.
+ *
+ * @param <A> the type of repeatable annotation supported by this {@code ExecutionCondition}
+ */
+public abstract class RepeatableAnnotationCondition<A extends Annotation> implements ExecutionCondition {
+    private final Class<A> annotationType;
+
+    public RepeatableAnnotationCondition(Class<A> annotationType) {
+        this.annotationType = annotationType;
+    }
+
+    @Override
+    public final ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+        Optional<AnnotatedElement> optionalElement = context.getElement();
+
+        if (optionalElement.isPresent()) {
+            AnnotatedElement annotatedElement = optionalElement.get();
+            List<A> repeatableAnnotations = AnnotationSupport.findRepeatableAnnotations(annotatedElement, this.annotationType);
+
+            for (A annotation : repeatableAnnotations) {
+                ConditionEvaluationResult result = evaluate(annotation);
+
+                if (result.isDisabled()) {
+                    return result;
+                }
+            }
+        }
+
+        return getNoDisabledConditionsEncounteredResult();
+    }
+
+    protected abstract ConditionEvaluationResult evaluate(A annotation);
+
+    protected abstract ConditionEvaluationResult getNoDisabledConditionsEncounteredResult();
+}

--- a/test-framework/junit-common/src/test/java/io/quarkus/test/junit/condition/DisabledIfConfigConditionTest.java
+++ b/test-framework/junit-common/src/test/java/io/quarkus/test/junit/condition/DisabledIfConfigConditionTest.java
@@ -1,0 +1,107 @@
+package io.quarkus.test.junit.condition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.OPTIONAL;
+import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+
+final class DisabledIfConfigConditionTest {
+
+    private final DisabledIfConfigCondition condition = new DisabledIfConfigCondition();
+
+    @DisabledIfConfig(named = "disabled.if.config.test.property", matches = "target-value")
+    private static class ExactMatch {
+    }
+
+    @DisabledIfConfig(named = "disabled.if.config.test.property", matches = "other-value")
+    private static class NoMatch {
+    }
+
+    @DisabledIfConfig(named = "disabled.if.config.nonexistent.property", matches = ".*")
+    private static class MissingProperty {
+    }
+
+    @DisabledIfConfig(named = "disabled.if.config.test.property", matches = "target.*")
+    private static class RegexMatch {
+    }
+
+    @DisabledIfConfig(named = "disabled.if.config.test.property", matches = "^other.*$")
+    private static class RegexNoMatch {
+    }
+
+    @DisabledIfConfig(named = " disabled.if.config.test.property ", matches = "target-value")
+    private static class WhitespaceInName {
+    }
+
+    @Test
+    void disabledWhenPropertyMatchesExactValue() {
+        assertThat(condition.evaluate(annotationFrom(ExactMatch.class)))
+                .isNotNull()
+                .satisfies(result -> assertThat(result.isDisabled()).isTrue())
+                .extracting(ConditionEvaluationResult::getReason)
+                .asInstanceOf(OPTIONAL)
+                .get(STRING)
+                .contains("matches regular expression");
+    }
+
+    @Test
+    void enabledWhenPropertyDoesNotMatch() {
+        assertThat(condition.evaluate(annotationFrom(NoMatch.class)))
+                .isNotNull()
+                .satisfies(result -> assertThat(result.isDisabled()).isFalse())
+                .extracting(ConditionEvaluationResult::getReason)
+                .asInstanceOf(OPTIONAL)
+                .get(STRING)
+                .contains("does not match regular expression");
+    }
+
+    @Test
+    void enabledWhenPropertyDoesNotExist() {
+        assertThat(condition.evaluate(annotationFrom(MissingProperty.class)))
+                .isNotNull()
+                .satisfies(result -> assertThat(result.isDisabled()).isFalse())
+                .extracting(ConditionEvaluationResult::getReason)
+                .asInstanceOf(OPTIONAL)
+                .get(STRING)
+                .contains("does not exist");
+    }
+
+    @Test
+    void disabledWhenPropertyMatchesRegex() {
+        assertThat(condition.evaluate(annotationFrom(RegexMatch.class)))
+                .isNotNull()
+                .satisfies(result -> assertThat(result.isDisabled()).isTrue())
+                .extracting(ConditionEvaluationResult::getReason)
+                .asInstanceOf(OPTIONAL)
+                .get(STRING)
+                .contains("matches regular expression");
+    }
+
+    @Test
+    void enabledWhenPropertyDoesNotMatchRegex() {
+        assertThat(condition.evaluate(annotationFrom(RegexNoMatch.class)))
+                .isNotNull()
+                .satisfies(result -> assertThat(result.isDisabled()).isFalse())
+                .extracting(ConditionEvaluationResult::getReason)
+                .asInstanceOf(OPTIONAL)
+                .get(STRING)
+                .contains("does not match regular expression");
+    }
+
+    @Test
+    void disabledWhenPropertyNameHasWhitespace() {
+        assertThat(condition.evaluate(annotationFrom(WhitespaceInName.class)))
+                .isNotNull()
+                .satisfies(result -> assertThat(result.isDisabled()).isTrue())
+                .extracting(ConditionEvaluationResult::getReason)
+                .asInstanceOf(OPTIONAL)
+                .get(STRING)
+                .contains("matches regular expression");
+    }
+
+    private static DisabledIfConfig annotationFrom(Class<?> source) {
+        return source.getAnnotation(DisabledIfConfig.class);
+    }
+}

--- a/test-framework/junit-common/src/test/java/io/quarkus/test/junit/condition/DisabledIfConfigRepeatedTest.java
+++ b/test-framework/junit-common/src/test/java/io/quarkus/test/junit/condition/DisabledIfConfigRepeatedTest.java
@@ -1,0 +1,62 @@
+package io.quarkus.test.junit.condition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Proxy;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+final class DisabledIfConfigRepeatedTest {
+
+    private final DisabledIfConfigCondition condition = new DisabledIfConfigCondition();
+
+    @DisabledIfConfig(named = "disabled.if.config.repeated.prop1", matches = "one")
+    @DisabledIfConfig(named = "disabled.if.config.repeated.prop2", matches = "no-match")
+    private static class FirstMatches {
+    }
+
+    @DisabledIfConfig(named = "disabled.if.config.repeated.prop1", matches = "no-match")
+    @DisabledIfConfig(named = "disabled.if.config.repeated.prop2", matches = "two")
+    private static class SecondMatches {
+    }
+
+    @DisabledIfConfig(named = "disabled.if.config.repeated.prop1", matches = "wrong")
+    @DisabledIfConfig(named = "disabled.if.config.repeated.prop2", matches = "also-wrong")
+    private static class NoneMatch {
+    }
+
+    @Test
+    void disabledWhenFirstConditionMatches() {
+        assertThat(condition.evaluateExecutionCondition(extensionContextFor(FirstMatches.class)))
+                .isNotNull()
+                .satisfies(result -> assertThat(result.isDisabled()).isTrue());
+    }
+
+    @Test
+    void disabledWhenSecondConditionMatches() {
+        assertThat(condition.evaluateExecutionCondition(extensionContextFor(SecondMatches.class)))
+                .isNotNull()
+                .satisfies(result -> assertThat(result.isDisabled()).isTrue());
+    }
+
+    @Test
+    void enabledWhenNoConditionsMatch() {
+        assertThat(condition.evaluateExecutionCondition(extensionContextFor(NoneMatch.class)))
+                .isNotNull()
+                .satisfies(result -> assertThat(result.isDisabled()).isFalse());
+    }
+
+    private static ExtensionContext extensionContextFor(Class<?> annotatedElement) {
+        return (ExtensionContext) Proxy.newProxyInstance(
+                ExtensionContext.class.getClassLoader(),
+                new Class<?>[] { ExtensionContext.class },
+                (proxy, method, args) -> {
+                    if ("getElement".equals(method.getName())) {
+                        return Optional.of(annotatedElement);
+                    }
+                    return null;
+                });
+    }
+}

--- a/test-framework/junit-common/src/test/java/io/quarkus/test/junit/condition/EnabledIfConfigConditionTest.java
+++ b/test-framework/junit-common/src/test/java/io/quarkus/test/junit/condition/EnabledIfConfigConditionTest.java
@@ -1,0 +1,92 @@
+package io.quarkus.test.junit.condition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.OPTIONAL;
+import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+
+final class EnabledIfConfigConditionTest {
+
+    private final EnabledIfConfigCondition condition = new EnabledIfConfigCondition();
+
+    @EnabledIfConfig(named = "enabled.if.config.test.property", matches = "expected-value")
+    private static class ExactMatch {
+    }
+
+    @EnabledIfConfig(named = "enabled.if.config.test.property", matches = "wrong-value")
+    private static class NoMatch {
+    }
+
+    @EnabledIfConfig(named = "enabled.if.config.nonexistent.property", matches = ".*")
+    private static class MissingProperty {
+    }
+
+    @EnabledIfConfig(named = "enabled.if.config.test.property", matches = "expected.*")
+    private static class RegexMatch {
+    }
+
+    @EnabledIfConfig(named = "enabled.if.config.test.property", matches = "^other.*$")
+    private static class RegexNoMatch {
+    }
+
+    @Test
+    void enabledWhenPropertyMatchesExactValue() {
+        assertThat(condition.evaluate(annotationFrom(ExactMatch.class)))
+                .isNotNull()
+                .satisfies(result -> assertThat(result.isDisabled()).isFalse())
+                .extracting(ConditionEvaluationResult::getReason)
+                .asInstanceOf(OPTIONAL)
+                .get(STRING)
+                .contains("matches regular expression");
+    }
+
+    @Test
+    void disabledWhenPropertyDoesNotMatch() {
+        assertThat(condition.evaluate(annotationFrom(NoMatch.class)))
+                .isNotNull()
+                .satisfies(result -> assertThat(result.isDisabled()).isTrue())
+                .extracting(ConditionEvaluationResult::getReason)
+                .asInstanceOf(OPTIONAL)
+                .get(STRING)
+                .contains("does not match regular expression");
+    }
+
+    @Test
+    void disabledWhenPropertyDoesNotExist() {
+        assertThat(condition.evaluate(annotationFrom(MissingProperty.class)))
+                .isNotNull()
+                .satisfies(result -> assertThat(result.isDisabled()).isTrue())
+                .extracting(ConditionEvaluationResult::getReason)
+                .asInstanceOf(OPTIONAL)
+                .get(STRING)
+                .contains("does not exist");
+    }
+
+    @Test
+    void enabledWhenPropertyMatchesRegex() {
+        assertThat(condition.evaluate(annotationFrom(RegexMatch.class)))
+                .isNotNull()
+                .satisfies(result -> assertThat(result.isDisabled()).isFalse())
+                .extracting(ConditionEvaluationResult::getReason)
+                .asInstanceOf(OPTIONAL)
+                .get(STRING)
+                .contains("matches regular expression");
+    }
+
+    @Test
+    void disabledWhenPropertyDoesNotMatchRegex() {
+        assertThat(condition.evaluate(annotationFrom(RegexNoMatch.class)))
+                .isNotNull()
+                .satisfies(result -> assertThat(result.isDisabled()).isTrue())
+                .extracting(ConditionEvaluationResult::getReason)
+                .asInstanceOf(OPTIONAL)
+                .get(STRING)
+                .contains("does not match regular expression");
+    }
+
+    private static EnabledIfConfig annotationFrom(Class<?> source) {
+        return source.getAnnotation(EnabledIfConfig.class);
+    }
+}

--- a/test-framework/junit-common/src/test/java/io/quarkus/test/junit/condition/EnabledIfConfigRepeatedTest.java
+++ b/test-framework/junit-common/src/test/java/io/quarkus/test/junit/condition/EnabledIfConfigRepeatedTest.java
@@ -1,0 +1,62 @@
+package io.quarkus.test.junit.condition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Proxy;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+final class EnabledIfConfigRepeatedTest {
+
+    private final EnabledIfConfigCondition condition = new EnabledIfConfigCondition();
+
+    @EnabledIfConfig(named = "enabled.if.config.repeated.prop1", matches = "alpha")
+    @EnabledIfConfig(named = "enabled.if.config.repeated.prop2", matches = "beta")
+    private static class AllMatch {
+    }
+
+    @EnabledIfConfig(named = "enabled.if.config.repeated.prop1", matches = "alpha")
+    @EnabledIfConfig(named = "enabled.if.config.repeated.prop2", matches = "wrong")
+    private static class SecondDoesNotMatch {
+    }
+
+    @EnabledIfConfig(named = "enabled.if.config.repeated.prop1", matches = "wrong")
+    @EnabledIfConfig(named = "enabled.if.config.repeated.prop2", matches = "beta")
+    private static class FirstDoesNotMatch {
+    }
+
+    @Test
+    void enabledWhenAllConditionsMatch() {
+        assertThat(condition.evaluateExecutionCondition(extensionContextFor(AllMatch.class)))
+                .isNotNull()
+                .satisfies(result -> assertThat(result.isDisabled()).isFalse());
+    }
+
+    @Test
+    void disabledWhenOneConditionDoesNotMatch() {
+        assertThat(condition.evaluateExecutionCondition(extensionContextFor(SecondDoesNotMatch.class)))
+                .isNotNull()
+                .satisfies(result -> assertThat(result.isDisabled()).isTrue());
+    }
+
+    @Test
+    void disabledWhenFirstConditionDoesNotMatch() {
+        assertThat(condition.evaluateExecutionCondition(extensionContextFor(FirstDoesNotMatch.class)))
+                .isNotNull()
+                .satisfies(result -> assertThat(result.isDisabled()).isTrue());
+    }
+
+    private static ExtensionContext extensionContextFor(Class<?> annotatedElement) {
+        return (ExtensionContext) Proxy.newProxyInstance(
+                ExtensionContext.class.getClassLoader(),
+                new Class<?>[] { ExtensionContext.class },
+                (proxy, method, args) -> {
+                    if ("getElement".equals(method.getName())) {
+                        return Optional.of(annotatedElement);
+                    }
+                    return null;
+                });
+    }
+}

--- a/test-framework/junit-common/src/test/resources/META-INF/microprofile-config.properties
+++ b/test-framework/junit-common/src/test/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,6 @@
+enabled.if.config.test.property=expected-value
+enabled.if.config.repeated.prop1=alpha
+enabled.if.config.repeated.prop2=beta
+disabled.if.config.test.property=target-value
+disabled.if.config.repeated.prop1=one
+disabled.if.config.repeated.prop2=two


### PR DESCRIPTION
Introduce `@EnabledIfApplicationProperty` and `@DisabledIfApplicationProperty` annotations, along with their supporting conditions, to conditionally enable or disable test execution based on application property values.

Modeled after JUnit's `@EnabledIfSystemProperty` and `@DisabledIfSystemProperty` annotations & implementations.