### PR TITLE
Add HTTP Host header validation filter for vertx-http

### DIFF
--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -448,6 +448,68 @@ port.
 To make your Quarkus application accessible to another application running on a different domain, you need to configure cross-origin resource sharing (CORS).
 For more information about the CORS filter that Quarkus provides, see the Quarkus xref:security-cors.adoc#cors-filter[CORS filter] section of the "Cross-origin resource sharing" guide.
 
+[[host-header-validation]]
+== HTTP Host header validation
+
+Quarkus can validate the HTTP `Host` header on incoming requests to protect against DNS rebinding attacks and host header poisoning.
+
+When `quarkus.http.host` is set to a localhost name (`localhost`, `127.0.0.1`, or `[::1]`), host validation is automatically enabled in **dev** and **production** modes.
+Only requests whose `Host` header matches one of the known localhost names are accepted; all others receive a `400 Bad Request` response.
+
+[WARNING]
+====
+This automatic behavior is a change from previous Quarkus versions, where no `Host` header validation was performed.
+If your application runs behind a reverse proxy that rewrites the `Host` header, you may need to either:
+
+* configure the allowed hosts explicitly with `quarkus.http.host-validation.allowed-hosts`, or
+* disable the automatic validation with `quarkus.http.host-validation.require-localhost=false`.
+====
+
+=== Configuring allowed hosts
+
+To restrict requests to a specific set of host names, use `allowed-hosts`:
+
+[source, properties]
+----
+quarkus.http.host-validation.allowed-hosts=example.com,api.example.com
+----
+
+The check is case-insensitive and only validates the host name, not the port.
+
+=== Requiring localhost only
+
+To explicitly require that only localhost names are accepted:
+
+[source, properties]
+----
+quarkus.http.host-validation.require-localhost=true
+----
+
+To disable automatic localhost validation when the server is bound to a localhost address:
+
+[source, properties]
+----
+quarkus.http.host-validation.require-localhost=false
+----
+
+NOTE: `allowed-hosts` and `require-localhost` are mutually exclusive.
+Setting both results in a configuration error.
+
+=== Reverse proxy considerations
+
+When running behind a reverse proxy, enable proxy header forwarding so that Quarkus validates the forwarded host instead of the proxy's internal host name:
+
+[source, properties]
+----
+quarkus.http.proxy.proxy-address-forwarding=true
+quarkus.http.proxy.allow-forwarded=true
+quarkus.http.host-validation.allowed-hosts=public-api.example.com
+----
+
+This works with both the standard `Forwarded` header and the `X-Forwarded-Host` header.
+
+include::{generated-dir}/config/quarkus-vertx-http_quarkus.http.host-validation.adoc[leveloffset=+1, opts=optional]
+
 == HTTP Limits Configuration
 
 include::{generated-dir}/config/quarkus-vertx-http_quarkus.http.limits.adoc[leveloffset=+1, opts=optional]
@@ -772,9 +834,10 @@ Route order constants defined in `io.quarkus.vertx.http.runtime.RouteConstants` 
 | `Integer.MIN_VALUE` | `ROUTE_ORDER_ACCESS_LOG_HANDLER` | Access-log handler, if enabled in the configuration.
 | `Integer.MIN_VALUE` | `ROUTE_ORDER_RECORD_START_TIME` | Handler adding the start-time, if enabled in the configuration.
 | `Integer.MIN_VALUE` | `ROUTE_ORDER_HOT_REPLACEMENT` | -replacement body handler.
-| `Integer.MIN_VALUE` | `ROUTE_ORDER_BODY_HANDLER_MANAGEMENT` | Body handler for the management router.
 | `Integer.MIN_VALUE` | `ROUTE_ORDER_HEADERS` | Handlers that add headers specified in the configuration.
-| `Integer.MIN_VALUE` | `ROUTE_ORDER_CORS_MANAGEMENT` | CORS-Origin handler of the management router.
+| `Integer.MIN_VALUE + 1` | `ROUTE_ORDER_HOST_VALIDATION_MANAGEMENT` | Host validation handler of the management router.
+| `Integer.MIN_VALUE + 2` | `ROUTE_ORDER_CORS_MANAGEMENT` | CORS-Origin handler of the management router.
+| `Integer.MIN_VALUE + 3` | `ROUTE_ORDER_BODY_HANDLER_MANAGEMENT` | Body handler for the management router.
 | `Integer.MIN_VALUE + 1` | `ROUTE_ORDER_BODY_HANDLER` | Body handler.
 | `-2` | `ROUTE_ORDER_UPLOAD_LIMIT` | Route that enforces the upload body size limit.
 | `0` | `ROUTE_ORDER_COMPRESSION` | Compression handler.

--- a/docs/src/main/asciidoc/management-interface-reference.adoc
+++ b/docs/src/main/asciidoc/management-interface-reference.adoc
@@ -263,6 +263,38 @@ quarkus.management.cors.origins=http://example.com
 
 When CORS is enabled without configuring specific origins, only same-origin requests are allowed.
 
+== HTTP Host header validation
+
+The management interface supports the same HTTP `Host` header validation as the main HTTP server, but with separate configuration under `quarkus.management.host-validation.*`.
+
+When `quarkus.management.host` is set to a localhost name (`localhost`, `127.0.0.1`, or `[::1]`), host validation is automatically enabled in **dev** and **production** modes.
+
+[WARNING]
+====
+This automatic behavior is a change from previous Quarkus versions.
+If the management interface is accessed through a reverse proxy or a non-localhost host name, configure the allowed hosts explicitly or disable automatic validation.
+====
+
+For example, to restrict requests to specific host names:
+
+[source, properties]
+----
+quarkus.management.enabled=true
+quarkus.management.host-validation.allowed-hosts=management.example.com
+----
+
+To disable automatic localhost validation:
+
+[source, properties]
+----
+quarkus.management.enabled=true
+quarkus.management.host-validation.require-localhost=false
+----
+
+For more details on the available options and reverse proxy considerations, see the xref:http-reference.adoc#host-header-validation[HTTP Host header validation] section in the HTTP reference guide.
+
+include::{generated-dir}/config/quarkus-vertx-http_quarkus.management.host-validation.adoc[leveloffset=+1, opts=optional]
+
 == Security
 
 Security for the management endpoints exposed in the separate HTTP server needs to be enabled explicitly like in the example below:

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
@@ -74,6 +74,7 @@ import io.quarkus.vertx.http.deployment.spi.HttpServerStartedBuildItem;
 import io.quarkus.vertx.http.deployment.spi.UseManagementInterfaceBuildItem;
 import io.quarkus.vertx.http.runtime.CurrentRequestProducer;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
