### PR TITLE
Enable previously disabled test

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/DefaultReflectionFreeSerializerTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/DefaultReflectionFreeSerializerTest.java
@@ -13,7 +13,6 @@ import jakarta.ws.rs.Path;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -23,7 +22,6 @@ import io.quarkus.resteasy.reactive.jackson.DisableSecureSerialization;
 import io.quarkus.test.QuarkusExtensionTest;
 import io.smallrye.common.annotation.NonBlocking;
 
-@Disabled("This needs to be disable until we make the reflection-free serializers the default")
 public class DefaultReflectionFreeSerializerTest {
 
     @RegisterExtension


### PR DESCRIPTION
This test can be re-enabled now that the
reflection-free serializers are the default