### PR TITLE
Check for not found type before applying escapes

### DIFF
--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/propertynotfound/BeanPropertyNotFoundTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/propertynotfound/BeanPropertyNotFoundTest.java
@@ -1,0 +1,49 @@
+package io.quarkus.qute.deployment.propertynotfound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.Engine;
+import io.quarkus.qute.Template;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tests for GitHub issue #55438: property-not-found-strategy should apply to bean properties.
+ *
+ * Uses dynamic template parsing to avoid build-time validation issues.
+ */
+public class BeanPropertyNotFoundTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.qute.property-not-found-strategy", "noop")
+            .overrideConfigKey("quarkus.qute.strict-rendering", "false");
+
+    @Inject
+    Engine engine;
+
+    @Test
+    public void testBeanPropertyNoop() {
+        Template template = engine.parse("{@java.lang.String item}{item.missingProperty}");
+        String result = template.data("item", "test").render();
+        assertThat(result).as("Missing bean property with NOOP strategy").isEmpty();
+    }
+
+    @Test
+    public void testTemplateVariableNoop() {
+        Template template = engine.parse("{missingVar}");
+        String result = template.render();
+        assertThat(result).as("Missing template variable with NOOP strategy").isEmpty();
+    }
+
+    @Test
+    public void testConsistency() {
+        Template template = engine.parse("{@java.lang.String item}{missingVar}:{item.missingProperty}");
+        String result = template.data("item", "test").render();
+        assertThat(result).as("Both missing var and bean property should be empty").isEqualTo(":");
+    }
+}

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/HtmlEscaper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/HtmlEscaper.java
@@ -67,7 +67,7 @@ public class HtmlEscaper extends CharReplacementResultMapper {
 
     @Override
     public boolean appliesTo(Origin origin, Object result) {
-        if (result instanceof RawString) {
+        if (result instanceof RawString || Results.isNotFound(result)) {
             return false;
         }
         Optional<Variant> variant = origin.getVariant();

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/JsonEscaper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/JsonEscaper.java
@@ -174,7 +174,7 @@ public final class JsonEscaper implements ResultMapper {
 
     @Override
     public boolean appliesTo(Origin origin, Object result) {
-        if (result instanceof RawString) {
+        if (result instanceof RawString || Results.isNotFound(result)) {
             return false;
         }
         Optional<Variant> variant = origin.getVariant();


### PR DESCRIPTION
Fixes #55438 (and pretty simply, too).

The cause of the preference being ignored is that the html and json escapers don't check for `Results.NotFound` before escaping. They should skip escaping when the result is `Results.NotFound`, so that the property-not-found-strategy mappers can handle it.
