### PR TITLE
Fix broken fragment anchor links in documentation

### DIFF
--- a/docs/src/main/asciidoc/_includes/extension-status.adoc
+++ b/docs/src/main/asciidoc/_includes/extension-status.adoc
@@ -1,4 +1,5 @@
 ifdef::extension-status[]
+[[extension-status-note]]
 [NOTE]
 ====
 This technology is considered {extension-status}.

--- a/docs/src/main/asciidoc/container-image.adoc
+++ b/docs/src/main/asciidoc/container-image.adoc
@@ -146,6 +146,7 @@ Use either the `quarkus-container-image-docker` or `quarkus-container-image-podm
 For example, building multi-platform images is implemented differently for Docker and Podman. Docker uses https://docs.docker.com/engine/reference/commandline/buildx_build/[the buildx plugin] whereas Podman can build multi-platform images https://docs.podman.io/en/latest/markdown/podman-build.1.html#platform-os-arch-variant[natively]. Because of this, you would need to use the specific extension to perform that function.
 ====
 
+[[s2i]]
 [[openshift]]
 === OpenShift
 

--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -1088,6 +1088,7 @@ Here are some examples:
 The table below describe all the available configuration options.
 
 .Kubernetes
+[[duration-note-anchor-quarkus-kubernetes_quarkus-kubernetes]]
 :no-duration-note: true
 include::{generated-dir}/config/quarkus-kubernetes_quarkus.kubernetes.adoc[opts=optional, leveloffset=+1]
 
@@ -1116,6 +1117,7 @@ quarkus.kubernetes-client.trust-certs=true
 
 The full list of the Kubernetes client configuration properties is provided below.
 
+[[duration-note-anchor-quarkus-kubernetes-client_quarkus-kubernetes-client]]
 :no-duration-note: true
 include::{generated-dir}/config/quarkus-kubernetes-client.adoc[opts=optional, leveloffset=+1]
 
@@ -1227,6 +1229,7 @@ relieves OpenShift users of the necessity of setting the `deployment-target` pro
 The OpenShift resources can be customized in a similar approach with Kubernetes.
 
 .OpenShift
+[[duration-note-anchor-quarkus-kubernetes_quarkus-openshift]]
 :no-duration-note: true
 include::{generated-dir}/config/quarkus-kubernetes_quarkus.openshift.adoc[opts=optional, leveloffset=+1]
 
@@ -1292,6 +1295,7 @@ kubectl apply -f target/kubernetes/knative.json
 The generated service can be customized using the following properties:
 
 .Knative
+[[duration-note-anchor-quarkus-kubernetes_quarkus-knative]]
 :no-duration-note: true
 include::{generated-dir}/config/quarkus-kubernetes_quarkus.knative.adoc[opts=optional, leveloffset=+1]
 

--- a/docs/src/main/asciidoc/doc-contribute-docs-howto.adoc
+++ b/docs/src/main/asciidoc/doc-contribute-docs-howto.adoc
@@ -38,7 +38,7 @@ To ensure that your content shows up correctly on the link:https://quarkus.io/gu
 
 . Decide on a xref:doc-concept.adoc[Diataxis] content type that best fits the content that you are contributing.
 +
-TIP: To help you decide, see the content type descriptions in xref:doc-reference.adoc#titles-and-headings[Titles and headings] on the "About Quarkus documentation" page.
+TIP: To help you decide, see the content type descriptions in xref:doc-reference.adoc#titles-headings[Titles and headings] on the "About Quarkus documentation" page.
 
 . Go to the `src/main/asciidoc/_templates` directory, and make a copy of the relevant template for the content type you have chosen. Be sure to:
 ** Use the filename syntax of`<category>-<titlekeyword>-<titlekeyword>.adoc`. For example, `security-basic-authentication.adoc`.
@@ -58,10 +58,10 @@ include::_attributes.adoc[] <3>
 <6>
 ----
 <1> Set the `id` value to be the same as the file name but without the extension.
-<2> For information about how to create a good title for each content type, see xref:doc-reference.adoc#titles-and-headings[Titles and headings] on the "Quarkus style and content guidelines" page.
+<2> For information about how to create a good title for each content type, see xref:doc-reference.adoc#titles-headings[Titles and headings] on the "Quarkus style and content guidelines" page.
 <3> The `_attributes.adoc` include is required to ensure that attributes get resolved and the table of contents is generated.
 <4> Specify the diataxis type: `concept`, `howto`, `reference`, or `tutorial`.
-<5> Set at least one category to ensure that the content is findable on the link:https://quarkus.io/guides/[Quarkus documentation home page]. For a list of Quarkus categories, see xref:doc-reference.adoc#document-attributes-and-variables[Document attributes and variables] on the "Quarkus style and content guidelines" page.
+<5> Set at least one category to ensure that the content is findable on the link:https://quarkus.io/guides/[Quarkus documentation home page]. For a list of Quarkus categories, see xref:doc-reference.adoc#categories[Categories] on the "Quarkus style and content guidelines" page.
 <6> Insert a blank line after all document attributes and before the abstract.
 +
 [IMPORTANT]
@@ -77,7 +77,7 @@ The first sentence of the abstract must explain the value and some benefit of th
 There must also be a line break before and after the abstract.
 ====
 
-For more information about the minimum header requirements, see xref:doc-reference.adoc#document-structure[Document structure] on the "Quarkus style and content guidelines" page.
+For more information about the minimum header requirements, see xref:doc-reference.adoc#doc-structure[Document structure] on the "Quarkus style and content guidelines" page.
 
 [id="add-prerequisites"]
 == Add a prerequisites section


### PR DESCRIPTION
This is another one found by https://github.com/quarkusio/quarkusio.github.io/pull/2713. The first iteration didn't look at anchors, and there are a bunch of dead ones. I've done a mix of using the correct anchor, and, where a correct anchor didn't exist, adding a missing anchor.

Fix 12 broken fragment anchor references found by LinkCrawlerTest:

- Add [[extension-status-note]] anchor to extension-status.adoc include (referenced by funqy.adoc and update-quarkus.adoc)

- Add [[s2i]] anchor to container-image.adoc OpenShift section (referenced by deploying-to-kubernetes.adoc)

- Add duration-note-anchor anchors in deploying-to-kubernetes.adoc for Kubernetes, Knative, OpenShift, and kubernetes-client config sections (referenced by generated config documentation)

- Fix cross-reference links in doc-contribute-docs-howto.adoc to use existing anchors in doc-reference.adoc:
  * #titles-and-headings → #titles-headings
  * #document-attributes-and-variables → #categories
  * #document-structure → #doc-structure
