### PR TITLE
Deprecate `H2DatabaseTestResource` in favor of DevServices and update most ITs to avoid it

### DIFF
--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -720,6 +720,8 @@ Use a remote connection to a separate database, or use Dev Services to run the d
 ifndef::no-deprecated-test-resource[]
 ==== Run an integration test
 
+WARNING: `H2DatabaseTestResource` is deprecated. Dev Services for H2 automatically starts an in-process database when `quarkus.datasource.db-kind=h2` is set and no JDBC URL is configured. See xref:databases-dev-services.adoc[Dev Services for databases] for details.
+
 . Add a dependency on the artifacts providing the additional tools that are under the following Maven coordinates:
 +
 * `io.quarkus:quarkus-test-h2` for H2

--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -1209,7 +1209,7 @@ remove duplicates. If you want to only enable a test resource on a single test c
 
 NOTE: When using multiple test resources, they can be started concurrently. For that you need to set `@QuarkusTestResource(parallel = true)`.
 
-Quarkus provides a few implementations of `QuarkusTestResourceLifecycleManager` out of the box (see `io.quarkus.test.h2.H2DatabaseTestResource` which starts an H2 database, or `io.quarkus.test.kubernetes.client.KubernetesServerTestResource` which starts a mock Kubernetes API server),
+Quarkus provides a few implementations of `QuarkusTestResourceLifecycleManager` out of the box (see `io.quarkus.test.kubernetes.client.KubernetesServerTestResource` which starts a mock Kubernetes API server),
 but it is common to create custom implementations to address specific application needs.
 Common cases include starting docker containers using https://www.testcontainers.org/[Testcontainers] (an example of which can be found https://github.com/quarkusio/quarkus/blob/main/test-framework/keycloak-server/src/main/java/io/quarkus/test/keycloak/server/KeycloakTestResourceLifecycleManager.java[here]),
 or starting a mock HTTP server using https://wiremock.org/[Wiremock] (an example of which can be found https://github.com/geoand/quarkus-test-demo/blob/main/src/test/java/org/acme/getting/started/country/WiremockCountries.java[here]).

--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/H2DatabaseTestResourceTest.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/H2DatabaseTestResourceTest.java
@@ -1,0 +1,39 @@
+package io.quarkus.agroal.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Connection;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.agroal.api.AgroalDataSource;
+import io.agroal.api.configuration.AgroalConnectionPoolConfiguration;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class H2DatabaseTestResourceTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withEmptyApplication()
+            .overrideConfigKey("quarkus.datasource.db-kind", "h2")
+            .overrideConfigKey("quarkus.datasource.jdbc.url",
+                    "jdbc:h2:tcp://localhost/mem:h2_test_resource_compat");
+
+    @Inject
+    AgroalDataSource dataSource;
+
+    @Test
+    public void testDatasourceUsesH2TestResource() throws Exception {
+        AgroalConnectionPoolConfiguration configuration = dataSource.getConfiguration()
+                .connectionPoolConfiguration();
+        String url = configuration.connectionFactoryConfiguration().jdbcUrl();
+        assertThat(url).contains("mem:h2_test_resource_compat");
+        assertThat(url).doesNotContain("mem:quarkus");
+        try (Connection connection = dataSource.getConnection()) {
+            connection.createStatement().execute("SELECT 1");
+        }
+    }
+}

--- a/integration-tests/cache/pom.xml
+++ b/integration-tests/cache/pom.xml
@@ -50,11 +50,6 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-test-h2</artifactId>
-            <scope>test</scope>
-        </dependency>
 
         <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
         <dependency>

