### PR TITLE
Enable native mode SingleCallsiteInliner by default

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -942,6 +942,8 @@ public class NativeImageBuildStep {
                     nativeImageArgs.add("--install-exit-handlers");
                 }
 
+                // Enable the new single callsite inliner on Mandrel 25.0.4+ by default.
+                // The feature is not yet available upstream, so do not enable for versions >= 25.1
                 if (graalVMVersion.compareTo(io.quarkus.runtime.graal.GraalVM.Version.VERSION_25_0_4) >= 0
                         && graalVMVersion.compareTo(io.quarkus.runtime.graal.GraalVM.Version.VERSION_25_1_0) < 0
                         && graalVMVersion.getDistribution() == Distribution.MANDREL) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -944,7 +944,7 @@ public class NativeImageBuildStep {
 
                 if (graalVMVersion.compareTo(io.quarkus.runtime.graal.GraalVM.Version.VERSION_25_0_4) >= 0
                         && graalVMVersion.compareTo(io.quarkus.runtime.graal.GraalVM.Version.VERSION_25_1_0) < 0
-                        && graalVMVersion.getDistribution() != Distribution.ORACLE) {
+                        && graalVMVersion.getDistribution() == Distribution.MANDREL) {
                     final List<String> additionalBuildArgs = NativeConfigUtils.getNativeAdditionalBuildArgs(nativeConfig);
                     if (additionalBuildArgs.stream().noneMatch(arg -> arg.contains("AOTSingleCallsiteInline"))) {
                         log.info(

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -942,6 +942,17 @@ public class NativeImageBuildStep {
                     nativeImageArgs.add("--install-exit-handlers");
                 }
 
+                if (graalVMVersion.compareTo(io.quarkus.runtime.graal.GraalVM.Version.VERSION_25_0_4) >= 0
+                        && graalVMVersion.compareTo(io.quarkus.runtime.graal.GraalVM.Version.VERSION_25_1_0) < 0
+                        && graalVMVersion.getDistribution() != Distribution.ORACLE) {
+                    final List<String> additionalBuildArgs = NativeConfigUtils.getNativeAdditionalBuildArgs(nativeConfig);
+                    if (additionalBuildArgs.stream().noneMatch(arg -> arg.contains("AOTSingleCallsiteInline"))) {
+                        log.info(
+                                "Single callsite inlining has been enabled for this build. It aims to improve runtime performance at the expense of 1-2% binary size increase. To disable this feature use quarkus.native.additional-build-args=-H:-AOTSingleCallsiteInline");
+                        addExperimentalVMOption(nativeImageArgs, "-H:+AOTSingleCallsiteInline");
+                    }
+                }
+
                 /*
                  * Any parameters following this call are forced over the user provided parameters in
                  * quarkus.native.additional-build-args or quarkus.native.additional-build-args-append. So if you need

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -950,7 +950,7 @@ public class NativeImageBuildStep {
                     final List<String> additionalBuildArgs = NativeConfigUtils.getNativeAdditionalBuildArgs(nativeConfig);
                     if (additionalBuildArgs.stream().noneMatch(arg -> arg.contains("AOTSingleCallsiteInline"))) {
                         log.info(
-                                "Single callsite inlining has been enabled for this build. It aims to improve runtime performance at the expense of 1-2% binary size increase. To disable this feature use quarkus.native.additional-build-args=-H:-AOTSingleCallsiteInline");
+                                "Single callsite inlining has been enabled for this build. It aims to improve runtime performance at the expense of 1-2% binary size increase. To disable this feature use -Dquarkus.native.additional-build-args-append=-H:-AOTSingleCallsiteInline");
                         addExperimentalVMOption(nativeImageArgs, "-H:+AOTSingleCallsiteInline");
                     }
                 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/GraalVM.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/GraalVM.java
@@ -98,6 +98,7 @@ public final class GraalVM {
         public static final Version VERSION_24_1_999 = new Version("GraalVM 24.1.999", "24.1.999", "23", Distribution.GRAALVM);
         public static final Version VERSION_24_2_0 = new Version("GraalVM 24.2.0", "24.2.0", "24", Distribution.GRAALVM);
         public static final Version VERSION_25_0_0 = new Version("GraalVM 25.0.0", "25.0.0", "25", Distribution.GRAALVM);
+        public static final Version VERSION_25_0_4 = new Version("GraalVM 25.0.4", "25.0.4", "25", Distribution.GRAALVM);
         public static final Version VERSION_25_1_0 = new Version("GraalVM 25.1.0", "25.1.0", "25", Distribution.GRAALVM);
 
         // Temporarily work around https://github.com/quarkusio/quarkus/issues/36246,

--- a/docs/src/main/asciidoc/native-reference.adoc
+++ b/docs/src/main/asciidoc/native-reference.adoc
@@ -2828,7 +2828,7 @@ The community edition of GraalVM 25.0 Native Image has 2 inliners. There is the 
 
 Both inliners are enabled by default when available. The trivial inliner is available in all versions of GraalVM. The single callsite inliner is only available with GraalVM community edition 25.0.4+ and Mandrel 25.0.4+.
 
-To disable the trivial inliner use: `quarkus.native.additional-build-args=-H:-AOTTrivialInline`.
+To disable the trivial inliner use: `-Dquarkus.native.additional-build-args-append=-H:-AOTTrivialInline`.
 
 To disable the single callsite inliner use: `-Dquarkus.native.additional-build-args-append=-H:-AOTSingleCallsiteInline`. To enable the single callsite inliner on non-Mandrel builds use: `-Dquarkus.native.additional-build-args-append=-H:+AOTSingleCallsiteInline`
 

--- a/docs/src/main/asciidoc/native-reference.adoc
+++ b/docs/src/main/asciidoc/native-reference.adoc
@@ -2830,7 +2830,7 @@ Both inliners are enabled by default when available. The trivial inliner is avai
 
 To disable the trivial inliner use: `quarkus.native.additional-build-args=-H:-AOTTrivialInline`.
 
-To disable the single callsite inliner use: `quarkus.native.additional-build-args=-H:-AOTTrivialInline`.
+To disable the single callsite inliner use: `-Dquarkus.native.additional-build-args-append=-H:-AOTSingleCallsiteInline`. To enable the single callsite inliner on non-Mandrel builds use: `-Dquarkus.native.additional-build-args-append=-H:+AOTSingleCallsiteInline`
 
 === Why are native executables “big”?
 

--- a/docs/src/main/asciidoc/native-reference.adoc
+++ b/docs/src/main/asciidoc/native-reference.adoc
@@ -2824,7 +2824,7 @@ That requires keeping runtime info that allow a compiled stack frame to be repla
 It also requires runtime extensible profile counters to be allocated and updated to track what has or has not been executed.
 
 ==== Native mode inliners
-The community edition of GraalVM Native Image has 2 inliners. There is the trivial inliner, which is responsible for inlining very small methods. There is also the single callsite inliner, which is responsible for inlining methods with only one caller.
+The community edition of GraalVM 25.0 Native Image has 2 inliners. There is the trivial inliner, which is responsible for inlining very small methods. There is also the single callsite inliner, which is responsible for inlining methods with only one caller.
 
 Both inliners are enabled by default when available. The trivial inliner is available in all versions of GraalVM. The single callsite inliner is only available with GraalVM community edition 25.0.4+ and Mandrel 25.0.4+.
 

--- a/docs/src/main/asciidoc/native-reference.adoc
+++ b/docs/src/main/asciidoc/native-reference.adoc
@@ -2823,6 +2823,15 @@ At that point the JVM has to jump out of the compiled code into the interpreter 
 That requires keeping runtime info that allow a compiled stack frame to be replaced with one or more interpreter frames.
 It also requires runtime extensible profile counters to be allocated and updated to track what has or has not been executed.
 
+==== Native mode inliners
+The community edition of GraalVM Native Image has 2 inliners. There is the trivial inliner, which is responsible for inlining very small methods. There is also the single callsite inliner, which is responsible for inlining methods with only one caller.
+
+Both inliners are enabled by default when available. The trivial inliner is available in all versions of GraalVM. The single callsite inliner is only available with GraalVM community edition 25.0.4+ and Mandrel 25.0.4+.
+
+To disable the trivial inliner use: `quarkus.native.additional-build-args=-H:-AOTTrivialInline`.
+
+To disable the single callsite inliner use: `quarkus.native.additional-build-args=-H:-AOTTrivialInline`.
+
 === Why are native executables “big”?
 
 This can be attributed to a number of different reasons:


### PR DESCRIPTION
### Summary
This PR enables native mode single callsite inlining by default if using Mandrel 25.0.4+ and not 25.1. Users can expect this to increase binary size by a few percent, while increasing runtime performance by 3-9% depending on the workload. Users can switch off this feature by using `quarkus.native.additional-build-args=-H:-AOTSingleCallsiteInline`.

I've added some logging explaining that this feature is being switched on as well as some text to the native reference guide. 

- Closes: https://github.com/quarkusio/quarkus/issues/55004