### PR TITLE
Disable Mockito class cache so thenThrow works across component tests

### DIFF
--- a/test-framework/junit-component/src/test/java/io/quarkus/test/component/mockthrow/GreetingException.java
+++ b/test-framework/junit-component/src/test/java/io/quarkus/test/component/mockthrow/GreetingException.java
@@ -1,0 +1,4 @@
+package io.quarkus.test.component.mockthrow;
+
+public class GreetingException extends RuntimeException {
+}

--- a/test-framework/junit-component/src/test/java/io/quarkus/test/component/mockthrow/GreetingService.java
+++ b/test-framework/junit-component/src/test/java/io/quarkus/test/component/mockthrow/GreetingService.java
@@ -1,0 +1,16 @@
+package io.quarkus.test.component.mockthrow;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class GreetingService {
+
+    @Inject
+    GreetingSubService greetingSubService;
+
+    public String greeting() {
+        return greetingSubService.greet("hello there!");
+    }
+
+}

--- a/test-framework/junit-component/src/test/java/io/quarkus/test/component/mockthrow/GreetingSubService.java
+++ b/test-framework/junit-component/src/test/java/io/quarkus/test/component/mockthrow/GreetingSubService.java
@@ -1,0 +1,12 @@
+package io.quarkus.test.component.mockthrow;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class GreetingSubService {
+
+    public String greet(String greeting) {
+        return greeting;
+    }
+
+}

--- a/test-framework/junit-component/src/test/java/io/quarkus/test/component/mockthrow/OtherGreetingService.java
+++ b/test-framework/junit-component/src/test/java/io/quarkus/test/component/mockthrow/OtherGreetingService.java
@@ -1,0 +1,16 @@
+package io.quarkus.test.component.mockthrow;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class OtherGreetingService {
+
+    @Inject
+    GreetingSubService greetingSubService;
+
+    public String greeting() {
+        return greetingSubService.greet("hello there!");
+    }
+
+}

--- a/test-framework/junit-component/src/test/java/io/quarkus/test/component/mockthrow/ThenThrowExceptionClassLoaderTest1.java
+++ b/test-framework/junit-component/src/test/java/io/quarkus/test/component/mockthrow/ThenThrowExceptionClassLoaderTest1.java
@@ -1,0 +1,29 @@
+package io.quarkus.test.component.mockthrow;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.component.QuarkusComponentTest;
+
+// #55093: thenThrow(Exception.class) must work across component tests (separate class loaders)
+@QuarkusComponentTest
+public class ThenThrowExceptionClassLoaderTest1 {
+
+    @Inject
+    GreetingService service;
+
+    @InjectMock
+    GreetingSubService subService;
+
+    @Test
+    public void testGreetingService() {
+        when(subService.greet("hello there!")).thenThrow(GreetingException.class);
+        assertThrows(GreetingException.class, service::greeting);
+    }
+
+}

--- a/test-framework/junit-component/src/test/java/io/quarkus/test/component/mockthrow/ThenThrowExceptionClassLoaderTest2.java
+++ b/test-framework/junit-component/src/test/java/io/quarkus/test/component/mockthrow/ThenThrowExceptionClassLoaderTest2.java
@@ -1,0 +1,37 @@
+package io.quarkus.test.component.mockthrow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.component.QuarkusComponentTest;
+
+// Companion to ThenThrowExceptionClassLoaderTest1 (#55093)
+@QuarkusComponentTest
+public class ThenThrowExceptionClassLoaderTest2 {
+
+    @Inject
+    OtherGreetingService service;
+
+    @InjectMock
+    GreetingSubService subService;
+
+    @Test
+    public void testGreetingService() {
+        when(subService.greet("hello there!")).thenThrow(GreetingException.class);
+        try {
+            subService.greet("hello there!");
+        } catch (Exception e) {
+            // The thrown exception must come from this test's class loader
+            assertEquals(GreetingException.class.getClassLoader(), e.getClass().getClassLoader());
+            assertEquals(GreetingException.class, e.getClass());
+        }
+        assertThrows(GreetingException.class, service::greeting);
+    }
+
+}

--- a/test-framework/junit-mockito-config/src/main/java/org/mockito/configuration/MockitoConfiguration.java
+++ b/test-framework/junit-mockito-config/src/main/java/org/mockito/configuration/MockitoConfiguration.java
@@ -19,4 +19,10 @@ public class MockitoConfiguration extends DefaultMockitoConfiguration {
             throw new RuntimeException("Failed to load MutinyAnswer from the TCCL", e);
         }
     }
+
+    // Per-test class loaders + Objenesis name-based cache break thenThrow(Exception.class) across tests (#55093)
+    @Override
+    public boolean enableClassCache() {
+        return false;
+    }
 }


### PR DESCRIPTION
Since 3.29, `QuarkusComponentTest` loads each test class in its own class loader. Mockito's Objenesis layer caches `ObjectInstantiator`s by class *name*, so when two tests both do `thenThrow(MyException.class)`, the second one can get an instance of the exception type from the first test's class loader. `assertThrows(MyException.class, ...)` then fails even though the simple names match.

Mockito already has a knob for this (`IMockitoConfiguration.enableClassCache()`), intended for environments that reload classes — which is exactly what we do. Turning it off in our `MockitoConfiguration` is enough.

- Fixes: #55093