--- a/integration-tests/cache/src/test/java/io/quarkus/it/cache/TreeTestCase.java
+++ b/integration-tests/cache/src/test/java/io/quarkus/it/cache/TreeTestCase.java
@@ -7,12 +7,9 @@ import static org.hamcrest.core.IsNot.not;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.h2.H2DatabaseTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(H2DatabaseTestResource.class)
 @DisplayName("Tests the integration between panache and the cache extension")
 public class TreeTestCase {
 

--- a/integration-tests/grpc-hibernate/pom.xml
+++ b/integration-tests/grpc-hibernate/pom.xml
@@ -27,11 +27,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-test-h2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>

--- a/integration-tests/grpc-hibernate/src/test/java/com/example/grpc/hibernate/TestResources.java
+++ b/integration-tests/grpc-hibernate/src/test/java/com/example/grpc/hibernate/TestResources.java
@@ -1,8 +1,0 @@
-package com.example.grpc.hibernate;
-
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.h2.H2DatabaseTestResource;
-
-@QuarkusTestResource(H2DatabaseTestResource.class)
-public class TestResources {
-}

--- a/integration-tests/hibernate-orm-envers/pom.xml
+++ b/integration-tests/hibernate-orm-envers/pom.xml
@@ -40,11 +40,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-test-h2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>

--- a/integration-tests/hibernate-orm-envers/src/test/java/io/quarkus/it/envers/TestResources.java
+++ b/integration-tests/hibernate-orm-envers/src/test/java/io/quarkus/it/envers/TestResources.java
@@ -1,8 +1,0 @@
-package io.quarkus.it.envers;
-
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.h2.H2DatabaseTestResource;
-
-@QuarkusTestResource(H2DatabaseTestResource.class)
-public class TestResources {
-}

--- a/integration-tests/hibernate-orm-graphql-panache/pom.xml
+++ b/integration-tests/hibernate-orm-graphql-panache/pom.xml
@@ -33,11 +33,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-test-h2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/integration-tests/hibernate-orm-graphql-panache/src/test/java/io/quarkus/it/hibertnate/orm/graphql/panache/TestResources.java
+++ b/integration-tests/hibernate-orm-graphql-panache/src/test/java/io/quarkus/it/hibertnate/orm/graphql/panache/TestResources.java
@@ -1,8 +1,0 @@
-package io.quarkus.it.hibertnate.orm.graphql.panache;
-
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.h2.H2DatabaseTestResource;
-
-@QuarkusTestResource(H2DatabaseTestResource.class)
-public class TestResources {
-}

--- a/integration-tests/hibernate-orm-panache-kotlin/pom.xml
+++ b/integration-tests/hibernate-orm-panache-kotlin/pom.xml
@@ -56,10 +56,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-test-h2</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jackson</artifactId>
             <scope>test</scope>
         </dependency>

--- a/integration-tests/hibernate-orm-panache-kotlin/src/test/kotlin/io/quarkus/it/panache/TestResources.kt
+++ b/integration-tests/hibernate-orm-panache-kotlin/src/test/kotlin/io/quarkus/it/panache/TestResources.kt
@@ -1,6 +1,0 @@
-package io.quarkus.it.panache
-
-import io.quarkus.test.common.QuarkusTestResource
-import io.quarkus.test.h2.H2DatabaseTestResource
-
-@QuarkusTestResource(H2DatabaseTestResource::class) class TestResources

--- a/integration-tests/hibernate-orm-panache/pom.xml
+++ b/integration-tests/hibernate-orm-panache/pom.xml
@@ -79,11 +79,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-test-h2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jackson</artifactId>
             <scope>test</scope>
         </dependency>

--- a/integration-tests/hibernate-orm-panache/src/test/java/DefaultPackageWithFastJarPMT.java
+++ b/integration-tests/hibernate-orm-panache/src/test/java/DefaultPackageWithFastJarPMT.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.builder.Version;
-import io.quarkus.it.panache.defaultpu.TestResources;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -14,7 +13,7 @@ public class DefaultPackageWithFastJarPMT {
     @RegisterExtension
     static final QuarkusProdModeTest config = new QuarkusProdModeTest()
             .withApplicationRoot((jar) -> jar
-                    .addClasses(PackagelessCat.class, TestResources.class))
+                    .addClasses(PackagelessCat.class))
             .setApplicationName("default-package")
             .setApplicationVersion(Version.getVersion())
             .withConfigurationResource("application.properties")

--- a/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/defaultpu/TestResources.java
+++ b/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/defaultpu/TestResources.java
@@ -1,8 +1,0 @@
-package io.quarkus.it.panache.defaultpu;
-
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.h2.H2DatabaseTestResource;
-
-@QuarkusTestResource(H2DatabaseTestResource.class)
-public class TestResources {
-}

--- a/integration-tests/hibernate-orm-rest-data-panache/pom.xml
+++ b/integration-tests/hibernate-orm-rest-data-panache/pom.xml
@@ -36,11 +36,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-test-h2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jsonp</artifactId>
             <scope>test</scope>
         </dependency>

--- a/integration-tests/hibernate-orm-rest-data-panache/src/test/java/io/quarkus/it/hibernate/orm/rest/data/panache/TestResources.java
+++ b/integration-tests/hibernate-orm-rest-data-panache/src/test/java/io/quarkus/it/hibernate/orm/rest/data/panache/TestResources.java
@@ -1,8 +1,0 @@
-package io.quarkus.it.hibernate.orm.rest.data.panache;
-
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.h2.H2DatabaseTestResource;
-
-@QuarkusTestResource(H2DatabaseTestResource.class)
-public class TestResources {
-}

--- a/integration-tests/hibernate-search-orm-elasticsearch-outbox-polling/pom.xml
+++ b/integration-tests/hibernate-search-orm-elasticsearch-outbox-polling/pom.xml
@@ -51,11 +51,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-test-h2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>

--- a/integration-tests/hibernate-search-orm-elasticsearch-outbox-polling/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/coordination/outboxpolling/TestResources.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch-outbox-polling/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/coordination/outboxpolling/TestResources.java
@@ -1,8 +1,0 @@
-package io.quarkus.it.hibernate.search.orm.elasticsearch.coordination.outboxpolling;
-
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.h2.H2DatabaseTestResource;
-
-@QuarkusTestResource(H2DatabaseTestResource.class)
-public class TestResources {
-}

--- a/integration-tests/hibernate-search-orm-elasticsearch/pom.xml
+++ b/integration-tests/hibernate-search-orm-elasticsearch/pom.xml
@@ -46,11 +46,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-test-h2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/TestResources.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/TestResources.java
@@ -1,8 +1,0 @@
-package io.quarkus.it.hibernate.search.orm.elasticsearch;
-
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.h2.H2DatabaseTestResource;
-
-@QuarkusTestResource(H2DatabaseTestResource.class)
-public class TestResources {
-}

--- a/integration-tests/hibernate-search-orm-opensearch/pom.xml
+++ b/integration-tests/hibernate-search-orm-opensearch/pom.xml
@@ -42,11 +42,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-test-h2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>

--- a/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/TestResources.java
+++ b/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/TestResources.java
@@ -1,8 +1,0 @@
-package io.quarkus.it.hibernate.search.orm.opensearch;
-
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.h2.H2DatabaseTestResource;
-
-@QuarkusTestResource(H2DatabaseTestResource.class)
-public class TestResources {
-}

--- a/integration-tests/hibernate-validator-resteasy-reactive/pom.xml
+++ b/integration-tests/hibernate-validator-resteasy-reactive/pom.xml
@@ -70,11 +70,6 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-test-h2</artifactId>
-            <scope>test</scope>
-        </dependency>
         <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/hibernate-validator-resteasy-reactive/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
+++ b/integration-tests/hibernate-validator-resteasy-reactive/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
@@ -18,15 +18,12 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.hibernate.validator.runtime.jaxrs.ResteasyReactiveViolationException;
 import io.quarkus.test.InMemoryLogHandler;
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.h2.H2DatabaseTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.ValidatableResponse;
 
 @QuarkusTest
-@QuarkusTestResource(H2DatabaseTestResource.class)
 public class HibernateValidatorFunctionalityTest {
     private static final Formatter LOG_FORMATTER = new PatternFormatter("%s");
     private static final java.util.logging.Logger rootLogger = LogManager.getLogManager().getLogger("io.quarkus");

--- a/integration-tests/hibernate-validator/pom.xml
+++ b/integration-tests/hibernate-validator/pom.xml
@@ -66,11 +66,6 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-test-h2</artifactId>
-            <scope>test</scope>
-        </dependency>
         <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/hibernate-validator/src/main/resources/application.properties
+++ b/integration-tests/hibernate-validator/src/main/resources/application.properties
@@ -1,7 +1,6 @@
 quarkus.locales=en,hr-HR,en-US,fr-FR
 
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:test
 quarkus.hibernate-orm.database.generation = drop-and-create
 
 io.quarkus.it.hibernate.validator.injection.pattern=[^0-9]++

--- a/integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
+++ b/integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
@@ -16,7 +16,6 @@ import io.quarkus.hibernate.validator.runtime.jaxrs.ResteasyViolationExceptionIm
 import io.quarkus.test.LogCollectingTestResource;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
-import io.quarkus.test.h2.H2DatabaseTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -26,7 +25,6 @@ import io.restassured.response.ValidatableResponse;
  * Test various Bean Validation operations running in Quarkus
  */
 @QuarkusTest
-@QuarkusTestResource(H2DatabaseTestResource.class)
 @QuarkusTestResource(value = LogCollectingTestResource.class, restrictToAnnotatedClass = true, initArgs = {
         @ResourceArg(name = LogCollectingTestResource.LOGGER, value = "io.quarkus"),
         @ResourceArg(name = LogCollectingTestResource.LEVEL, value = "WARNING")

--- a/integration-tests/jpa/pom.xml
+++ b/integration-tests/jpa/pom.xml
@@ -38,11 +38,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-test-h2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>

--- a/integration-tests/jpa/src/test/java/io/quarkus/it/jpa/configurationless/TestResources.java
+++ b/integration-tests/jpa/src/test/java/io/quarkus/it/jpa/configurationless/TestResources.java
@@ -1,8 +1,0 @@
-package io.quarkus.it.jpa.configurationless;
-
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.h2.H2DatabaseTestResource;
-
-@QuarkusTestResource(H2DatabaseTestResource.class)
-public class TestResources {
-}

--- a/integration-tests/liquibase/pom.xml
+++ b/integration-tests/liquibase/pom.xml
@@ -46,11 +46,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-test-h2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>

--- a/integration-tests/liquibase/src/test/java/io/quarkus/it/liquibase/LiquibaseTestResources.java
+++ b/integration-tests/liquibase/src/test/java/io/quarkus/it/liquibase/LiquibaseTestResources.java
@@ -1,8 +1,0 @@
-package io.quarkus.it.liquibase;
-
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.h2.H2DatabaseTestResource;
-
-@QuarkusTestResource(H2DatabaseTestResource.class)
-public class LiquibaseTestResources {
-}

--- a/integration-tests/main/pom.xml
+++ b/integration-tests/main/pom.xml
@@ -15,10 +15,6 @@
 
     <properties>
         <datasource.db-kind>h2</datasource.db-kind>
-        <datasource.url>jdbc:h2:tcp://localhost/mem:test</datasource.url>
-        <datasource.username></datasource.username>
-        <datasource.password></datasource.password>
-
         <hibernate-orm.dialect>org.hibernate.dialect.H2Dialect</hibernate-orm.dialect>
 
         <!-- do not update this dependency, it is only used for testing -->

--- a/integration-tests/main/src/main/resources/application.properties
+++ b/integration-tests/main/src/main/resources/application.properties
@@ -18,18 +18,13 @@ org.eclipse.microprofile.rest.client.propagateHeaders=header-name
 # we probably won't be able to test SSL proper so it seems reasonable to set it globally
 quarkus.ssl.native=false
 
-# don't start the dev services
-quarkus.devservices.enabled=false
-
 # in tests 'quarkus.application.name' and `quarkus.application.version` do not get set from the build tool
 # here we are testing that override from properties works
 quarkus.application.name=main-integration-test
 quarkus.application.version=1.0
 
 quarkus.datasource.db-kind=${datasource.db-kind}
-quarkus.datasource.username=${datasource.username}
-quarkus.datasource.password=${datasource.password}
-quarkus.datasource.jdbc.url=${datasource.url}
+quarkus.lra.devservices.enabled=false
 quarkus.security.users.file.enabled=true
 quarkus.resteasy.gzip.enabled=true
 quarkus.resteasy.gzip.max-input=10

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/TestResources.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/TestResources.java
@@ -1,8 +1,0 @@
-package io.quarkus.it.main;
-
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.h2.H2DatabaseTestResource;
-
-@QuarkusTestResource(H2DatabaseTestResource.class)
-public class TestResources {
-}

--- a/integration-tests/micrometer-prometheus/pom.xml
+++ b/integration-tests/micrometer-prometheus/pom.xml
@@ -75,11 +75,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-test-h2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-orm-panache-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>

--- a/integration-tests/micrometer-prometheus/src/test/java/io/quarkus/it/micrometer/prometheus/TestResources.java
+++ b/integration-tests/micrometer-prometheus/src/test/java/io/quarkus/it/micrometer/prometheus/TestResources.java
@@ -1,8 +1,0 @@
-package io.quarkus.it.micrometer.prometheus;
-
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.h2.H2DatabaseTestResource;
-
-@QuarkusTestResource(H2DatabaseTestResource.class)
-public class TestResources {
-}

--- a/integration-tests/quartz-deferred-datasource/pom.xml
+++ b/integration-tests/quartz-deferred-datasource/pom.xml
@@ -49,11 +49,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-test-h2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>

--- a/integration-tests/quartz-deferred-datasource/src/main/resources/application.properties
+++ b/integration-tests/quartz-deferred-datasource/src/main/resources/application.properties
@@ -1,6 +1,5 @@
 # datasource configuration
 quarkus.datasource.test.db-kind=h2
-quarkus.datasource.test.jdbc.url=jdbc:h2:tcp://localhost/mem:test
 
 # Quartz configuration
 quarkus.quartz.store-type=jdbc-cmt

--- a/integration-tests/quartz-deferred-datasource/src/test/java/io/quarkus/it/quartz/TestResources.java
+++ b/integration-tests/quartz-deferred-datasource/src/test/java/io/quarkus/it/quartz/TestResources.java
@@ -1,8 +1,0 @@
-package io.quarkus.it.quartz;
-
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.h2.H2DatabaseTestResource;
-
-@QuarkusTestResource(H2DatabaseTestResource.class)
-public class TestResources {
-}

--- a/integration-tests/quartz/pom.xml
+++ b/integration-tests/quartz/pom.xml
@@ -49,11 +49,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-test-h2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>

--- a/integration-tests/quartz/src/main/resources/application.properties
+++ b/integration-tests/quartz/src/main/resources/application.properties
@@ -1,6 +1,5 @@
 # datasource configuration
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:test
 
 # Quartz configuration
 quarkus.quartz.store-type=jdbc-cmt

--- a/integration-tests/quartz/src/test/java/io/quarkus/it/quartz/TestResources.java
+++ b/integration-tests/quartz/src/test/java/io/quarkus/it/quartz/TestResources.java
@@ -1,8 +1,0 @@
-package io.quarkus.it.quartz;
-
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.h2.H2DatabaseTestResource;
-
-@QuarkusTestResource(H2DatabaseTestResource.class)
-public class TestResources {
-}

--- a/integration-tests/qute/pom.xml
+++ b/integration-tests/qute/pom.xml
@@ -34,11 +34,6 @@
         <!-- Test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-test-h2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>

--- a/integration-tests/qute/src/test/java/io/quarkus/it/qute/TestResources.java
+++ b/integration-tests/qute/src/test/java/io/quarkus/it/qute/TestResources.java
@@ -1,8 +1,0 @@
-package io.quarkus.it.qute;
-
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.h2.H2DatabaseTestResource;
-
-@QuarkusTestResource(H2DatabaseTestResource.class)
-public class TestResources {
-}

--- a/integration-tests/smallrye-context-propagation/pom.xml
+++ b/integration-tests/smallrye-context-propagation/pom.xml
@@ -51,11 +51,6 @@
             <artifactId>quarkus-jdbc-h2-deployment</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-test-h2</artifactId>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>io.rest-assured</groupId>

--- a/integration-tests/smallrye-context-propagation/src/test/java/io/quarkus/context/test/SimpleContextPropagationTest.java
+++ b/integration-tests/smallrye-context-propagation/src/test/java/io/quarkus/context/test/SimpleContextPropagationTest.java
@@ -26,7 +26,7 @@ import io.restassured.RestAssured;
  */
 public class SimpleContextPropagationTest {
     private static Class[] testClasses = {
-            ContextEndpoint.class, RequestBean.class, ContextEntity.class, TestResources.class, CompletionExceptionMapper.class,
+            ContextEndpoint.class, RequestBean.class, ContextEntity.class, CompletionExceptionMapper.class,
             TransactionalBean.class
     };
 

--- a/integration-tests/smallrye-context-propagation/src/test/java/io/quarkus/context/test/TestResources.java
+++ b/integration-tests/smallrye-context-propagation/src/test/java/io/quarkus/context/test/TestResources.java
@@ -1,8 +1,0 @@
-package io.quarkus.context.test;
-
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.h2.H2DatabaseTestResource;
-
-@QuarkusTestResource(H2DatabaseTestResource.class)
-public class TestResources {
-}

--- a/integration-tests/smallrye-context-propagation/src/test/java/io/quarkus/context/test/mutiny/MutinyContextPropagationTest.java
+++ b/integration-tests/smallrye-context-propagation/src/test/java/io/quarkus/context/test/mutiny/MutinyContextPropagationTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.context.test.CompletionExceptionMapper;
 import io.quarkus.context.test.RequestBean;
-import io.quarkus.context.test.TestResources;
 import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 
@@ -25,7 +24,6 @@ import io.restassured.RestAssured;
 public class MutinyContextPropagationTest {
     private static Class[] testClasses = {
             MutinyContextEndpoint.class, RequestBean.class, SomeEntity.class, SomeOtherEntity.class, Person.class,
-            TestResources.class,
             CompletionExceptionMapper.class,
             MutinyTransactionalBean.class
     };

--- a/integration-tests/spring-data-jpa/pom.xml
+++ b/integration-tests/spring-data-jpa/pom.xml
@@ -56,11 +56,6 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-test-h2</artifactId>
-            <scope>test</scope>
-        </dependency>
 
         <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
         <dependency>

--- a/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/TestResources.java
+++ b/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/TestResources.java
@@ -1,8 +1,0 @@
-package io.quarkus.it.spring.data.jpa;
-
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.h2.H2DatabaseTestResource;
-
-@QuarkusTestResource(H2DatabaseTestResource.class)
-public class TestResources {
-}

--- a/integration-tests/spring-data-rest/pom.xml
+++ b/integration-tests/spring-data-rest/pom.xml
@@ -36,11 +36,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-test-h2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jsonp</artifactId>
             <scope>test</scope>
         </dependency>

--- a/integration-tests/spring-data-rest/src/test/java/io/quarkus/it/spring/data/rest/TestResources.java
+++ b/integration-tests/spring-data-rest/src/test/java/io/quarkus/it/spring/data/rest/TestResources.java
@@ -1,8 +1,0 @@
-package io.quarkus.it.spring.data.rest;
-
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.h2.H2DatabaseTestResource;
-
-@QuarkusTestResource(H2DatabaseTestResource.class)
-public class TestResources {
-}

--- a/test-framework/h2/src/main/java/io/quarkus/test/h2/H2DatabaseTestResource.java
+++ b/test-framework/h2/src/main/java/io/quarkus/test/h2/H2DatabaseTestResource.java
@@ -9,6 +9,11 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
+/**
+ * @deprecated Use Dev Services instead: simply set {@code quarkus.datasource.db-kind=h2} without configuring a JDBC URL,
+ *             and Quarkus will automatically start an H2 database for tests.
+ */
+@Deprecated(forRemoval = true)
 public class H2DatabaseTestResource implements QuarkusTestResourceLifecycleManager {
 
     private static final Logger log = Logger.getLogger(H2DatabaseTestResource.class);


### PR DESCRIPTION
Still testing locally, so opening as draft, but I'm far enough along to dare ask: why wouldn't we do that?

@gastaldi do you see any reason to still use `H2DatabaseTestResource` instead of Dev Services?