### PR TITLE
Fix serialization of java.time.Duration in generated reflection-free Jackson serializers

### DIFF
--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonSerializerFactory.java
@@ -550,10 +550,16 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
                 writeFormattedValue(fieldSpecs, bytecode, ctx, pkgName, arg);
             } else if ("STRING".equals(formatShape) && writeMethodForPrimitiveFields(typeName) != null) {
                 writeStringShapedValue(fieldSpecs, bytecode, ctx, pkgName, typeName, arg);
+            } else if ("STRING".equals(formatShape) && fieldSpecs.formatPattern() == null && isJavaTimeDateType(typeName)) {
+                writeToStringValue(fieldSpecs, bytecode, ctx, pkgName, arg);
+            } else if ("STRING".equals(formatShape) && isJavaUtilDateType(typeName)) {
+                writeToStringValue(fieldSpecs, bytecode, ctx, pkgName, arg);
             } else if (fieldSpecs.isFormatShapeNumber() && isBooleanType(typeName)) {
                 writeNumberShapedBoolean(fieldSpecs, bytecode, ctx, pkgName, typeName, arg);
             } else if (fieldSpecs.isFormatShapeNumber() && isJavaUtilDateType(typeName)) {
                 writeDateAsTimestamp(fieldSpecs, bytecode, ctx, pkgName, arg);
+            } else if (fieldSpecs.isFormatShapeNumber() && isJavaTimeDateType(typeName)) {
+                writeTemporalAsTimestamp(fieldSpecs, bytecode, ctx, pkgName, arg);
             } else if (fieldSpecs.formatPattern() != null && isJavaUtilDateType(typeName)) {
                 writeFormattedDateValue(fieldSpecs, bytecode, ctx, pkgName, arg, false);
             } else if (fieldSpecs.formatPattern() != null && isJavaTimeDateType(typeName)) {
@@ -606,6 +612,18 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
                 ctx.jsonGenerator);
     }
 
