### PR TITLE
Fix NPE in modularity when processing removed resources

### DIFF
--- a/extensions/packaging/modular/deployment/src/main/java/io/quarkus/modular/deployment/ModularitySteps.java
+++ b/extensions/packaging/modular/deployment/src/main/java/io/quarkus/modular/deployment/ModularitySteps.java
@@ -251,15 +251,26 @@ public final class ModularitySteps {
         for (Set<TransformedClassesBuildItem.TransformedClass> set : transformedClasses.getTransformedClassesByJar().values()) {
             for (TransformedClassesBuildItem.TransformedClass tc : set) {
                 String bn = tc.getClassName();
+                String fileName = tc.getFileName();
                 String pn;
-                int idx = bn.lastIndexOf('.');
-                if (idx == -1) {
-                    pn = "";
+                if (bn == null) {
+                    // a removed resource rather than a transformed class (see TransformedClassesBuildItem);
+                    // derive the package from the resource path, as is done for generated resources above
+                    int idx = fileName.lastIndexOf('/');
+                    if (idx == -1) {
+                        pn = "";
+                    } else {
+                        pn = fileName.substring(0, idx).replace('/', '.');
+                    }
                 } else {
-                    pn = bn.substring(0, idx);
+                    int idx = bn.lastIndexOf('.');
+                    if (idx == -1) {
+                        pn = "";
+                    } else {
+                        pn = bn.substring(0, idx);
+                    }
                 }
                 // replace any existing entry
-                String fileName = tc.getFileName();
                 byte[] data = tc.getData();
                 if (data == null) {
                     // TODO


### PR DESCRIPTION
`TransformedClassesBuildItem.TransformedClass` is also used to represent removed resources, with a null class name and null data. OpenTelemetry produces such entries for SPI service files it removes. `ModularitySteps` assumed every transformed entry had a class name and NPE'd when building a jlink image.

Derive the package from the resource path when the class name is null, matching how generated resources are already handled.

- Fixes: #55385
