### PR TITLE
Omit OpenShift Route path for passthrough TLS termination

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftProcessor.java
@@ -288,6 +288,11 @@ public class OpenshiftProcessor extends BaseKubeProcessor<AddPortToOpenshiftConf
             for (Map.Entry<String, String> label : config.route().labels().entrySet()) {
                 context.add(new AddLabelDecorator(name, label.getKey(), label.getValue(), ROUTE));
             }
+
+            // OpenShift rejects any path (including "/") with passthrough TLS termination.
+            if (config.route().tls().termination().filter("passthrough"::equalsIgnoreCase).isPresent()) {
+                context.add(new RemovePathFromRouteDecorator(name));
+            }
         }
 
         config.containerName().ifPresent(containerName -> {

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RemovePathFromRouteDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RemovePathFromRouteDecorator.java
@@ -1,0 +1,32 @@
+package io.quarkus.kubernetes.deployment;
+
+import static io.quarkus.kubernetes.deployment.Constants.ROUTE;
+
+import io.dekorate.kubernetes.decorator.Decorator;
+import io.dekorate.kubernetes.decorator.NamedResourceDecorator;
+import io.dekorate.openshift.decorator.AddPortToRouteDecorator;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.openshift.api.model.RouteSpecFluent;
+
+/**
+ * Clears {@code spec.path} from an OpenShift Route.
+ * <p>
+ * OpenShift rejects any path (including {@code /}) when TLS termination is
+ * {@code passthrough}, because the router cannot inspect the HTTP path.
+ */
+public class RemovePathFromRouteDecorator extends NamedResourceDecorator<RouteSpecFluent<?>> {
+
+    public RemovePathFromRouteDecorator(String name) {
+        super(ROUTE, name);
+    }
+
+    @Override
+    public void andThenVisit(RouteSpecFluent<?> spec, ObjectMeta resourceMeta) {
+        spec.withPath(null);
+    }
+
+    @Override
+    public Class<? extends Decorator>[] after() {
+        return new Class[] { AddPortToRouteDecorator.class };
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithRoutePassthroughTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithRoutePassthroughTest.java
@@ -1,0 +1,55 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.openshift.api.model.Route;
+import io.fabric8.openshift.api.model.TLSConfig;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class OpenshiftWithRoutePassthroughTest {
+
+    private static final String APP_NAME = "openshift-with-route-passthrough";
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot((jar) -> jar.addClasses(GreetingResource.class))
+            .setApplicationName(APP_NAME)
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .withConfigurationResource(APP_NAME + ".properties");
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        assertThat(kubernetesDir)
+                .isDirectoryContaining(p -> p.getFileName().endsWith("openshift.json"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("openshift.yml"));
+        List<HasMetadata> openshiftList = DeserializationUtil
+                .deserializeAsList(kubernetesDir.resolve("openshift.yml"));
+
+        assertThat(openshiftList).filteredOn(i -> "Route".equals(i.getKind())).singleElement().satisfies(i -> {
+            assertThat(i).isInstanceOfSatisfying(Route.class, r -> {
+                // Passthrough termination must not include a path (OpenShift rejects it).
+                assertThat(r.getSpec().getPath()).isNull();
+
+                TLSConfig tls = r.getSpec().getTls();
+                assertThat(tls).isNotNull();
+                assertThat(tls.getTermination()).isEqualTo("passthrough");
+                assertThat(tls.getInsecureEdgeTerminationPolicy()).isEqualTo("Redirect");
+                assertThat(r.getSpec().getPort().getTargetPort().getStrVal()).isEqualTo("http");
+            });
+        });
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/openshift-with-route-passthrough.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/openshift-with-route-passthrough.properties
@@ -1,0 +1,7 @@
+quarkus.kubernetes.deployment-target=openshift
+quarkus.openshift.ports.http.tls=true
+quarkus.openshift.ports.http.container-port=8443
+quarkus.openshift.ports.http.host-port=8443
+quarkus.openshift.route.expose=true
+quarkus.openshift.route.tls.termination=passthrough
+quarkus.openshift.route.tls.insecure-edge-termination-policy=Redirect


### PR DESCRIPTION
OpenShift rejects any `spec.path` (including `/`) when TLS termination is `passthrough`, because the router cannot inspect the HTTP path. Configuring port properties caused Quarkus to copy the default port path `/` onto the generated Route, making it undeployable.

When `quarkus.openshift.route.tls.termination=passthrough`, clear the Route path after dekorate sets it from the port configuration.

- Fixes: #45227