+    private static void writeToStringValue(FieldSpecs fieldSpecs, BytecodeCreator bytecode, SerializationContext ctx,
+            String pkgName, ResultHandle arg) {
+        writeFieldName(fieldSpecs, bytecode, ctx, pkgName);
+        MethodDescriptor writeString = MethodDescriptor.ofMethod(JsonGenerator.class, "writeString", void.class, String.class);
+        BranchResult nullCheck = bytecode.ifNotNull(arg);
+        ResultHandle strValue = nullCheck.trueBranch().invokeVirtualMethod(
+                MethodDescriptor.ofMethod(Object.class, "toString", String.class), arg);
+        nullCheck.trueBranch().invokeVirtualMethod(writeString, ctx.jsonGenerator, strValue);
+        nullCheck.falseBranch().invokeVirtualMethod(
+                MethodDescriptor.ofMethod(JsonGenerator.class, "writeNull", void.class), ctx.jsonGenerator);
+    }
+
     private static void writeStringShapedValue(FieldSpecs fieldSpecs, BytecodeCreator bytecode, SerializationContext ctx,
             String pkgName, String typeName, ResultHandle arg) {
         writeFieldName(fieldSpecs, bytecode, ctx, pkgName);
@@ -644,6 +662,14 @@ public class JacksonSerializerFactory extends JacksonCodeGenerator {
         writeFieldName(fieldSpecs, bytecode, ctx, pkgName);
         MethodDescriptor serializeMethod = MethodDescriptor.ofMethod(JacksonMapperUtil.class,
                 "serializeDateAsTimestamp", void.class, java.util.Date.class, JsonGenerator.class);
+        bytecode.invokeStaticMethod(serializeMethod, arg, ctx.jsonGenerator);
+    }
+
+    private static void writeTemporalAsTimestamp(FieldSpecs fieldSpecs, BytecodeCreator bytecode, SerializationContext ctx,
+            String pkgName, ResultHandle arg) {
+        writeFieldName(fieldSpecs, bytecode, ctx, pkgName);
+        MethodDescriptor serializeMethod = MethodDescriptor.ofMethod(JacksonMapperUtil.class.getName(),
+                "serializeTemporalAsTimestamp", void.class, Object.class, JsonGenerator.class);
         bytecode.invokeStaticMethod(serializeMethod, arg, ctx.jsonGenerator);
     }
 

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/AbstractGeneratedAnnotationTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/AbstractGeneratedAnnotationTest.java
@@ -615,6 +615,31 @@ public abstract class AbstractGeneratedAnnotationTest {
                 .body("dateTime", Matchers.is("2024-03-13T10:05:01.000Z"));
     }
 
+    // --- @JsonFormat(shape=NUMBER) with Instant and Duration ---
+
+    @Test
+    public void testFormatTemporalAsNumberSerialization() {
+        RestAssured.get("/generated/number-shaped-temporal")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("name", Matchers.is("number-shaped"))
+                .body("instant", Matchers.is(1710324301.5f))
+                .body("duration", Matchers.is(76975.5f));
+    }
+
+    // --- @JsonFormat(shape=STRING) with Duration ---
+
+    @Test
+    public void testFormatDurationAsStringSerialization() {
+        RestAssured.get("/generated/duration-format")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("name", Matchers.is("duration-test"))
+                .body("duration", Matchers.is("PT21H22M55S"));
+    }
+
     // --- @JsonFormat ---
 
     @Test

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/DurationFormatBean.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/DurationFormatBean.java
@@ -1,0 +1,29 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import java.time.Duration;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+public class DurationFormatBean {
+
+    private String name;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    private Duration duration;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Duration getDuration() {
+        return duration;
+    }
+
+    public void setDuration(Duration duration) {
+        this.duration = duration;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationResource.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationResource.java
@@ -1,5 +1,7 @@
 package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -335,6 +337,29 @@ public class GeneratedAnnotationResource {
         ZonedDateTimeFormatBean bean = new ZonedDateTimeFormatBean();
         bean.setName("zoned-date-test");
         bean.setDateTime(ZonedDateTime.of(2024, 3, 13, 10, 5, 1, 0, ZoneOffset.UTC));
+        return bean;
+    }
+
+    // --- NumberShapedTemporalBean: @JsonFormat(shape=NUMBER) with Instant and Duration ---
+
+    @GET
+    @Path("/number-shaped-temporal")
+    public NumberShapedTemporalBean getNumberShapedTemporal() {
+        NumberShapedTemporalBean bean = new NumberShapedTemporalBean();
+        bean.setName("number-shaped");
+        bean.setInstant(Instant.ofEpochSecond(1710324301L, 500_000_000));
+        bean.setDuration(Duration.ofSeconds(76975, 500_000_000));
+        return bean;
+    }
+
+    // --- DurationFormatBean: @JsonFormat(shape=STRING) with Duration ---
+
+    @GET
+    @Path("/duration-format")
+    public DurationFormatBean getDurationFormat() {
+        DurationFormatBean bean = new DurationFormatBean();
+        bean.setName("duration-test");
+        bean.setDuration(Duration.ofHours(21).plusMinutes(22).plusSeconds(55));
         return bean;
     }
 

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationTest.java
@@ -41,6 +41,8 @@ public class GeneratedAnnotationTest extends AbstractGeneratedAnnotationTest {
                                     ManagedReferenceParent.class,
                                     ManagedReferenceChild.class,
                                     DateFormatBean.class,
+                                    DurationFormatBean.class,
+                                    NumberShapedTemporalBean.class,
                                     ZonedDateTimeFormatBean.class,
                                     FormatShape.class,
                                     FormatBean.class,

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationWithReflectionFreeSerializersTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/GeneratedAnnotationWithReflectionFreeSerializersTest.java
@@ -44,6 +44,8 @@ public class GeneratedAnnotationWithReflectionFreeSerializersTest extends Abstra
                                     ManagedReferenceParent.class,
                                     ManagedReferenceChild.class,
                                     DateFormatBean.class,
+                                    DurationFormatBean.class,
+                                    NumberShapedTemporalBean.class,
                                     ZonedDateTimeFormatBean.class,
                                     FormatShape.class,
                                     FormatBean.class,

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/NumberShapedTemporalBean.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/NumberShapedTemporalBean.java
@@ -1,0 +1,41 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+public class NumberShapedTemporalBean {
+
+    private String name;
+
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+    private Instant instant;
+
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+    private Duration duration;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Instant getInstant() {
+        return instant;
+    }
+
+    public void setInstant(Instant instant) {
+        this.instant = instant;
+    }
+
+    public Duration getDuration() {
+        return duration;
+    }
+
+    public void setDuration(Duration duration) {
+        this.duration = duration;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/StringShapedDateBean.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/StringShapedDateBean.java
@@ -1,0 +1,29 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import java.util.Date;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+public class StringShapedDateBean {
+
+    private String name;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    private Date date;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Date getDate() {
+        return date;
+    }
+
+    public void setDate(Date date) {
+        this.date = date;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/StringShapedDateResource.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/StringShapedDateResource.java
@@ -1,0 +1,23 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.Date;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import io.smallrye.common.annotation.NonBlocking;
+
+@Path("/string-shaped-date")
+@NonBlocking
+public class StringShapedDateResource {
+
+    @GET
+    public StringShapedDateBean get() {
+        StringShapedDateBean bean = new StringShapedDateBean();
+        bean.setName("string-shaped-date");
+        bean.setDate(Date.from(LocalDate.of(2025, 6, 15).atStartOfDay().toInstant(ZoneOffset.UTC)));
+        return bean;
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/StringShapedDateWithTimestampsEnabledTest.java
+++ b/extensions/resteasy-reactive/rest-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/generated/StringShapedDateWithTimestampsEnabledTest.java
@@ -1,0 +1,41 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.generated;
+
+import java.util.function.Supplier;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+
+public class StringShapedDateWithTimestampsEnabledTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest test = new QuarkusExtensionTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(StringShapedDateResource.class,
+                                    StringShapedDateBean.class)
+                            .addAsResource(new StringAsset(
+                                    "quarkus.jackson.write-dates-as-timestamps=true\n" +
+                                            "quarkus.rest.jackson.optimization.enable-reflection-free-serializers=true\n"),
+                                    "application.properties");
+                }
+            });
+
+    @Test
+    public void testStringShapedDateWithTimestampsEnabled() {
+        RestAssured.get("/string-shaped-date")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("name", Matchers.is("string-shaped-date"))
+                .body("date", Matchers.isA(String.class));
+    }
+}

--- a/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/mappers/JacksonMapperUtil.java
+++ b/extensions/resteasy-reactive/rest-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/mappers/JacksonMapperUtil.java
@@ -4,8 +4,13 @@ import java.io.IOException;
 import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
+import java.math.BigDecimal;
 import java.text.SimpleDateFormat;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
 import java.util.ArrayList;
@@ -100,6 +105,31 @@ public class JacksonMapperUtil {
             formatter = formatter.withZone(ZoneId.of(timezone));
         }
         generator.writeString(formatter.format((TemporalAccessor) value));
+    }
+
+    public static void serializeTemporalAsTimestamp(Object value, JsonGenerator generator) throws IOException {
+        if (value == null) {
+            generator.writeNull();
+        } else if (value instanceof Instant i) {
+            generator.writeNumber(toBigDecimal(i.getEpochSecond(), i.getNano()));
+        } else if (value instanceof ZonedDateTime zdt) {
+            Instant inst = zdt.toInstant();
+            generator.writeNumber(toBigDecimal(inst.getEpochSecond(), inst.getNano()));
+        } else if (value instanceof OffsetDateTime odt) {
+            Instant inst = odt.toInstant();
+            generator.writeNumber(toBigDecimal(inst.getEpochSecond(), inst.getNano()));
+        } else if (value instanceof Duration d) {
+            generator.writeNumber(toBigDecimal(d.getSeconds(), d.getNano()));
+        } else {
+            generator.writeString(value.toString());
+        }
+    }
+
+    private static BigDecimal toBigDecimal(long seconds, int nanoseconds) {
+        if (nanoseconds == 0) {
+            return BigDecimal.valueOf(seconds);
+        }
+        return new BigDecimal(seconds + "." + String.format("%09d", nanoseconds));
     }
 
     public static boolean isViewIncluded(Class<?> activeView, Class<?>[] viewClasses) {


### PR DESCRIPTION
Fixes the issue reported in this comment https://github.com/quarkusio/quarkus/issues/55318#issuecomment-4967164937 handling `@JsonFormat` on `java.time.*` types.

In more details it fixes the following:

- @JsonFormat(pattern=...) on ZonedDateTime, LocalDateTime, OffsetDateTime, LocalDate, LocalTime, Instant — pattern was silently ignored
- @JsonFormat(shape=STRING) on Duration (and other java.time types) — serialized as number instead of ISO-8601 string
- @JsonFormat(shape=NUMBER) on Instant, ZonedDateTime, OffsetDateTime, Duration — serialized as string instead of epoch timestamp
- @JsonFormat(shape=STRING) on java.util.Date — ignored when write-dates-as-timestamps=true

