### PR TITLE
Remove redundant check in MicroProfileRestClientEnricher

### DIFF
--- a/extensions/resteasy-reactive/rest-client/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/MicroProfileRestClientEnricher.java
+++ b/extensions/resteasy-reactive/rest-client/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/MicroProfileRestClientEnricher.java
@@ -855,11 +855,9 @@ class MicroProfileRestClientEnricher implements JaxrsClientReactiveEnricher {
                         }
                         headerFillingMethod = findMethod(clazz, declaringClass, staticMethodName,
                                 CLIENT_HEADER_PARAM.toString());
-                    } else if (accessibleType == AccessibleType.INTERFACE_METHOD) {
+                    } else {
                         headerFillingMethod = findMethod(declaringClass, declaringClass, accessibleName,
                                 CLIENT_HEADER_PARAM.toString());
-                    } else {
-                        throw new IllegalStateException("Unknown type " + accessibleType);
                     }
 
                     Type valueType = null;


### PR DESCRIPTION
The check was always true given how `accessibleType` is set above