### PR TITLE
Make /deployments writable in generated Dockerfile.jvm for remote-dev

### DIFF
--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-layout.include.qute
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-layout.include.qute
@@ -92,6 +92,8 @@ ENV LANGUAGE='en_US:en'
 
 {#insert copy /}
 
+USER root
+RUN chmod 775 /deployments && chown 185:0 /deployments
 EXPOSE 8080
 USER 185
 {#if java.version == '11'}

--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -294,7 +294,18 @@ Before you start Quarkus on the remote host set the environment variable `QUARKU
 on bare metal you can set it via the `export QUARKUS_LAUNCH_DEVMODE=true` command and then run the application with the proper `java -jar ...` command to run the application.
 
 If you plan on running the application via Docker, then you'll need to add `-e QUARKUS_LAUNCH_DEVMODE=true` to the `docker run` command.
-When the application starts you should now see the following line in the logs: `Profile dev activated. Live Coding activated`. You will also need to give the application the rights to update the deployment resources by adding `RUN chmod o+rw -R /deployments` after the `COPY` commands into your Dockerfile. For security reasons, this option should not be added to the production Dockerfile.
+When the application starts you should now see the following line in the logs: `Profile dev activated. Live Coding activated`.
+The generated `Dockerfile.jvm` already configures `/deployments` to be writable by the application user, which is required for remote dev mode.
+If you are using a custom Dockerfile, add the following after the `COPY` commands:
+
+[source,dockerfile]
+----
+USER root
+RUN chmod 775 /deployments && chown 185:0 /deployments
+USER 185
+----
+
+For security reasons, do not use remote dev mode in production.
 
 
 NOTE: The remote side does not need to include Maven or any other development tools. The normal `fast-jar` Dockerfile

--- a/docs/src/main/asciidoc/maven-tooling.adoc
+++ b/docs/src/main/asciidoc/maven-tooling.adoc
@@ -243,7 +243,18 @@ Before you start Quarkus on the remote host set the environment variable `QUARKU
 on bare metal you can set it via the `export QUARKUS_LAUNCH_DEVMODE=true` command and then run the application with the proper `java -jar ...` command to run the application.
 
 If you plan on running the application via Docker, then you'll need to add `-e QUARKUS_LAUNCH_DEVMODE=true` to the `docker run` command.
-When the application starts you should now see the following line in the logs: `Profile dev activated. Live Coding activated`. You will also need to give the application the rights to update the deployment resources by adding `RUN chmod o+rw -R /deployments` after the `COPY` commands into your Dockerfile. For security reasons, this option should not be added to the production Dockerfile.
+When the application starts you should now see the following line in the logs: `Profile dev activated. Live Coding activated`.
+The generated `Dockerfile.jvm` already configures `/deployments` to be writable by the application user, which is required for remote dev mode.
+If you are using a custom Dockerfile, add the following after the `COPY` commands:
+
+[source,dockerfile]
+----
+USER root
+RUN chmod 775 /deployments && chown 185:0 /deployments
+USER 185
+----
+
+For security reasons, do not use remote dev mode in production.
 
 NOTE: The remote side does not need to include Maven or any other development tools. The normal `fast-jar` Dockerfile
 that is generated with a new Quarkus application is all you need. If you are using bare metal launch the Quarkus runner

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-layout.include.qute
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-layout.include.qute
@@ -92,6 +92,8 @@ ENV LANGUAGE='en_US:en'
 
 {#insert copy /}
 
+USER root
+RUN chmod 775 /deployments && chown 185:0 /deployments
 EXPOSE 8080
 USER 185
 {#if java.version == '11'}

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartGenerationTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartGenerationTest.java
@@ -338,6 +338,7 @@ class QuarkusCodestartGenerationTest {
                 .satisfies(checkContains("./mvnw package"))
                 .satisfies(checkContains("docker build -f src/main/docker/Dockerfile.jvm"))
                 .satisfies(checkContains("registry.access.redhat.com/ubi8/openjdk-17:"))
+                .satisfies(checkContains("RUN chmod 775 /deployments && chown 185:0 /deployments"))
                 .satisfies(checkContains("ENV JAVA_APP_JAR=\"/deployments/quarkus-run.jar\""))
                 .satisfies(checkContains("ENTRYPOINT [ \"/opt/jboss/container/java/run/run-java.sh\" ]"));
         assertThat(projectDir.resolve("src/main/docker/Dockerfile.legacy-jar")).exists()
@@ -364,6 +365,7 @@ class QuarkusCodestartGenerationTest {
                 .satisfies(checkContains("./gradlew build"))
                 .satisfies(checkContains("docker build -f src/main/docker/Dockerfile.jvm"))
                 .satisfies(checkContains("registry.access.redhat.com/ubi8/openjdk-17:"))
+                .satisfies(checkContains("RUN chmod 775 /deployments && chown 185:0 /deployments"))
                 .satisfies(checkContains("ENV JAVA_APP_JAR=\"/deployments/quarkus-run.jar\""))
                 .satisfies(checkContains("ENTRYPOINT [ \"/opt/jboss/container/java/run/run-java.sh\" ]"));
         assertThat(projectDir.resolve("src/main/docker/Dockerfile.legacy-jar")).exists()


### PR DESCRIPTION
Fixes #53407

Remote-dev mode fails to start in containers built with the default `Dockerfile.jvm` because `DevModeTask` cannot create `/deployments/dev` when the process runs as `USER 185` and `/deployments` is owned by root (`755`) in the UBI OpenJDK runtime image.

The generated Dockerfile now switches to root after the `COPY` steps, sets `/deployments` to `775` owned by `185:0`, then switches back to `USER 185`. This matches the approach already used by the Jib container-image extension for mutable jars. The remote-dev docs are updated because the previous `chmod o+rw` guidance no longer works on current UBI images that default to a non-root user.


