### PR TITLE
Properly stop containers after `@QuarkusTest`

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesRegistryBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesRegistryBuildItem.java
@@ -228,7 +228,8 @@ public final class DevServicesRegistryBuildItem extends SimpleBuildItem {
                 allDevServicesOverrideConfigs.putAll(overrideConfig);
 
                 RunningService service = new RunningService(request.getName(), request.getDescription(),
-                        new HashMap<>(currentDevServiceConfig), overrideConfig, startable.getContainerId(), startable);
+                        new HashMap<>(currentDevServiceConfig), overrideConfig, startable.getContainerId(), startable,
+                        startable.isReusable());
 
                 for (DevServicesAdditionalConfigBuildItem additionalConfigBuildItem : additionalConfigBuildItems) {
                     Map<String, String> extraFromBuildItem = additionalConfigBuildItem.getConfigProvider()

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/Startable.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/Startable.java
@@ -10,4 +10,8 @@ public interface Startable extends Closeable {
     // This starts to couple to containers, so we could move it to sub-interface and use that in dev services
     String getContainerId();
 
+    default boolean isReusable() {
+        return false;
+    }
+
 }

--- a/core/runtime/src/main/java/io/quarkus/devservices/crossclassloader/runtime/RunningDevServicesRegistry.java
+++ b/core/runtime/src/main/java/io/quarkus/devservices/crossclassloader/runtime/RunningDevServicesRegistry.java
@@ -60,12 +60,16 @@ public final class RunningDevServicesRegistry {
                 if (services != null) {
                     services.remove(service);
                 }
-                try {
-                    logClosing(owner.featureName(), launchMode, service.containerId());
-                    service.close();
-                } catch (Exception e) {
-                    // We don't want to fail the shutdown hook if a service fails to close
-                    logFailedToClose(e, owner.featureName(), launchMode, service.containerId());
+                if (service.isReusable()) {
+                    log.debugf("Not closing reusable dev service for %s in launch mode %s: %s",
+                            owner.featureName(), launchMode, service.containerId());
+                } else {
+                    try {
+                        logClosing(owner.featureName(), launchMode, service.containerId());
+                        service.close();
+                    } catch (Exception e) {
+                        logFailedToClose(e, owner.featureName(), launchMode, service.containerId());
+                    }
                 }
             }
         }

--- a/core/runtime/src/main/java/io/quarkus/devservices/crossclassloader/runtime/RunningService.java
+++ b/core/runtime/src/main/java/io/quarkus/devservices/crossclassloader/runtime/RunningService.java
@@ -19,16 +19,18 @@ public final class RunningService implements Closeable {
     private final Map<String, String> overrideConfigs;
     private final String containerId;
     private final Closeable closeable;
+    private final boolean reusable;
 
     public RunningService(String feature, String description, Map<String, String> configs, Map<String, String> overrideConfig,
             String containerId,
-            Closeable closeable) {
+            Closeable closeable, boolean reusable) {
         this.feature = feature;
         this.description = description;
         this.configs = configs;
         this.overrideConfigs = overrideConfig;
         this.containerId = containerId;
         this.closeable = closeable;
+        this.reusable = reusable;
     }
 
     @Override
@@ -58,5 +60,9 @@ public final class RunningService implements Closeable {
 
     public String containerId() {
         return containerId;
+    }
+
+    public boolean isReusable() {
+        return reusable;
     }
 }

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/StartableContainer.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/StartableContainer.java
@@ -2,7 +2,9 @@ package io.quarkus.devservices.common;
 
 import java.util.function.Function;
 
+import org.jboss.logging.Logger;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.TestcontainersConfiguration;
 
 import io.quarkus.deployment.builditem.Startable;
 
@@ -12,6 +14,8 @@ import io.quarkus.deployment.builditem.Startable;
  * @param <T> the type of the container
  */
 public class StartableContainer<T extends GenericContainer<?>> implements Startable {
+
+    private static final Logger LOG = Logger.getLogger(StartableContainer.class);
 
     private final T container;
     private final Function<T, String> connectionInfoFunction;
@@ -49,6 +53,11 @@ public class StartableContainer<T extends GenericContainer<?>> implements Starta
 
     @Override
     public void close() {
+        if (TestcontainersConfiguration.getInstance().environmentSupportsReuse()
+                && container.isShouldBeReused()) {
+            LOG.infof("Not stopping Dev Services container %s as reuse is enabled", container.getContainerId());
+            return;
+        }
         container.close();
     }
 }

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/StartableContainer.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/StartableContainer.java
@@ -2,7 +2,6 @@ package io.quarkus.devservices.common;
 
 import java.util.function.Function;
 
-import org.jboss.logging.Logger;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.TestcontainersConfiguration;
 
@@ -14,8 +13,6 @@ import io.quarkus.deployment.builditem.Startable;
  * @param <T> the type of the container
  */
 public class StartableContainer<T extends GenericContainer<?>> implements Startable {
-
-    private static final Logger LOG = Logger.getLogger(StartableContainer.class);
 
     private final T container;
     private final Function<T, String> connectionInfoFunction;
@@ -53,11 +50,16 @@ public class StartableContainer<T extends GenericContainer<?>> implements Starta
 
     @Override
     public void close() {
-        if (TestcontainersConfiguration.getInstance().environmentSupportsReuse()
-                && container.isShouldBeReused()) {
-            LOG.infof("Not stopping Dev Services container %s as reuse is enabled", container.getContainerId());
-            return;
-        }
         container.close();
+    }
+
+    @Override
+    public boolean isReusable() {
+        return isContainerReusable(container);
+    }
+
+    public static boolean isContainerReusable(GenericContainer<?> container) {
+        return TestcontainersConfiguration.getInstance().environmentSupportsReuse()
+                && container.isShouldBeReused();
     }
 }

--- a/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
+++ b/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
@@ -33,6 +33,7 @@ import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.JBossLoggingConsumer;
 import io.quarkus.devservices.common.Labels;
+import io.quarkus.devservices.common.StartableContainer;
 import io.quarkus.devservices.common.Volumes;
 import io.quarkus.runtime.LaunchMode;
 
@@ -211,6 +212,11 @@ public class DB2DevServicesProcessor {
         @Override
         public String getConnectionInfo() {
             return getEffectiveJdbcUrl();
+        }
+
+        @Override
+        public boolean isReusable() {
+            return StartableContainer.isContainerReusable(this);
         }
 
         @Override

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/compose/ComposeDevServicesProcessor.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/compose/ComposeDevServicesProcessor.java
@@ -137,7 +137,7 @@ public class ComposeDevServicesProcessor {
                 Feature.COMPOSE.getName(), "Compose project: " + result.projectName,
                 result.configs, Map.of(), null,
                 result.isOwner ? result.compose::stop : () -> {
-                });
+                }, false);
         devServicesRegistry.addRunningService(Feature.COMPOSE.getName(), null, configuration, service);
 
         return toComposeBuildItem(result.compose);

--- a/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDevServicesProcessor.java
+++ b/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDevServicesProcessor.java
@@ -26,6 +26,7 @@ import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.JBossLoggingConsumer;
 import io.quarkus.devservices.common.Labels;
+import io.quarkus.devservices.common.StartableContainer;
 import io.quarkus.devservices.common.Volumes;
 import io.quarkus.runtime.LaunchMode;
 
@@ -146,6 +147,11 @@ public class MariaDBDevServicesProcessor {
 
         public String getReactiveUrl() {
             return getEffectiveJdbcUrl().replaceFirst("jdbc:mariadb:", "vertx-reactive:mysql:");
+        }
+
+        @Override
+        public boolean isReusable() {
+            return StartableContainer.isContainerReusable(this);
         }
 
         @Override

--- a/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
+++ b/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
@@ -25,6 +25,7 @@ import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.JBossLoggingConsumer;
 import io.quarkus.devservices.common.Labels;
+import io.quarkus.devservices.common.StartableContainer;
 import io.quarkus.devservices.common.Volumes;
 import io.quarkus.runtime.LaunchMode;
 
@@ -166,6 +167,11 @@ public class MSSQLDevServicesProcessor {
         @Override
         public String getConnectionInfo() {
             return getEffectiveJdbcUrl();
+        }
+
+        @Override
+        public boolean isReusable() {
+            return StartableContainer.isContainerReusable(this);
         }
 
         @Override

--- a/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/mysql/deployment/MySQLDevServicesProcessor.java
+++ b/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/mysql/deployment/MySQLDevServicesProcessor.java
@@ -27,6 +27,7 @@ import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.JBossLoggingConsumer;
 import io.quarkus.devservices.common.Labels;
+import io.quarkus.devservices.common.StartableContainer;
 import io.quarkus.devservices.common.Volumes;
 import io.quarkus.runtime.LaunchMode;
 
@@ -149,6 +150,11 @@ public class MySQLDevServicesProcessor {
 
         public String getReactiveUrl() {
             return getEffectiveJdbcUrl().replaceFirst("jdbc:", "vertx-reactive:");
+        }
+
+        @Override
+        public boolean isReusable() {
+            return StartableContainer.isContainerReusable(this);
         }
 
         @Override

--- a/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
+++ b/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
@@ -27,6 +27,7 @@ import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.JBossLoggingConsumer;
 import io.quarkus.devservices.common.Labels;
+import io.quarkus.devservices.common.StartableContainer;
 import io.quarkus.devservices.common.Volumes;
 import io.quarkus.runtime.LaunchMode;
 
@@ -165,6 +166,11 @@ public class OracleDevServicesProcessor {
 
         public String getReactiveUrl() {
             return getEffectiveJdbcUrl().replaceFirst("jdbc:", "vertx-reactive:");
+        }
+
+        @Override
+        public boolean isReusable() {
+            return StartableContainer.isContainerReusable(this);
         }
 
         @Override

--- a/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
+++ b/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
@@ -32,6 +32,7 @@ import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.JBossLoggingConsumer;
 import io.quarkus.devservices.common.Labels;
+import io.quarkus.devservices.common.StartableContainer;
 import io.quarkus.devservices.common.Volumes;
 import io.quarkus.runtime.LaunchMode;
 import io.smallrye.common.cpu.CPU;
@@ -232,6 +233,11 @@ public class PostgresqlDevServicesProcessor {
         @Override
         public void close() {
             super.close();
+        }
+
+        @Override
+        public boolean isReusable() {
+            return StartableContainer.isContainerReusable(this);
         }
 
         @Override

--- a/integration-tests/jpa-postgresql/pom.xml
+++ b/integration-tests/jpa-postgresql/pom.xml
@@ -58,11 +58,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.awaitility</groupId>
-            <artifactId>awaitility</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-test-maven</artifactId>
             <scope>test</scope>

--- a/integration-tests/jpa-postgresql/src/test/java/io/quarkus/it/jpa/postgresql/DevServicesPostgresqlContainerNoReuseTest.java
+++ b/integration-tests/jpa-postgresql/src/test/java/io/quarkus/it/jpa/postgresql/DevServicesPostgresqlContainerNoReuseTest.java
@@ -1,7 +1,6 @@
 package io.quarkus.it.jpa.postgresql;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -9,7 +8,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -76,16 +74,12 @@ class DevServicesPostgresqlContainerNoReuseTest extends MojoTestBase {
                 .isZero();
         firstRun.stop();
 
-        // Container shutdown may not be instantaneous: for some reason,
-        // Quarkus doesn't shut down containers itself but lets Ryuk take care of it.
-        // See https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/Hibernate.20test.20failures.20on.20CI/near/608660701
-        await().atMost(30, TimeUnit.SECONDS)
-                .pollInterval(1, TimeUnit.SECONDS)
-                .untilAsserted(() -> assertThat(findContainerOnPort(FIXED_PORT))
-                        .as("Container on port %d should be stopped after the first run"
-                                + " (reuse is not enabled, so ContainerShutdownCloseable must call container.stop())",
-                                FIXED_PORT)
-                        .isNull());
+        // With default settings, the container should have been stopped on shutdown
+        assertThat(findContainerOnPort(FIXED_PORT))
+                .as("Container on port %d should be stopped after the first run"
+                        + " (reuse is not enabled, so the container must be stopped on shutdown)",
+                        FIXED_PORT)
+                .isNull();
 
         // IsContainerRuntimeWorking must not persist testcontainers.reuse.enable to disk
         if (TESTCONTAINERS_PROPS_FILE.exists()) {

--- a/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -606,7 +606,6 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
             throw new IllegalStateException(
                     "Internal error: ClassLoader " + cl + " does not have a linked curated application.");
         }
-        cl.getCuratedApplication().setEligibleForReuse(isSameCuratedApplication);
 
         // Let's clear the class-based caches of JDK/libraries when we switch to another application
         if (!isSameCuratedApplication) {
@@ -623,10 +622,17 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
         if ((state == null && !failedBoot) || (runningQuarkusApplication != null && isNewApplication)) {
             if (isNewApplication) {
                 if (state != null) {
+                    // Tell the close task in StartupActionImpl.run() whether the
+                    // CuratedApplication will be reused by the next test class.
+                    cl.getCuratedApplication().setEligibleForReuse(isSameCuratedApplication);
                     try {
                         state.close();
                     } catch (Throwable throwable) {
                         markTestAsFailed(extensionContext, throwable);
+                    } finally {
+                        // Reset: eligibleForReuse only applies to this transition,
+                        // not to the eventual final shutdown where nothing can be reused.
+                        cl.getCuratedApplication().setEligibleForReuse(false);
                     }
                 }
             }


### PR DESCRIPTION
Follows up on #55316, where I discovered that (some?) DevServices containers were actually never stopped...

See [#dev > Hibernate test failures on CI @ 💬](https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/Hibernate.20test.20failures.20on.20CI/near/608956840).

DevServices containers were not being stopped after `@QuarkusTest` shutdown because `CuratedApplication.close()` was never called — `eligibleForReuse` was incorrectly set to `true` on every `ensureStarted()` invocation, preventing cleanup even at final JVM shutdown. The fix moves `setEligibleForReuse()` to only apply during test class transitions and resets it immediately after, so the flag is always false at final shutdown.

On top of that, `RunningDevServicesRegistry.closeOwnRunningServices()` now checks a reusable flag on `RunningService` to preserve containers that are genuinely marked for Testcontainers reuse (`withReuse(true)` +
 `testcontainers.reuse.enable`).

This decouples two concerns that were previously conflated: `CuratedApplication` lifecycle across test classes vs. container reuse across JVM runs.

Marking as draft until @holly-cummins or @ozangunalp can have a look and confirm it's not entirely nonsensical.