### PR TITLE
Make `@ServerExceptionMapper` in sub-resource specific to that sub-resource

### DIFF
--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customexceptions/SubResourceExceptionMapperTest.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customexceptions/SubResourceExceptionMapperTest.java
@@ -1,0 +1,89 @@
+package io.quarkus.resteasy.reactive.server.test.customexceptions;
+
+import static io.quarkus.resteasy.reactive.server.test.ExceptionUtil.removeStackTrace;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
+
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.resteasy.reactive.server.test.ExceptionUtil;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+
+class SubResourceExceptionMapperTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .withApplicationRoot(jar -> jar.addClasses(RootResource.class, SubResource.class,
+                    OtherSubResource.class, OtherResource.class, ExceptionUtil.class));
+
+    @Test
+    void subResourceMapperHandlesOwnException() {
+        RestAssured.get("/root/sub/throw").then().statusCode(416);
+    }
+
+    @Test
+    void subResourceMapperDoesNotAffectOtherResources() {
+        RestAssured.get("/other/throw").then().statusCode(500);
+    }
+
+    @Test
+    void subResourceMapperDoesNotAffectOtherSubResources() {
+        RestAssured.get("/root/other-sub/throw").then().statusCode(500);
+    }
+
+    @Path("root")
+    public static class RootResource {
+
+        @Path("sub")
+        public SubResource sub() {
+            return new SubResource();
+        }
+
+        @Path("other-sub")
+        public OtherSubResource otherSub() {
+            return new OtherSubResource();
+        }
+    }
+
+    public static class SubResource {
+
+        @ServerExceptionMapper
+        public Response handleException(IllegalArgumentException e) {
+            return Response.status(416).build();
+        }
+
+        @GET
+        @Path("throw")
+        @Produces("text/plain")
+        public String throwsException() {
+            throw removeStackTrace(new IllegalArgumentException("from sub-resource"));
+        }
+    }
+
+    public static class OtherSubResource {
+
+        @GET
+        @Path("throw")
+        @Produces("text/plain")
+        public String throwsException() {
+            throw removeStackTrace(new IllegalArgumentException("from other sub-resource"));
+        }
+    }
+
+    @Path("other")
+    public static class OtherResource {
+
+        @GET
+        @Path("throw")
+        @Produces("text/plain")
+        public String throwsException() {
+            throw removeStackTrace(new IllegalArgumentException("from other resource"));
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/scanning/ResteasyReactiveScanner.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/scanning/ResteasyReactiveScanner.java
@@ -388,6 +388,22 @@ public class ResteasyReactiveScanner {
                 requestScopedResources.add(classInfo.name());
             }
             possibleSubResources.put(classInfo.name(), classInfo);
+            // If a concrete leaf sub-resource class declares @ServerExceptionMapper, treat it as
+            // scoped to that sub-resource rather than global. Abstract classes, interfaces, and classes with subclasses
+            // are excluded because we cannot reliably distinguish actual sub-resources from other
+            // classes with JAX-RS annotations at this point without unnecessary complexity
+            if (!classInfo.isAbstract() && !classInfo.isInterface()
+                    && index.getAllKnownSubclasses(classInfo.name()).isEmpty()) {
+                List<AnnotationInstance> exceptionMapperAnnotationInstances = classInfo.annotationsMap()
+                        .get(ResteasyReactiveDotNames.SERVER_EXCEPTION_MAPPER);
+                if (exceptionMapperAnnotationInstances != null) {
+                    for (AnnotationInstance exMapperInstance : exceptionMapperAnnotationInstances) {
+                        if (exMapperInstance.target().kind() == AnnotationTarget.Kind.METHOD) {
+                            methodExceptionMappers.add(exMapperInstance.target().asMethod());
+                        }
+                    }
+                }
+            }
             //we need to also look for all subclasses and interfaces
             //they may have type variables that need to be handled
             toScan.addAll(index.getKnownDirectImplementors(classInfo.name()));

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeMappingDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeMappingDeployment.java
@@ -92,7 +92,7 @@ class RuntimeMappingDeployment {
                     null, null,
                     new ServerRestHandler[] { mapper }, null, new Class[0], null, false,
                     false, null, null, null, null, null,
-                    Collections.emptyMap());
+                    resources.get(0).getClassExceptionMappers());
             currentMapperPerMethodTemplates.add(new RequestMapper.RequestPath<>(false, fake.getPath(), fake));
         }
     }


### PR DESCRIPTION
* Closes: https://github.com/quarkusio/quarkus/issues/55426


_P.S. if this was accepted, I'd like backports to 3.33.x as well, but it could be considered a breaking change, so if not possible, np_
