### PR TITLE
Upgrade sshd to 2.19.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -209,7 +209,7 @@
         <jose4j.version>0.9.6</jose4j.version>
         <java-buildpack-client.version>0.0.14</java-buildpack-client.version>
         <crac.version>1.5.0</crac.version>
-        <sshd-common.version>2.18.0</sshd-common.version>
+        <sshd-common.version>2.19.0</sshd-common.version>
         <mime4j.version>0.8.12</mime4j.version>
         <mutiny-zero.version>1.2.1</mutiny-zero.version>
         <pulsar-client.version>4.2.1</pulsar-client.version>


### PR DESCRIPTION
Proposal to upgrade sshd to 2.19.0. This upgrade also targets Quarkus 3.



<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md
and the AI/LLM usage policy at https://github.com/quarkusio/quarkus/blob/main/AI_POLICY.md
-->

* The upgrade has been done on camel side and is expected for next LTS (which would mean quarkus 3.40 if I am correct): https://github.com/apache/camel/pull/24568
FYI @jamesnetherton @ppalaga 

* The upgrade is in PR on infinispan side: https://github.com/infinispan/infinispan/pull/17783
@karesti @wburns what is the plan for infinispan ?

<!--
Please include in the description above the list of GitHub issues this Pull Request addresses in the following format:

* Fixes #xxxxx
* Fixes #yyyyy
* Fixes #zzzzz
* ....

See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
for more information about linking issues to the Pull Request.
-->

