### PR TITLE
Make sure MavenProjects available through the API are added to the Quarkus workspace

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapProvider.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapProvider.java
@@ -40,7 +40,6 @@ import io.quarkus.bootstrap.resolver.AppModelResolverException;
 import io.quarkus.bootstrap.resolver.BootstrapAppModelResolver;
 import io.quarkus.bootstrap.resolver.maven.BootstrapMavenContext;
 import io.quarkus.bootstrap.resolver.maven.BootstrapMavenContextConfig;
-import io.quarkus.bootstrap.resolver.maven.BootstrapMavenException;
 import io.quarkus.bootstrap.resolver.maven.EffectiveModelResolver;
 import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
 import io.quarkus.bootstrap.resolver.maven.workspace.LocalProject;
@@ -92,11 +91,17 @@ public class QuarkusBootstrapProvider implements Closeable {
 
     private static List<MavenProject> getSortedProjects(MavenSession session) {
         if (session.getAllProjects().size() == session.getProjects().size()) {
-            // these are supposed to be sorted already
-            return session.getProjects();
+            final MavenProject topParent = session.getTopLevelProject().getParent();
+            if (topParent == null || topParent.getFile() == null) {
+                return session.getProjects();
+            }
         }
-        final List<MavenProject> sorted = new ArrayList<>(session.getAllProjects().size());
-        addAfterParent(session.getTopLevelProject(), new HashSet<>(session.getAllProjects().size()), sorted);
+        final List<MavenProject> allProjects = session.getAllProjects();
+        final List<MavenProject> sorted = new ArrayList<>(allProjects.size());
+        final Set<File> added = new HashSet<>(allProjects.size());
+        for (MavenProject mp : allProjects) {
+            addAfterParent(mp, added, sorted);
+        }
         return sorted;
     }
 
@@ -259,37 +264,36 @@ public class QuarkusBootstrapProvider implements Closeable {
         private CuratedApplication testApp;
 
         private MavenArtifactResolver artifactResolver(QuarkusBootstrapMojo mojo, LaunchMode mode) {
-            try {
-                if (mode == LaunchMode.DEVELOPMENT || mode == LaunchMode.TEST || isWorkspaceDiscovery(mojo)) {
-                    final BootstrapMavenContextConfig<?> config = BootstrapMavenContext.config()
-                            // it's important to pass user settings in case the process was not launched using the original mvn script,
-                            // for example, using org.codehaus.plexus.classworlds.launcher.Launcher
-                            .setUserSettings(mojo.mavenSession().getRequest().getUserSettingsFile())
-                            .setCurrentProject(getOriginalPomFile(mojo.mavenProject()).toString())
-                            .setPreferPomsFromWorkspace(true)
-                            // pass the repositories since Maven extensions could manipulate repository configs
-                            .setRemoteRepositories(mojo.remoteRepositories())
-                            .setEffectiveModelBuilder(BootstrapMavenContextConfig
-                                    .getEffectiveModelBuilderProperty(mojo.mavenProject().getProperties()));
-                    setProvidedModules(config, mojo.mavenSession(), mojo.reloadPoms);
-                    var resolver = workspaceProvider.createArtifactResolver(config);
-                    final LocalProject currentProject = resolver.getMavenContext().getCurrentProject();
-                    if (currentProject != null && workspaceId == 0) {
-                        workspaceId = currentProject.getWorkspace().getId();
-                    }
-                    return resolver;
-                }
-                // PROD packaging mode with workspace discovery disabled
-                return MavenArtifactResolver.builder()
-                        .setWorkspaceDiscovery(false)
-                        .setRepositorySystem(repoSystem)
-                        .setRepositorySystemSession(mojo.repositorySystemSession())
+            if (mode == LaunchMode.DEVELOPMENT || mode == LaunchMode.TEST || isWorkspaceDiscovery(mojo)) {
+                final BootstrapMavenContextConfig<?> config = BootstrapMavenContext.config()
+                        // it's important to pass user settings in case the process was not launched using the original mvn script,
+                        // for example, using org.codehaus.plexus.classworlds.launcher.Launcher
+                        .setUserSettings(mojo.mavenSession().getRequest().getUserSettingsFile())
+                        .setCurrentProject(getOriginalPomFile(mojo.mavenProject()).toString())
+                        .setPreferPomsFromWorkspace(true)
+                        // pass the repositories since Maven extensions could manipulate repository configs
                         .setRemoteRepositories(mojo.remoteRepositories())
-                        .setRemoteRepositoryManager(remoteRepoManager)
-                        .build();
-            } catch (BootstrapMavenException e) {
-                throw new RuntimeException("Failed to initialize Quarkus bootstrap Maven artifact resolver", e);
+                        .setEffectiveModelBuilder(BootstrapMavenContextConfig
+                                .getEffectiveModelBuilderProperty(mojo.mavenProject().getProperties()));
+                setProvidedModules(config, mojo.mavenSession(), mojo.reloadPoms);
+                var resolver = workspaceProvider.createArtifactResolver(config);
+                final LocalProject currentProject = resolver.getMavenContext().getCurrentProject();
+                if (currentProject != null && workspaceId == 0) {
+                    workspaceId = currentProject.getWorkspace().getId();
+                }
+                return resolver;
             }
+            // PROD packaging mode: workspace from reactor projects only, no filesystem discovery
+            final BootstrapMavenContextConfig<?> prodConfig = BootstrapMavenContext.config()
+                    .setWorkspaceDiscovery(false)
+                    .setRepositorySystem(repoSystem)
+                    .setRepositorySystemSession(mojo.repositorySystemSession())
+                    .setRemoteRepositories(mojo.remoteRepositories())
+                    .setRemoteRepositoryManager(remoteRepoManager)
+                    .setCurrentProject(getOriginalPomFile(mojo.mavenProject()).toString())
+                    .setPreferPomsFromWorkspace(true);
+            setProvidedModules(prodConfig, mojo.mavenSession(), mojo.reloadPoms);
+            return workspaceProvider.createArtifactResolver(prodConfig);
         }
 
         private CuratedApplication doBootstrap(QuarkusBootstrapMojo mojo, LaunchMode mode,

--- a/extensions/grpc/codegen/src/main/java/io/quarkus/grpc/codegen/GrpcCodeGen.java
+++ b/extensions/grpc/codegen/src/main/java/io/quarkus/grpc/codegen/GrpcCodeGen.java
@@ -69,6 +69,9 @@ public class GrpcCodeGen implements CodeGenProvider {
     private static final String USE_ARG_FILE = "quarkus.generate-code.grpc.use-arg-file";
 
     private static final String GENERATE_KOTLIN = "quarkus.generate-code.grpc.kotlin.generate";
+    private static final String SRC_MAIN_PROTO_DIR = "src/main/proto/";
+    private static final String SRC_TEST_PROTO_DIR = "src/test/proto/";
+    private static final String PROTO_DIR = "proto/";
 
     private Executables executables;
     private String input;
@@ -397,60 +400,65 @@ public class GrpcCodeGen implements CodeGenProvider {
             Set<String> protoDirectories, ResolvedDependency artifact, Collection<String> filesToInclude,
             Collection<String> filesToExclude, boolean isDependency) throws CodeGenException {
 
+        // Proto files from dependencies are always copied to a work directory with known
+        // path prefixes (src/main/proto/, src/test/proto/, proto/) stripped. This ensures
+        // consistent --proto_path entries for protoc regardless of whether the artifact
+        // resolved to a JAR (archive) or a directory (e.g. workspace project's target/classes).
+        Path protoOutputDir = getProtoOutputDir(workDir, artifact);
         try {
             artifact.getContentTree(new PathFilter(filesToInclude, filesToExclude)).walk(
                     pathVisit -> {
                         Path path = pathVisit.getPath();
                         if (Files.isRegularFile(path) && path.getFileName().toString().endsWith(PROTO)) {
-                            Path root = pathVisit.getRoot();
-                            if (Files.isDirectory(root)) {
-                                protoFiles.add(path);
-                                protoDirectories.add(path.getParent().normalize().toAbsolutePath().toString());
-                            } else { // archive
-                                Path relativePath = path.getRoot().relativize(path);
-                                String relativePathStr = relativePath.toString().replace('\\', '/');
-                                if (relativePathStr.startsWith("src/main/proto/")) {
-                                    relativePathStr = relativePathStr.substring("src/main/proto/".length());
-                                } else if (relativePathStr.startsWith("src/test/proto/")) {
-                                    relativePathStr = relativePathStr.substring("src/test/proto/".length());
-                                } else if (relativePathStr.startsWith("proto/")) {
-                                    relativePathStr = relativePathStr.substring("proto/".length());
+                            String strippedPathStr = stripProtoPrefix(pathVisit.getResourceName());
+                            try {
+                                Files.createDirectories(protoOutputDir);
+                                protoDirectories.add(protoOutputDir.toString());
+                            } catch (IOException e) {
+                                throw new GrpcCodeGenException("Failed to create directory: " + protoOutputDir, e);
+                            }
+                            Path outPath = protoOutputDir.resolve(strippedPathStr);
+                            try {
+                                Files.createDirectories(outPath.getParent());
+                                if (isDependency) {
+                                    copySanitizedProtoFile(artifact, path, outPath);
+                                } else {
+                                    Files.copy(path, outPath, StandardCopyOption.REPLACE_EXISTING);
                                 }
-                                String uniqueName = artifact.getGroupId() + ":" + artifact.getArtifactId();
-                                if (artifact.getVersion() != null) {
-                                    uniqueName += ":" + artifact.getVersion();
-                                }
-                                if (artifact.getClassifier() != null) {
-                                    uniqueName += "-" + artifact.getClassifier();
-                                }
-                                Path protoUnzipDir = workDir
-                                        .resolve(HashUtil.sha1(uniqueName))
-                                        .normalize().toAbsolutePath();
-                                try {
-                                    Files.createDirectories(protoUnzipDir);
-                                    protoDirectories.add(protoUnzipDir.toString());
-                                } catch (IOException e) {
-                                    throw new GrpcCodeGenException("Failed to create directory: " + protoUnzipDir, e);
-                                }
-                                Path outPath = protoUnzipDir.resolve(relativePathStr);
-                                try {
-                                    Files.createDirectories(outPath.getParent());
-                                    if (isDependency) {
-                                        copySanitizedProtoFile(artifact, path, outPath);
-                                    } else {
-                                        Files.copy(path, outPath, StandardCopyOption.REPLACE_EXISTING);
-                                    }
-                                    protoFiles.add(outPath);
-                                } catch (IOException e) {
-                                    throw new GrpcCodeGenException("Failed to extract proto file" + path + " to target: "
-                                            + outPath, e);
-                                }
+                                protoFiles.add(outPath);
+                            } catch (IOException e) {
+                                throw new GrpcCodeGenException("Failed to extract proto file" + path + " to target: "
+                                        + outPath, e);
                             }
                         }
                     });
         } catch (GrpcCodeGenException e) {
             throw new CodeGenException(e.getMessage(), e);
         }
+    }
+
+    private static String stripProtoPrefix(String relativePathStr) {
+        if (relativePathStr.startsWith(SRC_MAIN_PROTO_DIR)) {
+            return relativePathStr.substring(SRC_MAIN_PROTO_DIR.length());
+        }
+        if (relativePathStr.startsWith(SRC_TEST_PROTO_DIR)) {
+            return relativePathStr.substring(SRC_TEST_PROTO_DIR.length());
+        }
+        if (relativePathStr.startsWith(PROTO_DIR)) {
+            return relativePathStr.substring(PROTO_DIR.length());
+        }
+        return relativePathStr;
+    }
+
+    private static Path getProtoOutputDir(Path workDir, ResolvedDependency artifact) {
+        String uniqueName = artifact.getGroupId() + ":" + artifact.getArtifactId();
+        if (artifact.getVersion() != null) {
+            uniqueName += ":" + artifact.getVersion();
+        }
+        if (artifact.getClassifier() != null) {
+            uniqueName += "-" + artifact.getClassifier();
+        }
+        return workDir.resolve(HashUtil.sha1(uniqueName)).normalize().toAbsolutePath();
     }
 
     private String escapeWhitespace(String path) {

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContext.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContext.java
@@ -209,6 +209,17 @@ public class BootstrapMavenContext {
                     }
                 }
             }
+        } else if (config.providedModules != null && !config.providedModules.isEmpty()) {
+            final Path currentPom = getCurrentProjectPomOrNull();
+            if (currentPom != null) {
+                currentProject = LocalProject.createFromProvidedModules(this, currentPom, config.providedModules);
+                this.workspace = currentProject == null ? null : currentProject.getWorkspace();
+                if (workspace != null
+                        && config.repoSession == null && repoSession != null
+                        && repoSession.getWorkspaceReader() == null) {
+                    repoSession = new DefaultRepositorySystemSession(repoSession).setWorkspaceReader(workspace);
+                }
+            }
         }
     }
 

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/LocalProject.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/LocalProject.java
@@ -117,6 +117,34 @@ public class LocalProject {
         return wsLoader.load();
     }
 
+    /**
+     * Creates a workspace from provided modules without filesystem discovery.
+     *
+     * @param ctx bootstrap maven context
+     * @param currentProjectPom POM of the current project
+     * @param providedModules pre-loaded modules to populate the workspace with
+     * @return current project with the workspace or null if the current project is not among the provided modules
+     */
+    public static LocalProject createFromProvidedModules(BootstrapMavenContext ctx, Path currentProjectPom,
+            List<WorkspaceModulePom> providedModules) {
+        final LocalWorkspace workspace = new LocalWorkspace();
+        workspace.setBootstrapMavenContext(ctx);
+        LocalProject currentProject = null;
+        final Path currentProjectDir = currentProjectPom.normalize().toAbsolutePath().getParent();
+        for (var module : providedModules) {
+            var project = new LocalProject(
+                    module.getResolvedGroupId(),
+                    module.getResolvedVersion(),
+                    module.getModel(),
+                    module.effectiveModel,
+                    workspace);
+            if (currentProject == null && project.getDir().equals(currentProjectDir)) {
+                currentProject = project;
+            }
+        }
+        return currentProject;
+    }
+
     static Model readModel(Path pom) throws BootstrapMavenException {
         try {
             final Model model = ModelUtils.readModel(pom);

--- a/independent-projects/bootstrap/maven-resolver/src/test/java/io/quarkus/bootstrap/workspace/test/LocalWorkspaceDiscoveryTest.java
+++ b/independent-projects/bootstrap/maven-resolver/src/test/java/io/quarkus/bootstrap/workspace/test/LocalWorkspaceDiscoveryTest.java
@@ -773,6 +773,40 @@ public class LocalWorkspaceDiscoveryTest {
         assertThat(src.getOutputDir()).isEqualTo(module1Dir.resolve("target/classes/META-INF/resources"));
     }
 
+    @Test
+    public void createWorkspaceFromProvidedModules() throws Exception {
+        final Path rootDir = workDir.resolve("root");
+        final Path module1Dir = rootDir.resolve("module1");
+        final Path module2Dir = rootDir.resolve("module2");
+
+        final Path rootPom = rootDir.resolve("pom.xml");
+        final Path module1Pom = module1Dir.resolve("pom.xml");
+        final Path module2Pom = module2Dir.resolve("pom.xml");
+
+        final LocalProject currentProject = new BootstrapMavenContext(BootstrapMavenContext.config()
+                .setWorkspaceDiscovery(false)
+                .setCurrentProject(module2Pom.toString())
+                .setPreferPomsFromWorkspace(true)
+                .addProvidedModule(rootPom, ModelUtils.readModel(rootPom), ModelUtils.readModel(rootPom))
+                .addProvidedModule(module1Pom, ModelUtils.readModel(module1Pom), ModelUtils.readModel(module1Pom))
+                .addProvidedModule(module2Pom, ModelUtils.readModel(module2Pom), ModelUtils.readModel(module2Pom)))
+                .getCurrentProject();
+
+        assertNotNull(currentProject);
+        assertEquals("root-module-with-parent", currentProject.getArtifactId());
+
+        final LocalWorkspace ws = currentProject.getWorkspace();
+        assertNotNull(ws);
+        assertEquals(3, ws.getProjects().size());
+        assertNotNull(ws.getProject(MvnProjectBuilder.DEFAULT_GROUP_ID, "root"));
+        assertNotNull(ws.getProject(MvnProjectBuilder.DEFAULT_GROUP_ID, "root-no-parent-module"));
+        assertNotNull(ws.getProject(MvnProjectBuilder.DEFAULT_GROUP_ID, "root-module-with-parent"));
+
+        // modules not provided should NOT be discovered via filesystem
+        assertNull(ws.getProject(MvnProjectBuilder.DEFAULT_GROUP_ID, "root-module-not-direct-child"));
+        assertNull(ws.getProject(MvnProjectBuilder.DEFAULT_GROUP_ID, "empty-parent-relative-path-module"));
+    }
+
     private void assertCompleteWorkspace(final LocalProject project) {
         final Map<ArtifactKey, LocalProject> projects = project.getWorkspace().getProjects();
         assertEquals(5, projects.size());


### PR DESCRIPTION
This change adds a limited workspace support in prod mode. The modules that would be available are the projects in the reactor (which, depending on the context, might not be a complete set of modules) and their parent POMs.

This prevents errors when parent POMs haven't been installed but need to be resolvable, e.g. for SBOM generation.

- Fixes: https://github.com/quarkusio/quarkus/issues/55455