### PR TITLE
Add quarkus.config.fixed-at-build-time to freeze all config at build time

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/ConfigBuildTimeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/ConfigBuildTimeConfig.java
@@ -23,4 +23,24 @@ public interface ConfigBuildTimeConfig {
     @WithName("sources.system-only")
     @WithDefault("false")
     boolean systemOnly();
+
+    /**
+     * If set to {@code true}, all configuration is frozen at build time. All values from
+     * {@code application.properties} and similar file-based sources are baked into the application artifact at the
+     * highest priority. At runtime, no external configuration sources are consulted: no {@code application.properties},
+     * no {@code .env} files, no system properties, and no environment variables can affect configuration values.
+     * <p>
+     * The only exceptions are a small set of JVM environment properties ({@code java.io.tmpdir},
+     * {@code user.home}, {@code user.dir}) which are resolved at runtime to support
+     * {@code @WithDefault} expressions whose values are inherently machine-dependent.
+     * <p>
+     * This is useful for CLI applications and sealed/immutable deployments where the binary's behavior must be
+     * fully determined at build time.
+     * <p>
+     * Computed defaults ({@code @WithDefault}) and programmatic values set by recorders still work normally.
+     * When enabled, this supersedes {@code quarkus.config.sources.system-only}.
+     */
+    @WithName("fixed-at-build-time")
+    @WithDefault("false")
+    boolean fixedAtBuildTime();
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
@@ -31,7 +31,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.function.BooleanSupplier;
 
 import jakarta.annotation.Priority;
 
@@ -105,6 +104,7 @@ import io.quarkus.runtime.configuration.ConfigDiagnostic;
 import io.quarkus.runtime.configuration.ConfigRecorder;
 import io.quarkus.runtime.configuration.ConfigUtils;
 import io.quarkus.runtime.configuration.DisableableConfigSource;
+import io.quarkus.runtime.configuration.FixedAtBuildTimeConfigBuilder;
 import io.quarkus.runtime.configuration.QuarkusConfigValue;
 import io.quarkus.runtime.configuration.RuntimeConfigBuilder;
 import io.quarkus.runtime.configuration.StaticInitConfigBuilder;
@@ -180,6 +180,7 @@ public class ConfigGenerationBuildStep {
 
     @BuildStep
     void buildTimeRunTimeConfig(
+            ConfigBuildTimeConfig configBuildTimeConfig,
             ConfigurationBuildItem configItem,
             BuildProducer<GeneratedClassBuildItem> generatedClass,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
@@ -206,6 +207,15 @@ public class ConfigGenerationBuildStep {
                 if (entry.getValue().getValue() != null) {
                     clinit.invokeInterfaceMethod(put, map, clinit.load(entry.getKey()),
                             clinit.load(entry.getValue().getValue()));
+                }
+            }
+
+            if (configBuildTimeConfig.fixedAtBuildTime()) {
+                for (Map.Entry<String, ConfigValue> entry : configItem.getReadResult().getRunTimeValues().entrySet()) {
+                    if (entry.getValue().getValue() != null) {
+                        clinit.invokeInterfaceMethod(put, map, clinit.load(entry.getKey()),
+                                clinit.load(entry.getValue().getValue()));
+                    }
                 }
             }
 
@@ -382,20 +392,26 @@ public class ConfigGenerationBuildStep {
         }
     }
 
-    @BuildStep(onlyIf = SystemOnlySources.class)
-    void systemOnlySources(BuildProducer<StaticInitConfigBuilderBuildItem> staticInitConfigBuilder,
+    @BuildStep
+    void systemOnlySources(ConfigBuildTimeConfig config,
+            BuildProducer<StaticInitConfigBuilderBuildItem> staticInitConfigBuilder,
             BuildProducer<RunTimeConfigBuilderBuildItem> runTimeConfigBuilder) {
         // TODO - radcortez - YAML sources are still available because they are registered directly.
-        staticInitConfigBuilder.produce(new StaticInitConfigBuilderBuildItem(SystemOnlySourcesConfigBuilder.class.getName()));
-        runTimeConfigBuilder.produce(new RunTimeConfigBuilderBuildItem(SystemOnlySourcesConfigBuilder.class.getName()));
+        if (config.systemOnly() && !config.fixedAtBuildTime()) {
+            staticInitConfigBuilder
+                    .produce(new StaticInitConfigBuilderBuildItem(SystemOnlySourcesConfigBuilder.class.getName()));
+            runTimeConfigBuilder.produce(new RunTimeConfigBuilderBuildItem(SystemOnlySourcesConfigBuilder.class.getName()));
+        }
     }
 
-    private static class SystemOnlySources implements BooleanSupplier {
-        ConfigBuildTimeConfig configBuildTimeConfig;
-
-        @Override
-        public boolean getAsBoolean() {
-            return configBuildTimeConfig.systemOnly();
+    @BuildStep
+    void fixedAtBuildTimeSources(ConfigBuildTimeConfig config,
+            BuildProducer<StaticInitConfigBuilderBuildItem> staticInitConfigBuilder,
+            BuildProducer<RunTimeConfigBuilderBuildItem> runTimeConfigBuilder) {
+        if (config.fixedAtBuildTime()) {
+            staticInitConfigBuilder
+                    .produce(new StaticInitConfigBuilderBuildItem(FixedAtBuildTimeConfigBuilder.class.getName()));
+            runTimeConfigBuilder.produce(new RunTimeConfigBuilderBuildItem(FixedAtBuildTimeConfigBuilder.class.getName()));
         }
     }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
@@ -105,6 +105,7 @@ import io.quarkus.runtime.configuration.ConfigDiagnostic;
 import io.quarkus.runtime.configuration.ConfigRecorder;
 import io.quarkus.runtime.configuration.ConfigUtils;
 import io.quarkus.runtime.configuration.DisableableConfigSource;
+import io.quarkus.runtime.configuration.FixedAtBuildTimeConfigBuilder;
 import io.quarkus.runtime.configuration.QuarkusConfigValue;
 import io.quarkus.runtime.configuration.RuntimeConfigBuilder;
 import io.quarkus.runtime.configuration.StaticInitConfigBuilder;
@@ -213,6 +214,7 @@ public class ConfigGenerationBuildStep {
 
     @BuildStep
     void buildTimeRunTimeConfig(
+            ConfigBuildTimeConfig configBuildTimeConfig,
             ConfigurationBuildItem configItem,
             BuildProducer<GeneratedClassBuildItem> generatedClass,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
@@ -239,6 +241,15 @@ public class ConfigGenerationBuildStep {
                 if (entry.getValue().getValue() != null) {
                     clinit.invokeInterfaceMethod(put, map, clinit.load(entry.getKey()),
                             clinit.load(entry.getValue().getValue()));
+                }
+            }
+
+            if (configBuildTimeConfig.fixedAtBuildTime()) {
+                for (Map.Entry<String, ConfigValue> entry : configItem.getReadResult().getRunTimeValues().entrySet()) {
+                    if (entry.getValue().getValue() != null) {
+                        clinit.invokeInterfaceMethod(put, map, clinit.load(entry.getKey()),
+                                clinit.load(entry.getValue().getValue()));
+                    }
                 }
             }
 
@@ -443,7 +454,18 @@ public class ConfigGenerationBuildStep {
 
         @Override
         public boolean getAsBoolean() {
-            return configBuildTimeConfig.systemOnly();
+            return configBuildTimeConfig.systemOnly() && !configBuildTimeConfig.fixedAtBuildTime();
+        }
+    }
+
+    @BuildStep
+    void fixedAtBuildTimeSources(ConfigBuildTimeConfig config,
+            BuildProducer<StaticInitConfigBuilderBuildItem> staticInitConfigBuilder,
+            BuildProducer<RunTimeConfigBuilderBuildItem> runTimeConfigBuilder) {
+        if (config.fixedAtBuildTime()) {
+            staticInitConfigBuilder
+                    .produce(new StaticInitConfigBuilderBuildItem(FixedAtBuildTimeConfigBuilder.class.getName()));
+            runTimeConfigBuilder.produce(new RunTimeConfigBuilderBuildItem(FixedAtBuildTimeConfigBuilder.class.getName()));
         }
     }
 

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/FixedAtBuildTimeConfigBuilder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/FixedAtBuildTimeConfigBuilder.java
@@ -1,0 +1,58 @@
+package io.quarkus.runtime.configuration;
+
+import java.util.Set;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+import io.smallrye.config.SmallRyeConfigBuilder;
+
+public class FixedAtBuildTimeConfigBuilder implements ConfigBuilder {
+    @Override
+    public SmallRyeConfigBuilder configBuilder(final SmallRyeConfigBuilder builder) {
+        builder.setAddDefaultSources(false);
+        builder.withSources(new JvmEnvironmentConfigSource());
+        return builder;
+    }
+
+    @Override
+    public int priority() {
+        return Integer.MAX_VALUE;
+    }
+
+    /**
+     * A minimal config source that exposes only a small set of standard JVM system properties
+     * needed for {@code @WithDefault} expression resolution. These describe the runtime
+     * environment (temp directory, home directory, working directory) and are not configuration
+     * overrides. Uses the lowest possible ordinal so frozen values always take precedence.
+     */
+    private static class JvmEnvironmentConfigSource implements ConfigSource {
+        private static final Set<String> ALLOWED_PROPERTIES = Set.of(
+                "java.io.tmpdir",
+                "user.home",
+                "user.dir");
+
+        @Override
+        public Set<String> getPropertyNames() {
+            // Not listed to avoid being reported as unknown. Expression resolution only needs getValue().
+            return Set.of();
+        }
+
+        @Override
+        public String getValue(final String propertyName) {
+            if (ALLOWED_PROPERTIES.contains(propertyName)) {
+                return System.getProperty(propertyName);
+            }
+            return null;
+        }
+
+        @Override
+        public String getName() {
+            return "FixedAtBuildTimeJvmEnvironment";
+        }
+
+        @Override
+        public int getOrdinal() {
+            return Integer.MIN_VALUE;
+        }
+    }
+}

--- a/integration-tests/test-extension/extension/deployment/src/main/resources/application.properties
+++ b/integration-tests/test-extension/extension/deployment/src/main/resources/application.properties
@@ -51,6 +51,8 @@ quarkus.mapping.rt.value=value
 quarkus.mapping.rt.group.value=value
 quarkus.mapping.rt.record-secret=${handler::secret}
 
+fixed-at-build-time.cache-dir=${java.io.tmpdir}/cache
+
 proprietary.mapping.config.value=1234
 proprietary.should.not.report.unknown=1234
 

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/FixedAtBuildTimeConfigTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/FixedAtBuildTimeConfigTest.java
@@ -1,0 +1,89 @@
+package io.quarkus.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.smallrye.config.SmallRyeConfig;
+
+public class FixedAtBuildTimeConfigTest {
+    @RegisterExtension
+    static final QuarkusExtensionTest TEST = new QuarkusExtensionTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.config.fixed-at-build-time", "true")
+            .overrideRuntimeConfigKey("quarkus.mapping.rt.value", "runtime-override");
+
+    @Inject
+    SmallRyeConfig config;
+
+    @Test
+    void frozenValueIsServedFromBuildTimeSource() {
+        assertEquals("value", config.getRawValue("quarkus.mapping.rt.value"));
+        assertEquals("BuildTime RunTime Fixed", config.getConfigValue("quarkus.mapping.rt.value").getConfigSourceName());
+    }
+
+    @Test
+    void runtimeApplicationPropertiesChangeDoesNotOverride() {
+        // overrideRuntimeConfigKey injects "runtime-override" as a runtime config override,
+        // simulating an external source trying to change the value after the build
+        assertEquals("value", config.getRawValue("quarkus.mapping.rt.value"));
+    }
+
+    @Test
+    void systemPropertyDoesNotOverride() {
+        System.setProperty("quarkus.mapping.rt.value", "sys-override");
+        try {
+            assertEquals("value", config.getRawValue("quarkus.mapping.rt.value"));
+        } finally {
+            System.clearProperty("quarkus.mapping.rt.value");
+        }
+    }
+
+    @Test
+    void externalConfigSourcesAreNotRegistered() {
+        for (var source : config.getConfigSources()) {
+            var name = source.getName();
+            if (name.contains("EnvConfigSource") || name.contains("SysPropConfigSource")
+                    || name.contains("PropertiesConfigSource")) {
+                throw new AssertionError("External config source should not be registered: " + name);
+            }
+        }
+    }
+
+    @Test
+    void unknownPropertyFromEnvironmentIsNotVisible() {
+        // With external sources removed, a stray system property should not be visible to the config
+        // system at all — so it cannot trigger "unrecognized property" warnings
+        System.setProperty("quarkus.some.unknown.property", "stray-value");
+        try {
+            assertNull(config.getRawValue("quarkus.some.unknown.property"));
+        } finally {
+            System.clearProperty("quarkus.some.unknown.property");
+        }
+    }
+
+    @Test
+    void expressionWithJvmPropertyResolvesAtRuntime() {
+        String original = System.getProperty("java.io.tmpdir");
+        System.setProperty("java.io.tmpdir", "/custom/tmp");
+        try {
+            assertEquals("/custom/tmp/cache", config.getRawValue("fixed-at-build-time.cache-dir"));
+        } finally {
+            System.setProperty("java.io.tmpdir", original);
+        }
+    }
+
+    @Test
+    void withDefaultStillWorks() {
+        var value = config.getRawValue("quarkus.mapping.rt.record-default");
+        assertTrue(value != null && !value.isEmpty());
+    }
+}


### PR DESCRIPTION
When enabled, all configuration values from application.properties are baked into the application artifact at the highest priority. At runtime, no external config sources are consulted — no application.properties, no .env files, no system properties, and no environment variables can affect configuration values.

Only three JVM environment properties (java.io.tmpdir, user.home, user.dir) are resolved at runtime via a minimal allowlisted config source at the lowest ordinal, to support @WithDefault expressions whose values are inherently machine-dependent.

- Closes: #55457

