### PR TITLE
Enable container tests in Windows CI

### DIFF
--- a/.github/docker-prune.bat
+++ b/.github/docker-prune.bat
@@ -1,7 +1,7 @@
 @echo off
 
 rem See remarks in docker-prune.sh
-if "%GITHUB_ACTIONS%"== "true" (
+if "%GITHUB_ACTIONS%"=="true" (
   docker container prune -f || exit /b
   docker image prune -f || exit /b
   docker network prune -f || exit /b

--- a/.github/matrix-jvm-tests.json
+++ b/.github/matrix-jvm-tests.json
@@ -104,10 +104,11 @@
         "tag": "jvm-tests-integration",
         "java-version": 17,
         "java-distribution": "temurin",
-        "maven_args": "-DskipDocs -Dformat.skip",
+        "maven_args": "$JVM_TEST_MAVEN_ARGS",
         "maven_opts": "-Xmx2g -XX:MaxMetaspaceSize=1g",
         "os-name": "windows-latest",
-        "runs-on": false,
+        "runs-on": true,
+        "container-support": true,
         "modules": "-f\nintegration-tests\n-pl\n!gradle\n-pl\n!maven\n-pl\n!devmode\n-pl\n!devtools"
     },
     {

--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -604,6 +604,13 @@ jobs:
       - name: Support longpaths on Windows
         if: startsWith(matrix.java.os-name, 'windows')
         run: git config --global core.longpaths true
+      - name: Verify Linux container support on Windows
+        if: startsWith(matrix.java.os-name, 'windows') && matrix.java.container-support
+        shell: pwsh
+        run: |
+          docker version
+          docker info --format '{{json .OSType}}' | Select-String -Pattern '^"linux"$'
+          docker run --rm hello-world
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # this is important for Scalpel to work
@@ -688,6 +695,10 @@ jobs:
           # IMPORTANT: we cannot simply replace all spaces with new lines as we have a module with spaces in the name (to test spaces are supported)
           echo -e "$MATRIX_JAVA_MODULES" >> .mvn/maven.config
           ./mvnw $COMMON_MAVEN_ARGS $COMMON_TEST_MAVEN_ARGS $PTS_MAVEN_ARGS clean install -Dsurefire.timeout=1200 -Dno-test-kubernetes ${{ matrix.java.maven_args }}
+      - name: Prune containers on Windows
+        if: always() && startsWith(matrix.java.os-name, 'windows') && matrix.java.container-support
+        shell: cmd
+        run: .github\docker-prune.bat
       - name: Clean Gradle temp directory
         if: always()
         run: devtools/gradle/gradlew --stop && rm -rf devtools/gradle/gradle-extension-plugin/build/tmp


### PR DESCRIPTION
This enables container-dependent integration tests in the Windows CI workflow. The Windows integration-test lane now uses the existing container test arguments, verifies that the runner supports Linux containers before starting the build, and cleans up Docker resources afterward.

The workflow was validated with `actionlint`. The test matrix JSON was parsed successfully, and `git diff --check` completed without errors.

* Fixes #55102