+import io.quarkus.vertx.http.runtime.HostValidationRecorder;
 import io.quarkus.vertx.http.runtime.HttpCertificateUpdateEventListener;
 import io.quarkus.vertx.http.runtime.HttpStaticDirConfig;
 import io.quarkus.vertx.http.runtime.VertxConfigBuilder;
@@ -166,6 +167,13 @@ class VertxHttpProcessor {
         return new FilterBuildItem(
                 recorder.corsHandler(programmaticCorsConfig, capabilities.isPresent(Capability.SECURITY)),
                 SecurityHandlerPriorities.CORS);
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    FilterBuildItem hostValidation(HostValidationRecorder recorder) {
+        // If the handler is null, it will be automatically filtered out by finalizeRouter.
+        return new FilterBuildItem(recorder.hostValidationHandler(), SecurityHandlerPriorities.HOST_VALIDATION);
     }
 
     @BuildStep

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/HostValidationAllowedHostsTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/HostValidationAllowedHostsTest.java
@@ -1,0 +1,144 @@
+package io.quarkus.vertx.http;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.logging.LogRecord;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.event.Observes;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+public class HostValidationAllowedHostsTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(LocalBeanRegisteringRoute.class)
+                    .addAsResource(new StringAsset(
+                            "quarkus.http.host-validation.allowed-hosts=public-api.com,another-public-api.com,moRe-puBlic-aPi.com\n"
+                                    + "quarkus.log.category.\"io.quarkus.vertx.http.runtime.HostValidationFilter\".level=DEBUG\n"),
+                            "application.properties"))
+            .setLogRecordPredicate(r -> r.getLoggerName().contains("HostValidation"))
+            .assertLogRecords(HostValidationAllowedHostsTest::assertLogRecords);
+
+    @Test
+    void localHostRequest() {
+        given().header("Host", "localhost")
+                .get("/test").then()
+                .statusCode(400)
+                .body(emptyString());
+    }
+
+    @Test
+    void localHostRequestWithPort() {
+        given().header("Host", "localhost:8081")
+                .get("/test").then()
+                .statusCode(400)
+                .body(emptyString());
+    }
+
+    @Test
+    void loopbackRequest() {
+        given().header("Host", "127.0.0.1:8081")
+                .get("/test").then()
+                .statusCode(400)
+                .body(emptyString());
+    }
+
+    @Test
+    void invalidLongHostRequest() {
+        given().header("Host", "www.verylonghost-name-myservice-mymicroservice-localhost.com")
+                .get("/test").then()
+                .statusCode(400)
+                .body(emptyString());
+    }
+
+    @Test
+    void publicHostRequest() {
+        given().header("Host", "public-api.com:8080")
+                .get("/test").then()
+                .statusCode(200)
+                .body(equalTo("test route"));
+    }
+
+    @Test
+    void publicHostCaseInsensitiveRequest() {
+        given().header("Host", "Public-Api.com:8080")
+                .get("/test").then()
+                .statusCode(200)
+                .body(equalTo("test route"));
+    }
+
+    @Test
+    void anotherPublicHostRequest() {
+        given().header("Host", "another-public-api.com:8080")
+                .get("/test").then()
+                .statusCode(200)
+                .body(equalTo("test route"));
+    }
+
+    @Test
+    void anotherPublicHostCaseInsensitiveRequest() {
+        given().header("Host", "Another-Public-Api.com:8080")
+                .get("/test").then()
+                .statusCode(200)
+                .body(equalTo("test route"));
+    }
+
+    @Test
+    void morePublicHostCaseInsensitiveRequest() {
+        given().header("Host", "More-Public-Api.com:8080")
+                .get("/test").then()
+                .statusCode(200)
+                .body(equalTo("test route"));
+    }
+
+    static class LocalBeanRegisteringRoute {
+
+        void init(@Observes Router router) {
+            Handler<RoutingContext> handler = rc -> rc.response().end("test route");
+            router.get("/test").handler(handler);
+        }
+    }
+
+    private static String formatMessage(LogRecord r) {
+        if (r.getParameters() != null && r.getParameters().length > 0) {
+            return String.format(r.getMessage(), r.getParameters());
+        }
+        return r.getMessage();
+    }
+
+    private static void assertLogRecords(List<LogRecord> records) {
+        List<String> invalidHostMessages = records.stream()
+                .filter(r -> r.getMessage() != null)
+                .map(HostValidationAllowedHostsTest::formatMessage)
+                .filter(m -> m.contains("rejected by the Host Validation filter"))
+                .collect(Collectors.toList());
+        assertEquals(4, invalidHostMessages.size());
+
+        assertEquals(2, invalidHostMessages.stream()
+                .filter(m -> m.contains("Request host localhost"))
+                .count());
+
+        assertEquals(1, invalidHostMessages.stream()
+                .filter(m -> m.contains("Request host 127.0.0.1"))
+                .count());
+
+        assertEquals(1, invalidHostMessages.stream()
+                .filter(m -> m.contains("Request host "
+                        + "www.verylonghost-name-myservice-mymicroservice-localhost.com".substring(0, 30) + "..."))
+                .count());
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/HostValidationAllowedHostsWithForwardedHostTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/HostValidationAllowedHostsWithForwardedHostTest.java
@@ -1,0 +1,54 @@
+package io.quarkus.vertx.http;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+
+import jakarta.enterprise.event.Observes;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+public class HostValidationAllowedHostsWithForwardedHostTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(LocalBeanRegisteringRoute.class)
+                    .addAsResource(new StringAsset(
+                            "quarkus.http.proxy.proxy-address-forwarding=true\n"
+                                    + "quarkus.http.proxy.allow-forwarded=true\n"
+                                    + "quarkus.http.host-validation.allowed-hosts=public-api.com\n"),
+                            "application.properties"));
+
+    @Test
+    void somePublicApiHostRequest() {
+        given().header("Host", "some-public-api")
+                .get("/test").then()
+                .statusCode(400)
+                .body(emptyString());
+    }
+
+    @Test
+    void somePublicApiHostWithForwardedHostRequest() {
+        given().header("Host", "some-public-api")
+                .header("Forwarded", "host=public-api.com")
+                .get("/test").then()
+                .statusCode(200)
+                .body(equalTo("test route"));
+    }
+
+    static class LocalBeanRegisteringRoute {
+
+        void init(@Observes Router router) {
+            Handler<RoutingContext> handler = rc -> rc.response().end("test route");
+            router.get("/test").handler(handler);
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/HostValidationAllowedHostsWithXForwardedHostTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/HostValidationAllowedHostsWithXForwardedHostTest.java
@@ -1,0 +1,55 @@
+package io.quarkus.vertx.http;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+
+import jakarta.enterprise.event.Observes;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+public class HostValidationAllowedHostsWithXForwardedHostTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(LocalBeanRegisteringRoute.class)
+                    .addAsResource(new StringAsset(
+                            "quarkus.http.proxy.proxy-address-forwarding=true\n"
+                                    + "quarkus.http.proxy.allow-x-forwarded=true\n"
+                                    + "quarkus.http.proxy.enable-forwarded-host=true\n"
+                                    + "quarkus.http.host-validation.allowed-hosts=public-api.com\n"),
+                            "application.properties"));
+
+    @Test
+    void somePublicApiHostRequest() {
+        given().header("Host", "some-public-api")
+                .get("/test").then()
+                .statusCode(400)
+                .body(emptyString());
+    }
+
+    @Test
+    void somePublicApiHostWithXForwardedHostRequest() {
+        given().header("Host", "some-public-api")
+                .header("X-Forwarded-Host", "public-api.com")
+                .get("/test").then()
+                .statusCode(200)
+                .body(equalTo("test route"));
+    }
+
+    static class LocalBeanRegisteringRoute {
+
+        void init(@Observes Router router) {
+            Handler<RoutingContext> handler = rc -> rc.response().end("test route");
+            router.get("/test").handler(handler);
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/HostValidationAllowedLocalHostTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/HostValidationAllowedLocalHostTest.java
@@ -1,0 +1,67 @@
+package io.quarkus.vertx.http;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+
+import jakarta.enterprise.event.Observes;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+public class HostValidationAllowedLocalHostTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(LocalBeanRegisteringRoute.class)
+                    .addAsResource(new StringAsset(
+                            "quarkus.http.host-validation.require-localhost=true\n"),
+                            "application.properties"));
+
+    @Test
+    void localHostRequest() {
+        given().header("Host", "localhost:8081")
+                .get("/test").then()
+                .statusCode(200)
+                .body(equalTo("test route"));
+    }
+
+    @Test
+    void localHostCaseInsensitiveRequest() {
+        given().header("Host", "LocalHost:8081")
+                .get("/test").then()
+                .statusCode(200)
+                .body(equalTo("test route"));
+    }
+
+    @Test
+    void loopbackRequest() {
+        given().header("Host", "127.0.0.1:8081")
+                .get("/test").then()
+                .statusCode(200)
+                .body(equalTo("test route"));
+    }
+
+    @Test
+    void publicHostRequest() {
+        given().header("Host", "public-api.com:8080")
+                .get("/test").then()
+                .statusCode(400)
+                .body(emptyString());
+    }
+
+    static class LocalBeanRegisteringRoute {
+
+        void init(@Observes Router router) {
+            Handler<RoutingContext> handler = rc -> rc.response().end("test route");
+            router.get("/test").handler(handler);
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/HostValidationAndCorsTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/HostValidationAndCorsTest.java
@@ -1,0 +1,72 @@
+package io.quarkus.vertx.http;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+
+import jakarta.enterprise.event.Observes;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+public class HostValidationAndCorsTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(LocalBeanRegisteringRoute.class)
+                    .addAsResource(new StringAsset(
+                            "quarkus.http.host-validation.allowed-hosts=localhost\n"
+                                    + "quarkus.http.cors.enabled=true\n"),
+                            "application.properties"));
+
+    @Test
+    void hostWithoutPortAndOrigin() {
+        given().header("Host", "localhost")
+                .header("Origin", "http://localhost:8081")
+                .get("/test").then()
+                .statusCode(403)
+                .body(emptyString());
+    }
+
+    @Test
+    void hostWithWrongPortAndOrigin() {
+        given().header("Host", "localhost:9000")
+                .header("Origin", "http://localhost:8081")
+                .get("/test").then()
+                .statusCode(403)
+                .body(emptyString());
+    }
+
+    @Test
+    void hostWithCorrectPortAndOrigin() {
+        given().header("Host", "localhost:8081")
+                .header("Origin", "http://localhost:8081")
+                .get("/test").then()
+                .statusCode(200)
+                .body(equalTo("test route"));
+    }
+
+    @Test
+    void wrongHostWithCorrectPortAndOrigin() {
+        given().header("Host", "public-api.com:8081")
+                .header("Origin", "http://public-api.com:8081")
+                .get("/test").then()
+                .statusCode(400)
+                .body(emptyString());
+    }
+
+    static class LocalBeanRegisteringRoute {
+
+        void init(@Observes Router router) {
+            Handler<RoutingContext> handler = rc -> rc.response().end("test route");
+            router.get("/test").handler(handler);
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/HostValidationAnyHostTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/HostValidationAnyHostTest.java
@@ -1,0 +1,59 @@
+package io.quarkus.vertx.http;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import jakarta.enterprise.event.Observes;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+public class HostValidationAnyHostTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(LocalBeanRegisteringRoute.class)
+                    .addAsResource(new StringAsset(
+                            "quarkus.http.host=localhost\n"
+                                    + "quarkus.http.host-validation.require-localhost=false\n"),
+                            "application.properties"));
+
+    @Test
+    void loopbackRequest() {
+        given().header("Host", "127.0.0.1:8081")
+                .get("/test").then()
+                .statusCode(200)
+                .body(equalTo("test route"));
+    }
+
+    @Test
+    void localHostRequest() {
+        given().header("Host", "localhost:8081")
+                .get("/test").then()
+                .statusCode(200)
+                .body(equalTo("test route"));
+    }
+
+    @Test
+    void publicHostRequest() {
+        given().header("Host", "public-api.com:8080")
+                .get("/test").then()
+                .statusCode(200)
+                .body(equalTo("test route"));
+    }
+
+    static class LocalBeanRegisteringRoute {
+
+        void init(@Observes Router router) {
+            Handler<RoutingContext> handler = rc -> rc.response().end("test route");
+            router.get("/test").handler(handler);
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/HostValidationConfigurationErrorTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/HostValidationConfigurationErrorTest.java
@@ -1,0 +1,30 @@
+package io.quarkus.vertx.http;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class HostValidationConfigurationErrorTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset(
+                            "quarkus.http.host-validation.allowed-hosts=localhost,127.0.0.1\n"
+                                    + "quarkus.http.host-validation.require-localhost=true\n"),
+                            "application.properties"))
+            .assertException(t -> {
+                Assertions.assertInstanceOf(ConfigurationException.class, t);
+                Assertions.assertTrue(t.getMessage().contains("mutually exclusive properties"),
+                        "Exception message should mention 'mutually exclusive properties', got: " + t.getMessage());
+            });
+
+    @Test
+    public void test() {
+        Assertions.fail();
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/HostValidationQuarkusHttpHostTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/HostValidationQuarkusHttpHostTest.java
@@ -1,0 +1,59 @@
+package io.quarkus.vertx.http;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+
+import jakarta.enterprise.event.Observes;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+public class HostValidationQuarkusHttpHostTest {
+
+    @RegisterExtension
+    static QuarkusDevModeTest runner = new QuarkusDevModeTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(LocalBeanRegisteringRoute.class)
+                    .addAsResource(new StringAsset(
+                            "quarkus.http.host=localhost\n"),
+                            "application.properties"));
+
+    @Test
+    void loopbackRequest() {
+        given().header("Host", "127.0.0.1:8081")
+                .get("/test").then()
+                .statusCode(200)
+                .body(equalTo("test route"));
+    }
+
+    @Test
+    void localHostRequest() {
+        given().header("Host", "localhost:8081")
+                .get("/test").then()
+                .statusCode(200)
+                .body(equalTo("test route"));
+    }
+
+    @Test
+    void publicHostRequest() {
+        given().header("Host", "public-api.com:8080")
+                .get("/test").then()
+                .statusCode(400)
+                .body(emptyString());
+    }
+
+    static class LocalBeanRegisteringRoute {
+
+        void init(@Observes Router router) {
+            Handler<RoutingContext> handler = rc -> rc.response().end("test route");
+            router.get("/test").handler(handler);
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/HostValidationWithoutHostTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/HostValidationWithoutHostTest.java
@@ -1,0 +1,54 @@
+package io.quarkus.vertx.http;
+
+import java.net.Socket;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+import jakarta.enterprise.event.Observes;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.deployment.util.IoUtil;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+public class HostValidationWithoutHostTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(LocalBeanRegisteringRoute.class)
+                    .addAsResource(new StringAsset(
+                            "quarkus.http.host-validation.allowed-hosts=localhost\n"),
+                            "application.properties"));
+
+    @TestHTTPResource
+    URI uri;
+
+    @Test
+    public void requestWithoutHost() throws Exception {
+        try (Socket s = new Socket(uri.getHost(), uri.getPort())) {
+            s.getOutputStream().write("GET /test HTTP/1.0\r\nConnection: close\r\n\r\n"
+                    .getBytes(StandardCharsets.UTF_8));
+            String result = new String(IoUtil.readBytes(s.getInputStream()), StandardCharsets.UTF_8);
+            Assertions.assertTrue(result.contains("400 Bad Request\r\n"),
+                    "Expected 400 Bad Request but got: " + result);
+            Assertions.assertFalse(result.contains("test-route"),
+                    "Response must not contain 'test-route' but got: " + result);
+        }
+    }
+
+    static class LocalBeanRegisteringRoute {
+
+        void init(@Observes Router router) {
+            Handler<RoutingContext> handler = rc -> rc.response().end("test route");
+            router.get("/test").handler(handler);
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementHostValidationAllowedHostsTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementHostValidationAllowedHostsTest.java
@@ -1,0 +1,106 @@
+package io.quarkus.vertx.http.management;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.net.URL;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.vertx.http.ManagementInterface;
+
+public class ManagementHostValidationAllowedHostsTest {
+
+    private static final String configuration = "quarkus.management.enabled=true\n"
+            + "quarkus.management.root-path=/management\n"
+            + "quarkus.management.host-validation.allowed-hosts=public-api.com,another-public-api.com,moRe-puBlic-aPi.com\n";
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset(configuration), "application.properties")
+                    .addClasses(MyObserver.class));
+
+    @TestHTTPResource(value = "/my-route", management = true)
+    URL myRoute;
+
+    @Test
+    void localHostRequest() {
+        given().header("Host", "localhost")
+                .get(myRoute).then()
+                .statusCode(400)
+                .body(emptyString());
+    }
+
+    @Test
+    void localHostRequestWithPort() {
+        given().header("Host", "localhost:9001")
+                .get(myRoute).then()
+                .statusCode(400)
+                .body(emptyString());
+    }
+
+    @Test
+    void loopbackRequest() {
+        given().header("Host", "127.0.0.1:9001")
+                .get(myRoute).then()
+                .statusCode(400)
+                .body(emptyString());
+    }
+
+    @Test
+    void publicHostRequest() {
+        given().header("Host", "public-api.com:9001")
+                .get(myRoute).then()
+                .statusCode(200)
+                .body(equalTo("test route"));
+    }
+
+    @Test
+    void publicHostCaseInsensitiveRequest() {
+        given().header("Host", "Public-Api.com:9001")
+                .get(myRoute).then()
+                .statusCode(200)
+                .body(equalTo("test route"));
+    }
+
+    @Test
+    void anotherPublicHostRequest() {
+        given().header("Host", "another-public-api.com:9001")
+                .get(myRoute).then()
+                .statusCode(200)
+                .body(equalTo("test route"));
+    }
+
+    @Test
+    void anotherPublicHostCaseInsensitiveRequest() {
+        given().header("Host", "Another-Public-Api.com:9001")
+                .get(myRoute).then()
+                .statusCode(200)
+                .body(equalTo("test route"));
+    }
+
+    @Test
+    void morePublicHostCaseInsensitiveRequest() {
+        given().header("Host", "More-Public-Api.com:9001")
+                .get(myRoute).then()
+                .statusCode(200)
+                .body(equalTo("test route"));
+    }
+
+    @Singleton
+    static class MyObserver {
+
+        public void registerManagementRoutes(@Observes ManagementInterface mi) {
+            mi.router().get("/management/my-route").handler(rc -> rc.response().end("test route"));
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementHostValidationAllowedLocalHostTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementHostValidationAllowedLocalHostTest.java
@@ -1,0 +1,74 @@
+package io.quarkus.vertx.http.management;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.net.URL;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.vertx.http.ManagementInterface;
+
+public class ManagementHostValidationAllowedLocalHostTest {
+
+    private static final String configuration = "quarkus.management.enabled=true\n"
+            + "quarkus.management.root-path=/management\n"
+            + "quarkus.management.host-validation.require-localhost=true\n";
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset(configuration), "application.properties")
+                    .addClasses(MyObserver.class));
+
+    @TestHTTPResource(value = "/my-route", management = true)
+    URL myRoute;
+
+    @Test
+    void localHostRequest() {
+        given().header("Host", "localhost:9001")
+                .get(myRoute).then()
+                .statusCode(200)
+                .body(equalTo("test route"));
+    }
+
+    @Test
+    void localHostCaseInsensitiveRequest() {
+        given().header("Host", "LocalHost:9001")
+                .get(myRoute).then()
+                .statusCode(200)
+                .body(equalTo("test route"));
+    }
+
+    @Test
+    void loopbackRequest() {
+        given().header("Host", "127.0.0.1:9001")
+                .get(myRoute).then()
+                .statusCode(200)
+                .body(equalTo("test route"));
+    }
+
+    @Test
+    void publicHostRequest() {
+        given().header("Host", "public-api.com:9001")
+                .get(myRoute).then()
+                .statusCode(400)
+                .body(emptyString());
+    }
+
+    @Singleton
+    static class MyObserver {
+
+        public void registerManagementRoutes(@Observes ManagementInterface mi) {
+            mi.router().get("/management/my-route").handler(rc -> rc.response().end("test route"));
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementHostValidationAndCorsTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementHostValidationAndCorsTest.java
@@ -1,0 +1,79 @@
+package io.quarkus.vertx.http.management;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.net.URL;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.vertx.http.ManagementInterface;
+
+public class ManagementHostValidationAndCorsTest {
+
+    private static final String configuration = "quarkus.management.enabled=true\n"
+            + "quarkus.management.root-path=/management\n"
+            + "quarkus.management.host-validation.allowed-hosts=localhost\n"
+            + "quarkus.management.cors.enabled=true\n";
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset(configuration), "application.properties")
+                    .addClasses(MyObserver.class));
+
+    @TestHTTPResource(value = "/my-route", management = true)
+    URL myRoute;
+
+    @Test
+    void hostWithoutPortAndOrigin() {
+        given().header("Host", "localhost")
+                .header("Origin", "http://localhost:9001")
+                .get(myRoute).then()
+                .statusCode(403)
+                .body(emptyString());
+    }
+
+    @Test
+    void hostWithWrongPortAndOrigin() {
+        given().header("Host", "localhost:9000")
+                .header("Origin", "http://localhost:9001")
+                .get(myRoute).then()
+                .statusCode(403)
+                .body(emptyString());
+    }
+
+    @Test
+    void hostWithCorrectPortAndOrigin() {
+        given().header("Host", "localhost:9001")
+                .header("Origin", "http://localhost:9001")
+                .get(myRoute).then()
+                .statusCode(200)
+                .body(equalTo("test route"));
+    }
+
+    @Test
+    void wrongHostWithCorrectPortAndOrigin() {
+        given().header("Host", "public-api.com:9001")
+                .header("Origin", "http://public-api.com:9001")
+                .get(myRoute).then()
+                .statusCode(400)
+                .body(emptyString());
+    }
+
+    @Singleton
+    static class MyObserver {
+
+        public void registerManagementRoutes(@Observes ManagementInterface mi) {
+            mi.router().get("/management/my-route").handler(rc -> rc.response().end("test route"));
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementHostValidationAnyHostTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementHostValidationAnyHostTest.java
@@ -1,0 +1,66 @@
+package io.quarkus.vertx.http.management;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.net.URL;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.vertx.http.ManagementInterface;
+
+public class ManagementHostValidationAnyHostTest {
+
+    private static final String configuration = "quarkus.management.enabled=true\n"
+            + "quarkus.management.root-path=/management\n"
+            + "quarkus.management.host=localhost\n"
+            + "quarkus.management.host-validation.require-localhost=false\n";
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset(configuration), "application.properties")
+                    .addClasses(MyObserver.class));
+
+    @TestHTTPResource(value = "/my-route", management = true)
+    URL myRoute;
+
+    @Test
+    void loopbackRequest() {
+        given().header("Host", "127.0.0.1:9001")
+                .get(myRoute).then()
+                .statusCode(200)
+                .body(equalTo("test route"));
+    }
+
+    @Test
+    void localHostRequest() {
+        given().header("Host", "localhost:9001")
+                .get(myRoute).then()
+                .statusCode(200)
+                .body(equalTo("test route"));
+    }
+
+    @Test
+    void publicHostRequest() {
+        given().header("Host", "public-api.com:9001")
+                .get(myRoute).then()
+                .statusCode(200)
+                .body(equalTo("test route"));
+    }
+
+    @Singleton
+    static class MyObserver {
+
+        public void registerManagementRoutes(@Observes ManagementInterface mi) {
+            mi.router().get("/management/my-route").handler(rc -> rc.response().end("test route"));
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementHostValidationConfigurationErrorTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementHostValidationConfigurationErrorTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.vertx.http.management;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class ManagementHostValidationConfigurationErrorTest {
+
+    private static final String configuration = "quarkus.management.enabled=true\n"
+            + "quarkus.management.host-validation.allowed-hosts=localhost,127.0.0.1\n"
+            + "quarkus.management.host-validation.require-localhost=true\n";
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset(configuration), "application.properties"))
+            .assertException(t -> {
+                Assertions.assertInstanceOf(ConfigurationException.class, t);
+                Assertions.assertTrue(t.getMessage().contains("mutually exclusive properties"),
+                        "Exception message should mention 'mutually exclusive properties', got: " + t.getMessage());
+            });
+
+    @Test
+    public void test() {
+        Assertions.fail();
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementHostValidationWithForwardedHostTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementHostValidationWithForwardedHostTest.java
@@ -1,0 +1,61 @@
+package io.quarkus.vertx.http.management;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.net.URL;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.vertx.http.ManagementInterface;
+
+public class ManagementHostValidationWithForwardedHostTest {
+
+    private static final String configuration = "quarkus.management.enabled=true\n"
+            + "quarkus.management.root-path=/management\n"
+            + "quarkus.management.proxy.proxy-address-forwarding=true\n"
+            + "quarkus.management.proxy.allow-forwarded=true\n"
+            + "quarkus.management.host-validation.allowed-hosts=public-api.com\n";
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset(configuration), "application.properties")
+                    .addClasses(MyObserver.class));
+
+    @TestHTTPResource(value = "/my-route", management = true)
+    URL myRoute;
+
+    @Test
+    void somePublicApiHostRequest() {
+        given().header("Host", "some-public-api")
+                .get(myRoute).then()
+                .statusCode(400)
+                .body(emptyString());
+    }
+
+    @Test
+    void somePublicApiHostWithForwardedHostRequest() {
+        given().header("Host", "some-public-api")
+                .header("Forwarded", "host=public-api.com")
+                .get(myRoute).then()
+                .statusCode(200)
+                .body(equalTo("test route"));
+    }
+
+    @Singleton
+    static class MyObserver {
+
+        public void registerManagementRoutes(@Observes ManagementInterface mi) {
+            mi.router().get("/management/my-route").handler(rc -> rc.response().end("test route"));
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementHostValidationWithXForwardedHostTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementHostValidationWithXForwardedHostTest.java
@@ -1,0 +1,62 @@
+package io.quarkus.vertx.http.management;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.net.URL;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.vertx.http.ManagementInterface;
+
+public class ManagementHostValidationWithXForwardedHostTest {
+
+    private static final String configuration = "quarkus.management.enabled=true\n"
+            + "quarkus.management.root-path=/management\n"
+            + "quarkus.management.proxy.proxy-address-forwarding=true\n"
+            + "quarkus.management.proxy.allow-x-forwarded=true\n"
+            + "quarkus.management.proxy.enable-forwarded-host=true\n"
+            + "quarkus.management.host-validation.allowed-hosts=public-api.com\n";
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset(configuration), "application.properties")
+                    .addClasses(MyObserver.class));
+
+    @TestHTTPResource(value = "/my-route", management = true)
+    URL myRoute;
+
+    @Test
+    void somePublicApiHostRequest() {
+        given().header("Host", "some-public-api")
+                .get(myRoute).then()
+                .statusCode(400)
+                .body(emptyString());
+    }
+
+    @Test
+    void somePublicApiHostWithXForwardedHostRequest() {
+        given().header("Host", "some-public-api")
+                .header("X-Forwarded-Host", "public-api.com")
+                .get(myRoute).then()
+                .statusCode(200)
+                .body(equalTo("test route"));
+    }
+
+    @Singleton
+    static class MyObserver {
+
+        public void registerManagementRoutes(@Observes ManagementInterface mi) {
+            mi.router().get("/management/my-route").handler(rc -> rc.response().end("test route"));
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementHostValidationWithoutHostTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/management/ManagementHostValidationWithoutHostTest.java
@@ -1,0 +1,55 @@
+package io.quarkus.vertx.http.management;
+
+import java.net.Socket;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.deployment.util.IoUtil;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.vertx.http.ManagementInterface;
+
+public class ManagementHostValidationWithoutHostTest {
+
+    private static final String configuration = "quarkus.management.enabled=true\n"
+            + "quarkus.management.root-path=/management\n"
+            + "quarkus.management.host-validation.allowed-hosts=localhost\n";
+
+    @RegisterExtension
+    static QuarkusExtensionTest runner = new QuarkusExtensionTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset(configuration), "application.properties")
+                    .addClasses(MyObserver.class));
+
+    @TestHTTPResource(value = "/my-route", management = true)
+    URL uri;
+
+    @Test
+    public void requestWithoutHost() throws Exception {
+        try (Socket s = new Socket(uri.getHost(), uri.getPort())) {
+            s.getOutputStream().write("GET /management/my-route HTTP/1.0\r\nConnection: close\r\n\r\n"
+                    .getBytes(StandardCharsets.UTF_8));
+            String result = new String(IoUtil.readBytes(s.getInputStream()), StandardCharsets.UTF_8);
+            Assertions.assertTrue(result.contains("400 Bad Request\r\n"),
+                    "Expected 400 Bad Request but got: " + result);
+            Assertions.assertFalse(result.contains("test-route"),
+                    "Response must not contain 'test-route' but got: " + result);
+        }
+    }
+
+    @Singleton
+    static class MyObserver {
+
+        public void registerManagementRoutes(@Observes ManagementInterface mi) {
+            mi.router().get("/management/my-route").handler(rc -> rc.response().end("test route"));
+        }
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HostValidationConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HostValidationConfig.java
@@ -1,0 +1,34 @@
+package io.quarkus.vertx.http.runtime;
+
+import java.util.Optional;
+import java.util.Set;
+
+import io.quarkus.runtime.configuration.TrimmedStringConverter;
+import io.smallrye.config.WithConverter;
+
+/**
+ * HTTP Host header validation.
+ */
+public interface HostValidationConfig {
+
+    /**
+     * Require that HTTP Host authority can only contain valid localhost names
+     * such as "localhost", "127.0.0.1" or "[::1]".
+     * <p>
+     * This requirement is enforced in production and dev modes, when neither this nor the {@link #allowedHosts()} properties
+     * are configured and the "quarkus.http.host" property has a valid localhost name.
+     * Set this property to {@code false} if it is not required.
+     * <p>
+     * Note this property is mutually exclusive with the {@link #allowedHosts()} property.
+     */
+    Optional<Boolean> requireLocalhost();
+
+    /**
+     * Allowed hosts.
+     * <p>
+     * A comma-separated set of hosts, for example: "localhost", "quarkus.io".
+     * <p>
+     * Note this property is mutually exclusive with the {@link #requireLocalhost()} property.
+     */
+    Optional<Set<@WithConverter(TrimmedStringConverter.class) String>> allowedHosts();
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HostValidationFilter.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HostValidationFilter.java
@@ -1,0 +1,54 @@
+package io.quarkus.vertx.http.runtime;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.jboss.logging.Logger;
+
+import io.vertx.core.Handler;
+import io.vertx.core.net.HostAndPort;
+import io.vertx.ext.web.RoutingContext;
+
+public final class HostValidationFilter implements Handler<RoutingContext> {
+
+    private static final Logger LOG = Logger.getLogger(HostValidationFilter.class);
+    private static final int MAX_LOGGED_HOST_LENGTH = 30;
+
+    private final Set<String> allowedHosts;
+
+    public HostValidationFilter(Set<String> allowedHosts) {
+        Objects.requireNonNull(allowedHosts);
+        if (allowedHosts.isEmpty()) {
+            throw new IllegalStateException("A set of allowed hosts must not be empty");
+        }
+        this.allowedHosts = Set.copyOf(allowedHosts.stream().map(String::toLowerCase).collect(Collectors.toSet()));
+    }
+
+    @Override
+    public void handle(RoutingContext context) {
+        HostAndPort authority = context.request().authority();
+        if (authority == null || authority.host() == null) {
+            LOG.debug("Request HTTP Host header is not available, Host Validation filter requires a valid HTTP Host header");
+            endResponse(context);
+            return;
+        }
+
+        if (!allowedHosts.contains(authority.host().toLowerCase())) {
+            LOG.debugf("Request host %s rejected by the Host Validation filter", truncateHost(authority.host()));
+            endResponse(context);
+            return;
+        }
+
+        context.next();
+    }
+
+    private static String truncateHost(String host) {
+        return host.length() > MAX_LOGGED_HOST_LENGTH ? (host.substring(0, MAX_LOGGED_HOST_LENGTH) + "...") : host;
+    }
+
+    private static void endResponse(RoutingContext context) {
+        context.response().setStatusCode(400);
+        context.response().end();
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HostValidationRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HostValidationRecorder.java
@@ -1,0 +1,70 @@
+package io.quarkus.vertx.http.runtime;
+
+import java.util.Set;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.runtime.LaunchMode;
+import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.annotations.Recorder;
+import io.quarkus.runtime.configuration.ConfigurationException;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+
+@Recorder
+public class HostValidationRecorder {
+    private static final Logger LOG = Logger.getLogger(HostValidationRecorder.class);
+    private static final Set<String> LOCAL_HOSTNAMES = Set.of("localhost", "127.0.0.1", "[::1]");
+
+    private final RuntimeValue<VertxHttpConfig> httpConfig;
+
+    public HostValidationRecorder(RuntimeValue<VertxHttpConfig> httpConfig) {
+        this.httpConfig = httpConfig;
+    }
+
+    public Handler<RoutingContext> hostValidationHandler() {
+        return hostValidationHandler(httpConfig.getValue().hostValidation(), httpConfig.getValue().host(), false);
+    }
+
+    static Handler<RoutingContext> hostValidationHandler(HostValidationConfig hostValidationConfig, String quarkusHttpHost,
+            boolean managementRouter) {
+
+        String interfaceName = managementRouter ? "management" : "http";
+
+        // Allowing a localhost only is not permitted when a list of hosts is explicitly configured and vice versa
+        if (hostValidationConfig.allowedHosts().isPresent()
+                && !hostValidationConfig.allowedHosts().get().isEmpty()
+                && hostValidationConfig.requireLocalhost().orElse(false)) {
+            throw new ConfigurationException(
+                    "'quarkus." + interfaceName
+                            + ".host-validation.allowed-hosts' and 'quarkus." + interfaceName
+                            + ".host-validation.require-localhost' are mutually exclusive properties.");
+        }
+
+        if (hostValidationConfig.allowedHosts().isPresent()
+                && !hostValidationConfig.allowedHosts().get().isEmpty()) {
+            LOG.debugf(
+                    "HTTP Host header will be expected to match one of %d hosts configured with 'quarkus.%s.host-validation.allowed-hosts'",
+                    hostValidationConfig.allowedHosts().get().size(), interfaceName);
+            return new HostValidationFilter(hostValidationConfig.allowedHosts().get());
+        }
+
+        if (hostValidationConfig.requireLocalhost().isPresent()) {
+            if (hostValidationConfig.requireLocalhost().get()) {
+                LOG.debug("HTTP Host header will be expected to contain one of the valid localhost names only");
+                return new HostValidationFilter(LOCAL_HOSTNAMES);
+            }
+            return null;
+        }
+
+        // When in prod or dev mode, require localhost if the host has a valid localhost name
+        if ((LaunchMode.current().isProduction() || LaunchMode.current().isDev())
+                && LOCAL_HOSTNAMES.contains(quarkusHttpHost)) {
+            LOG.debugf("Enabling localhost name validation for the %s interface because the server is launched on localhost",
+                    managementRouter ? "management" : "HTTP");
+            return new HostValidationFilter(LOCAL_HOSTNAMES);
+        }
+
+        return null;
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/RouteConstants.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/RouteConstants.java
@@ -22,17 +22,21 @@ public final class RouteConstants {
      */
     public static final int ROUTE_ORDER_HOT_REPLACEMENT = Integer.MIN_VALUE;
     /**
-     * Order value ({@value #ROUTE_ORDER_BODY_HANDLER_MANAGEMENT}) for the body handler for the management router.
-     */
-    public static final int ROUTE_ORDER_BODY_HANDLER_MANAGEMENT = Integer.MIN_VALUE;
-    /**
      * Order value ({@value #ROUTE_ORDER_HEADERS}) for the handlers that add headers specified in the configuration.
      */
     public static final int ROUTE_ORDER_HEADERS = Integer.MIN_VALUE;
     /**
+     * Order value ({@value #ROUTE_ORDER_HOST_VALIDATION_MANAGEMENT}) for the Host header validation of the management router.
+     */
+    public static final int ROUTE_ORDER_HOST_VALIDATION_MANAGEMENT = Integer.MIN_VALUE + 1;
+    /**
      * Order value ({@value #ROUTE_ORDER_CORS_MANAGEMENT}) for the CORS-Origin handler of the management router.
      */
-    public static final int ROUTE_ORDER_CORS_MANAGEMENT = Integer.MIN_VALUE;
+    public static final int ROUTE_ORDER_CORS_MANAGEMENT = Integer.MIN_VALUE + 2;
+    /**
+     * Order value ({@value #ROUTE_ORDER_BODY_HANDLER_MANAGEMENT}) for the body handler for the management router.
+     */
+    public static final int ROUTE_ORDER_BODY_HANDLER_MANAGEMENT = Integer.MIN_VALUE + 3;
     /**
      * Order value ({@value #ROUTE_ORDER_BODY_HANDLER}) for the body handler.
      */

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpConfig.java
@@ -127,6 +127,12 @@ public interface VertxHttpConfig {
     CORSConfig cors();
 
     /**
+     * The HTTP Host header validation
+     */
+    @ConfigDocSection(generated = true)
+    HostValidationConfig hostValidation();
+
+    /**
      * The SSL config
      */
     ServerSslConfig ssl();

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -601,12 +601,21 @@ public class VertxHttpRecorder {
                     new QuarkusErrorHandler(launchMode.isDevOrTest(), decorateStacktrace(launchMode, logBuildTimeConfig),
                             httpConfig.unhandledErrorContentTypeDefault(), srcMainJava, knowClasses, actions));
 
-            mr.route().order(RouteConstants.ROUTE_ORDER_BODY_HANDLER_MANAGEMENT)
-                    .handler(createBodyHandlerForManagementInterface());
+            Handler<RoutingContext> hostValidationHandler = HostValidationRecorder.hostValidationHandler(
+                    managementConfig.getValue().hostValidation(),
+                    managementConfig.getValue().host(),
+                    true);
+            if (hostValidationHandler != null) {
+                mr.route().order(RouteConstants.ROUTE_ORDER_HOST_VALIDATION_MANAGEMENT).handler(hostValidationHandler);
+            }
+
             if (managementConfig.getValue().cors().enabled()) {
                 mr.route().order(RouteConstants.ROUTE_ORDER_CORS_MANAGEMENT)
                         .handler(new CORSFilter(managementConfig.getValue().cors()));
             }
+
+            mr.route().order(RouteConstants.ROUTE_ORDER_BODY_HANDLER_MANAGEMENT)
+                    .handler(createBodyHandlerForManagementInterface());
 
             HttpServerCommonHandlers.applyFilters(managementConfig.getValue().filter(), mr);
             for (Filter filter : managementInterfaceFilterList) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/management/ManagementConfig.java
@@ -12,6 +12,7 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 import io.quarkus.vertx.http.runtime.BodyConfig;
 import io.quarkus.vertx.http.runtime.FilterConfig;
 import io.quarkus.vertx.http.runtime.HeaderConfig;
+import io.quarkus.vertx.http.runtime.HostValidationConfig;
 import io.quarkus.vertx.http.runtime.ProxyConfig;
 import io.quarkus.vertx.http.runtime.ServerLimitsConfig;
 import io.quarkus.vertx.http.runtime.ServerSslConfig;
@@ -74,6 +75,12 @@ public interface ManagementConfig {
      */
     @ConfigDocSection(generated = true)
     CORSConfig cors();
+
+    /**
+     * The HTTP Host header validation
+     */
+    @ConfigDocSection(generated = true)
+    HostValidationConfig hostValidation();
 
     /**
      * The SSL config

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/SecurityHandlerPriorities.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/SecurityHandlerPriorities.java
@@ -2,6 +2,7 @@ package io.quarkus.vertx.http.runtime.security;
 
 public class SecurityHandlerPriorities {
 
+    public static final int HOST_VALIDATION = 400;
     public static final int CORS = 300;
     public static final int AUTHENTICATION = 200;
     public static final int FORM_AUTHENTICATION = 150;

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/HostValidationFilterTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/HostValidationFilterTest.java
@@ -1,0 +1,85 @@
+package io.quarkus.vertx.http.runtime;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.vertx.core.net.HostAndPort;
+import io.vertx.ext.web.RoutingContext;
+
+@ExtendWith(MockitoExtension.class)
+class HostValidationFilterTest {
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    RoutingContext context;
+
+    @Test
+    void requestWithoutAuthority() {
+        when(context.request().authority()).thenReturn(null);
+
+        new HostValidationFilter(Set.of("localhost")).handle(context);
+
+        verify(context.response()).setStatusCode(400);
+        verify(context.response()).end();
+        verify(context, never()).next();
+    }
+
+    @Test
+    void allowedHostMatch() {
+        when(context.request().authority()).thenReturn(HostAndPort.create("localhost", 8080));
+
+        new HostValidationFilter(Set.of("localhost")).handle(context);
+
+        verify(context).next();
+        verify(context.response(), never()).setStatusCode(400);
+    }
+
+    @Test
+    void hostNotInAllowedSet() {
+        when(context.request().authority()).thenReturn(HostAndPort.create("evil.com", 8080));
+
+        new HostValidationFilter(Set.of("localhost")).handle(context);
+
+        verify(context.response()).setStatusCode(400);
+        verify(context.response()).end();
+        verify(context, never()).next();
+    }
+
+    @Test
+    void caseInsensitiveMatching() {
+        when(context.request().authority()).thenReturn(HostAndPort.create("LocalHost", 8080));
+
+        new HostValidationFilter(Set.of("localhost")).handle(context);
+
+        verify(context).next();
+        verify(context.response(), never()).setStatusCode(400);
+    }
+
+    @Test
+    void hostWithPort() {
+        when(context.request().authority()).thenReturn(HostAndPort.create("localhost", 9999));
+
+        new HostValidationFilter(Set.of("localhost")).handle(context);
+
+        verify(context).next();
+        verify(context.response(), never()).setStatusCode(400);
+    }
+
+    @Test
+    void multipleAllowedHosts() {
+        when(context.request().authority()).thenReturn(HostAndPort.create("api.example.com", 443));
+
+        new HostValidationFilter(Set.of("localhost", "api.example.com")).handle(context);
+
+        verify(context).next();
+        verify(context.response(), never()).setStatusCode(400);
+    }
+}


### PR DESCRIPTION
This protects against DNS rebinding and host header poisoning by validating the HTTP Host header. When quarkus.http.host is set to localhost, validation is automatically enabled in dev and production modes.

Superseedes https://github.com/quarkusio/quarkus/pull/52957
