### PR TITLE
Record output-directory metadata for native container images

### DIFF
--- a/extensions/container-image/container-image-docker-common/deployment/src/main/java/io/quarkus/container/image/docker/common/deployment/CommonProcessor.java
+++ b/extensions/container-image/container-image-docker-common/deployment/src/main/java/io/quarkus/container/image/docker/common/deployment/CommonProcessor.java
@@ -225,7 +225,8 @@ public abstract class CommonProcessor<C extends CommonConfig> {
             }
 
             if (buildContainerImage) {
-                LOGGER.infof("Starting (local) container image build for jar using %s", getProcessorImplementation());
+                LOGGER.infof("Starting (local) container image build for native binary using %s",
+                        getProcessorImplementation());
             }
 
             var executableName = getExecutableName(config, containerRuntimes);
@@ -241,7 +242,8 @@ public abstract class CommonProcessor<C extends CommonConfig> {
                             "native-container",
                             Map.of(
                                     "container-image", builtContainerImage,
-                                    "pull-required", "false")));
+                                    "pull-required", "false",
+                                    "output-directory", out.getOutputDirectory().toAbsolutePath().toString())));
 
             containerImageBuilder.produce(new ContainerImageBuilderBuildItem(getProcessorImplementation()));
         }


### PR DESCRIPTION
Running `@QuarkusIntegrationTest` against a native container image prints an unactionable message at every test class teardown:

    Unable to close ArtifactLauncher: null

`CommonProcessor.buildFromJar` records `output-directory` in the artifact result metadata, but `buildFromNativeImage` does not, so native container builds produce a `quarkus-artifact.properties` without `metadata.output-directory`:

    metadata.container-image=org.acme/g37-maven-repro:1.0.0-SNAPSHOT
    metadata.pull-required=false
    path=g37-maven-repro-1.0.0-SNAPSHOT-runner
    type=native-container

`DefaultDockerContainerLauncher.close()` reads that key to record the container metadata (and to generate the AOT file), and fails with a `NullPointerException` in `recordMetadata()` on `Path.of(null)`. The integration test extension swallows the exception and prints only `e.getMessage()`, which for an NPE is the literal `null` above.

Reproducible with both Maven and Gradle on a default project with the `rest` and `container-image-docker` extensions:

    mvn verify -Dnative -Dquarkus.native.container-build=true -Dquarkus.container-image.build=true

This records `output-directory` in `buildFromNativeImage` the same way `buildFromJar` already does, so the launcher's close completes and `quarkus-container-it.properties` is written for native containers too.

It also corrects the native build log message, which said "for jar".