### PR TITLE
Ignore unresolvable POMs for bundled CycloneDX components

### DIFF
--- a/extensions/cyclonedx/generator/src/main/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGenerator.java
+++ b/extensions/cyclonedx/generator/src/main/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGenerator.java
@@ -390,6 +390,10 @@ public class CycloneDxSbomGenerator {
     }
 
     private Component renderComponentCore(ComponentDescriptor descriptor) {
+        return renderComponentCore(descriptor, false);
+    }
+
+    private Component renderComponentCore(ComponentDescriptor descriptor, boolean bundled) {
         Component c = new Component();
 
         // Identity from Purl
@@ -419,7 +423,7 @@ public class CycloneDxSbomGenerator {
 
         // POM metadata for Maven components
         if (Purl.TYPE_MAVEN.equals(purl.getType())) {
-            addPomMetadata(toArtifactCoords(purl), c);
+            addPomMetadata(toArtifactCoords(purl), c, bundled);
         }
 
         // Evidence/occurrence from distribution path
@@ -470,7 +474,7 @@ public class CycloneDxSbomGenerator {
 
         // Nested (bundled) components
         for (ComponentDescriptor nested : descriptor.getComponents()) {
-            c.addComponent(renderComponentCore(nested));
+            c.addComponent(renderComponentCore(nested, true));
         }
 
         c.setProperties(props);
@@ -511,7 +515,31 @@ public class CycloneDxSbomGenerator {
     }
 
     private void addPomMetadata(ArtifactCoords dep, org.cyclonedx.model.Component component) {
-        var model = modelResolver == null ? null : modelResolver.resolveEffectiveModel(dep);
+        addPomMetadata(dep, component, false);
+    }
+
+    private void addPomMetadata(ArtifactCoords dep, org.cyclonedx.model.Component component, boolean bundled) {
+        if (modelResolver == null) {
+            return;
+        }
+        final Model model;
+        if (bundled) {
+            // Bundled (shaded) components are discovered from pom.properties entries found inside JARs.
+            // Their POMs may not be available in any configured repository (e.g. build-time-only artifacts
+            // that were shaded into a published JAR), so a resolution failure must not fail the build.
+            try {
+                model = modelResolver.resolveEffectiveModel(dep);
+            } catch (Exception e) {
+                log.warnf(
+                        "Failed to resolve the effective model of the bundled component %s; "
+                                + "SBOM will omit POM metadata for this component",
+                        dep.toCompactCoords());
+                log.debug("Failed to resolve the effective model of the bundled component " + dep.toCompactCoords(), e);
+                return;
+            }
+        } else {
+            model = modelResolver.resolveEffectiveModel(dep);
+        }
         if (model != null) {
             extractComponentMetadata(model, component);
         }

--- a/extensions/cyclonedx/generator/src/test/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGeneratorTest.java
+++ b/extensions/cyclonedx/generator/src/test/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGeneratorTest.java
@@ -9,6 +9,7 @@ import org.cyclonedx.model.Bom;
 import org.cyclonedx.model.Dependency;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.bootstrap.resolver.maven.EffectiveModelResolver;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.maven.dependency.ResolvedDependencyBuilder;
@@ -298,6 +299,42 @@ class CycloneDxSbomGeneratorTest {
         assertThat(nestedComp.getName()).isEqualTo("bundled-dep");
         assertThat(nestedComp.getGroup()).isEqualTo("org.bundled");
         assertThat(nestedComp.getVersion()).isEqualTo("2.0.0");
+    }
+
+    @Test
+    void unresolvableBundledComponentPomDoesNotFailGeneration() {
+        // https://github.com/quarkusio/quarkus/issues/55373
+        // org.jacoco:org.jacoco.agent:runtime bundles org.jacoco.agent.rt, whose POM
+        // is never published to Maven Central. Resolving POM metadata for such bundled
+        // components must not fail the SBOM generation.
+        ComponentDescriptor nested = ComponentDescriptor.builder()
+                .setPurl(Purl.maven("org.jacoco", "org.jacoco.agent.rt", "0.8.15", "jar", null))
+                .setBomRef("pkg:maven/org.jacoco/org.jacoco.agent.rt@0.8.15?type=jar#bundled")
+                .build();
+        ComponentDescriptor parent = ComponentDescriptor.builder()
+                .setPurl(Purl.maven("org.jacoco", "org.jacoco.agent", "0.8.15", "jar", "runtime"))
+                .addComponent(nested)
+                .build();
+
+        EffectiveModelResolver resolver = (coords, repos) -> {
+            if (coords.getArtifactId().equals("org.jacoco.agent.rt")) {
+                throw new RuntimeException("Failed to resolve " + coords.toCompactCoords());
+            }
+            return null;
+        };
+
+        Bom bom = parseBom(CycloneDxSbomGenerator.newInstance()
+                .setFormat("json")
+                .setEffectiveModelResolver(resolver)
+                .setContributions(List.of(SbomContribution.ofComponents(List.of(parent))))
+                .generateText().get(0));
+
+        org.cyclonedx.model.Component parentComp = bom.getComponents().stream()
+                .filter(c -> c.getName().equals("org.jacoco.agent"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(parentComp.getComponents()).hasSize(1);
+        assertThat(parentComp.getComponents().get(0).getName()).isEqualTo("org.jacoco.agent.rt");
     }
 
     private static Bom parseBom(String json) {


### PR DESCRIPTION
CycloneDX SBOM generation fails when Jacoco is on the classpath because shaded JARs such as `org.jacoco.agent:runtime` embed build-only artifacts (for example `org.jacoco.agent.rt`) whose POMs are never published. Resolving POM metadata for those heuristically discovered bundled components is now best-effort, so packaging can complete and the SBOM still lists the nested components without the missing metadata.


- Fixes: #55373