### PR TITLE
Avoid Lambda mock event server port conflict with Vert.x HTTP in Dev Mode

### DIFF
--- a/docs/src/main/asciidoc/aws-lambda.adoc
+++ b/docs/src/main/asciidoc/aws-lambda.adoc
@@ -313,6 +313,11 @@ include::{includes}/devtools/dev.adoc[]
 $ curl -d "{\"name\":\"John\"}" -X POST http://localhost:8080
 ----
 
+If you also have an HTTP extension on the classpath (for example `quarkus-rest`), both Vert.x HTTP and the
+Lambda mock event server would otherwise default to port `8080`. In that case Quarkus automatically assigns an
+ephemeral port to the mock event server in Dev Mode and logs the chosen address so you can still invoke it.
+You can also set the port explicitly (see below).
+
 For your unit tests, you can also invoke on the mock event server using any HTTP client you want.  Here's an example
 using rest-assured.  Quarkus starts up a separate Mock Event server under port 8081.
 The default port for Rest Assured is automatically set to 8081 by Quarkus, so you can invoke

--- a/extensions/amazon-lambda/common-deployment/src/main/java/io/quarkus/amazon/lambda/deployment/DevServicesLambdaProcessor.java
+++ b/extensions/amazon-lambda/common-deployment/src/main/java/io/quarkus/amazon/lambda/deployment/DevServicesLambdaProcessor.java
@@ -14,6 +14,8 @@ import io.quarkus.amazon.lambda.runtime.AmazonLambdaApi;
 import io.quarkus.amazon.lambda.runtime.LambdaHotReplacementRecorder;
 import io.quarkus.amazon.lambda.runtime.MockEventServer;
 import io.quarkus.amazon.lambda.runtime.MockEventServerConfig;
+import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.IsLiveReloadSupportedByLaunchMode;
 import io.quarkus.deployment.IsProduction;
@@ -55,6 +57,7 @@ public class DevServicesLambdaProcessor {
     @BuildStep(onlyIfNot = IsProduction.class) // This is required for testing so run it even if devservices.enabled=false
     public void startEventServer(LaunchModeBuildItem launchModeBuildItem,
             LambdaBuildConfig config,
+            Capabilities capabilities,
             Optional<EventServerOverrideBuildItem> override,
             Optional<EventServerPortOverrideBuildItem> portOverride,
             BuildProducer<DevServicesResultBuildItem> devServicePropertiesProducer) {
@@ -78,7 +81,16 @@ public class DevServicesLambdaProcessor {
         String portPropertySuffix = isTest ? "test-port" : "dev-port";
         String propName = "quarkus.lambda.mock-event-server." + portPropertySuffix;
 
-        int overridePort = portOverride.map(EventServerPortOverrideBuildItem::getPort).orElse(Integer.MIN_VALUE);
+        int resolvedOverridePort = portOverride.map(EventServerPortOverrideBuildItem::getPort).orElse(Integer.MIN_VALUE);
+        // Both the Lambda mock event server and Vert.x HTTP default to 8080 in dev mode.
+        // When HTTP is present, use an ephemeral port for the event server to avoid the conflict.
+        // amazon-lambda-http / amazon-lambda-rest may already supply EventServerPortOverrideBuildItem(0).
+        if (resolvedOverridePort < 0
+                && launchMode == LaunchMode.DEVELOPMENT
+                && capabilities.isPresent(Capability.VERTX_HTTP)) {
+            resolvedOverridePort = 0;
+        }
+        final int overridePort = resolvedOverridePort;
 
         // No compose support, and no using of external services, so no need to discover existing services
 


### PR DESCRIPTION
When `quarkus-amazon-lambda` is used together with an HTTP extension (for example `quarkus-rest`), both the Lambda mock event server and Vert.x HTTP default to port `8080` in Dev Mode. That caused a bind failure on Linux and confusing hung requests when the conflict was less visible.

This change detects `Capability.VERTX_HTTP` in Dev Mode and automatically assigns an ephemeral port to the mock event server, matching the approach already used by `amazon-lambda-http` / `amazon-lambda-rest`. Explicit `quarkus.lambda.mock-event-server.dev-port` configuration still wins.

A `QuarkusDevModeTest` verifies HTTP keeps `8080` while the Lambda mock event server uses a different port, and that both sides remain reachable.

- Fixes: #33312