### PR TITLE
Kubernetes: generate Gateway API HTTPRoute resources

### DIFF
--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -912,6 +912,103 @@ Now, Kubernetes will validate all the incoming connections using SSL with the ce
 More information about how to create the secret in https://kubernetes.io/docs/concepts/services-networking/ingress/#tls[here].
 ====
 
+==== Exposing with the Kubernetes Gateway API
+
+The https://gateway-api.sigs.k8s.io/[Kubernetes Gateway API] is the successor to Ingress.
+Some implementations (for example kgateway) only support Gateway API resources.
+
+To generate an `HTTPRoute` that attaches to an existing `Gateway`:
+
+[source,properties]
+----
+quarkus.kubernetes.gateway.expose=true
+quarkus.kubernetes.gateway.parent-refs.main.name=my-gateway
+quarkus.kubernetes.gateway.parent-refs.main.namespace=infra
+quarkus.kubernetes.gateway.host=myapp.example.com
+# Optional: additional hostnames
+# quarkus.kubernetes.gateway.hosts=api.example.com,admin.example.com
+# Optional: named Service port used as HTTPRoute backend (default is http)
+# quarkus.kubernetes.gateway.target-port=http
+# Optional: annotations (quote keys that contain dots)
+# quarkus.kubernetes.gateway.annotations."example.com/gate"=enabled
+----
+
+This generates an `HTTPRoute` similar to:
+
+[source,yaml]
+----
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: myapp
+spec:
+  parentRefs:
+    - name: my-gateway
+      namespace: infra
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  hostnames:
+    - myapp.example.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: myapp
+          kind: Service
+          port: 8080
+----
+
+Optionally also generate a namespaced `Gateway` (the cluster must still provide a matching `GatewayClass`).
+By default a single HTTP listener on port `80` named `http` is created and uses `quarkus.kubernetes.gateway.host`
+(or the first `hosts` entry) as the listener hostname:
+
+[source,properties]
+----
+quarkus.kubernetes.gateway.expose=true
+quarkus.kubernetes.gateway.generate-gateway=true
+quarkus.kubernetes.gateway.gateway-class-name=istio
+quarkus.kubernetes.gateway.host=myapp.example.com
+----
+
+Custom listeners can be defined with `quarkus.kubernetes.gateway.listeners.<id>.*`.
+When any listener is configured, Quarkus no longer synthesizes the default HTTP/80 listener,
+and each listener must set its own `hostname` if needed:
+
+[source,properties]
+----
+quarkus.kubernetes.gateway.listeners.http.name=http
+quarkus.kubernetes.gateway.listeners.http.protocol=HTTP
+quarkus.kubernetes.gateway.listeners.http.port=80
+quarkus.kubernetes.gateway.listeners.http.hostname=myapp.example.com
+----
+
+[NOTE]
+====
+HTTPS/TLS listener `certificateRefs` are not generated yet.
+Prefer `HTTP` listeners, or configure TLS on the Gateway out-of-band.
+====
+
+Additional HTTPRoute rules can be defined similarly to Ingress rules.
+When `service-name` points to a different Service, `service-port-number` is required
+(Gateway API backends use numeric ports, and Quarkus cannot resolve named ports of another Service):
+
+[source,properties]
+----
+quarkus.kubernetes.gateway.rules.api.path=/api
+quarkus.kubernetes.gateway.rules.api.path-type=PathPrefix
+quarkus.kubernetes.gateway.rules.alt.path=/ea
+quarkus.kubernetes.gateway.rules.alt.service-name=updated-service
+quarkus.kubernetes.gateway.rules.alt.service-port-number=8080
+----
+
+[NOTE]
+====
+The cluster must install Gateway API CRDs and a controller.
+Quarkus only generates the manifests; it does not install CRDs or controllers.
+====
+
 === Using the Kubernetes client
 
 Applications that are deployed to Kubernetes and need to access the API server will usually make use of the `kubernetes-client` extension:

--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -917,20 +917,23 @@ More information about how to create the secret in https://kubernetes.io/docs/co
 The https://gateway-api.sigs.k8s.io/[Kubernetes Gateway API] is the successor to Ingress.
 Some implementations (for example kgateway) only support Gateway API resources.
 
+HTTPRoute settings live under `quarkus.kubernetes.gateway.http.*` so additional route types
+(for example `quarkus.kubernetes.gateway.grpc.*`) can be added later.
+
 To generate an `HTTPRoute` that attaches to an existing `Gateway`:
 
 [source,properties]
 ----
 quarkus.kubernetes.gateway.expose=true
-quarkus.kubernetes.gateway.parent-refs.main.name=my-gateway
-quarkus.kubernetes.gateway.parent-refs.main.namespace=infra
-quarkus.kubernetes.gateway.host=myapp.example.com
+quarkus.kubernetes.gateway.http.parent-refs.main.name=my-gateway
+quarkus.kubernetes.gateway.http.parent-refs.main.namespace=infra
+quarkus.kubernetes.gateway.http.host=myapp.example.com
 # Optional: additional hostnames
-# quarkus.kubernetes.gateway.hosts=api.example.com,admin.example.com
+# quarkus.kubernetes.gateway.http.hosts=api.example.com,admin.example.com
 # Optional: named Service port used as HTTPRoute backend (default is http)
-# quarkus.kubernetes.gateway.target-port=http
+# quarkus.kubernetes.gateway.http.target-port=http
 # Optional: annotations (quote keys that contain dots)
-# quarkus.kubernetes.gateway.annotations."example.com/gate"=enabled
+# quarkus.kubernetes.gateway.http.annotations."example.com/gate"=enabled
 ----
 
 This generates an `HTTPRoute` similar to:
@@ -961,15 +964,15 @@ spec:
 ----
 
 Optionally also generate a namespaced `Gateway` (the cluster must still provide a matching `GatewayClass`).
-By default a single HTTP listener on port `80` named `http` is created and uses `quarkus.kubernetes.gateway.host`
-(or the first `hosts` entry) as the listener hostname:
+By default a single HTTP listener on port `80` named `http` is created and uses `quarkus.kubernetes.gateway.http.host`
+(or the first `http.hosts` entry) as the listener hostname:
 
 [source,properties]
 ----
 quarkus.kubernetes.gateway.expose=true
 quarkus.kubernetes.gateway.generate-gateway=true
 quarkus.kubernetes.gateway.gateway-class-name=istio
-quarkus.kubernetes.gateway.host=myapp.example.com
+quarkus.kubernetes.gateway.http.host=myapp.example.com
 ----
 
 Custom listeners can be defined with `quarkus.kubernetes.gateway.listeners.<id>.*`.
@@ -996,11 +999,11 @@ When `service-name` points to a different Service, `service-port-number` is requ
 
 [source,properties]
 ----
-quarkus.kubernetes.gateway.rules.api.path=/api
-quarkus.kubernetes.gateway.rules.api.path-type=PathPrefix
-quarkus.kubernetes.gateway.rules.alt.path=/ea
-quarkus.kubernetes.gateway.rules.alt.service-name=updated-service
-quarkus.kubernetes.gateway.rules.alt.service-port-number=8080
+quarkus.kubernetes.gateway.http.rules.api.path=/api
+quarkus.kubernetes.gateway.http.rules.api.path-type=PathPrefix
+quarkus.kubernetes.gateway.http.rules.alt.path=/ea
+quarkus.kubernetes.gateway.http.rules.alt.service-name=updated-service
+quarkus.kubernetes.gateway.http.rules.alt.service-port-number=8080
 ----
 
 [NOTE]

--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -911,6 +911,106 @@ Now, Kubernetes will validate all the incoming connections using SSL with the ce
 More information about how to create the secret in https://kubernetes.io/docs/concepts/services-networking/ingress/#tls[here].
 ====
 
+==== Exposing with the Kubernetes Gateway API
+
+The https://gateway-api.sigs.k8s.io/[Kubernetes Gateway API] is the successor to Ingress.
+Some implementations (for example kgateway) only support Gateway API resources.
+
+HTTPRoute settings live under `quarkus.kubernetes.gateway.http.*` so additional route types
+(for example `quarkus.kubernetes.gateway.grpc.*`) can be added later.
+
+To generate an `HTTPRoute` that attaches to an existing `Gateway`:
+
+[source,properties]
+----
+quarkus.kubernetes.gateway.expose=true
+quarkus.kubernetes.gateway.http.parent-refs.main.name=my-gateway
+quarkus.kubernetes.gateway.http.parent-refs.main.namespace=infra
+quarkus.kubernetes.gateway.http.host=myapp.example.com
+# Optional: additional hostnames
+# quarkus.kubernetes.gateway.http.hosts=api.example.com,admin.example.com
+# Optional: named Service port used as HTTPRoute backend (default is http)
+# quarkus.kubernetes.gateway.http.target-port=http
+# Optional: annotations (quote keys that contain dots)
+# quarkus.kubernetes.gateway.http.annotations."example.com/gate"=enabled
+----
+
+This generates an `HTTPRoute` similar to:
+
+[source,yaml]
+----
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: myapp
+spec:
+  parentRefs:
+    - name: my-gateway
+      namespace: infra
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  hostnames:
+    - myapp.example.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: myapp
+          kind: Service
+          port: 8080
+----
+
+Optionally also generate a namespaced `Gateway` (the cluster must still provide a matching `GatewayClass`).
+By default a single HTTP listener on port `80` named `http` is created and uses `quarkus.kubernetes.gateway.http.host`
+(or the first `http.hosts` entry) as the listener hostname:
+
+[source,properties]
+----
+quarkus.kubernetes.gateway.expose=true
+quarkus.kubernetes.gateway.generate-gateway=true
+quarkus.kubernetes.gateway.gateway-class-name=istio
+quarkus.kubernetes.gateway.http.host=myapp.example.com
+----
+
+Custom listeners can be defined with `quarkus.kubernetes.gateway.listeners.<id>.*`.
+When any listener is configured, Quarkus no longer synthesizes the default HTTP/80 listener,
+and each listener must set its own `hostname` if needed:
+
+[source,properties]
+----
+quarkus.kubernetes.gateway.listeners.http.name=http
+quarkus.kubernetes.gateway.listeners.http.protocol=HTTP
+quarkus.kubernetes.gateway.listeners.http.port=80
+quarkus.kubernetes.gateway.listeners.http.hostname=myapp.example.com
+----
+
+[NOTE]
+====
+HTTPS/TLS listener `certificateRefs` are not generated yet.
+Prefer `HTTP` listeners, or configure TLS on the Gateway out-of-band.
+====
+
+Additional HTTPRoute rules can be defined similarly to Ingress rules.
+When `service-name` points to a different Service, `service-port-number` is required
+(Gateway API backends use numeric ports, and Quarkus cannot resolve named ports of another Service):
+
+[source,properties]
+----
+quarkus.kubernetes.gateway.http.rules.api.path=/api
+quarkus.kubernetes.gateway.http.rules.api.path-type=PathPrefix
+quarkus.kubernetes.gateway.http.rules.alt.path=/ea
+quarkus.kubernetes.gateway.http.rules.alt.service-name=updated-service
+quarkus.kubernetes.gateway.http.rules.alt.service-port-number=8080
+----
+
+[NOTE]
+====
+The cluster must install Gateway API CRDs and a controller.
+Quarkus only generates the manifests; it does not install CRDs or controllers.
+====
+
 === Using the Kubernetes client
 
 Applications that are deployed to Kubernetes and need to access the API server will usually make use of the `kubernetes-client` extension:

