### PR TITLE
Apply Kubernetes labels and annotations to Flyway init-task resources

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddAnnotationToResourceDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddAnnotationToResourceDecorator.java
@@ -1,0 +1,59 @@
+package io.quarkus.kubernetes.deployment;
+
+import java.util.Objects;
+
+import io.dekorate.kubernetes.decorator.AddAnnotationDecorator;
+import io.dekorate.kubernetes.decorator.Decorator;
+import io.dekorate.kubernetes.decorator.NamedResourceDecorator;
+import io.dekorate.kubernetes.decorator.ResourceProvidingDecorator;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+
+/**
+ * Adds an annotation to a named resource.
+ * <p>
+ * Unlike {@link AddAnnotationDecorator}, equality includes the resource name so the same annotation can be applied to
+ * multiple init-task resources without being deduplicated by dekorate's {@link java.util.TreeSet}.
+ */
+class AddAnnotationToResourceDecorator extends NamedResourceDecorator<ObjectMetaBuilder> {
+
+    private final String resourceName;
+    private final String key;
+    private final String value;
+
+    AddAnnotationToResourceDecorator(String resourceName, String key, String value) {
+        super(resourceName);
+        this.resourceName = resourceName;
+        this.key = key;
+        this.value = value;
+    }
+
+    @Override
+    public void andThenVisit(ObjectMetaBuilder meta, ObjectMeta objectMeta) {
+        meta.addToAnnotations(key, value);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Class<? extends Decorator>[] after() {
+        return new Class[] { ResourceProvidingDecorator.class };
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof AddAnnotationToResourceDecorator other)) {
+            return false;
+        }
+        return Objects.equals(resourceName, other.resourceName)
+                && Objects.equals(key, other.key)
+                && Objects.equals(value, other.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(resourceName, key, value);
+    }
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddLabelToResourceDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddLabelToResourceDecorator.java
@@ -1,0 +1,60 @@
+package io.quarkus.kubernetes.deployment;
+
+import java.util.Objects;
+
+import io.dekorate.kubernetes.decorator.AddLabelDecorator;
+import io.dekorate.kubernetes.decorator.Decorator;
+import io.dekorate.kubernetes.decorator.NamedResourceDecorator;
+import io.dekorate.kubernetes.decorator.ResourceProvidingDecorator;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectMetaFluent;
+
+/**
+ * Adds a label to a named resource.
+ * <p>
+ * Unlike {@link AddLabelDecorator}, equality includes the resource name. Dekorate stores decorators in a
+ * {@link java.util.TreeSet}, and {@link AddLabelDecorator#equals(Object)} only compares the label key/value, which
+ * would drop additional decorators that apply the same label to init-task resources.
+ */
+class AddLabelToResourceDecorator extends NamedResourceDecorator<ObjectMetaFluent<?>> {
+
+    private final String resourceName;
+    private final String key;
+    private final String value;
+
+    AddLabelToResourceDecorator(String resourceName, String key, String value) {
+        super(resourceName);
+        this.resourceName = resourceName;
+        this.key = key;
+        this.value = value;
+    }
+
+    @Override
+    public void andThenVisit(ObjectMetaFluent<?> meta, ObjectMeta objectMeta) {
+        meta.addToLabels(key, value);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Class<? extends Decorator>[] after() {
+        return new Class[] { ResourceProvidingDecorator.class };
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof AddLabelToResourceDecorator other)) {
+            return false;
+        }
+        return Objects.equals(resourceName, other.resourceName)
+                && Objects.equals(key, other.key)
+                && Objects.equals(value, other.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(resourceName, key, value);
+    }
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/BaseKubeProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/BaseKubeProcessor.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -57,6 +58,8 @@ import io.dekorate.utils.Labels;
 import io.dekorate.utils.Strings;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.ContainerFluent;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
 import io.fabric8.kubernetes.api.model.rbac.PolicyRule;
@@ -831,6 +834,56 @@ public abstract class BaseKubeProcessor<P, C extends PlatformConfiguration> {
             List<KubernetesJobBuildItem> jobs) {
         createInitContainerDecorators(context, initContainers);
         createInitJobDecorators(context, jobs);
+        createInitTaskMetadataDecorators(context, jobs);
+    }
+
+    private void createInitTaskMetadataDecorators(DecoratorsContext context, List<KubernetesJobBuildItem> jobs) {
+        List<KubernetesJobBuildItem> jobsForTarget = Targetable.filteredByTarget(jobs, context.target).toList();
+        if (jobsForTarget.isEmpty()) {
+            return;
+        }
+
+        List<String> resourceNames = new ArrayList<>();
+        for (KubernetesJobBuildItem job : jobsForTarget) {
+            resourceNames.add(job.getName());
+        }
+        // Same Role / RoleBinding names produced by InitTaskProcessor (binding name defaults to <app>-<role>).
+        resourceNames.add(InitTaskProcessor.VIEW_JOBS_ROLE_NAME);
+        resourceNames.add(context.name() + "-" + InitTaskProcessor.VIEW_JOBS_ROLE_NAME);
+
+        // Re-apply the same label/annotation decorators that target the main app resource.
+        // Init-task resources use different names, so the original decorators never match them.
+        // Use Quarkus-specific decorators whose equals() includes the resource name: dekorate stores
+        // decorators in a TreeSet and AddLabelDecorator/RemoveLabelDecorator/AddAnnotationDecorator
+        // ignore the name in equals(), which would drop these per-resource copies.
+        for (AddLabelDecorator labelDecorator : context.decoratorsOfType(AddLabelDecorator.class)) {
+            var label = labelDecorator.getLabel();
+            for (String resourceName : resourceNames) {
+                context.add(new AddLabelToResourceDecorator(resourceName, label.getKey(), label.getValue()));
+            }
+        }
+        for (AddAnnotationDecorator annotationDecorator : context.decoratorsOfType(AddAnnotationDecorator.class)) {
+            var annotation = annotationOf(annotationDecorator);
+            for (String resourceName : resourceNames) {
+                context.add(new AddAnnotationToResourceDecorator(resourceName, annotation.getKey(), annotation.getValue()));
+            }
+        }
+        for (RemoveLabelDecorator removeLabelDecorator : context.decoratorsOfType(RemoveLabelDecorator.class)) {
+            String key = removeLabelDecorator.getLabelKey();
+            for (String resourceName : resourceNames) {
+                context.add(new RemoveLabelFromResourceDecorator(resourceName, key));
+            }
+        }
+    }
+
+    private static io.dekorate.kubernetes.config.Annotation annotationOf(AddAnnotationDecorator decorator) {
+        try {
+            var field = AddAnnotationDecorator.class.getDeclaredField("annotation");
+            field.setAccessible(true);
+            return (io.dekorate.kubernetes.config.Annotation) field.get(decorator);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Unable to read annotation from AddAnnotationDecorator", e);
+        }
     }
 
     private void createInitContainerDecorators(DecoratorsContext context, List<KubernetesInitContainerBuildItem> items) {
@@ -910,6 +963,7 @@ public abstract class BaseKubeProcessor<P, C extends PlatformConfiguration> {
             serviceAccount = Optional.empty();
         }
 
+        final String deploymentName = context.name();
         Targetable.filteredByTarget(items, context.target).forEach(item -> {
 
             final var name = item.getName();
@@ -918,13 +972,26 @@ public abstract class BaseKubeProcessor<P, C extends PlatformConfiguration> {
             // this is needed as we've removed decorators that were previously applied to the simple job resource created here
             // with this specialized job creator, we inherit the behavior that directly sets values instead of using decorators but add specialized behavior as well
             final var job = new AddJobResourceDecorator(name, config(), null) {
+                private Map<String, String> labels = Map.of();
+
+                @Override
+                protected void prepare(List<HasMetadata> items, KubernetesListBuilder list) {
+                    super.prepare(items, list);
+                    // Same approach as RBAC resources: inherit name/version labels from the main deployment.
+                    labels = mergeLabelsFromDeploymentWith(items, Map.of(), deploymentName);
+                }
+
                 @Override
                 protected void initBuilderWithDefaults(JobBuilder builder) {
+                    updateMetadata(builder.editOrNewMetadata(), null, labels).endMetadata();
                     super.initBuilderWithDefaults(builder);
 
                     builder.editOrNewSpec()
                             .withCompletionMode(DEFAULT_COMPLETION_MODE)
                             .editOrNewTemplate()
+                            .editOrNewMetadata()
+                            .addToLabels(new TreeMap<>(labels))
+                            .endMetadata()
                             .editOrNewSpec()
                             .withRestartPolicy(DEFAULT_RESTART_POLICY)
                             .withServiceAccountName(serviceAccountName)

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/InitTaskProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/InitTaskProcessor.java
@@ -22,6 +22,8 @@ import io.quarkus.kubernetes.spi.PolicyRule;
 
 public class InitTaskProcessor {
 
+    static final String VIEW_JOBS_ROLE_NAME = "view-jobs";
+
     private static final String INIT_CONTAINER_WAITER_NAME = "wait-for-";
 
     public static void process(
@@ -77,13 +79,13 @@ public class InitTaskProcessor {
         }
 
         if (generateRoleForJobs) {
-            roles.produce(new KubernetesRoleBuildItem("view-jobs", Collections.singletonList(
+            roles.produce(new KubernetesRoleBuildItem(VIEW_JOBS_ROLE_NAME, Collections.singletonList(
                     new PolicyRule(
                             Collections.singletonList("batch"),
                             Collections.singletonList("jobs"),
                             List.of("get"))),
                     target));
-            roleBindings.produce(new KubernetesRoleBindingBuildItem(null, "view-jobs", false, target));
+            roleBindings.produce(new KubernetesRoleBindingBuildItem(null, VIEW_JOBS_ROLE_NAME, false, target));
             serviceAccount.produce(new KubernetesServiceAccountBuildItem(true));
         }
     }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RemoveLabelFromResourceDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RemoveLabelFromResourceDecorator.java
@@ -1,0 +1,58 @@
+package io.quarkus.kubernetes.deployment;
+
+import java.util.Objects;
+
+import io.dekorate.kubernetes.decorator.AddLabelDecorator;
+import io.dekorate.kubernetes.decorator.Decorator;
+import io.dekorate.kubernetes.decorator.NamedResourceDecorator;
+import io.dekorate.kubernetes.decorator.RemoveLabelDecorator;
+import io.dekorate.kubernetes.decorator.ResourceProvidingDecorator;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectMetaFluent;
+
+/**
+ * Removes a label from a named resource.
+ * <p>
+ * Unlike {@link RemoveLabelDecorator}, equality includes the resource name. Dekorate stores decorators in a
+ * {@link java.util.TreeSet}, and {@link RemoveLabelDecorator#equals(Object)} only compares the label key, which would
+ * drop additional removals for init-task resources (e.g. stripping {@code app.kubernetes.io/version} in idempotent
+ * mode).
+ */
+class RemoveLabelFromResourceDecorator extends NamedResourceDecorator<ObjectMetaFluent<?>> {
+
+    private final String resourceName;
+    private final String key;
+
+    RemoveLabelFromResourceDecorator(String resourceName, String key) {
+        super(resourceName);
+        this.resourceName = resourceName;
+        this.key = key;
+    }
+
+    @Override
+    public void andThenVisit(ObjectMetaFluent<?> meta, ObjectMeta objectMeta) {
+        meta.removeFromLabels(key);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Class<? extends Decorator>[] after() {
+        return new Class[] { ResourceProvidingDecorator.class, AddLabelDecorator.class, AddLabelToResourceDecorator.class };
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof RemoveLabelFromResourceDecorator other)) {
+            return false;
+        }
+        return Objects.equals(resourceName, other.resourceName) && Objects.equals(key, other.key);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(resourceName, key);
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithFlywayInitBase.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithFlywayInitBase.java
@@ -9,8 +9,10 @@ import java.util.List;
 import java.util.Optional;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
+import io.fabric8.kubernetes.api.model.rbac.Role;
 import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
 
 public class KubernetesWithFlywayInitBase {
@@ -50,14 +52,19 @@ public class KubernetesWithFlywayInitBase {
             });
         });
 
+        ObjectMeta deploymentMetadata = deployment.get().getMetadata();
+        ObjectMeta deploymentTemplateMetadata = deployment.get().getSpec().getTemplate().getMetadata();
+
         Optional<Job> job = kubernetesList.stream()
                 .filter(j -> "Job".equals(j.getKind()) && jobName.equals(j.getMetadata().getName()))
                 .map(j -> (Job) j)
                 .findAny();
         assertThat(job).isPresent().get().satisfies(j -> {
+            assertSameLabelsAndAnnotations(j.getMetadata(), deploymentMetadata);
             assertThat(j.getSpec()).satisfies(jobSpec -> {
                 assertThat(jobSpec.getCompletionMode()).isEqualTo("NonIndexed");
                 assertThat(jobSpec.getTemplate()).satisfies(t -> {
+                    assertSameLabelsAndAnnotations(t.getMetadata(), deploymentTemplateMetadata);
                     assertThat(t.getSpec()).satisfies(podSpec -> {
                         assertThat(podSpec.getImagePullSecrets()).singleElement()
                                 .satisfies(s -> assertThat(s.getName()).isEqualTo(imagePullSecret));
@@ -84,5 +91,18 @@ public class KubernetesWithFlywayInitBase {
                 r -> r instanceof RoleBinding && (name + "-view-jobs").equals(r.getMetadata().getName()))
                 .map(r -> (RoleBinding) r).findFirst();
         assertTrue(roleBinding.isPresent());
+        assertSameLabelsAndAnnotations(roleBinding.get().getMetadata(), deploymentMetadata);
+
+        Optional<Role> role = kubernetesList.stream()
+                .filter(r -> r instanceof Role && "view-jobs".equals(r.getMetadata().getName()))
+                .map(r -> (Role) r)
+                .findFirst();
+        assertTrue(role.isPresent());
+        assertSameLabelsAndAnnotations(role.get().getMetadata(), deploymentMetadata);
+    }
+
+    private void assertSameLabelsAndAnnotations(ObjectMeta actual, ObjectMeta expected) {
+        assertThat(actual.getLabels()).containsAllEntriesOf(expected.getLabels());
+        assertThat(actual.getAnnotations()).containsAllEntriesOf(expected.getAnnotations());
     }
 }


### PR DESCRIPTION
Fixes #50789

Flyway init-task resources (Job, Role, RoleBinding) are generated with different names than the main application Deployment, so `quarkus.kubernetes.labels` / `annotations` and default Quarkus metadata such as `app.kubernetes.io/managed-by` were never applied to them.

The same gap affected idempotent mode: with `quarkus.kubernetes.idempotent=true`, Deployment/Service correctly drop `app.kubernetes.io/version` and keep `managed-by`, but the init-task Role/RoleBinding still kept `version` and missed `managed-by`.

This change re-applies the same label/annotation (and idempotent label-removal) logic to those init-task resources using name-aware decorators, and inherits the Deployment name/version labels onto the init Job the same way RBAC resources already do.