### PR TITLE
 Qute: add bean property tests for property-not-found-strategy

### DIFF
--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/propertynotfound/PropertyNotFoundDefaultTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/propertynotfound/PropertyNotFoundDefaultTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.qute.Template;
 import io.quarkus.test.QuarkusExtensionTest;
 
-public class PropertyNotFoundNoopTest {
+public class PropertyNotFoundDefaultTest {
 
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
@@ -22,7 +22,6 @@ public class PropertyNotFoundNoopTest {
                             new StringAsset(
                                     "name:{item.name} nonExistent:{item.nonExistent}"),
                             "templates/beantest.txt"))
-            .overrideConfigKey("quarkus.qute.property-not-found-strategy", "noop")
             .overrideConfigKey("quarkus.qute.strict-rendering", "false");
 
     @Inject
@@ -32,16 +31,14 @@ public class PropertyNotFoundNoopTest {
     Template beantest;
 
     @Test
-    public void testNoop() {
-        // Missing top-level template data key should produce empty output
-        assertEquals("foos:", test.render());
+    public void testDefaultTopLevel() {
+        assertEquals("foos:NOT_FOUND", test.render());
     }
 
     @Test
-    public void testNoopBeanProperty() {
-        // NOOP strategy should also apply to missing bean properties;
-        // i.e. {item.nonExistent} should produce empty output, not "NOT_FOUND"
-        assertEquals("name:Hello nonExistent:", beantest.data("item", new Item("Hello")).render());
+    public void testDefaultBeanProperty() {
+        assertEquals("name:Hello nonExistent:NOT_FOUND",
+                beantest.data("item", new Item("Hello")).render());
     }
 
     public static class Item {

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/propertynotfound/PropertyNotFoundOutputOriginalTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/propertynotfound/PropertyNotFoundOutputOriginalTest.java
@@ -15,18 +15,42 @@ public class PropertyNotFoundOutputOriginalTest {
 
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
-            .withApplicationRoot((jar) -> jar
+            .withApplicationRoot(root -> root
+                    .addClass(Item.class)
                     .addAsResource(new StringAsset("foos:{foos}"), "templates/test.html")
-                    .addAsResource(new StringAsset("quarkus.qute.property-not-found-strategy=output-original"
-                            + "\nquarkus.qute.strict-rendering=false"),
-                            "application.properties"));
+                    .addAsResource(
+                            new StringAsset(
+                                    "name:{item.name} nonExistent:{item.nonExistent}"),
+                            "templates/beantest.txt"))
+            .overrideConfigKey("quarkus.qute.property-not-found-strategy", "output-original")
+            .overrideConfigKey("quarkus.qute.strict-rendering", "false");
 
     @Inject
     Template test;
 
+    @Inject
+    Template beantest;
+
     @Test
     public void testOriginal() {
+        // Missing top-level template data key should output the original expression
         assertEquals("foos:{foos}", test.render());
+    }
+
+    @Test
+    public void testOriginalBeanProperty() {
+        // OUTPUT_ORIGINAL strategy should also apply to missing bean properties
+        assertEquals("name:Hello nonExistent:{item.nonExistent}",
+                beantest.data("item", new Item("Hello")).render());
+    }
+
+    public static class Item {
+
+        public final String name;
+
+        public Item(String name) {
+            this.name = name;
+        }
     }
 
 }

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/propertynotfound/PropertyNotFoundThrowExceptionTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/propertynotfound/PropertyNotFoundThrowExceptionTest.java
@@ -1,6 +1,8 @@
 package io.quarkus.qute.deployment.propertynotfound;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -19,14 +21,20 @@ public class PropertyNotFoundThrowExceptionTest {
 
     @RegisterExtension
     static final QuarkusExtensionTest config = new QuarkusExtensionTest()
-            .withApplicationRoot((jar) -> jar
+            .withApplicationRoot(root -> root
+                    .addClass(Item.class)
                     .addAsResource(new StringAsset("foos:{foos}"), "templates/test.html")
-                    .addAsResource(new StringAsset("quarkus.qute.property-not-found-strategy=throw-exception"
-                            + "\nquarkus.qute.strict-rendering=false"),
-                            "application.properties"));
+                    .addAsResource(
+                            new StringAsset("{item.nonExistent}"),
+                            "templates/beantest.txt"))
+            .overrideConfigKey("quarkus.qute.property-not-found-strategy", "throw-exception")
+            .overrideConfigKey("quarkus.qute.strict-rendering", "false");
 
     @Inject
     Template test;
+
+    @Inject
+    Template beantest;
 
     @Test
     public void testException() {
@@ -38,6 +46,26 @@ public class PropertyNotFoundThrowExceptionTest {
             assertEquals(TemplateException.class, rootCause.getClass());
             assertTrue(rootCause.getMessage().contains("Key \"foos\" not found in the template data map with keys []"),
                     rootCause.getMessage());
+        }
+    }
+
+    @Test
+    public void testExceptionBeanProperty() {
+        // THROW_EXCEPTION strategy should also apply to missing bean properties
+        Exception expected = assertThrows(Exception.class,
+                () -> beantest.data("item", new Item("Hello")).render());
+        Throwable rootCause = ExceptionUtil.getRootCause(expected);
+        assertInstanceOf(TemplateException.class, rootCause);
+        assertTrue(rootCause.getMessage().contains("Property \"nonExistent\" not found on the base object"),
+                rootCause.getMessage());
+    }
+
+    public static class Item {
+
+        public final String name;
+
+        public Item(String name) {
+            this.name = name;
         }
     }
 


### PR DESCRIPTION
- existing tests only covered missing top-level template data keys
- add test coverage for missing bean/object properties for all strategies
