### PR TITLE
Record tree-shaken classes in embedded SBOMs

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -44,6 +45,7 @@ import io.quarkus.deployment.pkg.jar.FastJarBuilder;
 import io.quarkus.deployment.pkg.jar.LegacyThinJarBuilder;
 import io.quarkus.deployment.pkg.jar.NativeImageSourceJarBuilder;
 import io.quarkus.deployment.pkg.jar.UberJarBuilder;
+import io.quarkus.deployment.sbom.SbomGeneratedResourceBuildItem;
 import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.maven.dependency.DependencyFlags;
 import io.quarkus.maven.dependency.GACT;
@@ -110,12 +112,15 @@ public class JarResultBuildStep {
             MainClassBuildItem mainClassBuildItem,
             Optional<JvmStartupOptimizerArchiveRequestedBuildItem> jvmStartupOptimizerArchiveRequested,
             JarTreeShakeBuildItem treeShakeResult,
+            List<SbomGeneratedResourceBuildItem> sbomResources,
             ExecutorService buildExecutor)
             throws Exception {
 
         if (jvmStartupOptimizerArchiveRequested.isPresent()) {
             handleAppCDSSupportFileGeneration(transformedClasses, generatedClasses, jvmStartupOptimizerArchiveRequested.get());
         }
+
+        List<GeneratedResourceBuildItem> allResources = mergeResources(generatedResources, sbomResources);
 
         Set<ArtifactKey> removedArtifactKeys = getRemovedArtifactKeys(classLoadingConfig);
         Set<ArtifactKey> parentFirstArtifactKeys = getParentFirstArtifactKeys(curateOutcomeBuildItem, classLoadingConfig);
@@ -129,7 +134,7 @@ public class JarResultBuildStep {
                     applicationArchivesBuildItem,
                     transformedClasses,
                     generatedClasses,
-                    generatedResources,
+                    allResources,
                     generatedServiceProviders,
                     removedArtifactKeys,
                     uberJarMergedResourceBuildItems,
@@ -145,7 +150,7 @@ public class JarResultBuildStep {
                     applicationArchivesBuildItem,
                     transformedClasses,
                     generatedClasses,
-                    generatedResources,
+                    allResources,
                     generatedServiceProviders,
                     removedArtifactKeys,
                     buildExecutor,
@@ -160,7 +165,7 @@ public class JarResultBuildStep {
                     additionalApplicationArchiveBuildItems,
                     transformedClasses,
                     generatedClasses,
-                    generatedResources,
+                    allResources,
                     generatedServiceProviders,
                     parentFirstArtifactKeys,
                     removedArtifactKeys,
@@ -176,7 +181,7 @@ public class JarResultBuildStep {
                     additionalApplicationArchiveBuildItems,
                     transformedClasses,
                     generatedClasses,
-                    generatedResources,
+                    allResources,
                     generatedServiceProviders,
                     parentFirstArtifactKeys,
                     removedArtifactKeys,
@@ -203,6 +208,7 @@ public class JarResultBuildStep {
             MainClassBuildItem mainClassBuildItem,
             ClassLoadingConfig classLoadingConfig,
             JarTreeShakeBuildItem treeShakeResult,
+            List<SbomGeneratedResourceBuildItem> sbomResources,
             ExecutorService buildExecutor,
             ResolvedJVMRequirements jvmRequirements) throws Exception {
 
@@ -214,7 +220,7 @@ public class JarResultBuildStep {
                 applicationArchivesBuildItem,
                 transformedClasses,
                 generatedClasses,
-                generatedResources,
+                mergeResources(generatedResources, sbomResources),
                 generatedServiceProviders,
                 nativeImageResources,
                 getRemovedArtifactKeys(classLoadingConfig),
@@ -251,6 +257,20 @@ public class JarResultBuildStep {
                 writer.write(classes.toString());
             }
         }
+    }
+
+    private static List<GeneratedResourceBuildItem> mergeResources(
+            List<GeneratedResourceBuildItem> generatedResources,
+            List<SbomGeneratedResourceBuildItem> sbomResources) {
+        if (sbomResources.isEmpty()) {
+            return generatedResources;
+        }
+        List<GeneratedResourceBuildItem> result = new ArrayList<>(generatedResources.size() + sbomResources.size());
+        result.addAll(generatedResources);
+        for (SbomGeneratedResourceBuildItem sbom : sbomResources) {
+            result.add(new GeneratedResourceBuildItem(sbom.getName(), sbom.getData()));
+        }
+        return result;
     }
 
     static class JarRequired implements BooleanSupplier {

--- a/core/deployment/src/main/java/io/quarkus/deployment/sbom/SbomGeneratedResourceBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/sbom/SbomGeneratedResourceBuildItem.java
@@ -1,0 +1,30 @@
+package io.quarkus.deployment.sbom;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * Resource to be included in the application archive as part of SBOM generation.
+ * <p>
+ * SBOM generators must use this build item instead of
+ * {@link io.quarkus.deployment.builditem.GeneratedResourceBuildItem}
+ * to avoid build-step cycles with tree-shake analysis, which collects
+ * roots from {@code GeneratedResourceBuildItem} instances.
+ */
+public final class SbomGeneratedResourceBuildItem extends MultiBuildItem {
+
+    private final String name;
+    private final byte[] data;
+
+    public SbomGeneratedResourceBuildItem(String name, byte[] data) {
+        this.name = name;
+        this.data = data;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public byte[] getData() {
+        return data;
+    }
+}

--- a/extensions/cyclonedx/deployment/src/main/java/io/quarkus/cyclonedx/deployment/CycloneDxProcessor.java
+++ b/extensions/cyclonedx/deployment/src/main/java/io/quarkus/cyclonedx/deployment/CycloneDxProcessor.java
@@ -4,7 +4,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.zip.GZIPOutputStream;
 
 import io.quarkus.bootstrap.app.DependencyInfoProvider;
@@ -18,9 +20,12 @@ import io.quarkus.deployment.builditem.AppModelProviderBuildItem;
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.deployment.pkg.builditem.JarTreeShakeBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
 import io.quarkus.deployment.sbom.SbomBuildItem;
 import io.quarkus.deployment.sbom.SbomContributionBuildItem;
+import io.quarkus.deployment.sbom.SbomGeneratedResourceBuildItem;
+import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.sbom.CoreSbomContributionConfig;
 import io.quarkus.sbom.SbomContribution;
 
@@ -93,45 +98,62 @@ public class CycloneDxProcessor {
     }
 
     /**
-     * Embeds a dependency SBOM as a compressed resource inside the application artifact.
+     * Generates the embedded dependency SBOM resource.
      * <p>
      * Assembles the core application contribution from {@link CurateOutcomeBuildItem}
      * (without distribution paths, since the embedded SBOM describes dependencies rather
-     * than the distribution layout) and merges it with extension contributions from
+     * than the distribution layout), applies tree-shake pedigree notes from
+     * {@link JarTreeShakeBuildItem}, and merges with extension contributions from
      * {@link SbomContributionBuildItem}.
      * <p>
-     * This step does not depend on {@link ArtifactResultBuildItem}, avoiding a build cycle
-     * with the jar packaging steps.
+     * This step produces {@link SbomGeneratedResourceBuildItem} instead of
+     * {@link GeneratedResourceBuildItem} to avoid a build-step cycle with tree-shake
+     * root collection. The JAR build step merges these into the generated resources
+     * passed to JAR builders. It does not produce {@link EmbeddedSbomMetadataBuildItem}
+     * either, since that feeds into endpoint registration and would create a separate
+     * cycle through the main class build step; see {@link #embedDependencySbomMetadata}.
      *
-     * @param generatedResourceBuildItem producer for the embedded SBOM resource
-     * @param embeddedSbomMetadataProducer producer for embedded SBOM metadata
+     * @param sbomResourceProducer producer for the embedded SBOM resource
      * @param cdxConfig CycloneDX SBOM configuration
      * @param curateOutcomeBuildItem application dependency model
      * @param appModelProviderBuildItem application model provider for POM metadata resolution
+     * @param treeShakeResult tree-shake results used to compute pedigree notes for shaken dependencies
      * @param embeddedSbomRequests explicit requests to embed an SBOM
      * @param sbomContributions extension SBOM contributions (npm, PyPI, etc.)
      */
     @BuildStep
-    public void embedDependencySbom(BuildProducer<GeneratedResourceBuildItem> generatedResourceBuildItem,
-            BuildProducer<EmbeddedSbomMetadataBuildItem> embeddedSbomMetadataProducer,
+    public void generateEmbeddedSbom(BuildProducer<SbomGeneratedResourceBuildItem> sbomResourceProducer,
             CycloneDxConfig cdxConfig,
             CurateOutcomeBuildItem curateOutcomeBuildItem,
             AppModelProviderBuildItem appModelProviderBuildItem,
+            JarTreeShakeBuildItem treeShakeResult,
             List<EmbeddedSbomRequestBuildItem> embeddedSbomRequests,
             List<SbomContributionBuildItem> sbomContributions) {
-        if (!cdxConfig.enabled() || !cdxConfig.embedded().enabled() && embeddedSbomRequests.isEmpty()) {
+        if (!isEmbeddedSbomEnabled(cdxConfig, embeddedSbomRequests)) {
             return;
         }
 
-        final CycloneDxConfig.EmbeddedSbomConfig dependencySbomConfig = cdxConfig.embedded();
-        final String resourceName = dependencySbomConfig.resourceName();
-        if (resourceName == null || resourceName.isEmpty()) {
-            throw new IllegalArgumentException("resourceName is not configured for the embedded dependency SBOM");
+        byte[] sbomBytes = generateEmbeddedSbomBytes(cdxConfig, curateOutcomeBuildItem, appModelProviderBuildItem,
+                computePedigrees(treeShakeResult), sbomContributions);
+        String effectiveResourceName = effectiveResourceName(cdxConfig.embedded());
+        if (cdxConfig.embedded().compress()) {
+            sbomBytes = gzip(sbomBytes);
         }
 
-        SbomContribution coreContribution = new CoreSbomContributionConfig()
+        sbomResourceProducer.produce(new SbomGeneratedResourceBuildItem(effectiveResourceName, sbomBytes));
+    }
+
+    private byte[] generateEmbeddedSbomBytes(CycloneDxConfig cdxConfig,
+            CurateOutcomeBuildItem curateOutcomeBuildItem,
+            AppModelProviderBuildItem appModelProviderBuildItem,
+            Map<ArtifactKey, String> pedigrees,
+            List<SbomContributionBuildItem> sbomContributions) {
+        final String resourceName = cdxConfig.embedded().resourceName();
+
+        CoreSbomContributionConfig config = new CoreSbomContributionConfig()
                 .setApplicationModel(curateOutcomeBuildItem.getApplicationModel())
-                .toSbomContribution();
+                .setPedigrees(pedigrees);
+        SbomContribution coreContribution = config.toSbomContribution();
 
         var depInfoProvider = getDependencyInfoProvider(appModelProviderBuildItem);
         List<String> result = CycloneDxSbomGenerator.newInstance()
@@ -148,18 +170,64 @@ public class CycloneDxProcessor {
                     "Embedded dependency SBOM has more than 1 result for configured resource " + resourceName);
         }
 
-        byte[] sbomBytes = result.get(0).getBytes(StandardCharsets.UTF_8);
-        final boolean compressed = dependencySbomConfig.compress();
-        String effectiveResourceName = resourceName;
-        if (compressed) {
-            sbomBytes = gzip(sbomBytes);
-            if (!resourceName.endsWith(".gz")) {
-                effectiveResourceName = resourceName + ".gz";
+        return result.get(0).getBytes(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Produces {@link EmbeddedSbomMetadataBuildItem} for the embedded SBOM.
+     * <p>
+     * Separated from {@link #generateEmbeddedSbom} so that metadata production does not
+     * depend on {@link JarTreeShakeBuildItem}, avoiding a build-step cycle through
+     * endpoint registration and the main class build step.
+     */
+    @BuildStep
+    public void embedDependencySbomMetadata(
+            BuildProducer<EmbeddedSbomMetadataBuildItem> embeddedSbomMetadataProducer,
+            CycloneDxConfig cdxConfig,
+            List<EmbeddedSbomRequestBuildItem> embeddedSbomRequests) {
+        if (!isEmbeddedSbomEnabled(cdxConfig, embeddedSbomRequests)) {
+            return;
+        }
+        final CycloneDxConfig.EmbeddedSbomConfig embeddedConfig = cdxConfig.embedded();
+        embeddedSbomMetadataProducer
+                .produce(new EmbeddedSbomMetadataBuildItem(effectiveResourceName(embeddedConfig), embeddedConfig.compress()));
+    }
+
+    private static boolean isEmbeddedSbomEnabled(CycloneDxConfig cdxConfig,
+            List<EmbeddedSbomRequestBuildItem> embeddedSbomRequests) {
+        if (!cdxConfig.enabled()) {
+            return false;
+        }
+        if (!cdxConfig.embedded().enabled() && embeddedSbomRequests.isEmpty()) {
+            return false;
+        }
+        final String resourceName = cdxConfig.embedded().resourceName();
+        if (resourceName == null || resourceName.isEmpty()) {
+            throw new IllegalArgumentException("resourceName is not configured for the embedded dependency SBOM");
+        }
+        return true;
+    }
+
+    private static String effectiveResourceName(CycloneDxConfig.EmbeddedSbomConfig config) {
+        String resourceName = config.resourceName();
+        if (config.compress() && !resourceName.endsWith(".gz")) {
+            return resourceName + ".gz";
+        }
+        return resourceName;
+    }
+
+    private static Map<ArtifactKey, String> computePedigrees(JarTreeShakeBuildItem treeShakeResult) {
+        if (!treeShakeResult.isClassesShaken()) {
+            return null;
+        }
+        Map<ArtifactKey, String> pedigrees = new HashMap<>();
+        for (ArtifactKey key : treeShakeResult.getRemovedClasses().keySet()) {
+            String pedigree = treeShakeResult.computePedigree(key);
+            if (pedigree != null) {
+                pedigrees.put(key, pedigree);
             }
         }
-
-        generatedResourceBuildItem.produce(new GeneratedResourceBuildItem(effectiveResourceName, sbomBytes));
-        embeddedSbomMetadataProducer.produce(new EmbeddedSbomMetadataBuildItem(effectiveResourceName, compressed));
+        return pedigrees.isEmpty() ? null : pedigrees;
     }
 
     private static byte[] gzip(byte[] data) {

--- a/extensions/cyclonedx/endpoint/deployment/src/main/java/io/quarkus/cyclonedx/endpoint/deployment/CycloneDxEndpointProcessor.java
+++ b/extensions/cyclonedx/endpoint/deployment/src/main/java/io/quarkus/cyclonedx/endpoint/deployment/CycloneDxEndpointProcessor.java
@@ -1,15 +1,19 @@
 package io.quarkus.cyclonedx.endpoint.deployment;
 
+import java.util.List;
 import java.util.Optional;
 
 import io.quarkus.cyclonedx.deployment.spi.EmbeddedSbomMetadataBuildItem;
 import io.quarkus.cyclonedx.deployment.spi.EmbeddedSbomRequestBuildItem;
 import io.quarkus.cyclonedx.endpoint.runtime.CycloneDxEndpointRecorder;
+import io.quarkus.deployment.IsProduction;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
+import io.quarkus.deployment.sbom.SbomGeneratedResourceBuildItem;
 import io.quarkus.vertx.http.deployment.spi.RouteBuildItem;
 import io.quarkus.vertx.http.runtime.management.ManagementInterfaceBuildTimeConfig;
 
@@ -31,6 +35,22 @@ public class CycloneDxEndpointProcessor {
             BuildProducer<EmbeddedSbomRequestBuildItem> producer) {
         if (config.enabled()) {
             producer.produce(new EmbeddedSbomRequestBuildItem());
+        }
+    }
+
+    /**
+     * Makes SBOM resources available on the dev-mode classpath.
+     * <p>
+     * In dev and test modes the JAR packaging step that merges
+     * {@link SbomGeneratedResourceBuildItem} into the archive is not executed,
+     * so this step re-publishes them as {@link GeneratedResourceBuildItem}
+     * instances so the endpoint handler can load the SBOM from the classpath.
+     */
+    @BuildStep(onlyIfNot = IsProduction.class)
+    void registerSbomResourcesForDevMode(List<SbomGeneratedResourceBuildItem> sbomResources,
+            BuildProducer<GeneratedResourceBuildItem> resourceProducer) {
+        for (SbomGeneratedResourceBuildItem sbom : sbomResources) {
+            resourceProducer.produce(new GeneratedResourceBuildItem(sbom.getName(), sbom.getData()));
         }
     }
 

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/sbom/CoreSbomContributionConfig.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/sbom/CoreSbomContributionConfig.java
@@ -81,6 +81,7 @@ public class CoreSbomContributionConfig {
     private Purl mainPurl;
     private ResolvedDependency mainArtifact;
     private Collection<ArtifactCoords> mainDependencies;
+    private Map<ArtifactKey, String> pedigrees;
     private List<ComponentHolder> additionalComponents = new ArrayList<>();
     private Map<Path, List<Path>> extraFileDependencies = new HashMap<>();
 
@@ -136,6 +137,19 @@ public class CoreSbomContributionConfig {
      */
     public CoreSbomContributionConfig setMainDependencies(Collection<ArtifactCoords> dependencies) {
         this.mainDependencies = dependencies;
+        return this;
+    }
+
+    /**
+     * Sets pedigree notes for application model dependencies, keyed by artifact.
+     * The pedigree for each dependency is applied when
+     * {@link #toSbomContribution()} creates its component descriptor.
+     *
+     * @param pedigrees artifact-key-to-pedigree map, or {@code null}
+     * @return this config
+     */
+    public CoreSbomContributionConfig setPedigrees(Map<ArtifactKey, String> pedigrees) {
+        this.pedigrees = pedigrees;
         return this;
     }
 
@@ -269,7 +283,14 @@ public class CoreSbomContributionConfig {
         addComponentHolder(toMavenDescriptor(appArtifact), appArtifact, compArtifacts, compPaths, compList);
         registerBomRef(appArtifact.toCompactCoords(), bomRefCounters);
         for (ResolvedDependency dep : applicationModel.getDependencies()) {
-            ComponentHolder holder = addComponentHolder(toMavenDescriptor(dep), dep, compArtifacts, compPaths, compList);
+            ComponentDescriptor.Builder builder = toMavenDescriptor(dep);
+            if (pedigrees != null) {
+                String pedigree = pedigrees.get(dep.getKey());
+                if (pedigree != null) {
+                    builder.setPedigree(pedigree);
+                }
+            }
+            ComponentHolder holder = addComponentHolder(builder, dep, compArtifacts, compPaths, compList);
             registerBomRef(holder.component.getBomRef(), bomRefCounters);
             detectShadedContent(dep, holder, bomRefCounters);
         }

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/TreeShakeSbomIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/TreeShakeSbomIT.java
@@ -1,10 +1,12 @@
 package io.quarkus.maven.it;
 
+import static io.quarkus.maven.it.CycloneDxTestUtils.parseCompressedEmbeddedSbom;
 import static io.quarkus.maven.it.CycloneDxTestUtils.parseSbom;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -40,6 +42,20 @@ public class TreeShakeSbomIT extends MojoTestBase {
         assertThat(invoker.log()).containsIgnoringCase("BUILD SUCCESS");
 
         Bom bom = parseSbom(new File(testDir, "app"), "quarkus-run-cyclonedx.json");
+        assertPedigreeContains(bom, "org.acme", "lib", "org/acme/lib/UnusedHelper.class");
+    }
+
+    @Test
+    void testEmbeddedSbomPedigree() throws Exception {
+        RunningInvoker invoker = new RunningInvoker(testDir, false);
+        MavenProcessInvocationResult result = invoker.execute(
+                List.of("clean", "package", "-DskipTests"), Map.of());
+        assertThat(result.getProcess().waitFor()).isEqualTo(0);
+        assertThat(invoker.log()).containsIgnoringCase("BUILD SUCCESS");
+
+        Path generatedJar = testDir.toPath()
+                .resolve("app/target/quarkus-app/quarkus/generated-bytecode.jar");
+        Bom bom = parseCompressedEmbeddedSbom(generatedJar, "META-INF/sbom/dependency.cdx.json.gz");
         assertPedigreeContains(bom, "org.acme", "lib", "org/acme/lib/UnusedHelper.class");
     }
 

--- a/integration-tests/maven/src/test/resources-filtered/projects/tree-shake-sbom/app/src/main/resources/application.properties
+++ b/integration-tests/maven/src/test/resources-filtered/projects/tree-shake-sbom/app/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 quarkus.package.jar.tree-shake.mode=classes
+quarkus.cyclonedx.embedded.enabled=true


### PR DESCRIPTION
This adds support for recording tree-shaken classes in embedded SBOMs.

I had to introduce `SbomGeneratedResourceBuildItem`, which is effectively `GeneratedResourceBuildItem`, just to break the build step cyclic dependency.