### PR TITLE
librariesOnly option to include only library components in generated SBOMs

### DIFF
--- a/docs/src/main/asciidoc/cyclonedx.adoc
+++ b/docs/src/main/asciidoc/cyclonedx.adoc
@@ -184,6 +184,35 @@ By default, generated JSON SBOMs are not pretty-printed. To enable pretty-printi
 quarkus.cyclonedx.pretty-print=true
 ----
 
+=== Libraries-only mode
+
+By default, the generated SBOM includes all components of the application distribution, including generic file components such as non-Maven JARs and other generated files. To include only components identified as libraries (i.e., those with a recognized package type such as Maven or npm), use:
+
+[source,properties]
+----
+quarkus.cyclonedx.libraries-only=true
+----
+
+When enabled, components that would be classified as `file` type in CycloneDX (generic PURL components with a file system path or distribution path) are excluded from the generated SBOM along with their dependency relationships.
+
+=== CycloneDX schema version
+
+By default, the SBOM is generated using the latest CycloneDX schema version supported by the integrated library. A specific version can be requested:
+
+[source,properties]
+----
+quarkus.cyclonedx.schema-version=1.5
+----
+
+=== License text
+
+License text is not included in generated SBOMs by default. To include the full text of resolved licenses:
+
+[source,properties]
+----
+quarkus.cyclonedx.include-license-text=true
+----
+
 === Pedigree
 
 Pedigree is a way to provide information that patches or modifications have been applied to a component.

