### PR TITLE
Use `getAnnotationsWithRepeatable` for handling repeatable annotations in proxy registration logic

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/RegisterForProxyBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/RegisterForProxyBuildStep.java
@@ -2,6 +2,7 @@ package io.quarkus.deployment.steps;
 
 import java.util.ArrayList;
 
+import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.DotName;
 
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -12,11 +13,20 @@ import io.quarkus.runtime.annotations.RegisterForProxy;
 
 public class RegisterForProxyBuildStep {
 
+    private static final DotName REGISTER_FOR_PROXY = DotName.createSimple(RegisterForProxy.class.getName());
+    private static final DotName REGISTER_FOR_PROXY_LIST = DotName.createSimple(RegisterForProxy.List.class.getName());
+
     @BuildStep
     public void build(CombinedIndexBuildItem combinedIndexBuildItem,
             BuildProducer<NativeImageProxyDefinitionBuildItem> proxy) {
-        for (var annotationInstance : combinedIndexBuildItem.getIndex()
-                .getAnnotations(DotName.createSimple(RegisterForProxy.class.getName()))) {
+        var index = combinedIndexBuildItem.getIndex();
+        var instances = new ArrayList<>(index.getAnnotations(REGISTER_FOR_PROXY));
+        for (var list : index.getAnnotations(REGISTER_FOR_PROXY_LIST)) {
+            for (var nested : list.value().asNestedArray()) {
+                instances.add(AnnotationInstance.create(nested.name(), list.target(), nested.values()));
+            }
+        }
+        for (var annotationInstance : instances) {
             var targetsValue = annotationInstance.value("targets");
             var types = new ArrayList<String>();
             if (targetsValue == null) {

--- a/core/deployment/src/test/java/io/quarkus/deployment/steps/RegisterForProxyBuildStepTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/steps/RegisterForProxyBuildStepTest.java
@@ -1,0 +1,67 @@
+package io.quarkus.deployment.steps;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.jboss.jandex.Index;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageProxyDefinitionBuildItem;
+import io.quarkus.runtime.annotations.RegisterForProxy;
+
+class RegisterForProxyBuildStepTest {
+
+    interface Alpha {
+    }
+
+    interface Beta extends Alpha {
+    }
+
+    // Repeated @RegisterForProxy: the compiler wraps these in a generated @RegisterForProxy.List container.
+    @RegisterForProxy(targets = Alpha.class)
+    @RegisterForProxy(targets = Beta.class)
+    interface RepeatedTargets {
+    }
+
+    @RegisterForProxy(targets = { Alpha.class, Beta.class })
+    interface CombinedTargets {
+    }
+
+    @RegisterForProxy
+    interface NoTargets extends Alpha {
+    }
+
+    @Test
+    void registersEveryRepeatedAnnotation() throws IOException {
+        assertThat(runBuildStep(RepeatedTargets.class))
+                .containsExactlyInAnyOrder(
+                        List.of(Alpha.class.getName()),
+                        List.of(Beta.class.getName()));
+    }
+
+    @Test
+    void registersMultipleTargetsAsSingleProxy() throws IOException {
+        assertThat(runBuildStep(CombinedTargets.class))
+                .containsExactly(List.of(Alpha.class.getName(), Beta.class.getName()));
+    }
+
+    @Test
+    void registersAnnotatedTypeWithItsSuperInterfaces() throws IOException {
+        assertThat(runBuildStep(NoTargets.class))
+                .containsExactly(List.of(NoTargets.class.getName(), Alpha.class.getName()));
+    }
+
+    private static List<List<String>> runBuildStep(Class<?>... classes) throws IOException {
+        Index index = Index.of(classes);
+        List<NativeImageProxyDefinitionBuildItem> produced = new ArrayList<>();
+        new RegisterForProxyBuildStep().build(new CombinedIndexBuildItem(index, index), produced::add);
+        return produced.stream()
+                .map(NativeImageProxyDefinitionBuildItem::getClasses)
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
- Fix #55401