### PR TITLE
Add gRPC server max-connection-age configuration

### DIFF
--- a/docs/src/main/asciidoc/grpc-kubernetes.adoc
+++ b/docs/src/main/asciidoc/grpc-kubernetes.adoc
@@ -92,3 +92,19 @@ If your application does not use any Quarkus extension that exposes an HTTP serv
 ----
 quarkus.kubernetes.readiness-probe.grpc-action-enabled=true
 ----
+
+== Client-side load balancing and long-lived connections
+
+gRPC uses long-lived HTTP/2 connections.
+When you scale out your service, existing clients keep using their established connections and do not notice the new instances (see https://kubernetes.io/blog/2018/11/07/grpc-load-balancing-on-kubernetes-without-tears/[gRPC Load Balancing on Kubernetes without Tears]).
+
+To force clients to periodically re-establish their connections, and thus to re-resolve and pick up new instances, configure a maximum connection age (the gRPC https://grpc.io/docs/guides/keepalive/[`MAX_CONNECTION_AGE`] setting).
+Once a connection reaches its maximum age, the server sends a `GOAWAY` frame, and the client transparently opens a new connection for subsequent calls:
+
+[source,properties]
+----
+quarkus.grpc.server.max-connection-age=5m <1>
+quarkus.grpc.server.max-connection-age-grace=1m <2>
+----
+<1> Maximum time a connection may exist. A jitter of ±10% is applied to avoid all connections being shut down at the same time.
+<2> Grace period given to in-flight calls to complete after the connection reaches its maximum age. When not set, in-flight calls are given an unlimited amount of time to complete.

--- a/docs/src/main/asciidoc/grpc-kubernetes.adoc
+++ b/docs/src/main/asciidoc/grpc-kubernetes.adoc
@@ -91,3 +91,19 @@ If your application does not use any Quarkus extension that exposes an HTTP serv
 ----
 quarkus.kubernetes.readiness-probe.grpc-action-enabled=true
 ----
+
+== Client-side load balancing and long-lived connections
+
+gRPC uses long-lived HTTP/2 connections.
+When you scale out your service, existing clients keep using their established connections and do not notice the new instances (see https://kubernetes.io/blog/2018/11/07/grpc-load-balancing-on-kubernetes-without-tears/[gRPC Load Balancing on Kubernetes without Tears]).
+
+To force clients to periodically re-establish their connections, and thus to re-resolve and pick up new instances, configure a maximum connection age (the gRPC https://grpc.io/docs/guides/keepalive/[`MAX_CONNECTION_AGE`] setting).
+Once a connection reaches its maximum age, the server sends a `GOAWAY` frame, and the client transparently opens a new connection for subsequent calls:
+
+[source,properties]
+----
+quarkus.grpc.server.max-connection-age=5m <1>
+quarkus.grpc.server.max-connection-age-grace=1m <2>
+----
+<1> Maximum time a connection may exist. A jitter of ±10% is applied to avoid all connections being shut down at the same time.
+<2> Grace period given to in-flight calls to complete after the connection reaches its maximum age. When not set, in-flight calls are given an unlimited amount of time to complete.

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcServerRecorder.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcServerRecorder.java
@@ -229,11 +229,16 @@ public class GrpcServerRecorder {
 
         LOGGER.info("Enabling gRPC server");
 
+        MaxConnectionAgeEnforcer maxConnectionAgeEnforcer = MaxConnectionAgeEnforcer.of(vertx, configuration);
+
         Route route = router.route()
                 .handler(ctx -> {
                     if (!isGrpc(ctx)) {
                         ctx.next();
                     } else {
+                        if (maxConnectionAgeEnforcer != null) {
+                            maxConnectionAgeEnforcer.register(ctx.request().connection());
+                        }
                         if (securityPresent) {
                             GrpcSecurityInterceptor.propagateSecurityIdentityWithDuplicatedCtx(ctx);
                         }

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcServerRecorder.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcServerRecorder.java
@@ -222,11 +222,16 @@ public class GrpcServerRecorder {
 
         LOGGER.info("Enabling gRPC server");
 
+        MaxConnectionAgeEnforcer maxConnectionAgeEnforcer = MaxConnectionAgeEnforcer.of(vertx, configuration);
+
         Route route = router.route()
                 .handler(ctx -> {
                     if (!isGrpc(ctx)) {
                         ctx.next();
                     } else {
+                        if (maxConnectionAgeEnforcer != null) {
+                            maxConnectionAgeEnforcer.register(ctx.request().connection());
+                        }
                         if (securityPresent) {
                             GrpcSecurityInterceptor.propagateSecurityIdentityWithDuplicatedCtx(ctx);
                         }

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/MaxConnectionAgeEnforcer.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/MaxConnectionAgeEnforcer.java
@@ -1,0 +1,74 @@
+package io.quarkus.grpc.runtime;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.grpc.runtime.config.GrpcServerConfiguration;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpConnection;
+
+/**
+ * Enforces the gRPC {@code MAX_CONNECTION_AGE} and {@code MAX_CONNECTION_AGE_GRACE} semantics for
+ * connections carrying gRPC traffic.
+ * <p>
+ * When a connection reaches the configured maximum age, a graceful shutdown is initiated: a
+ * {@code GOAWAY} frame is sent so the client opens a new connection, in-flight calls are given the
+ * configured grace period to complete, and then the connection is closed.
+ */
+final class MaxConnectionAgeEnforcer {
+
+    private static final Logger LOGGER = Logger.getLogger(MaxConnectionAgeEnforcer.class.getName());
+
+    /**
+     * Grace period used when {@code max-connection-age-grace} is not set, mimicking the "infinite"
+     * default of gRPC's {@code MAX_CONNECTION_AGE_GRACE}.
+     */
+    private static final Duration UNLIMITED_GRACE = Duration.ofDays(365);
+
+    private final Vertx vertx;
+    private final long maxAgeMillis;
+    private final Duration grace;
+    private final Set<HttpConnection> trackedConnections = ConcurrentHashMap.newKeySet();
+
+    private MaxConnectionAgeEnforcer(Vertx vertx, Duration maxAge, Duration grace) {
+        this.vertx = vertx;
+        this.maxAgeMillis = Math.max(1, maxAge.toMillis());
+        this.grace = grace;
+    }
+
+    /**
+     * @return an enforcer for the given configuration, or {@code null} if {@code max-connection-age} is not set
+     */
+    static MaxConnectionAgeEnforcer of(Vertx vertx, GrpcServerConfiguration configuration) {
+        if (configuration.maxConnectionAge().isEmpty()) {
+            return null;
+        }
+        return new MaxConnectionAgeEnforcer(vertx, configuration.maxConnectionAge().get(),
+                configuration.maxConnectionAgeGrace().orElse(UNLIMITED_GRACE));
+    }
+
+    /**
+     * Starts tracking the given connection if it is not tracked yet, scheduling its graceful shutdown
+     * once it reaches the maximum connection age.
+     */
+    void register(HttpConnection connection) {
+        if (!trackedConnections.add(connection)) {
+            return;
+        }
+        // Apply a +/-10% jitter, like grpc-java, to avoid all connections being shut down at the same time
+        double jitterFactor = 0.9 + ThreadLocalRandom.current().nextDouble() * 0.2;
+        long delay = Math.max(1, (long) (maxAgeMillis * jitterFactor));
+        // The tracking entry is removed when the timer fires instead of using a close handler:
+        // HttpConnection only holds a single close handler and other components (e.g. the HTTP connection
+        // limiter) may have registered one already. Shutting down an already closed connection is a no-op.
+        vertx.setTimer(delay, ignored -> {
+            trackedConnections.remove(connection);
+            LOGGER.debugf("gRPC connection reached its maximum age (%d ms), initiating graceful shutdown", maxAgeMillis);
+            connection.shutdown(grace);
+        });
+    }
+}

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/GrpcServerConfiguration.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/GrpcServerConfiguration.java
@@ -1,5 +1,6 @@
 package io.quarkus.grpc.runtime.config;
 
+import java.time.Duration;
 import java.util.Optional;
 import java.util.OptionalInt;
 
@@ -13,6 +14,30 @@ public interface GrpcServerConfiguration {
      * The max inbound message size in bytes.
      */
     OptionalInt maxInboundMessageSize();
+
+    /**
+     * The maximum time a connection may exist before it is gracefully shut down (the gRPC
+     * {@code MAX_CONNECTION_AGE} setting).
+     * <p>
+     * When a connection reaches this age, the server sends a {@code GOAWAY} frame so that the client
+     * re-establishes a new connection. This is useful in Kubernetes environments where long-lived HTTP/2
+     * connections prevent clients from discovering new server instances.
+     * <p>
+     * A jitter of ±10% is applied to avoid connection storms.
+     * If not set, connections have an unlimited lifetime.
+     */
+    Optional<Duration> maxConnectionAge();
+
+    /**
+     * The grace period given to in-flight calls to complete after the connection reaches its maximum age
+     * (the gRPC {@code MAX_CONNECTION_AGE_GRACE} setting).
+     * <p>
+     * Once the grace period expires, remaining calls are cancelled and the connection is closed.
+     * If not set, in-flight calls are given an unlimited amount of time to complete.
+     * <p>
+     * This setting is only effective when {@code quarkus.grpc.server.max-connection-age} is set.
+     */
+    Optional<Duration> maxConnectionAgeGrace();
 
     /**
      * Enables the gRPC Reflection Service.


### PR DESCRIPTION
Long-lived gRPC HTTP/2 connections prevent clients from discovering new server instances when scaling out in Kubernetes. This adds `quarkus.grpc.server.max-connection-age` and `quarkus.grpc.server.max-connection-age-grace` so the server can periodically send a GOAWAY frame and gracefully close connections, matching gRPC's `MAX_CONNECTION_AGE` and `MAX_CONNECTION_AGE_GRACE` semantics via Vert.x 5's `HttpConnection.shutdown(Duration)`.

- Closes: #41263

Release note: gRPC server connections can now be configured with `quarkus.grpc.server.max-connection-age` and `quarkus.grpc.server.max-connection-age-grace` to force clients to periodically reconnect, which helps with client-side load balancing in Kubernetes.