--- a/extensions/cyclonedx/deployment/src/main/java/io/quarkus/cyclonedx/deployment/CycloneDxConfig.java
+++ b/extensions/cyclonedx/deployment/src/main/java/io/quarkus/cyclonedx/deployment/CycloneDxConfig.java
@@ -54,6 +54,15 @@ public interface CycloneDxConfig {
     boolean prettyPrint();
 
     /**
+     * Whether to include only library components in generated SBOMs, excluding
+     * generic file components such as non-Maven JARs and other files.
+     *
+     * @return whether to include only library components
+     */
+    @WithDefault("false")
+    boolean librariesOnly();
+
+    /**
      * Embedded dependency SBOM configuration
      */
     @ConfigDocSection

--- a/extensions/cyclonedx/deployment/src/main/java/io/quarkus/cyclonedx/deployment/CycloneDxProcessor.java
+++ b/extensions/cyclonedx/deployment/src/main/java/io/quarkus/cyclonedx/deployment/CycloneDxProcessor.java
@@ -72,6 +72,7 @@ public class CycloneDxProcessor {
                     .setSchemaVersion(cdxSbomConfig.schemaVersion().orElse(null))
                     .setIncludeLicenseText(cdxSbomConfig.includeLicenseText())
                     .setPrettyPrint(cdxSbomConfig.prettyPrint())
+                    .setLibrariesOnly(cdxSbomConfig.librariesOnly())
                     .setContributions(contributions)
                     .generate()) {
                 sbomProducer.produce(new SbomBuildItem(sbom));
@@ -162,6 +163,7 @@ public class CycloneDxProcessor {
                 .setSchemaVersion(cdxConfig.schemaVersion().orElse(null))
                 .setIncludeLicenseText(cdxConfig.includeLicenseText())
                 .setPrettyPrint(cdxConfig.prettyPrint())
+                .setLibrariesOnly(cdxConfig.librariesOnly())
                 .setContributions(collectContributions(coreContribution, sbomContributions))
                 .generateText();
 

--- a/extensions/cyclonedx/generator/src/main/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGenerator.java
+++ b/extensions/cyclonedx/generator/src/main/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGenerator.java
@@ -84,6 +84,7 @@ public class CycloneDxSbomGenerator {
     private EffectiveModelResolver modelResolver;
     private boolean includeLicenseText;
     private boolean prettyPrint;
+    private boolean librariesOnly;
     private Instant outputTimestamp;
     private List<SbomContribution> contributions = List.of();
 
@@ -135,6 +136,12 @@ public class CycloneDxSbomGenerator {
     public CycloneDxSbomGenerator setPrettyPrint(boolean prettyPrint) {
         ensureNotGenerated();
         this.prettyPrint = prettyPrint;
+        return this;
+    }
+
+    public CycloneDxSbomGenerator setLibrariesOnly(boolean librariesOnly) {
+        ensureNotGenerated();
+        this.librariesOnly = librariesOnly;
         return this;
     }
 
@@ -228,6 +235,25 @@ public class CycloneDxSbomGenerator {
             allDependencies.addAll(contribution.dependencies());
         }
 
+        // Filter out non-library components when librariesOnly is enabled
+        final Set<String> excludedBomRefs;
+        if (librariesOnly) {
+            excludedBomRefs = new HashSet<>();
+            allDescriptors.removeIf(d -> {
+                if (d.getBomRef().equals(mainComponentBomRef)) {
+                    return false;
+                }
+                if (isFileComponent(d)) {
+                    excludedBomRefs.add(d.getBomRef());
+                    return true;
+                }
+                return false;
+            });
+            allDependencies.removeIf(d -> excludedBomRefs.contains(d.getBomRef()));
+        } else {
+            excludedBomRefs = Set.of();
+        }
+
         // Sort for consistent ordering across builds
         allDescriptors.sort(Comparator.comparing(ComponentDescriptor::getBomRef));
         allDependencies.sort(Comparator.comparing(ComponentDependencies::getBomRef));
@@ -248,7 +274,9 @@ public class CycloneDxSbomGenerator {
             List<String> sortedDeps = new ArrayList<>(dep.getDependsOn());
             Collections.sort(sortedDeps);
             for (String depRef : sortedDeps) {
-                d.addDependency(new Dependency(depRef));
+                if (!excludedBomRefs.contains(depRef)) {
+                    d.addDependency(new Dependency(depRef));
+                }
             }
             dependencyMap.put(dep.getBomRef(), d);
         }
@@ -338,6 +366,12 @@ public class CycloneDxSbomGenerator {
         return refs;
     }
 
+    private static boolean isFileComponent(ComponentDescriptor descriptor) {
+        Purl purl = descriptor.getPurl();
+        return Purl.TYPE_GENERIC.equals(purl.getType())
+                && (descriptor.getPath() != null || descriptor.getDistributionPath() != null);
+    }
+
     private static PackageURL toCycloneDxPurl(Purl purl) {
         try {
             TreeMap<String, String> qualifiers = purl.getQualifiers().isEmpty()
@@ -408,8 +442,7 @@ public class CycloneDxSbomGenerator {
         }
 
         // Component type
-        if (Purl.TYPE_GENERIC.equals(purl.getType())
-                && (descriptor.getPath() != null || descriptor.getDistributionPath() != null)) {
+        if (isFileComponent(descriptor)) {
             c.setType(Component.Type.FILE);
         } else {
             c.setType(Component.Type.LIBRARY);

--- a/extensions/cyclonedx/generator/src/test/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGeneratorTest.java
+++ b/extensions/cyclonedx/generator/src/test/java/io/quarkus/cyclonedx/generator/CycloneDxSbomGeneratorTest.java
@@ -2,12 +2,16 @@ package io.quarkus.cyclonedx.generator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Instant;
 import java.util.List;
 
 import org.cyclonedx.model.Bom;
+import org.cyclonedx.model.Component;
 import org.cyclonedx.model.Dependency;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import io.quarkus.bootstrap.resolver.maven.EffectiveModelResolver;
 import io.quarkus.maven.dependency.ArtifactCoords;
@@ -335,6 +339,109 @@ class CycloneDxSbomGeneratorTest {
                 .orElseThrow();
         assertThat(parentComp.getComponents()).hasSize(1);
         assertThat(parentComp.getComponents().get(0).getName()).isEqualTo("org.jacoco.agent.rt");
+    }
+
+    @Test
+    void librariesOnlyExcludesFileComponents(@TempDir Path tempDir) throws Exception {
+        // Create a temporary file so the descriptor has a real path
+        Path runnerJar = tempDir.resolve("quarkus-run.jar");
+        Files.createFile(runnerJar);
+
+        // Main component (APPLICATION type, should be kept)
+        ResolvedDependency mainArtifact = resolvedDep("org.acme", "acme-app", "1.0.0",
+                List.of(ArtifactCoords.jar("io.quarkus", "quarkus-rest", "3.0.0")));
+        ResolvedDependency restDep = resolvedDep("io.quarkus", "quarkus-rest", "3.0.0", List.of());
+
+        SbomContribution coreContribution = new CoreSbomContributionConfig()
+                .setMainArtifact(mainArtifact)
+                .addComponent(restDep)
+                .toSbomContribution();
+
+        // FILE component: generic PURL with a distribution path
+        ComponentDescriptor fileComponent = ComponentDescriptor.builder()
+                .setPurl(Purl.generic("quarkus-run.jar", "1.0.0"))
+                .setDistributionPath("quarkus-run.jar")
+                .build();
+
+        // FILE component: generic PURL with a file system path
+        ComponentDescriptor fileWithPath = ComponentDescriptor.builder()
+                .setPurl(Purl.generic("app-data.dat", "1.0.0"))
+                .setPath(runnerJar)
+                .build();
+
+        // LIBRARY component: npm package (should be kept)
+        ComponentDescriptor npmLib = ComponentDescriptor.builder()
+                .setPurl(Purl.npm(null, "react", "18.0.0"))
+                .build();
+
+        SbomContribution extContribution = SbomContribution.of(
+                List.of(fileComponent, fileWithPath, npmLib),
+                List.of(ComponentDependencies.of(
+                        fileComponent.getBomRef(),
+                        List.of(npmLib.getBomRef()))));
+
+        // Generate with librariesOnly=true
+        Bom bom = parseBom(CycloneDxSbomGenerator.newInstance()
+                .setFormat("json")
+                .setLibrariesOnly(true)
+                .setContributions(List.of(coreContribution, extContribution))
+                .generateText().get(0));
+
+        List<String> componentNames = bom.getComponents().stream()
+                .map(Component::getName)
+                .toList();
+
+        // Library and main components should be present
+        assertThat(componentNames).contains("react", "quarkus-rest", "acme-app");
+        // File components should be excluded
+        assertThat(componentNames).doesNotContain("quarkus-run.jar", "app-data.dat");
+
+        // Dependency graph should not reference excluded components
+        List<String> allDepRefs = bom.getDependencies().stream()
+                .map(Dependency::getRef)
+                .toList();
+        assertThat(allDepRefs).doesNotContain(fileComponent.getBomRef(), fileWithPath.getBomRef());
+
+        // References to excluded components should be removed from other entries' dependsOn
+        for (Dependency dep : bom.getDependencies()) {
+            if (dep.getDependencies() != null) {
+                List<String> depRefs = dep.getDependencies().stream()
+                        .map(Dependency::getRef)
+                        .toList();
+                assertThat(depRefs)
+                        .as("Dependency %s should not reference excluded file components", dep.getRef())
+                        .doesNotContain(fileComponent.getBomRef(), fileWithPath.getBomRef());
+            }
+        }
+    }
+
+    @Test
+    void librariesOnlyDisabledIncludesFileComponents() {
+        // FILE component: generic PURL with a distribution path
+        ComponentDescriptor fileComponent = ComponentDescriptor.builder()
+                .setPurl(Purl.generic("quarkus-run.jar", "1.0.0"))
+                .setDistributionPath("quarkus-run.jar")
+                .build();
+
+        ComponentDescriptor npmLib = ComponentDescriptor.builder()
+                .setPurl(Purl.npm(null, "react", "18.0.0"))
+                .build();
+
+        SbomContribution contribution = SbomContribution.ofComponents(List.of(fileComponent, npmLib));
+
+        // Generate with librariesOnly=false (default)
+        Bom bom = parseBom(CycloneDxSbomGenerator.newInstance()
+                .setFormat("json")
+                .setLibrariesOnly(false)
+                .setContributions(List.of(contribution))
+                .generateText().get(0));
+
+        List<String> componentNames = bom.getComponents().stream()
+                .map(Component::getName)
+                .toList();
+
+        // Both should be present when librariesOnly is off
+        assertThat(componentNames).contains("react", "quarkus-run.jar");
     }
 
     private static Bom parseBom(String json) {


### PR DESCRIPTION
Following feedback from users at a conference, this option allows including only library components (Maven, NPM, etc), leaving other files out.