--- a/extensions/kubernetes/vanilla/deployment/pom.xml
+++ b/extensions/kubernetes/vanilla/deployment/pom.xml
@@ -111,6 +111,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-gatewayapi</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit-internal</artifactId>
             <scope>test</scope>

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddGatewayResourceDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddGatewayResourceDecorator.java
@@ -1,0 +1,68 @@
+package io.quarkus.kubernetes.deployment;
+
+import java.util.Map;
+import java.util.Optional;
+
+import io.dekorate.kubernetes.decorator.ResourceProvidingDecorator;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.GatewayBuilder;
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.GatewayFluent;
+
+public class AddGatewayResourceDecorator extends ResourceProvidingDecorator<KubernetesListBuilder> {
+
+    private final String name;
+    private final String gatewayClassName;
+    private final Map<String, GatewayConfig.ListenerConfig> listeners;
+    private final Map<String, String> annotations;
+    private final Optional<String> defaultHostname;
+
+    public AddGatewayResourceDecorator(String name, String gatewayClassName,
+            Map<String, GatewayConfig.ListenerConfig> listeners,
+            Map<String, String> annotations,
+            Optional<String> defaultHostname) {
+        this.name = name;
+        this.gatewayClassName = gatewayClassName;
+        this.listeners = listeners;
+        this.annotations = annotations;
+        this.defaultHostname = defaultHostname;
+    }
+
+    @Override
+    public void visit(KubernetesListBuilder list) {
+        ObjectMeta meta = getMandatoryDeploymentMetadata(list, ANY);
+
+        GatewayBuilder builder = new GatewayBuilder();
+        GatewayFluent<?>.MetadataNested<?> metadata = builder.withNewMetadata()
+                .withName(name)
+                .withLabels(meta.getLabels());
+        if (annotations != null && !annotations.isEmpty()) {
+            metadata.addToAnnotations(annotations);
+        }
+        metadata.endMetadata();
+
+        var spec = builder.withNewSpec()
+                .withGatewayClassName(gatewayClassName);
+
+        if (listeners == null || listeners.isEmpty()) {
+            var listener = spec.addNewListener()
+                    .withName("http")
+                    .withProtocol("HTTP")
+                    .withPort(80);
+            defaultHostname.ifPresent(listener::withHostname);
+            listener.endListener();
+        } else {
+            for (GatewayConfig.ListenerConfig listenerConfig : listeners.values()) {
+                var listener = spec.addNewListener()
+                        .withName(listenerConfig.name())
+                        .withProtocol(listenerConfig.protocol())
+                        .withPort(listenerConfig.port());
+                listenerConfig.hostname().ifPresent(listener::withHostname);
+                listener.endListener();
+            }
+        }
+
+        spec.endSpec();
+        list.addToItems(builder.build());
+    }
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddHttpRouteResourceDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddHttpRouteResourceDecorator.java
@@ -1,0 +1,143 @@
+package io.quarkus.kubernetes.deployment;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import io.dekorate.kubernetes.decorator.ResourceProvidingDecorator;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.HTTPRoute;
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.HTTPRouteBuilder;
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.HTTPRouteRule;
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.HTTPRouteRuleBuilder;
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.ParentReference;
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.ParentReferenceBuilder;
+
+public class AddHttpRouteResourceDecorator extends ResourceProvidingDecorator<KubernetesListBuilder> {
+
+    private static final String GATEWAY_API_GROUP = "gateway.networking.k8s.io";
+    private static final String GATEWAY_KIND = "Gateway";
+    private static final String SERVICE_KIND = "Service";
+
+    private final String name;
+    private final List<String> hostnames;
+    private final String path;
+    private final String pathType;
+    private final String backendServiceName;
+    private final int backendPort;
+    private final Map<String, GatewayConfig.ParentRefConfig> parentRefs;
+    private final List<Rule> extraRules;
+    private final Map<String, String> annotations;
+    private final boolean generateGateway;
+    private final String gatewayName;
+
+    public AddHttpRouteResourceDecorator(String name,
+            List<String> hostnames,
+            String path,
+            String pathType,
+            String backendServiceName,
+            int backendPort,
+            Map<String, GatewayConfig.ParentRefConfig> parentRefs,
+            List<Rule> extraRules,
+            Map<String, String> annotations,
+            boolean generateGateway,
+            String gatewayName) {
+        this.name = name;
+        this.hostnames = hostnames;
+        this.path = path;
+        this.pathType = pathType;
+        this.backendServiceName = backendServiceName;
+        this.backendPort = backendPort;
+        this.parentRefs = parentRefs;
+        this.extraRules = extraRules;
+        this.annotations = annotations;
+        this.generateGateway = generateGateway;
+        this.gatewayName = gatewayName;
+    }
+
+    @Override
+    public void visit(KubernetesListBuilder list) {
+        ObjectMeta meta = getMandatoryDeploymentMetadata(list, ANY);
+
+        List<ParentReference> resolvedParentRefs = new ArrayList<>();
+        if (parentRefs != null && !parentRefs.isEmpty()) {
+            for (GatewayConfig.ParentRefConfig ref : parentRefs.values()) {
+                ParentReferenceBuilder parentRefBuilder = new ParentReferenceBuilder()
+                        .withName(ref.name())
+                        .withKind(ref.kind().orElse(GATEWAY_KIND))
+                        .withGroup(ref.group().orElse(GATEWAY_API_GROUP));
+                ref.namespace().ifPresent(parentRefBuilder::withNamespace);
+                ref.sectionName().ifPresent(parentRefBuilder::withSectionName);
+                resolvedParentRefs.add(parentRefBuilder.build());
+            }
+        } else if (generateGateway) {
+            resolvedParentRefs.add(new ParentReferenceBuilder()
+                    .withName(gatewayName)
+                    .withKind(GATEWAY_KIND)
+                    .withGroup(GATEWAY_API_GROUP)
+                    .build());
+        }
+
+        List<HTTPRouteRule> rules = new ArrayList<>();
+        rules.add(buildRule(path, pathType, backendServiceName, backendPort));
+        if (extraRules != null) {
+            for (Rule rule : extraRules) {
+                rules.add(buildRule(rule.path(), rule.pathType(), rule.serviceName(), rule.port()));
+            }
+        }
+
+        HTTPRouteBuilder builder = new HTTPRouteBuilder()
+                .withNewMetadata()
+                .withName(name)
+                .withLabels(meta.getLabels())
+                .endMetadata()
+                .withNewSpec()
+                .withParentRefs(resolvedParentRefs)
+                .withRules(rules)
+                .endSpec();
+
+        if (annotations != null && !annotations.isEmpty()) {
+            builder.editMetadata().addToAnnotations(annotations).endMetadata();
+        }
+        if (hostnames != null && !hostnames.isEmpty()) {
+            builder.editSpec().withHostnames(hostnames).endSpec();
+        }
+
+        HTTPRoute route = builder.build();
+        list.addToItems(route);
+    }
+
+    private static HTTPRouteRule buildRule(String path, String pathType, String serviceName, int port) {
+        return new HTTPRouteRuleBuilder()
+                .addNewMatch()
+                .withNewPath()
+                .withType(pathType)
+                .withValue(path)
+                .endPath()
+                .endMatch()
+                .addNewBackendRef()
+                .withName(serviceName)
+                .withKind(SERVICE_KIND)
+                .withPort(port)
+                .endBackendRef()
+                .build();
+    }
+
+    public static List<String> combineHostnames(Optional<String> host, Optional<List<String>> hosts) {
+        List<String> result = new ArrayList<>();
+        host.ifPresent(result::add);
+        hosts.ifPresent(list -> {
+            for (String h : list) {
+                if (!result.contains(h)) {
+                    result.add(h);
+                }
+            }
+        });
+        return result;
+    }
+
+    public record Rule(String path, String pathType, String serviceName, int port) {
+    }
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddHttpRouteResourceDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddHttpRouteResourceDecorator.java
@@ -1,0 +1,143 @@
+package io.quarkus.kubernetes.deployment;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import io.dekorate.kubernetes.decorator.ResourceProvidingDecorator;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.HTTPRoute;
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.HTTPRouteBuilder;
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.HTTPRouteRule;
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.HTTPRouteRuleBuilder;
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.ParentReference;
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.ParentReferenceBuilder;
+
+public class AddHttpRouteResourceDecorator extends ResourceProvidingDecorator<KubernetesListBuilder> {
+
+    private static final String GATEWAY_API_GROUP = "gateway.networking.k8s.io";
+    private static final String GATEWAY_KIND = "Gateway";
+    private static final String SERVICE_KIND = "Service";
+
+    private final String name;
+    private final List<String> hostnames;
+    private final String path;
+    private final String pathType;
+    private final String backendServiceName;
+    private final int backendPort;
+    private final Map<String, GatewayConfig.Http.ParentRefConfig> parentRefs;
+    private final List<Rule> extraRules;
+    private final Map<String, String> annotations;
+    private final boolean generateGateway;
+    private final String gatewayName;
+
+    public AddHttpRouteResourceDecorator(String name,
+            List<String> hostnames,
+            String path,
+            String pathType,
+            String backendServiceName,
+            int backendPort,
+            Map<String, GatewayConfig.Http.ParentRefConfig> parentRefs,
+            List<Rule> extraRules,
+            Map<String, String> annotations,
+            boolean generateGateway,
+            String gatewayName) {
+        this.name = name;
+        this.hostnames = hostnames;
+        this.path = path;
+        this.pathType = pathType;
+        this.backendServiceName = backendServiceName;
+        this.backendPort = backendPort;
+        this.parentRefs = parentRefs;
+        this.extraRules = extraRules;
+        this.annotations = annotations;
+        this.generateGateway = generateGateway;
+        this.gatewayName = gatewayName;
+    }
+
+    @Override
+    public void visit(KubernetesListBuilder list) {
+        ObjectMeta meta = getMandatoryDeploymentMetadata(list, ANY);
+
+        List<ParentReference> resolvedParentRefs = new ArrayList<>();
+        if (parentRefs != null && !parentRefs.isEmpty()) {
+            for (GatewayConfig.Http.ParentRefConfig ref : parentRefs.values()) {
+                ParentReferenceBuilder parentRefBuilder = new ParentReferenceBuilder()
+                        .withName(ref.name())
+                        .withKind(ref.kind().orElse(GATEWAY_KIND))
+                        .withGroup(ref.group().orElse(GATEWAY_API_GROUP));
+                ref.namespace().ifPresent(parentRefBuilder::withNamespace);
+                ref.sectionName().ifPresent(parentRefBuilder::withSectionName);
+                resolvedParentRefs.add(parentRefBuilder.build());
+            }
+        } else if (generateGateway) {
+            resolvedParentRefs.add(new ParentReferenceBuilder()
+                    .withName(gatewayName)
+                    .withKind(GATEWAY_KIND)
+                    .withGroup(GATEWAY_API_GROUP)
+                    .build());
+        }
+
+        List<HTTPRouteRule> rules = new ArrayList<>();
+        rules.add(buildRule(path, pathType, backendServiceName, backendPort));
+        if (extraRules != null) {
+            for (Rule rule : extraRules) {
+                rules.add(buildRule(rule.path(), rule.pathType(), rule.serviceName(), rule.port()));
+            }
+        }
+
+        HTTPRouteBuilder builder = new HTTPRouteBuilder()
+                .withNewMetadata()
+                .withName(name)
+                .withLabels(meta.getLabels())
+                .endMetadata()
+                .withNewSpec()
+                .withParentRefs(resolvedParentRefs)
+                .withRules(rules)
+                .endSpec();
+
+        if (annotations != null && !annotations.isEmpty()) {
+            builder.editMetadata().addToAnnotations(annotations).endMetadata();
+        }
+        if (hostnames != null && !hostnames.isEmpty()) {
+            builder.editSpec().withHostnames(hostnames).endSpec();
+        }
+
+        HTTPRoute route = builder.build();
+        list.addToItems(route);
+    }
+
+    private static HTTPRouteRule buildRule(String path, String pathType, String serviceName, int port) {
+        return new HTTPRouteRuleBuilder()
+                .addNewMatch()
+                .withNewPath()
+                .withType(pathType)
+                .withValue(path)
+                .endPath()
+                .endMatch()
+                .addNewBackendRef()
+                .withName(serviceName)
+                .withKind(SERVICE_KIND)
+                .withPort(port)
+                .endBackendRef()
+                .build();
+    }
+
+    public static List<String> combineHostnames(Optional<String> host, Optional<List<String>> hosts) {
+        List<String> result = new ArrayList<>();
+        host.ifPresent(result::add);
+        hosts.ifPresent(list -> {
+            for (String h : list) {
+                if (!result.contains(h)) {
+                    result.add(h);
+                }
+            }
+        });
+        return result;
+    }
+
+    public record Rule(String path, String pathType, String serviceName, int port) {
+    }
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddHttpRouteResourceDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddHttpRouteResourceDecorator.java
@@ -27,7 +27,7 @@ public class AddHttpRouteResourceDecorator extends ResourceProvidingDecorator<Ku
     private final String pathType;
     private final String backendServiceName;
     private final int backendPort;
-    private final Map<String, GatewayConfig.ParentRefConfig> parentRefs;
+    private final Map<String, GatewayConfig.Http.ParentRefConfig> parentRefs;
     private final List<Rule> extraRules;
     private final Map<String, String> annotations;
     private final boolean generateGateway;
@@ -39,7 +39,7 @@ public class AddHttpRouteResourceDecorator extends ResourceProvidingDecorator<Ku
             String pathType,
             String backendServiceName,
             int backendPort,
-            Map<String, GatewayConfig.ParentRefConfig> parentRefs,
+            Map<String, GatewayConfig.Http.ParentRefConfig> parentRefs,
             List<Rule> extraRules,
             Map<String, String> annotations,
             boolean generateGateway,
@@ -63,7 +63,7 @@ public class AddHttpRouteResourceDecorator extends ResourceProvidingDecorator<Ku
 
         List<ParentReference> resolvedParentRefs = new ArrayList<>();
         if (parentRefs != null && !parentRefs.isEmpty()) {
-            for (GatewayConfig.ParentRefConfig ref : parentRefs.values()) {
+            for (GatewayConfig.Http.ParentRefConfig ref : parentRefs.values()) {
                 ParentReferenceBuilder parentRefBuilder = new ParentReferenceBuilder()
                         .withName(ref.name())
                         .withKind(ref.kind().orElse(GATEWAY_KIND))

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/BaseVanillaKubernetesProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/BaseVanillaKubernetesProcessor.java
@@ -1,5 +1,6 @@
 package io.quarkus.kubernetes.deployment;
 
+import static io.quarkus.kubernetes.deployment.Constants.DEFAULT_HTTP_PORT;
 import static io.quarkus.kubernetes.deployment.Constants.INGRESS;
 import static io.quarkus.kubernetes.deployment.Constants.MAX_NODE_PORT_VALUE;
 import static io.quarkus.kubernetes.deployment.Constants.MAX_PORT_NUMBER;
@@ -11,15 +12,19 @@ import static io.quarkus.kubernetes.deployment.KubernetesConfigUtil.managementPo
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
+import org.jboss.logging.Logger;
 
 import io.dekorate.kubernetes.annotation.ServiceType;
 import io.dekorate.kubernetes.config.IngressRuleBuilder;
 import io.dekorate.kubernetes.config.Port;
 import io.dekorate.kubernetes.decorator.AddAnnotationDecorator;
 import io.dekorate.kubernetes.decorator.AddIngressRuleDecorator;
+import io.dekorate.kubernetes.decorator.AddServiceResourceDecorator;
 import io.quarkus.container.spi.ContainerImageInfoBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
@@ -49,6 +54,7 @@ import io.quarkus.kubernetes.spi.KubernetesRoleBuildItem;
 
 public abstract class BaseVanillaKubernetesProcessor extends BaseKubeProcessor<AddPortToKubernetesConfig, KubernetesConfig> {
     private static final String DEFAULT_HASH_ALGORITHM = "SHA-256";
+    private static final Logger log = Logger.getLogger(BaseVanillaKubernetesProcessor.class);
 
     @Override
     protected AddPortToKubernetesConfig portConfigurator(Port port) {
@@ -98,9 +104,7 @@ public abstract class BaseVanillaKubernetesProcessor extends BaseKubeProcessor<A
         final var config = config();
         // Do not bind the Management port to the Service resource unless it's explicitly used by the user.
         if (managementPortIsEnabled()
-                && (config.ingress() == null
-                        || !config.ingress().expose()
-                        || !config.ingress().targetPort().equals(MANAGEMENT_PORT_NAME))) {
+                && !isExposingManagementPort(config)) {
             context.add(new RemovePortFromServiceDecorator(context.name(), MANAGEMENT_PORT_NAME));
         }
 
@@ -114,8 +118,25 @@ public abstract class BaseVanillaKubernetesProcessor extends BaseKubeProcessor<A
         service(context, config);
 
         ingress(context, ports, config);
+        gateway(context, ports, config);
 
         return context;
+    }
+
+    private static boolean isExposingManagementPort(KubernetesConfig config) {
+        return isIngressExposingManagement(config) || isGatewayExposingManagement(config);
+    }
+
+    private static boolean isIngressExposingManagement(KubernetesConfig config) {
+        return config.ingress() != null
+                && config.ingress().expose()
+                && MANAGEMENT_PORT_NAME.equals(config.ingress().targetPort());
+    }
+
+    private static boolean isGatewayExposingManagement(KubernetesConfig config) {
+        return config.gateway() != null
+                && config.gateway().expose()
+                && MANAGEMENT_PORT_NAME.equals(config.gateway().targetPort());
     }
 
     protected void ingress(DecoratorsContext context, List<KubernetesPortBuildItem> ports, KubernetesConfig config) {
@@ -138,6 +159,123 @@ public abstract class BaseVanillaKubernetesProcessor extends BaseKubeProcessor<A
                             .withServicePortNumber(rule.servicePortNumber().orElse(-1))
                             .build()));
         }
+    }
+
+    protected void gateway(DecoratorsContext context, List<KubernetesPortBuildItem> ports, KubernetesConfig config) {
+        if (config.gateway() == null || !config.gateway().expose()) {
+            return;
+        }
+
+        GatewayConfig gateway = config.gateway();
+
+        if (config.ingress() != null && config.ingress().expose()) {
+            log.warn("Both quarkus.kubernetes.ingress.expose and quarkus.kubernetes.gateway.expose are true; "
+                    + "generating both Ingress and Gateway API resources.");
+        }
+
+        boolean hasParentRefs = gateway.parentRefs() != null && !gateway.parentRefs().isEmpty();
+        if (!gateway.generateGateway() && !hasParentRefs) {
+            throw new IllegalArgumentException(
+                    "quarkus.kubernetes.gateway.expose=true requires either "
+                            + "quarkus.kubernetes.gateway.parent-refs.<id>.name or "
+                            + "quarkus.kubernetes.gateway.generate-gateway=true");
+        }
+
+        if (gateway.generateGateway() && gateway.gatewayClassName().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "quarkus.kubernetes.gateway.generate-gateway=true requires "
+                            + "quarkus.kubernetes.gateway.gateway-class-name");
+        }
+
+        if (gateway.generateGateway() && hasParentRefs) {
+            log.warn("Both quarkus.kubernetes.gateway.generate-gateway and "
+                    + "quarkus.kubernetes.gateway.parent-refs are set; "
+                    + "HTTPRoute will use parent-refs and the generated Gateway may be unused.");
+        }
+
+        Optional<Port> port = KubernetesCommonHelper.getPort(ports, config, gateway.targetPort());
+        int backendPort = port.map(AddServiceResourceDecorator::calculateHostPort).orElse(DEFAULT_HTTP_PORT);
+
+        String path = gateway.path();
+        PortConfig portConfig = config.ports().get(gateway.targetPort());
+        if (portConfig != null && portConfig.path().isPresent()) {
+            path = portConfig.path().get();
+        }
+
+        List<String> hostnames = AddHttpRouteResourceDecorator.combineHostnames(gateway.host(), gateway.hosts());
+        String resourceName = context.name();
+
+        if (gateway.generateGateway()) {
+            warnUnsupportedTlsListeners(gateway.listeners());
+            context.add(new AddGatewayResourceDecorator(
+                    resourceName,
+                    gateway.gatewayClassName().get(),
+                    gateway.listeners(),
+                    gateway.annotations(),
+                    hostnames.stream().findFirst()));
+        }
+
+        List<AddHttpRouteResourceDecorator.Rule> extraRules = new ArrayList<>();
+        if (gateway.rules() != null) {
+            for (GatewayConfig.GatewayRuleConfig rule : gateway.rules().values()) {
+                int rulePort = resolveGatewayBackendPort(ports, config, resourceName, rule, backendPort);
+                extraRules.add(new AddHttpRouteResourceDecorator.Rule(
+                        rule.path(),
+                        rule.pathType(),
+                        rule.serviceName().orElse(resourceName),
+                        rulePort));
+            }
+        }
+
+        context.add(new AddHttpRouteResourceDecorator(
+                resourceName,
+                hostnames,
+                path,
+                gateway.pathType(),
+                resourceName,
+                backendPort,
+                gateway.parentRefs(),
+                extraRules,
+                gateway.annotations(),
+                gateway.generateGateway(),
+                resourceName));
+    }
+
+    private static void warnUnsupportedTlsListeners(Map<String, GatewayConfig.ListenerConfig> listeners) {
+        if (listeners == null) {
+            return;
+        }
+        for (GatewayConfig.ListenerConfig listener : listeners.values()) {
+            String protocol = listener.protocol();
+            if ("HTTPS".equalsIgnoreCase(protocol) || "TLS".equalsIgnoreCase(protocol)) {
+                log.warnf(
+                        "Gateway listener '%s' uses protocol %s, but quarkus.kubernetes.gateway does not generate "
+                                + "listener TLS certificateRefs yet; the Gateway may be invalid until TLS is configured "
+                                + "out-of-band.",
+                        listener.name(), protocol);
+            }
+        }
+    }
+
+    private static int resolveGatewayBackendPort(List<KubernetesPortBuildItem> ports, KubernetesConfig config,
+            String applicationServiceName, GatewayConfig.GatewayRuleConfig rule, int defaultPort) {
+        if (rule.servicePortNumber().isPresent()) {
+            return rule.servicePortNumber().get();
+        }
+
+        Optional<String> customService = rule.serviceName()
+                .filter(name -> !name.equals(applicationServiceName));
+        if (customService.isPresent()) {
+            throw new IllegalArgumentException(
+                    "quarkus.kubernetes.gateway.rules.<id>.service-port-number is required when "
+                            + "service-name points to a different service ('" + customService.get() + "'). "
+                            + "Named ports from the current application cannot be resolved for another service.");
+        }
+
+        String portName = rule.servicePortName().orElse(config.gateway().targetPort());
+        return KubernetesCommonHelper.getPort(ports, config, portName)
+                .map(AddServiceResourceDecorator::calculateHostPort)
+                .orElse(defaultPort);
     }
 
     protected void service(DecoratorsContext context, KubernetesConfig config) {

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/BaseVanillaKubernetesProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/BaseVanillaKubernetesProcessor.java
@@ -136,7 +136,7 @@ public abstract class BaseVanillaKubernetesProcessor extends BaseKubeProcessor<A
     private static boolean isGatewayExposingManagement(KubernetesConfig config) {
         return config.gateway() != null
                 && config.gateway().expose()
-                && MANAGEMENT_PORT_NAME.equals(config.gateway().targetPort());
+                && MANAGEMENT_PORT_NAME.equals(config.gateway().http().targetPort());
     }
 
     protected void ingress(DecoratorsContext context, List<KubernetesPortBuildItem> ports, KubernetesConfig config) {
@@ -167,17 +167,18 @@ public abstract class BaseVanillaKubernetesProcessor extends BaseKubeProcessor<A
         }
 
         GatewayConfig gateway = config.gateway();
+        GatewayConfig.Http http = gateway.http();
 
         if (config.ingress() != null && config.ingress().expose()) {
             log.warn("Both quarkus.kubernetes.ingress.expose and quarkus.kubernetes.gateway.expose are true; "
                     + "generating both Ingress and Gateway API resources.");
         }
 
-        boolean hasParentRefs = gateway.parentRefs() != null && !gateway.parentRefs().isEmpty();
+        boolean hasParentRefs = http.parentRefs() != null && !http.parentRefs().isEmpty();
         if (!gateway.generateGateway() && !hasParentRefs) {
             throw new IllegalArgumentException(
                     "quarkus.kubernetes.gateway.expose=true requires either "
-                            + "quarkus.kubernetes.gateway.parent-refs.<id>.name or "
+                            + "quarkus.kubernetes.gateway.http.parent-refs.<id>.name or "
                             + "quarkus.kubernetes.gateway.generate-gateway=true");
         }
 
@@ -189,20 +190,20 @@ public abstract class BaseVanillaKubernetesProcessor extends BaseKubeProcessor<A
 
         if (gateway.generateGateway() && hasParentRefs) {
             log.warn("Both quarkus.kubernetes.gateway.generate-gateway and "
-                    + "quarkus.kubernetes.gateway.parent-refs are set; "
+                    + "quarkus.kubernetes.gateway.http.parent-refs are set; "
                     + "HTTPRoute will use parent-refs and the generated Gateway may be unused.");
         }
 
-        Optional<Port> port = KubernetesCommonHelper.getPort(ports, config, gateway.targetPort());
+        Optional<Port> port = KubernetesCommonHelper.getPort(ports, config, http.targetPort());
         int backendPort = port.map(AddServiceResourceDecorator::calculateHostPort).orElse(DEFAULT_HTTP_PORT);
 
-        String path = gateway.path();
-        PortConfig portConfig = config.ports().get(gateway.targetPort());
+        String path = http.path();
+        PortConfig portConfig = config.ports().get(http.targetPort());
         if (portConfig != null && portConfig.path().isPresent()) {
             path = portConfig.path().get();
         }
 
-        List<String> hostnames = AddHttpRouteResourceDecorator.combineHostnames(gateway.host(), gateway.hosts());
+        List<String> hostnames = AddHttpRouteResourceDecorator.combineHostnames(http.host(), http.hosts());
         String resourceName = context.name();
 
         if (gateway.generateGateway()) {
@@ -211,13 +212,13 @@ public abstract class BaseVanillaKubernetesProcessor extends BaseKubeProcessor<A
                     resourceName,
                     gateway.gatewayClassName().get(),
                     gateway.listeners(),
-                    gateway.annotations(),
+                    http.annotations(),
                     hostnames.stream().findFirst()));
         }
 
         List<AddHttpRouteResourceDecorator.Rule> extraRules = new ArrayList<>();
-        if (gateway.rules() != null) {
-            for (GatewayConfig.GatewayRuleConfig rule : gateway.rules().values()) {
+        if (http.rules() != null) {
+            for (GatewayConfig.Http.RuleConfig rule : http.rules().values()) {
                 int rulePort = resolveGatewayBackendPort(ports, config, resourceName, rule, backendPort);
                 extraRules.add(new AddHttpRouteResourceDecorator.Rule(
                         rule.path(),
@@ -231,12 +232,12 @@ public abstract class BaseVanillaKubernetesProcessor extends BaseKubeProcessor<A
                 resourceName,
                 hostnames,
                 path,
-                gateway.pathType(),
+                http.pathType(),
                 resourceName,
                 backendPort,
-                gateway.parentRefs(),
+                http.parentRefs(),
                 extraRules,
-                gateway.annotations(),
+                http.annotations(),
                 gateway.generateGateway(),
                 resourceName));
     }
@@ -258,7 +259,7 @@ public abstract class BaseVanillaKubernetesProcessor extends BaseKubeProcessor<A
     }
 
     private static int resolveGatewayBackendPort(List<KubernetesPortBuildItem> ports, KubernetesConfig config,
-            String applicationServiceName, GatewayConfig.GatewayRuleConfig rule, int defaultPort) {
+            String applicationServiceName, GatewayConfig.Http.RuleConfig rule, int defaultPort) {
         if (rule.servicePortNumber().isPresent()) {
             return rule.servicePortNumber().get();
         }
@@ -267,12 +268,12 @@ public abstract class BaseVanillaKubernetesProcessor extends BaseKubeProcessor<A
                 .filter(name -> !name.equals(applicationServiceName));
         if (customService.isPresent()) {
             throw new IllegalArgumentException(
-                    "quarkus.kubernetes.gateway.rules.<id>.service-port-number is required when "
+                    "quarkus.kubernetes.gateway.http.rules.<id>.service-port-number is required when "
                             + "service-name points to a different service ('" + customService.get() + "'). "
                             + "Named ports from the current application cannot be resolved for another service.");
         }
 
-        String portName = rule.servicePortName().orElse(config.gateway().targetPort());
+        String portName = rule.servicePortName().orElse(config.gateway().http().targetPort());
         return KubernetesCommonHelper.getPort(ports, config, portName)
                 .map(AddServiceResourceDecorator::calculateHostPort)
                 .orElse(defaultPort);

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/BaseVanillaKubernetesProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/BaseVanillaKubernetesProcessor.java
@@ -1,5 +1,6 @@
 package io.quarkus.kubernetes.deployment;
 
+import static io.quarkus.kubernetes.deployment.Constants.DEFAULT_HTTP_PORT;
 import static io.quarkus.kubernetes.deployment.Constants.INGRESS;
 import static io.quarkus.kubernetes.deployment.Constants.MAX_NODE_PORT_VALUE;
 import static io.quarkus.kubernetes.deployment.Constants.MAX_PORT_NUMBER;
@@ -11,15 +12,19 @@ import static io.quarkus.kubernetes.deployment.KubernetesConfigUtil.managementPo
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
+import org.jboss.logging.Logger;
 
 import io.dekorate.kubernetes.annotation.ServiceType;
 import io.dekorate.kubernetes.config.IngressRuleBuilder;
 import io.dekorate.kubernetes.config.Port;
 import io.dekorate.kubernetes.decorator.AddAnnotationDecorator;
 import io.dekorate.kubernetes.decorator.AddIngressRuleDecorator;
+import io.dekorate.kubernetes.decorator.AddServiceResourceDecorator;
 import io.quarkus.container.spi.ContainerImageInfoBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
@@ -49,6 +54,7 @@ import io.quarkus.kubernetes.spi.KubernetesRoleBuildItem;
 
 public abstract class BaseVanillaKubernetesProcessor extends BaseKubeProcessor<AddPortToKubernetesConfig, KubernetesConfig> {
     private static final String DEFAULT_HASH_ALGORITHM = "SHA-256";
+    private static final Logger log = Logger.getLogger(BaseVanillaKubernetesProcessor.class);
 
     @Override
     protected AddPortToKubernetesConfig portConfigurator(Port port) {
@@ -98,9 +104,7 @@ public abstract class BaseVanillaKubernetesProcessor extends BaseKubeProcessor<A
         final var config = config();
         // Do not bind the Management port to the Service resource unless it's explicitly used by the user.
         if (managementPortIsEnabled()
-                && (config.ingress() == null
-                        || !config.ingress().expose()
-                        || !config.ingress().targetPort().equals(MANAGEMENT_PORT_NAME))) {
+                && !isExposingManagementPort(config)) {
             context.add(new RemovePortFromServiceDecorator(context.name(), MANAGEMENT_PORT_NAME));
         }
 
@@ -114,8 +118,25 @@ public abstract class BaseVanillaKubernetesProcessor extends BaseKubeProcessor<A
         service(context, config);
 
         ingress(context, ports, config);
+        gateway(context, ports, config);
 
         return context;
+    }
+
+    private static boolean isExposingManagementPort(KubernetesConfig config) {
+        return isIngressExposingManagement(config) || isGatewayExposingManagement(config);
+    }
+
+    private static boolean isIngressExposingManagement(KubernetesConfig config) {
+        return config.ingress() != null
+                && config.ingress().expose()
+                && MANAGEMENT_PORT_NAME.equals(config.ingress().targetPort());
+    }
+
+    private static boolean isGatewayExposingManagement(KubernetesConfig config) {
+        return config.gateway() != null
+                && config.gateway().expose()
+                && MANAGEMENT_PORT_NAME.equals(config.gateway().http().targetPort());
     }
 
     protected void ingress(DecoratorsContext context, List<KubernetesPortBuildItem> ports, KubernetesConfig config) {
@@ -138,6 +159,124 @@ public abstract class BaseVanillaKubernetesProcessor extends BaseKubeProcessor<A
                             .withServicePortNumber(rule.servicePortNumber().orElse(-1))
                             .build()));
         }
+    }
+
+    protected void gateway(DecoratorsContext context, List<KubernetesPortBuildItem> ports, KubernetesConfig config) {
+        if (config.gateway() == null || !config.gateway().expose()) {
+            return;
+        }
+
+        GatewayConfig gateway = config.gateway();
+        GatewayConfig.Http http = gateway.http();
+
+        if (config.ingress() != null && config.ingress().expose()) {
+            log.warn("Both quarkus.kubernetes.ingress.expose and quarkus.kubernetes.gateway.expose are true; "
+                    + "generating both Ingress and Gateway API resources.");
+        }
+
+        boolean hasParentRefs = http.parentRefs() != null && !http.parentRefs().isEmpty();
+        if (!gateway.generateGateway() && !hasParentRefs) {
+            throw new IllegalArgumentException(
+                    "quarkus.kubernetes.gateway.expose=true requires either "
+                            + "quarkus.kubernetes.gateway.http.parent-refs.<id>.name or "
+                            + "quarkus.kubernetes.gateway.generate-gateway=true");
+        }
+
+        if (gateway.generateGateway() && gateway.gatewayClassName().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "quarkus.kubernetes.gateway.generate-gateway=true requires "
+                            + "quarkus.kubernetes.gateway.gateway-class-name");
+        }
+
+        if (gateway.generateGateway() && hasParentRefs) {
+            log.warn("Both quarkus.kubernetes.gateway.generate-gateway and "
+                    + "quarkus.kubernetes.gateway.http.parent-refs are set; "
+                    + "HTTPRoute will use parent-refs and the generated Gateway may be unused.");
+        }
+
+        Optional<Port> port = KubernetesCommonHelper.getPort(ports, config, http.targetPort());
+        int backendPort = port.map(AddServiceResourceDecorator::calculateHostPort).orElse(DEFAULT_HTTP_PORT);
+
+        String path = http.path();
+        PortConfig portConfig = config.ports().get(http.targetPort());
+        if (portConfig != null && portConfig.path().isPresent()) {
+            path = portConfig.path().get();
+        }
+
+        List<String> hostnames = AddHttpRouteResourceDecorator.combineHostnames(http.host(), http.hosts());
+        String resourceName = context.name();
+
+        if (gateway.generateGateway()) {
+            warnUnsupportedTlsListeners(gateway.listeners());
+            context.add(new AddGatewayResourceDecorator(
+                    resourceName,
+                    gateway.gatewayClassName().get(),
+                    gateway.listeners(),
+                    http.annotations(),
+                    hostnames.stream().findFirst()));
+        }
+
+        List<AddHttpRouteResourceDecorator.Rule> extraRules = new ArrayList<>();
+        if (http.rules() != null) {
+            for (GatewayConfig.Http.RuleConfig rule : http.rules().values()) {
+                int rulePort = resolveGatewayBackendPort(ports, config, resourceName, rule, backendPort);
+                extraRules.add(new AddHttpRouteResourceDecorator.Rule(
+                        rule.path(),
+                        rule.pathType(),
+                        rule.serviceName().orElse(resourceName),
+                        rulePort));
+            }
+        }
+
+        context.add(new AddHttpRouteResourceDecorator(
+                resourceName,
+                hostnames,
+                path,
+                http.pathType(),
+                resourceName,
+                backendPort,
+                http.parentRefs(),
+                extraRules,
+                http.annotations(),
+                gateway.generateGateway(),
+                resourceName));
+    }
+
+    private static void warnUnsupportedTlsListeners(Map<String, GatewayConfig.ListenerConfig> listeners) {
+        if (listeners == null) {
+            return;
+        }
+        for (GatewayConfig.ListenerConfig listener : listeners.values()) {
+            String protocol = listener.protocol();
+            if ("HTTPS".equalsIgnoreCase(protocol) || "TLS".equalsIgnoreCase(protocol)) {
+                log.warnf(
+                        "Gateway listener '%s' uses protocol %s, but quarkus.kubernetes.gateway does not generate "
+                                + "listener TLS certificateRefs yet; the Gateway may be invalid until TLS is configured "
+                                + "out-of-band.",
+                        listener.name(), protocol);
+            }
+        }
+    }
+
+    private static int resolveGatewayBackendPort(List<KubernetesPortBuildItem> ports, KubernetesConfig config,
+            String applicationServiceName, GatewayConfig.Http.RuleConfig rule, int defaultPort) {
+        if (rule.servicePortNumber().isPresent()) {
+            return rule.servicePortNumber().get();
+        }
+
+        Optional<String> customService = rule.serviceName()
+                .filter(name -> !name.equals(applicationServiceName));
+        if (customService.isPresent()) {
+            throw new IllegalArgumentException(
+                    "quarkus.kubernetes.gateway.http.rules.<id>.service-port-number is required when "
+                            + "service-name points to a different service ('" + customService.get() + "'). "
+                            + "Named ports from the current application cannot be resolved for another service.");
+        }
+
+        String portName = rule.servicePortName().orElse(config.gateway().http().targetPort());
+        return KubernetesCommonHelper.getPort(ports, config, portName)
+                .map(AddServiceResourceDecorator::calculateHostPort)
+                .orElse(defaultPort);
     }
 
     protected void service(DecoratorsContext context, KubernetesConfig config) {

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/GatewayConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/GatewayConfig.java
@@ -1,0 +1,169 @@
+package io.quarkus.kubernetes.deployment;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.smallrye.config.WithDefault;
+
+public interface GatewayConfig {
+
+    /**
+     * If true, generate Gateway API resources to expose the application.
+     */
+    @WithDefault("false")
+    boolean expose();
+
+    /**
+     * If true, also generate a Gateway resource. Usually the platform already provides a shared Gateway;
+     * in that case leave this false and configure {@code parent-refs} instead.
+     */
+    @WithDefault("false")
+    boolean generateGateway();
+
+    /**
+     * The GatewayClass name to use when {@code generate-gateway} is true.
+     */
+    Optional<String> gatewayClassName();
+
+    /**
+     * The host under which the application is going to be exposed (HTTPRoute hostname).
+     */
+    Optional<String> host();
+
+    /**
+     * Additional hostnames for the HTTPRoute. Combined with {@code host} when both are set.
+     */
+    Optional<List<String>> hosts();
+
+    /**
+     * The default path match value. Default is {@code /}.
+     * Can also be overridden via {@code quarkus.kubernetes.ports.<target-port>.path}.
+     */
+    @WithDefault("/")
+    String path();
+
+    /**
+     * The path match type. One of {@code Exact}, {@code PathPrefix}, or {@code RegularExpression}.
+     */
+    @WithDefault("PathPrefix")
+    String pathType();
+
+    /**
+     * The default target named port. If not provided matching ports exist, it falls back to {@code http}.
+     */
+    @WithDefault("http")
+    String targetPort();
+
+    /**
+     * Custom annotations to add to the generated HTTPRoute (and Gateway when generated).
+     */
+    @ConfigDocMapKey("annotation-name")
+    Map<String, String> annotations();
+
+    /**
+     * Parent Gateway references the HTTPRoute attaches to.
+     * Required when {@code expose=true} and {@code generate-gateway=false}.
+     */
+    Map<String, ParentRefConfig> parentRefs();
+
+    /**
+     * Additional HTTPRoute rules (in addition to the default rule from path/target-port).
+     */
+    Map<String, GatewayRuleConfig> rules();
+
+    /**
+     * Listeners when {@code generate-gateway=true}. If empty, a default HTTP listener on port 80 named
+     * {@code http} is used.
+     */
+    Map<String, ListenerConfig> listeners();
+
+    interface ParentRefConfig {
+
+        /**
+         * Name of the parent Gateway.
+         */
+        String name();
+
+        /**
+         * Namespace of the parent Gateway. Defaults to the HTTPRoute namespace when omitted.
+         */
+        Optional<String> namespace();
+
+        /**
+         * Section name (listener name) on the parent Gateway.
+         */
+        Optional<String> sectionName();
+
+        /**
+         * Group of the parent resource. Defaults to {@code gateway.networking.k8s.io}.
+         */
+        Optional<String> group();
+
+        /**
+         * Kind of the parent resource. Defaults to {@code Gateway}.
+         */
+        Optional<String> kind();
+    }
+
+    interface GatewayRuleConfig {
+
+        /**
+         * The path under which the rule is going to be used. Default is {@code /}.
+         */
+        @WithDefault("/")
+        String path();
+
+        /**
+         * The path match type. Default is {@code PathPrefix}.
+         */
+        @WithDefault("PathPrefix")
+        String pathType();
+
+        /**
+         * The service name to be used by this rule. Default is the generated service name of the application.
+         */
+        Optional<String> serviceName();
+
+        /**
+         * The named service port to resolve to a number for this rule.
+         * Used when {@code service-port-number} is not set.
+         */
+        Optional<String> servicePortName();
+
+        /**
+         * The service port number to be used by this rule.
+         * Required by Gateway API {@code backendRefs} when {@code service-name} points to a different Service.
+         * Preferred when set; otherwise the named port is resolved from the current application only.
+         */
+        Optional<Integer> servicePortNumber();
+    }
+
+    interface ListenerConfig {
+
+        /**
+         * Listener name (used as sectionName on HTTPRoute parentRefs).
+         */
+        String name();
+
+        /**
+         * Protocol for the listener: {@code HTTP}, {@code HTTPS}, {@code TLS}, {@code TCP}, or {@code UDP}.
+         * Note: HTTPS/TLS certificateRefs are not generated yet; prefer {@code HTTP} unless TLS is configured
+         * out-of-band on the Gateway.
+         */
+        @WithDefault("HTTP")
+        String protocol();
+
+        /**
+         * Port the listener binds to.
+         */
+        @WithDefault("80")
+        int port();
+
+        /**
+         * Optional hostname for the listener.
+         */
+        Optional<String> hostname();
+    }
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/GatewayConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/GatewayConfig.java
@@ -17,7 +17,7 @@ public interface GatewayConfig {
 
     /**
      * If true, also generate a Gateway resource. Usually the platform already provides a shared Gateway;
-     * in that case leave this false and configure {@code parent-refs} instead.
+     * in that case leave this false and configure {@code http.parent-refs} instead.
      */
     @WithDefault("false")
     boolean generateGateway();
@@ -28,116 +28,125 @@ public interface GatewayConfig {
     Optional<String> gatewayClassName();
 
     /**
-     * The host under which the application is going to be exposed (HTTPRoute hostname).
-     */
-    Optional<String> host();
-
-    /**
-     * Additional hostnames for the HTTPRoute. Combined with {@code host} when both are set.
-     */
-    Optional<List<String>> hosts();
-
-    /**
-     * The default path match value. Default is {@code /}.
-     * Can also be overridden via {@code quarkus.kubernetes.ports.<target-port>.path}.
-     */
-    @WithDefault("/")
-    String path();
-
-    /**
-     * The path match type. One of {@code Exact}, {@code PathPrefix}, or {@code RegularExpression}.
-     */
-    @WithDefault("PathPrefix")
-    String pathType();
-
-    /**
-     * The default target named port. If not provided matching ports exist, it falls back to {@code http}.
-     */
-    @WithDefault("http")
-    String targetPort();
-
-    /**
-     * Custom annotations to add to the generated HTTPRoute (and Gateway when generated).
-     */
-    @ConfigDocMapKey("annotation-name")
-    Map<String, String> annotations();
-
-    /**
-     * Parent Gateway references the HTTPRoute attaches to.
-     * Required when {@code expose=true} and {@code generate-gateway=false}.
-     */
-    Map<String, ParentRefConfig> parentRefs();
-
-    /**
-     * Additional HTTPRoute rules (in addition to the default rule from path/target-port).
-     */
-    Map<String, GatewayRuleConfig> rules();
-
-    /**
      * Listeners when {@code generate-gateway=true}. If empty, a default HTTP listener on port 80 named
      * {@code http} is used.
      */
     Map<String, ListenerConfig> listeners();
 
-    interface ParentRefConfig {
+    /**
+     * HTTPRoute configuration.
+     * Nested under {@code http} so additional route types (for example {@code grpc}) can be added later.
+     */
+    Http http();
+
+    interface Http {
 
         /**
-         * Name of the parent Gateway.
+         * The host under which the application is going to be exposed (HTTPRoute hostname).
          */
-        String name();
+        Optional<String> host();
 
         /**
-         * Namespace of the parent Gateway. Defaults to the HTTPRoute namespace when omitted.
+         * Additional hostnames for the HTTPRoute. Combined with {@code host} when both are set.
          */
-        Optional<String> namespace();
+        Optional<List<String>> hosts();
 
         /**
-         * Section name (listener name) on the parent Gateway.
-         */
-        Optional<String> sectionName();
-
-        /**
-         * Group of the parent resource. Defaults to {@code gateway.networking.k8s.io}.
-         */
-        Optional<String> group();
-
-        /**
-         * Kind of the parent resource. Defaults to {@code Gateway}.
-         */
-        Optional<String> kind();
-    }
-
-    interface GatewayRuleConfig {
-
-        /**
-         * The path under which the rule is going to be used. Default is {@code /}.
+         * The default path match value. Default is {@code /}.
+         * Can also be overridden via {@code quarkus.kubernetes.ports.<target-port>.path}.
          */
         @WithDefault("/")
         String path();
 
         /**
-         * The path match type. Default is {@code PathPrefix}.
+         * The path match type. One of {@code Exact}, {@code PathPrefix}, or {@code RegularExpression}.
          */
         @WithDefault("PathPrefix")
         String pathType();
 
         /**
-         * The service name to be used by this rule. Default is the generated service name of the application.
+         * The default target named port. If not provided matching ports exist, it falls back to {@code http}.
          */
-        Optional<String> serviceName();
+        @WithDefault("http")
+        String targetPort();
 
         /**
-         * The named service port to resolve to a number for this rule.
-         * Used when {@code service-port-number} is not set.
+         * Custom annotations to add to the generated HTTPRoute (and Gateway when generated).
          */
-        Optional<String> servicePortName();
+        @ConfigDocMapKey("annotation-name")
+        Map<String, String> annotations();
 
         /**
-         * The service port number to be used by this rule.
-         * Required by Gateway API {@code backendRefs} when {@code service-name} points to a different Service.
-         * Preferred when set; otherwise the named port is resolved from the current application only.
+         * Parent Gateway references the HTTPRoute attaches to.
+         * Required when {@code expose=true} and {@code generate-gateway=false}.
          */
-        Optional<Integer> servicePortNumber();
+        Map<String, ParentRefConfig> parentRefs();
+
+        /**
+         * Additional HTTPRoute rules (in addition to the default rule from path/target-port).
+         */
+        Map<String, RuleConfig> rules();
+
+        interface ParentRefConfig {
+
+            /**
+             * Name of the parent Gateway.
+             */
+            String name();
+
+            /**
+             * Namespace of the parent Gateway. Defaults to the HTTPRoute namespace when omitted.
+             */
+            Optional<String> namespace();
+
+            /**
+             * Section name (listener name) on the parent Gateway.
+             */
+            Optional<String> sectionName();
+
+            /**
+             * Group of the parent resource. Defaults to {@code gateway.networking.k8s.io}.
+             */
+            Optional<String> group();
+
+            /**
+             * Kind of the parent resource. Defaults to {@code Gateway}.
+             */
+            Optional<String> kind();
+        }
+
+        interface RuleConfig {
+
+            /**
+             * The path under which the rule is going to be used. Default is {@code /}.
+             */
+            @WithDefault("/")
+            String path();
+
+            /**
+             * The path match type. Default is {@code PathPrefix}.
+             */
+            @WithDefault("PathPrefix")
+            String pathType();
+
+            /**
+             * The service name to be used by this rule. Default is the generated service name of the application.
+             */
+            Optional<String> serviceName();
+
+            /**
+             * The named service port to resolve to a number for this rule.
+             * Used when {@code service-port-number} is not set.
+             */
+            Optional<String> servicePortName();
+
+            /**
+             * The service port number to be used by this rule.
+             * Required by Gateway API {@code backendRefs} when {@code service-name} points to a different Service.
+             * Preferred when set; otherwise the named port is resolved from the current application only.
+             */
+            Optional<Integer> servicePortNumber();
+        }
     }
 
     interface ListenerConfig {

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/GatewayConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/GatewayConfig.java
@@ -1,0 +1,178 @@
+package io.quarkus.kubernetes.deployment;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.smallrye.config.WithDefault;
+
+public interface GatewayConfig {
+
+    /**
+     * If true, generate Gateway API resources to expose the application.
+     */
+    @WithDefault("false")
+    boolean expose();
+
+    /**
+     * If true, also generate a Gateway resource. Usually the platform already provides a shared Gateway;
+     * in that case leave this false and configure {@code http.parent-refs} instead.
+     */
+    @WithDefault("false")
+    boolean generateGateway();
+
+    /**
+     * The GatewayClass name to use when {@code generate-gateway} is true.
+     */
+    Optional<String> gatewayClassName();
+
+    /**
+     * Listeners when {@code generate-gateway=true}. If empty, a default HTTP listener on port 80 named
+     * {@code http} is used.
+     */
+    Map<String, ListenerConfig> listeners();
+
+    /**
+     * HTTPRoute configuration.
+     * Nested under {@code http} so additional route types (for example {@code grpc}) can be added later.
+     */
+    Http http();
+
+    interface Http {
+
+        /**
+         * The host under which the application is going to be exposed (HTTPRoute hostname).
+         */
+        Optional<String> host();
+
+        /**
+         * Additional hostnames for the HTTPRoute. Combined with {@code host} when both are set.
+         */
+        Optional<List<String>> hosts();
+
+        /**
+         * The default path match value. Default is {@code /}.
+         * Can also be overridden via {@code quarkus.kubernetes.ports.<target-port>.path}.
+         */
+        @WithDefault("/")
+        String path();
+
+        /**
+         * The path match type. One of {@code Exact}, {@code PathPrefix}, or {@code RegularExpression}.
+         */
+        @WithDefault("PathPrefix")
+        String pathType();
+
+        /**
+         * The default target named port. If not provided matching ports exist, it falls back to {@code http}.
+         */
+        @WithDefault("http")
+        String targetPort();
+
+        /**
+         * Custom annotations to add to the generated HTTPRoute (and Gateway when generated).
+         */
+        @ConfigDocMapKey("annotation-name")
+        Map<String, String> annotations();
+
+        /**
+         * Parent Gateway references the HTTPRoute attaches to.
+         * Required when {@code expose=true} and {@code generate-gateway=false}.
+         */
+        Map<String, ParentRefConfig> parentRefs();
+
+        /**
+         * Additional HTTPRoute rules (in addition to the default rule from path/target-port).
+         */
+        Map<String, RuleConfig> rules();
+
+        interface ParentRefConfig {
+
+            /**
+             * Name of the parent Gateway.
+             */
+            String name();
+
+            /**
+             * Namespace of the parent Gateway. Defaults to the HTTPRoute namespace when omitted.
+             */
+            Optional<String> namespace();
+
+            /**
+             * Section name (listener name) on the parent Gateway.
+             */
+            Optional<String> sectionName();
+
+            /**
+             * Group of the parent resource. Defaults to {@code gateway.networking.k8s.io}.
+             */
+            Optional<String> group();
+
+            /**
+             * Kind of the parent resource. Defaults to {@code Gateway}.
+             */
+            Optional<String> kind();
+        }
+
+        interface RuleConfig {
+
+            /**
+             * The path under which the rule is going to be used. Default is {@code /}.
+             */
+            @WithDefault("/")
+            String path();
+
+            /**
+             * The path match type. Default is {@code PathPrefix}.
+             */
+            @WithDefault("PathPrefix")
+            String pathType();
+
+            /**
+             * The service name to be used by this rule. Default is the generated service name of the application.
+             */
+            Optional<String> serviceName();
+
+            /**
+             * The named service port to resolve to a number for this rule.
+             * Used when {@code service-port-number} is not set.
+             */
+            Optional<String> servicePortName();
+
+            /**
+             * The service port number to be used by this rule.
+             * Required by Gateway API {@code backendRefs} when {@code service-name} points to a different Service.
+             * Preferred when set; otherwise the named port is resolved from the current application only.
+             */
+            Optional<Integer> servicePortNumber();
+        }
+    }
+
+    interface ListenerConfig {
+
+        /**
+         * Listener name (used as sectionName on HTTPRoute parentRefs).
+         */
+        String name();
+
+        /**
+         * Protocol for the listener: {@code HTTP}, {@code HTTPS}, {@code TLS}, {@code TCP}, or {@code UDP}.
+         * Note: HTTPS/TLS certificateRefs are not generated yet; prefer {@code HTTP} unless TLS is configured
+         * out-of-band on the Gateway.
+         */
+        @WithDefault("HTTP")
+        String protocol();
+
+        /**
+         * Port the listener binds to.
+         */
+        @WithDefault("80")
+        int port();
+
+        /**
+         * Optional hostname for the listener.
+         */
+        Optional<String> hostname();
+    }
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfig.java
@@ -53,6 +53,11 @@ public interface KubernetesConfig extends PlatformConfiguration, ReplicasAware {
     IngressConfig ingress();
 
     /**
+     * Kubernetes Gateway API configuration (HTTPRoute / optional Gateway).
+     */
+    GatewayConfig gateway();
+
+    /**
      * Optionally set directory generated Kubernetes resources will be written to. Default is `target/kubernetes`.
      */
     Optional<String> outputDirectory();

--- a/integration-tests/kubernetes/quarkus-standard-way/pom.xml
+++ b/integration-tests/kubernetes/quarkus-standard-way/pom.xml
@@ -71,8 +71,13 @@
                     <artifactId>jakarta.xml.bind-api</artifactId>
                 </exclusion>
             </exclusions>
-         </dependency>
-         <dependency>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-gatewayapi</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>knative-model</artifactId>
             <scope>test</scope>

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithGatewayTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithGatewayTest.java
@@ -1,0 +1,64 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.Gateway;
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.HTTPRoute;
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class KubernetesWithGatewayTest {
+
+    private static final String APP_NAME = "kubernetes-with-gateway";
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot((jar) -> jar.addClasses(GreetingResource.class))
+            .setApplicationName(APP_NAME)
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .withConfigurationResource(APP_NAME + ".properties")
+            .setLogFileName("k8s.log")
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-kubernetes", Version.getVersion())));
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        final Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        List<HasMetadata> kubernetesList = DeserializationUtil
+                .deserializeAsList(kubernetesDir.resolve("kubernetes.yml"));
+
+        assertThat(kubernetesList).filteredOn(i -> "Gateway".equals(i.getKind())).singleElement()
+                .isInstanceOfSatisfying(Gateway.class, gateway -> {
+                    assertThat(gateway.getMetadata().getName()).isEqualTo(APP_NAME);
+                    assertThat(gateway.getSpec().getGatewayClassName()).isEqualTo("istio");
+                    assertThat(gateway.getSpec().getListeners()).singleElement().satisfies(listener -> {
+                        assertThat(listener.getName()).isEqualTo("http");
+                        assertThat(listener.getProtocol()).isEqualTo("HTTP");
+                        assertThat(listener.getPort()).isEqualTo(80);
+                        assertThat(listener.getHostname()).isEqualTo("prod.svc.url");
+                    });
+                });
+
+        assertThat(kubernetesList).filteredOn(i -> "HTTPRoute".equals(i.getKind())).singleElement()
+                .isInstanceOfSatisfying(HTTPRoute.class, route -> {
+                    assertThat(route.getSpec().getParentRefs()).singleElement().satisfies(ref -> {
+                        assertThat(ref.getName()).isEqualTo(APP_NAME);
+                        assertThat(ref.getKind()).isEqualTo("Gateway");
+                    });
+                    assertThat(route.getSpec().getHostnames()).containsExactly("prod.svc.url");
+                });
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithHttpRouteRulesTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithHttpRouteRulesTest.java
@@ -1,0 +1,70 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.HTTPRoute;
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.HTTPRouteRule;
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class KubernetesWithHttpRouteRulesTest {
+
+    private static final String APP_NAME = "kubernetes-with-http-route-rules";
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot((jar) -> jar.addClasses(GreetingResource.class))
+            .setApplicationName(APP_NAME)
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .withConfigurationResource(APP_NAME + ".properties")
+            .setLogFileName("k8s.log")
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-kubernetes", Version.getVersion())));
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        final Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        List<HasMetadata> list = DeserializationUtil
+                .deserializeAsList(kubernetesDir.resolve("kubernetes.yml"));
+
+        assertThat(list).filteredOn(i -> "HTTPRoute".equals(i.getKind())).singleElement()
+                .isInstanceOfSatisfying(HTTPRoute.class, route -> {
+                    assertThat(route.getSpec().getHostnames()).containsExactly("prod.svc.url");
+                    assertThat(route.getSpec().getRules()).hasSize(3);
+                    assertThat(route.getSpec().getRules()).anyMatch(this::defaultRule);
+                    assertThat(route.getSpec().getRules()).anyMatch(this::exactPathRule);
+                    assertThat(route.getSpec().getRules()).anyMatch(this::customBackendRule);
+                });
+    }
+
+    private boolean defaultRule(HTTPRouteRule rule) {
+        return rule.getMatches().stream().anyMatch(m -> "/prod".equals(m.getPath().getValue())
+                && "PathPrefix".equals(m.getPath().getType()))
+                && rule.getBackendRefs().stream().anyMatch(b -> APP_NAME.equals(b.getName()));
+    }
+
+    private boolean exactPathRule(HTTPRouteRule rule) {
+        return rule.getMatches().stream().anyMatch(m -> "/dev".equals(m.getPath().getValue())
+                && "Exact".equals(m.getPath().getType()))
+                && rule.getBackendRefs().stream().anyMatch(b -> APP_NAME.equals(b.getName()));
+    }
+
+    private boolean customBackendRule(HTTPRouteRule rule) {
+        return rule.getMatches().stream().anyMatch(m -> "/ea".equals(m.getPath().getValue()))
+                && rule.getBackendRefs().stream().anyMatch(b -> "updated-service".equals(b.getName())
+                        && Integer.valueOf(8080).equals(b.getPort()));
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithHttpRouteTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithHttpRouteTest.java
@@ -1,0 +1,73 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.gatewayapi.v1.HTTPRoute;
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class KubernetesWithHttpRouteTest {
+
+    private static final String APP_NAME = "kubernetes-with-http-route";
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot((jar) -> jar.addClasses(GreetingResource.class))
+            .setApplicationName(APP_NAME)
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .withConfigurationResource(APP_NAME + ".properties")
+            .setLogFileName("k8s.log")
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-kubernetes", Version.getVersion())));
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        final Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        assertThat(kubernetesDir)
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.json"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.yml"));
+        List<HasMetadata> kubernetesList = DeserializationUtil
+                .deserializeAsList(kubernetesDir.resolve("kubernetes.yml"));
+
+        assertThat(kubernetesList).filteredOn(i -> "HTTPRoute".equals(i.getKind())).singleElement().satisfies(item -> {
+            assertThat(item).isInstanceOfSatisfying(HTTPRoute.class, route -> {
+                assertThat(route.getMetadata().getName()).isEqualTo(APP_NAME);
+                assertThat(route.getMetadata().getAnnotations())
+                        .containsEntry("example.com/gate", "enabled");
+                assertThat(route.getSpec().getParentRefs()).singleElement().satisfies(ref -> {
+                    assertThat(ref.getName()).isEqualTo("shared-gateway");
+                    assertThat(ref.getNamespace()).isEqualTo("infra");
+                    assertThat(ref.getKind()).isEqualTo("Gateway");
+                });
+                assertThat(route.getSpec().getHostnames()).containsExactly("prod.svc.url");
+                assertThat(route.getSpec().getRules()).isNotEmpty();
+                assertThat(route.getSpec().getRules().get(0).getBackendRefs())
+                        .singleElement()
+                        .satisfies(backend -> {
+                            assertThat(backend.getName()).isEqualTo(APP_NAME);
+                            assertThat(backend.getKind()).isEqualTo("Service");
+                            assertThat(backend.getPort()).isEqualTo(8080);
+                        });
+                assertThat(route.getSpec().getRules().get(0).getMatches())
+                        .singleElement()
+                        .satisfies(match -> {
+                            assertThat(match.getPath().getType()).isEqualTo("PathPrefix");
+                            assertThat(match.getPath().getValue()).isEqualTo("/");
+                        });
+            });
+        });
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-gateway.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-gateway.properties
@@ -1,0 +1,4 @@
+quarkus.kubernetes.gateway.expose=true
+quarkus.kubernetes.gateway.generate-gateway=true
+quarkus.kubernetes.gateway.gateway-class-name=istio
+quarkus.kubernetes.gateway.host=prod.svc.url

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-gateway.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-gateway.properties
@@ -1,0 +1,4 @@
+quarkus.kubernetes.gateway.expose=true
+quarkus.kubernetes.gateway.generate-gateway=true
+quarkus.kubernetes.gateway.gateway-class-name=istio
+quarkus.kubernetes.gateway.http.host=prod.svc.url

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-gateway.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-gateway.properties
@@ -1,4 +1,4 @@
 quarkus.kubernetes.gateway.expose=true
 quarkus.kubernetes.gateway.generate-gateway=true
 quarkus.kubernetes.gateway.gateway-class-name=istio
-quarkus.kubernetes.gateway.host=prod.svc.url
+quarkus.kubernetes.gateway.http.host=prod.svc.url

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-http-route-rules.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-http-route-rules.properties
@@ -1,0 +1,12 @@
+quarkus.kubernetes.gateway.expose=true
+quarkus.kubernetes.gateway.parent-refs.main.name=shared-gateway
+quarkus.kubernetes.gateway.host=prod.svc.url
+quarkus.kubernetes.ports.http.path=/prod
+
+# Extra rules
+quarkus.kubernetes.gateway.rules.1.path=/dev
+quarkus.kubernetes.gateway.rules.1.path-type=Exact
+
+quarkus.kubernetes.gateway.rules.2.path=/ea
+quarkus.kubernetes.gateway.rules.2.service-name=updated-service
+quarkus.kubernetes.gateway.rules.2.service-port-number=8080

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-http-route-rules.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-http-route-rules.properties
@@ -1,12 +1,12 @@
 quarkus.kubernetes.gateway.expose=true
-quarkus.kubernetes.gateway.parent-refs.main.name=shared-gateway
-quarkus.kubernetes.gateway.host=prod.svc.url
+quarkus.kubernetes.gateway.http.parent-refs.main.name=shared-gateway
+quarkus.kubernetes.gateway.http.host=prod.svc.url
 quarkus.kubernetes.ports.http.path=/prod
 
 # Extra rules
-quarkus.kubernetes.gateway.rules.1.path=/dev
-quarkus.kubernetes.gateway.rules.1.path-type=Exact
+quarkus.kubernetes.gateway.http.rules.1.path=/dev
+quarkus.kubernetes.gateway.http.rules.1.path-type=Exact
 
-quarkus.kubernetes.gateway.rules.2.path=/ea
-quarkus.kubernetes.gateway.rules.2.service-name=updated-service
-quarkus.kubernetes.gateway.rules.2.service-port-number=8080
+quarkus.kubernetes.gateway.http.rules.2.path=/ea
+quarkus.kubernetes.gateway.http.rules.2.service-name=updated-service
+quarkus.kubernetes.gateway.http.rules.2.service-port-number=8080

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-http-route-rules.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-http-route-rules.properties
@@ -1,0 +1,12 @@
+quarkus.kubernetes.gateway.expose=true
+quarkus.kubernetes.gateway.http.parent-refs.main.name=shared-gateway
+quarkus.kubernetes.gateway.http.host=prod.svc.url
+quarkus.kubernetes.ports.http.path=/prod
+
+# Extra rules
+quarkus.kubernetes.gateway.http.rules.1.path=/dev
+quarkus.kubernetes.gateway.http.rules.1.path-type=Exact
+
+quarkus.kubernetes.gateway.http.rules.2.path=/ea
+quarkus.kubernetes.gateway.http.rules.2.service-name=updated-service
+quarkus.kubernetes.gateway.http.rules.2.service-port-number=8080

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-http-route.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-http-route.properties
@@ -1,0 +1,5 @@
+quarkus.kubernetes.gateway.expose=true
+quarkus.kubernetes.gateway.parent-refs.main.name=shared-gateway
+quarkus.kubernetes.gateway.parent-refs.main.namespace=infra
+quarkus.kubernetes.gateway.host=prod.svc.url
+quarkus.kubernetes.gateway.annotations."example.com/gate"=enabled

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-http-route.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-http-route.properties
@@ -1,0 +1,5 @@
+quarkus.kubernetes.gateway.expose=true
+quarkus.kubernetes.gateway.http.parent-refs.main.name=shared-gateway
+quarkus.kubernetes.gateway.http.parent-refs.main.namespace=infra
+quarkus.kubernetes.gateway.http.host=prod.svc.url
+quarkus.kubernetes.gateway.http.annotations."example.com/gate"=enabled

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-http-route.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-http-route.properties
@@ -1,5 +1,5 @@
 quarkus.kubernetes.gateway.expose=true
-quarkus.kubernetes.gateway.parent-refs.main.name=shared-gateway
-quarkus.kubernetes.gateway.parent-refs.main.namespace=infra
-quarkus.kubernetes.gateway.host=prod.svc.url
-quarkus.kubernetes.gateway.annotations."example.com/gate"=enabled
+quarkus.kubernetes.gateway.http.parent-refs.main.name=shared-gateway
+quarkus.kubernetes.gateway.http.parent-refs.main.namespace=infra
+quarkus.kubernetes.gateway.http.host=prod.svc.url
+quarkus.kubernetes.gateway.http.annotations."example.com/gate"=enabled


### PR DESCRIPTION
Today the Kubernetes extension can generate Ingress resources but not Gateway API resources. Controllers such as kgateway only support Gateway API, and with Ingress NGINX retiring this gap becomes more important.

This adds `quarkus.kubernetes.gateway.*` configuration to generate an `HTTPRoute` (and optionally a `Gateway`) using fabric8 gatewayapi models, mirroring the existing Ingress exposure flow.

- Closes: #47501