### PR TITLE
Fix bad link syntax and update cross-document references to use xref 

### DIFF
--- a/docs/src/main/asciidoc/dev-mode-differences.adoc
+++ b/docs/src/main/asciidoc/dev-mode-differences.adoc
@@ -16,7 +16,7 @@ This document explains how the dev mode in Quarkus differs from a production app
 Quarkus provides a dev mode which greatly aids
 during development but should *NEVER* be used in production.
 
-These pages have instruction on how to use dev mode with xref:maven-tooling.adoc#dev-mode[Maven], link:gradle-tooling#dev-mode[Gradle] or with the xref:cli-tooling#development-mode[Quarkus CLI].
+These pages have instruction on how to use dev mode with xref:maven-tooling.adoc#dev-mode[Maven], xref:gradle-tooling.adoc#dev-mode[Gradle] or with the xref:cli-tooling#development-mode[Quarkus CLI].
 
 [[architectural-differences]]
 == Architectural differences

--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -1339,7 +1339,7 @@ public class GreetingResourceIT extends GreetingResourceTest { // <2>
 The executable is retrieved by the _Failsafe Maven Plugin_.
 <2> We extend our previous tests as a convenience, but you can also implement your tests.
 
-More information can be found in the link:building-native-image#testing-the-native-executable[Testing the native executable Guide].
+More information can be found in the xref:building-native-image.adoc#testing-the-native-executable[Testing the native executable Guide].
 
 [IMPORTANT]
 ====

--- a/docs/src/main/asciidoc/quartz.adoc
+++ b/docs/src/main/asciidoc/quartz.adoc
@@ -192,7 +192,7 @@ public class TaskBean {
 ----
 <1> Inject the underlying `org.quartz.Scheduler` instance.
 <2> Schedule a new job using the Quartz API.
-<3> Invoke the `TaskBean#performTask()` method from the job. Jobs are also xref:cdi.adoc[container-managed] beans if they belong to a link:cdi-reference[bean archive].
+<3> Invoke the `TaskBean#performTask()` method from the job. Jobs are also xref:cdi.adoc[container-managed] beans if they belong to a xref:cdi-reference.adoc[bean archive].
 
 NOTE: By default, the scheduler is not started unless a `@Scheduled` business method is found. You may need to force the start of the scheduler for "pure" programmatic scheduling. See also <<quartz-configuration-reference>>.
 

--- a/docs/src/main/asciidoc/security-webauthn.adoc
+++ b/docs/src/main/asciidoc/security-webauthn.adoc
@@ -822,7 +822,7 @@ Or, if you need to customise the endpoints:
 
 === CSRF considerations
 
-If you use the endpoints provided by Quarkus, they will not be protected by xdoc:security-csrf-prevention.adoc[CSRF], but
+If you use the endpoints provided by Quarkus, they will not be protected by xref:security-csrf-prevention.adoc[CSRF], but
 if you define your own endpoints and use this JavaScript library to access them you will need to configure CSRF via headers:
 
 [source,javascript]

--- a/docs/src/main/asciidoc/smallrye-graphql.adoc
+++ b/docs/src/main/asciidoc/smallrye-graphql.adoc
@@ -291,7 +291,7 @@ The GraphQL UI can be accessed from http://localhost:8080/q/graphql-ui/ .
 
 image:graphql-ui-screenshot01.png[alt=GraphQL UI]
 
-Have a look at the link:security-authorize-web-endpoints-reference[Authorization of Web Endpoints] Guide on how to add/remove security for the GraphQL UI.
+Have a look at the xref:security-authorize-web-endpoints-reference.adoc[Authorization of Web Endpoints] Guide on how to add/remove security for the GraphQL UI.
 
 == Query the GraphQL API
 


### PR DESCRIPTION
Our internal documentation-on-documentation and also the asciidoc guides say to use `xref:` instead of `link:`. Jekyll tolerated `link:`, but sadly, Roq does not. The symptom is broken links, because the relative link is resolved one level too high. I don't think we can consider this to be a Roq bug because all of the [asciidoc documentation about the issue](https://docs.asciidoctor.org/asciidoc/latest/macros/inter-document-xref/#mapping-references-to-a-different-structure) says "and to fix it, use xref!"

I'm rewriting links to xrefs as part of the migration, but because we import guides from this repo, it would be cleaner if the source documents just used the preferred style in the first place. 

While doing this, Claude also found a case where we'd writing `xdoc:` instead of `xref:`. I confirm it does not look good in the published document. :) 

<img width="776" height="203" alt="image" src="https://github.com/user-attachments/assets/1a4ab3e4-6a65-4465-93c5-ee6bf5d4a66b" />

I've converted link: to xref: for internal guide cross-references in:
- dev-mode-differences.adoc (gradle-tooling reference)
- getting-started-testing.adoc (building-native-image reference)
- quartz.adoc (cdi-reference reference)
- security-webauthn.adoc (security-csrf-prevention reference, also fix xdoc: typo)
- smallrye-graphql.adoc (security-authorize-web-endpoints-reference reference)

Because this is affects Roq publishing, I'm marking this for backport to all the guides we still publish. Annoying, but hopefully simple and low-risk. :(

(If we don't back-port, the symptom is a broken link.)